### PR TITLE
add `contact_id` to email params in `emailLetter` function

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -465,7 +465,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
       }
 
       $defaults = [
-        'contact_id' => $contact['id'],
+        'contactId' => $contact['id'],
         'toName' => $contact['display_name'],
         'toEmail' => $contact['email'],
         'text' => '',

--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -465,6 +465,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
       }
 
       $defaults = [
+        'contact_id' => $contact['id'],
         'toName' => $contact['display_name'],
         'toEmail' => $contact['email'],
         'text' => '',
@@ -488,8 +489,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
         $defaults['html'] = ts('Please see attached');
         $defaults['attachments'] = [CRM_Utils_Mail::appendPDF('ThankYou.pdf', $html, $format)];
       }
-      $params = array_merge($defaults);
-      return CRM_Utils_Mail::send($params);
+      return CRM_Utils_Mail::send($defaults);
     }
     catch (CRM_Core_Exception $e) {
       return FALSE;

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -159,6 +159,7 @@ class CRM_Utils_Mail {
    *   fullPath : complete pathname to the file
    *   mime_type: mime type of the attachment
    *   cleanName: the user friendly name of the attachmment
+   * contactId : contact id to send the email to (optional)
    *
    * @param array $params
    *   (by reference).

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -27,6 +27,7 @@ return new class() extends EventCheck implements HookInterface {
     'autoSubmitted' => ['type' => 'bool', 'for' => 'messageTemplate'],
     'Message-ID' => ['type' => 'string', 'for' => ['messageTemplate', 'singleEmail']],
     'messageId' => ['type' => 'string', 'for' => ['messageTemplate', 'singleEmail']],
+    'contactId' => ['type' => 'int|NULL', 'for' => ['messageTemplate' /* deprecated in favor of tokenContext[contactId] */, 'singleEmail']],
 
     // ## Envelope: CiviMail/Flexmailer
 
@@ -49,7 +50,6 @@ return new class() extends EventCheck implements HookInterface {
 
     'tokenContext' => ['type' => 'array', 'for' => 'messageTemplate'],
     'tplParams' => ['type' => 'array', 'for' => 'messageTemplate'],
-    'contactId' => ['type' => 'int|NULL', 'for' => 'messageTemplate' /* deprecated in favor of tokenContext[contactId] */],
     'workflow' => [
       'regex' => '/^([a-zA-Z_]+)$/',
       'type' => 'string',

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -39,6 +39,9 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     parent::setUp();
     $this->_individualId = $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']);
     $this->_docTypes = CRM_Core_SelectValues::documentApplicationType();
+    $hooks = \CRM_Utils_Hook::singleton();
+    $hooks->setHook('civicrm_alterMailParams',
+      array($this, 'hook_alterMailParams'));
   }
 
   /**
@@ -678,6 +681,13 @@ value=$contact_aggregate+$contribution.total_amount}
       'source' => 'Contribution Source',
     ], $contributionParams);
     return $this->callAPISuccess('Contribution', 'create', $contributionParams)['id'];
+  }
+
+  /**
+   * @see CRM_Utils_Hook::alterMailParams
+   */
+  public function hook_alterMailParams(&$params, $context = NULL) {
+    $this->assertTrue(isset($params['contactId']));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
I add the `contact_id` to email params in `emailLetter()` function.

Before
----------------------------------------
If you use Mail hooks (`alterMailParams` and `postEmailSend`) you do not know which contact you are sending the email to, or at least it is not easy to know.


After
----------------------------------------
Now, if you use `alterMailParams` or `postEmailSend` hooks, you can know contact and get all its details.

Technical Details
----------------------------------------
I use `contact_id` key and not `contactId` because everywhere is called this.

Comments
----------------------------------------
I removed the unnecessary line:
```
$params = array_merge($defaults);
```
