### PR TITLE
[WIP] dev/core#3036 - avoid crash after upgrade to 5.45 with afform-admin installed but not search kit

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.45.2.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.45.2.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.45.2 during upgrade *}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3036

If afform-admin (form builder) is installed but not search kit, then after upgrading to 5.45 you can get a crash on some screens when it checks if extension upgrades need to be run.

Before
----------------------------------------
Error: Class CRM_Search_Upgrader not found.

After
----------------------------------------
Search kit is automatically installed if you have afform-admin installed.

Technical Details
----------------------------------------
see ticket

Comments
----------------------------------------
I'm trying to get my head around whether this needs to also be in a 5.46 upgrade file, but I don't think so.
