### PR TITLE
[REF] Simplify getContributionStatuses

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -228,14 +228,7 @@ LIMIT 1
     ];
     // on create fetch statuses on basis of component
     if (!$name) {
-      $statusNamesToUnset = array_merge($statusNamesToUnset, [
-        'Refunded',
-        'Chargeback',
-        'Pending refund',
-        'In Progress',
-        'Overdue',
-        'Partially paid',
-      ]);
+      return self::getPendingCompleteFailedAndCancelledStatuses();
     }
     else {
       switch ($name) {

--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -236,13 +236,6 @@ LIMIT 1
         'Overdue',
         'Partially paid',
       ]);
-
-      if ($usedFor && $usedFor !== 'contribution') {
-        $statusNamesToUnset = array_merge($statusNamesToUnset, [
-          'Cancelled',
-          'Failed',
-        ]);
-      }
     }
     else {
       switch ($name) {
@@ -299,6 +292,34 @@ LIMIT 1
     }
 
     return $statuses;
+  }
+
+  /**
+   * Get the options for pending and completed as an array with labels as values.
+   *
+   * @return array
+   */
+  public static function getPendingAndCompleteStatuses(): array {
+    $statusIDS = [
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+    ];
+    return array_intersect_key(CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id'), array_flip($statusIDS));
+  }
+
+  /**
+   * Get the options for pending and completed as an array with labels as values.
+   *
+   * @return array
+   */
+  public static function getPendingCompleteFailedAndCancelledStatuses(): array {
+    $statusIDS = [
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Failed'),
+      CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled'),
+    ];
+    return array_intersect_key(CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id'), array_flip($statusIDS));
   }
 
   /**

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2093,7 +2093,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       );
     }
     elseif ($fieldName === 'contribution_status_id') {
-      $contributionStatuses = CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses();
+      $contributionStatuses = CRM_Contribute_BAO_Contribution_Utils::getPendingCompleteFailedAndCancelledStatuses();
 
       $form->add('select', $name, $title,
         $contributionStatuses, $required, ['placeholder' => TRUE]

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1733,7 +1733,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
 
         $form->add('select', 'contribution_status_id',
-          ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses('participant')
+          ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses()
         );
 
         $form->add('text', 'check_number', ts('Check Number'),

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1733,7 +1733,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
 
         $form->add('select', 'contribution_status_id',
-          ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses('participant')
+          ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses('participant')
         );
 
         $form->add('text', 'check_number', ts('Check Number'),

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -598,7 +598,7 @@ DESC limit 1");
       );
 
       $this->add('select', 'contribution_status_id',
-        ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses('membership')
+        ts('Payment Status'), CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses()
       );
       $this->add('text', 'check_number', ts('Check Number'),
         CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Contribution', 'check_number')

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -359,7 +359,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       );
 
       $this->add('select', 'contribution_status_id', ts('Payment Status'),
-        CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses('membership')
+        CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses('membership')
       );
 
       $this->add('text', 'check_number', ts('Check Number'),

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -359,7 +359,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       );
 
       $this->add('select', 'contribution_status_id', ts('Payment Status'),
-        CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses('membership')
+        CRM_Contribute_BAO_Contribution_Utils::getPendingAndCompleteStatuses()
       );
 
       $this->add('text', 'check_number', ts('Check Number'),


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Simplify getContributionStatuses

The existing function is really confusing - but all that confusion is designed for one
form - back office contribution form - and augmented by overloading by other functions.

This splits it out. The same options are returned - however if sites have added their own options they would not be returned - we don't support that in the UI and our financial code really does expect a limited range of statuses so I don't know if that is a thing - maybe highlight in release notes?

Before
----------------------------------------
Function is super hard to read - being called to do different things makes that hard to unwravel. The function is used to get the drop down options for available statuses in 5 scenarions

1) new contribution backoffice (available options are Pending, Completed, Failed, Cancelled)
![image](https://user-images.githubusercontent.com/336308/146704348-57b166c2-f2f2-44d0-b2ed-ddebf06de7fb.png)
2) new membership with record payment (available options are Pending & Completed)
3) new participant with record payment (available options are Pending & Completed)
4) Profile form with contribution status included  (available options are Pending, Completed, Failed, Cancelled)
5) edit contribution back-office - this one is all over the show and untouched by this PR


After
----------------------------------------
The first 4 scenarios call simpler functions - leaving the last to be fixed up.

Technical Details
----------------------------------------
Could sites be using 'weird and wonderful other statuses'? Our system really is set up
around supporting specific statuses and doing financial entries for those so I think maybe
we are right to not try to pander to any that could exist

Comments
----------------------------------------
