### PR TITLE
(dev/core#3012) Expose email on hold as filter for report

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -150,6 +150,13 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
             'title' => ts('Email on hold'),
           ],
         ],
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_BOOLEAN,
+            'options' => ['' => ts('Any')] + CRM_Core_SelectValues::boolean(),
+          ],
+        ],
       ],
       'civicrm_phone' => [
         'dao' => 'CRM_Core_DAO_Phone',


### PR DESCRIPTION
Overview
----------------------------------------
It could be useful to expose _email on hold_ status as a filter for report

Before
----------------------------------------
No way to search on on hold contacts

After
----------------------------------------
Voila!