### PR TITLE
SearchKit - Allow smarty in field rewrite

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -203,8 +203,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
-   * @param $column
-   * @param $data
+   * @param array $column
+   * @param array $data
    * @return array{val: mixed, links: array, edit: array, label: string, title: string, image: array, cssClass: string}
    */
   private function formatColumn($column, $data) {
@@ -217,7 +217,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           $out['val'] = $this->replaceTokens($column['empty_value'], $data, 'view');
         }
         elseif ($column['rewrite']) {
-          $out['val'] = $this->replaceTokens($column['rewrite'], $data, 'view');
+          $out['val'] = $this->rewrite($column, $data);
         }
         else {
           $out['val'] = $this->formatViewValue($column['key'], $rawValue);
@@ -273,6 +273,23 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $out['cssClass'] = implode(' ', $cssClass);
     }
     return $out;
+  }
+
+  /**
+   * Rewrite field value, subtituting tokens and evaluating smarty tags
+   *
+   * @param array $column
+   * @param array $data
+   * @return string
+   */
+  private function rewrite(array $column, array $data): string {
+    $output = $this->replaceTokens($column['rewrite'], $data, 'view');
+    // Cheap strpos to skip Smarty processing if not needed
+    if (strpos($output, '{') !== FALSE) {
+      $smarty = \CRM_Core_Smarty::singleton();
+      $output = $smarty->fetchWith("string:$output", []);
+    }
+    return $output;
   }
 
   /**
@@ -545,7 +562,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   private function replaceTokens($tokenExpr, $data, $format, $index = 0) {
-    if ($tokenExpr) {
+    if (strpos($tokenExpr, '[') !== FALSE) {
       foreach ($this->getTokens($tokenExpr) as $token) {
         $val = $data[$token] ?? NULL;
         if (isset($val) && $format === 'view') {


### PR DESCRIPTION
Overview
----------------------------------------
This gives the ability to use Smarty syntax in the "rewrite" of SearchKit displays.

Before
----------------------------------------
Tokens like `[first_name]` supported.

After
----------------------------------------
Those tokens still work and will be evaluated first. They can be mixed in with Smarty tags like `{if "[first_name]"}`.

Technical Details
----------------------------------------
Smarty will see the evaluated values for the tokens (which should be quoted if string and inside a smarty tag).

Note: Due to #1371, PHP filters like `strtolower` or `ucfirst` cannot be used.

Comments
----------------------------------------
This is #22346 without assigning the variables, which @eileenmcnaughton recommended against.