### PR TITLE
SearchKit - Fix column headers for custom fields in default display

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -154,7 +154,7 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
       if (!empty($field['explicit_join'])) {
         $label = $this->getJoinLabel($field['explicit_join']) . ': ';
       }
-      if (!empty($field['implicit_join'])) {
+      if (!empty($field['implicit_join']) && empty($field['custom_field_id'])) {
         $field = $this->getField(substr($expr->getAlias(), 0, -1 - strlen($field['name'])));
       }
       return $label . $field['label'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the column headers for custom fields on the default (standalone) view of a saved search.

Before
----------------------------------------
- Create a search with at least one custom field as a column
- Click the "View" button to visit the standalone display
- Column header for custom fields will be blank

After
----------------------------------------
Column headers display correctly