### PR TITLE
Use field value function to get html signature

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -316,7 +316,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
             ->tokens('contact', $token, "cs={$cs}");
         }
         elseif ($token === 'signature_html') {
-          $row->format('text/html')->tokens('contact', $token, html_entity_decode($row->context['contact'][$token]));
+          $row->format('text/html')->tokens('contact', $token, html_entity_decode($this->getFieldValue($row, $token)));
         }
         else {
           parent::evaluateToken($row, $this->entity, $token, $row->context['contact']);


### PR DESCRIPTION

Overview
----------------------------------------
Use field value function to get html signature

Before
----------------------------------------
Enotice when accessing signature_text if not set

After
----------------------------------------
no notice

Technical Details
----------------------------------------
The  `getFieldValue` function is used for all other tokens on the contact object and will better access
the right value and return an empty string rather NULL if not set.

I hit this as an enotice writing a test - but it is possibly the cause of this issue
https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/issues/58#issuecomment-966611004

hence targetting the rc

The tokens() function does weird things if you pass it NULL

Comments
----------------------------------------
