### PR TITLE
(NFC) Correct type hints for bad null default values

### DIFF
--- a/CRM/Bridge/OG/Utils.php
+++ b/CRM/Bridge/OG/Utils.php
@@ -99,8 +99,8 @@ class CRM_Bridge_OG_Utils {
   }
 
   /**
-   * @param $source
-   * @param null $title
+   * @param string $source
+   * @param string|null $title
    * @param bool $abort
    *
    * @return null|string

--- a/CRM/Case/PseudoConstant.php
+++ b/CRM/Case/PseudoConstant.php
@@ -47,8 +47,7 @@ class CRM_Case_PseudoConstant extends CRM_Core_PseudoConstant {
   /**
    * Get all the redaction rules.
    *
-   *
-   * @param null $filter
+   * @param int $filter
    *
    * @return array
    *   array reference of all redaction rules

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1862,7 +1862,7 @@ AND cc.sort_name LIKE '%$name%'";
    *
    * @param array $params
    *   Api input array.
-   * @param null $direction
+   * @param string $direction
    *
    * @return array|void
    * @throws \CiviCRM_API3_Exception

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -607,14 +607,12 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
    * convert it into the same format that we use in QF and BAO object
    *
    * @param array $params
-   *   Associative array of property name/value.
-   *                             pairs to insert in new contact.
+   *   Associative array of property name/value
+   *   pairs to insert in new contact.
    * @param array $values
    *   The reformatted properties that we can use internally.
-   *                            '
-   *
    * @param bool $create
-   * @param null $onDuplicate
+   * @param int $onDuplicate
    *
    * @return array|CRM_Error
    */

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -166,7 +166,7 @@ class CRM_Core_Action {
    *
    * @param array $links
    *   The set of link items.
-   * @param int $mask
+   * @param int|null $mask
    *   The mask to be used. a null mask means all items.
    * @param array $values
    *   The array of values for parameter substitution in the link items.
@@ -311,8 +311,8 @@ class CRM_Core_Action {
    *   The mask to be used. a null mask means all items.
    * @param array $values
    *   The array of values for parameter substitution in the link items.
-   * @param null $op
-   * @param null $objectName
+   * @param string|null $op
+   * @param string|null $objectName
    * @param int $objectId
    *
    * @return array|null

--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -61,7 +61,8 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
    * Build a nested array from hierarchical tags.
    *
    * Supports infinite levels of nesting.
-   * @param null $usedFor
+   *
+   * @param string|null $usedFor
    * @param bool $excludeHidden
    */
   public function buildTree($usedFor = NULL, $excludeHidden = FALSE) {

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1674,8 +1674,7 @@ abstract class CRM_Core_Payment {
    * it is better to standardise to being here.
    *
    * @param int $invoiceId The ID to check.
-   *
-   * @param null $contributionID
+   * @param int|null $contributionID
    *   If a contribution exists pass in the contribution ID.
    *
    * @return bool
@@ -1693,8 +1692,8 @@ abstract class CRM_Core_Payment {
   /**
    * Get url for users to manage this recurring contribution for this processor.
    *
-   * @param int $entityID
-   * @param null $entity
+   * @param int|null $entityID
+   * @param string|null $entity
    * @param string $action
    *
    * @return string|null
@@ -1723,6 +1722,10 @@ abstract class CRM_Core_Payment {
           return NULL;
         }
         $url = 'civicrm/contribute/updaterecur';
+        break;
+
+      default:
+        $url = '';
         break;
     }
 

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -695,7 +695,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * Get url for users to manage this recurring contribution for this processor.
    *
    * @param int $entityID
-   * @param null $entity
+   * @param string|null $entity
    * @param string $action
    *
    * @return string|null

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -335,7 +335,7 @@ class CRM_Core_Permission {
 
   /**
    * @param int $type
-   * @param null $prefix
+   * @param string $prefix
    * @param bool $returnUFGroupIds
    *
    * @return array|string

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -40,10 +40,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Event_Import_Parser {
    * Class constructor.
    *
    * @param array $mapperKeys
-   * @param null $mapperLocType
-   * @param null $mapperPhoneType
    */
-  public function __construct(&$mapperKeys, $mapperLocType = NULL, $mapperPhoneType = NULL) {
+  public function __construct(&$mapperKeys) {
     parent::__construct();
     $this->_mapperKeys = &$mapperKeys;
   }

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -924,7 +924,7 @@ COLS;
    * Get trigger info.
    *
    * @param array $info
-   * @param null $tableName
+   * @param string|null $tableName
    * @param bool $force
    */
   public function triggerInfo(&$info, $tableName = NULL, $force = FALSE) {

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -104,7 +104,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
    *
    * @param $restrict
    * @param bool $skipPermission
-   * @param null $profileIds
+   * @param int[]|null $profileIds
    *
    * @param bool $isShowEmailTaskLink
    *

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -181,7 +181,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
    * @param bool $map
    * @param bool $editLink
    * @param bool $ufLink
-   * @param null $gids
+   * @param int[]|null $gids
    *
    * @return array
    */

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5221,7 +5221,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    *
    * @param string $baseTable
    * @param string $field
-   * @param null $tableAlias
+   * @param string|null $tableAlias
    */
   public function setFromBase($baseTable, $field = 'id', $tableAlias = NULL) {
     if (!$tableAlias) {

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -397,7 +397,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
    * @todo get rid of $recordType param. It's only because 3 separate contact tables
    * are mis-declared as one that we need it.
    *
-   * @param null $recordType deprecated
+   * @param string $recordType deprecated
    *   Parameter to hack around the bad decision made in construct to misrepresent
    *   different tables as the same table.
    */

--- a/CRM/Report/Page/TemplateList.php
+++ b/CRM/Report/Page/TemplateList.php
@@ -22,7 +22,7 @@ class CRM_Report_Page_TemplateList extends CRM_Core_Page {
 
   /**
    * @param int $compID
-   * @param null $grouping
+   * @param string|null $grouping
    *
    * @return array
    */

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -48,7 +48,8 @@ class CRM_Utils_HttpClient {
   }
 
   /**
-   * @param null $connectionTimeout
+   * @param int|null $connectionTimeout
+   *   seconds; or NULL to use system default
    */
   public function __construct($connectionTimeout = NULL) {
     $this->connectionTimeout = $connectionTimeout;

--- a/api/api.php
+++ b/api/api.php
@@ -180,7 +180,7 @@ function _civicrm_api3_api_getfields(&$apiRequest) {
  * 'format.is_success' => 1
  * will result in a boolean success /fail being returned if that is what you need.
  *
- * @param $result
+ * @param mixed $result
  *
  * @return bool
  *   true if error, false otherwise

--- a/ext/eventcart/CRM/Event/Cart/BAO/EventInCart.php
+++ b/ext/eventcart/CRM/Event/Cart/BAO/EventInCart.php
@@ -157,7 +157,7 @@ class CRM_Event_Cart_BAO_EventInCart extends CRM_Event_Cart_DAO_EventInCart impl
   }
 
   /**
-   * @param null $event_cart
+   * @param CRM_Event_Cart_BAO_Cart|null $event_cart
    */
   public function load_associations($event_cart = NULL) {
     if ($this->assocations_loaded) {

--- a/ext/eventcart/CRM/Event/Cart/BAO/MerParticipant.php
+++ b/ext/eventcart/CRM/Event/Cart/BAO/MerParticipant.php
@@ -30,8 +30,7 @@ class CRM_Event_Cart_BAO_MerParticipant extends CRM_Event_BAO_Participant {
   public $cart = NULL;
 
   /**
-   * XXX.
-   * @param null $participant
+   * @param array $participant
    */
   public function __construct($participant = NULL) {
     parent::__construct();

--- a/ext/eventcart/CRM/Event/Cart/Controller/Checkout.php
+++ b/ext/eventcart/CRM/Event/Cart/Controller/Checkout.php
@@ -6,7 +6,7 @@
 class CRM_Event_Cart_Controller_Checkout extends CRM_Core_Controller {
 
   /**
-   * @param null $title
+   * @param string $title
    * @param bool|int $action
    * @param bool $modal
    */

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Sample.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Sample.php
@@ -83,7 +83,7 @@ class CRM_Contact_Form_Search_Custom_Sample extends CRM_Contact_Form_Search_Cust
   /**
    * @param int $offset
    * @param int $rowcount
-   * @param null $sort
+   * @param string|null $sort
    * @param bool $returnSQL
    *
    * @return string
@@ -95,7 +95,7 @@ class CRM_Contact_Form_Search_Custom_Sample extends CRM_Contact_Form_Search_Cust
   /**
    * @param int $offset
    * @param int $rowcount
-   * @param null $sort
+   * @param string|null $sort
    * @param bool $includeContactIDs
    * @param bool $justIDs
    *

--- a/install/index.php
+++ b/install/index.php
@@ -839,7 +839,7 @@ class InstallRequirements {
   }
 
   /**
-   * @param null $section
+   * @param string|null $section
    */
   public function showTable($section = NULL) {
     if ($section) {

--- a/tools/scripts/solr/createSolrJSON.php
+++ b/tools/scripts/solr/createSolrJSON.php
@@ -133,7 +133,7 @@ function getValues(&$contactIDs, &$values) {
  * @param $tableName
  * @param $fields
  * @param $whereField
- * @param null $additionalWhereCond
+ * @param string|null $additionalWhereCond
  */
 function getTableInfo(&$contactIDs, &$values, $tableName, &$fields, $whereField, $additionalWhereCond = NULL) {
   $selectString = implode(',', array_keys($fields));

--- a/tools/scripts/solr/createSolrXML.php
+++ b/tools/scripts/solr/createSolrXML.php
@@ -106,7 +106,7 @@ function getValues(&$contactIDs, &$values) {
  * @param $tableName
  * @param $fields
  * @param $whereField
- * @param null $additionalWhereCond
+ * @param string|null $additionalWhereCond
  */
 function getTableInfo(&$contactIDs, &$values, $tableName, &$fields, $whereField, $additionalWhereCond = NULL) {
   $selectString = implode(',', array_keys($fields));

--- a/tools/scripts/solr/createSyncJSON.php
+++ b/tools/scripts/solr/createSyncJSON.php
@@ -84,7 +84,7 @@ function getValues(&$contactIDs, &$values, &$allContactIDs, &$addditionalContact
  * @param $tableName
  * @param $fields
  * @param $whereField
- * @param null $additionalWhereCond
+ * @param string|null $additionalWhereCond
  * @param bool $flat
  */
 function getTableInfo(&$contactIDs, &$values, $tableName, &$fields,


### PR DESCRIPTION
Overview
----------------------------------------
Correct type hints for bad null default values.

I've been trying to get rid of cases where the phpdoc has been defaulted to `null`, despite an actual value being expected in most cases (e.g. `@param null $title`, where `$title` is not always expected to be `null`). These were added in bulk based on the default argument several years ago.

Before
----------------------------------------
Bad types in PHPDoc comments.

After
----------------------------------------
Fewer bad docs (there are still a few other tricker examples of this which should be tackled seperately).

Comments
----------------------------------------
I've just been searching for `@param null ` and working through the list. In some cases the default value is `null` but I've not included `null` in the PHPDoc because in practice a proper value is always expected. These could be tidied up at a later date (e.g. to change the default value).
