### PR TITLE
Add system status check for missing dedupe rules

### DIFF
--- a/CRM/Utils/Check/Component/DedupeRules.php
+++ b/CRM/Utils/Check/Component/DedupeRules.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_Check_Component_DedupeRules extends CRM_Utils_Check_Component {
+
+  /**
+   * Get dedupe rules, grouped by contact type, for a specific usage
+   *
+   * @param string $used (Supervised, Unsupervised, General)
+   * @return string[]
+   */
+  private static function getContactTypesForRule($used) {
+    $dedupeRules = \Civi\Api4\DedupeRuleGroup::get()
+      ->addSelect('contact_type')
+      ->addGroupBy('contact_type')
+      ->addWhere('used', '=', $used)
+      ->execute();
+
+    $types = [];
+    foreach ($dedupeRules as $rule) {
+      if (!in_array($rule, $types)) {
+        $types[] = $rule['contact_type'];
+      }
+    }
+    return $types;
+  }
+
+  /**
+   * Returns an array of missing expected contact types
+   *
+   * @param string[] $rules
+   * @return array
+   */
+  private static function getMissingRules($rules) {
+    $types = array_column(CRM_Contact_BAO_ContactType::basicTypeInfo(), 'label', 'name');
+    return array_diff_key($types, array_flip($rules));
+  }
+
+  /**
+   * @return CRM_Utils_Check_Message[]
+   */
+  public static function checkDedupeRulesExist() {
+    $messages = [];
+
+    $ruleTypes = ['Supervised' => ts('Supervised'), 'Unsupervised' => ts('Unsupervised')];
+    foreach ($ruleTypes as $ruleType => $ruleLabel) {
+      $rules = self::getContactTypesForRule($ruleType);
+      $missingRules = self::getMissingRules($rules);
+      if ($missingRules) {
+        $message = new CRM_Utils_Check_Message(
+          __FUNCTION__ . $ruleType,
+          ts('For CiviCRM to function correctly you must have at least 2 dedupe rules configured for each contact type. You are missing a rule of type %1 for: %2', [1 => $ruleLabel, 2 => implode(', ', $missingRules)]),
+          ts('%1 dedupe rules missing', [1 => $ruleLabel]),
+          \Psr\Log\LogLevel::WARNING,
+          'fa-server'
+        );
+        $message->addAction(
+          ts('Configure dedupe rules'),
+          FALSE,
+          'href',
+          ['path' => 'civicrm/contact/deduperules', 'query' => ['reset' => 1]]
+        );
+        $messages[] = $message;
+      }
+    }
+    return $messages;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
As discussed in [core#2918](https://lab.civicrm.org/dev/core/-/issues/2918), CiviCRM assumes that `Unsupervised` and `Supervised` dedupe rules will always exist, but allows the system to get into a state where only `General` rules are actually configured. This adds a system check to warn when either `Unsupervised` or `Supervised` dedupe rules are missing.

Before
----------------------------------------
It was possible to configure CiviCRM without either `Unsupervised` or `Supervised` dedupe rules. This can lead to exceptions being thrown, blocking certain functionality from working correctly. For example:

- Adding users in WordPress (this is the bug reported in [core#2918](https://lab.civicrm.org/dev/core/-/issues/2918))
- Registering users for events on the public facing area of the site (this is an issue I have noticed more recently when dedupe rules were missing)

After
----------------------------------------
If dedupe rules have not been configured correctly, system messages will be shown warning the user that they should review their configuration. A link to the dedupe contacts screen is included, and from here the configuration can be changed:

<img width="1349" alt="Screenshot 2022-01-04 at 18 57 59" src="https://user-images.githubusercontent.com/1931323/148109807-554b7d43-5f76-4f8c-9148-100dc5e124c9.png">

Note that it's still too easy (in my opinion) to get into a bad state, and I'd still like to implement the UI improvements suggested on [core#2918](https://lab.civicrm.org/dev/core/-/issues/2918) if I can find time.

Technical Details
----------------------------------------
The code felt tidiest when split into two check functions, both using a shared `getContactTypesForRule` method. This does mean that two very similar database queries are required, rather than a single query. However, I belive this should be a fairly efficient database call and so I don't think this should be a massive problem.

I've not included tests because:

- I wasn't quite sure how you'd go about writing tests for something like this,
- None of the other checks in `CRM/Utils/Check/Component/` had tests which I could use as a reference.

Comments
----------------------------------------
I wasn't 100% sure which severity and icon to go for. I've settled on `\Psr\Log\LogLevel::WARNING` and `fa-server`, but did very much wonder if `\Psr\Log\LogLevel::ERROR` would be more appropriate. 
