### PR TITLE
Event Registration: allow default Price Set values from the URL

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -288,13 +288,22 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         }
         $optionFullIds = CRM_Utils_Array::value('option_full_ids', $val, []);
         foreach ($val['options'] as $keys => $values) {
-          if ($values['is_default'] && empty($values['is_full'])) {
-
-            if ($val['html_type'] == 'CheckBox') {
-              $this->_defaults["price_{$key}"][$keys] = 1;
-            }
-            else {
-              $this->_defaults["price_{$key}"] = $keys;
+          $priceFieldName = 'price_' . $values['price_field_id'];
+          $priceFieldValue = CRM_Price_BAO_PriceSet::getPriceFieldValueFromURL($this, $priceFieldName);
+          if (!empty($priceFieldValue)) {
+            CRM_Price_BAO_PriceSet::setDefaultPriceSetField($priceFieldName, $priceFieldValue, $val['html_type'], $this->_defaults);
+            // break here to prevent overwriting of default due to 'is_default'
+            // option configuration. The value sent via URL get's higher priority.
+            break;
+          }
+          else {
+            if ($values['is_default'] && empty($values['is_full'])) {
+              if ($val['html_type'] == 'CheckBox') {
+                $this->_defaults["price_{$key}"][$keys] = 1;
+              }
+              else {
+                $this->_defaults["price_{$key}"] = $keys;
+              }
             }
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------

Contribution Pages allow site-admins to share an URL with arguments such as `price_123=22`  so that the form has specific default values. This was is not currently possible with events.

This PR implements the same solution for default values for public Event registration.

See: https://civicrm.stackexchange.com/questions/40181/query-string-to-pre-select-price-field-for-events

![image](https://user-images.githubusercontent.com/254741/147259756-4b8b9aee-e63a-4451-9974-a3a7570a9043.png)

Technical Details
----------------------------------------

Based on the code from Contribution Pages. Admittedly some copy-pasting.

Comments
----------------------------------------

It does not work for multiple-participant registration (it only sets on the first participant).