### PR TITLE
dev/core#2122 - prevent E_NOTICEs and blank dates being converted to current datetime

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -361,9 +361,15 @@ ORDER BY start_date desc
         }
         CRM_Core_DAO::storeValues($dao, $manageEvent[$dao->id]);
 
+        // avoid enotices
+        foreach (CRM_Event_BAO_Event::tz_fields as $field) {
+          $manageEvent[$dao->id][$field . '_with_tz'] = NULL;
+        }
         if (!is_null($dao->event_tz) && $dao->event_tz != CRM_Core_Config::singleton()->userSystem->getTimeZoneString()) {
           foreach (CRM_Event_BAO_Event::tz_fields as $field) {
-            $manageEvent[$dao->id][$field . '_with_tz'] = CRM_Utils_Date::convertTimeZone($dao->{$field} ?? '', $dao->event_tz);
+            if (!empty($dao->{$field})) {
+              $manageEvent[$dao->id][$field . '_with_tz'] = CRM_Utils_Date::convertTimeZone($dao->{$field}, $dao->event_tz);
+            }
           }
         }
         $manageEvent[$dao->id]['event_tz'] = $dao->event_tz ? CRM_Core_SelectValues::timezone()[$dao->event_tz] : FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
On the manage events page, there's E_NOTICES and also if e.g. there is no end date it gets displayed as "now".

Before
----------------------------------------
On the manage events page, there's E_NOTICES and also if e.g. there is no end date it gets displayed as "now".

Undefined index: start_date_with_tz

After
----------------------------------------
ok

Technical Details
----------------------------------------


Comments
----------------------------------------
@agileware-fj Not sure if this was something that changed between PR versions, especially the end date part.
