### PR TITLE
Remove method getWordReplacement.

### DIFF
--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -39,26 +39,6 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implemen
   }
 
   /**
-   * Get the domain BAO.
-   *
-   * @param null $reset
-   *
-   * @return null|CRM_Core_BAO_WordReplacement
-   * @throws CRM_Core_Exception
-   */
-  public static function getWordReplacement($reset = NULL) {
-    static $wordReplacement = NULL;
-    if (!$wordReplacement || $reset) {
-      $wordReplacement = new CRM_Core_BAO_WordReplacement();
-      $wordReplacement->id = CRM_Core_Config::wordReplacementID();
-      if (!$wordReplacement->find(TRUE)) {
-        throw new CRM_Core_Exception('Unable to find word replacement');
-      }
-    }
-    return $wordReplacement;
-  }
-
-  /**
    * Deprecated update function.
    *
    * @deprecated


### PR DESCRIPTION
Overview
----------------------------------------
Remove method `getWordReplacement`.

It appears to have never been used since its introduction 8 years ago,
and furthermore calls functions which don't exist.

Therefore, it would be unlikely to work even if it were used.

Before
----------------------------------------
Function `CRM_Core_BAO_WordReplacement::getWordReplacement()` exists. I highly expect it does not work, and would not work even if sometried to use it. Specifically, the method `CRM_Core_Config::wordReplacementID()`, which the removed method calls, does not appear to exist.

After
----------------------------------------
Method removed.

Technical Details
----------------------------------------
The method was introduced here: https://github.com/civicrm/civicrm-core/commit/d83a3991c7f830d4f44847907f163b11b66cf3c7

A search with `git log -S "getWordReplacement("` shows no other references to this method since.

Comments
----------------------------------------
There may be an argument for deprecating, but the unlikelyhood of this method actually working makes me think its probably safe to just remove.