### PR TITLE
Support contributionRecur tokens via ImpliedContextSubscriber when a membership or contribution is passed to tokenProcessor

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -584,7 +584,9 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
         $html_message = str_replace('{contribution.' . $token . '}', implode($separator, $resolvedTokens[$token]), $html_message);
       }
     }
-    $tokenContext['contributionId'] = $contributionID;
+    else {
+      $tokenContext['contributionId'] = $contributionID;
+    }
     return CRM_Core_TokenSmarty::render(['html' => $html_message], $tokenContext)['html'];
   }
 

--- a/Civi/Token/ImpliedContextSubscriber.php
+++ b/Civi/Token/ImpliedContextSubscriber.php
@@ -109,6 +109,18 @@ class ImpliedContextSubscriber implements EventSubscriberInterface {
       'fk' => 'civicrm_participant.event_id',
       'destEntityId' => 'eventId',
     ];
+    yield [
+      'srcEntityId' => 'membershipId',
+      'srcEntityRec' => 'membership',
+      'fk' => 'civicrm_membership.contribution_recur_id',
+      'destEntityId' => 'contribution_recurId',
+    ];
+    yield [
+      'srcEntityId' => 'contributionId',
+      'srcEntityRec' => 'contribution',
+      'fk' => 'civicrm_contribution.contribution_recur_id',
+      'destEntityId' => 'contribution_recurId',
+    ];
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -377,6 +377,11 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
     foreach (CRM_Core_SelectValues::contributionTokens() as $token => $label) {
       $legacyTokens[substr($token, 14, -1)] = $label;
       if (strpos($token, ':') === FALSE) {
+        // Legacy tokens did not support "implied tokens" so does not return contribution_recur.X
+        // But tokenProcessor will do if contribution is linked to contribution_recur.
+        if (substr($token, 1, 19) === 'contribution_recur.') {
+          continue;
+        }
         $realLegacyTokens[substr($token, 14, -1)] = $label;
       }
     }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -506,7 +506,7 @@ contribution_recur.payment_instrument_id:name :Check
     ]);
     $tokens = $tokenProcessor->listTokens();
     // Add in custom tokens as token processor supports these.
-    $expectedTokens = array_merge($expectedTokens, $this->getTokensAdvertisedByTokenProcessorButNotLegacy());
+    $expectedTokens = array_merge($expectedTokens, $this->getTokensAdvertisedByTokenProcessorButNotLegacy(), $this->getContributionRecurTokens());
     $this->assertEquals(array_merge($expectedTokens, $this->getDomainTokens()), $tokens);
     $tokenProcessor->addMessage('html', $tokenString, 'text/plain');
     $tokenProcessor->addRow(['membershipId' => $this->getMembershipID()]);

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -507,7 +507,9 @@ contribution_recur.payment_instrument_id:name :Check
     $tokens = $tokenProcessor->listTokens();
     // Add in custom tokens as token processor supports these.
     $expectedTokens = array_merge($expectedTokens, $this->getTokensAdvertisedByTokenProcessorButNotLegacy(), $this->getContributionRecurTokens());
-    $this->assertEquals(array_merge($expectedTokens, $this->getDomainTokens()), $tokens);
+    // $expectedTokens contains unadvertised tokens (ie. won't show for selection for the user).
+    // But listTokens() only gets us the "advertised" tokens so we need to "remove" all the unadvertised ones before checking they are equal.
+    $this->assertEquals(array_diff_key(array_merge($expectedTokens, $this->getDomainTokens()), $this->getUnadvertisedTokens()), $tokens);
     $tokenProcessor->addMessage('html', $tokenString, 'text/plain');
     $tokenProcessor->addRow(['membershipId' => $this->getMembershipID()]);
     $tokenProcessor->evaluate();


### PR DESCRIPTION
Overview
----------------------------------------
Following the recent work on tokenProcessor by @totten we can automatically render linked entities via `ImpliedContextSubscriber`. Eg. participant gives you event. This PR adds support for membership and contribution giving you contribution_recur

Before
----------------------------------------
`contribution_recur` tokens not automatically available unless you pass in the contributionRecur ID.

After
----------------------------------------
`contribution_recur` tokens automatically available when you pass in a contribution or membership and it has a linked contribution_recur ID (via the contribution_recur_id field).

Technical Details
----------------------------------------
Adds test for the two new implied contexts (membership->contributionRecur, contirbution->contributionRecur).

Comments
----------------------------------------

