### PR TITLE
dev/core#3001 escape single quotes when rendering tokens in html format

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -280,7 +280,7 @@ class TokenRow {
                 $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }
               else {
-                $htmlTokens[$entity][$field] = is_object($value) ? $value : htmlentities($value);
+                $htmlTokens[$entity][$field] = is_object($value) ? $value : htmlentities($value, ENT_QUOTES);
               }
             }
           }

--- a/release-notes/5.45.0.md
+++ b/release-notes/5.45.0.md
@@ -303,6 +303,10 @@ Released January 5, 2022
 - **[Smarty variables] [Activity form] Ensure activityTypeFile is always
   assigned ([22153](https://github.com/civicrm/civicrm-core/pull/22153))**
 
+- **TokenProcessor - Escape single quotes in HTML format
+  ([dev/core#3001](https://lab.civicrm.org/dev/core/-/issues/3001):
+  [22387](https://github.com/civicrm/civicrm-core/pull/22387))**
+
 - **Remove issets from Activity search screen
   ([22180](https://github.com/civicrm/civicrm-core/pull/22180))**
 

--- a/tests/phpunit/CRM/Core/TokenSmartyTest.php
+++ b/tests/phpunit/CRM/Core/TokenSmartyTest.php
@@ -132,7 +132,10 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
     ];
   }
 
-  public function testTokenDataEscape() {
+  /**
+   * Test appropriate escaping is applied to tokens with appostrophes.
+   */
+  public function testTokenDataEscape(): void {
     $cutesyContactId = $this->individualCreate([
       'first_name' => 'Ivan\'s "The Ter<r>ib`le"',
     ]);

--- a/tests/phpunit/CRM/Core/TokenSmartyTest.php
+++ b/tests/phpunit/CRM/Core/TokenSmartyTest.php
@@ -132,6 +132,21 @@ class CRM_Core_TokenSmartyTest extends CiviUnitTestCase {
     ];
   }
 
+  public function testTokenDataEscape() {
+    $cutesyContactId = $this->individualCreate([
+      'first_name' => 'Ivan\'s "The Ter<r>ib`le"',
+    ]);
+    $rendered = CRM_Core_TokenSmarty::render(
+      [
+        'msg_html' => 'First name is <b>{contact.first_name}</b>.',
+        'msg_text' => 'First name is __{contact.first_name}__.',
+      ],
+      ['contactId' => $cutesyContactId]
+    );
+    $this->assertEquals('First name is <b>Ivan&#039;s &quot;The Ter&lt;r&gt;ib`le&quot;</b>.', $rendered['msg_html']);
+    $this->assertEquals('First name is __Ivan\'s "The Ter<r>ib`le"__.', $rendered['msg_text']);
+  }
+
   /**
    * Someone malicious gives cutesy expressions (via token-content) that tries to provoke extra evaluation.
    */


### PR DESCRIPTION
port fix from https://github.com/civicrm/civicrm-core/pull/22285