### PR TITLE
DAO - Centralize logic to derive unique name from label

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -277,19 +277,6 @@ WHERE  $where";
    * @return \CRM_Contact_DAO_SavedSearch
    */
   public static function create(&$params) {
-    // Auto-create unique name from label if supplied
-    if (empty($params['id']) && empty($params['name']) && !empty($params['label'])) {
-      $name = CRM_Utils_String::munge($params['label']);
-      $existing = Civi\Api4\SavedSearch::get(FALSE)
-        ->addWhere('name', 'LIKE', $name . '%')
-        ->addSelect('name')
-        ->execute()->column('name');
-      $suffix = '';
-      while (in_array($name . $suffix, $existing)) {
-        $suffix = '_' . (1 + str_replace('_', '', $suffix));
-      }
-      $params['name'] = $name . $suffix;
-    }
     $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
     if ($loggedInContactID) {
       if (empty($params['id'])) {

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -83,15 +83,6 @@ function search_kit_civicrm_entityTypes(&$entityTypes) {
  * Implements hook_civicrm_pre().
  */
 function search_kit_civicrm_pre($op, $entity, $id, &$params) {
-  // Supply default name/label when creating new SearchDisplay
-  if ($entity === 'SearchDisplay' && $op === 'create') {
-    if (empty($params['label'])) {
-      $params['label'] = $params['name'];
-    }
-    elseif (empty($params['name'])) {
-      $params['name'] = \CRM_Utils_String::munge($params['label']);
-    }
-  }
   // When deleting a saved search, also delete the displays
   // This would happen anyway in sql because of the ON DELETE CASCADE foreign key,
   // But this ensures that pre and post hooks are called

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace api\v4\SearchDisplay;
 
+use Civi\Api4\SavedSearch;
 use Civi\Api4\SearchDisplay;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
@@ -48,6 +49,46 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertEquals('crm-search-display-table', $display['type:name']);
     $this->assertEquals('fa-table', $display['type:icon']);
     $this->assertNull($display['saved_search_id']);
+  }
+
+  public function testAutoFormatName() {
+    // Create 3 saved searches; they should all get unique names
+    $savedSearch0 = SavedSearch::create(FALSE)
+      ->addValue('label', 'My test search')
+      ->execute()->first();
+    $savedSearch1 = SavedSearch::create(FALSE)
+      ->addValue('label', 'My test search')
+      ->execute()->first();
+    $savedSearch2 = SavedSearch::create(FALSE)
+      ->addValue('label', 'My test search')
+      ->execute()->first();
+    // Name will be created from munged label
+    $this->assertEquals('My_test_search', $savedSearch0['name']);
+    // Name will have _1, _2, etc. appended to ensure it's unique
+    $this->assertEquals('My_test_search_1', $savedSearch1['name']);
+    $this->assertEquals('My_test_search_2', $savedSearch2['name']);
+
+    $display0 = SearchDisplay::create()
+      ->addValue('saved_search_id', $savedSearch0['id'])
+      ->addValue('label', 'My test display')
+      ->addValue('type', 'table')
+      ->execute()->first();
+    $display1 = SearchDisplay::create()
+      ->addValue('saved_search_id', $savedSearch0['id'])
+      ->addValue('label', 'My test display')
+      ->addValue('type', 'table')
+      ->execute()->first();
+    $display2 = SearchDisplay::create()
+      ->addValue('saved_search_id', $savedSearch1['id'])
+      ->addValue('label', 'My test display')
+      ->addValue('type', 'table')
+      ->execute()->first();
+    // Name will be created from munged label
+    $this->assertEquals('My_test_display', $display0['name']);
+    // Name will have _1 appended to ensure it's unique to savedSearch0
+    $this->assertEquals('My_test_display_1', $display1['name']);
+    // This is for a different saved search so doesn't need a number appended
+    $this->assertEquals('My_test_display', $display2['name']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
New centralized function to derive `name` from `label`, ensuring it's unique and sanitized.

Before
----------------------------------------
Wild West

After
----------------------------------------
More civilized.

Technical Details
----------------------------------------
This function checks db indices to enforce uniqueness of "name" column when deriving it from the label.

**To opt-in to this behavior, an entity must:**
1. Have a `name` and a `label` field.
1. Use `DAO::writeRecord()` from its `create()` function.
2. Have a unique index declared for the `name` column.