### PR TITLE
Fix tests that fail after 2021

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -90,7 +90,7 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
     CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $propertyBag);
     // This means we can test failing transactions by setting a past year in expiry. A full expiry check would
     // be more complete.
-    if (!empty($params['credit_card_exp_date']['Y']) && date('Y') >
+    if (!empty($params['credit_card_exp_date']['Y']) && CRM_Utils_Time::date('Y') >
       CRM_Core_Payment_Form::getCreditCardExpirationYear($params)) {
       throw new PaymentProcessorException(ts('Invalid expiry date'));
     }

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -77,7 +77,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'cvv2' => 234,
       'credit_card_exp_date' => [
         'M' => 2,
-        'Y' => 2021,
+        'Y' => CRM_Utils_Time::date('Y') + 1,
       ],
       'credit_card_type' => 'Visa',
       'email-5' => 'test@test.com',


### PR DESCRIPTION
Overview
----------------------------------------
The MembershipRenewalTest setup() function freezes time in 2020 (queue the virus jokes...) but the payment processor doesn't know about that, so the credit card which expires in 2020+1 is considered expired.

An alternative might be to use real time in getBaseSubmitParams(), but this seems more flexible for future tests.

The second commit is slightly different but the fail there is also because of an expired card.