### PR TITLE
Fix Grant::retrieve to meet full phpcs standard

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1502,8 +1502,7 @@ LIKE %1
    * @param array $returnProperities
    *   An assoc array of fields that need to be returned, eg array( 'first_name', 'last_name').
    *
-   * @return object
-   *   an object of type referenced by daoName
+   * @return static|null
    */
   public static function commonRetrieve($daoName, &$params, &$defaults, $returnProperities = NULL) {
     $object = new $daoName();

--- a/ext/civigrant/CRM/Grant/BAO/Grant.php
+++ b/ext/civigrant/CRM/Grant/BAO/Grant.php
@@ -60,23 +60,20 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
   }
 
   /**
-   * Fetch object based on array of properties.
+   * Retrieve DB object and copy to defaults array.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
+   *   Array of criteria values.
    * @param array $defaults
-   *   (reference ) an assoc array to hold the flattened values.
+   *   Array to be populated with found values.
    *
-   * @return CRM_Grant_DAO_Grant
+   * @return self|null
+   *   The DAO object, if found.
+   *
+   * @deprecated
    */
-  public static function retrieve(&$params, &$defaults) {
-    $grant = new CRM_Grant_DAO_Grant();
-    $grant->copyValues($params);
-    if ($grant->find(TRUE)) {
-      CRM_Core_DAO::storeValues($grant, $defaults);
-      return $grant;
-    }
-    return NULL;
+  public static function retrieve(array $params, array &$defaults = []) {
+    return self::commonRetrieve(self::class, $params, $defaults);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix Grant::retrieve to meet full phpcs standard

Before
----------------------------------------
After applying https://github.com/civicrm/civicrm-core/pull/22543 I find the changes don't meet the full drupal standard

After
----------------------------------------
The new boilerplate meets the full drupal standard

Technical Details
----------------------------------------
The reason our standard falls short of 'the full drupal' it that it was too big a lift to retrofit it all at once. We have been slowly raising the bar. Since we are basically creating new boilerplate I was concerned we were actually going backwards against 'the full drupal' so I worked through it on this file to see what a fully compliant bit of boilerplate would look like

Comments
----------------------------------------
