### PR TITLE
[REF] Deprecated old getContributionStatuses

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -207,6 +207,14 @@ LIMIT 1
   /**
    * Get contribution statuses by entity e.g. contribution, membership or 'participant'
    *
+   * @deprecated
+   *
+   * This is called from a couple of places outside of core so it has been made
+   * unused and deprecated rather than having the now-obsolete parameter change.
+   * It should work much the same for the places that call it with a notice. It is
+   * not an api function & not supported for use outside core. Extensions should write
+   * their own functions.
+   *
    * @param string $usedFor
    * @param string $name
    *   Contribution ID
@@ -216,7 +224,10 @@ LIMIT 1
    */
   public static function getContributionStatuses($usedFor = 'contribution', $name = NULL) {
     $statusNames = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate');
-
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
+    if ($usedFor !== 'contribution') {
+      return self::getPendingAndCompleteStatuses();
+    }
     $statusNamesToUnset = [
       // For records which represent a data template for a recurring
       // contribution that may not yet have a payment. This status should not


### PR DESCRIPTION
It is no longer used in core but I found 2 universe places so I added back
some handling for other entities & deprecated it and stopped using it
entirely in core

See https://github.com/civicrm/civicrm-core/pull/22280

Overview
----------------------------------------
[REF] Deprecated old getContributionStatuses

Before
----------------------------------------
`getContributionStatuses` is now only called from one place in core - but I found 2 places in universe -

After
----------------------------------------
function is deprecated but will still work the way it did (with deprecation noise) for the extensions that call it. The core usage has been copied back to the only form that uses it

Technical Details
----------------------------------------
Per code comments I think there is ALSO a problem with what is actually returned - but that is left out of scope - the goal here is to get back to the situation where the code actually used is sane to the actual usage

Comments
----------------------------------------
