### PR TITLE
dev/report#90 - Don't crash search_kit on upgrade from 5.35

### DIFF
--- a/ext/search_kit/CRM/Search/Upgrader.php
+++ b/ext/search_kit/CRM/Search/Upgrader.php
@@ -51,6 +51,14 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1001(): bool {
+    // If you upgrade direct from 5.35 to 5.40+ then upgrade_1001 which is
+    // from 5.36 triggers api4 to use the field that gets added in 5.40.
+    // So rather than rewrite all these upgrades in straight SQL, let's just
+    // add the field now, and then upgrade_1005 will be a no-op if upgrading
+    // from 5.36 or earlier.
+    $this->ctx->log->info('Applying update 1005 before 1001 to avoid chicken and egg problem.');
+    $this->addColumn('civicrm_search_display', 'acl_bypass', "tinyint DEFAULT 0 COMMENT 'Skip permission checks and ACLs when running this display.'");
+
     $this->ctx->log->info('Applying update 1001 - normalize search display columns.');
     $savedSearches = \Civi\Api4\SavedSearch::get(FALSE)
       ->addWhere('api_params', 'IS NOT NULL')


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/report/-/issues/90
Running extension upgrades crashes if you upgrade search kit directly from 5.35 or earlier to 5.40 or later and have an existing search_display. Note that 5.35 was a security release so there are still lots of sites on 5.35 (http://stats.civicrm.org/?tab=sites)

Before
----------------------------------------
1. Install 5.35.2 and enable search kit.
1. Create a search with a display and save it.
1. Upgrade to e.g. 5.44.0. The civi upgrade itself runs ok.
1. Visit the system status page and run the extension upgrades.
1. Error about "acl_bypass doesn't exist" because upgrade_1001 triggers something that doesn't exist until upgrade_1005.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
While the right thing might be to do as suggested in https://docs.civicrm.org/dev/en/latest/framework/upgrade/#tips-prefer-simple-sql-semantics-over-apibaodao and rewrite the upgrade steps without using apis, this seems a simpler fix.

Comments
----------------------------------------

