### PR TITLE
SearchKit - Support conditional links

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -8,16 +8,51 @@
       apiParams: '<',
       links: '<'
     },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkGroup.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
-        linkProps = ['path', 'entity', 'action', 'join', 'target', 'icon', 'text', 'style'];
+        linkProps = ['path', 'entity', 'action', 'join', 'target', 'icon', 'text', 'style', 'condition'];
+
+      var permissionOperators = [
+        {key: '=', value: ts('Has')},
+        {key: '!=', value: ts('Lacks')}
+      ];
+
+      this.getOperators = function(clause) {
+        if (clause[0] === 'check user permission') {
+          return permissionOperators;
+        }
+        return CRM.crmSearchAdmin.operators;
+      };
 
       this.styles = CRM.crmSearchAdmin.styles;
 
       this.getStyle = function(item) {
         return _.findWhere(this.styles, {key: item.style});
+      };
+
+      this.getField = searchMeta.getField;
+
+      this.fields = function() {
+        var selectFields = ctrl.crmSearchAdmin.getSelectFields();
+        var permissionField = [{
+          text: ts('Current User Permission'),
+          id: 'check user permission',
+          description: ts('Check permission of logged-in user')
+        }];
+        return {results: permissionField.concat(selectFields)};
+      };
+
+      this.onChangeCondition = function(item) {
+        if (item.condition[0]) {
+          item.condition[1] = '=';
+        } else {
+          item.condition = [];
+        }
       };
 
       this.sortableOptions = {
@@ -32,23 +67,31 @@
         }
       };
 
+      this.permissions = CRM.crmSearchAdmin.permissions;
+
       $scope.pickIcon = function(index) {
         searchMeta.pickIcon().then(function(icon) {
           ctrl.group[index].icon = icon;
         });
       };
 
+      function setDefaults(item, newValue) {
+        _.each(linkProps, function(prop) {
+          item[prop] = newValue[prop] || (prop === 'condition' ? [] : '');
+        });
+      }
+
       this.addItem = function(item) {
-        ctrl.group.push(_.pick(item, linkProps));
+        var newItem = _.pick(item, linkProps);
+        setDefaults(newItem, newItem);
+        ctrl.group.push(newItem);
       };
 
       this.onChangeLink = function(item, newValue) {
         if (newValue.path === 'civicrm/') {
           newValue = JSON.parse(this.default);
         }
-        _.each(linkProps, function(prop) {
-          item[prop] = newValue[prop] || '';
-        });
+        setDefaults(item, newValue);
       };
 
       this.serialize = JSON.stringify;
@@ -58,10 +101,14 @@
           style: 'default',
           text: ts('Link'),
           icon: 'fa-external-link',
+          condition: [],
           path: 'civicrm/'
         });
         var defaultLinks = _.filter(ctrl.links, function(link) {
           return !link.join;
+        });
+        _.each(ctrl.group, function(item) {
+          setDefaults(item, item);
         });
         if (!ctrl.group.length) {
           if (defaultLinks.length) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -6,6 +6,7 @@
       <th>{{:: ts('Open') }}</th>
       <th>{{:: ts('Text') }}</th>
       <th>{{:: ts('Link') }}</th>
+      <th>{{:: ts('Show if') }}</th>
       <th>{{:: ts('Style') }}</th>
       <th class="crm-search-admin-icon-col"></th>
     </tr>
@@ -33,6 +34,17 @@
       </td>
       <td class="form-inline">
         <crm-search-admin-link-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" link="item" links="$ctrl.links" on-change="$ctrl.onChangeLink(item, newLink)"></crm-search-admin-link-select>
+      </td>
+      <td class="form-inline">
+        <input ng-model="item.condition[0]" crm-ui-select="{placeholder: item.action ? ts('Allowed') : ts('Always'), data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition(item)">
+        <select ng-if="item.condition[0]" class="form-control api4-operator" ng-model="item.condition[1]" ng-options="o.key as o.value for o in $ctrl.getOperators(item.condition)">
+        </select>
+        <div class="form-group" ng-if="item.condition[0] === 'check user permission'">
+          <input class="form-control" crm-ui-select="{data: $ctrl.permissions}" ng-model="item.condition[2]">
+        </div>
+        <div class="form-group" ng-if="item.condition[0] && item.condition[0] !== 'check user permission' && item.condition[1].indexOf('IS ') !== 0">
+          <crm-search-input ng-model="item.condition[2]" field="$ctrl.getField(item.condition[0])" option-key="'name'" op="item.condition[1]" class="form-group"></crm-search-input>
+        </div>
       </td>
       <td>
         <div class="btn-group">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -28,14 +28,8 @@
 
       this.getTokens = function() {
         var allFields = ctrl.admin.getAllFields(ctrl.suffix || '', ['Field', 'Custom', 'Extra', 'Pseudo']);
-        _.eachRight(ctrl.admin.savedSearch.api_params.select, function(fieldName) {
-          allFields.unshift({
-            id: _.last(fieldName.split(' AS ')),
-            text: searchMeta.getDefaultLabel(fieldName)
-          });
-        });
         return {
-          results: allFields
+          results: ctrl.admin.getSelectFields().concat(allFields)
         };
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Advanced feature to conditionally show/hide links in a links/buttons/menu column, based on user permissions or row values.

Before
----------------------------------------
Links would display unconditionally.

After
----------------------------------------
Links can be hidden based on user permissions (e.g. "access CiviCase") or according to a value (e.g. `is_active = TRUE`).
