### PR TITLE
dev/event#66: allow duplicate price field labels

### DIFF
--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -427,20 +427,6 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       }
     }
 
-    //avoid the same price field label in Within PriceSet
-    $priceFieldLabel = new CRM_Price_DAO_PriceField();
-    $priceFieldLabel->label = $fields['label'];
-    $priceFieldLabel->price_set_id = $form->_sid;
-
-    $dupeLabel = FALSE;
-    if ($priceFieldLabel->find(TRUE) && $form->getEntityId() != $priceFieldLabel->id) {
-      $dupeLabel = TRUE;
-    }
-
-    if ($dupeLabel) {
-      $errors['label'] = ts('Name already exists in Database.');
-    }
-
     if ((is_numeric(CRM_Utils_Array::value('count', $fields)) &&
         empty($fields['count'])
       ) &&


### PR DESCRIPTION
Overview
----------------------------------------
Reference ticket: https://lab.civicrm.org/dev/event/-/issues/66

Community discussion in that ticket indicates it would be desirable to allow two price fields to have the same label, which is currently prevented by CiviCRM. This PR removes that restriction, allowing two price fields to have the same label.

Before
----------------------------------------
If a price field labeled "Test" already exists, user will receive a form validation error when trying to create a second price field in that price set with label "Test".

![before](https://user-images.githubusercontent.com/759449/149556091-fcb88462-22d6-4347-89a0-4d9c8ff732d1.png)


After
----------------------------------------
If a price field labeled "Test" already exists, user will NOT receive a form validation error when trying to create a second price field in that price set with label "Test"; instead, the price field is simply created.

![after](https://user-images.githubusercontent.com/759449/149556273-58af11de-5a7d-40d9-a4a6-a89efb2b88e4.png)



Technical Details
----------------------------------------
This PR simply removes the form validation rule that was enforcing unique field labels. In the OP ticket, someone mentioned that other civicrm entities append an integer to the `name` column value where `name` is not unique, but no attempt was made to emulate that behavior. (In a quick scan of the code and some trial-and-error, I was unable to find any entities that do that, and I'm convinced, along with other commenters in that ticket, that failure to enforce a unique `name` column is not going to cause problems, as there are many entities which do not enforce that requirement.)

Comments
----------------------------------------
Thanks to DaveD for pointing out the code block referenced in this PR.