### PR TITLE
Enotice fix

### DIFF
--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -26,7 +26,7 @@
   </tbody>
 </table>
 
-<div class="crm-submit-buttons">{if in_array($batchStatus, array('Open', 'Reopened'))}{$form.close_batch.html}{/if} {$form.export_batch.html}</div>
+<div class="crm-submit-buttons">{if array_key_exists('close_batch', $form)}{$form.close_batch.html}{/if} {if array_key_exists('close_batch', $form)}{$form.export_batch.html}{/if}</div>
 
 {if in_array($batchStatus, array('Open', 'Reopened'))} {* Add / remove transactions only allowed for Open/Reopened batches *}
   <br /><div class="form-layout-compressed">{$form.trans_remove.html}&nbsp;{$form.rSubmit.html}</div><br/>
@@ -75,17 +75,17 @@ CRM.$(function($) {
 });
 function assignRemove(recordID, op) {
   var recordBAO = 'CRM_Batch_BAO_Batch';
-  if (op == 'assign' || op == 'remove') {
-    recordBAO = 'CRM_Batch_BAO_EntityBatch';   
+  if (op === 'assign' || op === 'remove') {
+    recordBAO = 'CRM_Batch_BAO_EntityBatch';
   }
   var entityID = {/literal}"{$entityID}"{literal};
-  if (op == 'close' || op == 'export') {
+  if (op === 'close' || op === 'export') {
     var mismatch = checkMismatch();
   }
   else {
     CRM.$('#mark_x_' + recordID).closest('tr').block({message: {/literal}'{ts escape="js"}Updating{/ts}'{literal}});
   }
-  if (op == 'close' || (op == 'export' && mismatch.length)) {
+  if (op === 'close' || (op === 'export' && mismatch.length)) {
     CRM.$("#enableDisableStatusMsg").dialog({
       title: {/literal}'{ts escape="js"}Close Batch{/ts}'{literal},
       modal: true,


### PR DESCRIPTION
Overview
----------------------------------------
The form [conditionally adds the export & close buttons to the template](https://github.com/civicrm/civicrm-core/blob/52187095f75ab846347c02fdc38121bb1dffccef/CRM/Financial/Form/BatchTransaction.php#L77-L92
). The template does a check before adding the close button, and not before adding the export button. However, the conditional it DOES apply (checking status) is also applied by the form - so better to just check if it is applied.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/148704113-a1834a60-9042-4f1a-aa6b-88a92969978d.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/148704101-e05d32bb-740f-49f8-9b5c-a9c4a983f31e.png)


Technical Details
----------------------------------------
The buttons are not applied due to permissions - I think the demo user should have the ability to see these buttons & will do a PR to that effect

Comments
----------------------------------------

https://github.com/civicrm/civicrm-buildkit/pull/666 adds the permissions