### PR TITLE
Use rolling window for translating 2-digit years into 4-digit years

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -540,8 +540,6 @@ class CRM_Utils_Date {
    */
   public static function convertToDefaultDate(&$params, $dateType, $dateParam) {
     $now = getdate();
-    $cen = substr($now['year'], 0, 2);
-    $prevCen = $cen - 1;
 
     $value = NULL;
     if (!empty($params[$dateParam])) {
@@ -693,15 +691,15 @@ class CRM_Utils_Date {
     $month = ($month < 10) ? "0" . "$month" : $month;
     $day = ($day < 10) ? "0" . "$day" : $day;
 
-    $year = (int ) $year;
-    // simple heuristic to determine what century to use
-    // 00 - 20 is always 2000 - 2020
-    // 21 - 99 is always 1921 - 1999
-    if ($year < 21) {
-      $year = (strlen($year) == 1) ? $cen . '0' . $year : $cen . $year;
-    }
-    elseif ($year < 100) {
-      $year = $prevCen . $year;
+    $year = (int) $year;
+    if ($year < 100) {
+      $year = substr($now['year'], 0, 2) * 100 + $year;
+      if ($year > ($now['year'] + 5)) {
+        $year = $year - 100;
+      }
+      elseif ($year <= ($now['year'] - 95)) {
+        $year = $year + 100;
+      }
     }
 
     if ($params[$dateParam]) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix outdated hard-coded import logic: translate 2-digit years to 4 using rolling -95yr to +5yr window

Before
----------------------------------------
1/1/22 is imported as 1922-01-01

After
----------------------------------------
1/1/22 is imported as 2022-01-01

and, if this code is still running in 2096, 1/1/1 will be imported at 2101-01-01

Comments
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3037#note_68816
