### PR TITLE
APIv4 - Set default status when creating GroupContact record

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/GroupContactCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/GroupContactCreationSpecProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class GroupContactCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('status')->setDefaultValue('Added');
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'GroupContact' && $action === 'create';
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/GroupContactTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupContactTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\GroupContact;
+
+/**
+ * @group headless
+ */
+class GroupContactTest extends UnitTestCase {
+
+  public function testCreate() {
+    $contact = $this->createEntity(['type' => 'Individual']);
+    $group = $this->createEntity(['type' => 'Group']);
+    $result = GroupContact::create(FALSE)
+      ->addValue('group_id', $group['id'])
+      ->addValue('contact_id', $contact['id'])
+      ->execute()
+      ->first();
+    $this->assertEquals('Added', $result['status']);
+  }
+
+}

--- a/tests/phpunit/api/v4/UnitTestCase.php
+++ b/tests/phpunit/api/v4/UnitTestCase.php
@@ -264,6 +264,9 @@ class UnitTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
         'subject' => 'unit testing',
         'source_contact_id' => 'dummy.Individual',
       ],
+      'Group' => [
+        'title' => 'unit testing',
+      ],
     ];
     if ($type == 'Contact') {
       $type = 'Individual';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/2924 by setting the default value for 'status' when adding a contact to a group using APIv4.

Before
----------------------------------------
Unlike APIv3, APIv4 does not set the default for GroupContact 'status', resulting in unexpected behavior.

After
----------------------------------------
APIv4 works the same as v3.