### PR TITLE
Address test fails in php 7 min matrix

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1145,7 +1145,8 @@ HTACCESS;
     finally {
       restore_error_handler();
     }
-    return $is_dir;
+    // In php8 the return value from is_dir() is always bool but in php7 it can be null, so normalize.
+    return (bool) $is_dir;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
In php 7 is_dir() could return null in unusual situations. In php 8 it always returns bool.

Before
----------------------------------------
Type error

After
----------------------------------------
It might output warnings in the jenkins log for php 7 but test passes.

Technical Details
----------------------------------------
Coerce null to bool (false) to match php 8.

Comments
----------------------------------------
@totten @seamuslee001 