### PR TITLE
Format money on transaction list

### DIFF
--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -355,10 +355,10 @@ class CRM_Financial_Page_AJAX {
             $row[$financialItem->id][$columnKey] = $row[$financialItem->id][$columnKey] . $checkNumber;
           }
         }
-        elseif ($columnKey == 'amount' && $financialItem->$columnKey) {
-          $row[$financialItem->id][$columnKey] = CRM_Utils_Money::format($financialItem->$columnKey, $financialItem->currency);
+        elseif ($columnKey === 'amount' && $financialItem->$columnKey) {
+          $row[$financialItem->id][$columnKey] = Civi::format()->money($financialItem->$columnKey, $financialItem->currency);
         }
-        elseif ($columnKey == 'transaction_date' && $financialItem->$columnKey) {
+        elseif ($columnKey === 'transaction_date' && $financialItem->$columnKey) {
           $row[$financialItem->id][$columnKey] = CRM_Utils_Date::customFormat($financialItem->$columnKey);
         }
         elseif ($columnKey == 'receive_date' && $financialItem->$columnKey) {

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -29,7 +29,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
    *
    * Test focus is on ensuring changes to how labels are retrieved does not cause regression.
    */
-  public function testGetFinancialTransactionsList() {
+  public function testGetFinancialTransactionsList(): void {
     $individualID = $this->individualCreate();
     $this->contributionCreate(['contact_id' => $individualID, 'trxn_id' => 12345]);
     $batch = $this->callAPISuccess('Batch', 'create', ['title' => 'test', 'status_id' => 'Open']);
@@ -43,7 +43,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
     $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList();
     $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
     $this->assertEquals('{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["","<a href=\"/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3\" data-tooltip-url=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4&amp;is_show_email_task=1\" class=\"crm-summary-link\"><div'
-    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 100.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
+    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$100.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
     . '"Credit Card","Completed","Donation","<span><a href=\"/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
     . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a></span>"]] }', $json);
   }
@@ -51,7 +51,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
   /**
    * Test getting open batch.
    */
-  public function testGetFinancialTransactionsListOpenBatch() {
+  public function testGetFinancialTransactionsListOpenBatch(): void {
     $individualID = $this->individualCreate();
     $this->contributionCreate(['contact_id' => $individualID, 'trxn_id' => 12345]);
     $batch = $this->callAPISuccess('Batch', 'create', ['title' => 'test', 'status_id' => 'Open']);
@@ -67,7 +67,7 @@ class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
     $json = CRM_Financial_Page_AJAX::getFinancialTransactionsList();
     $json = str_replace(rtrim(CIVICRM_UF_BASEURL, '/'), 'http://FIX ME', $json);
     $this->assertEquals('{"sEcho": 1, "iTotalRecords": 1, "iTotalDisplayRecords": 1, "aaData": [ ["<input type=\'checkbox\' id=\'mark_x_2\' name=\'mark_x_2\' value=\'1\' onclick=enableActions(\'x\')></input>","<a href=\"/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3\" data-tooltip-url=\"/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=3&amp;snippet=4&amp;is_show_email_task=1\" class=\"crm-summary-link\"><div'
-    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$ 5.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
+    . ' class=\"icon crm-icon Individual-icon\"></div></a>","<a href=/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=3>Anderson, Anthony</a>","$5.00","12345","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM","' . CRM_Utils_Date::customFormat(date('Ymd')) . ' 12:00 AM",'
     . '"Credit Card","Completed","Donation","<span><a href=\"/index.php?q=civicrm/contact/view/contribution&amp;reset=1&amp;id=1&amp;cid=3&amp;action=view&amp;context=contribution&amp;'
     . 'selectedChild=contribute\" class=\"action-item crm-hover-button\" title=\'View Contribution\' >View</a><a href=\"#\" class=\"action-item crm-hover-button disable-action\" title=\'Assign Transaction\' onclick = \"assignRemove( 2,\'assign\' );\">Assign</a></span>"]] }', $json);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Format money on transaction list civicrm/batchtransaction?reset=1&bid=1

Before
----------------------------------------
In testing #20884 I couldn't tell if it was being correct or mean in complaining I had 2 currencies in my batch - this makes it clear by showing CAD differently to USD (on a US locale site).

(& now I can see that it IS complaining when it shouldn't in the PR I'm testing)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/148705379-0592dbf9-b61d-4bf7-9ece-e2cd08a13f40.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
