### PR TITLE
Fix more phpdoc comments in member links functions

### DIFF
--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -28,6 +28,16 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
   public $_contactId = NULL;
 
   /**
+   * @var bool
+   */
+  private $_isPaymentProcessor = FALSE;
+
+  /**
+   * @var bool
+   */
+  private $_accessContribution = FALSE;
+
+  /**
    * called when action is browse.
    */
   public function browse() {
@@ -118,8 +128,8 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         $isCancelSupported = CRM_Member_BAO_Membership::isCancelSubscriptionSupported(
           $membership[$dao->id]['membership_id']);
         $links = self::links('all',
-            NULL,
-            NULL,
+            FALSE,
+            FALSE,
             $isCancelSupported,
             $isUpdateBilling
         );
@@ -240,7 +250,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
   /**
    * called when action is view.
    *
-   * @return null
+   * @return mixed
    */
   public function view() {
     $controller = new CRM_Core_Controller_Simple(
@@ -258,7 +268,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
   /**
    * called when action is update or new.
    *
-   * @return null
+   * @return mixed
    */
   public function edit() {
     // We're trying to edit existing memberships or create a new one so we'll first check that a membership
@@ -486,8 +496,8 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    * Get action links.
    *
    * @param string $status
-   * @param null $isPaymentProcessor
-   * @param null $accessContribution
+   * @param bool $isPaymentProcessor
+   * @param bool $accessContribution
    * @param bool $isCancelSupported
    * @param bool $isUpdateBilling
    *
@@ -496,8 +506,8 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
    */
   public static function &links(
     $status = 'all',
-    $isPaymentProcessor = NULL,
-    $accessContribution = NULL,
+    $isPaymentProcessor = FALSE,
+    $accessContribution = FALSE,
     $isCancelSupported = FALSE,
     $isUpdateBilling = FALSE
   ) {

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -165,17 +165,17 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
    *
    * @param string $status
    * @param bool $isPaymentProcessor
-   * @param null $accessContribution
-   * @param null $qfKey
-   * @param null $context
+   * @param bool $accessContribution
+   * @param string|null $qfKey
+   * @param string|null $context
    * @param bool $isCancelSupported
    *
    * @return array
    */
   public static function &links(
     $status = 'all',
-    $isPaymentProcessor = NULL,
-    $accessContribution = NULL,
+    $isPaymentProcessor = FALSE,
+    $accessContribution = FALSE,
     $qfKey = NULL,
     $context = NULL,
     $isCancelSupported = FALSE
@@ -308,19 +308,15 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
     $processors = CRM_Core_PseudoConstant::paymentProcessor(FALSE, FALSE,
       "billing_mode IN ( 1, 3 )"
     );
+    $isPaymentProcessor = FALSE;
     if (count($processors) > 0) {
-      $this->_isPaymentProcessor = TRUE;
-    }
-    else {
-      $this->_isPaymentProcessor = FALSE;
+      $isPaymentProcessor = TRUE;
     }
 
     // Only show credit card membership signup and renewal if user has CiviContribute permission
+    $accessContribution = FALSE;
     if (CRM_Core_Permission::access('CiviContribute')) {
-      $this->_accessContribution = TRUE;
-    }
-    else {
-      $this->_accessContribution = FALSE;
+      $accessContribution = TRUE;
     }
 
     //get all campaigns.
@@ -375,8 +371,8 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
 
         $isCancelSupported = CRM_Member_BAO_Membership::isCancelSubscriptionSupported($row['membership_id']);
         $links = self::links('all',
-          $this->_isPaymentProcessor,
-          $this->_accessContribution,
+          $isPaymentProcessor,
+          $accessContribution,
           $this->_key,
           $this->_context,
           $isCancelSupported
@@ -524,7 +520,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
   /**
    * Alphabet query.
    *
-   * @return mixed
+   * @return CRM_Core_DAO
    */
   public function alphabetQuery() {
     return $this->_query->alphabetQuery();


### PR DESCRIPTION
Overview
----------------------------------------
More PHPdoc fixes, this time in CiviMember. This mostly relates to the `links` function of these two classes.

Before
----------------------------------------
Inaccuracies, including bad defaults of type `null`. 

After
----------------------------------------
Accurate type definitions.

Comments
----------------------------------------
In `CRM_Member_Selector_Search`, `_isPaymentProcessor` and `_accessContribution` where previously properties, despite only being used in a single context. Therefore I have switched these to be standard variables. 

It did cross my mind that these properties could be there in order to allow their values to be read within hook callbacks,  but looking through the code it didn't look to me like that was the case. 
