### PR TITLE
SearchKit - Fix editable dates on standalone form

### DIFF
--- a/ext/search_kit/ang/crmSearchPage.module.js
+++ b/ext/search_kit/ang/crmSearchPage.module.js
@@ -10,7 +10,7 @@
         controller: 'crmSearchPageDisplay',
         // Dynamic template generates the directive for each display type
         template: '<h1 crm-page-title>{{:: $ctrl.display.label }}</h1>\n' +
-          '<div ng-include="\'~/crmSearchPage/displayType/\' + $ctrl.display.type + \'.html\'" id="bootstrap-theme"></div>',
+          '<form ng-include="\'~/crmSearchPage/displayType/\' + $ctrl.display.type + \'.html\'" id="bootstrap-theme"></form>',
         resolve: {
           // Load saved search display
           info: function($route, crmApi4) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes edit-in-place date widgets when viewing a search display as a standalone page.

Before
----------------------------------------
Page goes blank.
See https://lab.civicrm.org/dev/report/-/issues/91 and https://lab.civicrm.org/dev/core/-/issues/3017

After
----------------------------------------
Works

Technical Details
----------------------------------------
For better or worse, the crmDatePicker widget requires a parent `<form>` element.