### PR TITLE
Fix over-escaping when default escaping is on

### DIFF
--- a/templates/CRM/Custom/Page/Field.tpl
+++ b/templates/CRM/Custom/Page/Field.tpl
@@ -41,11 +41,11 @@
             <td class="crm-editable" data-field="label">{$row.label}</td>
             <td>{$row.data_type}</td>
             <td>{$row.html_type}</td>
-            <td class="nowrap">{$row.weight}</td>
+            <td class="nowrap">{$row.weight|smarty:nodefaults}</td>
             <td class="crm-editable" data-type="boolean" data-field="is_required">{if !empty($row.is_required)} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crm-editable" data-type="boolean" data-field="is_searchable">{if !empty($row.is_searchable)} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td>{if !empty($row.is_active)} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </tbody>


### PR DESCRIPTION
Overview
----------------------------------------
Fix over-escaping when default escaping is on
civicrm/admin/custom/group/field?reset=1&action=browse&gid=1

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/147988996-533cb180-204f-446b-a4d3-b305e504072d.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/147988971-5d12e889-1906-4448-b355-7c5eb3c03aa9.png)

Technical Details
----------------------------------------


Comments
----------------------------------------

