### PR TITLE
Add Send reminder hook

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -295,6 +295,9 @@ FROM civicrm_action_schedule cas
         if ($actionSchedule->mode === 'Email' || $actionSchedule->mode === 'User_Preference') {
           CRM_Utils_Array::extend($errors, self::sendReminderEmail($tokenRow, $actionSchedule, $dao->contactID));
         }
+
+        CRM_Utils_Hook::sendReminder($tokenRow, $actionSchedule, $dao->contactID, $errors);
+
         // insert activity log record if needed
         if ($actionSchedule->record_activity && empty($errors)) {
           $caseID = empty($dao->case_id) ? NULL : $dao->case_id;

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2680,6 +2680,24 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook is invoked when processing reminder.
+   *
+   * @param object $tokenRow
+   * @param object $actionSchedule
+   * @param int $contactID
+   * @param array $errors
+   *
+   * @return mixed
+   */
+  public static function sendReminder($tokenRow, $actionSchedule, $contactID, &$errors) {
+    return self::singleton()->invoke(
+      ['tokenRow', 'actionSchedule', 'contactID', 'errors'],
+      $tokenRow, $actionSchedule, $contactID, $errors, self::$_nullObject,
+      self::$_nullObject, 'civicrm_sendReminder'
+    );
+  }
+
+  /**
    * This hook is called before an inbound SMS is processed.
    *
    * @param \CRM_SMS_Message $message


### PR DESCRIPTION
Overview
----------------------------------------
This PR provides hook to allow send reminder via custom mode like Amazon SNS etc. 

Comments
----------------------------------------
Schedule reminder can be send either via SMS or Email at the moment. When adding new option in msg_mode option group, the schedule reminder form allows to save the reminder using custom mode, However when executed there is no way to call the custom method.

Original Discussion: https://github.com/civicrm/civicrm-core/pull/18563

The intention is to send reminder via other forms rather default two methods supported by Civi (i.e SMS or Email). May be to mattermost channel etc.

I think it can be done using tokenprocessor hook, but it concerns me about the action log and activity if it errors out(https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/ActionSchedule.php#L307).
