### PR TITLE
REF - Use `CRM_Contact_BAO_ContactType::basicTypes()` instead of hardcoded lists

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -161,9 +161,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $this->_contactType = CRM_Utils_Request::retrieve('ct', 'String',
         $this, TRUE, NULL, 'REQUEST'
       );
-      if (!in_array($this->_contactType,
-        ['Individual', 'Household', 'Organization']
-      )
+      if (!in_array($this->_contactType, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)
       ) {
         CRM_Core_Error::statusBounce(ts('Could not get a contact id and/or contact type'));
       }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -114,7 +114,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     if ($this->_onDuplicate != CRM_Import_Parser::DUPLICATE_NOCHECK) {
       //Mark Dedupe Rule Fields as required, since it's used in matching contact
-      foreach (['Individual', 'Household', 'Organization'] as $cType) {
+      foreach (CRM_Contact_BAO_ContactType::basicTypes() as $cType) {
         $ruleParams = [
           'contact_type' => $cType,
           'used' => 'Unsupervised',

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1003,7 +1003,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
     }
 
     // get array of subtypes - CRM-18708
-    if (in_array($csType, ['Individual', 'Organization', 'Household'])) {
+    if (in_array($csType, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
       $csType = self::getSubtypes($params['contact_type']);
     }
 
@@ -2115,9 +2115,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
       $requiredCheck = FALSE;
     }
     if ($requiredCheck) {
-      if (isset($params['id'])) {
-        $required = ['Individual', 'Household', 'Organization'];
-      }
       $required = [
         'Individual' => [
           ['first_name', 'last_name'],

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -408,7 +408,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           $value = NULL;
           foreach ($customDataType as $dataType) {
             if (array_key_exists($dataType, CRM_Core_SelectValues::customGroupExtends())) {
-              if (in_array($dataType, ['Individual', 'Household', 'Organization'])) {
+              if (in_array($dataType, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
                 $val = "'" . CRM_Utils_Type::escape($dataType, 'String') . "', 'Contact' ";
               }
               else {
@@ -2672,7 +2672,7 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
    */
   public function getEntity() {
     $entity = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->custom_group_id, 'extends');
-    return in_array($entity, ['Individual', 'Household', 'Organization']) ? 'Contact' : $entity;
+    return in_array($entity, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE) ? 'Contact' : $entity;
   }
 
   /**

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -1014,11 +1014,11 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Test\Ho
       return $fields;
     }
 
-    $types = ['Individual', 'Organization', 'Household'];
+    $types = CRM_Contact_BAO_ContactType::basicTypes(TRUE);
     foreach ($params['mapper'] as $key => $value) {
       $contactType = NULL;
       foreach ($value as $k => $v) {
-        if (in_array($v[0], $types)) {
+        if (in_array($v[0], $types, TRUE)) {
           if ($contactType && $contactType != $v[0]) {
             throw new CRM_Core_Exception(ts("Cannot have two clauses with different types: %1, %2",
               [1 => $contactType, 2 => $v[0]]

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -414,7 +414,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
       }
     }
 
-    $contactTypes = ['Individual', 'Household', 'Organization'];
+    $contactTypes = CRM_Contact_BAO_ContactType::basicTypes(TRUE);
     $subTypes = CRM_Contact_BAO_ContactType::subTypes();
 
     $profileTypeComponent = array_intersect($components, $profileTypes);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3340,8 +3340,7 @@ SELECT  group_id
   public static function checkForMixProfiles($profileIds) {
     $mixProfile = FALSE;
 
-    $contactTypes = ['Individual', 'Household', 'Organization'];
-    $subTypes = CRM_Contact_BAO_ContactType::subTypes();
+    $contactTypes = CRM_Contact_BAO_ContactType::basicTypes(TRUE);
 
     $components = ['Contribution', 'Participant', 'Membership', 'Activity'];
 
@@ -3352,7 +3351,7 @@ SELECT  group_id
       if ($profileType == 'Contact') {
         continue;
       }
-      if (in_array($profileType, $contactTypes)) {
+      if (in_array($profileType, $contactTypes, TRUE)) {
         if (!isset($typeCount['ctype'][$profileType])) {
           $typeCount['ctype'][$profileType] = 1;
         }
@@ -3363,7 +3362,7 @@ SELECT  group_id
           break;
         }
       }
-      elseif (in_array($profileType, $components)) {
+      elseif (in_array($profileType, $components, TRUE)) {
         $mixProfile = TRUE;
         break;
       }

--- a/CRM/Dedupe/BAO/DedupeRule.php
+++ b/CRM/Dedupe/BAO/DedupeRule.php
@@ -241,7 +241,7 @@ class CRM_Dedupe_BAO_DedupeRule extends CRM_Dedupe_DAO_DedupeRule {
     if (!$entity) {
       // This means we have stored a custom field rather than an entity name in rule_table, figure out the entity.
       $entity = civicrm_api3('CustomGroup', 'getvalue', ['table_name' => $this->rule_table, 'return' => 'extends']);
-      if (in_array($entity, ['Individual', 'Household', 'Organization'])) {
+      if (in_array($entity, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
         $entity = 'Contact';
       }
       $fieldName = 'custom_' . civicrm_api3('CustomField', 'getvalue', ['column_name' => $fieldName, 'return' => 'id']);

--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -87,7 +87,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
         'civicrm_website',
       ];
 
-      foreach (['Individual', 'Organization', 'Household'] as $ctype) {
+      foreach (CRM_Contact_BAO_ContactType::basicTypes() as $ctype) {
         // take the table.field pairs and their titles from importableFields() if the table is supported
         foreach (CRM_Contact_BAO_Contact::importableFields($ctype) as $iField) {
           if (isset($iField['where'])) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5426,7 +5426,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    */
   protected function getContactColumns($options = []) {
     $defaultOptions = [
-      'custom_fields' => ['Individual', 'Contact', 'Organization'],
+      'custom_fields' => CRM_Contact_BAO_ContactType::basicTypes(),
       'fields_defaults' => ['display_name', 'id'],
       'order_bys_defaults' => ['sort_name ASC'],
       'contact_type' => NULL,

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -968,8 +968,8 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
         }
         elseif (
           CRM_Utils_Array::value(1, $fields['field_name']) == 'contact_sub_type' &&
-          !in_array($profileType, ['Individual', 'Household', 'Organization']) &&
-          !in_array($profileType, CRM_Contact_BAO_ContactType::subTypes())
+          !in_array($profileType, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE) &&
+          !in_array($profileType, CRM_Contact_BAO_ContactType::subTypes(), TRUE)
         ) {
           $errors['field_name'] = ts('Cannot add or update profile field Contact Subtype as profile type is not one of Individual, Household or Organization.');
         }

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -210,7 +210,7 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
     }
 
     // Adding the oddball "formatting" field here because there's no other place to put it
-    foreach (['Individual', 'Organization', 'Household'] as $type) {
+    foreach (CRM_Contact_BAO_ContactType::basicTypes() as $type) {
       if (isset($civiSchema[$type . 'Model'])) {
         $civiSchema[$type . 'Model']['schema'] += [
           'formatting' => [

--- a/CRM/Utils/Migrate/Export.php
+++ b/CRM/Utils/Migrate/Export.php
@@ -483,7 +483,7 @@ class CRM_Utils_Migrate_Export {
             }
             $types = explode(CRM_Core_DAO::VALUE_SEPARATOR, substr($object->$name, 1, -1));
             $values = [];
-            if (in_array($object->extends, ['Individual', 'Organization', 'Household'])) {
+            if (in_array($object->extends, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
               $key = 'contact_type';
               $values = $types;
             }

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -221,7 +221,7 @@ WHERE      v.option_group_id = %1
                 $valueIDs[] = $relTypeId;
               }
             }
-            elseif (in_array($customGroup->extends, ['Individual', 'Organization', 'Household'])) {
+            elseif (in_array($customGroup->extends, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
               $valueIDs = $optionValues;
             }
             elseif (in_array($customGroup->extends, ['Contribution', 'ContributionRecur'])) {

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1096,7 +1096,7 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
   $values['custom'] = [];
   $checkCheckBoxField = FALSE;
   $entity = $extends;
-  if (in_array($extends, ['Household', 'Individual', 'Organization'])) {
+  if (in_array($extends, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
     $entity = 'Contact';
   }
 

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -109,7 +109,7 @@ class AfformAdminMeta {
       'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'fk_entity', 'readonly'],
       'where' => [['input_type', 'IS NOT NULL']],
     ];
-    if (in_array($entityName, ['Individual', 'Household', 'Organization'])) {
+    if (in_array($entityName, \CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
       $params['values']['contact_type'] = $entityName;
       $entityName = 'Contact';
     }

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -144,7 +144,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
         $scanBlocks($info['definition']['layout']);
       }
 
-      if (array_intersect($entities, ['Individual', 'Household', 'Organization'])) {
+      if (array_intersect($entities, \CRM_Contact_BAO_ContactType::basicTypes(TRUE))) {
         $entities[] = 'Contact';
       }
 
@@ -204,7 +204,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
 
     // Optimization - since contact fields are a combination of these three,
     // we'll combine them client-side rather than sending them via ajax.
-    elseif (array_intersect($entities, ['Individual', 'Household', 'Organization'])) {
+    elseif (array_intersect($entities, \CRM_Contact_BAO_ContactType::basicTypes(TRUE))) {
       $entities = array_diff($entities, ['Contact']);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Uses a function to return contact types wherever they're needed.

Before
----------------------------------------
Codebase littered with hardcoded arrays like `['Individual', 'Organization', 'Household']`.

After
----------------------------------------
Uses function which returns that array.

Technical Details
----------------------------------------
This makes code more flexible/forgiving if new contact types are added in the future, or if existing contact types are disabled.

Also passes `TRUE` as the 3rd param to `in_array()` which is best-practice to avoid type coercion.