### PR TITLE
Display label before input elements on SMTP settings page

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Smtp.tpl
+++ b/templates/CRM/Admin/Form/Setting/Smtp.tpl
@@ -12,8 +12,8 @@
   <h3>{ts}General{/ts}</h3>
      <table class="form-layout-compressed">
        <tr class="crm-smtp-form-block-allow_mail_from_logged_in_contact">
-         <td class="label">{$form.allow_mail_from_logged_in_contact.html}</td>
          <td>{$form.allow_mail_from_logged_in_contact.label} {help id=allow_mail_contact_email}</td>
+         <td class="label">{$form.allow_mail_from_logged_in_contact.html}</td>
        </tr>
      </table>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Flips label and input elements on SMTP settings page for consistency with other setting screens.

Before
----------------------------------------
On the SMTP settings screen the label "Allow mail from logged in contact" appeared after the radio elements. As well as being inconsistent with the rest of the CiviCRM templates, it just felt _off_ to look at:

<img width="1027" alt="Screenshot 2021-12-22 at 21 05 56" src="https://user-images.githubusercontent.com/1931323/147155235-f0f4f40f-9bb6-4665-86fc-b27d24ef1520.png">

After
----------------------------------------
The HTML elements have been flipped:

<img width="1030" alt="Screenshot 2021-12-22 at 21 08 17" src="https://user-images.githubusercontent.com/1931323/147155358-80f08fa9-7798-48c0-9bcd-b13645adfb2a.png">
