### PR TITLE
Generate button links in PHP instead of smarty for ContributionView form

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -10,44 +10,6 @@
 <div class="crm-block crm-content-block crm-contribution-view-form-block">
 <div class="action-link">
   <div class="crm-submit-buttons">
-    {if (call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && call_user_func(array('CRM_Core_Permission', 'check'), "edit contributions of type $financial_type") && !empty($canEdit)) ||
-    	(call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && $noACL)}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context"}
-      {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-        {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&key=$searchKey"}
-      {/if}
-      <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}" accesskey="e"><span>
-          <i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span>
-      </a>
-      {if !empty($paymentButtonName)}
-        <a class="button" href='{crmURL p="civicrm/payment" q="action=add&reset=1&component=`$component`&id=`$id`&cid=`$contact_id`"}'><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}{$paymentButtonName}{/ts}</a>
-      {/if}
-    {/if}
-    {if (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && call_user_func(array('CRM_Core_Permission', 'check'), "delete contributions of type $financial_type") && !empty($canDelete))     || (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && $noACL)}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context"}
-      {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-        {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&key=$searchKey"}
-      {/if}
-      <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}"><span>
-          <i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span>
-      </a>
-    {/if}
-    {assign var='pdfUrlParams' value="reset=1&id=$id&cid=$contact_id"}
-    {assign var='emailUrlParams' value="reset=1&id=$id&cid=$contact_id&select=email"}
-    {if $invoicing && empty($is_template)}
-      <div class="css_right">
-        <a class="button no-popup" href="{crmURL p='civicrm/contribute/invoice' q=$pdfUrlParams}">
-          <i class="crm-i fa-download" aria-hidden="true"></i>
-        {if $contribution_status != 'Refunded' && $contribution_status != 'Cancelled' }
-          {ts}Download Invoice{/ts}</a>
-        {else}
-          {ts}Download Invoice and Credit Note{/ts}</a>
-        {/if}
-        <a class="button" href="{crmURL p='civicrm/contribute/invoice/email' q=$emailUrlParams}">
-          <i class="crm-i fa-paper-plane" aria-hidden="true"></i>
-          {ts}Email Invoice{/ts}</a>
-      </div>
-    {/if}
     {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
 </div>
@@ -328,24 +290,6 @@
 {/if}
 
 <div class="crm-submit-buttons">
-  {if (call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && call_user_func(array('CRM_Core_Permission', 'check'), "edit contributions of type $financial_type") && $canEdit) ||
-    	(call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && $noACL)}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context"}
-    {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&key=$searchKey"}
-    {/if}
-    <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
-    {if $paymentButtonName}
-      <a class="button" href='{crmURL p="civicrm/payment" q="action=add&reset=1&component=`$component`&id=`$id`&cid=`$contact_id`"}'><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}{$paymentButtonName}{/ts}</a>
-    {/if}
-  {/if}
-  {if (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && call_user_func(array('CRM_Core_Permission', 'check'), "delete contributions of type $financial_type") && $canDelete)     || (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && $noACL)}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context"}
-    {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&key=$searchKey"}
-    {/if}
-    <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
-  {/if}
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
ContributionView form has some impressive and probably insecure code to create the "link" buttons such as edit/delete. Even better the code is duplicated for top and botton!

Before
----------------------------------------
Fairly complex smarty code to generate button links for Edit/Delete on contributionview form.

After
----------------------------------------
Smarty logic recreated in PHP form (no attempt to clean up at this stage - it's meant to be a straight refactor). Smarty logic removed from top/bottom buttons and now using standard "linkButtons".

Technical Details
----------------------------------------


Comments
----------------------------------------

