### PR TITLE
Stop calling hook twice

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -332,12 +332,6 @@ WHERE  id IN ( $idString )
     $relationships = $relationshipIds = [];
     $ids = ['contact' => $contactID];
 
-    //CRM-9015 - the hooks are called here & in add (since add doesn't call create)
-    // but in future should be tidied per ticket
-    $hook = 'create';
-    // @todo pre hook is called from add - remove it from here
-    CRM_Utils_Hook::pre($hook, 'Relationship', NULL, $params);
-
     // creating a new relationship
     $dataExists = CRM_Contact_BAO_Relationship::dataExists($params);
     if (!$dataExists) {

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -174,11 +174,6 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     $ids = ['contact' => $ids['contact']];
     // Likewise neither place ever passed in relationshipID
     $relationshipId = NULL;
-    $hook = 'create';
-    // CRM-9015 - the hooks are called here & in add (since add doesn't call create)
-    // but in future should be tidied per ticket
-    // @todo pre hook is called from add - remove it from here
-    CRM_Utils_Hook::pre($hook, 'Relationship', $relationshipId, $params);
 
     if (!$relationshipId) {
       // creating a new relationship


### PR DESCRIPTION

Overview
----------------------------------------
Stop calling hook twice

Before
----------------------------------------
Relationship pre hook called twice on import & when creating current employer (and a JMA extension)

After
----------------------------------------
Only called once - per standard behaviour

Technical Details
----------------------------------------
Per the code comments this hook is called here but also in add. This is all about the crazy
history of this function - which used to be tied to the relationship form.

I can't think of any valid use for calling the hook twice - but I can think of reasons it
would be bad...

Comments
----------------------------------------
I added  a note to the change log on this one https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/hooks/changes.md