### PR TITLE
(dev/core#3012) Expose email on hold as filter for contribution report

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -164,6 +164,14 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
             'no_repeat' => TRUE,
           ],
         ],
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
+          ],
+        ],
         'grouping' => 'contact-fields',
       ],
       'civicrm_phone' => [

--- a/CRM/Report/Form/Contribute/HouseholdSummary.php
+++ b/CRM/Report/Form/Contribute/HouseholdSummary.php
@@ -183,6 +183,14 @@ class CRM_Report_Form_Contribute_HouseholdSummary extends CRM_Report_Form {
         'fields' => [
           'email' => NULL,
         ],
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
+          ],
+        ],
         'grouping' => 'contact-fields',
       ],
     ];

--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -168,6 +168,14 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
       'civicrm_email' => [
         'dao' => 'CRM_Core_DAO_Email',
         'fields' => ['email' => NULL],
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
+          ],
+        ],
         'grouping' => 'contact-fields',
       ],
       'civicrm_financial_trxn' => [

--- a/CRM/Report/Form/Contribute/Repeat.php
+++ b/CRM/Report/Form/Contribute/Repeat.php
@@ -144,6 +144,14 @@ class CRM_Report_Form_Contribute_Repeat extends CRM_Report_Form {
             'no_repeat' => TRUE,
           ),
         ),
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
+          ],
+        ],
         'grouping' => 'contact-fields',
       ),
       'civicrm_phone' => array(

--- a/CRM/Report/Form/Contribute/Sybunt.php
+++ b/CRM/Report/Form/Contribute/Sybunt.php
@@ -154,6 +154,14 @@ class CRM_Report_Form_Contribute_Sybunt extends CRM_Report_Form {
             'default' => TRUE,
           ],
         ],
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
+          ],
+        ],
       ],
       'civicrm_phone' => [
         'dao' => 'CRM_Core_DAO_Phone',

--- a/CRM/Report/Form/Contribute/TopDonor.php
+++ b/CRM/Report/Form/Contribute/TopDonor.php
@@ -167,6 +167,14 @@ class CRM_Report_Form_Contribute_TopDonor extends CRM_Report_Form {
             'no_repeat' => TRUE,
           ],
         ],
+        'filters' => [
+          'on_hold' => [
+            'title' => ts('On Hold'),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
+          ],
+        ],
         'grouping' => 'email-fields',
       ],
       'civicrm_phone' => [


### PR DESCRIPTION
Overview
----------------------------------------
It could be useful to expose _email on hold_ status as a filter for contribution report

Before
----------------------------------------
No way to search on on hold contacts

After
----------------------------------------
Voila!

Comments
------------------------------
Following up on  https://github.com/civicrm/civicrm-core/pull/22357