### PR TITLE
dev/core#3026 - quickfix for fulltext search drupal block giving message about session timeout

### DIFF
--- a/templates/CRM/Block/FullTextSearch.tpl
+++ b/templates/CRM/Block/FullTextSearch.tpl
@@ -25,7 +25,7 @@
     <form method="post" id="id_fulltext_search">
     <div style="margin-bottom: 8px;">
     <input type="text" name="text" id='text' value="" class="crm-form-text" />
-    <input type="hidden" name="qfKey" value="{crmKey name='CRM_Contact_Controller_Search' addSequence=1}" />
+    <input type="hidden" name="qfKey" value="{crmKey name='CRM_Legacycustomsearches_Controller_Search' addSequence=1}" />
   </div>
   <select class="form-select" id="fulltext_table" name="fulltext_table">
 {if call_user_func(array('CRM_Core_Permission','giveMeAllACLs'))}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3026

Before
----------------------------------------
1. Drupal - enable the fulltext search sidebar block from the drupal admin pages
2. Type something in it and go.
3. "Because your session timed out, we have reset the search page" and the search doesn't work. (The main form in the content area works, but not from the sidebar.)

After
----------------------------------------
ok

Technical Details
----------------------------------------
Parts of the block are still in core not in the legacycustomsearches extension so there's a controller mismatch. The full fix is to figure out how to move this tpl and the corresponding code from CRM_Core_Block into the extension, or into a drupal module.

Comments
----------------------------------------

