### PR TITLE
dev/drupal#172 - module status used incorrectly in drupal 8 to determine which modules to care about for managed entities

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -553,8 +553,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     $module_data = \Drupal::service('extension.list.module')->reset()->getList();
     foreach ($module_data as $module_name => $extension) {
-      if (!isset($extension->info['hidden']) && $extension->origin != 'core') {
-        $modules[] = new CRM_Core_Module('drupal.' . $module_name, ($extension->status == 1));
+      if (!isset($extension->info['hidden']) && $extension->origin != 'core' && $extension->status == 1) {
+        $modules[] = new CRM_Core_Module('drupal.' . $module_name, TRUE);
       }
     }
     return $modules;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/172

See also conversation at https://github.com/civicrm/civicrm-core/pull/22337#discussion_r776904455

Before
----------------------------------------
Includes ALL non-core modules, and then indicates disabled status by incorrectly using the installation status. (In drupal 8 there is no such thing as disabled - "Do or do not - there is no try".)

After
----------------------------------------
Only includes installed modules, and then indicate enabled, since installed and enabled are the same in drupal 8.

Technical Details
----------------------------------------
 This makes it more like the drupal 7 version https://github.com/civicrm/civicrm-core/blob/29cc02ccc73cbda6f086e75932dc065098228d0f/CRM/Utils/System/DrupalBase.php#L296-L298, i.e.

Drupal 7: schema_version <> -1 means installed, status == 1 means enabled
Drupal 8: status == 1 means installed (and implicitly then enabled), status == 0 means uninstalled. Schema version not relevant.

Comments
----------------------------------------
You'll notice line 557 is unused. That's what #22337 is about.
