### PR TITLE
Fix input type for smarty number formatting (more forgiving)

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmMoney.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmMoney.php
@@ -18,7 +18,7 @@
 /**
  * Format the given monetary amount (and currency) for display
  *
- * @param float $amount
+ * @param string|int|float $amount
  *   The monetary amount up for display.
  * @param string|null $currency
  *   The (optional) currency.

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -23,7 +23,7 @@ class Format {
   /**
    * Get formatted money
    *
-   * @param string $amount
+   * @param string|int|float $amount
    * @param string|null $currency
    *   Currency, defaults to site currency if not provided.
    * @param string|null $locale
@@ -33,7 +33,15 @@ class Format {
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
    */
-  public function money(string $amount, ?string $currency = NULL, ?string $locale = NULL): string {
+  public function money($amount, ?string $currency = NULL, ?string $locale = NULL): string {
+    // Empty value => empty string
+    if (is_null($amount) || $amount === '' || $amount === FALSE) {
+      return '';
+    }
+    // Verify the amount is a number or numeric string/object
+    elseif ($amount === TRUE || !is_numeric((string) $amount)) {
+      throw new \CRM_Core_Exception('Invalid value for type money');
+    }
     if (!$currency) {
       $currency = Civi::settings()->get('defaultCurrency');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a hard-crash with CiviGrant, regression in 5.46 caused by #22309 .
This is a more forgiving version of #22427 

Before
----------------------------------------
- Enable CiviGrant
- Create a grant
- Hard crash on "Find Grants", "Grants Dashboard" or Grants tab of contact summary screen.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
There were confusing mismatches between docblocks and the function signatures. `smarty_modifier_crmMoney` had `$amount` annotated as type `float` but passed it into `Format::money` which requires type `string`, which passes it onto `Money::of` which accepts types `BigNumber|int|float|string`.
I think I've straightened it out.