### PR TITLE
[REF] Stop returning unused variables

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -222,7 +222,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
       self::addRecent($params, $relationship);
     }
 
-    return [$valid, $invalid, $duplicate, $saved, $relationshipIds, $relationships];
+    return [$valid, $duplicate];
   }
 
   /**

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -893,7 +893,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Contact_Import_Parser {
                 'contact' => $primaryContactId,
               ];
 
-              [$valid, $invalid, $duplicate, $saved, $relationshipIds] = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationParams, $relationIds);
+              [$valid, $duplicate] = CRM_Contact_BAO_Relationship::legacyCreateMultiple($relationParams, $relationIds);
 
               if ($valid || $duplicate) {
                 $relationIds['contactTarget'] = $relContactId;

--- a/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/RelationshipTest.php
@@ -147,82 +147,6 @@ DELETE FROM civicrm_contact_type
   }
 
   /**
-   * Methods create relationshipe within same contact type with invalid Relationships.
-   */
-  public function testRelationshipCreateInvalidWithinSameType() {
-    //check for Individual to Parent
-    $relTypeParams = [
-      'name_a_b' => 'indivToparent',
-      'name_b_a' => 'parentToindiv',
-      'contact_type_a' => 'Individual',
-      'contact_type_b' => 'Individual',
-      'contact_sub_type_b' => $this->parent,
-    ];
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
-    $params = [
-      'relationship_type_id' => $relType->id . '_a_b',
-      'contact_check' => [$this->indivi_student => 1],
-    ];
-    $ids = ['contact' => $this->individual];
-
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
-
-    $this->assertEquals($invalid, 1);
-    $this->assertEquals(empty($relationshipIds), TRUE);
-    $this->relationshipTypeDelete($relType->id);
-  }
-
-  /**
-   * Methods create relationshipe within diff contact type with invalid Relationships.
-   */
-  public function testRelCreateInvalidWithinDiffTypeSpocorIndivi() {
-    //check for Sponcer to Individual
-    $relTypeParams = [
-      'name_a_b' => 'SponsorToIndiv',
-      'name_b_a' => 'IndivToSponsor',
-      'contact_type_a' => 'Organization',
-      'contact_sub_type_a' => $this->sponsor,
-      'contact_type_b' => 'Individual',
-    ];
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
-    $params = [
-      'relationship_type_id' => $relType->id . '_a_b',
-      'contact_check' => [$this->individual => 1],
-    ];
-    $ids = ['contact' => $this->indivi_parent];
-
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
-
-    $this->assertEquals($invalid, 1);
-    $this->assertEquals(empty($relationshipIds), TRUE);
-    $this->relationshipTypeDelete($relType->id);
-  }
-
-  public function testRelCreateInvalidWithinDiffTypeStudentSponcor() {
-    //check for Student to Sponcer
-    $relTypeParams = [
-      'name_a_b' => 'StudentToSponser',
-      'name_b_a' => 'SponsorToStudent',
-      'contact_type_a' => 'Individual',
-      'contact_sub_type_a' => $this->student,
-      'contact_type_b' => 'Organization',
-      'contact_sub_type_b' => 'Sponser',
-    ];
-    $relType = CRM_Contact_BAO_RelationshipType::add($relTypeParams);
-    $params = [
-      'relationship_type_id' => $relType->id . '_a_b',
-      'contact_check' => [$this->individual => 1],
-    ];
-    $ids = ['contact' => $this->indivi_parent];
-
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
-
-    $this->assertEquals($invalid, 1);
-    $this->assertEquals(empty($relationshipIds), TRUE);
-    $this->relationshipTypeDelete($relType->id);
-  }
-
-  /**
    * Methods create relationshipe within same contact type with valid data.
    * success expected
    */
@@ -242,11 +166,9 @@ DELETE FROM civicrm_contact_type
       'contact_check' => [$this->indivi_parent => $this->indivi_parent],
     ];
     $ids = ['contact' => $this->individual];
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
+    list($valid) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($valid, 1);
-    $this->assertEquals(empty($relationshipIds), FALSE);
-    $this->relationshipTypeDelete($relType->id);
   }
 
   /**
@@ -269,10 +191,9 @@ DELETE FROM civicrm_contact_type
       'contact_check' => [$this->indivi_student => 1],
     ];
     $ids = ['contact' => $this->organization_sponsor];
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
+    list($valid) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($valid, 1);
-    $this->assertEquals(empty($relationshipIds), FALSE);
     $this->relationshipTypeDelete($relType->id);
   }
 
@@ -293,10 +214,9 @@ DELETE FROM civicrm_contact_type
       'contact_check' => [$this->organization_sponsor => 1],
     ];
     $ids = ['contact' => $this->indivi_student];
-    list($valid, $invalid, $duplicate, $saved, $relationshipIds) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
+    list($valid) = CRM_Contact_BAO_Relationship::legacyCreateMultiple($params, $ids);
 
     $this->assertEquals($valid, 1);
-    $this->assertEquals(empty($relationshipIds), FALSE);
     $this->relationshipTypeDelete($relType->id);
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Only 2 code places call this function (one an unsupported call outside core but in universe & the other in Parser_Contact)
and only the latter uses ANY of the return variables - this fixes the function to stop
returning those that are never used  - this stops them from returning them

Before
----------------------------------------
Only the first & third return values are used from the 2 places that call the function
Core usage in Parser_Contact

![image](https://user-images.githubusercontent.com/336308/148479708-5611c145-d54b-4c01-bb9d-be0a659e2347.png)

Unsupported extension usage

![image](https://user-images.githubusercontent.com/336308/148479784-f69821df-5211-4d67-b981-e067d67ac988.png)

After
----------------------------------------
Only the used values are returned

Technical Details
----------------------------------------
@seamuslee001 this won't break the jma grantapplications extension as you can see from the above screenshot (and none of my patches do as yet) - but the functions was deprecated in 4.6 so really the extension should call the api.... is it still used?

Comments
----------------------------------------
