### PR TITLE
Allow chart dropdown labels to be translatable.

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -540,6 +540,12 @@ class CRM_Report_Form extends CRM_Core_Form {
   public $optimisedForOnlyFullGroupBy = TRUE;
 
   /**
+   * Determines which chart types are supported for this report
+   * @var string[]
+   */
+  protected $_charts = [];
+
+  /**
    * Get the number of rows to show
    * @return int
    */

--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -16,12 +16,6 @@
  */
 class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   /**
    * This is the report that links will lead to.
    *
@@ -248,6 +242,13 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
 
     // If we have a campaign, build out the relevant elements
     $this->addCampaignFields('civicrm_contribution');
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
@@ -630,7 +631,7 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
     $current_year = $this->_params['yid_value'];
     $previous_year = $current_year - 1;
     $interval[$previous_year] = $previous_year;
-    $interval['life_time'] = 'Life Time';
+    $interval['life_time'] = ts('Life Time');
 
     foreach ($rows as $key => $row) {
       // The final row contains the totals so we don't need to include it here.

--- a/CRM/Report/Form/Contribute/SoftCredit.php
+++ b/CRM/Report/Form/Contribute/SoftCredit.php
@@ -20,11 +20,6 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
   protected $_emailFieldCredit = FALSE;
   protected $_phoneField = FALSE;
   protected $_phoneFieldCredit = FALSE;
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
 
   protected $_customGroupExtends = [
     'Contact',
@@ -298,6 +293,13 @@ class CRM_Report_Form_Contribute_SoftCredit extends CRM_Report_Form {
 
     // If we have a campaign, build out the relevant elements
     $this->addCampaignFields('civicrm_contribution');
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -16,11 +16,6 @@
  */
 class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
   protected $_customGroupExtends = ['Contribution', 'Contact', 'Individual'];
   protected $_customGroupGroupBy = TRUE;
 
@@ -337,6 +332,13 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
     ] + $this->addAddressFields();
 
     $this->addCampaignFields('civicrm_contribution', TRUE);
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
 
     $this->_tagFilter = TRUE;
     $this->_groupFilter = TRUE;

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -16,12 +16,6 @@
  */
 class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   protected $_customGroupExtends = [
     'Contact',
     'Individual',
@@ -243,6 +237,13 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
 
     // If we have a campaign, build out the relevant elements
     $this->addCampaignFields('civicrm_contribution');
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -37,12 +37,6 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
 
   public $_drilldownReport = ['contribute/detail' => 'Link to Detail Report'];
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   /**
    */
   public function __construct() {
@@ -186,6 +180,13 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
         ],
         'grouping' => 'phone-fields',
       ],
+    ];
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
     ];
 
     $this->_groupFilter = TRUE;

--- a/CRM/Report/Form/Event/IncomeCountSummary.php
+++ b/CRM/Report/Form/Event/IncomeCountSummary.php
@@ -18,12 +18,6 @@ class CRM_Report_Form_Event_IncomeCountSummary extends CRM_Report_Form {
 
   protected $_summary = NULL;
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   protected $_add2groupSupported = FALSE;
 
   protected $_customGroupExtends = [
@@ -136,6 +130,14 @@ class CRM_Report_Form_Event_IncomeCountSummary extends CRM_Report_Form {
         ],
       ],
     ];
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
+
     parent::__construct();
   }
 

--- a/CRM/Report/Form/Event/Summary.php
+++ b/CRM/Report/Form/Event/Summary.php
@@ -18,12 +18,6 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
 
   protected $_summary = NULL;
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   protected $_add2groupSupported = FALSE;
 
   protected $_customGroupExtends = [
@@ -105,6 +99,14 @@ class CRM_Report_Form_Event_Summary extends CRM_Report_Form {
       ],
     ];
     $this->_currencyColumn = 'civicrm_participant_fee_currency';
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
+
     parent::__construct();
   }
 

