### PR TITLE
Remove htmlFile validation rule, as it can't possibly work.

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -374,7 +374,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       'date',
       'currentDate',
       'asciiFile',
-      'htmlFile',
       'utf8File',
       'objectExists',
       'optionExists',

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -756,24 +756,6 @@ class CRM_Utils_Rule {
   }
 
   /**
-   * See how file rules are written in HTML/QuickForm/file.php
-   * Checks to make sure the uploaded file is html
-   *
-   * @param array $elementValue
-   *
-   * @return bool
-   *   True if file has been uploaded, false otherwise
-   */
-  public static function htmlFile($elementValue) {
-    if ((isset($elementValue['error']) && $elementValue['error'] == 0) ||
-      (!empty($elementValue['tmp_name']) && $elementValue['tmp_name'] != 'none')
-    ) {
-      return CRM_Utils_File::isHtmlFile($elementValue['tmp_name']);
-    }
-    return FALSE;
-  }
-
-  /**
    * Check if there is a record with the same name in the db.
    *
    * @param string $value


### PR DESCRIPTION
Overview
----------------------------------------
Remove htmlFile validation rule, as it can't possibly work.

Before
----------------------------------------
`CRM_Utils_Rule::htmlFile` is trying to call `CRM_Utils_File::isHtmlFile` which doesn't exist (and I can't find any history of it ever existing, although it might have in the SVN days). Therefore, I can't see how this function can possibly work, it makes sense to remove it.

After
----------------------------------------
htmlFile rule gone.