### PR TITLE
fixes core#3013 - error when creating > 25 thank-you letters

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -360,6 +360,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $resolvedContacts = civicrm_api3('Contact', 'get', [
       'return' => array_keys($returnProperties),
       'id' => ['IN' => array_keys($contacts)],
+      'options' => ['limit' => 0],
     ])['values'];
     foreach ($contacts as $contactID => $contact) {
       $contacts[$contactID] = array_merge($resolvedContacts[$contactID], $contact);


### PR DESCRIPTION
Overview
----------------------------------------
An error occurs when you try to create > 25 thank-you letters at once.  Replication steps on lab.c.o: https://lab.civicrm.org/dev/core/-/issues/3013

Before
----------------------------------------
```
TypeError: Argument 2 passed to CRM_Contribute_Form_Task_PDFLetter::resolveTokens() must be of the type int, null given, called in /home/jon/local/crcl/htdocs/sites/all/modules/civicrm/CRM/Contribute/Form/Task/PDFLetter.php on line 436 in CRM_Contribute_Form_Task_PDFLetter->resolveTokens() (line 553 of /home/jon/local/crcl/htdocs/sites/all/modules/civicrm/CRM/Contribute/Form/Task/PDFLetter.php).
```

After
----------------------------------------
Works.  Or at least crashes because you ran out of memory creating a 2000 page PDF and not because of a PHP error.

Technical Details
----------------------------------------
Just your typical API3 25 record limit bug.