### PR TITLE
APIv4 - Use empty string instead of 'null' to pass null values to the db

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -503,6 +503,10 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Te
     $missingGreetingParams = [];
 
     foreach ($allGreetingParams as $greetingIndex => $greetingParam) {
+      // An empty string means NULL
+      if (($params[$greetingParam] ?? NULL) === '') {
+        $params[$greetingParam] = 'null';
+      }
       if (empty($params[$greetingParam])) {
         $missingGreetingParams[$greetingIndex] = $greetingParam;
       }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -60,8 +60,8 @@ trait DAOActionTrait {
     else {
       $inputFields = array_keys($input);
       // Convert 'null' input to true null
-      foreach ($input as $key => $val) {
-        if ($val === 'null') {
+      foreach ($inputFields as $key) {
+        if (($bao->$key ?? NULL) === 'null') {
           $bao->$key = NULL;
         }
       }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -56,7 +56,8 @@ class FormattingUtil {
       /*
        * Because of the wacky way that database values are saved we need to format
        * some of the values here. In this strange world the string 'null' is used to
-       * unset values. Hence if we encounter true null we change it to string 'null'.
+       * unset values. If we encounter true null at this layer we change it to an empty string
+       * and it will be converted to 'null' by CRM_Core_DAO::copyValues.
        *
        * If we encounter the string 'null' then we assume the user actually wants to
        * set the value to string null. However since the string null is reserved for
@@ -66,7 +67,7 @@ class FormattingUtil {
        * 'Null'.
        */
       elseif (array_key_exists($name, $params) && $params[$name] === NULL) {
-        $params[$name] = 'null';
+        $params[$name] = '';
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
A less hacky way to treat NULL values in APIv4

Before
----------------------------------------
Passing the string `'null'` to represent null values.

After
----------------------------------------
Passing `''` to represent null values.

Technical Details
----------------------------------------
`CRM_Core_DAO::copyValues()` already converts `''` to `'null'`, and passing the string `'null'` into `BAO::create` functions prematurely can introduce subtle bugs because the string `'null'` is `!empty()` whereas `''` is `empty()`.