### PR TITLE
Ensure getDuplicateContacts always returns an array

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3572,8 +3572,9 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    *   The context if relevant, eg. ['event_id' => X]
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
-  public static function getDuplicateContacts($input, $contactType, $rule = 'Unsupervised', $excludedContactIDs = [], $checkPermissions = TRUE, $ruleGroupID = NULL, $contextParams = []) {
+  public static function getDuplicateContacts(array $input, string $contactType, string $rule = 'Unsupervised', $excludedContactIDs = [], $checkPermissions = TRUE, $ruleGroupID = NULL, $contextParams = []): array {
     $dedupeParams = CRM_Dedupe_Finder::formatParams($input, $contactType);
     $dedupeParams['check_permission'] = $checkPermissions;
     $dedupeParams['contact_type'] = $contactType;
@@ -3586,7 +3587,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     if (!$dedupeResults['handled']) {
       $dedupeResults['ids'] = CRM_Dedupe_Finder::dupesByParams($dedupeParams, $contactType, $rule, $excludedContactIDs, $ruleGroupID);
     }
-    return $dedupeResults['ids'];
+    return $dedupeResults['ids'] ?? [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Ensure getDuplicateContacts always returns an array

Before
----------------------------------------
The function returns an array but is not 'forced' to do so  it is theoretically possible a hook could cause it to return NULL or another empty variant 

After
----------------------------------------
Always returns an array - calling code no longer needs to check


Technical Details
----------------------------------------

Comments
----------------------------------------
