### PR TITLE
SearchKit - Tweak export explorer link icon + format

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -99,11 +99,13 @@
     $scope.$bindToRoute({
       expr: 'selectedTab.code',
       param: '_lang',
+      format: 'raw',
       default: 'php'
     });
     $scope.$bindToRoute({
       expr: '$ctrl.resultFormat',
       param: '_format',
+      format: 'raw',
       default: 'json'
     });
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
@@ -20,7 +20,7 @@
       ];
 
       this.$onInit = function() {
-        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?id=' + ctrl.savedSearchId);
+        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php&id=' + ctrl.savedSearchId);
 
         var findDisplays = _.transform(ctrl.displayNames, function(findDisplays, displayName) {
           findDisplays.push(['search_displays', 'CONTAINS', ctrl.savedSearchName + '.' + displayName]);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.html
@@ -5,7 +5,7 @@
       {{:: ts('Search configuration can be copied from here, then pasted into "Import" to e.g. transfer between sites.') }}
     </p>
     <p>
-      <i class="crm-i fa-gift"></i>
+      <i class="crm-i fa-suitcase"></i>
       {{:: ts('Note: to package for distribution in an extension, use:') }}
       <a ng-href="{{:: $ctrl.apiExplorerLink }}" target="_blank">
         <u>{{:: ts('API Explorer Export') }}</u>


### PR DESCRIPTION
Overview
----------------------------------------
Minor tweaks to UIs not yet released in master branch.

Before
----------------------------------------
Old icon for packaged searches
Link to explorer did not specify php format

After
----------------------------------------
New icon to match #22299 
Link to explorer specifies php format

Technical Details
----------------------------------------
Updates the explorer params to use raw strings, as json-encoding is not necessary.
