### PR TITLE
Remove check for contact_check as it is always an array here

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -332,11 +332,6 @@ WHERE  id IN ( $idString )
     $relationships = $relationshipIds = [];
     $ids = ['contact' => $contactID];
 
-    // creating a new relationship
-    $dataExists = CRM_Contact_BAO_Relationship::dataExists($params);
-    if (!$dataExists) {
-      return [FALSE, TRUE, FALSE, FALSE, NULL];
-    }
     $relationshipIds = [];
     foreach ($params['contact_check'] as $key => $value) {
       // check if the relationship is valid between contacts.

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -512,9 +512,11 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    *
    * @param array $params
    *
+   * @deprecated
    * @return bool
    */
   public static function dataExists($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('obsolete');
     return (isset($params['contact_check']) && is_array($params['contact_check']));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove check for contact_check as it is always an array here

Before
----------------------------------------
contact_check is always set & always an array in this function as it is only called from one place - that sets an array

![image](https://user-images.githubusercontent.com/336308/148518983-20fd31e0-dd38-4b0a-8d4c-0e2df5b716f0.png)

dataExists just checks that it IS an array AND it is only called from one place

After
----------------------------------------
dataExists call removed and as it is the last call it is deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
