### PR TITLE
APIv4 - Fix potential crash caused by limited group permissions

### DIFF
--- a/CRM/Contact/BAO/GroupNesting.php
+++ b/CRM/Contact/BAO/GroupNesting.php
@@ -193,6 +193,9 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting {
    *   List of groupIds that represent the requested group and its descendents
    */
   public static function getDescendentGroupIds($groupIds, $includeSelf = TRUE) {
+    if (!$groupIds) {
+      return [];
+    }
     if (!is_array($groupIds)) {
       $groupIds = [$groupIds];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash reported in https://github.com/civicrm/org.civicrm.contactlayout/issues/107

Technical Details
--------------------
Some users have reported a crash caused by an empty array being passed to
`CRM_Contact_BAO_GroupNesting::getDescendentGroupIds` via `APIv4`.
It seems to happen when permissions are limited.
