### PR TITLE
[dev/core#3029] Avoid risking a TypeError when evaluating tokens for non-existent custom fields

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -496,6 +496,8 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @param int $id
    *
    * @return string
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function getCustomFieldName(int $id): string {
     foreach ($this->getTokenMetadata() as $key => $field) {
@@ -503,6 +505,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         return $key;
       }
     }
+    throw new CRM_Core_Exception(
+      "A custom field with the ID {$id} does not exist"
+    );
   }
 
   /**
@@ -515,9 +520,14 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    */
   protected function getCustomFieldValue($entityID, string $field) {
     $id = str_replace('custom_', '', $field);
-    $value = $this->prefetch[$entityID][$this->getCustomFieldName($id)] ?? '';
-    if ($value !== NULL) {
-      return CRM_Core_BAO_CustomField::displayValue($value, $id);
+    try {
+      $value = $this->prefetch[$entityID][$this->getCustomFieldName($id)] ?? '';
+      if ($value !== NULL) {
+        return CRM_Core_BAO_CustomField::displayValue($value, $id);
+      }
+    }
+    catch (CRM_Core_Exception $exception) {
+      return NULL;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix for [core/dev#3029](https://lab.civicrm.org/dev/core/-/issues/3029)

Before
----------------------------------------
Evaluating tokens for non-existent custom fields fails with a 500 `TypeError`.

After
----------------------------------------
No error.

Technical Details
----------------------------------------
Due to type hinting in `CRM_Core_EntityTokens::getCustomFieldName()` a `TypeError` was being issued when the custom field in question did not exist. Instead, an exception is now being thrown, which is being caught in the currently only calling method `CRM_Core_EntityTokens::getCustomFieldValue()` which returns `NULL` instead of a formatted custom field value.

Comments
----------------------------------------
Maybe simply returning `NULL` (with PHP 7.1 supporting [nullable return types](https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types)) is easier? @eileenmcnaughton