### PR TITLE
Improve accessibility - associate label and fields

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -42,7 +42,11 @@ class CRM_Contact_Form_Edit_Email {
     $form->applyFilter('__ALL__', 'trim');
 
     //Email box
-    $form->addField("email[$blockId][email]", ['entity' => 'email', 'aria-label' => ts('Email %1', [1 => $blockId])]);
+    $form->addField("email[$blockId][email]", [
+      'entity' => 'email',
+      'aria-label' => ts('Email %1', [1 => $blockId]),
+      'label' => ts('Email %1', [1 => $blockId]),
+    ]);
     $form->addRule("email[$blockId][email]", ts('Email is not valid.'), 'email');
     if (isset($form->_contactType) || $blockEdit) {
       //Block type

--- a/CRM/Contact/Form/Edit/Phone.php
+++ b/CRM/Contact/Form/Edit/Phone.php
@@ -48,8 +48,17 @@ class CRM_Contact_Form_Edit_Phone {
       'placeholder' => NULL,
     ]);
     //main phone number with crm_phone class
-    $form->addField("phone[$blockId][phone]", ['entity' => 'phone', 'class' => 'crm_phone twelve', 'aria-label' => ts('Phone %1', [1 => $blockId])]);
-    $form->addField("phone[$blockId][phone_ext]", ['entity' => 'phone', 'aria-label' => ts('Phone Extension %1', [1 => $blockId])]);
+    $form->addField("phone[$blockId][phone]", [
+      'entity' => 'phone',
+      'class' => 'crm_phone twelve',
+      'aria-label' => ts('Phone %1', [1 => $blockId]),
+      'label' => ts('Phone %1:', [1 => $blockId]),
+    ]);
+    $form->addField("phone[$blockId][phone_ext]", [
+      'entity' => 'phone',
+      'aria-label' => ts('Phone Extension %1', [1 => $blockId]),
+      'label' => ts('ext.', ['context' => 'phone_ext']),
+    ]);
     if (isset($form->_contactType) || $blockEdit) {
       //Block type select
       $form->addField("phone[$blockId][location_type_id]", [

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -24,7 +24,7 @@
   </tr>
 {/if}
 <tr id="Phone_Block_{$blockId}">
-  <td>{$form.phone.$blockId.phone.html} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
+  <td>{$form.phone.$blockId.phone.html} {$form.phone.$blockId.phone_ext.label}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
   {if $className eq 'CRM_Contact_Form_Contact'}
   <td>{$form.phone.$blockId.location_type_id.html}</td>
   {/if}

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -31,7 +31,7 @@
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
     <tr id="Phone_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-        <td>{$form.phone.$blockId.phone.html} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
+        <td>{$form.phone.$blockId.phone.html} {$form.phone.$blockId.phone_ext.label}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
         <td>{$form.phone.$blockId.location_type_id.html}</td>
         <td>{$form.phone.$blockId.phone_type_id.html}</td>
         <td align="center" class="crm-phone-is_primary">{$form.phone.$blockId.is_primary.1.html}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -54,20 +54,20 @@
   {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1}
   <table class="form-layout-compressed">
     <tr>
-      <td><label>{ts}Email 1:{/ts}</label></td>
+      <td>{$form.email.1.email.label}</td>
       <td>{$form.email.1.email.html|crmAddClass:email}</td>
     </tr>
     <tr>
-      <td><label>{ts}Email 2:{/ts}</label></td>
+      <td>{$form.email.2.email.label}</td>
       <td>{$form.email.2.email.html|crmAddClass:email}</td>
     </tr>
     <tr>
-      <td><label>{ts}Phone 1:{/ts}</label></td>
-      <td>{$form.phone.1.phone.html|crmAddClass:phone} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.1.phone_type_id.html}</td>
+      <td>{$form.phone.1.phone.label}</td>
+      <td>{$form.phone.1.phone.html|crmAddClass:phone} {$form.phone.1.phone_ext.label}&nbsp;{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.1.phone_type_id.html}</td>
     </tr>
     <tr>
-      <td><label>{ts}Phone 2:{/ts}</label></td>
-      <td>{$form.phone.2.phone.html|crmAddClass:phone} {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.2.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.2.phone_type_id.html}</td>
+      <td>{$form.phone.2.phone.label}</td>
+      <td>{$form.phone.2.phone.html|crmAddClass:phone} {$form.phone.2.phone_ext.label}&nbsp;{$form.phone.2.phone_ext.html|crmAddClass:four}&nbsp;{$form.phone.2.phone_type_id.html}</td>
     </tr>
   </table>
 


### PR DESCRIPTION
Overview
----------------------------------------
The primary purpose of this change was to associate the labels on the event location form with the relevant inputs:

<img width="578" alt="Screenshot 2022-01-03 at 17 41 14" src="https://user-images.githubusercontent.com/1931323/147962044-7049cbbd-a83c-4f0b-95c1-b36780c7f6fb.png">

As part of this change, I have also updated the contact forms so that the "ext" text becomes a label for the relevant telephone extension fields.

Before
----------------------------------------
The labels "Email 1:", "Phone 1:", "Ext" did not have a `for` attribute, and so were not associated with the `input` elements. This wasn't the end of the world as there is `aria-label` attributes in place, but adding the associations improves consistency, and means that mouse users can click on the labels to focus the relevant fields.

After
----------------------------------------
The labels have `for` attributes and so are semantically linked with the relevant fields.

Technical Details
----------------------------------------
I did consider just adding a hardcoded `for` attribute to the elements within the templates. However this seemed more brittle than using the style `{$form.email.1.email.label}`. This does mean that `CRM_Contact_Form_Edit_Email::buildQuickForm` and `CRM_Contact_Form_Edit_Phone::buildQuickForm` now set labels which may not be relevant to all scenarios where these methods are used. However I considered this ok, and any other contexts will simply ignore the labels unless they are explicitely rendered.
