### PR TITLE
Fix notices on acl page

### DIFF
--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -125,7 +125,7 @@ ORDER BY entity_id
     ] + CRM_Event_PseudoConstant::event();
 
     while ($dao->fetch()) {
-      $acl[$dao->id] = [];
+      $acl[$dao->id] = ['class' => ''];
       $acl[$dao->id]['name'] = $dao->name;
       $acl[$dao->id]['operation'] = $dao->operation;
       $acl[$dao->id]['entity_id'] = $dao->entity_id;

--- a/templates/CRM/ACL/Header.tpl
+++ b/templates/CRM/ACL/Header.tpl
@@ -16,24 +16,30 @@
 
 {php}
   $currentStep = $this->get_template_vars('step');
-  $wizard = array(
-    'style' => array(),
+  $wizard = [
+    'style' => ['barClass' => '', 'showTitle' => FALSE],
     'currentStepNumber' => $currentStep,
-    'steps' => array(
-      array(
+    'steps' => [
+      [
         'title' => ts('Manage Roles'),
         'link' => CRM_Utils_System::url('civicrm/admin/options/acl_role', 'reset=1'),
-      ),
-      array(
+        'collapsed' => FALSE,
+        'name' => '',
+      ],
+      [
         'title' => ts('Assign Users'),
         'link' => CRM_Utils_System::url('civicrm/acl/entityrole', 'reset=1'),
-      ),
-      array(
+        'collapsed' => FALSE,
+        'name' => '',
+      ],
+      [
         'title' => ts('Manage ACLs'),
         'link' => CRM_Utils_System::url('civicrm/acl', 'reset=1'),
-      ),
-    ),
-  );
+        'collapsed' => FALSE,
+        'name' => '',
+      ],
+    ],
+  ];
   foreach ($wizard['steps'] as $num => &$step) {
     $step['step'] = $step['valid'] = $step['stepNumber'] = $num + 1;
     if ($step['stepNumber'] == $currentStep) {

--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -35,7 +35,7 @@
             </thead>
             <tbody>
             {foreach from=$rows item=row key=aclID}
-              <tr id="acl-{$aclID}" class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if} crm-acl crm-entity {if NOT $row.is_active} disabled{/if}">
+              <tr id="acl-{$aclID}" class="{cycle values="odd-row,even-row"} {$row.class} crm-acl crm-entity {if NOT $row.is_active} disabled{/if}">
                 <td class="crm-acl-entity">{$row.entity}</td>
                 <td class="crm-acl-operation" >{$row.operation}</td>
                 <td class="crm-acl-object_name">{$row.object_name}</td>

--- a/templates/CRM/common/WizardHeader.tpl
+++ b/templates/CRM/common/WizardHeader.tpl
@@ -10,7 +10,7 @@
 {if count( $wizard.steps ) > 1}
 {* wizard.style variable is passed by some Wizards to allow alternate styling for progress "bar". *}
 <div id="wizard-steps">
-   <ul class="wizard-bar{if !empty($wizard.style.barClass)}-{$wizard.style.barClass}{/if}">
+   <ul class="wizard-bar{if $wizard.style.barClass}-{$wizard.style.barClass}{/if}">
     {section name=step loop=$wizard.steps}
         {if count ( $wizard.steps ) > 5 }
             {* truncate step titles so header isn't too wide *}
@@ -19,7 +19,7 @@
             {assign var="title" value=$wizard.steps[step].title}
         {/if}
         {* Show each wizard link unless collapsed value is true. Also excluding quest app submit steps. Should create separate WizardHeader for Quest at some point.*}
-        {if empty($wizard.steps[step].collapsed) && !empty($wizard.steps[step].name) && $wizard.steps[step].name NEQ 'Submit' && $wizard.steps[step].name NEQ 'PartnerSubmit'}
+        {if !$wizard.steps[step].collapsed && $wizard.steps[step].name && $wizard.steps[step].name NEQ 'Submit' && $wizard.steps[step].name NEQ 'PartnerSubmit'}
             {assign var=i value=$smarty.section.step.iteration}
             {if $wizard.currentStepNumber > $wizard.steps[step].stepNumber}
                 {if $wizard.steps[step].step}


### PR DESCRIPTION

Overview
----------------------------------------
Fix notices on acl page civicrm/acl?reset=1


Before
----------------------------------------
With default modifier enabled....

![image](https://user-images.githubusercontent.com/336308/148134189-4c634fce-3f33-447b-8e82-2bdb03d5ce20.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/148134088-7f9a524f-3e92-4a0e-989e-6a620da8b7c6.png)


Technical Details
----------------------------------------
This alters wizard.tpl - which could cause some smarty e-notices to 'regress' elsewhere - but since we no longer consider the addition of empty checks to be a smarty e-notice fix I don't think this is a bad thing

Comments
----------------------------------------
