### PR TITLE
SearchKit - Improve field/operator/value selection UI

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -17,17 +17,10 @@
         ctrl = this,
         linkProps = ['path', 'entity', 'action', 'join', 'target', 'icon', 'text', 'style', 'condition'];
 
-      var permissionOperators = [
+      ctrl.permissionOperators = [
         {key: '=', value: ts('Has')},
         {key: '!=', value: ts('Lacks')}
       ];
-
-      this.getOperators = function(clause) {
-        if (clause[0] === 'check user permission') {
-          return permissionOperators;
-        }
-        return CRM.crmSearchAdmin.operators;
-      };
 
       this.styles = CRM.crmSearchAdmin.styles;
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -37,14 +37,17 @@
       </td>
       <td class="form-inline">
         <input ng-model="item.condition[0]" crm-ui-select="{placeholder: item.action ? ts('Allowed') : ts('Always'), data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition(item)">
-        <select ng-if="item.condition[0]" class="form-control api4-operator" ng-model="item.condition[1]" ng-options="o.key as o.value for o in $ctrl.getOperators(item.condition)">
-        </select>
         <div class="form-group" ng-if="item.condition[0] === 'check user permission'">
+          <select class="form-control api4-operator" ng-model="item.condition[1]" ng-options="o.key as o.value for o in $ctrl.permissionOperators"></select>
           <input class="form-control" crm-ui-select="{data: $ctrl.permissions}" ng-model="item.condition[2]">
         </div>
-        <div class="form-group" ng-if="item.condition[0] && item.condition[0] !== 'check user permission' && item.condition[1].indexOf('IS ') !== 0">
-          <crm-search-input ng-model="item.condition[2]" field="$ctrl.getField(item.condition[0])" option-key="'name'" op="item.condition[1]" class="form-group"></crm-search-input>
-        </div>
+        <crm-search-condition class="form-group"
+          ng-if="item.condition[0] && item.condition[0] !== 'check user permission'"
+          clause="item.condition"
+          field="$ctrl.getField(item.condition[0])"
+          offset="1"
+          option-key="'name'">
+        </crm-search-condition>
       </td>
       <td>
         <div class="btn-group">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
@@ -19,8 +19,7 @@
         <span ng-if="!$ctrl.hasFunction(clause[0])">
           <input class="form-control collapsible-optgroups" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
         </span>
-        <select class="form-control api4-operator" ng-model="clause[1]" ng-options="o.key as o.value for o in $ctrl.getOperators(clause)" ng-change="$ctrl.changeClauseOperator(clause)" ></select>
-        <crm-search-input ng-if="$ctrl.operatorTakesInput(clause[1])" ng-model="clause[2]" field="$ctrl.getFieldOrFunction(clause[0])" option-key="$ctrl.getOptionKey(clause[0])" op="clause[1]" format="$ctrl.format" class="form-group"></crm-search-input>
+        <crm-search-condition clause="clause" field="$ctrl.getFieldOrFunction(clause[0])" offset="1" option-key="$ctrl.getOptionKey(clause[0])" format="$ctrl.format" class="form-group"></crm-search-condition>
       </div>
       <fieldset class="clearfix" ng-if="$ctrl.conjunctions[clause[0]]">
         <crm-search-clause allow-functions="$ctrl.allowFunctions" clauses="clause[1]" format="{{ $ctrl.format }}" op="{{ clause[0] }}" fields="$ctrl.fields" delete-group="$ctrl.deleteRow(index)" ></crm-search-clause>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
@@ -1,0 +1,91 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('crmSearchCondition', {
+    bindings: {
+      field: '<',
+      clause: '<',
+      format: '<',
+      optionKey: '<',
+      offset: '@'
+    },
+    templateUrl: '~/crmSearchAdmin/crmSearchCondition.html',
+    controller: function ($scope, $element, searchMeta) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+      this.operators = {};
+
+      this.$onInit = function() {
+        $scope.$watch('$ctrl.field', updateOperators);
+      };
+
+      function getOperator() {
+        return ctrl.clause[ctrl.offset];
+      }
+
+      function setOperator(op) {
+        if (op !== getOperator()) {
+          ctrl.clause[ctrl.offset] = op;
+          ctrl.changeClauseOperator();
+        }
+      }
+
+      // Return a list of operators allowed for the current field
+      this.getOperators = function() {
+        var field = ctrl.field || {},
+          allowedOps = field.operators;
+        if (!allowedOps && field.data_type === 'Boolean') {
+          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT EMPTY'];
+        }
+        if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
+          allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];
+        }
+        if (!allowedOps) {
+          return CRM.crmSearchAdmin.operators;
+        }
+        var opKey = allowedOps.join();
+        if (!ctrl.operators[opKey]) {
+          ctrl.operators[opKey] = _.filter(CRM.crmSearchAdmin.operators, function(operator) {
+            return _.includes(allowedOps, operator.key);
+          });
+        }
+        return ctrl.operators[opKey];
+      };
+
+      // Ensures clause is using an operator that is allowed for the field
+      function updateOperators() {
+        if ((!getOperator() || !_.includes(_.pluck(ctrl.getOperators(), 'key'), getOperator()))) {
+          setOperator(ctrl.getOperators()[0].key);
+        }
+      }
+
+      // Returns false for 'IS NULL', 'IS EMPTY', etc. true otherwise.
+      this.operatorTakesInput = function() {
+        return getOperator().indexOf('IS ') !== 0;
+      };
+
+      this.changeClauseOperator = function() {
+        // Add/remove value depending on whether operator allows for one
+        if (!ctrl.operatorTakesInput()) {
+          ctrl.clause.length = ctrl.offset + 1;
+        } else {
+          if (ctrl.clause.length === ctrl.offset + 1) {
+            ctrl.clause.push('');
+          }
+          // Change multi/single value to/from an array
+          var shouldBeArray = _.includes(['IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN'], getOperator());
+          if (!_.isArray(ctrl.clause[ctrl.offset + 1]) && shouldBeArray) {
+            ctrl.clause[ctrl.offset + 1] = [];
+          } else if (_.isArray(ctrl.clause[ctrl.offset + 1]) && !shouldBeArray) {
+            ctrl.clause[ctrl.offset + 1] = '';
+          }
+          if (_.includes(['BETWEEN', 'NOT BETWEEN'], getOperator())) {
+            ctrl.clause[ctrl.offset + 1].length = 2;
+          }
+        }
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.html
@@ -1,0 +1,2 @@
+<select class="form-control api4-operator" ng-model="$ctrl.clause[$ctrl.offset]" ng-options="o.key as o.value for o in $ctrl.getOperators()" ng-change="$ctrl.changeClauseOperator()" ></select>
+<crm-search-input ng-if="$ctrl.operatorTakesInput()" ng-model="$ctrl.clause[$ctrl.offset + 1]" field="$ctrl.field" option-key="$ctrl.optionKey" op="$ctrl.clause[$ctrl.offset]" format="$ctrl.format" class="form-group"></crm-search-input>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
@@ -64,7 +64,6 @@
         return !this.item.cssRules || !this.item.cssRules.length || _.last(this.item.cssRules)[1];
       };
 
-      this.operators = CRM.crmSearchAdmin.operators;
     }
   });
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
@@ -22,9 +22,7 @@
   </div>
   <label>{{:: ts('If') }}</label>
   <input class="form-control collapsible-optgroups" ng-model="clause[1]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(clause)" />
