### PR TITLE
Fix batch summary to use the api

### DIFF
--- a/CRM/Batch/BAO/Batch.php
+++ b/CRM/Batch/BAO/Batch.php
@@ -50,24 +50,21 @@ class CRM_Batch_BAO_Batch extends CRM_Batch_DAO_Batch {
   }
 
   /**
-   * Retrieve the information about the batch.
+   * Retrieve DB object and copy to defaults array.
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   * @param array $defaults
-   *   (reference ) an assoc array to hold the flattened values.
+   *   Array of criteria values.
+   * @param array|null $defaults
+   *   Array to be populated with found values.
    *
-   * @return CRM_Batch_BAO_Batch|null
-   *   CRM_Batch_BAO_Batch object on success, null otherwise
+   * @return self|null
+   *   The DAO object, if found.
+   *
+   * @deprecated
    */
-  public static function retrieve(&$params, &$defaults) {
-    $batch = new CRM_Batch_DAO_Batch();
-    $batch->copyValues($params);
-    if ($batch->find(TRUE)) {
-      CRM_Core_DAO::storeValues($batch, $defaults);
-      return $batch;
-    }
-    return NULL;
+  public static function retrieve(array $params, ?array &$defaults = NULL) {
+    $defaults = $defaults ?? [];
+    return self::commonRetrieve(self::class, $params, $defaults);
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
@@ -20,13 +20,14 @@ class CRM_Financial_Page_AjaxBatchSummaryTest extends CiviUnitTestCase {
    *
    * We want to ensure changing the method of obtaining status and payment_instrument
    * does not cause any regression.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  public function testMakeBatchSummary() {
+  public function testMakeBatchSummary(): void {
     $batch = $this->callAPISuccess('Batch', 'create', ['title' => 'test', 'status_id' => 'Open', 'payment_instrument_id' => 'Cash']);
 
-    $batchID = $batch['id'];
-    $params = ['id' => $batchID];
-    $makeBatchSummary = CRM_Financial_Page_AJAX::makeBatchSummary($batchID, $params);
+    $makeBatchSummary = CRM_Financial_Page_AJAX::makeBatchSummary($batch['id']);
 
     $this->assertEquals('Open', $makeBatchSummary['status']);
     $this->assertEquals('Cash', $makeBatchSummary['payment_instrument']);


### PR DESCRIPTION


Overview
----------------------------------------
Fix batch summary to use the api & fix retrieve

Before
----------------------------------------
Old batch retrieve but when we try to update per #22543 we get a test error - this softens the update - but also avoids the function in the specific test fail
https://test.civicrm.org/job/CiviCRM-Core-PR/46718/testReport/junit/(root)/CRM_Financial_Page_AjaxBatchSummaryTest/testMakeBatchSummary/

After
----------------------------------------
No change

![image](https://user-images.githubusercontent.com/336308/150932855-a3ca4c69-9a9b-44f5-94fc-9e5afcb9792d.png)


Technical Details
----------------------------------------
In looking at @colemanw's work to clean up the retrieve function it
turned out that in at least one place NULL is being passed to Batch::retrieve

Since I dug into that 1 place I fixed it to use v4 api (it is
the screen accessed after creating a new accounting batch
from contribution->accounting batches->new batch)

However, it seems safer to continue to accept NULL

Comments
----------------------------------------
