### PR TITLE
[NFC] isDir unit test fails on php 7 'min' matrix

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1124,9 +1124,10 @@ HTACCESS;
    * It should either return FALSE, or the value returned from is_dir().
    *
    * @param string|null $dir
-   * @return bool
+   * @return bool|null
+   *   In php8 the return value from is_dir() is always bool but in php7 it can be null.
    */
-  public static function isDir(?string $dir): bool {
+  public static function isDir(?string $dir) {
     set_error_handler(function($errno, $errstr) {
       // If this is open_basedir-related, convert it to an exception so we
       // can catch it.

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -253,9 +253,16 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
 
     // Note that in php8 is_dir changed in php itself to return false with no warning for these. It used to give `is_dir() expects parameter 1 to be a valid path, string given`. See https://github.com/php/php-src/commit/7bc7a80445f2bb349891d3cccfef2d589c48607e
     clearstatcache();
-    $this->assertFalse(CRM_Utils_File::isDir('./testIsDir/' . chr(0)));
-    clearstatcache();
-    $this->assertFalse(CRM_Utils_File::isDir("testIsDir\0"));
+    if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+      $this->assertNull(CRM_Utils_File::isDir('./testIsDir/' . chr(0)));
+      clearstatcache();
+      $this->assertNull(CRM_Utils_File::isDir("testIsDir\0"));
+    }
+    else {
+      $this->assertFalse(CRM_Utils_File::isDir('./testIsDir/' . chr(0)));
+      clearstatcache();
+      $this->assertFalse(CRM_Utils_File::isDir("testIsDir\0"));
+    }
 
     $this->assertTrue(chdir($old_cwd));
     rmdir($a_dir);


### PR DESCRIPTION
Overview
----------------------------------------
testIsDirSlashVariations unit test fails on php 7 'min' matrix

Before
----------------------------------------
Type error

After
----------------------------------------
There might be some spurious output in the jenkins log on php 7, but test passes.

Technical Details
----------------------------------------
In php 7, is_dir() can return null in some unusual situations. In php 8 it always returns bool. So this just removes the return type hint from the function signature, and then the test checks for different results depending on php version.

Comments
----------------------------------------
In the original test I copied this from which is from php's own source code, they have the luxury of not having to test php against different versions of php within a given branch, and I didn't really think about it.

@totten @seamuslee001 