### PR TITLE
Fix campaign dashboard to work with default escaping

### DIFF
--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -148,9 +148,9 @@
 
     //build the search qill.
     //get the search criteria.
-    var searchParams = {/literal}{$searchParams}{literal};
-    var campaignTypes = {/literal}{$campaignTypes}{literal};
-    var campaignStatus = {/literal}{$campaignStatus}{literal};
+    var searchParams = {/literal}{$searchParams|smarty:nodefaults}{literal};
+    var campaignTypes = {/literal}{$campaignTypes|smarty:nodefaults}{literal};
+    var campaignStatus = {/literal}{$campaignStatus|smarty:nodefaults}{literal};
     var noRecordFoundMsg = '{/literal}{ts escape='js'}No matches found for:{/ts}{literal}';
     noRecordFoundMsg += '<div class="qill">';
 
@@ -226,7 +226,7 @@
         var searchCriteria = [];
 
         //get the search criteria.
-        var searchParams = {/literal}{$searchParams}{literal};
+        var searchParams = {/literal}{$searchParams|smarty:nodefaults}{literal};
         for (param in searchParams) {
           fldName = param;
           if (param == 'campaign_title') {


### PR DESCRIPTION
Overview
----------------------------------------
Fix campaign dashboard to work with default escaping

Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------
I just added the general escape by-pass - but I notice they are json encoded - I wonder if there is something more clever to consider

![image](https://user-images.githubusercontent.com/336308/147992612-76d7b262-44fa-4ea1-a268-25c9481f9de5.png)

In general we want the decision not  to escape to be active (which this approach achieves)  - however there is a low level risk it could be a good decision at the time it's added & become compromised over time. (This is probably fine for now as we are raising the bar by making default escaping work at all & this is at least greppable)

Comments
----------------------------------------
