### PR TITLE
[Ref] Remove unused _colours property

### DIFF
--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -21,26 +21,7 @@
 class CRM_Utils_Chart {
 
   /**
-   * Colours.
-   * @var array
-   */
-  private static $_colours = [
-    "#C3CC38",
-    "#C8B935",
-    "#CEA632",
-    "#D3932F",
-    "#D9802C",
-    "#FA6900",
-    "#DC9B57",
-    "#F78F01",
-    "#5AB56E",
-    "#6F8069",
-    "#C92200",
-    "#EB6C5C",
-  ];
-
-  /**
-   * Build The Bar Gharph.
+   * Build The Bar Graph.
    *
    * @param array $params
    *   Assoc array of name/value pairs.


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Remove unused _colours property.

Comments
----------------------------------------
Multiple factors make me think this property is unused.

- Searching the codebase for _colours returns no other options,
- The commit which introduced the array contains the phrase "WIP" (work in progress),
- The property is marked as private, and so I don't think there is a risk of this breaking extensions.
