### PR TITLE
SearchKit - Allow aggregate columns to be links

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -195,13 +195,13 @@
         return arg.field && arg.field.type !== 'Pseudo';
       };
 
-      // Aggregate functions (COUNT, AVG, MAX) cannot display as links, except for GROUP_CONCAT
+      // Aggregate functions (COUNT, AVG, MAX) cannot autogenerate links, except for GROUP_CONCAT
       // which gets special treatment in APIv4 to convert it to an array.
-      this.canBeLink = function(col) {
-        var expr = ctrl.getExprFromSelect(col.key),
+      function canUseLinks(colKey) {
+        var expr = ctrl.getExprFromSelect(colKey),
           info = searchMeta.parseExpr(expr);
         return !info.fn || info.fn.category !== 'aggregate' || info.fn.name === 'GROUP_CONCAT';
-      };
+      }
 
       var linkProps = ['path', 'entity', 'action', 'join', 'target'];
 
@@ -237,10 +237,13 @@
 
       this.getLinks = function(columnKey) {
         if (!ctrl.links) {
-          ctrl.links = {'*': ctrl.crmSearchAdmin.buildLinks()};
+          ctrl.links = {'*': ctrl.crmSearchAdmin.buildLinks(), '0': []};
         }
         if (!columnKey) {
           return ctrl.links['*'];
+        }
+        if (!canUseLinks(columnKey)) {
+          return ctrl.links['0'];
         }
         var expr = ctrl.getExprFromSelect(columnKey),
           info = searchMeta.parseExpr(expr),

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -4,7 +4,7 @@
     {{:: ts('Image') }}
   </label>
 </div>
-<div class="form-inline crm-search-admin-flex-row" ng-if=":: $ctrl.parent.canBeLink(col)">
+<div class="form-inline crm-search-admin-flex-row" >
   <label title="{{:: ts('Display as clickable link') }}" >
     <input type="checkbox" ng-checked="col.link" ng-click="$ctrl.parent.toggleLink(col)" >
     {{:: ts('Link') }}

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/image.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/image.html
@@ -13,7 +13,7 @@
     <crm-search-admin-token-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" model="col.image" field="alt"></crm-search-admin-token-select>
   </div>
 </div>
-<div class="form-inline crm-search-admin-flex-row" ng-if=":: $ctrl.parent.canBeLink(col)">
+<div class="form-inline crm-search-admin-flex-row" >
   <label title="{{:: ts('Display as clickable link') }}" >
     <input type="checkbox" ng-checked="col.link" ng-click="$ctrl.parent.toggleLink(col)" >
     {{:: ts('Link') }}


### PR DESCRIPTION
Overview
----------------------------------------
Allows aggregate columns to be rendered as a link in SearchKit Displays

Before
----------------------------------------
Aggregate columns were excluded from being shown as links in search Displays.

After
----------------------------------------
That's overly strict. They can't have autogenerated links, but they can have custom link paths.

Technical Details
----------------------------------------
Calculating a value for an autogenerated link is complex for aggregated fields, but it's still easy to use a set path.