### PR TITLE
Add consistency between checkTemplateFileExists functions,

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1011,9 +1011,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   /**
    * Check template file exists.
    *
-   * @param string $suffix
+   * @param string|null $suffix
    *
-   * @return null|string
+   * @return string|null
+   *   Template file path, else null
    */
   public function checkTemplateFileExists($suffix = NULL) {
     if ($this->_id) {

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1056,13 +1056,14 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
-   * Check if template file exists.
+   * Check template file exists.
    *
-   * @param string $suffix
+   * @param string|null $suffix
    *
-   * @return null|string
+   * @return string|null
+   *   Template file path, else null
    */
-  public function checkTemplateFileExists($suffix = '') {
+  public function checkTemplateFileExists($suffix = NULL) {
     if ($this->_eventId) {
       $templateName = $this->_name;
       if (substr($templateName, 0, 12) == 'Participant_') {

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -1353,9 +1353,12 @@ class CRM_Profile_Form extends CRM_Core_Form {
   }
 
   /**
-   * @param null $suffix
+   * Check template file exists.
    *
-   * @return null|string
+   * @param string|null $suffix
+   *
+   * @return string|null
+   *   Template file path, else null
    */
   public function checkTemplateFileExists($suffix = NULL) {
     if ($this->_gid) {

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -388,11 +388,14 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
   }
 
   /**
-   * @param string $suffix
+   * Check template file exists.
    *
-   * @return null|string
+   * @param string|null $suffix
+   *
+   * @return string|null
+   *   Template file path, else null
    */
-  public function checkTemplateFileExists($suffix = '') {
+  public function checkTemplateFileExists($suffix = NULL) {
     if ($this->_gid) {
       $templateFile = "CRM/Profile/Page/{$this->_gid}/Dynamic.{$suffix}tpl";
       $template = CRM_Core_Page::getTemplate();

--- a/CRM/Profile/Page/Listings.php
+++ b/CRM/Profile/Page/Listings.php
@@ -449,11 +449,14 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
   }
 
   /**
-   * @param string $suffix
+   * Check template file exists.
    *
-   * @return null|string
+   * @param string|null $suffix
+   *
+   * @return string|null
+   *   Template file path, else null
    */
-  public function checkTemplateFileExists($suffix = '') {
+  public function checkTemplateFileExists($suffix = NULL) {
     if ($this->_gid) {
       $templateFile = "CRM/Profile/Page/{$this->_gid}/Listings.{$suffix}tpl";
       $template = CRM_Core_Page::getTemplate();

--- a/CRM/Profile/Page/View.php
+++ b/CRM/Profile/Page/View.php
@@ -161,11 +161,14 @@ class CRM_Profile_Page_View extends CRM_Core_Page {
   }
 
   /**
-   * @param string $suffix
+   * Check template file exists.
    *
-   * @return null|string
+   * @param string|null $suffix
+   *
+   * @return string|null
+   *   Template file path, else null
    */
-  public function checkTemplateFileExists($suffix = '') {
+  public function checkTemplateFileExists($suffix = NULL) {
     if ($this->_gid) {
       $templateFile = "CRM/Profile/Page/{$this->_gid}/View.{$suffix}tpl";
       $template = CRM_Core_Page::getTemplate();


### PR DESCRIPTION
Overview
----------------------------------------
Add consistency between `checkTemplateFileExists` functions, resolving phpdoc issues in the process.

Before
----------------------------------------
Each `checkTemplateFileExists` method in core is fundamentally performing the same job (on different components). Therefore it makes sense for the method comment to match.

In doing so, these methods have a consistent signature, accepting either `string|null` for `$suffix`.

The primary benefit of this is that the method in `CRM/Profile/Form.php` is now correctly documented as accepting a `string` for `$suffix`.

After
----------------------------------------
Consistency added.
