### PR TITLE
Clarify contents of ids for further fixes

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -165,26 +165,23 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
   public static function legacyCreateMultiple(&$params, $ids = []) {
     $valid = $invalid = $duplicate = $saved = 0;
     $relationships = $relationshipIds = [];
-    $relationshipId = CRM_Utils_Array::value('relationship', $ids, CRM_Utils_Array::value('id', $params));
-
-    //CRM-9015 - the hooks are called here & in add (since add doesn't call create)
+    // clarify that the only key ever pass in the ids array is 'contact'
+    // There is legacy handling for other keys but a universe search on
+    // calls to this function (not supported to be called from outside core)
+    // only returns 2 calls - one in CRM_Contact_Import_Parser_Contact
+    // and the other in jma grant applications (CRM_Grant_Form_Grant_Confirm)
+    // both only pass in contact as a key here.
+    $ids = ['contact' => $ids['contact']];
+    // Likewise neither place ever passed in relationshipID
+    $relationshipId = NULL;
+    $hook = 'create';
+    // CRM-9015 - the hooks are called here & in add (since add doesn't call create)
     // but in future should be tidied per ticket
-    if (empty($relationshipId)) {
-      $hook = 'create';
-    }
-    else {
-      $hook = 'edit';
-    }
-
     // @todo pre hook is called from add - remove it from here
     CRM_Utils_Hook::pre($hook, 'Relationship', $relationshipId, $params);
 
     if (!$relationshipId) {
       // creating a new relationship
-      $dataExists = self::dataExists($params);
-      if (!$dataExists) {
-        return [FALSE, TRUE, FALSE, FALSE, NULL];
-      }
       $relationshipIds = [];
       foreach ($params['contact_check'] as $key => $value) {
         // check if the relationship is valid between contacts.


### PR DESCRIPTION
Overview
----------------------------------------
Clarify contents of ids for further fixes

Before
----------------------------------------
The 2 functions that call this only pass in one key in the `$ids` array (contact) and never pass in `$params['id']` - however a universe search is required to figure that out

Here is the call from the (supported) core code that calls this function 

![image](https://user-images.githubusercontent.com/336308/148481721-95caeb5b-6348-4495-8c77-3471948b64c1.png)

And the unsupported extension code
![image](https://user-images.githubusercontent.com/336308/148481777-dc968182-c4a3-40e0-99af-c53b38cffbbf.png)

There are the only other values the extension passes in as `$params`

![image](https://user-images.githubusercontent.com/336308/148481832-873195a5-417b-4608-b593-5f8b7b7a8720.png)



After
----------------------------------------
It's clear in the function what comes in from the calling functions

Technical Details
----------------------------------------

Comments
----------------------------------------
