### PR TITLE
Remove empty check

### DIFF
--- a/templates/CRM/common/snippet.tpl
+++ b/templates/CRM/common/snippet.tpl
@@ -34,7 +34,7 @@
           {include file="CRM/common/status.tpl"}
         {/if}
 
-        {if !empty($isForm)}
+        {if $isForm}
           {include file="CRM/Form/default.tpl"}
         {else}
           {include file=$tplFile}


### PR DESCRIPTION
We had to ensure this was always assigned for default modifier so remove the
empty to make it clear it is 'sorted'
