### PR TITLE
Various phpdoc fixes

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -781,7 +781,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * Filter the activity types to only return the ones we actually asked for
    * Uses params['activity_type_id'] and params['activity_type_exclude_id']
    *
-   * @param $params
+   * @param array $params
    * @return array|null (Use in Activity.get API activity_type_id)
    */
   public static function filterActivityTypes($params) {
@@ -2288,7 +2288,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
   }
 
   /**
-   * @param $params
+   * @param array $params
    * @return array
    */
   protected static function getActivityParamsForDashboardFunctions($params) {

--- a/CRM/Activity/Form/Task/PDF.php
+++ b/CRM/Activity/Form/Task/PDF.php
@@ -94,7 +94,7 @@ class CRM_Activity_Form_Task_PDF extends CRM_Activity_Form_Task {
   /**
    * Render html from rows
    *
-   * @param $rows
+   * @param array $rows
    * @param string $msgPart
    *   The name registered with the TokenProcessor
    * @param array $formValues

--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -35,11 +35,23 @@ class CRM_Contact_BAO_ProximityQuery {
    */
 
   /**
-   * @var string
+   * @var float
    */
   static protected $_earthFlattening;
+
+  /**
+   * @var float
+   */
   static protected $_earthRadiusSemiMinor;
+
+  /**
+   * @var float
+   */
   static protected $_earthRadiusSemiMajor;
+
+  /**
+   * @var float
+   */
   static protected $_earthEccentricitySQ;
 
   public static function initialize() {
@@ -353,9 +365,8 @@ ACOS(
 
   /**
    * @param array $input
-   * retun void
    *
-   * @return null
+   * @return void
    */
   public static function fixInputParams(&$input) {
     foreach ($input as $param) {
@@ -378,7 +389,6 @@ ACOS(
             }
           }
         }
-        return NULL;
       }
     }
   }

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -227,7 +227,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
    * to use a trait based approach. For now this is renamed to
    * permit the use of a non-static function with this name
    *
-   * @param $form CRM_Core_Form
+   * @param CRM_Core_Form_Task $form
    *
    * @return array $contactIds
    */

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -231,7 +231,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
   }
 
   /**
-   * @param $page
+   * @param CRM_Core_Page $page
    * @param int $contactID
    */
   public static function checkUserPermission($page, $contactID = NULL) {
@@ -242,7 +242,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
       $contactID = $page->_contactId;
     }
 
-    // automatically grant permissin for users on their own record. makes
+    // automatically grant permission for users on their own record. makes
     // things easier in dashboard
     $session = CRM_Core_Session::singleton();
 

