### PR TITLE
Activity Details field on batch update via profile has wrong fieldname

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2177,7 +2177,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       }
     }
     elseif ($fieldName == 'activity_details') {
-      $form->add('wysiwyg', $fieldName, $title, ['rows' => 4, 'cols' => 60], $required);
+      $form->add('wysiwyg', $name, $title, ['rows' => 4, 'cols' => 60], $required);
     }
     elseif ($fieldName == 'activity_duration') {
       $form->add('text', $name, $title, $attributes, $required);


### PR DESCRIPTION
Overview
----------------------------------------
Details column is empty

<img width="154" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/150035861-998de172-3a40-44c7-b374-b036373e4898.png">


Before
----------------------------------------
1. Create a profile with a couple activity fields including the Details field.
2. Find Activities.
3. Select a couple and chose Update multiple from the actions dropdown.
4. Choose the profile you made.
5. The details column is blank and there's no input field.

After
----------------------------------------
Ok.
(Well, sort of - it's a ckeditor field so looks all squished when in a small column, but at least functions). There could be a future UI improvement.

Technical Details
----------------------------------------
Seems like a typo.

Comments
----------------------------------------

