### PR TITLE
Remove unreachable, nonsensical code

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -219,14 +219,6 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     }
 
     $session->replaceUserContext($this->_cancelURL);
-    // views are implemented as frozen form
-    if ($this->_action & CRM_Core_Action::VIEW) {
-      $this->freeze();
-      $this->addElement('xbutton', 'done', ts('Done'), [
-        'type' => 'button',
-        'onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'",
-      ]);
-    }
 
     // don't show option for contribution amounts section if membership price set
     // this flag is sent to template

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -317,15 +317,6 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       $buttons[0]['class'] = 'crm-warnDataLoss';
     }
     $this->addButtons($buttons);
-
-    // TODO: Is this condition ever true? Can this code be removed?
-    if ($this->_action & CRM_Core_Action::VIEW) {
-      $this->freeze();
-      $this->addElement('xbutton', 'done', ts('Done'), [
-        'type' => 'button',
-        'onclick' => "location.href='civicrm/admin/custom/group?reset=1&action=browse'",
-      ]);
-    }
   }
 
   /**

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -464,17 +464,6 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
 
     $this->addFormRule(['CRM_UF_Form_Field', 'formRule'], $this);
 
-    // if view mode pls freeze it with the done button.
-    if ($this->_action & CRM_Core_Action::VIEW) {
-      $this->freeze();
-      $this->addElement('xbutton', 'done', ts('Done'),
-        [
-          'type' => 'button',
-          'onclick' => "location.href='civicrm/admin/uf/group/field?reset=1&action=browse&gid=" . $this->_gid . "'",
-        ]
-      );
-    }
-
     $this->setDefaults($defaults);
   }
 

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -235,15 +235,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       ],
     ]);
 
-    // views are implemented as frozen form
-    if ($this->_action & CRM_Core_Action::VIEW) {
-      $this->freeze();
-      $this->addElement('xbutton', 'done', ts('Done'), [
-        'type' => 'button',
-        'onclick' => "location.href='civicrm/admin/uf/group?reset=1&action=browse'",
-      ]);
-    }
-
     $this->addFormRule(['CRM_UF_Form_Group', 'formRule'], $this);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Removes inactive, broken code from the "Configure Contribution Page" form, and its evil copy/paste siblings from 3 other forms.

Technical Details
----------------------------------------
This block of code appears to be unreachable, because the contribution page wizard is never frozen in "view" mode.
If it were reachable, it would do nothing sensible, as the button would link to a completely unrelated page (configure custom data) and the link would be broken because it is incorrectly bypassing `CRM_Utils_System::url()`.

Comments
---------------
It looked suspiciously like copy/paste so I searched and found 3 more broken links following the same pattern & deleted them all.