### PR TITLE
dev/core#2122 - Unused variable E_NOTICES on Manage Events page

### DIFF
--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -62,8 +62,8 @@
           <td class="crm-event-state_province">{$row.state_province}</td>
           <td class="crm-event-event_type">{$row.event_type}</td>
           <td class="crm-event-is_public">{if $row.is_public eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td class="crm-event-start_date" data-order="{$row.start_date|crmDate:'%Y-%m-%d %H:%M'}">{$row.start_date|crmDate:"%b %d, %Y %l:%M %P"}{if $row.start_date_with_tz}<br />{$row.start_date_with_tz|crmDate:"%b %d, %Y %l:%M %P"} {$row.event_tz}{elseif !$row.event_tz} <span class="error-message">{ts 1='<i class="crm-i fa-warning"></i>'}%1 No timezone set{/ts}</span>{/if}</td>
-          <td class="crm-event-end_date" data-order="{$row.end_date|crmDate:'%Y-%m-%d %H:%M'}">{$row.end_date|crmDate:"%b %d, %Y %l:%M %P"}{if $row.end_date_with_tz}<br />{$row.end_date_with_tz|crmDate:"%b %d, %Y %l:%M %P"} {$row.event_tz}{/if}</td>
+          <td class="crm-event-start_date" data-order="{$row.start_date|crmDate:'%Y-%m-%d %H:%M'}">{$row.start_date|crmDate:"%b %d, %Y %l:%M %P"}{if !$row.event_tz} <span class="error-message">{ts 1='<i class="crm-i fa-warning"></i>'}%1 No timezone set{/ts}</span>{/if}</td>
+          <td class="crm-event-end_date" data-order="{$row.end_date|crmDate:'%Y-%m-%d %H:%M'}">{$row.end_date|crmDate:"%b %d, %Y %l:%M %P"}</td>
           {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
             <td class="crm-event-campaign">{$row.campaign}</td>
           {/if}


### PR DESCRIPTION
Overview
----------------------------------------
On the manage events page there's E_NOTICES.

Before
----------------------------------------
Undefined index: start_date_with_tz

After
----------------------------------------


Technical Details
----------------------------------------
@agileware-fj  I don't think this is the right fix since it seems to be there on purpose but I'm not sure where this variable gets set?

Comments
----------------------------------------
