### PR TITLE
[Ref] Remove now-never-used parameter

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -207,14 +207,13 @@ LIMIT 1
   /**
    * Get contribution statuses by entity e.g. contribution, membership or 'participant'
    *
-   * @param string $usedFor
    * @param string $name
    *   Contribution ID
    *
    * @return array
    *   Array of contribution statuses in array('status id' => 'label') format
    */
-  public static function getContributionStatuses($usedFor = 'contribution', $name = NULL) {
+  public static function getContributionStatuses($name = NULL) {
     $statusNames = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate');
 
     $statusNamesToUnset = [

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -668,7 +668,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if ($this->_id) {
       $componentDetails = CRM_Contribute_BAO_Contribution::getComponentDetails($this->_id);
     }
-    $status = CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses('contribution', $this->getPreviousContributionStatus());
+    $status = CRM_Contribute_BAO_Contribution_Utils::getContributionStatuses($this->getPreviousContributionStatus());
 
     // define the status IDs that show the cancellation info, see CRM-17589
     $cancelInfo_show_ids = [];


### PR DESCRIPTION

Overview
----------------------------------------
[Ref] Remove now-never-used parameter
Follow up to https://github.com/civicrm/civicrm-core/pull/22280


Before
----------------------------------------
Function called from one place - $usedFor passed in but not used

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
