### PR TITLE
dev/core#3001 escape single quotes when rendering tokens in html format

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -280,7 +280,7 @@ class TokenRow {
                 $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }
               else {
-                $htmlTokens[$entity][$field] = is_object($value) ? $value : htmlentities($value);
+                $htmlTokens[$entity][$field] = is_object($value) ? $value : htmlentities($value, ENT_QUOTES);
               }
             }
           }

--- a/tests/phpunit/CRM/Core/TokenSmartyTest.php
+++ b/tests/phpunit/CRM/Core/TokenSmartyTest.php
@@ -132,6 +132,21 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
     ];
   }
 
+  public function testTokenDataEscape() {
+    $cutesyContactId = $this->individualCreate([
+      'first_name' => 'Ivan\'s "The Ter<r>ib`le"',
+    ]);
+    $rendered = CRM_Core_TokenSmarty::render(
+      [
+        'msg_html' => 'First name is <b>{contact.first_name}</b>.',
+        'msg_text' => 'First name is __{contact.first_name}__.',
+      ],
+      ['contactId' => $cutesyContactId]
+    );
+    $this->assertEquals('First name is <b>Ivan&#039;s &quot;The Ter&lt;r&gt;ib`le&quot;</b>.', $rendered['msg_html']);
+    $this->assertEquals('First name is __Ivan\'s "The Ter<r>ib`le"__.', $rendered['msg_text']);
+  }
+
   /**
    * Someone malicious gives cutesy expressions (via token-content) that tries to provoke extra evaluation.
    */


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3001 escape single quotes when rendering tokens in html format

Before
----------------------------------------
Given the contact : Mathew "Matty" O'Riley

 `{contact.last_name}`  renders in html mode as O'Riley
 `{contact.first_name}`  renders in html mode as Mathew &quot;Matty&quot;


After
----------------------------------------
 `{contact.last_name}`  renders in html mode as O&#039;Riley
 `{contact.first_name}`  renders in html mode as Mathew &quot;Matty&quot;


Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3001 for discussion

Comments
----------------------------------------
@totten 