### PR TITLE
Smarty modifier - stop using isset to check taxTerm

### DIFF
--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -48,6 +48,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       'id' => ts('Domain ID'),
       'description' => ts('Domain Description'),
       'now' => ts('Current time/date'),
+      'tax_term' => ts('Sales tax term (e.g VAT)'),
     ];
   }
 
@@ -92,9 +93,9 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
         $domain->find(TRUE);
       }
       $tokens = [
-        'name' => $domain->name,
+        'name' => $domain->name ?? '',
         'id' => $domain->id,
-        'description' => $domain->description,
+        'description' => $domain->description ?? '',
       ];
       $loc = $domain->getLocationValues();
       if ($html) {
@@ -107,6 +108,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       $email = reset($loc['email']);
       $tokens['phone'] = $phone['phone'] ?? '';
       $tokens['email'] = $email['email'] ?? '';
+      $tokens['tax_term'] = (string) Civi::settings()->get('tax_term');
       Civi::cache('metadata')->set($cacheKey, $tokens);
     }
     return Civi::cache('metadata')->get($cacheKey);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1038,7 +1038,9 @@ class CRM_Utils_String {
     $cachingValue = $smarty->caching;
     $smarty->caching = 0;
     $smarty->assign('smartySingleUseString', $templateString);
-    $templateString = $smarty->fetch('string:{eval var=$smartySingleUseString}');
+    // Do not escape the smartySingleUseString as that is our smarty template
+    // and is likely to contain html.
+    $templateString = (string) $smarty->fetch('string:{eval var=$smartySingleUseString|smarty:nodefaults}');
     $smarty->caching = $cachingValue;
     $smarty->assign('smartySingleUseString', NULL);
     return $templateString;

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -100,4 +100,15 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
     }
   }
 
+  /**
+   * Define tokens to be exported as smarty values.
+   *
+   * @param array $export
+   */
+  protected function exportExtraTokenContext(array &$export): void {
+    // Tax term is exposed at the generic level as so many templates use it
+    // (e.g. Membership, participant, pledge as well as contributions).
+    $export['smartyTokenAlias']['taxTerm'] = 'domain.tax_term';
+  }
+
 }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -15,15 +15,14 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
 
   /**
    * Post test cleanup.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function tearDown():void {
     $this->quickCleanup(['civicrm_address', 'civicrm_phone', 'civicrm_im', 'civicrm_website', 'civicrm_openid', 'civicrm_email'], TRUE);
     parent::tearDown();
+    Civi::cache('metadata')->clear();
   }
 
-  public function testRenderTemplate() {
+  public function testRenderTemplate(): void {
     $contactId = $this->individualCreate([
       'first_name' => 'Abba',
       'last_name' => 'Baab',
@@ -107,7 +106,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertStringContainsString('<p>Hello testSendTemplate_RenderMode_OpenTemplate Abba Baab!</p>', $messageHtml);
   }
 
-  public function testSendTemplate_RenderMode_DefaultTpl() {
+  public function testSendTemplate_RenderMode_DefaultTpl(): void {
     CRM_Core_Transaction::create(TRUE)->run(function(CRM_Core_Transaction $tx) {
       $tx->rollback();
 
@@ -144,7 +143,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     });
   }
 
-  public function testSendTemplate_RenderMode_TokenContext() {
+  public function testSendTemplateRenderModeTokenContext(): void {
     CRM_Core_Transaction::create(TRUE)->run(function(CRM_Core_Transaction $tx) {
       $tx->rollback();
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -769,6 +769,7 @@ December 21st, 2007
       '{domain.id}' => ts('Domain ID'),
       '{domain.description}' => ts('Domain Description'),
       '{domain.now}' => 'Current time/date',
+      '{domain.tax_term}' => 'Sales tax term (e.g VAT)',
     ];
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2733,7 +2733,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @param string $templateName
    * @param string $type
    */
