### PR TITLE
Tidy up functions related to printing.

### DIFF
--- a/CRM/Activity/Form/Task/Print.php
+++ b/CRM/Activity/Form/Task/Print.php
@@ -32,7 +32,7 @@ class CRM_Activity_Form_Task_Print extends CRM_Activity_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Campaign/Form/Task/Print.php
+++ b/CRM/Campaign/Form/Task/Print.php
@@ -27,7 +27,7 @@ class CRM_Campaign_Form_Task_Print extends CRM_Campaign_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Case/Form/Task/Print.php
+++ b/CRM/Case/Form/Task/Print.php
@@ -28,7 +28,7 @@ class CRM_Case_Form_Task_Print extends CRM_Case_Form_Task {
     parent::preProcess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Contact/Form/Task/Print.php
+++ b/CRM/Contact/Form/Task/Print.php
@@ -28,7 +28,7 @@ class CRM_Contact_Form_Task_Print extends CRM_Contact_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
     $this->assign('id', $this->get('id'));
     $this->assign('pageTitle', ts('CiviCRM Contact Listing'));
 

--- a/CRM/Contribute/Form/Task/Print.php
+++ b/CRM/Contribute/Form/Task/Print.php
@@ -27,7 +27,7 @@ class CRM_Contribute_Form_Task_Print extends CRM_Contribute_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -86,7 +86,9 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    * Are we in print mode? if so we need to modify the display
    * functionality to do a minimal display :)
    *
-   * @var bool
+   * @var int|string
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode
    */
   public $_print = 0;
 
