### PR TITLE
Fix params passed to setStatus method

### DIFF
--- a/CRM/Admin/Form/PdfFormats.php
+++ b/CRM/Admin/Form/PdfFormats.php
@@ -125,11 +125,11 @@ class CRM_Admin_Form_PdfFormats extends CRM_Admin_Form {
     $bao = new CRM_Core_BAO_PdfFormat();
     $bao->savePdfFormat($values, $this->_id);
 
-    $status = ts('Your new PDF Page Format titled <strong>%1</strong> has been saved.', [1 => $values['name']], ts('Saved'), 'success');
+    $status = ts('Your new PDF Page Format titled <strong>%1</strong> has been saved.', [1 => $values['name']]);
     if ($this->_action & CRM_Core_Action::UPDATE) {
-      $status = ts('Your PDF Page Format titled <strong>%1</strong> has been updated.', [1 => $values['name']], ts('Saved'), 'success');
+      $status = ts('Your PDF Page Format titled <strong>%1</strong> has been updated.', [1 => $values['name']]);
     }
-    CRM_Core_Session::setStatus($status);
+    CRM_Core_Session::setStatus($status, ts('Saved'), 'success');
   }
 
 }

--- a/CRM/Price/Form/DeleteSet.php
+++ b/CRM/Price/Form/DeleteSet.php
@@ -75,8 +75,8 @@ class CRM_Price_Form_DeleteSet extends CRM_Core_Form {
   public function postProcess() {
     if (CRM_Price_BAO_PriceSet::deleteSet($this->_sid)) {
       CRM_Core_Session::setStatus(ts('The Price Set \'%1\' has been deleted.',
-        [1 => $this->_title], ts('Deleted'), 'success'
-      ));
+        [1 => $this->_title]
+      ), ts('Deleted'), 'success');
     }
     else {
       CRM_Core_Session::setStatus(ts('The Price Set \'%1\' has not been deleted! You must delete all price fields in this set prior to deleting the set.',


### PR DESCRIPTION
Overview
----------------------------------------
In three cases, the second and third `CRM_Core_Session::setStatus` arguments were incorrectly passed to `ts` as unaccepted third and fourth arguments. This moves the arguments to the correct function.

Before
----------------------------------------
Arguments passed to incorrect function. Status message not rendered as intended.

After
----------------------------------------
Arguments correctly passed to `setStatus`
