### PR TITLE
Improve financial trxn spec to require required fields

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/FinancialTrxnCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FinancialTrxnCreationSpecProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class FinancialTrxnCreationSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * Modify the api spec.
+   *
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $spec->getFieldByName('to_financial_account_id')->setRequired(TRUE);
+    $field = new FieldSpec('entity_id', 'FinancialTrxn', 'Integer');
+    $field->setRequired(TRUE);
+    $field->setTitle(ts('Related entity (eg. contribution) id'));
+    $spec->addFieldSpec($field);
+    $spec->getFieldByName('status_id')->setDefaultValue(1);
+    $spec->getFieldByName('total_amount')->setRequired(TRUE);
+  }
+
+  /**
+   * Specify the entity & action it applies to.
+   *
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'FinancialTrxn' && $action === 'create';
+  }
+
+}

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1390,7 +1390,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Function tests that financial records are updated when Payment Instrument is changed.
    */
-  public function testCreateUpdateContributionPaymentInstrument() {
+  public function testCreateUpdateContributionPaymentInstrument(): void {
     $instrumentId = $this->_addPaymentInstrument();
     $contribParams = [
       'contact_id' => $this->_individualId,
@@ -1406,12 +1406,12 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'id' => $contribution['id'],
       'payment_instrument_id' => $instrumentId,
     ]);
-    $contribution = $this->callAPISuccess('contribution', 'create', $newParams);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $newParams);
     $this->assertAPISuccess($contribution);
     $this->checkFinancialTrxnPaymentInstrumentChange($contribution['id'], 4, $instrumentId);
 
     // cleanup - delete created payment instrument
-    $this->_deletedAddedPaymentInstrument();
+    $this->deletedAddedPaymentInstrument();
   }
 
   /**
@@ -1438,7 +1438,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->checkFinancialTrxnPaymentInstrumentChange($contribution['id'], 4, $instrumentId, -100);
 
     // cleanup - delete created payment instrument
-    $this->_deletedAddedPaymentInstrument();
+    $this->deletedAddedPaymentInstrument();
   }
 
   /**
@@ -3064,7 +3064,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * CRM-14151 - Test completing a transaction via the API.
    */
-  public function testCompleteTransactionWithReceiptDateSet() {
+  public function testCompleteTransactionWithReceiptDateSet(): void {
     $this->swapMessageTemplateForTestTemplate();
     $mut = new CiviMailUtils($this, TRUE);
     $this->createLoggedInUser();
@@ -4196,7 +4196,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     return $optionValue['values'][$optionValue['id']]['value'];
   }
 
-  public function _deletedAddedPaymentInstrument() {
+  public function deletedAddedPaymentInstrument() {
     $result = $this->callAPISuccess('OptionValue', 'get', [
       'option_group_id' => 'payment_instrument',
       'name' => 'Test Card',


### PR DESCRIPTION

Overview
----------------------------------------
Improve financial trxn spec to require required fields

Before
----------------------------------------
It turns out the apiv4 conformance test only passes because it
is bypassing the BAO create method because of the mis-named BAO which @pradpnayak has been working on. The problem is ultimately that the test is not passing in the right parameters in part because the spec is not requiring all the parameters required at the BAO. 


After
----------------------------------------
This updates the spec to be close to the v3 api requirements - it is still calling the wrong method but if we can get this to work then @pradpnayak's rename will work. 

Technical Details
----------------------------------------
Not this will fail :-( because it messes with the test expectations
- I don't know how to create complex valid test data for it though....

I guess we could create a contribution & pass it as entity_id - test conformance is hard

Comments
----------------------------------------
This is actually the first time I've ever gotten the v4 testConformance test to run locally :-). I hacked it per the patch below since it is never able to find the service - @colemanw why do we do the complicated, but hard to run, service config here - it doesn't seem to add much....


![image](https://user-images.githubusercontent.com/336308/150063873-5b06ee9e-ff2b-4310-a01e-870cf1e60e02.png)
