### PR TITLE
Fix class references in phpdoc comments

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -28,7 +28,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
   protected $_testID;
 
   /**
-   * @var \CRM_Core_DAO_PaymentProcessor
+   * @var \CRM_Financial_DAO_PaymentProcessorType
    * Payment Processor DAO Object
    */
   protected $_paymentProcessorDAO;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -48,7 +48,7 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case {
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
    *
-   * @return CRM_Case_BAO_Case
+   * @return CRM_Case_DAO_Case
    */
   public static function add(&$params) {
     $caseDAO = new CRM_Case_DAO_Case();
@@ -65,7 +65,7 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case {
    * @param array $params
    *   (reference) an assoc array of name/value pairs.
    *
-   * @return CRM_Case_BAO_Case
+   * @return CRM_Case_DAO_Case
    */
   public static function &create(&$params) {
     // CRM-20958 - These fields are managed by MySQL triggers. Watch out for clients resaving stale timestamps.

--- a/CRM/Contact/Form/Task/Map.php
+++ b/CRM/Contact/Form/Task/Map.php
@@ -118,7 +118,7 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
    * @param array $ids
    * @param int $locationId
    *   Location_id.
-   * @param CRM_Core_Page $page
+   * @param CRM_Core_Form $page
    * @param bool $addBreadCrumb
    * @param string $type
    */
@@ -209,12 +209,12 @@ class CRM_Contact_Form_Task_Map extends CRM_Contact_Form_Task {
     }
 
     $center = [
-      'lat' => (float ) $sumLat / count($locations),
-      'lng' => (float ) $sumLng / count($locations),
+      'lat' => (float) $sumLat / count($locations),
+      'lng' => (float) $sumLng / count($locations),
     ];
     $span = [
-      'lat' => (float ) ($maxLat - $minLat),
-      'lng' => (float ) ($maxLng - $minLng),
+      'lat' => (float) ($maxLat - $minLat),
+      'lng' => (float) ($maxLng - $minLng),
     ];
     $page->assign_by_ref('center', $center);
     $page->assign_by_ref('span', $span);

--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -17,10 +17,13 @@
 class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType implements \Civi\Test\HookInterface {
 
   /**
-   * Static holder for the default LT.
-   * @var int
+   * @var CRM_Core_DAO_LocationType|null
    */
   public static $_defaultLocationType = NULL;
+
+  /**
+   * @var int|null
+   */
   public static $_billingLocationType = NULL;
 
   /**
@@ -31,7 +34,7 @@ class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType implements \Ci
    * @param array $defaults
    *   (reference ) an assoc array to hold the flattened values.
    *
-   * @return CRM_Core_BAO_LocaationType|null
+   * @return CRM_Core_DAO_LocationType|null
    *   object on success, null otherwise
    */
   public static function retrieve(&$params, &$defaults) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix class references in phpdoc comments.

Before
----------------------------------------
Comments were wrong.

After
----------------------------------------
Comments are right.
