### PR TITLE
Use JS escaping for {ts} calls in a JS context

### DIFF
--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -311,7 +311,7 @@ var surveyActivityIds = {/literal}{$surveyActivityIds}{literal};
         if (interview.errors[error]) errorList =  errorList + '<li>' + interview.errors[error] + '</li>';
       }
       if ( errorList ) {
-        var allErrors = '<i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i> {/literal}{ts}Please correct the following errors in the survey fields below:{/ts}{literal}<ul>' + errorList + '</ul>';
+        var allErrors = '<i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i> {/literal}{ts escape='js'}Please correct the following errors in the survey fields below:{/ts}{literal}<ul>' + errorList + '</ul>';
         CRM.$('#responseErrors').show( ).html(allErrors);
       }
     }

--- a/templates/CRM/Contact/Form/Edit/Lock.tpl
+++ b/templates/CRM/Contact/Form/Edit/Lock.tpl
@@ -7,7 +7,7 @@ CRM.$(function($) {
   $('<br>')
     .appendTo($('#update_modified_date'));
   $('<button>')
-    .text("{/literal}{ts}Save Anyway{/ts}{literal}")
+    .text("{/literal}{ts escape='js'}Save Anyway{/ts}{literal}")
     .click(function() {
       $('input[name="modified_date"]').val(
               $('#update_modified_date').attr('data:latest_modified_date')
@@ -18,7 +18,7 @@ CRM.$(function($) {
     .appendTo($('#update_modified_date'))
     ;
   $('<button>')
-    .text("{/literal}{ts}Reload Page{/ts}{literal}")
+    .text("{/literal}{ts escape='js'}Reload Page{/ts}{literal}")
     .click(function() {
       window.location.href = CRM.url('civicrm/contact/add', {
         reset: 1,

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -294,10 +294,10 @@
     var add_new_check_length = this_controls.find(".location_operation_checkbox input:checked").length;
     if (mainBlock != false) {
       if (add_new_check_length > 0) {
-        operation_description = "{/literal}{ts}add new{/ts}{literal}";
+        operation_description = "{/literal}{ts escape='js'}add new{/ts}{literal}";
       }
       else {
-        operation_description = "{/literal}{ts}overwrite{/ts}{literal}";
+        operation_description = "{/literal}{ts escape='js'}overwrite{/ts}{literal}";
       }
     }
     this_controls.find(".location_operation_description").text("(" + operation_description + ")");
@@ -309,7 +309,7 @@
       if (mainBlock != false && (blockName == 'email' || blockName == 'phone')) {
         var op_id = 'location_blocks[' + blockName + '][' + blockId + '][operation]';
         this_controls.find(".location_operation_checkbox").html(
-                '<input id="' + op_id + '" name="' + op_id + '" type="checkbox" value="1" class="crm-form-checkbox"><label for="' + op_id + '">{/literal}{ts}Add new{/ts}{literal}</label>'
+                '<input id="' + op_id + '" name="' + op_id + '" type="checkbox" value="1" class="crm-form-checkbox"><label for="' + op_id + '">{/literal}{ts escape='js'}Add new{/ts}{literal}</label>'
         );
       }
       else {
@@ -323,7 +323,7 @@
       if (blockName != 'website' && (mainBlock == false || mainBlock['is_primary'] != "1" || add_new_check_length > 0)) {
         var prim_id = 'location_blocks[' + blockName + '][' + blockId + '][set_other_primary]';
         this_controls.find(".location_set_other_primary").html(
-                '<input id="' + prim_id + '" name="' + prim_id + '" type="checkbox" value="1" class="crm-form-checkbox"><label for="' + prim_id + '">{/literal}{ts}Set as primary{/ts}{literal}</label>'
+                '<input id="' + prim_id + '" name="' + prim_id + '" type="checkbox" value="1" class="crm-form-checkbox"><label for="' + prim_id + '">{/literal}{ts escape='js'}Set as primary{/ts}{literal}</label>'
         );
       }
       else {

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -110,7 +110,7 @@
             });
 
             if (!addressHTML) {
-              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please click the following link to edit that contact to add an address, or select a different contact.{/ts}"{literal} + ' <a target="_blank" href="' + CRM.url('civicrm/contact/add', 'reset=1&action=update&cid=' + sharedContactId) + '">{/literal}{ts}Edit Contact Details{/ts}{literal}</a>';
+              addressHTML = {/literal}"{ts escape='js'}Selected contact does not have an address. Please click the following link to edit that contact to add an address, or select a different contact.{/ts}"{literal} + ' <a target="_blank" href="' + CRM.url('civicrm/contact/add', 'reset=1&action=update&cid=' + sharedContactId) + '">{/literal}{ts escape='js'}Edit Contact Details{/ts}{literal}</a>';
             }
 
             $contentArea.html(addressHTML);

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -493,7 +493,7 @@
       var choose = "{/literal}{ts escape='js'}Choose price set{/ts}{literal}";
       cj("#price_set_id option[value='']").html(choose);
 
-      cj('label[for="total_amount"]').text('{/literal}{ts}Total Amount{/ts}{literal}');
+      cj('label[for="total_amount"]').text('{/literal}{ts escape='js'}Total Amount{/ts}{literal}');
       cj(".crm-contribution-form-block-financial_type_id").show();
       cj("#financial_type_id option[value='']").attr('selected', true);
 
@@ -527,7 +527,7 @@
     var manual = "{/literal}{ts escape='js'}Manual contribution amount{/ts}{literal}";
     cj("#price_set_id option[value='']").html(manual);
 
-    cj('label[for="total_amount"]').text('{/literal}{ts}Price Sets{/ts}{literal}');
+    cj('label[for="total_amount"]').text('{/literal}{ts escape='js'}Price Sets{/ts}{literal}');
     if (financialtypeIds) {
       cj("#financial_type_id option[value="+financialtypeIds[priceSetId]+"]").prop('selected', true);
     }

--- a/templates/CRM/Event/Form/SelfSvcUpdate.tpl
+++ b/templates/CRM/Event/Form/SelfSvcUpdate.tpl
@@ -40,7 +40,7 @@
     $('#action').on('change', function() {
       selected = $(this).find("option:selected").text();
       if (selected == 'Cancel' && contributionID) {
-        CRM.alert('{/literal}{ts}Cancellations are not refundable.{/ts}{literal}', 'Warning', 'alert');
+        CRM.alert('{/literal}{ts escape='js'}Cancellations are not refundable.{/ts}{literal}', 'Warning', 'alert');
       }
     });
   });


### PR DESCRIPTION
Overview
----------------------------------------
Use JS escaping for {ts} calls in a JS context.

Before
----------------------------------------
`{ts}` was used within a `<script>` context without the proper escaping strategy. This can cause issues with certain translations.

After
----------------------------------------
The risk of translations breaking the JS code is reduced.

Comments
----------------------------------------
This stems from my earlier pull request #22315, where @totten pulled me up on making this very mistake. I was sure I'd seen `{ts}` calls in JS code without escaping before, so this tidies up the remaining instances to stop others copying this bad practice in future (like I did!)
