### PR TITLE
Add state name to export fields

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -649,6 +649,11 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Test\Ho
             $relationships
           );
         }
+        if (!empty($fields[$contactType]['state_province']) && empty($fields[$contactType]['state_province_name'])) {
+          $fields[$contactType]['state_province_name'] = $fields[$contactType]['state_province'];
+          $fields[$contactType]['state_province_name']['title'] = ts('State/Province Name');
+          $fields[$contactType]['state_province']['title'] = ts('State/Province Abbreviation');
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add state name to export fields

Before
----------------------------------------
Export Contact only has a State field which render as state abbreviation. There is no way to export the name of the state in core.

To replicate:

- Search contacts.
- Export them and select `Choose fields to export`.
- On selecting the fields, you only have a single State field, which by default render as the abbreviation.

![image](https://user-images.githubusercontent.com/5929648/147359352-365e0ccb-9cae-40d7-b367-29ae5a5952d6.png)


After
----------------------------------------
New field added to export state name.

![image](https://user-images.githubusercontent.com/5929648/147359295-d511e95a-c428-4269-9f9a-bb96498c6c86.png)


Comments
----------------------------------------
Related GitLab - https://lab.civicrm.org/dev/core/-/issues/724. Probably we should also add `state_province_name` to the default [return properties](https://github.com/civicrm/civicrm-core/blob/master/CRM/Export/BAO/ExportProcessor.php#L1208) so its also available on the primary field export?