### PR TITLE
Remove category from case activity template

### DIFF
--- a/xml/templates/message_templates/case_activity_html.tpl
+++ b/xml/templates/message_templates/case_activity_html.tpl
@@ -60,7 +60,7 @@
             {foreach from=$activity.fields item=field}
               <tr>
                 <td {$labelStyle}>
-                  {$field.label}{if !empty($field.category)}({$field.category}){/if}
+                  {$field.label}
                 </td>
                 <td {$valueStyle}>
                   {if $field.type eq 'Date'}

--- a/xml/templates/message_templates/case_activity_text.tpl
+++ b/xml/templates/message_templates/case_activity_text.tpl
@@ -17,9 +17,9 @@
 
 {foreach from=$activity.fields item=field}
 {if $field.type eq 'Date'}
-{$field.label}{if !empty($field.category)}({$field.category}){/if} : {$field.value|crmDate:$config->dateformatDatetime}
+{$field.label} : {$field.value|crmDate:$config->dateformatDatetime}
 {else}
-{$field.label}{if !empty($field.category)}({$field.category}){/if} : {$field.value}
+{$field.label} : {$field.value}
 {/if}
 {/foreach}
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove category from case activity template

Before
----------------------------------------
The empty checks for `$activity['fields']['category'] cause enotices when smarty is in strict mode

After
----------------------------------------
I removed references to the parameters

Technical Details
----------------------------------------
@demeritcowboy I originally thought to ensure this was assigned - but I can't find anywhere where it is set outside the Audit report code `CRM_Case_Audit_Audit` that seems to use a different template so am suggesting just removing from the template. Note that I will regenerate the sql (before or after this is merged) if agreed but I won't do any upgrade changes as it's not going to matter for existing sites if it already is always empty & they are unlikely to see the notice anyway so we can wait for a more material change

Comments
----------------------------------------
This is not the only potential variable issue in this tpl -but there is enough complexity in confirming this change I kept it alone