### PR TITLE
Remove handling for impossible array

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2038,7 +2038,7 @@ class CRM_Contact_BAO_Query {
    * @return string
    * @throws \CRM_Core_Exception
    */
-  public function whereClause($isForcePrimaryEmailOnly = NULL) {
+  public function whereClause($isForcePrimaryEmailOnly = NULL): string {
     $this->_where[0] = [];
     $this->_qill[0] = [];
 

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -356,33 +356,22 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
     if (!self::isACLFinancialTypeStatus()) {
       return FALSE;
     }
-    if (is_array($whereClauses)) {
+    if ($component == 'contribution') {
       $types = self::getAllEnabledAvailableFinancialTypes();
-      if (empty($types)) {
-        $whereClauses[] = ' ' . $alias . '.financial_type_id IN (0)';
-      }
-      else {
-        $whereClauses[] = ' ' . $alias . '.financial_type_id IN (' . implode(',', array_keys($types)) . ')';
-      }
+      $column = "financial_type_id";
     }
-    else {
-      if ($component == 'contribution') {
-        $types = self::getAllEnabledAvailableFinancialTypes();
-        $column = "financial_type_id";
-      }
-      if ($component == 'membership') {
-        self::getAvailableMembershipTypes($types, CRM_Core_Action::VIEW);
-        $column = "membership_type_id";
-      }
-      if (!empty($whereClauses)) {
-        $whereClauses .= ' AND ';
-      }
-      if (empty($types)) {
-        $whereClauses .= " civicrm_{$component}.{$column} IN (0)";
-        return;
-      }
-      $whereClauses .= " civicrm_{$component}.{$column} IN (" . implode(',', array_keys($types)) . ")";
+    if ($component == 'membership') {
+      self::getAvailableMembershipTypes($types, CRM_Core_Action::VIEW);
+      $column = "membership_type_id";
     }
+    if (!empty($whereClauses)) {
+      $whereClauses .= ' AND ';
+    }
+    if (empty($types)) {
+      $whereClauses .= " civicrm_{$component}.{$column} IN (0)";
+      return;
+    }
+    $whereClauses .= " civicrm_{$component}.{$column} IN (" . implode(',', array_keys($types)) . ")";
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Remove handling for impossible array

Before
----------------------------------------
CRM_Financial_BAO_FinancialType::buildPermissionedClause is only called from one place
outside of tests. That place passes in this->_whereClause which is the result of calling
this->whereClause() a few lines earlier. As that function always returns a string
we know that it cannot be an array & can remove the handling

After
----------------------------------------
And then it waas gone

Technical Details
----------------------------------------

Comments
----------------------------------------

