### PR TITLE
Event Registration: initialize array

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -495,6 +495,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
     $contactID = CRM_Core_Session::getLoggedInContactID();
+    $fields = [];
 
     // we don't allow conflicting fields to be
     // configured via profile


### PR DESCRIPTION
Overview
----------------------------------------

Minor code nitpick to avoid a PHP fatal on PHP 8.0 in certain unusual circumstances. 

Before
----------------------------------------

Viewing Event Registration page as an organization results in fatal PHP error.

After
----------------------------------------

Viewing Event Registration page as an organization displays the form, although in a not-very-supported way.

Technical Details
----------------------------------------

Under PHP 8.0, this throws a fatal error. Previously it only throw a warning: 

```
php -r "array_intersect_key(NULL, []);"
```

Comments
----------------------------------------

Sure, it's not a supported use-case, and I stumbled on it by accident, but initializing variables is usually not a bad thing.