### PR TITLE
Fully deprecate `getTokenDetails`

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1178,6 +1178,7 @@ class CRM_Utils_Token {
     $className = NULL,
     $jobID = NULL
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('If you hit this in mailing code you should use flexmailer - otherwise use the token processor');
     $params = [];
     foreach ($contactIDs as $contactID) {
       $params[] = [

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -7,56 +7,6 @@
 class CRM_Utils_TokenTest extends CiviUnitTestCase {
 
   /**
-   * Basic test on getTokenDetails function.
-   */
-  public function testGetTokenDetails() {
-    $contactID = $this->individualCreate(['preferred_communication_method' => ['Phone', 'Fax']]);
-    [$resolvedTokens] = CRM_Utils_Token::getTokenDetails([$contactID]);
-    $this->assertEquals('Phone, Fax', $resolvedTokens[$contactID]['preferred_communication_method']);
-  }
-
-  /**
-   * Test getting contacts w/o primary location type
-   *
-   * Check for situation described in CRM-19876.
-   */
-  public function testSearchByPrimaryLocation() {
-    // Disable searchPrimaryDetailsOnly civi settings so we could test the functionality without it.
-    Civi::settings()->set('searchPrimaryDetailsOnly', '0');
-
-    // create a contact with multiple email address and among which one is primary
-    $contactID = $this->individualCreate();
-    $primaryEmail = uniqid() . '@primary.com';
-    $this->callAPISuccess('Email', 'create', [
-      'contact_id' => $contactID,
-      'email' => $primaryEmail,
-      'location_type_id' => 'Other',
-      'is_primary' => 1,
-    ]);
-    $this->callAPISuccess('Email', 'create', [
-      'contact_id' => $contactID,
-      'email' => uniqid() . '@galaxy.com',
-      'location_type_id' => 'Work',
-      'is_primary' => 0,
-    ]);
-    $this->callAPISuccess('Email', 'create', [
-      'contact_id' => $contactID,
-      'email' => uniqid() . '@galaxy.com',
-      'location_type_id' => 'Work',
-      'is_primary' => 0,
-    ]);
-
-    $contactIDs = [$contactID];
-
-    // when we are fetching contact details ON basis of primary address fields
-    [$contactDetails] = CRM_Utils_Token::getTokenDetails($contactIDs);
-    $this->assertEquals($primaryEmail, $contactDetails[$contactID]['email']);
-
-    // restore setting
-    Civi::settings()->set('searchPrimaryDetailsOnly', '1');
-  }
-
-  /**
    * Test for replaceGreetingTokens.
    *
    */
@@ -83,68 +33,6 @@ class CRM_Utils_TokenTest extends CiviUnitTestCase {
     $tokenString = 'Custom {custom.custom}';
     CRM_Utils_Token::replaceGreetingTokens($tokenString, $contactDetails, $contactId, $className, $escapeSmarty);
     $this->assertEquals($tokenString, 'Custom ');
-  }
-
-  /**
-   * Test getting multiple contacts.
-   *
-   * Check for situation described in CRM-19876.
-   */
-  public function testGetTokenDetailsMultipleEmails() {
-    $i = 0;
-
-    $params = [
-      'do_not_phone' => 1,
-      'do_not_email' => 0,
-      'do_not_mail' => 1,
-      'do_not_sms' => 1,
-      'do_not_trade' => 1,
-      'is_opt_out' => 0,
-      'email' => 'guardians@galaxy.com',
-      'legal_identifier' => 'convict 56',
-      'nick_name' => 'bob',
-      'contact_source' => 'bargain basement',
-      'formal_title' => 'Your silliness',
-      'job_title' => 'World Saviour',
-      'gender_id' => '1',
-      'birth_date' => '2017-01-01',
-      // 'city' => 'Metropolis',
-    ];
-    $contactIDs = [];
-    while ($i < 27) {
-      $contactIDs[] = $contactID = $this->individualCreate($params);
-      $this->callAPISuccess('Email', 'create', [
-        'contact_id' => $contactID,
-        'email' => 'goodguy@galaxy.com',
-        'location_type_id' => 'Other',
-        'is_primary' => 0,
-      ]);
-      $this->callAPISuccess('Email', 'create', [
-        'contact_id' => $contactID,
-        'email' => 'villain@galaxy.com',
-        'location_type_id' => 'Work',
-        'is_primary' => 1,
-      ]);
-      $i++;
-    }
-    unset($params['email']);
-
-    [$resolvedTokens] = CRM_Utils_Token::getTokenDetails($contactIDs);
-    foreach ($contactIDs as $contactID) {
-      $resolvedContactTokens = $resolvedTokens[$contactID];
-      $this->assertEquals('Individual', $resolvedContactTokens['contact_type']);
-      $this->assertEquals('Anderson, Anthony', $resolvedContactTokens['sort_name']);
-      $this->assertEquals('en_US', $resolvedContactTokens['preferred_language']);
-      $this->assertEquals('Both', $resolvedContactTokens['preferred_mail_format']);
-      $this->assertEquals(3, $resolvedContactTokens['prefix_id']);
-      $this->assertEquals(3, $resolvedContactTokens['suffix_id']);
-      $this->assertEquals('Mr. Anthony J. Anderson II', $resolvedContactTokens['addressee_display']);
-      $this->assertEquals('villain@galaxy.com', $resolvedContactTokens['email']);
-
-      foreach ($params as $key => $value) {
-        $this->assertEquals($value, $resolvedContactTokens[$key]);
-      }
-    }
   }
 
   /**

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -297,37 +297,6 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $this->assertStringNotContainsString("http://http://", $previewResult['values']['body_html']);
   }
 
-  /**
-   *
-   */
-  public function testMailerPreviewExtraScheme() {
-    try {
-      \Civi::settings()->set('flexmailer_traditional', 'bao');
-
-      $contactID = $this->individualCreate();
-      $displayName = $this->callAPISuccess('contact', 'get', ['id' => $contactID]);
-      $displayName = $displayName['values'][$contactID]['display_name'];
-      $this->assertNotEmpty($displayName);
-
-      $params = $this->_params;
-      $params['body_html'] = '<a href="http://{action.forward}">Forward this email written in ckeditor</a>';
-      $params['api.Mailing.preview'] = [
-        'id' => '$value.id',
-        'contact_id' => $contactID,
-      ];
-      $params['options']['force_rollback'] = 1;
-
-      $result = $this->callAPISuccess('mailing', 'create', $params);
-      $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
-      $this->assertRegexp('!>Forward this email written in ckeditor</a>!', $previewResult['values']['body_html']);
-      $this->assertRegexp('!<a href="([^"]+)civicrm/mailing/forward&amp;amp;reset=1&amp;jid=&amp;qid=&amp;h=\w*">!', $previewResult['values']['body_html']);
-      $this->assertStringNotContainsString("http://http://", $previewResult['values']['body_html']);
-
-    } finally {
-      \Civi::settings()->revert('flexmailer_traditional');
-    }
-  }
-
   public function testMailerPreviewUnknownContact(): void {
     $params = $this->_params;
     $params['api.Mailing.preview'] = [


### PR DESCRIPTION
Overview
----------------------------------------
#22482 (also in this PR) removes the last core call to  `getTokenDetails` outside of legacy Mailing BAO methods - now we can add deprecation notices & stop testing it


Before
----------------------------------------
Only deprecation annotations

After
----------------------------------------
Noisy deprecation

Technical Details
----------------------------------------

Comments
----------------------------------------
