### PR TITLE
SearchKit - Facilitate popup forms

### DIFF
--- a/ang/crmDialog.js
+++ b/ang/crmDialog.js
@@ -3,6 +3,32 @@
 
   angular.module('crmDialog', CRM.angRequires('crmDialog'));
 
+  // Convenience binding to automatically launch a dialog when clicking an element
+  // Ex: <button type="button" crm-dialog-popup="myDialogName" popup-tpl="~/myExt/MyDialogTpl.html" popup-data="{foo: bar}"
+  angular.module('crmDialog').directive('crmDialogPopup', function(dialogService) {
+    return {
+      restrict: 'A',
+      bindToController: {
+        popupTpl: '@',
+        popupName: '@crmDialogPopup',
+        popupData: '<'
+      },
+      controller: function($scope, $element) {
+        var ctrl = this;
+        $element.on('click', function() {
+          var options = CRM.utils.adjustDialogDefaults({
+            autoOpen: false,
+            title: _.trim($element.attr('title') || $element.text())
+          });
+          dialogService.open(ctrl.popupName, ctrl.popupTpl, ctrl.popupData || {}, options)
+            .then(function(success) {
+              $element.trigger('crmPopupFormSuccess');
+            });
+        });
+      }
+    };
+  });
+
   // Ex: <div crm-dialog="myDialogName"> ... <button ng-click="$dialog.cancel()">Cancel</button> ... </div>
   // Ex: <div crm-dialog="myDialogName"> ... <button ng-click="$dialog.close(outputData)">Close</button> ... </div>
   // Ex: <div crm-dialog="myDialogName"> ... <crm-dialog-button text="'Close'" on-click="$dialog.close()" /> ... </div>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -39,7 +39,8 @@
           });
         }
 
-        $element.on('crmPopupFormSuccess', this.getResults);
+        // Popup forms in this display or surrounding Afform trigger a refresh
+        $element.closest('form').on('crmPopupFormSuccess', this.getResults);
 
         function onChangeFilters() {
           ctrl.page = 1;


### PR DESCRIPTION
Overview
----------------------------------------
This adds two bits of utility code to facilitate adding a popup form to an Afform containing a Search Display.

Technical Details
----------------------------------------
- New `crmDialogPopup` directive makes it possible to invoke an Angular popup form without any extra controller code (works much nicer with Afforms).
- Updated SearchDisplay code to refresh the search results when any popup form in the Afform is submitted.

Comments
----------------------------------------
This is required by #22467 and veda-consulting-company/uk.co.vedaconsulting.mosaico#478
