### PR TITLE
Rationalise relationship validation

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -603,12 +603,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
         $sharedContact->id = $relationship->contact_id_a;
         $sharedContact->find(TRUE);
 
-        // CRM-15881 UPDATES
-        // changed FROM "...relationship->relationship_type_id == 4..." TO "...relationship->relationship_type_id == 5..."
-        // As the system should be looking for type "employer of" (id 5) and not "sibling of" (id 4)
-        // As suggested by @davecivicrm, the employee relationship type id is fetched using the CRM_Core_DAO::getFieldValue() class and method, since these ids differ from system to system.
-        $employerRelTypeId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', 'Employee of', 'id', 'name_a_b');
-
+        $employerRelTypeId = CRM_Contact_BAO_RelationshipType::getEmployeeRelationshipTypeID();
         if ($relationship->relationship_type_id == $employerRelTypeId && $relationship->contact_id_b == $sharedContact->employer_id) {
           CRM_Contact_BAO_Contact_Utils::clearCurrentEmployer($relationship->contact_id_a);
         }

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\RelationshipType;
+
 /**
  *
  * @package CRM
@@ -118,6 +120,34 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
         ->addWhere('relationship_type_id', '=', $event->id)
         ->execute();
     }
+  }
+
+
+  /**
+   * Get the id of the employee relationship, checking it is valid.
+   *
+   * @return int|string
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function getEmployeeRelationshipTypeID(): int {
+    try {
+      if (!Civi::cache('metadata')->has(__CLASS__ . __FUNCTION__)) {
+        $relationship = RelationshipType::get(FALSE)
+          ->addWhere('name_a_b', '=', 'Employee of')
+          ->addWhere('contact_type_a', '=', 'Individual')
+          ->addWhere('contact_type_b', '=', 'Organization')
+          ->addSelect('id')->execute()->first();
+        if (empty($relationship)) {
+          throw new API_Exception('no valid relationship');
+        }
+        Civi::cache('metadata')->set(__CLASS__ . __FUNCTION__, $relationship['id']);
+      }
+    }
+    catch (API_Exception $e) {
+      throw new CRM_Core_Exception(ts("You seem to have deleted the relationship type 'Employee of'"));
+    }
+    return Civi::cache('metadata')->get(__CLASS__ . __FUNCTION__);
   }
 
 }

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -9,7 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Relationship;
 use Civi\Api4\RelationshipType;
+use Civi\Core\Event\PreEvent;
 
 /**
  *
@@ -110,18 +112,20 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
 
   /**
    * Callback for hook_civicrm_pre().
+   *
    * @param \Civi\Core\Event\PreEvent $event
-   * @throws CRM_Core_Exception
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+  public static function self_hook_civicrm_pre(PreEvent $event): void {
     if ($event->action === 'delete') {
       // need to delete all option value field before deleting group
-      \Civi\Api4\Relationship::delete(FALSE)
+      Relationship::delete(FALSE)
         ->addWhere('relationship_type_id', '=', $event->id)
         ->execute();
     }
   }
-
 
   /**
    * Get the id of the employee relationship, checking it is valid.

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1324,7 +1324,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         \Civi\Api4\Relationship::create(FALSE)
           ->addValue('contact_id_a', $contactID)
           ->addValue('contact_id_b', $orgID)
-          ->addValue('relationship_type_id', CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType', 'Employee of', 'id', 'name_a_b'))
+          ->addValue('relationship_type_id', $relTypeId = CRM_Contact_BAO_RelationshipType::getEmployeeRelationshipTypeID())
           ->addValue('is_permission_a_b:name', 'View and update')
           ->execute();
       }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -909,8 +909,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test creating a current employer through API.
    *
    * Check it will re-activate a de-activated employer
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testContactCreateDuplicateCurrentEmployerEnables(): void {
     // Set up  - create employer relationship.


### PR DESCRIPTION
Overview
----------------------------------------
Rationalise relationship validation

Before
----------------------------------------
The previous relationship validation was
1) throw a message is no valid employer relationship - this seems to be done
in a place that would make the site unusable 


2) complicated look up to determine if the contact types match the relationship's
expectations. 

After
----------------------------------------
1) I've centralised this check into a
cached function that gets the id & throws the exception & is used from
places previously fetching it (there is one that
didn't throw an exception previously but I think enough places did
that extending to that place would not break the site any more if it didn't exist

2) Since we already know the relationship's expectations we
can simplify this to just check contact a is an individual and b is an org which is
much more reasonable. It doesn;t seem like this would ever actually be false so
I added a deprecation to be a bit vocal if it is

Technical Details
---------------------------------------


Comments
----------------------------------------
