### PR TITLE
Remove seemingly unreachable help text

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -51,11 +51,6 @@
 <p>{ts}Use tokens when you are sending mail to a number of recipients, and want to include their name and / or other values from their contact record automatically within your message.{/ts}</p>
 <p>{ts 1='&#123;contact.first_name&#125;'}EXAMPLE: If you want your message to begin with "Dear " followed by the recipient's first name, you can use the %1 token in your message. <em>Dear %1</em>{/ts}</p>
 <p>{ts}Place your cursor within the Message box where you want to the token to be inserted. Then click the &quot;Insert Tokens&quot; link in the upper right corner of the message box to see a list of available tokens. Insert the token by clicking the desired token name in the list (for example, click &quot;First Name&quot;).{/ts}</p>
-{if !empty($params.tplFile) and $params.tplFile EQ 'CRM/Mailing/Form/Upload.tpl'}
-    <p>
-    {ts}You will also use tokens to insert Unsubscribe, Opt out and Forwarding links in your message.{/ts}
-    </p>
-{/if}
 <p>{ts}Custom tokens (based on custom data) can be added for organizations as well. These tokens will not be displayed in the list of available tokens, but can be added manually. The format is {literal}{contact.custom_12}{/literal} – where 12 is the ID of the custom data field. To find the custom data field ID,
 go Administer > Customize Data & Screens > Custom Fields and click ‘edit’ on the field you want to use. Look at the URL. The last part of the URL will
 be an equal sign and a number (=12). The number (12 in this example) is the id of that custom field.{/ts}</p>
@@ -69,19 +64,6 @@ be an equal sign and a number (=12). The number (12 in this example) is the id o
 <p>{ts}Use tokens when you are sending mail or generating PDF letters for a number of recipients, and want to include their name and / or other values from their contact record automatically within your message.{/ts}</p>
 <p>{ts 1='&#123;contact.first_name&#125;'}EXAMPLE: If you want your message to begin with "Dear " followed by the recipient's first name, you can use the %1 token in your message. <em>Dear %1</em>{/ts}</p>
 <p>{ts}Place your cursor within the Message box where you want to the token to be inserted. Then click the &quot;Insert Tokens&quot; link in the upper right corner of the message box to see a list of available tokens. Insert the token by clicking the desired token name in the list (for example, click &quot;First Name&quot;).{/ts}</p>
-{if !empty($params.tplFile) and $params.tplFile EQ 'CRM/Mailing/Form/Upload.tpl'}
-    <p>
-    {ts}You will also use tokens to insert Unsubscribe, Opt out and Forwarding links in your message.{/ts}
-        {ts}Use these steps to insert clickable action links:{/ts}
-        <ul>
-            <li>{ts}Select the action token from the Insert Tokens pop-up list - e.g. Unsubscribe via web page - and insert into your message.{/ts}</li>
-            <li>{ts 1='&#123;action.unsubscribeUrl&#125;}'}Highlight the token and copy it to your clipboard - e.g. %1.{/ts}</li>
-            <li>{ts}Replace the token in your message with the text you want for the link - e.g. Click here to unsubscribe.{/ts}</li>
-            <li>{ts}With the text highlighted, click the Insert/Edit Link icon in the editor toolbar.{/ts}</li>
-            <li>{ts}Paste the action token into the URL field and click Insert (or Update).{/ts}</li>
-        </ul>
-    </p>
-{/if}
 <p>{ts}Custom tokens (based on custom data) can be added for organizations as well. These tokens will not be displayed in the list of available tokens, but can be added manually. The format is {literal}{contact.custom_12}{/literal} – where 12 is the ID of the custom data field. To find the custom data field ID,
 go Administer > Customize Data & Screens > Custom Fields and click ‘edit’ on the field you want to use. Look at the URL. The last part of the URL will
 be an equal sign and a number (=12). The number (12 in this example) is the id of that custom field.{/ts}</p>


### PR DESCRIPTION

Overview
----------------------------------------
Remove seemingly unreachable help text

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/148928351-5a163261-a82b-4711-8b2f-39272ca71956.png)


After
----------------------------------------
erm - only got some - not all

Technical Details
----------------------------------------
This text is e-notice causing (with default modifiers on). I could not find the tpl file
or the potentially corresponding php file & concluded they were likely long-gone

(If I'm wrong some possibly-outdated help text disappears but I couldnt find it)

Comments
----------------------------------------
