### PR TITLE
ExtensionUpgrades - Skip trying to upgrade missing dependencies

### DIFF
--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -441,7 +441,7 @@ class CRM_Extension_Mapper {
   }
 
   /**
-   * @return array
+   * @return CRM_Extension_Info[]
    *   Ex: $result['org.civicrm.foobar'] = new CRM_Extension_Info(...).
    * @throws \CRM_Extension_Exception
    * @throws \Exception

--- a/CRM/Extension/Upgrades.php
+++ b/CRM/Extension/Upgrades.php
@@ -127,7 +127,10 @@ class CRM_Extension_Upgrades {
   }
 
   /**
+   * Sorts active extensions according to their dependencies
+   *
    * @param string[] $keys
+   *   Names of all active modules
    *
    * @return string[]
    * @throws \CRM_Extension_Exception
@@ -137,30 +140,25 @@ class CRM_Extension_Upgrades {
   protected static function sortKeys($keys) {
     $infos = CRM_Extension_System::singleton()->getMapper()->getAllInfos();
 
-    // Start with our inputs in a normalized form.
+    // Ensure a stable starting order.
     $todoKeys = array_unique($keys);
     sort($todoKeys);
 
-    // Goal: Add all active items to $sorter and flag $doneKeys['org.example.foobar']=1.
-    $doneKeys = [];
     $sorter = new \MJS\TopSort\Implementations\FixedArraySort();
 
-    while (!empty($todoKeys)) {
-      $key = array_shift($todoKeys);
-      if (isset($doneKeys[$key])) {
-        continue;
-      }
-      $doneKeys[$key] = 1;
-
+    foreach ($todoKeys as $key) {
       /** @var CRM_Extension_Info $info */
-      $info = @$infos[$key];
+      $info = $infos[$key] ?? NULL;
 
-      if ($info && $info->requires) {
-        $sorter->add($key, $info->requires);
-        $todoKeys = array_merge($todoKeys, $info->requires);
+      // Add dependencies
+      if ($info) {
+        // Filter out missing dependencies; missing modules cannot be upgraded
+        $requires = array_intersect($info->requires ?? [], $keys);
+        $sorter->add($key, $requires);
       }
+      // This shouldn't ever happen if this function is being passed a list of active extensions.
       else {
-        $sorter->add($key, []);
+        throw new CRM_Extension_Exception('Invalid extension key: "' . $key . '"');
       }
     }
     return $sorter->sort();


### PR DESCRIPTION
Overview
----------------------------------------
This allows the extension upgrade to proceed without error, even if there are missing dependencies.
The user will be prompted to install the missing dependencies afterward, e.g. #22464 

See https://lab.civicrm.org/dev/core/-/issues/3036

Before
----------------------------------------
All dependencies would be added to the upgrade queue and then the extension upgrader would try and fail to upgrade them even if they were missing.

After
----------------------------------------
Upgrading dependencies is skipped.

Technical Details
----------------------------------
Maybe I'm missing something, but that `while` loop with the tracking variables and the `array_shift()` seemed overcomplicated. I had to read it a couple times to figure out that all it does is iterate through each item once. That can be more simply achieved with a `foreach` loop, so I changed it to that.