### PR TITLE
Support for pre() and post() hook for FinancialTrxn

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -36,22 +36,21 @@ class CRM_Core_BAO_FinancialTrxn extends CRM_Financial_DAO_FinancialTrxn {
    * @return CRM_Financial_DAO_FinancialTrxn
    */
   public static function create($params) {
-    $trxn = new CRM_Financial_DAO_FinancialTrxn();
-    $trxn->copyValues($params);
-
     if (isset($params['fee_amount']) && is_numeric($params['fee_amount'])) {
       if (!isset($params['total_amount'])) {
+        $trxn = new CRM_Financial_DAO_FinancialTrxn();
+        $trxn->copyValues($params);
         $trxn->fetch();
         $params['total_amount'] = $trxn->total_amount;
       }
-      $trxn->net_amount = $params['total_amount'] - $params['fee_amount'];
+      $params['net_amount'] = $params['total_amount'] - $params['fee_amount'];
     }
 
-    if (empty($params['id']) && !CRM_Utils_Rule::currencyCode($trxn->currency)) {
-      $trxn->currency = CRM_Core_Config::singleton()->defaultCurrency;
+    if (empty($params['id']) && !CRM_Utils_Rule::currencyCode($params['currency'])) {
+      $params['currency'] = CRM_Core_Config::singleton()->defaultCurrency;
     }
 
-    $trxn->save();
+    $trxn = self::writeRecord($params);
 
     if (!empty($params['id'])) {
       // For an update entity financial transaction record will already exist. Return early.


### PR DESCRIPTION
Overview
----------------------------------------
Not sure if its a right thing to allow to alter the financial trxn params using pre() and post() hook but I feel it should be allowed so that one can change the params like to/from_financial_account or create additional transactions in post() hook etc. Thoughts?

(Note: This PR is work in progress)

If approved will update the PR with
1. Move CRM/Core/BAO/FinancialTrxn.php to CRM/Financial/BAO/FinancialTrxn.
2. Replace class in all code from CRM_Core_BAO_FinancialTrxn to CRM_Financial_BAO_FinancialTrxn
3. Create empty file CRM/Core/BAO/FinancialTrxn.php which extends CRM_Financial_BAO_FinancialTrxn (not sure how to write deprecated warning!!!!)