### PR TITLE
Fix broken function reference

### DIFF
--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -76,7 +76,7 @@ class CRM_Utils_Mail_Incoming {
       return NULL;
     }
 
-    return self::formatMailUnrecognisedPart($part);
+    return self::formatUnrecognisedPart($part);
   }
 
   /**
@@ -110,7 +110,7 @@ class CRM_Utils_Mail_Incoming {
       return self::formatMailDeliveryStatus($part);
     }
 
-    return self::formatMailUnrecognisedPart($part);
+    return self::formatUnrecognisedPart($part);
   }
 
   /**
@@ -452,7 +452,8 @@ class CRM_Utils_Mail_Incoming {
     $contactID = NULL;
     if ($dao) {
       $contactID = $dao->contact_id;
-    } else {
+    }
+    else {
       $dao = CRM_Contact_BAO_Contact::matchContactOnEmail($email, 'Organization');
 
       if ($dao) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix broken function reference. (no method formatMailUnrecognisedPart exists)

Before
----------------------------------------
It appears the names of function created and subsequently used in https://github.com/civicrm/civicrm-core/commit/43155999495a5b9392d7f0f6e40dccf29f17ca6c didn't match. Therefore broken PHP.

After
----------------------------------------
Working PHP.
