### PR TITLE
dev/core#2486 Add v4 Mailing api (+ MailingJob)

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1478,7 +1478,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    *
    *  - _skip_evil_bao_auto_recipients_: bool
    *  - _skip_evil_bao_auto_schedule_: bool
-   *  - _evil_bao_validator_: string|callable
    *
    * </twowrongsmakesaright>
    *
@@ -1611,17 +1610,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     // check and attach and files as needed
     CRM_Core_BAO_File::processAttachment($params, 'civicrm_mailing', $mailing->id);
-
-    // If we're going to autosend, then check validity before saving.
-    if (empty($params['is_completed']) && !empty($params['scheduled_date']) && $params['scheduled_date'] != 'null' && !empty($params['_evil_bao_validator_'])) {
-      $cb = Civi\Core\Resolver::singleton()
-        ->get($params['_evil_bao_validator_']);
-      $errors = call_user_func($cb, $mailing);
-      if (!empty($errors)) {
-        $fields = implode(',', array_keys($errors));
-        throw new CRM_Core_Exception("Mailing cannot be sent. There are missing or invalid fields ($fields).", 'cannot-send', $errors);
-      }
-    }
 
     $transaction->commit();
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -457,6 +457,47 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
   }
 
   /**
+   * Do Submit actions.
+   *
+   * When submitting (as opposed to creating or updating) a mailing it should
+   * be scheduled.
+   *
+   * This function creates the initial job and the recipient list.
+   *
+   * @param array $params
+   * @param \CRM_Mailing_DAO_Mailing $mailing
+   *
+   * @return array
+   */
+  protected static function doSubmitActions(array $params, CRM_Mailing_DAO_Mailing $mailing): array {
+    // Create parent job if not yet created.
+    // Condition on the existence of a scheduled date.
+    if (!empty($params['scheduled_date']) && $params['scheduled_date'] != 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
+      $job = new CRM_Mailing_BAO_MailingJob();
+      $job->mailing_id = $mailing->id;
+      // If we are creating a new Completed mailing (e.g. import from another system) set the job to completed.
+      // Keeping former behaviour when an id is present is precautionary and may warrant reconsideration later.
+      $job->status = ((empty($params['is_completed']) || !empty($params['id'])) ? 'Scheduled' : 'Complete');
+      $job->is_test = 0;
+
+      if (!$job->find(TRUE)) {
+        // Don't schedule job until we populate the recipients.
+        $job->scheduled_date = NULL;
+        $job->save();
+      }
+      // Schedule the job now that it has recipients.
+      $job->scheduled_date = $params['scheduled_date'];
+      $job->save();
+    }
+
+    // Populate the recipients.
+    if (empty($params['_skip_evil_bao_auto_recipients_'])) {
+      self::getRecipients($mailing->id);
+    }
+    return $params;
+  }
+
+  /**
    * Returns the regex patterns that are used for preparing the text and html templates.
    *
    * @param bool $onlyHrefs
@@ -1613,29 +1654,12 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $transaction->commit();
 
-    // Create parent job if not yet created.
-    // Condition on the existence of a scheduled date.
-    if (!empty($params['scheduled_date']) && $params['scheduled_date'] != 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
-      $job = new CRM_Mailing_BAO_MailingJob();
-      $job->mailing_id = $mailing->id;
-      // If we are creating a new Completed mailing (e.g. import from another system) set the job to completed.
-      // Keeping former behaviour when an id is present is precautionary and may warrant reconsideration later.
-      $job->status = ((empty($params['is_completed']) || !empty($params['id'])) ? 'Scheduled' : 'Complete');
-      $job->is_test = 0;
-
-      if (!$job->find(TRUE)) {
-        // Don't schedule job until we populate the recipients.
-        $job->scheduled_date = NULL;
-        $job->save();
-      }
-      // Schedule the job now that it has recipients.
-      $job->scheduled_date = $params['scheduled_date'];
-      $job->save();
-    }
-
-    // Populate the recipients.
-    if (empty($params['_skip_evil_bao_auto_recipients_'])) {
-      self::getRecipients($mailing->id);
+    // These actions are really 'submit' not create actions.
+    // In v4 of the api they are not available via CRUD. At some
+    // point we will create a 'submit' function which will do the crud+submit
+    // but for now only CRUD is available via v4 api.
+    if (($params['version'] ?? '') !== 4) {
+      $params = self::doSubmitActions($params, $mailing);
     }
 
     return $mailing;

--- a/Civi/Api4/Mailing.php
+++ b/Civi/Api4/Mailing.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Mailing.
+ *
+ * Mailing entities store the contents and settings for bulk mails.
+ *
+ * @searchable secondary
+ * @see https://docs.civicrm.org/user/en/latest/email/what-is-civimail/
+ * @since 5.47
+ * @package Civi\Api4
+ */
+class Mailing extends Generic\DAOEntity {
+
+}

--- a/Civi/Api4/MailingJob.php
+++ b/Civi/Api4/MailingJob.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+use Civi\Api4\Generic\Traits\ReadOnlyEntity;
+
+/**
+ * Mailing job.
+ *
+ * Mailing job tracks the batching of CiviMails.
+ *
+ * @searchable none
+ *
+ * @see https://docs.civicrm.org/user/en/latest/email/what-is-civimail/
+ * @since 5.47
+ * @package Civi\Api4
+ */
+class MailingJob extends Generic\DAOEntity {
+  use ReadOnlyEntity;
+
+}

