### PR TITLE
(REF) Extract function `CRM_Core_Component::isEnabled()`

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -100,7 +100,7 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
    */
   protected function getBespokeTokens(): array {
     $tokens = [];
-    if (array_key_exists('CiviCase', CRM_Core_Component::getEnabledComponents())) {
+    if (CRM_Core_Component::isEnabled('CiviCase')) {
       $tokens['case_id'] = ts('Activity Case ID');
       return [
         'case_id' => [

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -372,7 +372,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     //don't build membership block when pledge_id is passed
     if (empty($this->_values['pledge_id']) && empty($this->_ccid)) {
       $this->_separateMembershipPayment = FALSE;
-      if (in_array('CiviMember', $config->enableComponents)) {
+      if (CRM_Core_Component::isEnabled('CiviMember')) {
         $isTest = 0;
         if ($this->_action & CRM_Core_Action::PREVIEW) {
           $isTest = 1;

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -142,7 +142,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
 
     // Preload libraries required by the "Profiles" tab
     $schemas = ['IndividualModel', 'OrganizationModel', 'ContributionModel'];
-    if (in_array('CiviMember', CRM_Core_Config::singleton()->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviMember')) {
       $schemas[] = 'MembershipModel';
     }
     CRM_UF_Page_ProfileEditor::registerProfileScripts();

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -423,4 +423,17 @@ class CRM_Core_Component {
     return $components;
   }
 
+  /**
+   * Is the specified component enabled.
+   *
+   * @param string $component
+   *   Component name - ie CiviMember, CiviContribute, CiviEvent...
+   *
+   * @return bool
+   *   Is the component enabled.
+   */
+  public static function isEnabled(string $component): bool {
+    return in_array($component, CRM_Core_Config::singleton()->enableComponents, TRUE);
+  }
+
 }


### PR DESCRIPTION

Overview
----------------------------------------
Add function Core_Component::isEnabled

It always feels like there should be an easier to discover way to check if
a component is enabled ....


Before
----------------------------------------
Myriad of ways that are not IDE guessable

After
----------------------------------------
Function exists

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw 