### PR TITLE
APIv4 - Fix incorrect placement of decodeRows in loop

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -169,7 +169,6 @@ trait DAOActionTrait {
       }
 
       $result[] = $this->baoToArray($createResult, $item);
-      \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
     }
 
     // Use bulk `writeRecords` method if the BAO doesn't have a create or add method
@@ -181,6 +180,7 @@ trait DAOActionTrait {
       }
     }
 
+    \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
     FormattingUtil::formatOutputValues($result, $this->entityFields());
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------
APIv4 - fix misplaced code which degrades performance.

Technical Details
----------------------------------------
The funciton is designed to loop through all items, so needs to be placed outside the loop that creates the items.