### PR TITLE
Fix Profile helptext menu reference to reCaptcha (by r4zoli)

### DIFF
--- a/templates/CRM/UF/Form/Group.hlp
+++ b/templates/CRM/UF/Form/Group.hlp
@@ -112,9 +112,9 @@
   {ts}reCaptcha{/ts}
 {/htxt}
 {htxt id='id-add_captcha'}
-{capture assign="miscURL"}{crmURL p="civicrm/admin/setting/recaptcha" q="reset=1"}{/capture}
+{capture assign="miscURL"}href="{crmURL p="civicrm/admin/setting/recaptcha" q="reset=1"}"{/capture}
 <p>{ts}When reCAPTCHA is enabled for a profile form, anonymous users are required to read an image with letters and numbers and enter the value in a field. This helps prevent abuse by automated scripts.{/ts}</p>
-<p>{ts 1="https://www.google.com/recaptcha" 2=$miscURL}To use reCAPTCHA you must sign up at <a href="%1" target="_blank">Google's reCaptcha site</a> to get your public and private keys. Then enter both keys in <a href="%2">Administer CiviCRM &raquo; Customize Data and Screens &raquo; reCAPTCHA settings</a>.{/ts}</p>
+<p>{ts 1="href='https://www.google.com/recaptcha' target='_blank'" 2=$miscURL}To use reCAPTCHA you must sign up at <a %1>Google's reCaptcha site</a> to get your public and private keys. Then enter both keys in <a %2>Administer CiviCRM &raquo; System Settings &raquo; reCAPTCHA settings</a>.{/ts}</p>
 <p><strong>{ts}Do not enable this feature if you are using this profile as an HTML Form Snippet embedded in a non-CiviCRM web page. reCAPTCHA requires dynamic page generation. Submitting a stand-alone form with reCAPTCHA included will always result in a reCAPTCHA validation error.{/ts}</strong></p>
 {if $config->userSystem->supports_form_extensions EQ '1'}
   <p><strong>{ts}reCAPTCHA is also not available when a profile is used inside the User Registration and My Account screens.{/ts}</strong></p>


### PR DESCRIPTION
Overview
----------------------------------------

A help text on Profiles references an incorrect menu path for reCaptcha settings.

Reported by r4zoli on the translation chat.

## Before

Administer CiviCRM &raquo; Customize Data and Screens &raquo; reCAPTCHA settings

## After

Administer CiviCRM &raquo; System Settings &raquo; reCAPTCHA settings

## Comments

In master, the menu is here:

![image](https://user-images.githubusercontent.com/254741/147572282-5ff3a2cc-1238-4fb0-bfbe-84dac6fac65c.png)
