### PR TITLE
Preserve selected tab when navigating between pages.

### DIFF
--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -16,6 +16,13 @@
           CRM.alert(ts('Your changes in the <em>%1</em> tab have not been saved.', {1: ui.oldTab.text()}), ts('Unsaved Changes'), 'warning');
         }
       })
+      .on('tabsactivate', function(e, ui) {
+        var tabId = ui.newTab.attr('id');
+        if (tabId && tabId.length) {
+          tabId = tabId.slice(4); // Remove leading 'tab_'
+          history.replaceState(null, '', updateUrlParameter('selectedChild', tabId));
+        }
+      })
       .on('tabsbeforeload', function(e, ui) {
         // Use civicrm ajax wrappers rather than the default $.load
         if (!ui.panel.data("civiCrmSnippet")) {
@@ -148,4 +155,31 @@
       $panel.crmSnippet('destroy');
     }
   };
+
+  /**
+   * Updates the query parameter in the page URL,
+   * or adds the parameter if its not currently there.
+   *
+   * @param {string} param
+   * @param {string} value
+   * @return void
+   */
+   function updateUrlParameter(param, value) {
+    var newUrl,
+      newSearch,
+      href = window.location.href,
+      search = window.location.search;
+    if (search.indexOf('?' + param) !== -1 || search.indexOf('&' + param) !== -1 ) {
+      var regExp = new RegExp(param + "(.+?)(&|$)", "g");
+      newSearch = search.replace(regExp, param + "=" + value + "$2");
+      newUrl = href.replace(search, newSearch);
+    } else if (search.length) {
+      newSearch = search + '&' + param + "=" + value;
+      newUrl = href.replace(search, newSearch);
+    } else {
+      newSearch = '?' + param + "=" + value;
+      newUrl = location.protocol + '//' + location.hostname + location.pathname + newSearch + location.hash;
+    }
+    window.history.replaceState("", "", newUrl);
+  }
 })(CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3003#note_68315

Many CiviCRM pages, in particular the contact page, are structured around a series of tabs: Summary, Contributions, Membership etc. There are often times when you click through from a contact to a related entity (say a related contact from the relationships tab). Prior to this change, using the back button returned the user to the first tab each time. With this change the tab the users previous tab is remembered as part of the URL history. 

This is a particular issue for users with the "Enable Popup Forms" option unticked, but all users are affected by this.

Before
----------------------------------------
If on the contact page you clicked through from e.g. the relationships tab to a different contact, and then used the browsers back button you would be returned to the summary tab enstead of going back to the relationships tab.

This also improves the behaviour of other tab areas in the same fashion. For example, on the message templates screen, on the "System Workflow Messages", previously clicking through to a message, and then using the back button to go back would have returned the user to the "User-driven Messages" tab.

After
----------------------------------------
When switching between tabs the `selectedChild` query argument is updated in the URL (`selectedChild` already existed in CiviCRM and is used for internal linking). Therefore, the browser history, including the back-forward history, now includes a reference to the tab the user was viewing.

Technical Details
----------------------------------------
The `updateUrlParameter` isn't as clean as some code examples you find online for acheiving this functionality. However, I couldn't find anything about what browsers CiviCRM officially supports so wanted to go for a solution that would support as many browsers as possible including Internet Explorer.

Comments
----------------------------------------
This turned out to be simpler than I expected! Originally I was going to add a new data attribute to each tab with the ID corresponding to the `selectedChild` value, but then I realised that each tab consistenly has an `ID` attribute of the format `tab_contribution'. Removing the leading `tab` gives us the component we need to make the URL segment `&selectedChild=contribution`
