### PR TITLE
SearchKit - Allow smarty tags in field rewrite

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -208,9 +208,9 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertNotEmpty($result->first()['data']['sort_name']);
 
     // These items are not part of the search, but will be added via links
-    $this->assertArrayNotHasKey('contact_type', $result->first());
-    $this->assertArrayNotHasKey('source', $result->first());
-    $this->assertArrayNotHasKey('last_name', $result->first());
+    $this->assertArrayNotHasKey('contact_type', $result->first()['data']);
+    $this->assertArrayNotHasKey('source', $result->first()['data']);
+    $this->assertArrayNotHasKey('last_name', $result->first()['data']);
 
     // Add links
     $params['display']['settings']['columns'][] = [
@@ -225,6 +225,78 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertEquals('Individual', $result->first()['data']['contact_type']);
     $this->assertEquals('Unit test', $result->first()['data']['source']);
     $this->assertEquals($lastName, $result->first()['data']['last_name']);
+  }
+
+  /**
+   * Test smarty rewrite syntax.
+   */
+  public function testRunWithSmartyRewrite() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'One', 'last_name' => $lastName, 'nick_name' => 'Uno'],
+      ['first_name' => 'Two', 'last_name' => $lastName],
+    ];
+    $contacts = Contact::save(FALSE)->setRecords($sampleData)->execute();
+    Email::create(FALSE)
+      ->addValue('contact_id', $contacts[0]['id'])
+      ->addValue('email', 'testmail@unit.test')
+      ->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'first_name', 'last_name', 'nick_name', 'Contact_Email_contact_id_01.email', 'Contact_Email_contact_id_01.location_type_id:label'],
+          'where' => [['last_name', '=', $lastName]],
+          'join' => [
+            [
+              "Email AS Contact_Email_contact_id_01",
+              "LEFT",
+              ["id", "=", "Contact_Email_contact_id_01.contact_id"],
+              ["Contact_Email_contact_id_01.is_primary", "=", TRUE],
+            ],
+          ],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'limit' => 20,
+          'pager' => TRUE,
+          'columns' => [
+            [
+              'key' => 'id',
+              'label' => 'Contact ID',
+              'type' => 'field',
+            ],
+            [
+              'key' => 'first_name',
+              'label' => 'Name',
+              'type' => 'field',
+              'rewrite' => '{if $nick_name}{$nick_name}{else}{$first_name}{/if} [last_name]',
+            ],
+            [
+              'key' => 'Contact_Email_contact_id_01.email',
+              'label' => 'Email',
+              'type' => 'field',
+              'rewrite' => '{if $Contact_Email_contact_id_01.email}{$Contact_Email_contact_id_01.email} ({$Contact_Email_contact_id_01.location_type_id_label}){/if}',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertEquals("Uno $lastName", $result[0]['columns'][1]['val']);
+    $this->assertEquals("Two $lastName", $result[1]['columns'][1]['val']);
+    $this->assertEquals("testmail@unit.test (Home)", $result[0]['columns'][2]['val']);
+    $this->assertEquals("", $result[1]['columns'][2]['val']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This gives the ability to use Smarty syntax in the "rewrite" of SearchKit displays.

Before
----------------------------------------
Tokens like `[first_name]` supported.

After
----------------------------------------
Those tokens still work. They can be mixed in with Smarty tags like `{$first_name}`.

Technical Details
----------------------------------------
Note1: Unlike "native" SearchKit tokens which get auto-added to the query, any field you want to reference as a Smarty variable must be added as a column.

Note2: Due to #1371, PHP filters like `strtolower` or `ucfirst` cannot be used.

Note3: Smarty syntax for accessing nested arrays is with a dot. Smarty does not allow dots or other special characters in the array key. So this converts dots to nested arrays, and `:` to `_`.

Comments
----------------------------------------
Thanks @petednz for sponsoring this work