### PR TITLE
Move permission checks from Query & BAO to financialacl extension

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -581,7 +581,11 @@ class CRM_Contact_BAO_Query {
     }
     if (isset($component) && !$this->_skipPermission) {
       // Unit test coverage in api_v3_FinancialTypeACLTest::testGetACLContribution.
-      CRM_Financial_BAO_FinancialType::buildPermissionedClause($this->_whereClause, $component);
+      $clauses = CRM_Financial_BAO_FinancialType::buildPermissionedClause($component);
+      if (!empty($this->_whereClause) && !empty($clauses)) {
+        $this->_whereClause .= ' AND ';
+      }
+      $this->_whereClause .= $clauses;
     }
 
     $this->_fromClause = self::fromClause($this->_tables, NULL, NULL, $this->_primaryLocation, $this->_mode, $apiEntity);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1157,34 +1157,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
   }
 
   /**
-   * @inheritDoc
-   */
-  public function addSelectWhereClause() {
-    $whereClauses = parent::addSelectWhereClause();
-    if ($whereClauses !== []) {
-      // In this case permisssions have been applied & we assume the
-      // financialaclreport is applying these
-      // https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport/blob/master/financialaclreport.php#L107
-      return $whereClauses;
-    }
-
-    if (!CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-      return $whereClauses;
-    }
-    $types = CRM_Financial_BAO_FinancialType::getAllEnabledAvailableFinancialTypes();
-    if (empty($types)) {
-      $whereClauses['financial_type_id'] = 'IN (0)';
-    }
-    else {
-      $whereClauses['financial_type_id'] = [
-        'IN (' . implode(',', array_keys($types)) . ')',
-      ];
-    }
-    return $whereClauses;
-  }
-
-  /**
-   * @param null $status
+   * @param string $status
    * @param null $startDate
    * @param null $endDate
    *

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -355,11 +355,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
       return '';
     }
     if ($component === 'contribution') {
-      $types = array_keys(self::getAllEnabledAvailableFinancialTypes());
-      if (empty($types)) {
-        $types = [0];
-      }
-      $clauses[] = ' civicrm_contribution.financial_type_id IN (' . implode(',', $types) . ')';
+      $clauses = CRM_Contribute_BAO_Contribution::getSelectWhereClause();
     }
     if ($component === 'membership') {
       self::getAvailableMembershipTypes($types, CRM_Core_Action::VIEW);

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -343,35 +343,34 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
   /**
    * Function to build a permissioned sql where clause based on available financial types.
    *
-   * @param array $whereClauses
-   *   (reference ) an array of clauses
    * @param string $component
    *   the type of component
-   * @param string $alias
-   *   the alias to use
    *
+   * @return string $clauses
    */
