### PR TITLE
DedupeRules - Translate contact type labels, respect enabled contact types

### DIFF
--- a/CRM/Contact/Page/DedupeRules.php
+++ b/CRM/Contact/Page/DedupeRules.php
@@ -113,13 +113,16 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
    * Browse all rule groups.
    */
   public function browse() {
-    // get all rule groups
-    $ruleGroups = [];
+    $contactTypes = array_column(CRM_Contact_BAO_ContactType::basicTypeInfo(), 'label', 'name');
+    $dedupeRuleTypes = CRM_Core_SelectValues::getDedupeRuleTypes();
+    $ruleGroups = array_fill_keys(array_keys($contactTypes), []);
+
+    // Get rule groups for enabled contact types
     $dao = new CRM_Dedupe_DAO_DedupeRuleGroup();
-    $dao->orderBy('contact_type ASC, used ASC, title ASC');
+    $dao->orderBy('used ASC, title ASC');
+    $dao->whereAdd('contact_type IN ("' . implode('","', array_keys($contactTypes)) . '")');
     $dao->find();
 
-    $dedupeRuleTypes = CRM_Core_SelectValues::getDedupeRuleTypes();
     while ($dao->fetch()) {
       $ruleGroups[$dao->contact_type][$dao->id] = [];
       CRM_Core_DAO::storeValues($dao, $ruleGroups[$dao->contact_type][$dao->id]);
@@ -127,10 +130,6 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
       // form all action links
       $action = array_sum(array_keys($this->links()));
       $links = self::links();
-      /* if ($dao->is_default) {
-      unset($links[CRM_Core_Action::MAP]);
-      unset($links[CRM_Core_Action::DELETE]);
-      }*/
 
       if ($dao->is_reserved) {
         unset($links[CRM_Core_Action::DELETE]);
@@ -150,6 +149,7 @@ class CRM_Contact_Page_DedupeRules extends CRM_Core_Page_Basic {
       $ruleGroups[$dao->contact_type][$dao->id]['used_display'] = $dedupeRuleTypes[$ruleGroups[$dao->contact_type][$dao->id]['used']];
     }
     $this->assign('brows', $ruleGroups);
+    $this->assign('contactTypes', $contactTypes);
   }
 
   /**

--- a/templates/CRM/Contact/Page/DedupeRules.tpl
+++ b/templates/CRM/Contact/Page/DedupeRules.tpl
@@ -23,13 +23,13 @@
     {if $brows}
     {include file="CRM/common/jsortable.tpl"}
     {foreach from=$brows key=contactType item=rows}
-      <div id="browseValues_{$contactType}">
+      <div id="browseValues_{$contactType}" class="crm-clearfix">
         <div>
         {strip}
           <table id="options_{$contactType}" class="display mergecontact">
             <thead>
             <tr>
-              <th>{ts 1=$contactType}%1 Rules{/ts}</th>
+              <th>{ts 1=$contactTypes.$contactType}%1 Rules{/ts}</th>
               <th>{ts}Usage{/ts}</th>
               <th></th>
             </tr>
@@ -45,7 +45,7 @@
         {/strip}
        </div>
        <div style="float:right">
-            {crmButton q="action=add&contact_type=$contactType&reset=1" icon="plus-circle"}{ts 1=$contactType}Add Rule for %1s{/ts}{/crmButton}
+            {crmButton q="action=add&contact_type=$contactType&reset=1" icon="plus-circle"}{ts 1=$contactTypes.$contactType}Add %1 Rule{/ts}{/crmButton}
         </div>
       </div>
     {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes up the Dedupe Rules page to properly handle contact types.

Before
----------------------------------------
Try renaming "Individual" to "Person", deleting all the rules for "Organization" and disabling the "Household" contact type. You get this screen:

![image](https://user-images.githubusercontent.com/2874912/148259382-4266ce69-348a-4a57-a734-0c38f790f4ac.png)
**Incorrect Behavior:**
- Machine names shown instead of labels ("Individual" should be "Person")
- Disabled status ignored for contact types ("Household" table should be hidden)
- If no rules existed for a contact type, there would be no way to add one! ("Organization has no rules so the table is completely missing)
- Weird floating button artifact at the bottom

After
----------------------------------------
With "Individual" renamed "Person", all rules deleted for "Organization", and "Household" contact type disabled, it now looks like this:

![image](https://user-images.githubusercontent.com/2874912/148259304-fa4cbd27-658a-4ef1-a9b1-caef23fb4d57.png)
