### PR TITLE
dev/core#983 Fix Access CiviCampaign permissions (instead of admin)

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -884,7 +884,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $includeComponent = !$excludeComponentHandledActivities || !empty($compObj->info['showActivitiesInCore']);
       if ($includeComponent) {
         if ($compObj->info['name'] == 'CiviCampaign') {
-          $componentPermission = "administer {$compObj->name}";
+          $componentPermission = "manage campaign";
         }
         else {
           $componentPermission = "access {$compObj->name}";

--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -347,7 +347,7 @@ civicrm_activity_assignment.record_type_id = $assigneeID ) ";
     );
 
     $showInterviewer = FALSE;
-    if (CRM_Core_Permission::check('administer CiviCampaign')) {
+    if (CRM_Core_Permission::check('manage campaign')) {
       $showInterviewer = TRUE;
     }
     $form->assign('showInterviewer', $showInterviewer);


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/983

and https://civicrm.stackexchange.com/questions/24409/whats-the-expected-behaviour-for-civicampaign-and-permissions

It's not possible for users without "administer CiviCampaign" to search/access some campaign activities.

Before
----------------------------------------

Non-admins cannot search for campaign data.

After
----------------------------------------

non-admins can search/view campaign data.

Comments
----------------------------------------

I have to admit that I have worked on this a while ago, patched locally and forgot about it. We have been running the patch in production for the past 2 years. A few NDI users required this feature, so I think it's well-tested.

ping @francescbassas @andyburnsco @pfigel (folks who commented on the gitlab issue)