### PR TITLE
Only format smarty aliases as money if specified

### DIFF
--- a/CRM/Contribute/WorkflowMessage/RecurringCancelled.php
+++ b/CRM/Contribute/WorkflowMessage/RecurringCancelled.php
@@ -19,8 +19,22 @@ class CRM_Contribute_WorkflowMessage_RecurringCancelled extends Civi\WorkflowMes
    */
   public $contact;
 
+  /**
+   * Export tokens to smarty as variables.
+   *
+   * The key represents the smarty token and the value is the token as
+   * requested from the token processor.
+   *
+   * The token is 'the entire part between the curly quotes' eg.
+   *
+   * '{contribution_recur.amount|crmMoney}.
+   *
+   * Unlike using the contribution directly it will default to 'raw' formatting.
+   *
+   * @param array $export
+   */
   protected function exportExtraTokenContext(array &$export): void {
-    $export['smartyTokenAlias']['amount'] = 'contribution_recur.amount';
+    $export['smartyTokenAlias']['amount'] = 'contribution_recur.amount|crmMoney';
     $export['smartyTokenAlias']['recur_frequency_unit'] = 'contribution_recur.frequency_unit:label';
     $export['smartyTokenAlias']['recur_frequency_interval'] = 'contribution_recur.frequency_interval';
   }

--- a/CRM/Contribute/WorkflowMessage/RecurringEdit.php
+++ b/CRM/Contribute/WorkflowMessage/RecurringEdit.php
@@ -33,13 +33,32 @@ class CRM_Contribute_WorkflowMessage_RecurringEdit extends Civi\WorkflowMessage\
    */
   public $receiptFromEmail;
 
+  /**
+   * Export tokens to smarty as variables.
+   *
+   * The key represents the smarty token and the value is the token as
+   * requested from the token processor.
+   *
+   * The token is 'the entire part between the curly quotes' eg.
+   *
+   * '{contribution_recur.amount|crmMoney}.
+   *
+   * Unlike using the contribution directly it will default to 'raw' formatting.
+   *
+   * @param array $export
+   */
   protected function exportExtraTokenContext(array &$export): void {
     $export['smartyTokenAlias']['installments'] = 'contribution_recur.installments';
-    $export['smartyTokenAlias']['amount'] = 'contribution_recur.amount';
+    $export['smartyTokenAlias']['amount'] = 'contribution_recur.amount|crmMoney';
     $export['smartyTokenAlias']['recur_frequency_unit'] = 'contribution_recur.frequency_unit:label';
     $export['smartyTokenAlias']['recur_frequency_interval'] = 'contribution_recur.frequency_interval';
   }
 
+  /**
+   * Extra variables to be exported to smarty based on being calculated.
+   *
+   * @param array $export
+   */
   protected function exportExtraTplParams(array &$export): void {
     if (empty($export['receipt_from_email']) && !empty($this->from)) {
       // At a minimum, we can at least autofill 'receipt_from_email' in the case where it's missing.


### PR DESCRIPTION


Overview
----------------------------------------
Only format smarty aliases as money if specified

Before
----------------------------------------
When defining a token that should be assigned as a smarty variable in a smarty template it is always assigned money formatted, if it is money

After
----------------------------------------
When defining a token that should be assigned as a smarty variable in a smarty template formatting should be specified

Technical Details
----------------------------------------
Smarty aliases allow tokens to be assigned to the template as smarty variables. They are very new,
have only been implemented in these 2 places and are not accessible from outside of core, which
both have unit test cover.

When trying to extend it to cover another variable (totalTaxAmount) in another template I found
that a raw format is appropriate. I think it makes sense to explicitly specify.

Comments
----------------------------------------

