### PR TITLE
Remove / deprecate case param handling

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -342,10 +342,6 @@ WHERE  id IN ( $idString )
         continue;
       }
 
-      //CRM-16978:check duplicate relationship as per case id.
-      if ($caseId = CRM_Utils_Array::value('case_id', $params)) {
-        $contactFields['case_id'] = $caseId;
-      }
       if (
         CRM_Contact_BAO_Relationship::checkDuplicateRelationship(
           $contactFields,

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -193,7 +193,9 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
         }
 
         //CRM-16978:check duplicate relationship as per case id.
+        // https://issues.civicrm.org/jira/browse/CRM-16978
         if ($caseId = CRM_Utils_Array::value('case_id', $params)) {
+          CRM_Core_Error::deprecatedWarning('this code is believed to be unreachable');
           $contactFields['case_id'] = $caseId;
         }
         if (


### PR DESCRIPTION


Overview
----------------------------------------
Remove / deprecate case param handling

Before
----------------------------------------
Handling for parameter that is explictly not passed in - relationshipParams is the `$params` in this function

![image](https://user-images.githubusercontent.com/336308/148627646-21da8349-dc3f-4a05-9f5b-9c62a125900b.png)

After
----------------------------------------
poof 

Technical Details
----------------------------------------

Comments
----------------------------------------