--- a/CRM/Report/Form/Mailing/Bounce.php
+++ b/CRM/Report/Form/Mailing/Bounce.php
@@ -29,12 +29,6 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
     'Organization',
   ];
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   /**
    * This report has not been optimised for group filtering.
    *
@@ -240,6 +234,13 @@ class CRM_Report_Form_Mailing_Bounce extends CRM_Report_Form {
       'dao' => 'CRM_Core_DAO_Phone',
       'fields' => ['phone' => NULL],
       'grouping' => 'contact-fields',
+    ];
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
     ];
 
     $this->_groupFilter = TRUE;

--- a/CRM/Report/Form/Mailing/Clicks.php
+++ b/CRM/Report/Form/Mailing/Clicks.php
@@ -29,12 +29,6 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
     'Organization',
   ];
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   /**
    * This report has not been optimised for group filtering.
    *
@@ -197,6 +191,13 @@ class CRM_Report_Form_Mailing_Clicks extends CRM_Report_Form {
         ],
       ],
       'grouping' => 'mailing-fields',
+    ];
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
     ];
 
     $this->_groupFilter = TRUE;

--- a/CRM/Report/Form/Mailing/Opened.php
+++ b/CRM/Report/Form/Mailing/Opened.php
@@ -29,12 +29,6 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
     'Organization',
   ];
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   /**
    * This report has not been optimised for group filtering.
    *
@@ -188,6 +182,13 @@ class CRM_Report_Form_Mailing_Opened extends CRM_Report_Form {
         ],
       ],
       'grouping' => 'mailing-fields',
+    ];
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
     ];
 
     $this->_groupFilter = TRUE;

--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -24,11 +24,6 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
 
   public $_drilldownReport = ['mailing/detail' => 'Link to Detail Report'];
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barchart' => 'Bar Chart',
-  ];
-
   /**
    * Class constructor.
    */
@@ -287,6 +282,13 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     ];
     // If we have campaigns enabled, add those elements to both the fields, filters.
     $this->addCampaignFields('civicrm_mailing');
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+    ];
+
     parent::__construct();
   }
 

--- a/CRM/Report/Form/Member/Lapse.php
+++ b/CRM/Report/Form/Member/Lapse.php
@@ -17,7 +17,6 @@
 class CRM_Report_Form_Member_Lapse extends CRM_Report_Form {
 
   protected $_summary = NULL;
-  protected $_charts = ['' => 'Tabular'];
   protected $_customGroupExtends = [
     'Membership',
   ];

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -18,11 +18,7 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
 
   protected $_summary = NULL;
   protected $_interval = NULL;
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
+
   protected $_add2groupSupported = FALSE;
 
   protected $_customGroupExtends = ['Membership'];
@@ -158,6 +154,13 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
 
     // If we have campaigns enabled, add those elements to both the fields, filters and group by
     $this->addCampaignFields('civicrm_membership', TRUE);
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
 
     $this->_groupFilter = TRUE;
     $this->_currencyColumn = 'civicrm_contribution_currency';

--- a/CRM/Report/Form/Membership/Summary.php
+++ b/CRM/Report/Form/Membership/Summary.php
@@ -18,12 +18,6 @@ class CRM_Report_Form_Membership_Summary extends CRM_Report_Form {
 
   protected $_summary = NULL;
 
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
-
   /**
    * Constructor function.
    */
@@ -117,6 +111,14 @@ class CRM_Report_Form_Membership_Summary extends CRM_Report_Form {
         ],
       ],
     ];
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
+
     parent::__construct();
   }
 

--- a/CRM/Report/Form/Pledge/Pbnp.php
+++ b/CRM/Report/Form/Pledge/Pbnp.php
@@ -15,11 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
-  protected $_charts = [
-    '' => 'Tabular',
-    'barChart' => 'Bar Chart',
-    'pieChart' => 'Pie Chart',
-  ];
   public $_drilldownReport = ['pledge/summary' => 'Link to Detail Report'];
 
   protected $_customGroupExtends = [
@@ -159,6 +154,13 @@ class CRM_Report_Form_Pledge_Pbnp extends CRM_Report_Form {
 
     // If we have a campaign, build out the relevant elements
     $this->addCampaignFields('civicrm_pledge');
+
+    // Add charts support
+    $this->_charts = [
+      '' => ts('Tabular'),
+      'barChart' => ts('Bar Chart'),
+      'pieChart' => ts('Pie Chart'),
+    ];
 
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Allow chart dropdown labels to be translatable.

Before
----------------------------------------
Prior to this change, the strings 'Tabular', 'Bar Chart' and 'Pie Chart' were hardcoded. This affects a handful of reports, which support bar and pie chart views:

<img width="1290" alt="Screenshot 2021-12-31 at 12 22 53" src="https://user-images.githubusercontent.com/1931323/147823193-a7bbd233-6ee0-4f61-80c4-58c227fe28b7.png">

After
----------------------------------------
It is possible for the strings to be translated, or for word replacement to be performed against the strings.

Technical Details
----------------------------------------
The labels were previously hardcoded within the `$_charts` array property against each report. However, in PHP properties cannot be directly assigned from a function call, so this would not have worked:

```
protected $_charts = [
  '' => ts('Tabular'),
  'barChart' => ts('Bar Chart'),
  'pieChart' => ts('Pie Chart'),
];
```

As a result, I have re-worked the `$_charts` property to only contain information about the types of charts supported, not the labels. The labels are added in the new `getChartLabels` method.

Every report supports a tabular display, and this is the default value. Therefore, this is no longer defined in the `$_charts` property, but instead gets added by default in `getChartLabels()`.

