### PR TITLE
fixes report#93: SearchKit shows broken external URLs

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -430,7 +430,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   private function getUrl(string $path, $query = NULL) {
-    if ($path[0] === '/' || strpos($path, 'http://') || strpos($path, 'https://')) {
+    if ($path[0] === '/' || strpos($path, 'http://') !== FALSE || strpos($path, 'https://') !== FALSE) {
       return $path;
     }
     // Use absolute urls when downloading spreadsheet


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit no longer links correctly to external URLs.  This is a regression introduced by #21820 in Civi 5.44.  Detailed replication steps here: https://lab.civicrm.org/dev/report/-/issues/93

Before
----------------------------------------
External URLs are prefixed with the internal URL.

After
----------------------------------------
External URLs are rendered correctly.

Technical Details
----------------------------------------
I think this is just a truthiness issue - `strpos` returns `0` if the needle is found at the first position in the haystack.