### PR TITLE
dev/core#2122 - Manage event online registration page doesn't determine timezone correctly

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -240,7 +240,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     if (!$this->_isTemplate) {
       $this->_tz = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_id, 'event_tz');
       $tz = CRM_Core_SelectValues::timezone()[$this->_tz];
-      $this->assign('event_tz', CRM_Core_SelectValues::timezone()[$tz] ?? '<span class="error-message">' . ts('%1 No timezone set', [1 => '<i class="crm-i fa-warning"></i>']) . '</span>');
+      $this->assign('event_tz', $tz ?? '<span class="error-message">' . ts('%1 No timezone set', [1 => '<i class="crm-i fa-warning"></i>']) . '</span>');
       $this->add('datepicker', 'registration_start_date', ts('Registration Start Date'), [], FALSE, ['time' => TRUE]);
       $this->add('datepicker', 'registration_end_date', ts('Registration End Date'), [], FALSE, ['time' => TRUE]);
     }


### PR DESCRIPTION
Overview
----------------------------------------
When managing an event, on the online registration tab, it says the event doesn't have a timezone when it really does.

Before
----------------------------------------
It says the event doesn't have a timezone when it really does.

After
----------------------------------------
It has the correct message

Technical Details
----------------------------------------
It seems like it double-converts

Comments
----------------------------------------
@agileware-fj 
