### PR TITLE
[REF] Centralize BAO handling of custom data

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -65,11 +65,6 @@ class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
       }
     }
 
-    //store custom data
-    if (!empty($params['custom']) && is_array($params['custom'])) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_campaign', $campaign->id);
-    }
-
     return $campaign;
   }
 

--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -74,9 +74,6 @@ class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey implements Civi\Te
 
     $dao = self::writeRecord($params);
 
-    if (!empty($params['custom']) && is_array($params['custom'])) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_survey', $dao->id);
-    }
     return $dao;
   }
 

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -153,24 +153,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
     }
     $paymentParams['status_id'] = $params['status_id'] ?? NULL;
 
-    CRM_Utils_Hook::pre($action, 'Pledge', $params['id'] ?? NULL, $params);
-    $pledge = new CRM_Pledge_DAO_Pledge();
-
-    // if pledge is complete update end date as current date
-    if ($pledge->status_id == 1) {
-      $pledge->end_date = date('Ymd');
-    }
-
-    $pledge->copyValues($params);
-    $pledge->save();
-    CRM_Utils_Hook::post($action, 'Pledge', $pledge->id, $pledge);
-
-    // handle custom data.
-    if (!empty($params['custom']) &&
-      is_array($params['custom'])
-    ) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_pledge', $pledge->id);
-    }
+    $pledge = self::writeRecord($params);
 
     // skip payment stuff in edit mode
     if (empty($params['id']) || $isRecalculatePledgePayment) {

--- a/api/v3/Navigation.php
+++ b/api/v3/Navigation.php
@@ -88,9 +88,11 @@ function civicrm_api3_navigation_create($params) {
 /**
  * Adjust metadata for navigation create action.
  *
- * @param array $params
+ * @param array[] $fields
  */
-function _civicrm_api3_navigation_delete_spec(&$params) {
+function _civicrm_api3_navigation_create_spec(&$fields) {
+  $fields['is_active']['api.default'] = TRUE;
+  $fields['domain_id']['api.default'] = CRM_Core_Config::domainID();
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Refactors the BAO to handle custom data from a central `writeRecords` function, and updates APIv3 accordingly.

Technical Details
----------------------------------------
- Refactors a couple BAOs which use `writeRecord`, as they no longer need to write the custom data themselves.
- Stops APIv3 passing the deprecated `$ids` param to `BAO::create`
- Switches APIv3 to use `BAO::writeRecord` when `BAO::create` or `BAO::add` are `@deprecated`
- In APIv3, trust `BAO::writeRecord` to handle custom data

Comments
----------------------------------------
The possible breaking change here is not passing the long-deprecated `$ids` from APIv3 to `BAO::create/add` functions, but I note that APIv4 calls those same functions without passing the param and works fine.