### PR TITLE
dev/core#3034 Ensure that filename contains the file extension for PDFs

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -263,7 +263,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     $fileName = $this->getFileName();
 
     if ($type === 'pdf') {
-      CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
+      CRM_Utils_PDF_Utils::html2pdf($html, $fileName . '.pdf', FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
       $fileName = pathinfo($formValues['document_file_path'], PATHINFO_FILENAME) . '.' . $type;


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that the file extension is within the content-disposition header when downloading a pdf file

Before
----------------------------------------
File extension may not be in the header

After
----------------------------------------
File extension is in the header and part of the file name

ping @eileenmcnaughton @demeritcowboy @colemanw 