### PR TITLE
(dev/core#3012) Expose more options for email on hold as filter for l…

### DIFF
--- a/CRM/Report/Form/Contribute/Lybunt.php
+++ b/CRM/Report/Form/Contribute/Lybunt.php
@@ -147,8 +147,9 @@ class CRM_Report_Form_Contribute_Lybunt extends CRM_Report_Form {
         'filters' => [
           'on_hold' => [
             'title' => ts('On Hold'),
-            'type' => CRM_Utils_Type::T_BOOLEAN,
-            'options' => ['' => ts('Any')] + CRM_Core_SelectValues::boolean(),
+            'type' => CRM_Utils_Type::T_INT,
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => ['' => ts('Any')] + CRM_Core_PseudoConstant::emailOnHoldOptions(),
           ],
         ],
       ],


### PR DESCRIPTION
…ybunt report

Overview
----------------------------------------
 Expose more options for email on hold as filter for lybunt report

Before
----------------------------------------
Only _Any/Yes/No_ are available options

After
----------------------------------------
Option _Any/No/On Hold Bounce/On Hold Opt Out_  are available