### PR TITLE
Add unit test on updateGreeting & remove deprecated fn call

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -1034,17 +1034,12 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
     }
 
     if (empty($filterContactFldIds)) {
-      $greetingDetails = [];
-      $filterContactFldIds[] = 0;
-    }
-    else {
-      // we do token replacement in the replaceGreetingTokens hook
-      [$greetingDetails] = CRM_Utils_Token::getTokenDetails(array_keys($filterContactFldIds), $greetingsReturnProperties, FALSE, FALSE);
+      return;
     }
     // perform token replacement and build update SQL
     $contactIds = [];
     $cacheFieldQuery = "UPDATE civicrm_contact SET {$greeting}_display = CASE id ";
-    foreach ($greetingDetails as $contactID => $contactDetails) {
+    foreach (array_keys($filterContactFldIds) as $contactID) {
       if (!$processAll &&
         !array_key_exists($contactID, $filterContactFldIds)
       ) {
@@ -1065,7 +1060,7 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
         }
       }
 
-      self::processGreetingTemplate($greetingString, $contactDetails, $contactID, 'CRM_UpdateGreeting');
+      self::processGreetingTemplate($greetingString, [], $contactID, 'CRM_UpdateGreeting');
       $greetingString = CRM_Core_DAO::escapeString($greetingString);
       $cacheFieldQuery .= " WHEN {$contactID} THEN '{$greetingString}' ";
 

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -18,6 +18,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Contact;
+
 /**
  * Class api_v3_JobTest
  *
@@ -180,15 +182,24 @@ class api_v3_JobTest extends CiviUnitTestCase {
   /**
    * Test greeting update job.
    *
-   * Note that this test is about testing the metadata / calling of the function & doesn't test the success of the called function
+   * Note that this test is about testing the metadata / calling of the
+   * function & doesn't test the success of the called function
    *
-   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
    */
   public function testCallUpdateGreetingSuccess(): void {
+    $contactID = $this->individualCreate();
+    // Clear out the postal greeting
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_contact SET postal_greeting_display = NULL WHERE id = ' . $contactID);
     $this->callAPISuccess($this->_entity, 'update_greeting', [
       'gt' => 'postal_greeting',
       'ct' => 'Individual',
     ]);
+    $this->assertEquals('Dear Anthony', Contact::get()
+      ->addWhere('id', '=', $contactID)
+      ->addSelect('postal_greeting_display')
+      ->execute()->first()['postal_greeting_display']
+    );
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Add unit test on updateGreeting & remove deprecated fn call

Before
----------------------------------------
The call to tokenDetails loads the contact details and they are passed along - however
if not loaded here they will be loaded later so there is no gain & it
calls a deprecated function

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
