### PR TITLE
Remove unused method getGrantStatusOptGroup

### DIFF
--- a/CRM/Grant/BAO/Grant.php
+++ b/CRM/Grant/BAO/Grant.php
@@ -60,30 +60,6 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
   }
 
   /**
-   * Get events Summary.
-   *
-   *
-   * @return array
-   *   Array of event summary values
-   *
-   * @throws CRM_Core_Exception
-   */
-  public static function getGrantStatusOptGroup() {
-
-    $params = [];
-    $params['name'] = CRM_Grant_BAO_Grant::$statusGroupName;
-
-    $defaults = [];
-
-    $og = CRM_Core_BAO_OptionGroup::retrieve($params, $defaults);
-    if (!$og) {
-      throw new CRM_Core_Exception('No option group for grant statuses - database discrepancy! Make sure you loaded civicrm_data.mysql');
-    }
-
-    return $og;
-  }
-
-  /**
    * Fetch object based on array of properties.
    *
    * @param array $params


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused method getGrantStatusOptGroup.

Technical Details
----------------------------------------
I spotted this method was unused as a result of my IDE warning me that `CRM_Grant_BAO_Grant::$statusGroupName` was unset. Therefore even if this method was in use, I do not belive it would work correctly. 

Checking with `git log -S getGrantStatusOptGroup` and `git log -S statusGroupName` it appears this method was not in use when the migration from SVN took place, and the method has not been referenced since.

Based on these factors it seems sensible to remove the method.