### PR TITLE
Fix return values for API3 Job.delete

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -98,7 +98,7 @@ function civicrm_api3_job_get($params) {
  * @param array $params
  */
 function civicrm_api3_job_delete($params) {
-  _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
API3 Job.delete missing return values

After
----------------------------------------
API3 Job.delete has standard return values.

Technical Details
----------------------------------------

Comments
----------------------------------------

