### PR TITLE
APIv4 Explorer - Format array params using add methods instead of set

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -789,6 +789,7 @@
     // Format oop params
     function formatOOP(entity, action, params, indent) {
       var info = getEntity(entity),
+        arrayParams = ['groupBy', 'records'],
         newLine = "\n" + _.repeat(' ', indent),
         code = '\\' + info.class + '::' + action + '(',
         perm = params.checkPermissions === false ? 'FALSE' : '';
@@ -803,6 +804,10 @@
           _.each(param, function(item, index) {
             val = phpFormat(index) + ', ' + phpFormat(item, 2 + indent);
             code += newLine + "->add" + ucfirst(key).replace(/s$/, '') + '(' + val + ')';
+          });
+        } else if (_.includes(arrayParams, key)) {
+          _.each(param, function(item) {
+            code += newLine + "->add" + ucfirst(key).replace(/s$/, '') + '(' + phpFormat(item, 2 + indent) + ')';
           });
         } else if (key === 'where') {
           _.each(param, function (clause) {


### PR DESCRIPTION
Overview
----------------------------------------
Improves OOP code generated from the APIv4 Explorer, by using sugar methods `addGroupBy()` and `addRecord()`.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/148250223-368a84fd-3ebd-4824-8d04-ea3ac52e7aab.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/148250036-1908c344-3a26-4da0-8089-a5977c0558b9.png)

