### PR TITLE
(NFC) Correctly document CRM_Utils_Hook::pre to allow null ID

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -331,7 +331,7 @@ abstract class CRM_Utils_Hook {
    *   The type of operation being performed.
    * @param string $objectName
    *   The name of the object.
-   * @param int $id
+   * @param int|null $id
    *   The object id if available.
    * @param array $params
    *   The parameters used for object creation / editing.

--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -44,7 +44,7 @@ class PreEvent extends GenericHookEvent {
    *
    * @param string $action
    * @param string $entity
-   * @param int $id
+   * @param int|null $id
    * @param array $params
    */
   public function __construct($action, $entity, $id, &$params) {


### PR DESCRIPTION
Overview
----------------------------------------
Correctly document CRM_Utils_Hook::pre to allow null ID

Before
----------------------------------------
A null ID is passed to `CRM_Utils_Hook::pre()` in 14 places throughout core, and this is legitamate behaviour. The docblock was incorrect.

After
----------------------------------------
Code comments improved.
