### PR TITLE
(REF) CRM_Core_Resources - Limit visibility of `getEntityRefMetadata`

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -496,7 +496,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
    *
    * @return array
    */
-  public static function getEntityRefMetadata() {
+  protected static function getEntityRefMetadata() {
     $data = [
       'filters' => [],
       'links' => [],

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\Invasive;
+
 /**
  * Tests for linking to resource files
  * @group headless
@@ -508,7 +510,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
    */
   public function testEntityRefFiltersHook() {
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_entityRefFilters', [$this, 'entityRefFilters']);
-    $data = CRM_Core_Resources::getEntityRefMetadata();
+    $data = Invasive::call(['CRM_Core_Resources', 'getEntityRefMetadata']);
     $this->assertEquals(count($data['links']['Contact']), 4);
     $this->assertEquals(!empty($data['links']['Contact']['new_staff']), TRUE);
   }


### PR DESCRIPTION
Overview
----------------------------------------

Tighten up class contract. `CRM_Core_Resources` is a de-facto public API for adding/removing resources to a page (`addScript`, `addStyleUrl`, etc). This method is a little out-of-scope. Limit visibility.

@colemanw This was inspired from reading #22506.

Before
------

* `CRM_Core_Resources::getEntityRefMetadata()` is nominally `public`.
* The only callers are within `CRM_Core_Resources` and `CRM_Core_ResourcesTest`.
* It seems likely that the method was `public` to support that unit-test.
* This seems like a weird place for the method to live.

After
------

* `CRM_Core_Resources::getEntityRefMetadata()` no longer `public`.
* The method is still in a weird place, but at least no one will expect it to remain there.
