### PR TITLE
(NFC) Minor phpdoc fixes to CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response

### DIFF
--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -293,9 +293,9 @@ WHERE  email = %2
    * Send a response email informing the contact of the groups from which he.
    * has been unsubscribed.
    *
-   * @param string $queue_id
+   * @param int $queue_id
    *   The queue event ID.
-   * @param array $groups
+   * @param array|null $groups
    *   List of group IDs.
    * @param bool $is_domain
    *   Is this domain-level?.


### PR DESCRIPTION
Overview
----------------------------------------
Ensure that the phpdoc types match the actual expected input. (and matches the types passed into the method whenever it is called throughout CiviCRM core)

