### PR TITLE
(NFC) Minor amends to getGroupByFromSelectColumns

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4873,16 +4873,15 @@ civicrm_relationship.start_date > {$today}
   }
 
   /**
-   * Include Select columns in groupBy clause.
+   * Include select columns in groupBy clause.
    *
    * @param array $selectClauses
-   * @param array $groupBy - Columns already included in GROUP By clause.
+   * @param array|string|null $groupBy - Columns already included in GROUP By clause.
    *
    * @return string
    */
   public static function getGroupByFromSelectColumns($selectClauses, $groupBy = NULL) {
     $groupBy = (array) $groupBy;
-    $mysqlVersion = CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
     $sqlMode = CRM_Core_DAO::singleValueQuery('SELECT @@sql_mode');
 
     //return if ONLY_FULL_GROUP_BY is not enabled.


### PR DESCRIPTION
Overview
----------------------------------------
Minor amends to getGroupByFromSelectColumns

Before
----------------------------------------

PHPDoc inaccuracies:
1. `$groupBy` is cast to an array, and so string values can (and more to the point, frequently are) be passed,
2. `$groupBy` can be `null`, and defaults to `null`

Also,  the variable `$mysqlVersion` is set, but never used. This was added in https://github.com/civicrm/civicrm-core/commit/bad98dd514b2a8313d4df2632758e21853de16f2, but the logic has since been refactored to use `CRM_Utils_SQL::supportsFullGroupBy()` making the `$mysqlVersion` redundant.

After
----------------------------------------

1. PHPDoc improvements.
2. `$mysqlVersion` removed.
