### PR TITLE
Fix phpdoc types for $_query in CRM_Core_Selector_Base subclasses

### DIFF
--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -113,7 +113,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
   /**
    * The query object.
    *
-   * @var \CRM_Contact_BAO_Query
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 
@@ -395,7 +395,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
   }
 
   /**
-   * @return \CRM_Contact_BAO_Query
+   * @return CRM_Contact_BAO_Query
    */
   public function &getQuery() {
     return $this->_query;

--- a/CRM/Campaign/Selector/Search.php
+++ b/CRM/Campaign/Selector/Search.php
@@ -103,7 +103,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
   /**
    * The query object.
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 
@@ -348,7 +348,7 @@ class CRM_Campaign_Selector_Search extends CRM_Core_Selector_Base implements CRM
   }
 
   /**
-   * @return string
+   * @return CRM_Contact_BAO_Query
    */
   public function &getQuery() {
     return $this->_query;

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -106,7 +106,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
   /**
    * The query object
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 
@@ -451,7 +451,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
   }
 
   /**
-   * @return string
+   * @return CRM_Contact_BAO_Query
    */
   public function &getQuery() {
     return $this->_query;

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -118,7 +118,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
   /**
    * The query object
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 
@@ -140,7 +140,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
    * @param string $context
    * @param null $compContext
    *
-   * @return \CRM_Contribute_Selector_Search
+   * @return CRM_Contribute_Selector_Search
    */
   public function __construct(
     &$queryParams,
@@ -622,7 +622,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
   }
 
   /**
-   * @return \CRM_Contact_BAO_Query
+   * @return CRM_Contact_BAO_Query
    */
   public function &getQuery() {
     return $this->_query;

--- a/CRM/Grant/Selector/Search.php
+++ b/CRM/Grant/Selector/Search.php
@@ -104,7 +104,7 @@ class CRM_Grant_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
   /**
    * The query object.
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -107,7 +107,7 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
   /**
    * The query object.
    *
-   * @var string
+   * @var CRM_Contact_BAO_Query
    */
   protected $_query;
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix phpdoc types for $_query in CRM_Core_Selector_Base subclasses

Before
----------------------------------------
$_query variable incorrectly declared as string in various classes, all of which extended CRM_Core_Selector_Base.

After
----------------------------------------
$_query variable correctly documented as CRM_Contact_BAO_Query. As the CRM_Core_Selector_Base objects are not namespaced, leading `\` removed from type for consistency in a handful of cases.
