### PR TITLE
Remove support for deprecated key

### DIFF
--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -62,9 +62,4 @@
     <tr>
       <td class="label">{ts}Local path{/ts}</td><td>{if !empty($extension.path)}{$extension.path|escape}{/if}</td>
     </tr>
-    {if !empty($extension.downloadUrl)}
-    <tr>
-      <td class="label">{ts}Download location{/ts}</td><td>{$extension.downloadUrl|escape}</td>
-    </tr>
-    {/if}
 </table>


### PR DESCRIPTION
downloadUrl causes notices when default modifier is on.

It turns out is was deprecated approximately 2 forevers ago

https://docs.civicrm.org/dev/en/latest/extensions/info-xml/#downloadUrl
