### PR TITLE
Show customised fields on load, if customised option selected.

### DIFF
--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.js.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.js.tpl
@@ -11,7 +11,7 @@
   <script type="text/javascript">
     CRM.$(function($) {
       var $form = $('form.{/literal}{$form.formClass}{literal}');
-      $('#postal_greeting_id, #addressee_id, #email_greeting_id', $form).change(function() {
+      function triggerCustomValueCommsFields() {
         var fldName = $(this).attr('id');
         if ($(this).val() == 4) {
           $("#greetings1, #greetings2", $form).show();
@@ -20,8 +20,11 @@
           $("#" + fldName + "_html, #" + fldName + "_label", $form).hide();
           $("#" + fldName.slice(0, -3) + "_custom", $form).val('');
         }
-      });
-      
+      }
+      $('#postal_greeting_id, #addressee_id, #email_greeting_id', $form)
+        .each(triggerCustomValueCommsFields)
+        .on('change', triggerCustomValueCommsFields);
+
       $('.replace-plain[data-id]', $form).click(function() {
         var element = $(this).data('id');
         $(this).hide();


### PR DESCRIPTION
Overview
----------------------------------------
Resolves [core#483](https://lab.civicrm.org/dev/core/-/issues/483)

If a customised communication preference was selected, but the page was reloaded due to a validation error, the customised value field was not shown.

Before
----------------------------------------
Following a validation error on the new contact form, the customised communication preference fields were not shown, even if "customized" was selected. This could be confusing, especially if an error message relating to these fields was shown.

After
----------------------------------------
The cusomised value fields are shown on page load if "Customized" is selected in the dropdown(s).

Comments
----------------------------------------
I don't love other parts of this file - in particular the hardcoded magic number `4`. But I considered any further refactoring seemed out of scope for this PR.
