### PR TITLE
Correctly mark updateStatusMessage method as static

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1477,7 +1477,7 @@ UPDATE  civicrm_participant
    *
    * @return string
    */
-  public function updateStatusMessage($participantId, $statusChangeTo, $fromStatusId) {
+  public static function updateStatusMessage($participantId, $statusChangeTo, $fromStatusId) {
     $statusMsg = NULL;
     $results = self::transitionParticipants([$participantId],
       $statusChangeTo, $fromStatusId, TRUE


### PR DESCRIPTION
Overview
----------------------------------------
Correctly mark updateStatusMessage method as static

Before
----------------------------------------
`CRM/Event/Form/Participant.php` contains the following code, despite `updateStatusMessage` not being static:

```
$updateStatusMsg = CRM_Event_BAO_Participant::updateStatusMessage($this->_id,
  $params['status_id'],
  $this->_statusId
);
```

The `updateStatusMessage` method is not used elsewhere in CiviCRM core.


After
----------------------------------------
The `updateStatusMessage` method is marked as static. This is consistent with other methods in the `CRM_Event_BAO_Participant` class.
