### PR TITLE
dev/report#94: ensure fieldsets look okay in Drupal default admin theme

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -378,6 +378,10 @@ input.crm-form-entityref {
   text-indent: 0;
   width: auto;
 }
+/* Fix for https://lab.civicrm.org/dev/report/-/issues/94 */
+.crm-container fieldset:not(.fieldgroup) > legend {
+  position: unset;
+}
 
 .crm-container fieldset.form-layout {
   margin: .25em 0 .5em 0;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/report/-/issues/94.


After
----------------------------------------

Looks like https://lab.civicrm.org/dev/report/uploads/73b9220c4663a082270657726b7a4663/Screenshot_from_2022-01-11_11-53-45.png

Technical Details
----------------------------------------

Adds CSS to main civicrm.css file.