--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -167,7 +167,7 @@ class CRM_Core_BAO_CustomOption {
   /**
    * Delete Option.
    *
-   * @param $optionId integer
+   * @param int $optionId
    *   option id
    *
    */

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -297,7 +297,8 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    * @param int $contactID
    * @param bool $count
    *
-   * @return array
+   * @return array|int
+   *   Dependant on $count
    */
   public static function getContactTags($contactID, $count = FALSE) {
     $contactTags = [];
@@ -319,7 +320,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
 
     if ($count) {
       $dao->fetch();
-      return $dao->cnt;
+      return (int) $dao->cnt;
     }
 
     while ($dao->fetch()) {
@@ -368,7 +369,7 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
    *
    * @return array
    */
-  public function mergeTags($tagAId, $tagBId) {
+  public static function mergeTags($tagAId, $tagBId) {
     $queryParams = [
       1 => [$tagAId, 'Integer'],
       2 => [$tagBId, 'Integer'],

--- a/CRM/Core/BAO/MailSettings.php
+++ b/CRM/Core/BAO/MailSettings.php
@@ -134,7 +134,7 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
    *   Reference array contains the values submitted by the form.
    *
    *
-   * @return object
+   * @return CRM_Core_DAO_MailSettings
    */
   public static function add(&$params) {
     $result = NULL;
@@ -167,7 +167,7 @@ class CRM_Core_BAO_MailSettings extends CRM_Core_DAO_MailSettings {
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
    *
-   * @return CRM_Core_BAO_MailSettings
+   * @return CRM_Core_DAO_MailSettings|CRM_Core_Error
    */
   public static function create(&$params) {
     $transaction = new CRM_Core_Transaction();

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -694,7 +694,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
    * care about output params appended.
    *
    * @param string $url
-   * @param array $url_params
+   * @param string $url_params
    *
    * @param int|null $parent_id
    *   Optionally restrict to one parent.

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -205,7 +205,7 @@ ORDER BY ph.is_primary DESC, phone_id ASC ";
   /**
    * Set NULL to phone, mapping, uffield
    *
-   * @param $optionId
+   * @param int $optionId
    *   Value of option to be deleted.
    */
   public static function setOptionToNull($optionId) {

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -287,7 +287,7 @@ FROM   civicrm_prevnext_cache pn
   }
 
   /**
-   * @param $string
+   * @param mixed $string
    *
    * @return bool
    */

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1604,7 +1604,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    * @param array $params
    *   (reference) an assoc array of name/value pairs.
    *
-   * @return CRM_Core_BAO_UFJoin
+   * @return CRM_Core_DAO_UFJoin
    */
   public static function addUFJoin(&$params) {
     $ufJoin = new CRM_Core_DAO_UFJoin();

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -40,8 +40,9 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
    *
    * @param array $params
    *
-   * @return bool|CRM_Core_BAO_Website
+   * @return CRM_Core_DAO_Website
    * @throws \CRM_Core_Exception
+   * @deprecated
    */
   public static function add($params) {
     CRM_Core_Error::deprecatedFunctionWarning('use apiv4');

--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -334,7 +334,7 @@ class CRM_Core_CodeGen_GenerateData {
   /**
    * Get a random item from the sample data or any other array
    *
-   * @param $items (array or string) - if string, used as key for sample data,
+   * @param array|string $items if string, used as key for sample data,
    *   if array, used as data source
    *
    * @return mixed (element from array)
@@ -908,8 +908,10 @@ class CRM_Core_CodeGen_GenerateData {
   /**
    * Create an address for a contact
    *
-   * @param $cid int: contact id
-   * @param $masterContactId int: set if this is a shared address
+   * @param int $cid
+   *   contact id
+   * @param int $masterContactId
+   *   set if this is a shared address
    *
    * @return array
    */
@@ -960,7 +962,7 @@ class CRM_Core_CodeGen_GenerateData {
   /**
    * Add a phone number for a contact
    *
-   * @param $cid int: contact id
+   * @param int $cid contact id
    *
    * @return array
    */
@@ -982,7 +984,7 @@ class CRM_Core_CodeGen_GenerateData {
   /**
    * Add an email for a contact
    *
-   * @param $cid int: contact id
+   * @param int $cid contact id
    * @param $email
    * @param $locationType
    *
@@ -1002,8 +1004,8 @@ class CRM_Core_CodeGen_GenerateData {
    * Add a website based on organization name
    * Using common naming patterns
    *
-   * @param $cid int: contact id
-   * @param $name str: contact name
+   * @param int $cid contact id
+   * @param string $name contact name
    *
    * @return array
    */
@@ -1043,8 +1045,8 @@ class CRM_Core_CodeGen_GenerateData {
    * Create an email address based on a person's name
    * Using common naming patterns
    *
-   * @param $contact obj: individual contact record
-   * @param $domain str: supply a domain (i.e. for a work address)
+   * @param CRM_Contact_DAO_Contact $contact individual contact record
+   * @param string $domain supply a domain (i.e. for a work address)
    *
    * @return string
    */

--- a/CRM/Core/CodeGen/Util/File.php
+++ b/CRM/Core/CodeGen/Util/File.php
@@ -6,7 +6,7 @@
 class CRM_Core_CodeGen_Util_File {
 
   /**
-   * @param $dir
+   * @param string $dir
    * @param int $perm
    */
   public static function createDir($dir, $perm = 0755) {
@@ -16,7 +16,7 @@ class CRM_Core_CodeGen_Util_File {
   }
 
   /**
-   * @param $dir
+   * @param string $dir
    */
   public static function cleanTempDir($dir) {
     foreach (glob("$dir/*") as $tempFile) {
@@ -31,7 +31,7 @@ class CRM_Core_CodeGen_Util_File {
   }
 
   /**
-   * @param $prefix
+   * @param string $prefix
    *
    * @return string
    */

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -332,7 +332,7 @@ abstract class CRM_Core_Component_Info {
   /**
    * Helper for instantiating component's elements.
    *
-   * @param $cl
+   * @param string $cl
    *
    * @return mixed
    *   component's element as class instance

--- a/CRM/Core/Controller/Simple.php
+++ b/CRM/Core/Controller/Simple.php
@@ -23,7 +23,7 @@ class CRM_Core_Controller_Simple extends CRM_Core_Controller {
   /**
    * Constructor.
    *
-   * @param null $path
+   * @param string $path
    *   The class Path of the form being implemented
    * @param bool $title
    * @param string $mode

--- a/CRM/Core/DAO/permissions.php
+++ b/CRM/Core/DAO/permissions.php
@@ -12,9 +12,9 @@
 /**
  * Decide what permissions to check for an api call
  *
- * @param $entity : (str) api entity
- * @param $action : (str) api action
- * @param $params : (array) api params
+ * @param string $entity api entity
+ * @param string $action api action
+ * @param array $params api params
  *
  * @return array
  *   Array of permissions to check for this entity-action combo

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -452,7 +452,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * so we can interrupt a potential POST/redirect
    *
    * @param string $name name of debug section
-   * @param $variable mixed reference to variables that we need a trace of
+   * @param mixed $variable reference to variables that we need a trace of
    * @param bool $log should we log or return the output
    * @param bool $html whether to generate a HTML-escaped output
    * @param bool $checkPermission should we check permissions before displaying output

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -196,7 +196,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
    * @param array $fields
    *   The input form values.
    * @param array $files
-   * @param array $self
+   * @param self $self
    *   Additional values form 'this'.
    *
    * @return bool
@@ -325,7 +325,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
   /**
    * @deprecated
    *
-   * @param $message
+   * @param string $message
    */
   public static function formatMessage(&$message) {
     $newLineOperators = [

--- a/CRM/Core/I18n/NativeGettext.php
+++ b/CRM/Core/I18n/NativeGettext.php
@@ -18,7 +18,7 @@
 class CRM_Core_I18n_NativeGettext {
 
   /**
-   * @param $string
+   * @param string $string
    *
    * @return string
    */
@@ -29,8 +29,8 @@ class CRM_Core_I18n_NativeGettext {
   /**
    * Based on php-gettext, since native gettext does not support this as is.
    *
-   * @param $context
-   * @param $text
+   * @param string $context
+   * @param string $text
    *
    * @return string
    */
@@ -47,9 +47,9 @@ class CRM_Core_I18n_NativeGettext {
   }
 
   /**
-   * @param $text
-   * @param $plural
-   * @param $count
+   * @param string $text
+   * @param string $plural
+   * @param int $count
    *
    * @return string
    */

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -451,8 +451,8 @@ class CRM_Core_I18n_Schema {
    *   schema structure class to use.
    * @param bool $isUpgradeMode
    *   Are we in upgrade mode therefore only build based off table not class
-   * @return array
-   *   array of CREATE INDEX queries
+   * @return string
+   *   The generated CREATE VIEW query
    */
   private static function createViewQuery($locale, $table, &$dao, $class = 'CRM_Core_I18n_SchemaStructure', $isUpgradeMode = FALSE) {
     $columns =& $class::columns();

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -528,7 +528,7 @@ class CRM_Core_Menu {
   }
 
   /**
-   * @param $path string
+   * @param string $path
    *   Path of menu item to retrieve.
    *
    * @return array

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -188,7 +188,7 @@ class CRM_Core_Payment_Form {
   }
 
   /**
-   * @param array $paymentProcessor
+   * @param CRM_Core_Payment $paymentProcessor
    *
    * @return string
    */

--- a/CRM/Core/Smarty/Permissions.php
+++ b/CRM/Core/Smarty/Permissions.php
@@ -7,7 +7,7 @@ class CRM_Core_Smarty_Permissions {
 
   /**
    * non-static adapter for CRM_Core_Permission::check
-   * @param $offset
+   * @param string|array $offset
    *
    * @return bool
    */

--- a/CRM/Event/BAO/ParticipantStatusType.php
+++ b/CRM/Event/BAO/ParticipantStatusType.php
@@ -19,7 +19,7 @@ class CRM_Event_BAO_ParticipantStatusType extends CRM_Event_DAO_ParticipantStatu
   /**
    * @param array $params
    *
-   * @return this|null
+   * @return self|null
    */
   public static function add(&$params) {
     if (empty($params)) {
@@ -33,7 +33,7 @@ class CRM_Event_BAO_ParticipantStatusType extends CRM_Event_DAO_ParticipantStatu
   /**
    * @param array $params
    *
-   * @return this|null
+   * @return self|null
    */
   public static function &create(&$params) {
     $transaction = new CRM_Core_Transaction();

--- a/CRM/Event/Import/Parser.php
+++ b/CRM/Event/Import/Parser.php
@@ -269,7 +269,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
    * Given a list of the importable field keys that the user has selected
    * set the active fields array to this list
    *
-   * @param $fieldKeys array mapped array of values
+   * @param array $fieldKeys mapped array of values
    *
    * @return void
    */

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -73,7 +73,7 @@ abstract class CRM_Financial_BAO_ExportFormat {
   /**
    * Abstract function that generates exports, and downloads them as zip file.
    *
-   * @param $exportDaos array with DAO's for queries to be exported.
+   * @param array $exportDaos with DAO's for queries to be exported.
    */
   abstract public function makeExport($exportDaos);
 

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -274,7 +274,7 @@ WHERE cft.id = %1
   /**
    * Get Financial Account type relations.
    *
-   * @param $flip bool
+   * @param bool $flip
    *
    * @return array
    *

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -51,13 +51,13 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
 
   /**
    * The header associated with this mailing.
-   * @var string
+   * @var CRM_Mailing_BAO_MailingComponent
    */
   private $header = NULL;
 
   /**
    * The footer associated with this mailing.
-   * @var string
+   * @var CRM_Mailing_BAO_MailingComponent
    */
   private $footer = NULL;
 

--- a/CRM/Mailing/Event/BAO/Opened.php
+++ b/CRM/Mailing/Event/BAO/Opened.php
@@ -145,7 +145,7 @@ class CRM_Mailing_Event_BAO_Opened extends CRM_Mailing_Event_DAO_Opened {
   /**
    * Get opened count for each mailing for a given set of mailing IDs and a specific contact.
    *
-   * @param int $mailingIDs
+   * @param int[] $mailingIDs
    *   IDs of the mailing (comma separated).
    * @param int $contactID
    *   ID of the contact.

--- a/CRM/Mailing/Event/BAO/Queue.php
+++ b/CRM/Mailing/Event/BAO/Queue.php
@@ -40,7 +40,7 @@ class CRM_Mailing_Event_BAO_Queue extends CRM_Mailing_Event_DAO_Queue {
    *
    * @param array $params
    *
-   * @return int
+   * @return string
    *   The hash
    */
   public static function hash($params) {

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -37,8 +37,8 @@ class CRM_Mailing_Event_BAO_Subscribe extends CRM_Mailing_Event_DAO_Subscribe {
    *   during event registration.
    * @param string $context
    *
-   * @return int|null
-   *   $se_id      The id of the subscription event, null on failure
+   * @return CRM_Mailing_Event_BAO_Subscribe|null
+   *   $se_id      The subscription event object, null on failure
    */
   public static function &subscribe($group_id, $email, $contactId = NULL, $context = NULL) {
     // CRM-1797 - allow subscription only to public groups

--- a/CRM/Mailing/Event/BAO/TrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/TrackableURLOpen.php
@@ -201,7 +201,7 @@ class CRM_Mailing_Event_BAO_TrackableURLOpen extends CRM_Mailing_Event_DAO_Track
   /**
    * Get tracked url count for each mailing for a given set of mailing IDs.
    *
-   * @param int $mailingIDs
+   * @param int[] $mailingIDs
    *   IDs of the mailing (comma separated).
    * @param int $contactID
    *   ID of the contact.

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -555,7 +555,7 @@ class CRM_Report_Form extends CRM_Core_Form {
 
   /**
    * set the number of rows to show
-   * @param $rowCount int
+   * @param int $rowCount
    */
   public function setRowCount($rowCount): void {
     $this->_rowCount = $rowCount;

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -160,7 +160,7 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
    * we're using this we don't care too much about the edge case where name
    * might not also be bidirectional.
    *
-   * @param $relationshipTypeId int
+   * @param int $relationshipTypeId
    *
    * @return bool
    */
@@ -190,7 +190,7 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
    * ONLY for ones using database storage - don't want to "fork" case types
    * that aren't currently forked.
    *
-   * @param $isDryRun bool
+   * @param bool $isDryRun
    *   If TRUE then don't actually change anything just report warnings.
    *
    * @return array List of warning messages.
@@ -326,9 +326,9 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
    * If it's unidirectional, we can't convert it if there's an edge case
    * where there's another type that has the same label.
    *
-   * @param $relationshipType array
-   * @param $caseTypeName string
-   * @param $xmlRoleName string
+   * @param array $relationshipType
+   * @param string $caseTypeName
+   * @param string $xmlRoleName
    *
    * @return string|NULL
    */

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -34,7 +34,7 @@ class CRM_Utils_Address {
    *   If true indicates, the address to be built in hcard-microformat standard.
    * @param bool $mailing
    *   If true indicates, the call has been made from mailing label.
-   * @param null $tokenFields
+   * @param string[] $tokenFields
    *
    * @return string
    *   formatted address string
@@ -265,7 +265,7 @@ class CRM_Utils_Address {
   }
 
   /**
-   * @param $format
+   * @param string $format
    *
    * @return array
    */

--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -65,7 +65,7 @@ class CRM_Utils_Cache {
   /**
    * Get cache relevant settings.
    *
-   * @param $cachePlugin
+   * @param string $cachePlugin
    *
    * @return array
    *   associative array of settings for the cache

--- a/CRM/Utils/Color.php
+++ b/CRM/Utils/Color.php
@@ -74,7 +74,7 @@ class CRM_Utils_Color {
   /**
    * Calculate a highlight color from a base color
    *
-   * @param $color
+   * @param string $color
    * @return string
    */
   public static function getHighlight($color) {
@@ -96,7 +96,7 @@ class CRM_Utils_Color {
   /**
    * Convert named color (e.g. springgreen) to hex
    *
-   * @param $colorName
+   * @param string $colorName
    * @return string|null
    */
   public static function nameToHex($colorName) {

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -267,7 +267,7 @@ class CRM_Utils_Date {
   }
 
   /**
-   * @param $string
+   * @param string $string
    *
    * @return int
    */

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -377,7 +377,7 @@ class CRM_Utils_File {
   }
 
   /**
-   * @param $ext
+   * @param string $ext
    *
    * @return bool
    */

--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -218,7 +218,7 @@ class CRM_Utils_JS {
    *   'bar' => 'function() {return "bar";}',
    * ]
    *
-   * @param $js
+   * @param string $js
    * @return array
    * @throws Exception
    */

--- a/CRM/Utils/Mail/Logger.php
+++ b/CRM/Utils/Mail/Logger.php
@@ -40,9 +40,9 @@ class CRM_Utils_Mail_Logger {
   }
 
   /**
-   * @param $to
-   * @param $headers
-   * @param $message
+   * @param string|string[] $to
+   * @param string[] $headers
+   * @param string $message
    */
   public static function log(&$to, &$headers, &$message) {
     if (is_array($to)) {

--- a/CRM/Utils/Migrate/ImportJSON.php
+++ b/CRM/Utils/Migrate/ImportJSON.php
@@ -189,8 +189,8 @@ class CRM_Utils_Migrate_ImportJSON {
   /**
    * @param $chunk
    * @param string $daoName
-   * @param null $lookUpMapping
-   * @param null $dateFields
+   * @param array|null $lookUpMapping
+   * @param array|null $dateFields
    */
   public function restore(&$chunk, $daoName, $lookUpMapping = NULL, $dateFields = NULL) {
     $object = new $daoName();

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -146,9 +146,9 @@ class CRM_Utils_Money {
    * 1.234 != 1.236 with a currency precision of 2 decimal points
    * 1.300 != 1.200 with a currency precision of 2 decimal points
    *
-   * @param $value1
-   * @param $value2
-   * @param $currency
+   * @param int|float $value1
+   * @param int|float $value2
+   * @param string $currency
    *
    * @return bool
    */

--- a/CRM/Utils/OptionBag.php
+++ b/CRM/Utils/OptionBag.php
@@ -61,7 +61,7 @@ class CRM_Utils_OptionBag implements ArrayAccess, IteratorAggregate, Countable {
   }
 
   /**
-   * @param $key
+   * @param mixed $key
    *
    * @return bool
    */

--- a/CRM/Utils/PDF/Document.php
+++ b/CRM/Utils/PDF/Document.php
@@ -127,9 +127,9 @@ class CRM_Utils_PDF_Document {
   }
 
   /**
-   * @param $value
-   * @param $metric
-   * @return int
+   * @param int $value
+   * @param string $metric
+   * @return float
    */
   public static function toTwip($value, $metric) {
     $point = CRM_Utils_PDF_Utils::convertMetric($value, $metric, 'pt');

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -28,7 +28,7 @@ class CRM_Utils_PDF_Utils {
    *   Ex: "HelloWorld.pdf".
    * @param bool $output
    *   FALSE to display PDF. TRUE to return as string.
-   * @param null $pdfFormat
+   * @param array|int|null $pdfFormat
    *   Unclear. Possibly PdfFormat or formValues.
    *
    * @return string|void
@@ -202,11 +202,11 @@ class CRM_Utils_PDF_Utils {
   }
 
   /**
-   * @param $paper_size
-   * @param $orientation
-   * @param $margins
-   * @param $html
-   * @param $output
+   * @param (float|int)[] $paper_size
+   * @param string $orientation
+   * @param array $margins
+   * @param string $html
+   * @param bool $output
    * @param string $fileName
    */
   public static function _html2pdf_wkhtmltopdf($paper_size, $orientation, $margins, $html, $output, $fileName) {
@@ -234,10 +234,10 @@ class CRM_Utils_PDF_Utils {
   /**
    * convert value from one metric to another.
    *
-   * @param $value
-   * @param $from
-   * @param $to
-   * @param null $precision
+   * @param int $value
+   * @param string $from
+   * @param string $to
+   * @param int|null $precision
    *
    * @return float|int
    */

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -76,7 +76,7 @@ class CRM_Utils_Recent {
    *   The link for the above title.
    * @param string $id
    *   Object id.
-   * @param $type
+   * @param string $type
    * @param int $contactId
    * @param string $contactName
    * @param array $others

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1361,14 +1361,13 @@ class CRM_Utils_System {
    *   Title of documentation wiki page.
    * @param bool $URLonly
    *   (optional) Whether to return URL only or full HTML link (default).
-   * @param string $text
+   * @param string|null $text
    *   (optional) Text of HTML link (no effect if $URLonly = false).
-   * @param string $title
+   * @param string|null $title
    *   (optional) Tooltip text for HTML link (no effect if $URLonly = false)
-   * @param string $style
+   * @param string|null $style
    *   (optional) Style attribute value for HTML link (no effect if $URLonly = false)
-   *
-   * @param null $resource
+   * @param string|null $resource
    *
    * @return string
    *   URL or link to documentation page, based on provided parameters.

--- a/CRM/Utils/System/Drupal6.php
+++ b/CRM/Utils/System/Drupal6.php
@@ -246,7 +246,8 @@ class CRM_Utils_System_Drupal6 extends CRM_Utils_System_DrupalBase {
   /**
    * Add a css file.
    *
-   * @param $url : string, absolute path to file
+   * @param string $url
+   *   absolute path to file
    * @param string $region
    *   location within the document: 'html-header', 'page-header', 'page-footer'.
    *

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -783,7 +783,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
-   * @param $dir
+   * @param string $dir
    *
    * @return bool
    */
@@ -963,7 +963,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   /**
    * @param array $params
-   * @param $errors
+   * @param array $errors
    * @param string $emailName
    */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
@@ -1401,8 +1401,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * is only as of PHP 7.3.0 that the setcookie() method supports the "SameSite"
    * attribute in its options and will accept "None" as a valid value.
    *
-   * @param $name The name of the cookie.
-   * @param $value The value of the cookie.
+   * @param string $name The name of the cookie.
+   * @param string $value The value of the cookie.
    * @param array $options The header options for the cookie.
    */
   private function setAuthCookie($name, $value, $options) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -855,7 +855,7 @@ class CRM_Utils_Token {
    *
    * @deprecated
    *
-   * @param $str ref to the string that will be scanned and modified
+   * @param string $str ref to the string that will be scanned and modified
    */
   public static function unescapeTokens(&$str) {
     $str = preg_replace('/\\\\|\{(\{\w+\.\w+\})\}/', '\\1', $str);

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -121,7 +121,7 @@ class Requirements {
   /**
    * Generates a mysql connection
    *
-   * @param $db_config array
+   * @param array $db_config
    * @return object mysqli connection
    */
   protected function connect($db_config) {

--- a/tests/phpunit/CRM/Case/Form/TaskTest.php
+++ b/tests/phpunit/CRM/Case/Form/TaskTest.php
@@ -11,9 +11,9 @@ class CRM_Case_Form_TaskTest extends CiviCaseTestCase {
    * Test the order of the corresponding ids in the output matches the order
    * of the ids in the input, i.e. case_contacts matches cases.
    *
-   * @param $input array
-   * @param $selected_search_results array
-   * @param $expected array
+   * @param array $input
+   * @param array $selected_search_results
+   * @param array $expected
    *
    * @dataProvider contactIDProvider
    */

--- a/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
@@ -531,9 +531,9 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
    * in the data provider.
    * Maybe it doesn't really make sense to use a data provider here, but kinda.
    *
-   * @param &$expected array Contains the placeholders to update.
-   * @param $client_id int
-   * @param $case_id int
+   * @param array &$expected Contains the placeholders to update.
+   * @param int $client_id
+   * @param int $case_id
    */
   private function updateExpectedBecauseDataProviderEvaluatesBeforeEverything(&$expected, $client_id, $case_id) {
     $display_name = $this->callAPISuccess('Contact', 'getsingle', [

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/FiveTwentyTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/FiveTwentyTest.php
@@ -328,8 +328,8 @@ ENDXML;
   /**
    * Set up some original and expected xml pairs.
    *
-   * @param $relationshipTypeNames array
-   * @param $stage int
+   * @param array $relationshipTypeNames
+   * @param int $stage
    *   We run it in a couple passes because we want to test with and without
    *   warning messages.
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
Lots more phpdoc fixes.

Largely these handle the case where previously the type definition was incorrectly placed at the end of the `@param` line, rather than before the variable name.

Before
----------------------------------------
PHPdoc inaccuracies.

After
----------------------------------------
PHPdoc (more) accurare.

Comments
----------------------------------------
This is far from comprehensive - there are still lots of PHPdoc issues left after this set of changes.
