### PR TITLE
Fix call to log method warn (should be warning)

### DIFF
--- a/Civi/Report/OutputHandlerFactory.php
+++ b/Civi/Report/OutputHandlerFactory.php
@@ -70,7 +70,7 @@ class OutputHandlerFactory {
       }
       catch (\Exception $e) {
         // no ts() since this is a sysadmin-y message
-        \Civi::log()->warn("Unable to use $candidate as an output handler. " . $e->getMessage());
+        \Civi::log()->warning("Unable to use $candidate as an output handler. " . $e->getMessage());
       }
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
`Civi::log()` has no method `warn`, but there is a method `warning`. Update the code so it wouldn't crash if ran.

Note that I'm not sure exactly how this exception is reached, but its fairly clear what the intended purpose of the code is and so I consider this a safe change regardless.