### PR TITLE
Remove use of .font-size11pt and .font-size12pt

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -871,14 +871,6 @@ input.crm-form-entityref {
   font-style: italic;
 }
 
-.crm-container .font-size11pt {
-  font-size: 1.1em;
-}
-
-.crm-container .font-size12pt {
-  font-size: 1.2em;
-}
-
 .crm-container .qill {
   font-weight: normal;
   line-height: 1.1em;

--- a/ext/civigrant/templates/CRM/Grant/Form/Search.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Search.tpl
@@ -20,7 +20,7 @@
         </div>
         <table class="form-layout">
             <tr>
-               <td class="font-size12pt" colspan="3">
+               <td colspan="3">
                     {$form.sort_name.label}&nbsp;&nbsp;{$form.sort_name.html}&nbsp;&nbsp;&nbsp;{$form.buttons.html}<br />
                </td>
             </tr>

--- a/templates/CRM/Activity/Form/Search.tpl
+++ b/templates/CRM/Activity/Form/Search.tpl
@@ -19,7 +19,7 @@
         {strip}
           <table class="form-layout">
             <tr>
-              <td class="font-size12pt" colspan="2">
+              <td colspan="2">
                 {$form.sort_name.label}&nbsp;&nbsp;{$form.sort_name.html|crmAddClass:'twenty'}
                 <div>
                   <div class="description font-italic">{ts}Complete OR Partial Name{/ts}

--- a/templates/CRM/Campaign/Form/Search/Common.tpl
+++ b/templates/CRM/Campaign/Form/Search/Common.tpl
@@ -23,7 +23,7 @@
     {strip}
       <table class="form-layout">
         <tr>
-          <td class="font-size12pt">
+          <td>
             {$form.campaign_survey_id.label}
           </td>
           <td>
@@ -31,17 +31,17 @@
           </td>
 
           {if $showInterviewer}
-            <td class="font-size12pt">
+            <td>
               {$form.survey_interviewer_id.label}
             </td>
-            <td class="font-size12pt ">
+            <td>
               {$form.survey_interviewer_id.html}
             </td>
           {/if}
 
         </tr>
         <tr>
-          <td class="font-size12pt">
+          <td>
             {$form.sort_name.label}
           </td>
           <td colspan="3">
@@ -64,13 +64,13 @@
         </tr>
 
         <tr>
-          <td class="font-size12pt">
+          <td>
             {$form.street_address.label}
           </td>
           <td>
             {$form.street_address.html}
           </td>
-          <td class="font-size12pt">
+          <td>
             {$form.street_name.label}
           </td>
           <td>
@@ -78,13 +78,13 @@
           </td>
         </tr>
         <tr>
-          <td class="font-size12pt">
+          <td>
             {$form.street_unit.label}
           </td>
           <td>
             {$form.street_unit.html}
           </td>
-          <td class="font-size12pt">
+          <td>
             {$form.city.label}
           </td>
           <td>
@@ -92,14 +92,14 @@
           </td>
         </tr>
         <tr>
-          <td class="font-size12pt">
+          <td>
             {$form.street_number.label}
           </td>
           <td>
             {$form.street_number.html}
           </td>
 
-          <td class="font-size12pt">
+          <td>
             {$form.postal_code.label}
           </td>
           <td>
@@ -110,7 +110,7 @@
           <tr>
             {if $customSearchFields.ward}
               {assign var='ward' value=$customSearchFields.ward}
-              <td class="font-size12pt">
+              <td>
                 {$form.$ward.label}
               </td>
               <td>
@@ -120,7 +120,7 @@
 
             {if $customSearchFields.precinct}
               {assign var='precinct' value=$customSearchFields.precinct}
-              <td class="font-size12pt">
+              <td>
                 {$form.$precinct.label}
               </td>
               <td>

--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -62,9 +62,9 @@
             <table class="form-layout-compressed">
               <tbody>
                 <tr id="with-clients" class="crm-case-activity-form-block-client_name">
-                  <td class="label font-size12pt">{ts}Client{/ts}</td>
+                  <td class="label">{ts}Client{/ts}</td>
                   <td class="view-value">
-                    <span class="font-size12pt">
+                    <span>
                       {foreach from=$client_names item=client name=clients key=id}
                         {foreach from=$client_names.$id item=client1}
                           {$client1.display_name}
@@ -131,7 +131,7 @@
                 <td class="view-value">
                   {$form.activity_date_time.html}
                   {if $action eq 2 && $activityTypeFile eq 'OpenCase'}
-                    <div class="description">Use a <a class="open-inline" href="{$changeStartURL}">Change Start Date</a> activity to change the date</div>
+                    <div class="description">{ts}Use a <a class="open-inline" href="{$changeStartURL}">Change Start Date</a> activity to change the date{/ts}</div>
                   {/if}
                 </td>
               </tr>

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -36,8 +36,8 @@
     {/if}
 {if !empty($clientName)}
     <tr class="crm-case-form-block-clientName">
-      <td class="label font-size12pt">{ts}Client{/ts}</td>
-      <td class="font-size12pt bold view-value">{$clientName}</td>
+      <td class="label">{ts}Client{/ts}</td>
+      <td class="bold view-value">{$clientName}</td>
     </tr>
 {elseif empty($clientName) and $action eq 1}
     {if $context eq 'standalone'}

--- a/templates/CRM/Case/Form/Search.tpl
+++ b/templates/CRM/Case/Form/Search.tpl
@@ -21,7 +21,7 @@
         {strip}
             <table class="form-layout">
             <tr class="crm-case-search-form-block-sort_name">
-               <td class="font-size12pt" colspan="2">
+               <td colspan="2">
                    {$form.sort_name.label}&nbsp;&nbsp;{$form.sort_name.html|crmAddClass:'twenty'}
                </td>
               <td>{include file="CRM/common/formButtons.tpl" location="top"}</td>

--- a/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
+++ b/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
@@ -1,5 +1,5 @@
 <tr>
-  <td class="font-size12pt">
+  <td>
     {$form.sort_name.label}
     <br>
     {$form.sort_name.html|crmAddClass:'twenty'}

--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -38,7 +38,7 @@
 
   <table class="form-layout-compressed">
   <tr>
-    <td class="font-size12pt" style="width: 30%;">
+    <td style="width: 30%;">
         {if !empty($savedSearch.name)}{$savedSearch.name} ({ts}smart group{/ts}) - {/if}
         {ts count=$pager->_totalItems plural='%count Contacts'}%count Contact{/ts}
     </td>
@@ -51,7 +51,7 @@
     </td>
   </tr>
   <tr>
-    <td class="font-size11pt"> {ts}Select Records{/ts}:</td>
+    <td> {ts}Select Records{/ts}:</td>
     <td class="nowrap">
       {assign var="checked" value=$selectedContactIds|@count}
       {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural='All %count records'}The found record{/ts}</label>

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -38,7 +38,7 @@
   </div>
   <table class="form-layout-compressed">
     <tr>
-      <td class="font-size12pt label"><strong>{if $component eq 'event'}{ts}Participant{/ts}{else}{ts}Contact{/ts}{/if}</strong></td><td class="font-size12pt"><strong>{$displayName}</strong></td>
+      <td class="label"><strong>{if $component eq 'event'}{ts}Participant{/ts}{else}{ts}Contact{/ts}{/if}</strong></td><td><strong>{$displayName}</strong></td>
     </tr>
     {if $eventName}
       <tr>

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -92,7 +92,7 @@ CRM.$(function($) {
   {/if}
   <table class="form-layout">
     <tr>
-      <td class="font-size12pt label"><strong>{ts}Participant{/ts}</strong></td><td class="font-size12pt"><strong>{$displayName}</strong></td>
+      <td class="label"><strong>{ts}Participant{/ts}</strong></td><td><strong>{$displayName}</strong></td>
     </tr>
     <tr>
       <td class='label'>{ts}Event{/ts}</td><td>{$eventName}</td>

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -19,7 +19,7 @@
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
           <tr>
-            <td class="font-size12pt" colspan="2">
+            <td colspan="2">
               {$form.sort_name.label}<br>
               {$form.sort_name.html|crmAddClass:'twenty'}
             </td>

--- a/templates/CRM/Friend/Form.tpl
+++ b/templates/CRM/Friend/Form.tpl
@@ -36,11 +36,11 @@
   </tr>
 
   <tr>
-    <td class="right font-size12pt">{$form.from_name.label}&nbsp;&nbsp;</td>
-    <td class="font-size12pt">{$form.from_name.html} &lt;{$form.from_email.html}&gt;</td>
+    <td class="right">{$form.from_name.label}&nbsp;&nbsp;</td>
+    <td>{$form.from_name.html} &lt;{$form.from_email.html}&gt;</td>
   </tr>
   <tr>
-    <td class="label font-size12pt">{$form.suggested_message.label}</td>
+    <td class="label">{$form.suggested_message.label}</td>
     <td>{$form.suggested_message.html}</td>
   </tr>
 

--- a/templates/CRM/common/searchResultTasks.tpl
+++ b/templates/CRM/common/searchResultTasks.tpl
@@ -12,7 +12,7 @@
 <div id="search-status">
   <table class="form-layout-compressed">
   <tr>
-    <td class="font-size12pt" style="width: 40%;">
+    <td style="width: 40%;">
     {if !empty($savedSearch.name)}{$savedSearch.name} ({ts}smart group{/ts}) - {/if}
     {ts count=$pager->_totalItems plural='%count Results'}%count Result{/ts}{if !empty($selectorLabel)}&nbsp;-&nbsp;{$selectorLabel}{/if}
     {if $context == 'Event' && $participantCount && ( $pager->_totalItems ne $participantCount ) }
@@ -34,7 +34,7 @@
   </tr>
 {/if}
   <tr>
-    <td class="font-size11pt"> {ts}Select Records{/ts}:</td>
+    <td>{ts}Select Records{/ts}:</td>
     <td class="nowrap">
       {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural='All %count records'}The found record{/ts}</label> &nbsp; {if $pager->_totalItems > 1} {$form.radio_ts.ts_sel.html} <label for="{$ts_sel_id}">{ts 1="<span></span>"}%1 Selected records only{/ts}</label>{/if}
     </td>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3004

civicrm.css contains the following CSS:

```
.crm-container .font-size11pt {
  font-size: 1.1em;
}

.crm-container .font-size12pt {
  font-size: 1.2em;
}
```

These are used, but rarely and inconsistently, throughout the CiviCRM codebase. I see the following issues with these classes:

 - These classes are used inconsistently, and I can't imendiately see what the rules are that decided their use.
 - When these classes are used, just the font-size is adjusted, which can lead to the area around that label appearing cramped.
 - Using font-size alone to pull attention to a label is fairly lazy design, and can look like a UI mistake rather than a feature.
 - These classes are treated inconsistently in different CiviCRM themes.
 - These class names are not semantic, and also are not strictly accurate given we're using em not pt.

Having looked through the Git hsitory there is only one occurance of someone having used one of these classes since the migration from SVN 9 years ago. Therefore, removing.