### PR TITLE
Remove unnecessary id attribute.

### DIFF
--- a/templates/CRM/Price/Form/Set.tpl
+++ b/templates/CRM/Price/Form/Set.tpl
@@ -36,7 +36,7 @@
           {/if}
           </td>
         </tr>
-        <tr id="min_amount" class="crm-price-set-form-block-min_amount">
+        <tr class="crm-price-set-form-block-min_amount">
            <td class="label">{$form.min_amount.label}</td>
            <td>{$form.min_amount.html}</td>
         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
The `min_amount` ID was used for both a tr and a input element, breaking the accessibility link between the `label` and `input` elements.

Before
----------------------------------------
The "Minimum Amount" label was not semantically linked with the appropriate input element due to a duplicate ID. The duplicate ID has been removed. This is on the settings page for a single price set. (civicrm/admin/price?action=update&sid=123)

After
----------------------------------------
The duplicate ID attribute been removed.

Technical Details
----------------------------------------
There are a handful of JS references to the `min_amount` ID. However, these all apply to other templates, and all assume that `#min_amount` is an input element (for example, because they read or write the elements value property).

