### PR TITLE
[REF] - Use CRM_Contact_BAO_ContactType::basicTypes() 

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -301,7 +301,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       'household_name',
     ];
 
-    $contactTypes = ['Contact', 'Individual', 'Household', 'Organization'];
+    $contactTypes = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
     $contactReturnProperties = [];
 
     for ($rowNumber = 1; $rowNumber <= $this->_batchInfo['item_count']; $rowNumber++) {

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -63,7 +63,8 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
     ];
 
     //check if there are any custom data searchable fields
-    $extends = array_merge(['Contact', 'Individual', 'Household', 'Organization'],
+    $extends = array_merge(['Contact'],
+      CRM_Contact_BAO_ContactType::basicTypes(),
       CRM_Contact_BAO_ContactType::subTypes()
     );
     $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE,

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -599,7 +599,8 @@ class CRM_Contact_Form_Search_Criteria {
    */
   public static function custom(&$form) {
     $form->add('hidden', 'hidden_custom', 1);
-    $extends = array_merge(['Contact', 'Individual', 'Household', 'Organization'],
+    $extends = array_merge(['Contact'],
+      CRM_Contact_BAO_ContactType::basicTypes(),
       CRM_Contact_BAO_ContactType::subTypes()
     );
     $groupDetails = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, TRUE,

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -327,7 +327,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       $checkPermission = CRM_Core_Permission::EDIT;
     }
     if (empty($customDataType)) {
-      $customDataType = ['Contact', 'Individual', 'Organization', 'Household'];
+      $customDataType = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes());
     }
     if ($customDataType === 'ANY') {
       // NULL should have been respected but the line above broke that.

--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -260,7 +260,7 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
     }
 
     // Do we have access to the target record?
-    if (in_array($extends, ['Contact', 'Individual', 'Organization', 'Household'])) {
+    if ($extends === 'Contact' || in_array($extends, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
       return \Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $eid], $userID);
     }
     elseif (\Civi\Api4\Utils\CoreUtil::getApiClass($extends)) {

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -444,7 +444,7 @@ class CRM_Core_BAO_CustomValueTable {
    *                                   Empty array if no custom values found.
    * @throws CRM_Core_Exception
    */
-  public static function &getEntityValues($entityID, $entityType = NULL, $fieldIDs = NULL, $formatMultiRecordField = FALSE, $DTparams = NULL) {
+  public static function getEntityValues($entityID, $entityType = NULL, $fieldIDs = NULL, $formatMultiRecordField = FALSE, $DTparams = NULL) {
     if (!$entityID) {
       // adding this here since an empty contact id could have serious repurcussions
       // like looping forever
@@ -463,7 +463,8 @@ class CRM_Core_BAO_CustomValueTable {
       $cond[] = "cf.id IN ( $fieldIDList )";
     }
     if (empty($cond)) {
-      $cond[] = "cg.extends IN ( 'Contact', 'Individual', 'Household', 'Organization' )";
+      $contactTypes = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
+      $cond[] = "cg.extends IN ( '" . implode("', '", $contactTypes) . "' )";
     }
     $cond = implode(' AND ', $cond);
 
@@ -714,7 +715,7 @@ AND    cf.id IN ( $fieldIDList )
    * @throws Exception
    * @return array
    */
-  public static function &getValues(&$params) {
+  public static function getValues($params) {
     if (empty($params)) {
       return NULL;
     }
@@ -738,11 +739,11 @@ AND    cf.id IN ( $fieldIDList )
             [1 => $idx]
           ));
         }
-        $fieldIDs[] = (int ) $idx;
+        $fieldIDs[] = (int) $idx;
       }
     }
 
-    $default = ['Contact', 'Individual', 'Household', 'Organization'];
+    $default = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
     if (!($type = CRM_Utils_Array::value('entityType', $params)) ||
       in_array($params['entityType'], $default)
     ) {

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -515,9 +515,8 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
     // suppress any subtypes if present
     CRM_Contact_BAO_ContactType::suppressSubTypes($profileTypes);
 
-    $contactTypes = ['Contact', 'Individual', 'Household', 'Organization'];
+    $contactTypes = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
     $components = ['Contribution', 'Participant', 'Membership', 'Activity'];
-    $fields = [];
 
     // check for mix profile condition
     if (count($profileTypes) > 1) {
@@ -583,7 +582,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
    */
   public static function calculateProfileType($ufGroupType, $returnMixType = TRUE, $onlyPure = FALSE, $skipComponentType = FALSE) {
     // profile types
-    $contactTypes = ['Contact', 'Individual', 'Household', 'Organization'];
+    $contactTypes = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
     $subTypes = CRM_Contact_BAO_ContactType::subTypes();
     $components = ['Contribution', 'Participant', 'Membership', 'Activity'];
 

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1037,7 +1037,7 @@ class CRM_Core_SelectValues {
     ];
     $custom = civicrm_api3('CustomField', 'get', [
       'return' => ['name', 'label', 'custom_group_id.title'],
-      'custom_group_id.extends' => ['IN' => ['Contact', 'Individual', 'Organization', 'Household']],
+      'custom_group_id.extends' => ['IN' => array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes())],
       'data_type' => ['NOT IN' => ['ContactReference', 'Date', 'File']],
       'custom_group_id.is_active' => 1,
       'is_active' => 1,

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -172,7 +172,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     $this->add('text', 'title', ts('Set Name'), $attributes['title'], TRUE);
 
     //Fix for code alignment, CRM-3058
-    $contactTypes = ['Contact', 'Individual', 'Household', 'Organization'];
+    $contactTypes = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes());
     $this->assign('contactTypes', json_encode($contactTypes));
 
     $sel1 = ["" => ts("- select -")] + CRM_Core_SelectValues::customGroupExtends();

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1128,7 +1128,7 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
  * @param $entity
  */
 function _civicrm_api3_format_params_for_create(&$params, $entity) {
-  $nonGenericEntities = ['Contact', 'Individual', 'Household', 'Organization'];
+  $nonGenericEntities = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
 
   $customFieldEntities = array_diff_key(CRM_Core_SelectValues::customGroupExtends(), array_fill_keys($nonGenericEntities, 1));
   if (!array_key_exists($entity, $customFieldEntities)) {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #22389 to cleanup more hardcoded references to contact types. 

Before
----------------------------------------
Hardcoded arrays.

After
----------------------------------------
Use function.

Technical Details
------------------------
Also cleans up a couple problematic pass-by-references.