### PR TITLE
SearchKit - Enable joins for custom fields and option groups

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -221,7 +221,7 @@ class Admin {
               // Sanity check - keyField must exist
               !$keyField ||
               // Exclude any joins that are better represented by pseudoconstants
-              is_a($reference, 'CRM_Core_Reference_OptionValue') || !empty($keyField['options']) ||
+              is_a($reference, 'CRM_Core_Reference_OptionValue') ||
               // Sanity check - table should match
               $daoClass::getTableName() !== $reference->getReferenceTable()
             ) {

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -96,6 +96,30 @@ class AdminTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
       ['EntityTag', ['id', '=', 'Activity_EntityTag_Tag.entity_id'], ['Activity_EntityTag_Tag.entity_table', '=', "'civicrm_activity'"]],
       $activityTagJoins[0]['conditions']
     );
+
+    // Ensure joins exist btw custom group & custom fields
+    $customGroupToField = \CRM_Utils_Array::findAll($joins['CustomGroup'], [
+      'entity' => 'CustomField',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $customGroupToField);
+    $customFieldToGroup = \CRM_Utils_Array::findAll($joins['CustomField'], [
+      'entity' => 'CustomGroup',
+      'multi' => FALSE,
+    ]);
+    $this->assertCount(1, $customFieldToGroup);
+
+    // Ensure joins btw option group and option value
+    $optionGroupToValue = \CRM_Utils_Array::findAll($joins['OptionGroup'], [
+      'entity' => 'OptionValue',
+      'multi' => TRUE,
+    ]);
+    $this->assertCount(1, $optionGroupToValue);
+    $optionValueToGroup = \CRM_Utils_Array::findAll($joins['OptionValue'], [
+      'entity' => 'OptionGroup',
+      'multi' => FALSE,
+    ]);
+    $this->assertCount(1, $optionValueToGroup);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Enables SearchKit to join custom groups to custom fields, and option groups to option values.

Toward https://lab.civicrm.org/dev/user-interface/-/issues/44#note_68378

Before
----------------------------------------
Joins were missing from SearchKit.

After
----------------------------------------
Can create a search for custom groups with an aggregate count of custom fields, like so:
![image](https://user-images.githubusercontent.com/2874912/147888055-fa94dfd5-487e-4df8-9e23-c7b4b67c50d2.png)


Technical Details
----------------------------------------
There are a few FKs in the database that also have a pseudoconstant.
Arguably there shouldn't be, it should be one or the other. But there they are.
Previously SearchKit would ignore those FKs, but they are needed for e.g. searching for custom groups and displaying the aggregate count of fields in that group.