### PR TITLE
Enable more currencies by default

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -765,7 +765,12 @@ VALUES
    (@option_group_id_nuf, '{ts escape="sql"}Participants{/ts}',  'civicrm_participant',  'Participant',  NULL, 0, NULL, 3, NULL, 0, 0, 1, NULL, NULL, NULL),
    (@option_group_id_nuf, '{ts escape="sql"}Contributions{/ts}', 'civicrm_contribution', 'Contribution', NULL, 0, NULL, 4, NULL, 0, 0, 1, NULL, NULL, NULL),
 
+-- Available currencies.
    (@option_group_id_currency, 'USD ($)',      'USD',     'USD',       NULL, 0, 1, 1, NULL, 0, 0, 1, NULL, NULL, NULL),
+   (@option_group_id_currency, 'CAD ($)',      'CAD',     'CAD',       NULL, 0, 0, 2, NULL, 0, 0, 1, NULL, NULL, NULL),
+   (@option_group_id_currency, 'EUR (€)',      'EUR',     'EUR',       NULL, 0, 0, 3, NULL, 0, 0, 1, NULL, NULL, NULL),
+   (@option_group_id_currency, 'GBP (£)',      'GBP',     'GBP',       NULL, 0, 0, 4, NULL, 0, 0, 1, NULL, NULL, NULL),
+   (@option_group_id_currency, 'JPY (¥)',      'JPY',     'JPY',       NULL, 0, 0, 5, NULL, 0, 0, 1, NULL, NULL, NULL),
 
 -- event name badges
   (@option_group_id_eventBadge,  '{ts escape="sql"}Name Only{/ts}'     , 1, 'CRM_Event_Badge_Simple'  ,  NULL, 0, 0, 1, '{ts escape="sql"}Simple Event Name Badge{/ts}', 0, 1, 1, NULL, NULL, NULL),


### PR DESCRIPTION
Overview
----------------------------------------
Enable more currencies by default

Before
----------------------------------------
Only USD is enabled on a brand new site

After
----------------------------------------
USD, CAD, EUR, GBP, JPY enabled

Technical Details
----------------------------------------
My driver for doing this is I want to make the default dataset multicurrency to reduce the work in replicating various scenarios. I could do this so it ONLY affects the default dataset if preferred. 

I think it's an advantage to make it affect all new installs - especially since with regards to the use of EUR and GBP. 

I selected these 4 extra currencies mostly to get a range of formatting (ie. CAD formats slightly differently when the locale is en_US and JPY has different default rounding.)

Comments
----------------------------------------
The alternative is to do this in GenerateData. Note that I ALSO want to add some default transactions in these currencies