### PR TITLE
Remove redundant option from lineItem entity_table

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1267,7 +1267,6 @@ WHERE li.contribution_id = %1";
    */
   public static function entityTables(): array {
     return [
-      'civicrm_contribution' => ts('Contribution'),
       'civicrm_participant' => ts('Participant'),
       'civicrm_membership' => ts('Membership'),
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Makes the LineItem table make more sense to SearchKit

Technical Details
----------------------------------------
Storing `civicrm_contribution` as the entity table is redundant and confusing because the table already has a `contribution_id` column.