### PR TITLE
Simplify variables pass in & out of function

### DIFF
--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -609,20 +609,21 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->assertNotContains('Alabama', $result['values']);
   }
 
-  public function testUpdateSharedAddressWithCustomFields() {
+  /**
+   * Ensure an update to the second address doesn't cause error.
+   *
+   * Avoid "db error: already exists" when re-saving the custom fields.
+   */
+  public function testUpdateSharedAddressWithCustomFields(): void {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
-
     $params = $this->_params;
-    $params['custom_' . $ids['custom_field_id']] = "custom string";
-
+    $params['custom_' . $ids['custom_field_id']] = 'custom string';
     $firstAddress = $this->callAPISuccess($this->_entity, 'create', $params);
-
     $contactIdB = $this->individualCreate();
 
     $secondAddressParams = array_merge(['contact_id' => $contactIdB, 'master_id' => $firstAddress['id']], $firstAddress);
     unset($secondAddressParams['id']);
     $secondAddress = $this->callAPISuccess('Address', 'create', $secondAddressParams);
-    // Ensure an update to the second address doesn't cause a "db error: already exists" when resaving the custom fields.
     $this->callAPISuccess('Address', 'create', ['id' => $secondAddress['id'], 'contact_id' => $contactIdB, 'master_id' => $firstAddress['id']]);
   }
 


### PR DESCRIPTION
Rather than compiling an array, pass in the 3 values. Also
its now obvious that there is only a max of 1 contact_check in the function
so just return rather than 'continuing' (allowing us to de-loop in a more
whitespacey follow up)