-  protected function swapMessageTemplateForTestTemplate($templateName = 'contribution_online_receipt', $type = 'html') {
+  protected function swapMessageTemplateForTestTemplate($templateName = 'contribution_online_receipt', $type = 'html'): void {
     $testTemplate = file_get_contents(__DIR__ . '/../../templates/message_templates/' . $templateName . '_' . $type . '.tpl');
     CRM_Core_DAO::executeQuery(
       "UPDATE civicrm_msg_template

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2082,7 +2082,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Test completing a transaction via the API with a non-USD transaction.
    */
-  public function testCompleteTransactionEuro() {
+  public function testCompleteTransactionEuro(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $this->swapMessageTemplateForTestTemplate();
     $this->createLoggedInUser();

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2052,8 +2052,9 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Note that we are creating a logged in user because email goes out from
    * that person
    */
-  public function testCompleteTransaction() {
+  public function testCompleteTransaction(): void {
     $mut = new CiviMailUtils($this, TRUE);
+    Civi::settings()->set('tax_term', 'GST');
     $this->swapMessageTemplateForTestTemplate();
     $this->createLoggedInUser();
     $params = array_merge($this->_params, ['contribution_status_id' => 2]);
@@ -2074,6 +2075,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       "receipt_date:::\n",
       'title:::Contribution',
       'contributionStatus:::Completed',
+      'taxTerm:::GST',
     ]);
     $mut->stop();
     $this->revertTemplateToReservedTemplate();

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -14,19 +14,19 @@
   contactID:::{$contactID}
   contributionID:::{$contributionID}
   amount:::{$amount}
-  {if isset($amount_level)}
+  {if !empty($amount_level)}
   amount_level:::{$amount_level}
   {/if}
-  {if isset($pay_later_receipt)}
+  {if !empty($pay_later_receipt)}
   pay_later_receipt:::{$pay_later_receipt}
   {/if}
-  {if isset($headerstyle)}
+  {if !empty($headerstyle)}
   headerStyle:::{$headerStyle}
   {/if}
-  {if isset($valueStyle)}
+  {if !empty($valueStyle)}
   valueStyle:::{$valueStyle}
   {/if}
-  {if isset($labelStyle)}
+  {if !empty($labelStyle)}
   labelStyle:::{$labelStyle}
   {/if}
   priceSetID:::{$priceSetID}
@@ -38,31 +38,31 @@
   getTaxDetails:::{$getTaxDetails}
   totalTaxAmount:::{$totalTaxAmount}
   {/if}
-  {if isset($is_monetary)}
+  {if !empty($is_monetary)}
   is_monetary:::{$is_monetary}
   {/if}
-  {if isset($isShare)}
+  {if !empty($isShare)}
   isShare:::{$isShare}
   {/if}
   honor_block_is_active:::{$honor_block_is_active}
   {if $honor_block_is_active}
   soft_credit_type:::{$soft_credit_type}
   {/if}
-  {if isset($is_recur)}
+  {if !empty($is_recur)}
   is_recur:::{$is_recur}
   {/if}
-  {if isset($trxn_id)}
+  {if !empty($trxn_id)}
   trxn_id:::{$trxn_id}
   {/if}
-  {if isset($cancelSubscriptionUrl)}
+  {if !empty($cancelSubscriptionUrl)}
   cancelSubscriptionUrl:::{$cancelSubscriptionUrl}
   updateSubscriptionBillingUrl:::{$updateSubscriptionBillingUrl}
   updateSubscriptionUrl:::{$updateSubscriptionUrl}
   {/if}
-  {if isset($priceset)}
+  {if !empty($priceset)}
   priceset:::{$priceset}
   {/if}
-  {if isset($taxTerm)}
+  {if !empty($taxTerm)}
   taxTerm:::{$taxTerm}
   {/if}
   {if !empty($pcpBlock)}
@@ -71,56 +71,56 @@
   pcp_roll_nickname:::{$pcp_roll_nickname}
   pcp_personal_note:::{$pcp_personal_note}
   {/if}
-  {if isset($onBehalfProfile_grouptitle)}
+  {if !empty($onBehalfProfile_grouptitle)}
   onBehalfProfile_grouptitle:::{$onBehalfProfile_grouptitle}
   {/if}
   email:::{$email}
-  {if isset($contributionPageId)}
+  {if !empty($contributionPageId)}
   contributionPageId:::{$contributionPageId}
   title:::{$title}
   {/if}
-  {if isset($isBillingAddressRequiredForPayLater)}
+  {if !empty($isBillingAddressRequiredForPayLater)}
   isBillingAddressRequiredForPayLater:::{$isBillingAddressRequiredForPayLater}
   {/if}
-  {if isset($billingName)}
+  {if !empty($billingName)}
   billingName:::{$billingName}
   address:::{$address}
   {/if}
-  {if isset($credit_card_type)}
+  {if !empty($credit_card_type)}
   credit_card_type:::{$credit_card_type}
   credit_card_number:::{$credit_card_number}
   credit_card_exp_date:::{$credit_card_exp_date}
   {/if}
-  {if isset($selectPremium)}
+  {if !empty($selectPremium)}
   selectPremium:::{$selectPremium}
   product_name:::{$product_name}
   option:::{$option}
   sku:::{$sku}
   {/if}
-  {if isset($start_date)}
+  {if !empty($start_date)}
   start_date:::{$start_date}
   end_date:::{$end_date}
   {/if}
-  {if isset($is_deductible)}
+  {if !empty($is_deductible)}
   is_deductible:::{$is_deductible}
   {/if}
-  {if isset($contact_email)}
+  {if !empty($contact_email)}
   contact_email:::{$contact_email}
   {/if}
-  {if isset($contact_phone)}
+  {if !empty($contact_phone)}
   contact_phone:::{$contact_phone}
   {/if}
-  {if isset($price)}
+  {if !empty($price)}
   price:::{$price}
   {/if}
-  {if isset($customPre_grouptitle)}
+  {if !empty($customPre_grouptitle)}
   customPre_grouptitle:::{$customPre_grouptitle}
   {/if}
-  {if isset($customPost_grouptitle)}
+  {if !empty($customPost_grouptitle)}
   customPost_grouptitle:::{$customPost_grouptitle}
   {/if}
   contributionStatus:::{$contributionStatus}
- {if isset($lineItem)}
+ {if !empty($lineItem)}
  {foreach from=$lineItem item=value key=priceset}
   {foreach from=$value item=line}
      line.html_type:::{$line.html_type}
@@ -129,7 +129,7 @@
      line.description:::{$line.description}
      line.qty:::{$line.qty}
      line.unit_price:::{$line.unit_price}
-     {if isset($line.tax_rate)}
+     {if !empty($line.tax_rate)}
      line.tax_rate:::{$line.tax_rate}
      line.tax_amount:::{$line.tax_amount}
      {/if}

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -62,9 +62,7 @@
   {if !empty($priceset)}
   priceset:::{$priceset}
   {/if}
-  {if !empty($taxTerm)}
   taxTerm:::{$taxTerm}
-  {/if}
   {if !empty($pcpBlock)}
   pcpBlock:::{$pcpBlock}
   pcp_display_in_roll:::{$pcp_display_in_roll}
@@ -82,10 +80,8 @@
   {if !empty($isBillingAddressRequiredForPayLater)}
   isBillingAddressRequiredForPayLater:::{$isBillingAddressRequiredForPayLater}
   {/if}
-  {if !empty($billingName)}
   billingName:::{$billingName}
   address:::{$address}
-  {/if}
   {if !empty($credit_card_type)}
   credit_card_type:::{$credit_card_type}
   credit_card_number:::{$credit_card_number}

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -75,7 +75,7 @@
                 <th style="text-align:left;font-weight:bold;width:100%"><font size="1">{ts}Description{/ts}</font></th>
                 <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts}Quantity{/ts}</font></th>
                 <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts}Unit Price{/ts}</font></th>
-                <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{if isset($taxTerm)}{$taxTerm}{/if}</font></th>
+                <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{$taxTerm}</font></th>
                 <th style="text-align:right;font-weight:bold;white-space: nowrap"><font size="1">{ts 1=$currency}Amount %1{/ts}</font></th>
               </tr>
               {foreach from=$lineItem item=value key=priceset name=taxpricevalue}
@@ -99,7 +99,7 @@
                   {if $value.tax_amount != ''}
                     <td style="text-align:right;"><font size="1">{if isset($value.tax_rate)}{$value.tax_rate}%{/if}</font></td>
                   {else}
-                    <td style="text-align:right;"><font size="1">{if isset($taxTerm)}{ts 1=$taxTerm}-{/ts}{/if}</font></td>
+                    <td style="text-align:right;"><font size="1">{if $taxTerm}{ts 1=$taxTerm}-{/ts}{/if}</font></td>
                   {/if}
                   <td style="text-align:right;"><font size="1">{$value.subTotal|crmMoney:$currency}</font></td>
                 </tr>
@@ -114,10 +114,10 @@
                 <tr>
                   <td colspan="3"></td>
                     {if $priceset}
-                      <td style="text-align:right;white-space: nowrap"><font size="1">{if isset($taxTerm)}{ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}{/if}</font></td>
+                      <td style="text-align:right;white-space: nowrap"><font size="1">{if $taxTerm}{ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}{/if}</font></td>
                       <td style="text-align:right"><font size="1" align="right">{$value|crmMoney:$currency}</font> </td>
                     {elseif $priceset == 0}
-                      <td style="text-align:right;white-space: nowrap"><font size="1">{if isset($taxTerm)}{ts 1=$taxTerm}TOTAL %1{/ts}{/if}</font></td>
+                      <td style="text-align:right;white-space: nowrap"><font size="1">{if $taxTerm}{ts 1=$taxTerm}TOTAL %1{/ts}{/if}</font></td>
                       <td style="text-align:right"><font size="1" align="right">{$value|crmMoney:$currency}</font> </td>
                     {/if}
                 </tr>
@@ -302,7 +302,7 @@
                 <th style="padding-right:28px;text-align:left;font-weight:bold;width:200px;"><font size="1">{ts}Description{/ts}</font></th>
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts}Quantity{/ts}</font></th>
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts}Unit Price{/ts}</font></th>
-                <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{if isset($taxTerm)}{$taxTerm}{/if}</font></th>
+                <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{$taxTerm}</font></th>
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts 1=$currency}Amount %1{/ts}</font></th>
               </tr>
               {foreach from=$lineItem item=value key=priceset name=pricevalue}