@@ -668,9 +670,17 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   }
 
   /**
-   * @param null $fileName
+   * Output HTTP headers for Word document
+   * (note .doc, not the newer .docx format)
+   *
+   * @deprecated
+   *
+   * @param string|null $fileName
+   * @return void
    */
   public function setWord($fileName = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
+
     //Mark as a CSV file.
     CRM_Utils_System::setHttpHeader('Content-Type', 'application/vnd.ms-word');
 
@@ -682,9 +692,17 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   }
 
   /**
-   * @param null $fileName
+   * Output HTTP headers for Excel document
+   * (note .xls, not the newer .xlsx format)
+   *
+   * @deprecated
+   *
+   * @param string|null $fileName
+   * @return void
    */
   public function setExcel($fileName = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
+
     //Mark as an excel file.
     CRM_Utils_System::setHttpHeader('Content-Type', 'application/vnd.ms-excel');
 
@@ -699,13 +717,20 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   /**
    * Setter for print.
    *
-   * @param bool $print
+   * Historically the $print argument has also accepted a string (xls or doc),
+   * but this usage is now deprecated.
+   *
+   * @param int|string $print
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode
+   *
+   * @return void
    */
   public function setPrint($print) {
-    if ($print == "xls") {
+    if ($print === "xls") {
       $this->setExcel();
     }
-    elseif ($print == "doc") {
+    elseif ($print === "doc") {
       $this->setWord();
     }
     $this->_print = $print;
@@ -714,8 +739,9 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   /**
    * Getter for print.
    *
-   * @return bool
-   *   return the print value
+   * @return int|string
+   *   Value matching a CRM_Core_Smarty::PRINT_* constant,
+   *   or 0 if not in print mode
    */
   public function getPrint() {
     return $this->_print;
@@ -729,7 +755,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       if ($this->_print == CRM_Core_Smarty::PRINT_PAGE) {
         return 'CRM/common/print.tpl';
       }
-      elseif ($this->_print == 'xls' || $this->_print == 'doc') {
+      elseif ($this->_print === 'xls' || $this->_print === 'doc') {
         return 'CRM/Contact/Form/Task/Excel.tpl';
       }
       else {

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -59,7 +59,9 @@ class CRM_Core_Page {
    * Are we in print mode? if so we need to modify the display
    * functionality to do a minimal display :)
    *
-   * @var bool
+   * @var int|string
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode
    */
   protected $_print = FALSE;
 
@@ -215,10 +217,10 @@ class CRM_Core_Page {
       //its time to call the hook.
       CRM_Utils_Hook::alterContent($content, 'page', $pageTemplateFile, $this);
 
-      if ($this->_print == CRM_Core_Smarty::PRINT_PDF) {
+      if ($this->_print === CRM_Core_Smarty::PRINT_PDF) {
         CRM_Utils_PDF_Utils::html2pdf($content, "{$this->_name}.pdf", FALSE);
       }
-      elseif ($this->_print == CRM_Core_Smarty::PRINT_JSON) {
+      elseif ($this->_print === CRM_Core_Smarty::PRINT_JSON) {
         $this->ajaxResponse['content'] = $content;
         CRM_Core_Page_AJAX::returnJsonResponse($this->ajaxResponse);
       }
@@ -386,7 +388,11 @@ class CRM_Core_Page {
   /**
    * Setter for print.
    *
-   * @param bool $print
+   * @param int|string $print
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode
+   *
+   * @return void
    */
   public function setPrint($print) {
     $this->_print = $print;
@@ -395,8 +401,9 @@ class CRM_Core_Page {
   /**
    * Getter for print.
    *
-   * @return bool
-   *   return the print value
+   * @return int|string
+   *   Value matching a CRM_Core_Smarty::PRINT_* constant,
+   *   or 0 if not in print mode
    */
   public function getPrint() {
     return $this->_print;

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -110,7 +110,9 @@ class CRM_Core_Selector_Controller {
    * Are we in print mode? if so we need to modify the display
    * functionality to do a minimal display :)
    *
-   * @var bool
+   * @var int|string
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode
    */
   protected $_print = FALSE;
 
@@ -516,7 +518,9 @@ class CRM_Core_Selector_Controller {
   /**
    * Setter for print.
    *
-   * @param bool $print
+   * @param int|string $print
+   *   Should match a CRM_Core_Smarty::PRINT_* constant,
+   *   or equal 0 if not in print mode
    *
    * @return void
    */
@@ -527,8 +531,9 @@ class CRM_Core_Selector_Controller {
   /**
    * Getter for print.
    *
-   * @return bool
-   *   return the print value
+   * @return int|string
+   *   Value matching a CRM_Core_Smarty::PRINT_* constant,
+   *   or 0 if not in print mode
    */
   public function getPrint() {
     return $this->_print;

--- a/CRM/Event/Form/Task/Print.php
+++ b/CRM/Event/Form/Task/Print.php
@@ -29,7 +29,7 @@ class CRM_Event_Form_Task_Print extends CRM_Event_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Mailing/Form/Task/Print.php
+++ b/CRM/Mailing/Form/Task/Print.php
@@ -27,7 +27,7 @@ class CRM_Mailing_Form_Task_Print extends CRM_Mailing_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Member/Form/Task/Print.php
+++ b/CRM/Member/Form/Task/Print.php
@@ -29,7 +29,7 @@ class CRM_Member_Form_Task_Print extends CRM_Member_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/CRM/Pledge/Form/Task/Print.php
+++ b/CRM/Pledge/Form/Task/Print.php
@@ -28,7 +28,7 @@ class CRM_Pledge_Form_Task_Print extends CRM_Pledge_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');

--- a/ext/civigrant/CRM/Grant/Form/Task/Print.php
+++ b/ext/civigrant/CRM/Grant/Form/Task/Print.php
@@ -29,7 +29,7 @@ class CRM_Grant_Form_Task_Print extends CRM_Grant_Form_Task {
     parent::preprocess();
 
     // set print view, so that print templates are called
-    $this->controller->setPrint(1);
+    $this->controller->setPrint(CRM_Core_Smarty::PRINT_PAGE);
 
     // get the formatted params
     $queryParams = $this->get('queryParams');


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up functions related to printing.

Before
----------------------------------------
Calls to setPrint updated to use proper boolean rather than 1 (int), which means they now match the intended value as documented by the PHPDoc comments. This has no immediate benefit, but helps to avoid confusion, and allows for strict type comarisons to be used with more confidence.

`setWord` and `setExcel` methods deprectated as they are not in use (not in core anyway, I've not checked universe), and they only support the older Microsoft Office formats (`doc`, not `docx`).

After
----------------------------------------
Use of functions clearer and with better inline documentation.

Comments
----------------------------------------
As noted in https://github.com/civicrm/civicrm-core/pull/22600, I'm trying to reduce the number of bad PHPDoc comments in core. This led me down the rabbit-hole of `setWord` and `setExcel` which I identified where almost certainly not in use and therefore ideal for deprecation. 
