### PR TITLE
Fix JS Error for Free event with multiple participant on registration…

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -159,7 +159,13 @@
     {literal}
 
     cj("#additional_participants").change(function () {
-      skipPaymentMethod();
+      if (typeof skipPaymentMethod == 'function') {
+        // For free event there is no involvement of payment processor, hence
+        // this function is not available. if above condition not present
+        // then you will receive JS Error in case you change multiple
+        // registrant option.
+        skipPaymentMethod();
+      }
     });
 
   {/literal}
@@ -225,7 +231,13 @@
         cj("#bypass_payment").val(0);
       }
       //reset value since user don't want or not eligible for waitlist
-      skipPaymentMethod();
+      if (typeof skipPaymentMethod == 'function') {
+        // For free event there is no involvement of payment processor, hence
+        // this function is not available. if above condition not present
+        // then you will receive JS Error in case register multiple participants
+        // enabled and require approval.
+        skipPaymentMethod();
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When the event is Non Paid Event (Free) and enabled for `Register multiple participants`.

On the Registration screen when a user changes an additional participant through the select field (`How many people are you registering?`), we get a JS error on the browser console.

<img width="1255" alt="Screenshot 2021-12-23 at 2 06 06 PM" src="https://user-images.githubusercontent.com/377735/147212812-8387c1a4-1551-4d01-85f2-7be4367b51e2.png">


Before
----------------------------------------
JS Error

After
----------------------------------------
No JS Error, checking function exist or not before calling it.
