### PR TITLE
Simplify getting contact_id from recurring contribution when generating subscription URLs

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1745,17 +1745,7 @@ abstract class CRM_Core_Payment {
           break;
 
         case 'recur':
-          $sql = "
-    SELECT DISTINCT con.contact_id
-      FROM civicrm_contribution_recur rec
-INNER JOIN civicrm_contribution con ON ( con.contribution_recur_id = rec.id )
-     WHERE rec.id = %1";
-          $contactID = CRM_Core_DAO::singleValueQuery($sql, [
-            1 => [
-              $entityID,
-              'Integer',
-            ],
-          ]);
+          $contactID = CRM_Core_DAO::getFieldValue("CRM_Contribute_DAO_ContributionRecur", $entityID, "contact_id");
           $entityArg = 'crid';
           break;
       }


### PR DESCRIPTION
Overview
----------------------------------------
This code has not been changed since at least 2013 (SVN import). I think there was probably a time when `civicrm_contribution_recur` did not have the `contact_id` so needed to be retrieved from the contribution instead.

Before
----------------------------------------
Uses a custom SQL query to get the `contact_id` from a contribution linked to the recurring contribution.

After
----------------------------------------
Uses a standard cached function to get the `contact_id` from the recurring contribution.

Technical Details
----------------------------------------
The recurring contribution has to have the same contact_id as the contribution. In any case this function is generating links to manage the recurring contribution and *not* the contribution so we would always want the contact_id associated with the recurring contribution.  Using a standard cached function may improve performance slightly and it removes an unnecessary custom query.

Comments
----------------------------------------
