### PR TITLE
when recurring contribution amount is change, ensure next contribution uses new amount, not old amount

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2245,6 +2245,9 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
         // array_filter with strlen filters out NULL, '' and FALSE but not 0.
       ], 'strlen')
     );
+    if (!empty($input['amount'])) {
+      $templateContribution['total_amount'] = $input['amount'];
+    }
     $contributionParams['line_item'] = $templateContribution['line_item'];
     $contributionParams['status_id'] = 'Pending';
 


### PR DESCRIPTION
When a recurring contribution amount is changed, ensure new contributions
are created using the new amount, not the amount from the template or
initial contribution.

Overview
----------------------------------------
I think this is a regression from 2a750a396be. Roughly speaking, we removed this line that allows the `total_amount` of a repeat transaction to be set via the`$input` array:

```
if (!empty($input['amount'])) {
      $contribution->total_amount = $contributionParams['total_amount'] = $input['amount'];
    }
```
Now, the `total_amount` of the contribution is overriden via the `$input['total_amount']` variable instead. However, that index  doesn't exist when this code is called via the AuthorizeNetIPN class (and, it seems, in most cases). 

As a result, we always get the `total_amount` set on the template or initial contribution, instead of the `total_amount` that the payment processor is reporting.

Before
----------------------------------------

 * Create a recurring contribution using Authorize.net
 * Process at least one contribution
 * Change the amount of the recurring contribution
 * The next recurring contribution will reflect a total amount matching the initial contribution, not matching the changed amount.

After
----------------------------------------
By passing in the 'amount' index, we are sure that the resulting contribution reflects what was actually processed by the payment processor.

Technical Details
----------------------------------------
@eileenmcnaughton - does it seem I am on the right track here? I suspect this would benefit from a unit test but would prefer to get your thoughts before going too far down that route.