### PR TITLE
Refactor buildPremiumPreviewBlock function to make intended usage clearer

### DIFF
--- a/CRM/Contribute/BAO/Premium.php
+++ b/CRM/Contribute/BAO/Premium.php
@@ -144,22 +144,19 @@ class CRM_Contribute_BAO_Premium extends CRM_Contribute_DAO_Premium {
   }
 
   /**
-   * Build Premium B im Contribution Pages.
+   * Build Premium Preview block for Contribution Pages.
    *
    * @param CRM_Core_Form $form
-   * @param int $productID
-   * @param int $premiumProductID
+   * @param int|null $productID
+   *
+   * @return void
    */
-  public function buildPremiumPreviewBlock($form, $productID, $premiumProductID = NULL) {
-    if ($premiumProductID) {
-      $dao = new CRM_Contribute_DAO_PremiumsProduct();
-      $dao->id = $premiumProductID;
-      $dao->find(TRUE);
-      $productID = $dao->product_id;
-    }
+  public static function buildPremiumPreviewBlock($form, $productID) {
     $productDAO = new CRM_Contribute_DAO_Product();
     $productDAO->id = $productID;
     $productDAO->is_active = 1;
+    $products = [];
+
     if ($productDAO->find(TRUE)) {
       CRM_Core_DAO::storeValues($productDAO, $products[$productDAO->id]);
     }

--- a/CRM/Contribute/Form/ContributionPage/AddProduct.php
+++ b/CRM/Contribute/Form/ContributionPage/AddProduct.php
@@ -123,7 +123,12 @@ class CRM_Contribute_Form_ContributionPage_AddProduct extends CRM_Contribute_For
     }
 
     if ($this->_action & CRM_Core_Action::PREVIEW) {
-      CRM_Contribute_BAO_Premium::buildPremiumPreviewBlock($this, NULL, $this->_pid);
+      $dao = new CRM_Contribute_DAO_PremiumsProduct();
+      $dao->id = $this->_pid;
+      $dao->find(TRUE);
+      $productID = $dao->product_id;
+
+      CRM_Contribute_BAO_Premium::buildPremiumPreviewBlock($this, $productID);
       $this->addButtons([
         [
           'type' => 'next',


### PR DESCRIPTION
Overview
----------------------------------------
Refactor buildPremiumPreviewBlock function to make intended usage clearer.

This is an alternative refactor to #22523, based on @eileenmcnaughton's comments.

Before
----------------------------------------
- Function comment was not particuarly clear
- Function not static, despite only ever being used statically
- Relationship between second and third argument confusing

After
----------------------------------------

- Function comment improved
- Function marked as static
- $premiumProductID argument removed, and that logic moved back to the `Form` object
- $products array explicitly set to avoid risk of referencing undefined variable


Comments
----------------------------------------
Only one of this and #22523 should be merged - for @eileenmcnaughton to make the call which.
