### PR TITLE
APIv4 - Make Permission 'group' discoverable in API Explorer

### DIFF
--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -43,6 +43,14 @@ class Permission extends Generic\AbstractEntity {
           'name' => 'group',
           'title' => 'Group',
           'data_type' => 'String',
+          'options' => [
+            'civicrm' => 'civicrm',
+            'cms' => 'cms',
+            'const' => 'const',
+            'afform' => 'afform',
+            'afformGeneric' => 'afformGeneric',
+            'unknown' => 'unknown',
+          ],
         ],
         [
           'name' => 'name',


### PR DESCRIPTION
Overview
----------------------------------------
Makes `group` options for the `Permission` api discoverable.

Before
----------------------------------------
No options for Permission group.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/149862757-a220cfc5-e631-47d1-b151-7df4f8b04784.png)
