### PR TITLE
Crash when adding a relationship when CiviMember is disabled

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2735,10 +2735,16 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
         return CRM_Core_BAO_Note::getContactNoteCount($contactId);
 
       case 'contribution':
-        return CRM_Contribute_BAO_Contribution::contributionCount($contactId);
+        if (array_key_exists('CiviContribute', CRM_Core_Component::getEnabledComponents())) {
+          return CRM_Contribute_BAO_Contribution::contributionCount($contactId);
+        }
+        return FALSE;
 
       case 'membership':
-        return CRM_Member_BAO_Membership::getContactMembershipCount((int) $contactId, TRUE);
+        if (array_key_exists('CiviMember', CRM_Core_Component::getEnabledComponents())) {
+          return CRM_Member_BAO_Membership::getContactMembershipCount((int) $contactId, TRUE);
+        }
+        return FALSE;
 
       case 'participant':
         return CRM_Event_BAO_Participant::getContactParticipantCount($contactId);


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3025 for a full explanation.  This is a regression introduced in 5.43.

Before
----------------------------------------
Relationship is added, but with error `Key id not found in api results` (in Civi 5.45) or `MembershipType API is not available because CiviMember component is disabled` (Civi 5.47).

After
----------------------------------------
Relationship added, no error.

Comments
----------------------------------------
I considered adding more conditionals for other components, but this problem doesn't seem to manifest on other components - most likely because only adding a relationship is the only way for these counts to change without taking an action that would require the component to be enabled (e.g. adding a membership changes the membership count, but requires CiviMember be enabled).