### PR TITLE
Add option to display money tokens without formatting

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -470,8 +470,18 @@ class TokenProcessor {
       }
     }
 
-    if ($value instanceof Money && $filter === NULL) {
-      $filter = ['crmMoney'];
+    if ($value instanceof Money) {
+      switch ($filter[0] ?? NULL) {
+        case NULL:
+        case 'crmMoney':
+          return \Civi::format()->money($value->getAmount(), $value->getCurrency());
+
+        case 'raw':
+          return $value->getAmount();
+
+        default:
+          throw new \CRM_Core_Exception("Invalid token filter: $filter");
+      }
     }
 
     switch ($filter[0] ?? NULL) {
@@ -483,11 +493,6 @@ class TokenProcessor {
 
       case 'lower':
         return mb_strtolower($value);
-
-      case 'crmMoney':
-        if ($value instanceof Money) {
-          return \Civi::format()->money($value->getAmount(), $value->getCurrency());
-        }
 
       case 'crmDate':
         if ($value instanceof \DateTime) {

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -213,6 +213,26 @@ case.custom_1 :' . '
   }
 
   /**
+   * Test that contribution recur tokens are consistently rendered.
+   */
+  public function testContributionRecurTokenRaw(): void {
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => __CLASS__,
+      'smarty' => FALSE,
+      'schema' => ['contribution_recurId'],
+    ]);
+    $tokenProcessor->addMessage('not_specified', '{contribution_recur.amount}', 'text/plain');
+    $tokenProcessor->addMessage('money', '{contribution_recur.amount|crmMoney}', 'text/plain');
+    $tokenProcessor->addMessage('raw', '{contribution_recur.amount|raw}', 'text/plain');
+    $tokenProcessor->addMessage('moneyNumber', '{contribution_recur.amount|crmMoneyNumber}', 'text/plain');
+    $tokenProcessor->addRow(['contribution_recurId' => $this->getContributionRecurID()]);
+    $tokenProcessor->evaluate();
+    $this->assertEquals('€5,990.99', $tokenProcessor->getRow(0)->render('not_specified'));
+    $this->assertEquals('€5,990.99', $tokenProcessor->getRow(0)->render('money'));
+    $this->assertEquals('5990.99', $tokenProcessor->getRow(0)->render('raw'));
+  }
+
+  /**
    * Test money format tokens can respect passed in locale.
    */
   public function testMoneyFormat(): void {


### PR DESCRIPTION

Overview
----------------------------------------
Add option to display money tokens without formatting

Before
----------------------------------------
No way to specify that an amount should be rendered to the template as a raw machine friendly value

Both of these return the same formatted value

`{contribution.total_amount}`
`{contribution.total_amount|crmMoney}`

After
----------------------------------------
`{contribution.total_amount|raw}`

Technical Details
----------------------------------------
In order to provide compatibility we have implemented our formatting with no
format being 'format as money' rather than 'no format'. This means
we still don't have a way to do no format....

obviously we can bikeshed whether 'raw' is an appropriate
format name for the raw value.... `crmMachineMoney` is an alternative 
that was in a previous discussion but fell out of scope

Comments
----------------------------------------
@totten I'm guessing you might have thoughts on what the 'do not format' version should look like.....