### PR TITLE
dev/financial#6 Use template contribution for Contribution.repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -493,7 +493,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    *
    * @param int $id
    * @param array $overrides
-   *   Parameters that should be overriden. Add unit tests if using parameters other than total_amount & financial_type_id.
+   *   Parameters that should be overridden. Add unit tests if using parameters other than total_amount & financial_type_id.
    *
    * @return array
    *

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -585,14 +585,11 @@ function _civicrm_api3_contribution_completetransaction_spec(&$params) {
 function civicrm_api3_contribution_repeattransaction($params) {
   civicrm_api3_verify_one_mandatory($params, NULL, ['contribution_recur_id', 'original_contribution_id']);
   if (empty($params['original_contribution_id'])) {
-    //  CRM-19873 call with test mode.
-    $params['original_contribution_id'] = civicrm_api3('contribution', 'getvalue', [
-      'return' => 'id',
-      'contribution_status_id' => ['IN' => ['Completed']],
-      'contribution_recur_id' => $params['contribution_recur_id'],
-      'contribution_test' => CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionRecur', $params['contribution_recur_id'], 'is_test'),
-      'options' => ['limit' => 1, 'sort' => 'id DESC'],
-    ]);
+    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($params['contribution_recur_id']);
+    if (empty($templateContribution)) {
+      throw new CiviCRM_API3_Exception('Contribution.repeattransaction failed to get original_contribution_id for recur with ID: ' . $params['contribution_recur_id']);
+    }
+    $params['original_contribution_id'] = $templateContribution['id'];
   }
   $contribution = new CRM_Contribute_BAO_Contribution();
   $contribution->id = $params['original_contribution_id'];


### PR DESCRIPTION
Overview
----------------------------------------
Calling contribution.repeattransaction without specifying `original_contribution_id` causes it to try to get the "previous" contribution in `Completed` status. That doesn't work if the previous contribution is in any other status (eg. `Refunded`, `Failed`).
We should be using the generic function to get the template contribution as this allows for us to get the values from the template contribution if available or the latest contribution otherwise.

Before
----------------------------------------
`Contribution.repeattransaction` crashes if first contribution is not "Completed". Template contribution is ignored.

After
----------------------------------------
Template contribution is retrieved and used.

Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/financial/-/issues/6

Comments
----------------------------------------