-  public static function buildPermissionedClause(&$whereClauses, $component = NULL, $alias = NULL) {
+  public static function buildPermissionedClause(string $component): string {
+    $clauses = [];
     // @todo the relevant addSelectWhere clause should be called.
     if (!self::isACLFinancialTypeStatus()) {
-      return FALSE;
+      return '';
     }
-    if ($component == 'contribution') {
-      $types = self::getAllEnabledAvailableFinancialTypes();
-      $column = "financial_type_id";
+    if ($component === 'contribution') {
+      $types = array_keys(self::getAllEnabledAvailableFinancialTypes());
+      if (empty($types)) {
+        $types = [0];
+      }
+      $clauses[] = ' civicrm_contribution.financial_type_id IN (' . implode(',', $types) . ')';
     }
-    if ($component == 'membership') {
+    if ($component === 'membership') {
       self::getAvailableMembershipTypes($types, CRM_Core_Action::VIEW);
-      $column = "membership_type_id";
+      $types = array_keys($types);
+      if (empty($types)) {
+        $types = [0];
+      }
+      $clauses[] = ' civicrm_membership.membership_type_id IN (' . implode(',', $types) . ')';
+
     }
-    if (!empty($whereClauses)) {
-      $whereClauses .= ' AND ';
-    }
-    if (empty($types)) {
-      $whereClauses .= " civicrm_{$component}.{$column} IN (0)";
-      return;
-    }
-    $whereClauses .= " civicrm_{$component}.{$column} IN (" . implode(',', array_keys($types)) . ")";
+    return implode(' AND ', $clauses);
   }
 
   /**

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -139,6 +139,7 @@ function financialacls_civicrm_selectWhereClause($entity, &$clauses) {
     case 'LineItem':
     case 'MembershipType':
     case 'ContributionRecur':
+    case 'Contribution':
       $clauses['financial_type_id'] = _financialacls_civicrm_get_type_clause();
       break;
 

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -16,8 +16,6 @@ class FinancialTypeTest extends BaseTestClass {
   /**
    * Test that a message is put in session when changing the name of a
    * financial type.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testChangeFinancialTypeName(): void {
     Civi::settings()->set('acl_financial_type', TRUE);
@@ -71,6 +69,27 @@ class FinancialTypeTest extends BaseTestClass {
     $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
     $type = \CRM_Financial_BAO_FinancialType::getIncomeFinancialType();
     $this->assertEquals([1 => 'Donation'], $type);
+  }
+
+  /**
+   * Check method test buildPermissionedClause()
+   */
+  public function testBuildPermissionedClause(): void {
+    Civi::settings()->set('acl_financial_type', 1);
+    $this->setPermissions([
+      'view contributions of type Donation',
+      'view contributions of type Member Dues',
+    ]);
+    $whereClause = \CRM_Financial_BAO_FinancialType::buildPermissionedClause('contribution');
+    $this->assertEquals(' civicrm_contribution.financial_type_id IN (1,2)', $whereClause);
+    $this->setPermissions([
+      'view contributions of type Donation',
+      'view contributions of type Member Dues',
+      'view contributions of type Event Fee',
+    ]);
+
+    $whereClause = \CRM_Financial_BAO_FinancialType::buildPermissionedClause('contribution');
+    $this->assertEquals(' civicrm_contribution.financial_type_id IN (1,4,2)', $whereClause);
   }
 
 }

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialTypeTest.php
@@ -81,7 +81,7 @@ class FinancialTypeTest extends BaseTestClass {
       'view contributions of type Member Dues',
     ]);
     $whereClause = \CRM_Financial_BAO_FinancialType::buildPermissionedClause('contribution');
-    $this->assertEquals(' civicrm_contribution.financial_type_id IN (1,2)', $whereClause);
+    $this->assertEquals('(`civicrm_contribution`.`financial_type_id` IS NULL OR (`civicrm_contribution`.`financial_type_id` IN (1,2)))', $whereClause);
     $this->setPermissions([
       'view contributions of type Donation',
       'view contributions of type Member Dues',
@@ -89,7 +89,7 @@ class FinancialTypeTest extends BaseTestClass {
     ]);
 
     $whereClause = \CRM_Financial_BAO_FinancialType::buildPermissionedClause('contribution');
-    $this->assertEquals(' civicrm_contribution.financial_type_id IN (1,4,2)', $whereClause);
+    $this->assertEquals('(`civicrm_contribution`.`financial_type_id` IS NULL OR (`civicrm_contribution`.`financial_type_id` IN (1,4,2)))', $whereClause);
   }
 
 }

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -302,26 +302,4 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
     $this->assertEquals($perm, TRUE, 'Verify that lineitems now have permission.');
   }
 
-  /**
-   * Check method testisACLFinancialTypeStatus()
-   */
-  public function testBuildPermissionedClause() {
-    $this->setACL();
-    $this->setPermissions([
-      'view contributions of type Donation',
-      'view contributions of type Member Dues',
-    ]);
-    CRM_Financial_BAO_FinancialType::buildPermissionedClause($whereClause, 'contribution');
-    $this->assertEquals($whereClause, ' civicrm_contribution.financial_type_id IN (1,2)');
-    $this->setPermissions([
-      'view contributions of type Donation',
-      'view contributions of type Member Dues',
-      'view contributions of type Event Fee',
-    ]);
-    $whereClause = NULL;
-
-    CRM_Financial_BAO_FinancialType::buildPermissionedClause($whereClause, 'contribution');
-    $this->assertEquals($whereClause, ' civicrm_contribution.financial_type_id IN (1,4,2)');
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
Move permission checks from Query & BAO to financialacl extension

I'll rebased this once the MOP one is merged

Before
----------------------------------------
Core code doing financial acl checks in Contribution_BAO & BAO_Query

After
----------------------------------------
Moved to the extension

Technical Details
----------------------------------------
I don't think we need to early return for the other financial reports extensions - I don't there there would be performance impact if we got an extra WHERE financial_type_id IN (1,2) - it was mostly just a transitional thing I think

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
