### PR TITLE
Smarty notice fix on Email help

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.hlp
+++ b/templates/CRM/Contact/Form/Task/Email.hlp
@@ -8,25 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {capture assign=tokentext}{ts}Find out more about CiviCRM Tokens{/ts}{/capture}
-{htxt id="id-from_email-title"}
-  {ts}From Address{/ts}
-{/htxt}
-{htxt id="id-from_email"}
-{if !empty($params.logged_in_email_setting) and $params.logged_in_email_setting == "1"}
-  <p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
-{else}
-  <p>{ts}CiviCRM is currently configured to only use the defined From Email addresses. If you wish to be able to use the email address of the logged in user as the From Address you will need to set the setting "Allow mail from logged in contact" setting. Users with Administer CiviCRM can set this setting in the SMTP settings.{/ts}<p>
-  {if !empty($params.isAdmin)}
-    {capture assign="smtpUrl"}{crmURL p="civicrm/admin/setting/smtp" q="reset=1"}{/capture}
-    <p>{ts 1=$smtpUrl}Go to <a href='%1'>Settings - Outbound Mail</a> to enable the usage of the logged in contact's email address as the from email{/ts}</p>
-  {/if}
-{/if}
-{if !empty($params.isAdmin)}
-   {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
-   <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
-{/if}
-{/htxt}
-
 {htxt id="id-to_email-title"}
   {ts}To Address{/ts}
 {/htxt}

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -14,11 +14,11 @@
         <p>{ts count=$suppressedEmails plural='Email will NOT be sent to %count contacts - (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).'}Email will NOT be sent to %count contact - (no email address on file, or communication preferences specify DO NOT EMAIL, or contact is deceased).{/ts}</p>
     </div>
 {/if}
-{crmSetting var="logged_in_email_setting" name="allow_mail_from_logged_in_contact"}
+
 <table class="form-layout-compressed">
   <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
     <td class="label">{$form.from_email_address.label}</td>
-    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin logged_in_email_setting=$logged_in_email_setting}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
   </tr>
     <tr class="crm-contactEmail-form-block-recipient">
        <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>

