### PR TITLE
(dev/core#1304) Civi::queue($name) - Add facade for accessing queues. Support naming convention.

### DIFF
--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -125,23 +125,26 @@ class CRM_Queue_Service {
    *   Ex: ['type' => 'SqlParallel', 'is_persistent' => TRUE, 'is_autorun' => TRUE]
    */
   protected function getDefaultSpec(string $name): array {
-    $defaults = ['is_persistent' => FALSE, 'is_autorun' => FALSE];
+    $defaults = ['is_autorun' => FALSE];
     if (FALSE !== ($questionPos = strpos($name, '?'))) {
       $flags = explode(',', substr($name, 1 + $questionPos));
 
       $flagDefs = [
         'bg' => ['is_persistent' => TRUE, 'is_autorun' => TRUE, 'type' => 'SqlParallel'],
         'fg' => ['is_persistent' => FALSE, 'is_autorun' => FALSE, 'type' => 'Sql'],
-        // More fine-grained flags might be more expressive. But are they really needed? Maybe...?
-        // 'parallel' => ['type' => 'SqlParallel'],
-        // 'linear' => ['type' => 'Sql'],
-        // 'persist' => ['is_persistent' => TRUE],
-        // 'autorun' => ['is_persistent' => TRUE, 'is_autorun' => TRUE],
+        'parallel' => ['type' => 'SqlParallel'],
+        'linear' => ['type' => 'Sql'],
+        'persist' => ['is_persistent' => TRUE],
+        'autorun' => ['is_autorun' => TRUE],
       ];
 
       foreach (array_intersect($flags, array_keys($flagDefs)) as $flag) {
         $defaults = array_merge($defaults, $flagDefs[$flag]);
       }
+    }
+
+    if (!isset($defaults['is_persistent'])) {
+      $defaults['is_persistent'] = $defaults['is_autorun'];
     }
     return $defaults;
   }

--- a/Civi.php
+++ b/Civi.php
@@ -106,6 +106,40 @@ class Civi {
   }
 
   /**
+   * Find or create a queue.
+   *
+   * This interface is somewhat opinionated about how to construct the
+   * queue object. If you need more fine-grained control, then directly
+   * use `CRM_Queue_Service::singleton()` or instantiate the queue directly.
+   *
+   * @param string $name
+   *   Name of the queue. The name should include a flag (`?bg` or `?fg`) that indicates
+   *   a general stereotype for usage.
+   *
+   *   Flags:
+   *   - `?bg` ("Background"): Queue tasks execute automatically in the background.
+   *   - `?fg` ("Foreground"): Queue tasks execute in the foreground. You must take extra
+   *     steps to ensure that the foreground page runs the queue.
+   *
+   *   Currently, the flags indicate the following queue configuration:
+   *   - `?bg`: `type=>SqlParallel`, 'is_persistent=>TRUE`, `is_autorun=>TRUE`
+   *   - `?fg`: `type=>Sql`, 'is_persistent=>FALSE`, `is_autorun=>FALSE`
+   *
+   *   At time of writing, there is no hook or mechanism to override or supplement these
+   *   flags. However, it could be appropriate to add a mechanism.
+   *
+   *   Ex: 'foobar?fg' or 'bazqux?bg'
+   * @return \CRM_Queue_Queue
+   * @see \CRM_Queue_Service
+   */
+  public static function queue(string $name): CRM_Queue_Queue {
+    return CRM_Queue_Service::singleton()->create([
+      'name' => $name,
+      'reset' => FALSE,
+    ]);
+  }
+
+  /**
    * Obtain the formatting object.
    *
    * @return \Civi\Core\Format

--- a/tests/phpunit/CRM/Queue/FacadeTest.php
+++ b/tests/phpunit/CRM/Queue/FacadeTest.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Ensure that the `Civi::queue()` facade works.
+ *
+ * @group headless
+ */
+class CRM_Queue_FacadeTest extends CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  public function tearDown(): void {
+    $tablesToTruncate = ['civicrm_queue_item', 'civicrm_queue'];
+    $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
+  }
+
+  public function testCreate() {
+    $this->assertQueueStats([]);
+
+    $apple = Civi::queue('apple?bg');
+    $this->assertInstanceOf(CRM_Queue_Queue_SqlParallel::class, $apple);
+    $this->assertDBQuery(1, 'SELECT is_autorun FROM civicrm_queue WHERE name = "apple?bg"');
+    // $this->assertCount(1, Civi\Api4\Queue::get(0)->addWhere('name', 'LIKE', 'apple%')->execute());
+    $apple->createItem(new CRM_Queue_Task([__CLASS__, 'trueFunc'], []));
+    $this->assertQueueStats(['apple?bg' => 1]);
+
+    $banana = Civi::queue('banana?fg');
+    $this->assertInstanceOf(CRM_Queue_Queue_Sql::class, $banana);
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_queue WHERE name LIKE "banana%"');
+    // $this->assertCount(0, Civi\Api4\Queue::get(0)->addWhere('name', 'LIKE', 'banana%')->execute());
+    $banana->createItem(new CRM_Queue_Task([__CLASS__, 'trueFunc'], []));
+    $banana->createItem(new CRM_Queue_Task([__CLASS__, 'trueFunc'], []));
+    $this->assertQueueStats(['apple?bg' => 1, 'banana?fg' => 2]);
+
+    $apple2 = Civi::queue('apple?bg');
+    $this->assertEquals($apple, $apple2);
+    $apple2->createItem(new CRM_Queue_Task([__CLASS__, 'trueFunc'], []));
+    $this->assertQueueStats(['apple?bg' => 2, 'banana?fg' => 2]);
+
+    // $queue = Civi::queue('cherry?bg,linear');
+    // $this->assertInstanceOf(CRM_Queue_Queue_Sql::class, $queue);
+    // $this->assertDBQuery(1, 'SELECT is_autorun FROM civicrm_queue WHERE name LIKE "cherry%"');
+    // $this->assertCount(0, Civi\Api4\Queue::get(1)->addWhere('name', 'LIKE', 'cherry%')->execute());
+  }
+
+  protected function assertQueueStats(array $expectedStats) {
+    $actualStats = CRM_Core_DAO::executeQuery('SELECT queue_name, count(*) cnt FROM civicrm_queue_item GROUP BY queue_name')
+      ->fetchMap('queue_name', 'cnt');
+    ksort($actualStats);
+    ksort($expectedStats);
+    $this->assertEquals($expectedStats, $actualStats);
+  }
+
+  protected static function trueFunc() {
+    return TRUE;
+  }
+
+}

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -27,13 +27,13 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $queueSpecs[] = [
       [
         'type' => 'Sql',
-        'name' => 'test-queue',
+        'name' => 'test-queue-sql',
       ],
     ];
     $queueSpecs[] = [
       [
         'type' => 'Memory',
-        'name' => 'test-queue',
+        'name' => 'test-queue-mem',
       ],
     ];
     $queueSpecs[] = [
@@ -56,7 +56,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
   public function tearDown(): void {
     CRM_Utils_Time::resetTime();
 
-    $tablesToTruncate = ['civicrm_queue_item'];
+    $tablesToTruncate = ['civicrm_queue_item', 'civicrm_queue'];
     $this->quickCleanup($tablesToTruncate);
     parent::tearDown();
   }


### PR DESCRIPTION
Overview
----------

This provides a simpler internal API for accessing queues.

Cross-References
----------

* Contributes towards https://lab.civicrm.org/dev/core/-/issues/1304
* Depends on #22324

Before
------

To get a reference to a `$queue` object, you need to find the singleton and specify
a concrete type (eg `Sql`).

```php
// Use a foreground queue -- to be processed linearly via AJAX/web-browser
$queue_1 = CRM_Queue_Service::singleton()->create([
  'name' => 'my-foreground-queue',
  'type' => 'Sql',
  'reset' => FALSE,
]);
$queue_1->createItem(...);
```
```php
// Use a background queue -- to be automatically processed in parallel by a worker in the background
$queue_2 = CRM_Queue_Service::singleton()->create([
  'name' => 'my-background-queue',
  'type' => 'SqlParallel',
  'reset' => FALSE,
]);
$dao = new CRM_Queue_DAO_Queue();
$dao->copyParams([
  'name' => 'my-background-queue',
  'type' => 'SqlParallel',
  'is_autorun' => TRUE,
]);
$dao->insert(); // Unless it already exists...
$queue_2->createItem(...);
```

After
-----

To get a reference to a `$queue` object, you can use `Civi::queue()`. This follows a "convention-over-configuration" approach. There are two conventions - the foreground convention (`?fg`) and the background convention (`?bg`).

```php
// Use a foreground queue -- to be processed linearly via AJAX/web-browser
Civi::queue('my-foreground-queue?fg')->createItem(...)
```
```php
// Use a background queue -- to be automatically processed in parallel by a worker in the background
Civi::queue('my-background-queue?bg')->createItem(...);
```

Comments
------

* The references to `Civi::queue()` are cleaner than `CRM_Queue_Service::singleton()->create()`.
* The references to `Civi::queue()` are not specifically tied to the `Sql` or `SqlParallel` implementations. If we ever need to migrate implementation, a future patch or extension might re-interpret the `bg`/`fg` types (assuming sufficient interop) -- or it might add other conventions (if it's not interoperable).
* The naming convention could be bike-shedded a bit more. Like...
    * The current `?suffix` is interesting because it allows multiple flags in the suffix. So if wanted a funny queue that doesn't quite meet either convention, you might add a couple different flags.
    * But maybe it'd be easier to read with a folder-style prefix? Ex: `fg/my-foreground-queue` and `bg/my-background-queue` This might also work better if you have dynamic queue-names (`fg/import/$csvName`)
       | Example | `?suffix` rendering | `prefix/` rendering |
       | --| --| --|
       | Basic foreground queue| `my-foreground?fg` | `fg/my-foreground` |
       | Basic background queue| `my-background?fg` | `bg/my-background` |
       | Funny/mixed-style queue| `my-foreground?linear,persist` | _n/a_|
       | Dynamically-named queue | `import/{$csvName}?fg` <br/>(*but prefilter any `?`s from `csvName`*) | `fg/import/{$csvName}` |