### PR TITLE
dev/drupal#172 - Deprecated function call in Drupal 9.3

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -554,7 +554,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $module_data = \Drupal::service('extension.list.module')->reset()->getList();
     foreach ($module_data as $module_name => $extension) {
       if (!isset($extension->info['hidden']) && $extension->origin != 'core') {
-        $extension->schema_version = drupal_get_installed_schema_version($module_name);
         $modules[] = new CRM_Core_Module('drupal.' . $module_name, ($extension->status == 1));
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/172

If you look at what it does with the return value, it does nothing with it, so I've just removed the function call.

Before
----------------------------------------
drupal_get_installed_schema_version() is deprecated in drupal:9.3.0 and is removed from drupal:10.0.0. Use \Drupal\Core\Update\UpdateHookRegistry::getInstalledVersion() or \Drupal\Core\Update\UpdateHookRegistry::getAllInstalledVersions() instead. See https://www.drupal.org/node/2444417

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
There's a future todo comment I've added if anybody is keen on following up on how managed entities actually uses the drupal module list.
