### PR TITLE
APIv4 - Docblock updates, mark BAO::create functions deprecated

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -75,13 +75,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
   }
 
   /**
-   * Takes an associative array and creates a custom field object.
+   * Deprecated in favor of writeRecords & APIv4
    *
-   * This function is invoked from within the web form layer and also from the api layer
-   *
+   * @deprecated
    * @param array $params
-   *   (reference) an assoc array of name/value pairs.
-   *
    * @return CRM_Core_DAO_CustomField
    */
   public static function create($params) {

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -42,12 +42,11 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
   }
 
   /**
-   * Add/update navigation record.
+   * Deprecated in favor of APIv4
    *
+   * @deprecated
    * @param array $params Submitted values
-   *
    * @return CRM_Core_DAO_Navigation
-   *   navigation object
    */
   public static function add(&$params) {
     $navigation = new CRM_Core_DAO_Navigation();

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -66,14 +66,15 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implemen
   }
 
   /**
-   * Save the values of a WordReplacement.
+   * Deprecated update function.
    *
+   * @deprecated
    * @param array $params
    * @param int $id
-   *
    * @return array
    */
   public static function edit(&$params, &$id) {
+    CRM_Core_Error::deprecatedWarning('APIv4');
     $wordReplacement = new CRM_Core_DAO_WordReplacement();
     $wordReplacement->id = $id;
     $wordReplacement->copyValues($params);
@@ -85,10 +86,10 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implemen
   }
 
   /**
-   * Create a new WordReplacement.
+   * Deprecated create function.
    *
+   * @deprecated
    * @param array $params
-   *
    * @return array
    */
   public static function create($params) {

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -95,7 +95,7 @@ trait DAOActionTrait {
   }
 
   /**
-   * Write bao objects as part of a create/update action.
+   * Write bao objects as part of a create/update/save action.
    *
    * @param array $items
    *   The records to write to the DB.


### PR DESCRIPTION
Overview
----------------------------------------
Marks some BAO functions `@deprecated` and gives a deprecation notice for an unused function.
