### PR TITLE
Import - Update 2-digit year parsing to keep up with the times

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -541,6 +541,7 @@ class CRM_Utils_Date {
   public static function convertToDefaultDate(&$params, $dateType, $dateParam) {
     $now = getdate();
     $cen = substr($now['year'], 0, 2);
+    $dec = substr($now['year'], 2, 2);
     $prevCen = $cen - 1;
 
     $value = NULL;
@@ -693,11 +694,9 @@ class CRM_Utils_Date {
     $month = ($month < 10) ? "0" . "$month" : $month;
     $day = ($day < 10) ? "0" . "$day" : $day;
 
-    $year = (int ) $year;
-    // simple heuristic to determine what century to use
-    // 00 - 20 is always 2000 - 2020
-    // 21 - 99 is always 1921 - 1999
-    if ($year < 21) {
+    // simple heuristic to determine what century to use if ommitted
+    // the next 10 years is assumed to be the current century, after that assume the past century
+    if ($year < ($dec + 10)) {
       $year = (strlen($year) == 1) ? $cen . '0' . $year : $cen . $year;
     }
     elseif ($year < 100) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3037](https://lab.civicrm.org/dev/core/-/issues/3037)

Before
----------------------------------------
2-digit years < 20 were assumed to be current century, above that were assumed to be last century.
So "20" was assumed to mean 2020, but "22" was assumed to mean 1922.

After
----------------------------------------
On a rolling basis, the current year + 10 is assumed to be the current century.
So "22" will be assumed to mean 2022, "33" will mean 1933, but a year from now if you type "33" it will mean 2033.

Comments
----------------------------------------
This is the sort of issue that could generate a lot of bikeshedding and over-engineering, but before that starts, I'd like to remind folks that it's been this way for a very long time with no complaints, and if we merge this PR it will work fine, no one will complain and we'll probably all forget about it again.