--- a/templates/CRM/Contact/Form/Task/Help/Email/id-from_email.hlp
+++ b/templates/CRM/Contact/Form/Task/Help/Email/id-from_email.hlp
@@ -1,0 +1,19 @@
+{htxt id="id-from_email-title"}
+  {ts}From Address{/ts}
+{/htxt}
+{htxt id="id-from_email"}
+{crmSetting var="allow_mail_from_logged_in_contact" name="allow_mail_from_logged_in_contact"}
+{if $allow_mail_from_logged_in_contact}
+  <p>{ts}By default, CiviCRM uses the primary email address of the logged in user as the FROM address when sending emails to contacts. However, users with Administer CiviCRM permission can configure one or more general email addresses that can be selected as an alternative. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
+{else}
+  <p>{ts}CiviCRM is currently configured to only use the defined From Email addresses. If you wish to be able to use the email address of the logged in user as the From Address you will need to set the setting "Allow mail from logged in contact" setting. Users with Administer CiviCRM can set this setting in the SMTP settings.{/ts}<p>
+    {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+        {capture assign="smtpUrl"}{crmURL p="civicrm/admin/setting/smtp" q="reset=1"}{/capture}
+      <p>{ts 1=$smtpUrl}Go to <a href='%1'>Settings - Outbound Mail</a> to enable the usage of the logged in contact's email address as the from email{/ts}</p>
+    {/if}
+{/if}
+{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+    {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
+  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
+{/if}
+{/htxt}

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -61,7 +61,7 @@
         </tr>
         <tr id="fromEmail" class="crm-payment-form-block-from_email_address" style="display:none;">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         </tr>
       {/if}
       {if $contributionMode}

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -217,7 +217,7 @@
         {if empty($is_template)}
         <tr id="fromEmail" class="crm-contribution-form-block-receipt_date" style="display:none;">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         </tr>
         {/if}
         {if empty($is_template)}

--- a/templates/CRM/Contribute/Form/Task/Invoice.hlp
+++ b/templates/CRM/Contribute/Form/Task/Invoice.hlp
@@ -7,9 +7,6 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{htxt id ="id-from_email-title"}
-  {ts}From Address{/ts}
-{/htxt}
 {htxt id="content-intro-title"}
   {ts}Message Formats{/ts}
 {/htxt}

--- a/templates/CRM/Contribute/Form/Task/Invoice.tpl
+++ b/templates/CRM/Contribute/Form/Task/Invoice.tpl
@@ -26,7 +26,7 @@
   {/if}
   <tr id="selectEmailFrom" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
     <td class="label">{$form.from_email_address.label}</td>
-    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
   </tr>
   <tr class="crm-email-element crm-contactEmail-form-block-cc_id">
     <td class="label">{$form.cc_id.label}</td>

--- a/templates/CRM/Contribute/Form/Task/PDF.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDF.tpl
@@ -21,7 +21,7 @@
   </tr>
   <tr id="selectEmailFrom" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
     <td class="label">{$form.from_email_address.label}</td>
-    <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+    <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
   </tr>
   <tr>
     <td>{$form.output.pdf_receipt.html}</td>

--- a/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
+++ b/templates/CRM/Contribute/Form/Task/PDFLetter.tpl
@@ -36,7 +36,7 @@
         <td>{$form.email_options.html}</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.from_email_address.label} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+        <td class="label-left">{$form.from_email_address.label}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         <td>{$form.from_email_address.html}</td>
       </tr>
     </table>

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -105,7 +105,7 @@
         </tr>
         <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+          <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         </tr>
         <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>
@@ -132,7 +132,7 @@
       </tr>
       <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
         <td class="label">{$form.from_email_address.label}</td>
-        <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+        <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
       </tr>
       <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -143,7 +143,7 @@ CRM.$(function($) {
        </tr>
        <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
          <td class="label">{$form.from_email_address.label}</td>
-         <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+         <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
        </tr>
        <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
          <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Member/Form/Membership.hlp
+++ b/templates/CRM/Member/Form/Membership.hlp
@@ -20,12 +20,3 @@
     </ul>
   {/if}
 {/htxt}
-{htxt id ="id-from_email"}
-  <p>{ts}Select the "FROM" Email Address for this mailing from the dropdown list. Available email addresses are configurable by users with Administer CiviCRM permission. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
-{if $params.isAdmin}
-  {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}
-  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; FROM Email Addresses</a> to add or edit email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
-{else}
-  {ts}Contact your site administrator if you need to use a "FROM" Email Address which is not in the dropdown list.{/ts}
-{/if}
-{/htxt}

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -198,7 +198,7 @@
         {/if}
         <tr id="fromEmail" style="display: none" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+          <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         </tr>
         <tr id='notice' style="display:none;">
           <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -118,7 +118,7 @@
         </tr>
         <tr id="fromEmail">
           <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+          <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         </tr>
         <tr id="notice" class="crm-member-membershiprenew-form-block-receipt_text_renewal">
           <td class="label">{$form.receipt_text_renewal.label}</td>

--- a/templates/CRM/Pledge/Form/Pledge.tpl
+++ b/templates/CRM/Pledge/Form/Pledge.tpl
@@ -99,7 +99,7 @@
         {/if}
           <tr id="fromEmail" style="display:none;">
             <td class="label">{$form.from_email_address.label}</td>
-            <td>{$form.from_email_address.html} {help id="id-from_email" file="CRM/Contact/Form/Task/Email.hlp" isAdmin=$isAdmin}</td>
+            <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
           </tr>
           <tr id="acknowledgeDate">
             <td class="label" class="crm-pledge-form-block-acknowledge_date">{$form.acknowledge_date.label}</td>


### PR DESCRIPTION

Overview
----------------------------------------
Smarty notice fix on Email help

Before
----------------------------------------
In full grumpy mode there are loads of enotices on any page with smarty help for the from email field

After
----------------------------------------
Erm ... less

Technical Details
----------------------------------------
I dug around a bit on how to deal with the endless 'params' notice in full-smarty-grump-mode
and I decided the help file was being called multiple times - so even if it is assigned in
the specific call for that id it isn't on the next call. I decided that
I could look up the setting & permission from within the template but only wanted to do it
once per template load so I split out a help file for that field (I didn't think
a whole directory structure was warranted to I added a folder 'Help' and then the
next folder is the main help filename with the file being the help id


Comments
----------------------------------------