@@ -329,7 +329,7 @@
                   {if $value.tax_amount != ''}
                     <td style="padding-left:28px;text-align:right;"><font size="1">{if isset($value.tax_rate)}{$value.tax_rate}%{/if}</font></td>
                   {else}
-                    <td style="padding-left:28px;text-align:right"><font size="1">{if isset($taxTerm)}{ts 1=$taxTerm}No %1{/ts}{/if}</font></td>
+                    <td style="padding-left:28px;text-align:right"><font size="1">{if $taxTerm}{ts 1=$taxTerm}No %1{/ts}{/if}</font></td>
                   {/if}
                   <td style="padding-left:28px;text-align:right;"><font size="1">{$value.subTotal|crmMoney:$currency}</font></td>
                 </tr>
@@ -345,10 +345,10 @@
                 <tr>
                   <td colspan="3"></td>
                   {if $priceset}
-                    <td style="padding-left:28px;text-align:right;"><font size="1">{if isset($taxTerm)}{ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}{/if}</font></td>
+                    <td style="padding-left:28px;text-align:right;"><font size="1">{if $taxTerm}{ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}{/if}</font></td>
                     <td style="padding-left:28px;text-align:right;"><font size="1" align="right">{$value|crmMoney:$currency}</font> </td>
                   {elseif $priceset == 0}