-  <select class="form-control api4-operator" ng-if="clause[1]" ng-model="clause[2]" ng-options="o.key as o.value for o in $ctrl.operators">
-  </select>
-  <crm-search-input ng-if="clause[1] && clause[2].indexOf('IS ') !== 0" ng-model="clause[3]" field="$ctrl.getField(clause[1])" option-key="'name'" op="clause[2]" format="$ctrl.format" class="form-group"></crm-search-input>
+  <crm-search-condition ng-if="clause[1]" clause="clause" field="$ctrl.getField(clause[1])" offset="2" option-key="'name'" format="$ctrl.format" class="form-group"></crm-search-condition>
   <button type="button" class="btn-xs btn-danger-outline" ng-click="$ctrl.item.cssRules.splice($index);" title="{{:: ts('Remove style') }}">
     <i class="crm-i fa-ban"></i>
   </button>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -14,16 +14,6 @@
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
-      this.isMulti = function() {
-        // If there's a search operator, return `true` if the operator takes multiple values, else `false`
-        if (ctrl.op) {
-          return ctrl.op === 'IN' || ctrl.op === 'NOT IN';
-        }
-        // If no search operator this is an input for e.g. the bulk update action
-        // Return `true` if the field is multi-valued, else `null`
-        return ctrl.field && (ctrl.field.serialize || ctrl.field.data_type === 'Array') ? true : null;
-      };
-
       this.$onInit = function() {
 
         $scope.$watch('$ctrl.value', function() {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.html
@@ -1,13 +1,13 @@
 <div ng-switch="$ctrl.op || ''" class="form-group">
 
   <div ng-switch-when="BETWEEN|NOT BETWEEN" ng-switch-when-separator="|" class="form-group">
-    <crm-search-input-val field="$ctrl.field" multi="false" option-key="$ctrl.optionKey" ng-model="$ctrl.value[0]" class="form-group"></crm-search-input-val>
+    <crm-search-input-val field="$ctrl.field" op="'&gt;'" option-key="$ctrl.optionKey" ng-model="$ctrl.value[0]" class="form-group"></crm-search-input-val>
     -
-    <crm-search-input-val field="$ctrl.field" multi="false" option-key="$ctrl.optionKey" ng-model="$ctrl.value[1]" class="form-group"></crm-search-input-val>
+    <crm-search-input-val field="$ctrl.field" op="'&lt;'" option-key="$ctrl.optionKey" ng-model="$ctrl.value[1]" class="form-group"></crm-search-input-val>
   </div>
 
   <div ng-switch-default class="form-group">
-    <crm-search-input-val field="$ctrl.field" multi="$ctrl.isMulti()" option-key="$ctrl.optionKey" ng-model="$ctrl.value" class="form-group"></crm-search-input-val>
+    <crm-search-input-val field="$ctrl.field" op="$ctrl.op" option-key="$ctrl.optionKey" ng-model="$ctrl.value" class="form-group"></crm-search-input-val>
   </div>
 
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -4,7 +4,7 @@
   angular.module('crmSearchTasks').component('crmSearchInputVal', {
     bindings: {
       field: '<',
-      'multi': '<',
+      'op': '<',
       'optionKey': '<'
     },
     require: {ngModel: 'ngModel'},
@@ -44,6 +44,16 @@
             ctrl.dateType = 'fixed';
           }
         }
+      };
+
+      this.isMulti = function() {
+        // If there's a search operator, return `true` if the operator takes multiple values, else `false`
+        if (ctrl.op) {
+          return ctrl.op === 'IN' || ctrl.op === 'NOT IN';
+        }
+        // If no search operator this is an input for e.g. the bulk update action
+        // Return `true` if the field is multi-valued, else `null`
+        return ctrl.field && (ctrl.field.serialize || ctrl.field.data_type === 'Array') ? true : null;
       };
 
       this.changeDateType = function() {
@@ -88,6 +98,10 @@
       this.getTemplate = function() {
         var field = ctrl.field || {};
 
+        if (_.includes(['LIKE', 'NOT LIKE', 'REGEXP', 'NOT REGEXP'], ctrl.op)) {
+          return '~/crmSearchTasks/crmSearchInput/text.html';
+        }
+
         if (field.input_type === 'Date') {
           return '~/crmSearchTasks/crmSearchInput/date.html';
         }
@@ -100,7 +114,7 @@
           return '~/crmSearchTasks/crmSearchInput/select.html';
         }
 
-        if (field.fk_entity || field.name === 'id') {
+        if ((field.fk_entity || field.name === 'id') && !_.includes(['>', '<', '>=', '<='], ctrl.op)) {
           return '~/crmSearchTasks/crmSearchInput/entityRef.html';
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Improves the SearchKit UI for selecting field/operator/value conditions. Affects various parts of the UI, like css conditions, link conditions, where/on/having clauses, etc.

Before
----------------------------------------
- Inappropriate operators shown for some fields. E.g. "LIKE" for numeric values, `<`, `>` or "REGEX" for boolean values are all irrelevant and just clutter the UI.
- Input widget doesn't always match operator. E.g. a dropdown select shouldn't be paired with the "REGEX" operator.

After
----------------------------------------
Situation improved.

Technical Details
----------------------------------------
Carves out yet another component to handle the logic of deciding which operators are appropriate to which fields, and how the input values should be rendered.