### PR TITLE
SearchKit - Fix token selector to use expression alias

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -30,7 +30,7 @@
         var allFields = ctrl.admin.getAllFields(ctrl.suffix || '', ['Field', 'Custom', 'Extra', 'Pseudo']);
         _.eachRight(ctrl.admin.savedSearch.api_params.select, function(fieldName) {
           allFields.unshift({
-            id: fieldName,
+            id: _.last(fieldName.split(' AS ')),
             text: searchMeta.getDefaultLabel(fieldName)
           });
         });


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the SearchKit token selector which caused it to output the wrong token for fields using a transformation.

Before
----------------------------------------
Incorrect token for fields using a transformation.

After
----------------------------------------
Correct token for all fields.

Comments
----------------------------------------
This regressed in 5.41 with #20880. The regression is recent enough and the fix simple enough to warrant an RC merge IMO.