### PR TITLE
Fix E_WARNING access array offset on null when creating new contribution page

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -37,7 +37,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
     if (isset($this->_id)) {
       $defaults = CRM_Member_BAO_Membership::getMembershipBlock($this->_id);
     }
-    $defaults['member_is_active'] = $defaults['is_active'];
+    $defaults['member_is_active'] = $defaults['is_active'] ?? FALSE;
 
     // Set Display Minimum Fee default to true if we are adding a new membership block
     if (!isset($defaults['id'])) {


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
1. Use php7.4+
1. Create a new contribution page.
1. Can just fill out the minimum needed.
1. Click Continue
1. Fill out the amounts - again can just do the minimum needed.
1. Click `Save And Next` - Warning: Trying to access array offset on value of type null in CRM_Member_Form_MembershipBlock->setDefaultValues() (line 40 of ...\CRM\Member\Form\MembershipBlock.php).

After
----------------------------------------


Technical Details
----------------------------------------
Line 38 can return null if there is no membership block yet

Comments
----------------------------------------

