### PR TITLE
Add authx_login() API for backend script authentication (alt)

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -356,7 +356,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @return int|null
    */
   public function getUfId($username) {
-    if ($id = user_load_by_name($username)->id()) {
+    $user = user_load_by_name($username);
+    if ($user && $id = $user->id()) {
       return $id;
     }
   }

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -28,6 +28,12 @@ class Authenticator {
   protected $authxUf;
 
   /**
+   * @var string
+   *   Ex: 'send' or 'exception
+   */
+  protected $rejectMode = 'send';
+
+  /**
    * Authenticator constructor.
    */
   public function __construct() {
@@ -223,11 +229,26 @@ class Authenticator {
   }
 
   /**
+   * Specify the rejection mode.
+   *
+   * @param string $mode
+   * @return $this
+   */
+  public function setRejectMode(string $mode) {
+    $this->rejectMode = $mode;
+    return $this;
+  }
+
+  /**
    * Reject a bad authentication attempt.
    *
    * @param string $message
    */
   protected function reject($message = 'Authentication failed') {
+    if ($this->rejectMode === 'exception') {
+      throw new AuthxException($message);
+    }
+
     \CRM_Core_Session::useFakeSession();
     $r = new Response(401, ['Content-Type' => 'text/plain'], "HTTP 401 $message");
     \CRM_Utils_System::sendResponse($r);

--- a/ext/authx/Civi/Authx/AuthxException.php
+++ b/ext/authx/Civi/Authx/AuthxException.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Authx;
+
+class AuthxException extends \CRM_Core_Exception {
+
+}

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -39,6 +39,44 @@ Civi::dispatcher()->addListener('civi.invoke.auth', function($e) {
 });
 
 /**
+ * Perform a system login.
+ *
+ * This is useful for backend scripts that need to switch to a specific user.
+ *
+ * As needed, this will update the Civi session and CMS data.
+ *
+ * @param array{flow: ?string, useSession: ?bool, principal: ?array, cred: ?string,} $details
+ *   Describe the authentication process with these properties:
+ *
+ *   - string $flow (default 'script');
+ *     The type of authentication flow being used
+ *     Ex: 'param', 'header', 'auto'
+ *   - bool $useSession (default FALSE)
+ *     If TRUE, then the authentication should be persistent (in a session variable).
+ *     If FALSE, then the authentication should be ephemeral (single page-request).
+ *
+ *   And then ONE of these properties to describe the user/principal:
+ *
+ *   - string $cred
+ *     The credential, as formatted in the 'Authorization' header.
+ *     Ex: 'Bearer 12345', 'Basic ASDFFDSA=='
+ *   - array $principal
+ *     Description of a validated principal.
+ *     Must include 'contactId', 'userId', xor 'user'
+ * @return array{contactId: int, userId: ?int, flow: string, credType: string, useSession: bool}
+ *   An array describing the authenticated session.
+ * @throws \Civi\Authx\AuthxException
+ */
+function authx_login(array $details): array {
+  $defaults = ['flow' => 'script', 'useSession' => FALSE];
+  $details = array_merge($defaults, $details);
+  $auth = new \Civi\Authx\Authenticator();
+  $auth->setRejectMode('exception');
+  $auth->auth(NULL, array_merge($defaults, $details));
+  return \CRM_Core_Session::singleton()->get("authx");
+}
+
+/**
  * @return \Civi\Authx\AuthxInterface
  */
 function _authx_uf() {

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -17,7 +17,7 @@ use CRM_Authx_ExtensionUtil as E;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 $_authx_settings = function() {
-  $flows = ['param', 'header', 'xheader', 'login', 'auto'];
+  $flows = ['param', 'header', 'xheader', 'login', 'auto', 'script'];
   $basic = [
     'group_name' => 'CiviCRM Preferences',
     'group' => 'authx',

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -464,6 +464,55 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
   }
 
   /**
+   * The internal API `authx_login()` should be used by background services to set the active user.
+   *
+   * To test this, we call `cv ev 'authx_login(...);'` and check the resulting identity.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testCliServiceLogin() {
+    $withCv = function($phpStmt) {
+      $cmd = strtr('cv ev -v @PHP', ['@PHP' => escapeshellarg($phpStmt)]);
+      exec($cmd, $output, $val);
+      $fullOutput = implode("\n", $output);
+      $this->assertEquals(0, $val, "Command returned error ($cmd) ($val):\n\"$fullOutput\"");
+      return json_decode($fullOutput, TRUE);
+    };
+
+    $principals = [
+      'contactId' => $this->getDemoCID(),
+      'userId' => $this->getDemoUID(),
+      'user' => $GLOBALS['_CV']['DEMO_USER'],
+    ];
+    foreach ($principals as $principalField => $principalValue) {
+      $msg = "Logged in with $principalField=$principalValue. We should see this user as authenticated.";
+
+      $loginArgs = ['principal' => [$principalField => $principalValue]];
+      $report = $withCv(sprintf('return authx_login(%s);', var_export($loginArgs, 1)));
+      $this->assertEquals($this->getDemoCID(), $report['contactId'], $msg);
+      $this->assertEquals($this->getDemoUID(), $report['userId'], $msg);
+      $this->assertEquals('script', $report['flow'], $msg);
+      $this->assertEquals('assigned', $report['credType'], $msg);
+      $this->assertEquals(FALSE, $report['useSession'], $msg);
+    }
+
+    $invalidPrincipals = [
+      ['contactId', 999999, AuthxException::CLASS, ';Contact ID 999999 is invalid;'],
+      ['userId', 999999, AuthxException::CLASS, ';Cannot login. Failed to determine contact ID.;'],
+      ['user', 'randuser' . mt_rand(0, 32767), AuthxException::CLASS, ';Must specify principal with valid user, userId, or contactId;'],
+    ];
+    foreach ($invalidPrincipals as $invalidPrincipal) {
+      [$principalField, $principalValue, $expectExceptionClass, $expectExceptionMessage] = $invalidPrincipal;
+
+      $loginArgs = ['principal' => [$principalField => $principalValue]];
+      $report = $withCv(sprintf('try { return authx_login(%s); } catch (Exception $e) { return [get_class($e), $e->getMessage()]; }', var_export($loginArgs, 1)));
+      $this->assertTrue(isset($report[0], $report[1]), "authx_login() should fail with invalid credentials ($principalField=>$principalValue). Received array: " . json_encode($report));
+      $this->assertRegExp($expectExceptionMessage, $report[1], "Invalid principal ($principalField=>$principalValue) should generate exception.");
+      $this->assertEquals($expectExceptionClass, $report[0], "Invalid principal ($principalField=>$principalValue) should generate exception.");
+    }
+  }
+
+  /**
    * Filter a request, applying the given authentication options
    *
    * @param \Psr\Http\Message\RequestInterface $request


### PR DESCRIPTION
Overview
----------------------------------------

Adds a function to login as a user. It is cross-platform; accepts contact ID, user ID, or username; and it updates relevant services (*eg Civi session; Drupal `$user`; MySQL `@civicrm_user_id`*).

(This is a dependency for https://lab.civicrm.org/dev/core/-/issues/1304. @demeritcowboy this replaces #22239; it generally the same functionality, but some commits have been squashed, and some signatures have changed. In particular, `authx_login()` accepts more inputs - `cred: string` or `principal: array` combined with `flow: string` and/or `useSession: bool`. Ex: Setting `flow=>script` means that it will use the setting `authx_script_user` to decide whether user-accounts are required.)

Before
----------------------------------------

Not available

After
----------------------------------------

```php
// Signature
function authx_login(array $params): array;

// Examples
authx_login(['principal' => ['contactId' => 202]]);
authx_login(['principal' => ['userId' => 1]]);
authx_login(['principal' => ['user' => 'admin']]);
authx_login(['cred' => 'Basic dXNlcjpwYXNz']);
authx_login(['cred' => 'Bearer dXNlcjpwYXNz']);

authx_login(['flow' => 'foo', 'useSession' => TRUE, 'principal' => ['user' => 'admin']]);
authx_login(['flow' => 'foo', 'useSession' => TRUE, 'cred' => 'Bearer dXNlcjpwYXNz']);
```

This shares much of its implementation with the login processes used by authx for JWT+ApiKey+Password authentication.

Like the JWT/key/password implementations, this has cross-platform E2E testing.

Technical Details
----------------------------------------

The new use-case is like this: you have some background worker processes. These processes need to execute some tasks *on behalf of* a user. This is similar to `authx`'s existing login functionality in some ways (*eg you want it to be portable; to integrate with login/session mechanics in the CMS; and to work with a range of user-accounts*); but it also differs in an important way (*eg there is no authentication credential presented by a user; the decision is made by a background agent*).

The main changes here:

* Update `Civi\Authx\Authenticator::auth()`  so that it can accept either (a) unvalidated credentials (`string $cred`; e.g. username-password/JWT/API-key) or (b) validated `array $principal` (e.g. validated `int $contactId` or `int $userId`).
* Add a wrapper method `authx_login()`. This calls `Civi\Authx\Authenticator::auth()` with some defaults that are more useful for custom scripts.

A quick way to see it in action is with `cv`, `drush`, or `wp-cli`. In each of these commands, we start Civi in different ways (`cv ev`, `drush ev`, etc) and try to login.

```bash
#### Valid examples (for standard demo data; cv)

cv ev 'authx_login(["principal"=>["contactId"=>202]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

cv ev 'authx_login(["principal"=>["userId"=>1]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

cv ev 'authx_login(["principal"=>["user"=>"admin"]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

#### Valid examples (for standard demo data; drush-d7, drush-d8, wp-cli)

drush ev 'civicrm_initialize(); authx_login(["principal"=>["contactId"=>202]],0); print_r(civicrm_api3("Contact","get",["id"=>"user_contact_id"]));'

drush ev '\Drupal::service("civicrm")->initialize(); authx_login(["principal"=>["contactId"=>202]],0); print_r(civicrm_api3("Contact","get",["id"=>"user_contact_id"]));'

wp eval 'civicrm_initialize(); authx_login(["principal"=>["contactId"=>202]],0); print_r(civicrm_api3("Contact","get",["id"=>"user_contact_id"]));'

#### Invalid examples (for standard demo data; cv)

cv ev 'authx_login(["principal"=>["contactId"=>99999]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  [Civi\Authx\AuthxException]
  Contact ID 99999 is invalid

cv ev 'authx_login(["principal"=>["userId"=>99999]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  [Civi\Authx\AuthxException]
  Cannot login. Failed to determine contact ID.

cv ev 'authx_login(["principal"=>["user"=>"nonexistent"]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  [Civi\Authx\AuthxException]
  Must specify principal with valid user, userId, or contactId

cv ev -U admin 'authx_login(["principal"=>["user"=>"demo"]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  [Civi\Authx\AuthxException]
  Cannot login. Session already active.

#### Invalid examples (for standard demo data; drush-d7, drush-d8)

drush ev 'civicrm_initialize(); authx_login(["principal"=>["contactId"=>99999]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  CRM_Core_Exception: [0: Contact ID 99999 is invalid                                                              [error]

drush -u admin ev 'civicrm_initialize(); authx_login(["principal"=>["user"=>"demo"]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  CRM_Core_Exception: [0: Cannot login. Session already active.                                                    [error]

drush ev '\Drupal::service("civicrm")->initialize(); authx_login(["principal"=>["contactId"=>99999]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  CRM_Core_Exception: [0: Contact ID 99999 is invalid                                                                      [error]

drush -u admin ev '\Drupal::service("civicrm")->initialize(); authx_login(["principal"=>["user"=>"demo"]],0); return civicrm_api3("Contact","get",["id"=>"user_contact_id"]);'

  CRM_Core_Exception: [0: Cannot login. Session already active.                                                                                                   [error]
```

(Note @demeritcowboy - I tested most of the above in `drupal-clean` w/php80+php74 and `drupal8-clean` w/php74. I couldn't reproduce the [type error mentioned here](https://github.com/civicrm/civicrm-core/pull/22239#issuecomment-998852365). If you still get the error, then I'll need more precise description of the environment.)

There are some existing alternatives, but each has issues.

* Use `CRM_Utils_System::loadBootStrap(...)` and pass username/password. However, in this function, the authentication and bootstrap processes are tightly coupled -- and some of its expectations are wonky.
* Use CMS-specific APIs, eg `\Drupal::service('account_switcher')->switchTo(...)` or `wp_set_current_user()`. Obviously not portable.
* Use `cv --user`, `drush --user`, or `wp --user`. However, these require you pick the target principal/user *before* launching the script.
* Use `CRM_Core_Config::singleton()->userSystem->loadUser(...)`. However, this only workswith a username (not contactId/userId); the incantation is very internal; and test coverage is unclear.

