### PR TITLE
Fix php comments

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2556,19 +2556,22 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
 
   /**
    * Get the right links depending on the activity type and other factors.
+   *
    * @param array $values
    * @param int $activityId
-   * @param ?int $contactId
+   * @param int|null $contactId
    * @param bool $isViewOnly Is this a special type that shouldn't be edited
-   * @param ?string $context
-   * @param ?int $mask
-   * @param bool $dontBreakCaseActivities Originally this function was
+   * @param string|null $context
+   * @param int|null $mask
+   * @param bool $dontBreakCaseActivities
+   *   Originally this function was
    *   part of another function that was only used on the contact's activity
    *   tab and this parameter would only be false when you're not displaying
    *   case activities anyway and so was effectively never used. And I'm not
    *   sure why for the purposes of links you would ever want a case activity
    *   to link to the regular form, so I think this can be removed, but am
    *   leaving it as-is for now.
+   *
    * @return string HTML string
    */
   public static function getActionLinks(

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2543,7 +2543,7 @@ class CRM_Contact_BAO_Query {
    *   Search on primary location. See note below.
    * @param int $mode
    *   Determines search mode based on bitwise MODE_* constants.
-   * @param string|NULL $apiEntity
+   * @param string|null $apiEntity
    *   Determines search mode based on entity by string.
    *
    * The $primaryLocation flag only seems to be used when

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -92,7 +92,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
   /**
    * Process the form after the input has been submitted and validated.
    *
-   * @param array|NULL $params
+   * @param array|null $params
    */
   public function postProcess($params = NULL) {
     $fv = $params ?: $this->controller->exportValues($this->_name);

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -815,12 +815,13 @@ LIMIT {$offset}, {$rowCount}
    *
    * @param int $cid
    * @param int $oid
-   * @param "dupe-nondupe|nondupe-dupe" $oper
+   * @param string $oper
+   *   'nondupe-dupe' or 'dupe-nondupe'
    *
    * @return \CRM_Core_DAO|mixed|null
    */
   public static function markNonDuplicates($cid, $oid, $oper) {
-    if ($oper == 'dupe-nondupe') {
+    if ($oper === 'dupe-nondupe') {
       try {
         civicrm_api3('Exception', 'create', ['contact_id1' => $cid, 'contact_id2' => $oid]);
         return TRUE;
@@ -841,7 +842,7 @@ LIMIT {$offset}, {$rowCount}
     $exception->find(TRUE);
     $status = NULL;
 
-    if ($oper == 'nondupe-dupe') {
+    if ($oper === 'nondupe-dupe') {
       $status = $exception->delete();
     }
     return $status;

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2708,12 +2708,16 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
   }
 
   /**
+   * Prepare params for the create operation.
+   *
    * @param CRM_Core_DAO_CustomField $field
-   * @param 'add|modify|delete' $operation
+   * @param string $operation
+   *   add|modify|delete
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
-  protected static function prepareCreateParams($field, $operation) {
+  protected static function prepareCreateParams($field, $operation): array {
     $tableName = CRM_Core_DAO::getFieldValue(
       'CRM_Core_DAO_CustomGroup',
       $field->custom_group_id,

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -100,7 +100,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   /**
    * Checks that the current DB schema is at least $min version
    *
-   * @param string|number $min
+   * @param string|int $min
    * @return bool
    */
   public static function isDBVersionAtLeast($min) {

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -157,7 +157,7 @@ class CRM_Core_BAO_SchemaHandler {
    * @param array $params
    * @param string $separator
    * @param string $prefix
-   * @param string|NULL $existingIndex
+   * @param string|null $existingIndex
    *
    * @return NULL|string
    */
@@ -609,7 +609,7 @@ MODIFY      {$columnName} varchar( $length )
    * @param bool $dropFalseIndices
    *  If set - this function deletes false indices present in the DB which mismatches the expected
    *  values of xml file so that civi re-creates them with correct values using createMissingIndices() function.
-   * @param array|FALSE $tables
+   * @param array|false $tables
    *   An optional array of tables - if provided the results will be restricted to these tables.
    *
    * @return array

--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -68,7 +68,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi
    * Given a constant list of of id/name/label options, convert to the
    * format required by pseudoconstant.
    *
-   * @param string|NULL $context
+   * @param string|null $context
    * @param array $options
    *   List of options, each as a record of id+name+label.
    *   Ex: [['id' => 123, 'name' => 'foo_bar', 'label' => 'Foo Bar']]

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1665,7 +1665,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    * @param bool $skipPermission
    * @param int $op
    *   Which operation (view, edit, create, etc) to check permission for.
-   * @param array|NULL $returnFields list of UFGroup fields to return; NULL for default
+   * @param array|null $returnFields
    *
    * @return array
    *   array of ufgroups for a module

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -333,7 +333,7 @@ class CRM_Core_Payment_BaseIPN {
    * @todo This is part of a bigger refactor for dev/core/issues/927 - "duplicate" functionality exists in CRM_Contribute_BAO_Contribution::cancel()
    * @param \CRM_Member_BAO_Membership $membership
    * @param int $membershipStatusID
-   * @param boolean $onlyCancelPendingMembership
+   * @param bool $onlyCancelPendingMembership
    *   Do we only cancel pending memberships? OR memberships in any status? (see CRM-18688)
    * @fixme Historically failed() cancelled membership in any status, cancelled() cancelled only pending memberships so we retain that behaviour for now.
    * @deprecated

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -570,7 +570,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
   }
 
   /**
-   * @param string|NULL $region
+   * @param string|null $region
    *   Optional request for a specific region. If NULL/omitted, use global default.
    * @return \CRM_Core_Region
    */

--- a/CRM/Core/Resources/Bundle.php
+++ b/CRM/Core/Resources/Bundle.php
@@ -29,8 +29,8 @@ class CRM_Core_Resources_Bundle implements CRM_Core_Resources_CollectionInterfac
   public $name;
 
   /**
-   * @param string|NULL $name
-   * @param string[]|NULL $types
+   * @param string|null $name
+   * @param string[]|null $types
    *   List of resource-types to permit in this bundle. NULL for a default list.
    *   Ex: ['styleFile', 'styleUrl']
    *   The following aliases are allowed: '*all*', '*default*', '*script*', '*style*'

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -26,7 +26,7 @@ class CRM_Core_Resources_Common {
    *
    * @param string $name
    *   Symbolic name of the bundle.
-   * @param callable|NULL $init
+   * @param callable|null $init
    *   Optional initialization function. Populate default resources.
    *   Signature: `function($bundle): void`
    *   Example: `function myinit($b) { $b->addScriptFile(...)->addStyleFile(...); }`

--- a/CRM/Core/Smarty/plugins/modifier.print_array.php
+++ b/CRM/Core/Smarty/plugins/modifier.print_array.php
@@ -23,8 +23,8 @@
  * Purpose:  formats array for output in DAO files and in APIv3 Examples
  * To find where this is used do a grep in Smarty templates for |@print_array
  * @param array|object $var
- * @param integer $depth
- * @param integer $length
+ * @param int $depth
+ * @param int $length
  * @return string
  */
 function smarty_modifier_print_array($var, $depth = 0, $length = 40) {


### PR DESCRIPTION
This commit contains 14 files worth of changes from the following steps

1) install https://github.com/civicrm/coder.git
2) comment out `<rule ref=Drupal.Commenting.FunctionComment.IncorrectParamVarName><severity>0</severity></rule>`
3) run phpcbf --standard=Drupal

This follows on from efforts from @braders - there are not many
instances (although I kept the comment small) and we could fairly easily get rid of them
all and enable that rule in CI - which would lift the bar a little
