### PR TITLE
SqlParallel - Enable more tests. Fix compatiblity with `release_time`

### DIFF
--- a/CRM/Queue/Queue/SqlParallel.php
+++ b/CRM/Queue/Queue/SqlParallel.php
@@ -116,12 +116,13 @@ class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue {
     $sql = "SELECT id, queue_name, submit_time, release_time, data
         FROM civicrm_queue_item
         WHERE queue_name = %1
-              AND release_time IS NULL
+              AND (release_time IS NULL OR release_time < %2)
         ORDER BY weight ASC, id ASC
         LIMIT 1
       ";
     $params = [
       1 => [$this->getName(), 'String'],
+      2 => [CRM_Utils_Time::getTime(), 'Timestamp'],
     ];
     $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, 'CRM_Queue_DAO_QueueItem');
     if (is_a($dao, 'DB_Error')) {

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -36,6 +36,12 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
         'name' => 'test-queue',
       ],
     ];
+    $queueSpecs[] = [
+      [
+        'type' => 'SqlParallel',
+        'name' => 'test-queue-sqlparallel',
+      ],
+    ];
     return $queueSpecs;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

The unit-test `CRM_Queue_QueueTest` provides some generic test-coverage for a couple different backends (`Sql`, `Memory`). This expands it to also test `SqlParallel`.

One test case, `testTimeoutRelease()`, was failing when run with `SqlParallel`. The PR updates it to pass.

@artfulrobot I can't recall if there is a reason why `SqlParallel` changed the `release_time` filter? 

Before
----------------------------------------

* In `Sql` and `Memory`-backed queues, the `claimItem()` logic will select items with any of these three dispositions:
    * New item, ready to go immediately (`release_time=null`)
    * New item, marked for future execution (`release_time=NNN`)
    * Previously attempted item that did not complete (eg it crashed; never finished; used up the full lease; `release_time=NNN`).
* In `SqlParallel`, `claimItem()` will only select items in this case:
   * New item, not previously attempted (`release_time=null`)


After
----------------------------------------

* In `Sql`, `Memory`, and `SqlParallel`, the `release_time` works the same way. It should support all 3 scenarios.
    * New item, ready to go immediately (`release_time=null`)
    * New item, marked for future execution (`release_time=NNN`)
    * Previously attempted item that did not complete (eg it crashed; never finished; used up the 