### PR TITLE
Don't pass redundent empty strings when instantiating CRM_Core_ShowHideBlocks

### DIFF
--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -124,7 +124,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
 
     // form fields of Custom Option rows
     $defaultOptionValues = [];
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
 
     $optionAttributes = CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue');
     $optionAttributes['label']['size'] = $optionAttributes['value']['size'] = 25;
@@ -214,7 +214,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
     }
 
     $_flagOption = $_rowError = 0;
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
 
     //capture duplicate Custom option values
     if (!empty($fields['option_value'])) {

--- a/CRM/Core/ShowHideBlocks.php
+++ b/CRM/Core/ShowHideBlocks.php
@@ -33,9 +33,9 @@ class CRM_Core_ShowHideBlocks {
   /**
    * Class constructor.
    *
-   * @param array $show
+   * @param array|null $show
    *   Initial value of show array.
-   * @param array $hide
+   * @param array|null $hide
    *   Initial value of hide array.
    *
    * @return \CRM_Core_ShowHideBlocks the newly created object

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -300,7 +300,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
 
     // form fields of Custom Option rows
     $defaultOption = [];
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
     for ($i = 1; $i <= self::NUM_OPTION; $i++) {
 
       //the show hide blocks
@@ -626,7 +626,7 @@ SELECT count(*)
      *  Incomplete row checking is also required.
      */
     $_flagOption = $_rowError = 0;
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
     $htmlType = $fields['html_type'];
 
     if (isset($fields['option_type']) && $fields['option_type'] == 1) {

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -306,7 +306,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
 
     // form fields of Discount sets
     $defaultOption = [];
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
 
     for ($i = 1; $i <= self::NUM_DISCOUNT; $i++) {
       //the show hide blocks

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -257,7 +257,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     }
 
     // form fields of Custom Option rows
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
 
     for ($i = 1; $i <= self::NUM_OPTION; $i++) {
 
@@ -440,7 +440,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
         $countemptyrows = 0;
         $publicOptionCount = $_flagOption = $_rowError = 0;
 
-        $_showHide = new CRM_Core_ShowHideBlocks('', '');
+        $_showHide = new CRM_Core_ShowHideBlocks();
         $visibilityOptions = CRM_Price_BAO_PriceFieldValue::buildOptions('visibility_id', 'validate');
 
         for ($index = 1; $index <= self::NUM_OPTION; $index++) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4267,7 +4267,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    */
   public function preProcessOrderBy(&$formValues) {
     // Object to show/hide form elements
-    $_showHide = new CRM_Core_ShowHideBlocks('', '');
+    $_showHide = new CRM_Core_ShowHideBlocks();
 
     $_showHide->addShow('optionField_1');
 


### PR DESCRIPTION
Overview
----------------------------------------
Another minor tidy up. The first two arguments (`$show`, `$hide`) of `CRM_Core_ShowHideBlocks` default to `NULL` and are documented as taking an array. Passing empty strings is redundant as both an empty string and the default value of `NULL` return false from the `!empty($show)` check. Passing in empty strings is unnecessarily confusing.

Before
----------------------------------------
Empty string arguments passed, despite `CRM_Core_ShowHideBlocks` defaulting to `NULL` which has the same outcome.

After
----------------------------------------
Empty string arguments removed in favor of using the default `NULL` values in the constructor.

Also, docblock updated to aknowledge that NULL is an acceptable default argument.