### PR TITLE
[REF] Improve APIv4 save functions

### DIFF
--- a/Civi/Api4/Action/Address/AddressSaveTrait.php
+++ b/Civi/Api4/Action/Address/AddressSaveTrait.php
@@ -47,14 +47,16 @@ trait AddressSaveTrait {
   /**
    * @inheritDoc
    */
-  protected function writeObjects(&$items) {
-    foreach ($items as &$item) {
+  protected function write(array $items) {
+    $saved = [];
+    foreach ($items as $item) {
       if ($this->streetParsing && !empty($item['street_address'])) {
         $item = array_merge($item, \CRM_Core_BAO_Address::parseStreetAddress($item['street_address']));
       }
       $item['skip_geocode'] = $this->skipGeocode;
+      $saved[] = \CRM_Core_BAO_Address::add($item, $this->fixAddress);
     }
-    return parent::writeObjects($items);
+    return $saved;
   }
 
 }

--- a/Civi/Api4/Action/CiviCase/CiviCaseSaveTrait.php
+++ b/Civi/Api4/Action/CiviCase/CiviCaseSaveTrait.php
@@ -18,20 +18,19 @@ namespace Civi\Api4\Action\CiviCase;
 trait CiviCaseSaveTrait {
 
   /**
-   * @param array $cases
+   * @param array $items
    * @return array
    */
-  protected function writeObjects(&$cases) {
-    $cases = array_values($cases);
-    $result = parent::writeObjects($cases);
-
-    // If the case doesn't have an id, it's new & needs to be opened.
-    foreach ($cases as $idx => $case) {
+  protected function write(array $items) {
+    $saved = [];
+    foreach ($items as $case) {
+      $saved[] = $result = \CRM_Case_BAO_Case::create($case);
+      // If the case doesn't have an id, it's new & needs to be opened.
       if (empty($case['id'])) {
-        $this->openCase($case, $result[$idx]['id']);
+        $this->openCase($case, $result->id);
       }
     }
-    return $result;
+    return $saved;
   }
 
   /**

--- a/Civi/Api4/Action/Contact/Save.php
+++ b/Civi/Api4/Action/Contact/Save.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Contact;
+
+/**
+ * @inheritDoc
+ */
+class Save extends \Civi\Api4\Generic\DAOSaveAction {
+
+  /**
+   * @param array $items
+   * @return array
+   */
+  protected function write(array $items) {
+    $saved = [];
+    foreach ($items as $item) {
+      // For some reason the contact BAO requires this for updates
+      if (!empty($item['id']) && !\CRM_Utils_System::isNull($item['id'])) {
+        $item['contact_id'] = $item['id'];
+      }
+      $saved[] = \CRM_Contact_BAO_Contact::create($item);
+    }
+    return $saved;
+  }
+
+}

--- a/Civi/Api4/Action/Contact/Update.php
+++ b/Civi/Api4/Action/Contact/Update.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Contact;
+
+/**
+ * @inheritDoc
+ */
+class Update extends \Civi\Api4\Generic\DAOUpdateAction {
+
+  /**
+   * @param array $items
+   * @return array
+   */
+  protected function write(array $items) {
+    $saved = [];
+    foreach ($items as $item) {
+      // For some reason the contact BAO requires this for updates
+      $item['contact_id'] = $item['id'];
+      $saved[] = \CRM_Contact_BAO_Contact::create($item);
+    }
+    return $saved;
+  }
+
+}

--- a/Civi/Api4/Action/EntityTag/Create.php
+++ b/Civi/Api4/Action/EntityTag/Create.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\EntityTag;
+
+/**
+ * @inheritDoc
+ */
+class Create extends \Civi\Api4\Generic\DAOCreateAction {
+  use EntityTagSaveTrait;
+
+}

--- a/Civi/Api4/Action/EntityTag/EntityTagSaveTrait.php
+++ b/Civi/Api4/Action/EntityTag/EntityTagSaveTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\EntityTag;
+
+/**
+ * @inheritDoc
+ */
+trait EntityTagSaveTrait {
+
+  /**
+   * Override method which defaults to 'create' for oddball DAO which uses 'add'
+   *
+   * @param array $items
+   * @return array
+   */
+  protected function write(array $items) {
+    $saved = [];
+    foreach ($items as $item) {
+      $saved[] = \CRM_Core_BAO_EntityTag::add($item);
+    }
+    return $saved;
+  }
+
+}

--- a/Civi/Api4/Action/EntityTag/Save.php
+++ b/Civi/Api4/Action/EntityTag/Save.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\EntityTag;
+
+/**
+ * @inheritDoc
+ */
+class Save extends \Civi\Api4\Generic\DAOSaveAction {
+  use EntityTagSaveTrait;
+
+}

--- a/Civi/Api4/Action/EntityTag/Update.php
+++ b/Civi/Api4/Action/EntityTag/Update.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\EntityTag;
+
+/**
+ * @inheritDoc
+ */
+class Update extends \Civi\Api4\Generic\DAOUpdateAction {
+  use EntityTagSaveTrait;
+
+}

--- a/Civi/Api4/Action/GroupContact/GroupContactSaveTrait.php
+++ b/Civi/Api4/Action/GroupContact/GroupContactSaveTrait.php
@@ -39,12 +39,12 @@ trait GroupContactSaveTrait {
   /**
    * @inheritDoc
    */
-  protected function writeObjects(&$items) {
+  protected function write(array $items) {
     foreach ($items as &$item) {
       $item['method'] = $this->method;
       $item['tracking'] = $this->tracking;
     }
-    return parent::writeObjects($items);
+    return \CRM_Contact_BAO_GroupContact::writeRecords($items);
   }
 
 }

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -28,6 +28,24 @@ class Contact extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\Contact\Update
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\Contact\Update(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Contact\Save
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\Contact\Save(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\Contact\Delete
    */
   public static function delete($checkPermissions = TRUE) {

--- a/Civi/Api4/EntityTag.php
+++ b/Civi/Api4/EntityTag.php
@@ -21,4 +21,31 @@ namespace Civi\Api4;
 class EntityTag extends Generic\DAOEntity {
   use Generic\Traits\EntityBridge;
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\EntityTag\Create
+   */
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\EntityTag\Create('EntityTag', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\EntityTag\Save
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\EntityTag\Save('EntityTag', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\EntityTag\Update
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\EntityTag\Update('EntityTag', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -63,7 +63,7 @@ trait CustomValueActionTrait {
   /**
    * @inheritDoc
    */
-  protected function writeObjects(&$items) {
+  protected function writeObjects($items) {
     $fields = $this->entityFields();
     foreach ($items as $idx => $item) {
       FormattingUtil::formatWriteParams($item, $fields);


### PR DESCRIPTION
Overview
----------------------------------------
Refactors APIv4 create/update functions to make the code more flexible & maintainable.

Before
----------------------------------------
Dealing with oddball BAOs meant a bunch of hardcoded exceptions written into the APIv4 `writeObjects` function.

After
----------------------------------------
APIv4 `writeObjects` function refactored into smaller pieces.
Oddball handling moved into specific APIs.
Use `@deprecated` annotations in the BAO to decide whether to use generic `writeRecords` function.
Starts to centralize saving custom data rather than make each BAO responsible for it, which should make it easier to opt-in new entities to having custom data.
