### PR TITLE
SearchKit - Allow non-required select field to be blank

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -23,39 +23,45 @@ class ActivitySpecProvider implements Generic\SpecProviderInterface {
   public function modifySpec(RequestSpec $spec) {
     $action = $spec->getAction();
 
-    $field = new FieldSpec('source_contact_id', 'Activity', 'Integer');
-    $field->setTitle(ts('Source Contact'));
-    $field->setLabel(ts('Added by'));
-    $field->setDescription(ts('Contact who created this activity.'));
-    $field->setRequired(TRUE);
-    $field->setFkEntity('Contact');
-    $field->setInputType('EntityRef');
-    $spec->addFieldSpec($field);
+    // The database default '1' is problematic as the option list is user-configurable,
+    // so activity type '1' doesn't necessarily exist. Best make the field required.
+    $spec->getFieldByName('activity_type_id')
+      ->setDefaultValue(NULL)
+      ->setRequired(TRUE);
 
-    $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
-    $field->setTitle(ts('Target Contacts'));
-    $field->setLabel(ts('With Contact(s)'));
-    $field->setDescription(ts('Contact(s) involved in this activity.'));
-    $field->setFkEntity('Contact');
-    $field->setInputType('EntityRef');
-    $field->setInputAttrs(['multiple' => TRUE]);
-    $spec->addFieldSpec($field);
-
-    $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
-    $field->setTitle(ts('Assignee Contacts'));
-    $field->setLabel(ts('Assigned to'));
-    $field->setDescription(ts('Contact(s) assigned to this activity.'));
-    $field->setFkEntity('Contact');
-    $field->setInputType('EntityRef');
-    $field->setInputAttrs(['multiple' => TRUE]);
-    $spec->addFieldSpec($field);
+    if (in_array($action, ['create', 'update'], TRUE)) {
+      $field = new FieldSpec('source_contact_id', 'Activity', 'Integer');
+      $field->setTitle(ts('Source Contact'));
+      $field->setLabel(ts('Added by'));
+      $field->setDescription(ts('Contact who created this activity.'));
+      $field->setRequired(TRUE);
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $spec->addFieldSpec($field);
+      $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
+      $field->setTitle(ts('Target Contacts'));
+      $field->setLabel(ts('With Contact(s)'));
+      $field->setDescription(ts('Contact(s) involved in this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setInputAttrs(['multiple' => TRUE]);
+      $spec->addFieldSpec($field);
+      $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
+      $field->setTitle(ts('Assignee Contacts'));
+      $field->setLabel(ts('Assigned to'));
+      $field->setDescription(ts('Contact(s) assigned to this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setInputAttrs(['multiple' => TRUE]);
+      $spec->addFieldSpec($field);
+    }
   }
 
   /**
    * @inheritDoc
    */
   public function applies($entity, $action) {
-    return $entity === 'Activity' && in_array($action, ['create', 'update'], TRUE);
+    return $entity === 'Activity';
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -27,7 +27,7 @@ class ActivitySpecProvider implements Generic\SpecProviderInterface {
     $field->setTitle(ts('Source Contact'));
     $field->setLabel(ts('Added by'));
     $field->setDescription(ts('Contact who created this activity.'));
-    $field->setRequired($action === 'create');
+    $field->setRequired(TRUE);
     $field->setFkEntity('Contact');
     $field->setInputType('EntityRef');
     $spec->addFieldSpec($field);

--- a/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
@@ -34,7 +34,7 @@ class CustomValueSpecProvider implements Generic\SpecProviderInterface {
     $entityField->setType('Field');
     $entityField->setColumnName('entity_id');
     $entityField->setTitle(ts('Entity ID'));
-    $entityField->setRequired($action === 'create');
+    $entityField->setRequired(TRUE);
     $entityField->setFkEntity('Contact');
     $entityField->setReadonly(TRUE);
     $spec->addFieldSpec($entityField);

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -97,7 +97,7 @@ class SpecGatherer {
       ) {
         continue;
       }
-      if ($action !== 'create' || isset($DAOField['default'])) {
+      if (isset($DAOField['default'])) {
         $DAOField['required'] = FALSE;
       }
       if ($DAOField['name'] == 'is_active' && empty($DAOField['default'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -491,7 +491,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         'options' => !empty($field['options']),
         'serialize' => !empty($field['serialize']),
         'fk_entity' => $field['fk_entity'],
-        'required' => $field['required'],
+        'required' => $field['required'] || $field['default_value'],
         'value_key' => $field['name'],
         'value_path' => $key,
         'id_key' => $idKey,

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -467,7 +467,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
   /**
    * @param $key
-   * @return array{entity: string, input_type: string, data_type: string, options: bool, serialize: bool, fk_entity: string, value_key: string, value_path: string, id_key: string, id_path: string}|null
+   * @return array{entity: string, input_type: string, data_type: string, options: bool, serialize: bool, required: bool, fk_entity: string, value_key: string, value_path: string, id_key: string, id_path: string}|null
    */
   private function getEditableInfo($key) {
     [$key] = explode(':', $key);
@@ -491,6 +491,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         'options' => !empty($field['options']),
         'serialize' => !empty($field['serialize']),
         'fk_entity' => $field['fk_entity'],
+        'required' => $field['required'],
         'value_key' => $field['name'],
         'value_path' => $key,
         'id_key' => $idKey,

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -29,6 +29,7 @@
           options: col.edit.options,
           fk_entity: col.edit.fk_entity,
           serialize: col.edit.serialize,
+          required: col.edit.required,
         };
 
         $(document).on('keydown.crmSearchDisplayEditable', function(e) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/select.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/select.html
@@ -2,7 +2,7 @@
   <input disabled class="form-control loading" crm-ui-select="{data: []}">
 </div>
 <div class="form-group" ng-if="!$ctrl.multi && $ctrl.field.options !== true">
-  <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{data: $ctrl.getFieldOptions}">
+  <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{data: $ctrl.getFieldOptions, placeholder: $ctrl.field.required ? null : ts('None')}">
 </div>
 <div class="form-group" ng-if="$ctrl.multi && $ctrl.field.options !== true">
   <input class="form-control" ng-model="$ctrl.value" crm-ui-select="{data: $ctrl.getFieldOptions, multiple: true}" ng-list >


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/report#92](https://lab.civicrm.org/dev/report/-/issues/92)

Before
----------------------------------------
Cannot save empty value for non-required field using in-place edit.

After
----------------------------------------
Now you can.