### PR TITLE
Cleanup Smarty e-notices on campaign dashboard

### DIFF
--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -448,12 +448,12 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       }
       //load the data in tabs.
       $this->{'browse' . ucfirst($subPageType)}();
-      $this->assign('subPageType', ucfirst($subPageType));
     }
     // Initialize tabs
     else {
       $this->buildTabs();
     }
+    $this->assign('subPageType', ucfirst($subPageType));
   }
 
   /**
@@ -477,6 +477,11 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
         'valid' => TRUE,
         'active' => TRUE,
         'link' => CRM_Utils_System::url('civicrm/campaign', "reset=1&type=$name"),
+        'extra' => NULL,
+        'template' => NULL,
+        'count' => NULL,
+        'icon' => NULL,
+        'class' => NULL,
       ];
     }
     $allTabs['campaign']['class'] = 'livePage';

--- a/templates/CRM/Campaign/Page/DashBoard.tpl
+++ b/templates/CRM/Campaign/Page/DashBoard.tpl
@@ -10,7 +10,7 @@
 {* CiviCampaign DashBoard (launch page) *}
 
 
-{if !empty($subPageType)}
+{if $subPageType}
   {* load campaign/survey/petition tab *}
   {include file="CRM/Campaign/Form/Search/$subPageType.tpl"}
 {else}


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup Smarty e-notices on campaign dashboard

Before
----------------------------------------
Lots of red with debugging enabled at https://dmaster.localhost:32353/civicrm/campaign?reset=1

After
----------------------------------------
No more red

Technical Details
----------------------------------------

Comments
----------------------------------------
