### PR TITLE
(NFC) Update PHPDoc for alterDeferredRevenueItems

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2589,11 +2589,8 @@ abstract class CRM_Utils_Hook {
    * inserted in civicrm_financial_trxn table
    *
    * @param array $deferredRevenues
-   *
-   * @param array $contributionDetails
-   *
+   * @param CRM_Contribute_BAO_Contribution $contributionDetails
    * @param bool $update
-   *
    * @param string $context
    *
    * @return mixed


### PR DESCRIPTION
Overview
----------------------------------------
Update PHPDoc for alterDeferredRevenueItems

Before
----------------------------------------
The param `$contributionDetails` was declared as an array. However, `CRM_Utils_Hook::alterDeferredRevenueItems` is only called once in core (CRM/Core/BAO/FinancialTrxn.php) where an instance of `CRM_Contribute_BAO_Contribution` is passed in as the second argument.

After
----------------------------------------
PHPDoc comment corrected.