--- a/ext/flexmailer/src/Validator.php
+++ b/ext/flexmailer/src/Validator.php
@@ -25,14 +25,20 @@ class Validator {
   const EVENT_CHECK_SENDABLE = 'civi.flexmailer.checkSendable';
 
   /**
-   * @param \CRM_Mailing_DAO_Mailing $mailing
+   * @param array $params
    *   The mailing which may or may not be sendable.
    * @return array
    *   List of error messages.
    */
-  public static function createAndRun($mailing) {
-    $validator = new \Civi\FlexMailer\Validator();
-    return $validator->run(array(
+  public static function createAndRun(array $params): array {
+    $mailing = new \CRM_Mailing_BAO_Mailing();
+    $mailing->id = $params['id'] ?? NULL;
+    if ($mailing->id) {
+      $mailing->find(TRUE);
+    }
+    $mailing->copyValues($params);
+
+    return (new Validator())->run(array(
       'mailing' => $mailing,
       'attachments' => \CRM_Core_BAO_File::getEntityFile('civicrm_mailing', $mailing->id),
     ));

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -86,9 +86,7 @@ class ValidatorTest extends \CiviUnitTestCase {
    * @dataProvider getExamples
    */
   public function testExamples($mailingData, $expectedErrors): void {
-    $mailing = new \CRM_Mailing_DAO_Mailing();
-    $mailing->copyValues($mailingData);
-    $actualErrors = Validator::createAndRun($mailing);
+    $actualErrors = Validator::createAndRun($mailingData);
     $this->assertEquals(
       array_keys($actualErrors),
       array_keys($expectedErrors)

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -77,15 +77,21 @@ class api_v3_MailingTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_mailing_create.
+   *
+   * @dataProvider versionThreeAndFour
+   *
+   * @param int $version
    */
-  public function testMailerCreateSuccess(): void {
+  public function testMailerCreateSuccess(int $version): void {
+    $this->_apiversion = $version;
+    $this->enableCiviCampaign();
     $this->callAPISuccess('Campaign', 'create', ['name' => 'big campaign', 'title' => 'abc']);
     $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign'], __FUNCTION__, __FILE__);
-    $jobs = $this->callAPISuccess('mailing_job', 'get', ['mailing_id' => $result['id']]);
+    $jobs = $this->callAPISuccess('MailingJob', 'get', ['mailing_id' => $result['id']]);
     $this->assertEquals(1, $jobs['count']);
     // return isn't working on this in getAndCheck so lets not check it for now
     unset($this->_params['created_id']);
-    $this->getAndCheck($this->_params, $result['id'], 'mailing');
+    $this->getAndCheck($this->_params, $result['id'], 'Mailing');
   }
 
   /**
@@ -103,9 +109,12 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   /**
    * Create a completed mailing (e.g when importing from a provider).
    *
-   * @throws \CRM_Core_Exception
+   * @dataProvider versionThreeAndFour
+   *
+   * @param int $version
    */
-  public function testMailerCreateCompleted() {
+  public function testMailerCreateCompleted(int $version): void {
+    $this->_apiversion = $version;
     $this->_params['body_html'] = 'I am completed so it does not matter if there is an opt out link since I have already been sent by another system';
     $this->_params['is_completed'] = 1;
     $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now'], __FUNCTION__, __FILE__);
@@ -120,7 +129,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   /**
    * Per CRM-20316 the mailing should still create without created_id (not mandatory).
    */
-  public function testMailerCreateSuccessNoCreatedID() {
+  public function testMailerCreateSuccessNoCreatedID(): void {
     unset($this->_params['created_id']);
     $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now'], __FUNCTION__, __FILE__);
     $this->getAndCheck($this->_params, $result['id'], 'mailing');

--- a/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
+++ b/tests/phpunit/api/v4/Service/TestCreationParameterProvider.php
@@ -150,9 +150,12 @@ class TestCreationParameterProvider {
       $params['where'] = [['contact_type', '=', 'Individual']];
     }
     $entityList = civicrm_api4($fkEntity, 'get', $params);
+    // If no existing entities, create one
     if ($entityList->count() < 1) {
-      $msg = sprintf('At least one %s is required in test', $fkEntity);
-      throw new \API_Exception($msg);
+      $entityList = civicrm_api4($fkEntity, 'create', [
+        'checkPermissions' => FALSE,
+        'values' => $this->getRequired($fkEntity),
+      ]);
     }
 
     return $entityList->last()['id'];


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2486 Add v4 Mailing api (+ MailingJob)

Before
----------------------------------------
No v4 api for Mailing

After
----------------------------------------
Tada

Technical Details
----------------------------------------
@colemanw @seamuslee001 @totten this is a starting point but there are some bizarre things regarding the Mailing create function

1) there is some permissions stuff in the v3 api layer - we could probably just move this to the BAO 
2) weird voodoo number 1 `_evil_bao_validator_` - this is where either flexmailer or the legacy method validate
3) weird voodoo number 2 - if you just want to create the entity & not have it start firing stuff out you have to pass in '_skip_evil_bao_auto_schedule_' and `_skip_evil_bao_auto_recipients_` ..... - UPDATE agreed `setPopulateReceipients` - default to FALSE

I'm not quite sure how best to deal with 2 & 3. Note we did talk about moving the legacy Mailing stuff to an extension - which probably would have made this easier at least WRT 2

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2486