-                    <td style="padding-left:28px;text-align:right;"><font size="1">{if isset($taxTerm)}{ts 1=$taxTerm}TOTAL NO %1{/ts}{/if}</font></td>
+                    <td style="padding-left:28px;text-align:right;"><font size="1">{if $taxTerm}{ts 1=$taxTerm}TOTAL NO %1{/ts}{/if}</font></td>
                     <td style="padding-left:28px;text-align:right;"><font size="1" align="right">{$value|crmMoney:$currency}</font> </td>
                   {/if}
                 </tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -121,10 +121,10 @@
       {foreach from=$dataArray item=value key=priceset}
         <tr>
         {if $priceset ||  $priceset == 0 || $value != ''}
-          <td>&nbsp;{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%</td>
+          <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
           <td>&nbsp;{$value|crmMoney:$currency}</td>
         {else}
-          <td>&nbsp;{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}</td>
+          <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
           <td>&nbsp;{$value|crmMoney:$currency}</td>
         {/if}
         </tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -37,9 +37,9 @@
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset ||  $priceset == 0 || $value != ''}
-{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}% : {$value|crmMoney:$currency}
+{$taxTerm} {$priceset|string_format:"%.2f"}% : {$value|crmMoney:$currency}
 {else}
-{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if} : {$value|crmMoney:$currency}
+{ts}No{/ts} {$taxTerm} : {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -109,10 +109,10 @@
         {foreach from=$dataArray item=value key=priceset}
          <tr>
           {if $priceset || $priceset == 0}
-           <td>&nbsp;{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%</td>
+           <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
           {else}
-           <td>&nbsp;{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}</td>
+           <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
           {/if}
          </tr>

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -5,7 +5,7 @@
 {if $is_pay_later}
 
 ===========================================================
-{if isset($pay_later_receipt)}{$pay_later_receipt}{/if}
+{$pay_later_receipt}
 ===========================================================
 {/if}
 
@@ -38,9 +38,9 @@
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}
-{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
+{$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
 {else}
-{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}: {$value|crmMoney:$currency}
+{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -226,10 +226,10 @@
         {foreach from=$dataArray item=value key=priceset}
           <tr>
            {if $priceset || $priceset == 0}
-            <td>&nbsp;{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%</td>
+            <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
             <td>&nbsp;{$value|crmMoney:$currency}</td>
            {else}
-            <td>&nbsp;{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}</td>
+            <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
             <td>&nbsp;{$value|crmMoney:$currency}</td>
            {/if}
           </tr>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -125,9 +125,9 @@
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}
-{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
+{$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
 {else}
-{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}: {$value|crmMoney:$currency}
+{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -269,10 +269,10 @@
         {foreach from=$dataArray item=value key=priceset}
          <tr>
           {if $priceset || $priceset == 0}
-           <td>&nbsp;{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%</td>
+           <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
           {else}
-           <td>&nbsp;{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}</td>
+           <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
           {/if}
          </tr>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -145,9 +145,9 @@ You were registered by: {$payer.name}
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}
-{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
+{$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
 {else}
-{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}: {$value|crmMoney:$currency}
+{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -157,10 +157,10 @@
                   {foreach from=$dataArray item=value key=priceset}
                     <tr>
                       {if $priceset}
-                        <td>&nbsp;{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%</td>
+                        <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
                         <td>&nbsp;{$value|crmMoney:$currency}</td>
                       {elseif  $priceset == 0}
-                        <td>&nbsp;{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}</td>
+                        <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
                         <td>&nbsp;{$value|crmMoney:$currency}</td>
                       {/if}
                     </tr>

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -52,9 +52,9 @@
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset}
-{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"} %: {$value|crmMoney:$currency}
+{$taxTerm} {$priceset|string_format:"%.2f"} %: {$value|crmMoney:$currency}
 {elseif  $priceset == 0}
-{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}: {$value|crmMoney:$currency}
+{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -217,10 +217,10 @@
         {foreach from=$dataArray item=value key=priceset}
          <tr>
          {if $priceset || $priceset == 0}
-           <td>&nbsp;{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%</td>
+           <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
          {else}
-           <td>&nbsp;{ts}NO{/ts} {if isset($taxTerm)}{$taxTerm}{/if}</td>
+           <td>&nbsp;{ts}NO{/ts} {$taxTerm}</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
          {/if}
          </tr>

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -74,9 +74,9 @@
 
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}
-{if isset($taxTerm)}{$taxTerm}{/if} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
+{$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
 {else}
-{ts}No{/ts} {if isset($taxTerm)}{$taxTerm}{/if}: {$value|crmMoney:$currency}
+{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Smarty modifier - stop using isset to check taxTerm. This works by adding a new domain token (domain.tax_term) and exporting it as the smarty variable `$taxTerm` to the smarty layer.

Before
----------------------------------------
Use of isset - which doesn't work with default modifiers

After
----------------------------------------
`$taxTerm` is always assigned (as an empty string if none exists). In addition it is available as a tomain token.

Technical Details
----------------------------------------
Adding it as a domain token helps to keep our logic in the tokens layer and makes it avialable from non-workflow templates. Realistically people likely would write it in in letters but if being copied from one site to another or used in a multisite it would make sense.

Comments
----------------------------------------
