### PR TITLE
Fix membership test fail for Dec 31

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -533,7 +533,13 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $form->_contactID = $this->_individualId;
     $form->testSubmit($params);
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
-    $this->assertEquals(date('Y') + 1 . '-12-31', $membership['end_date']);
+    $membershipEndYear = date('Y') + 1;
+    if (date('m-d') == '12-31') {
+      // If you join on Dec 31, then the first term would end right away, so
+      // add a year.
+      $membershipEndYear++;
+    }
+    $this->assertEquals($membershipEndYear . '-12-31', $membership['end_date']);
     $this->callAPISuccessGetCount('ContributionRecur', ['contact_id' => $this->_individualId], 0);
     $contribution = $this->callAPISuccess('Contribution', 'get', [
       'contact_id' => $this->_individualId,
@@ -573,7 +579,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->mut->stop();
     $this->assertEquals([
       [
-        'text' => 'AnnualFixed membership for Mr. Anthony Anderson II has been added. The new membership End Date is December 31st, ' . (date('Y') + 1) . '. A membership confirmation and receipt has been sent to anthony_anderson@civicrm.org.',
+        'text' => 'AnnualFixed membership for Mr. Anthony Anderson II has been added. The new membership End Date is December 31st, ' . $membershipEndYear . '. A membership confirmation and receipt has been sent to anthony_anderson@civicrm.org.',
         'title' => 'Complete',
         'type' => 'success',
         'options' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Tests are failing on Dec 31

Before
----------------------------------------
```
    CRM_Member_Form_MembershipTest.testSubmit with data set #0
    CRM_Member_Form_MembershipTest.testSubmit with data set #1

Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'2022-12-31'
+'2023-12-31'
```

After
----------------------------------------


Technical Details
----------------------------------------
I'm not sure what the real-life expectation is. Here it's for 2 terms, but let's say it's 1 term. If I join a fixed membership on Dec 31 that ends on Dec 31, does it end immediately, or should I expect a full year? What about Dec 30 - do I only get 1 day?

Comments
----------------------------------------

