### PR TITLE
SearchKit - Fix running searches for anonymous users

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -680,10 +680,16 @@ class Api4SelectQuery {
       return TRUE;
     }
     if (!isset($this->entityAccess[$entity])) {
-      $this->entityAccess[$entity] = (bool) civicrm_api4($entity, 'getActions', [
-        'where' => [['name', '=', 'get']],
-        'select' => ['name'],
-      ])->first();
+      try {
+        $this->entityAccess[$entity] = (bool) civicrm_api4($entity, 'getActions', [
+          'where' => [['name', '=', 'get']],
+          'select' => ['name'],
+        ])->first();
+      }
+      // Anonymous users might not even be allowed to use 'getActions'
+      catch (UnauthorizedException $e) {
+        $this->entityAccess[$entity] = FALSE;
+      }
     }
     return $this->entityAccess[$entity];
   }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -115,7 +115,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       throw new UnauthorizedException('Access denied');
     }
 
-    $this->_apiParams['checkPermissions'] = empty($this->display['acl_bypass']);
+    $this->_apiParams['checkPermissions'] = $this->savedSearch['api_params']['checkPermissions'] = empty($this->display['acl_bypass']);
     $this->display['settings']['columns'] = $this->display['settings']['columns'] ?? [];
 
     $this->processResult($result);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes SearchKit crash when displaying results to anonymous users.

Technical Details
----------------------------------------
Some internal api calls during the search Run process were incorrectly checking permissions when they shouldn't, causing errors and missing field data.