### PR TITLE
Fix inaccuracies and mistakes in comments (especially phpdoc comments)

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -57,7 +57,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
    * @param array $defaults
    *   (reference ) an assoc array to hold the flattened values.
    *
-   * @return array
+   * @return CRM_Batch_BAO_Batch|null
    *   CRM_Batch_BAO_Batch object on success, null otherwise
    */
   public static function retrieve(&$params, &$defaults) {
@@ -364,7 +364,7 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
    * @param array $params
    *   Associated array for params.
    *
-   * @return string
+   * @return string[]
    */
   public static function whereClause($params) {
     $clauses = [];

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1814,7 +1814,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       $formattedGroupTree[$key]['collapse_adv_display'] = $value['collapse_adv_display'] ?? NULL;
       $formattedGroupTree[$key]['style'] = $value['style'] ?? NULL;
 
-      // this params needed of bulding multiple values
+      // this params needed of building multiple values
       $formattedGroupTree[$key]['is_multiple'] = $value['is_multiple'] ?? NULL;
       $formattedGroupTree[$key]['extends'] = $value['extends'] ?? NULL;
       $formattedGroupTree[$key]['extends_entity_column_id'] = $value['extends_entity_column_id'] ?? NULL;

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -119,7 +119,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
    * @param array $params
    * @param $values
    *
-   * @return bool
+   * @return array
    */
   public static function &getValues(&$params = [], &$values = []) {
     $websites = [];

--- a/CRM/Core/Reference/Basic.php
+++ b/CRM/Core/Reference/Basic.php
@@ -15,7 +15,7 @@ class CRM_Core_Reference_Basic implements CRM_Core_Reference_Interface {
   /**
    * @param $refTable
    * @param $refKey
-   * @param null $targetTable
+   * @param string $targetTable
    * @param string $targetKey
    * @param null $refTypeColumn
    */

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -650,13 +650,12 @@ $event_summary_limit
   }
 
   /**
-   * Get the information to map a event.
+   * Get the information to map an event.
    *
    * @param int $id
    *   For which we want map info.
    *
-   * @return null|string
-   *   title of the event
+   * @return array
    */
   public static function &getMapInfo(&$id) {
 
@@ -1261,7 +1260,7 @@ WHERE civicrm_event.is_active = 1
    * @param int $id
    * @param string $name
    * @param int $cid
-   * @param string $template
+   * @param \CRM_Core_Smarty $template
    * @param int $participantId
    * @param bool $isTest
    * @param bool $returnResults
@@ -1663,7 +1662,7 @@ WHERE  id = $cfID
                   }
                 }
                 elseif ($dao->data_type == 'Float') {
-                  $customVal = (float ) ($params[$name]);
+                  $customVal = (float) ($params[$name]);
                 }
                 elseif ($dao->data_type == 'Date') {
                   //@todo note the currently we are using default date time formatting. Since you can select/set
@@ -2233,7 +2232,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    *
    * @param int $eventId
    *   Event id.
-   * @param sting $extraWhereClause
+   * @param string $extraWhereClause
    *   Extra filter on participants.
    *
    * @return int

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -798,7 +798,7 @@ WHERE  civicrm_participant.id = {$participantId}
    *
    * @param array $defaults
    * @param string $property
-   * @param string $lookup
+   * @param string[] $lookup
    * @param bool $reverse
    *
    * @return bool
@@ -1596,8 +1596,7 @@ UPDATE  civicrm_participant
    * @param int $newStatusId
    *   New status.
    *
-   * @return bool
-   *   true if allowed
+   * @return array
    */
   public static function getValidAdditionalIds($participantId, $oldStatusId, $newStatusId) {
 

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -311,7 +311,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    * Subroutine to insert a Profile Editor widget.
    * depends on getProfileSelectorTypes
    *
-   * @param array &$form
+   * @param \CRM_Core_Form &$form
    * @param int $count
    *   Unique index.
    * @param string $prefix
@@ -392,7 +392,6 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    * Build Email Block.
    *
    * @param CRM_Core_Form $form
-   *
    */
   public function buildMailBlock(&$form) {
     $form->registerRule('emailList', 'callback', 'emailList', 'CRM_Utils_Rule');
@@ -420,7 +419,6 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
   /**
    * Add local and global form rules.
-   *
    *
    * @return void
    */
@@ -621,7 +619,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    * Collect all email fields for an array of profile ids.
    *
    * @param $profileIds
-   * @return bool
+   * @return array
    */
   public static function getEmailFields($profileIds) {
     $emailFields = [];
@@ -770,7 +768,6 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
   /**
    * Process the form submission.
-   *
    *
    * @return void
    */

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2181,7 +2181,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   }
 
   /**
-   * Store the parameters to create a payment, if approprite, on the form.
+   * Store the parameters to create a payment, if appropriate, on the form.
    *
    * @param array $params
    *   Params as submitted.

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -16,7 +16,7 @@
  */
 
 /**
- * Event Info Page - Summmary about the event
+ * Event Info Page - Summary about the event
  */
 class CRM_Event_Page_EventInfo extends CRM_Core_Page {
 

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -117,7 +117,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
   /**
    * The query object.
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 

--- a/CRM/Extension/Browser.php
+++ b/CRM/Extension/Browser.php
@@ -119,7 +119,7 @@ class CRM_Extension_Browser {
   /**
    * Get a list of all available extensions.
    *
-   * @return array
+   * @return CRM_Extension_Info[]
    *   ($key => CRM_Extension_Info)
    */
   public function getExtensions() {
@@ -159,7 +159,7 @@ class CRM_Extension_Browser {
   }
 
   /**
-   * @return array
+   * @return CRM_Extension_Info[]
    * @throws CRM_Extension_Exception_ParseException
    */
   private function _discoverRemote() {

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -23,12 +23,28 @@ class CRM_Extension_Info {
   const FILENAME = 'info.xml';
 
   /**
-   * @var string
+   * @var string|null
    */
   public $key = NULL;
+
+  /**
+   * @var string|null
+   */
   public $type = NULL;
+
+  /**
+   * @var string|null
+   */
   public $name = NULL;
+
+  /**
+   * @var string|null
+   */
   public $label = NULL;
+
+  /**
+   * @var string|null
+   */
   public $file = NULL;
 
   /**
@@ -140,11 +156,11 @@ class CRM_Extension_Info {
   }
 
   /**
-   * @param null $key
-   * @param null $type
-   * @param null $name
-   * @param null $label
-   * @param null $file
+   * @param string|null $key
+   * @param string|null $type
+   * @param string|null $name
+   * @param string|null $label
+   * @param string|null $file
    */
   public function __construct($key = NULL, $type = NULL, $name = NULL, $label = NULL, $file = NULL) {
     $this->key = $key;

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -546,7 +546,7 @@ class CRM_Extension_Mapper {
    * @todo We should improve this to return more appropriate text. eg. when an extension is not installed
    *   it should not say "version xx is installed".
    *
-   * @param array $remoteExtensionInfo
+   * @param CRM_Extension_Info $remoteExtensionInfo
    * @param array $localExtensionInfo
    *
    * @return string

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -214,7 +214,7 @@ abstract class CRM_Financial_BAO_ExportFormat {
 
   /**
    * @param array $files
-   * @param null $destination
+   * @param string $destination
    * @param bool $overwrite
    *
    * @return bool
@@ -224,7 +224,7 @@ abstract class CRM_Financial_BAO_ExportFormat {
     if (file_exists($destination) && !$overwrite) {
       return FALSE;
     }
-    $valid_files = [];
+
     if (is_array($files)) {
       foreach ($files as $file) {
         // make sure the file exists

--- a/CRM/Financial/Form/Export.php
+++ b/CRM/Financial/Form/Export.php
@@ -31,9 +31,11 @@ class CRM_Financial_Form_Export extends CRM_Core_Form {
 
   /**
    * Financial batch ids.
-   * @var array
+   * (comma-separated array)
+   *
+   * @var string
    */
-  protected $_batchIds = [];
+  protected $_batchIds = '';
 
   /**
    * Export status id.

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -512,7 +512,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
    * Get column query.
    *
    * @param string $col
-   * @param bool $createQuery
+   * @param array $createQuery
    *
    * @return array|mixed|string
    */

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -995,7 +995,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @param bool $isForward
    *   Is this mailing compose for forward?.
    * @param string $fromEmail
-   *   Email address of who is forwardinf it.
+   *   Email address of who is forwarding it.
    *
    * @param null $replyToEmail
    *
@@ -2289,7 +2289,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    * @param int $offset
    *   The row number to start from.
    * @param int $rowCount
-   *   The nmber of rows to return.
+   *   The number of rows to return.
    * @param string $sort
    *   The sql string that describes the sort order.
    *

--- a/CRM/Mailing/Event/BAO/Forward.php
+++ b/CRM/Mailing/Event/BAO/Forward.php
@@ -30,8 +30,8 @@ class CRM_Mailing_Event_BAO_Forward extends CRM_Mailing_Event_DAO_Forward {
    * @param $queue_id
    * @param $hash
    * @param $forward_email
-   * @param null $fromEmail
-   * @param null $comment
+   * @param string|null $fromEmail
+   * @param array|null $comment
    *
    * @return bool
    */

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -17,7 +17,7 @@
 
 /**
  * This implements the profile page for all contacts. It uses a selector
- * object to do the actual dispay. The fields displayd are controlled by
+ * object to do the actual display. The fields displayed are controlled by
  * the admin
  */
 class CRM_Mailing_Page_Browse extends CRM_Core_Page {

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -638,7 +638,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
   /**
    * Send a receipt.
    *
-   * @param array $membership
+   * @param CRM_Member_BAO_Membership $membership
    *
    * @throws \CRM_Core_Exception
    */

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -103,7 +103,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
   /**
    * The query object.
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -107,7 +107,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
   /**
    * The query object
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 
@@ -428,7 +428,7 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
   /**
    * Get sql query string.
    *
-   * @return string
+   * @return CRM_Contact_BAO_Query
    */
   public function &getQuery() {
     return $this->_query;

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -492,7 +492,7 @@ WHERE li.contribution_id = %1";
    * @param array $params
    *   Form values.
    *
-   * @param string $entityId
+   * @param string[]|null $entityId
    *   Entity id.
    *
    * @param string $entityTable

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -297,10 +297,12 @@ class CRM_Report_Form extends CRM_Core_Form {
    * @var int
    */
   protected $_offsetValue = NULL;
+
   /**
-   * @var null
+   * @var array
    */
-  protected $_sections = NULL;
+  protected $_sections = [];
+
   protected $_autoIncludeIndexedFieldsAsOrderBys = 0;
 
   /**
@@ -3917,7 +3919,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
   }
 
   /**
-   * Buld contact acl clause
+   * Build contact acl clause
    * @deprecated in favor of buildPermissionClause
    *
    * Note that if the buildPermissionClause function is called (which most reports do from
@@ -3930,7 +3932,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
   }
 
   /**
-   * Build the permision clause for all entities in this report
+   * Build the permission clause for all entities in this report
    */
   public function buildPermissionClause() {
     $ret = [];

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -334,11 +334,10 @@ class CRM_Utils_Type {
 
       default:
         throw new CRM_Core_Exception(
-          $type . " is not a recognised (camel cased) data type."
+          $type . " is not a recognized (camel cased) data type."
         );
     }
 
-    // @todo Use exceptions instead of CRM_Core_Error::fatal().
     if ($abort) {
       $data = htmlentities($data);
 
@@ -607,7 +606,7 @@ class CRM_Utils_Type {
   }
 
   /**
-   * Get list of avaliable Data Types for Option Groups
+   * Get list of available Data Types for Option Groups
    *
    * @return array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fix inaccuracies and mistakes in comments (especially phpdoc comments).

A lot of the docblock areas in the CiviCRM codebase could do with improvement. This tackles some low-hanging fruit:
 - Inaccurate type definitions
 - Spelling mistakes
 - Inaccurate descriptions

A lot of the offending comments were generated and added in bulk in https://github.com/civicrm/civicrm-core/commit/a0ee39412f184b0b9406094847554851ca2869f2, and so it does make sense that the accuracy may be lacking.

Technical Details
----------------------------------------
In a handful of cases there are examples like this:
```
  /**
   * @param $refTable
   * @param $refKey
   * @param string $targetTable
   * @param string $targetKey
   * @param null $refTypeColumn
   */
  public function __construct($refTable, $refKey, $targetTable = null, $targetKey = 'id', $refTypeColumn = NULL) {
```

In these cases I've made the `* @param string $targetTable` match the expected input (`string`), and not document the `null` default value. There is an argument that either the default value in these cases should become and empty string, or the comment should be updated to `* @param string|null $targetTable`. However, it's not clear in these cases that `null` is actually a valid parameter for the function to work correctly.
