### PR TITLE
[NFC] CRM_Core_Exception incorrectly called without message

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1329,7 +1329,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
       return $contactTypes;
     }
     else {
-      throw new CRM_Core_Exception();
+      throw new CRM_Core_Exception('Cannot proceed without a valid contact');
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Exception` requires at least 1 argument - `$message`. This was missing in one scenario, therefore a message has been added. 


Comments
----------------------------------------
The language used in the message matches language used elsewhere within this class.
