### PR TITLE
APIv4 - Rename 'ReadOnly' trait to 'ReadOnlyEntity' to avoid PHP error

### DIFF
--- a/Civi/Api4/EntityFinancialTrxn.php
+++ b/Civi/Api4/EntityFinancialTrxn.php
@@ -22,7 +22,7 @@ namespace Civi\Api4;
  */
 class EntityFinancialTrxn extends Generic\DAOEntity {
   use Generic\Traits\EntityBridge;
-  use Generic\Traits\ReadOnly;
+  use Generic\Traits\ReadOnlyEntity;
 
   /**
    * @return array

--- a/Civi/Api4/FinancialItem.php
+++ b/Civi/Api4/FinancialItem.php
@@ -22,6 +22,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class FinancialItem extends Generic\DAOEntity {
-  use Generic\Traits\ReadOnly;
+  use Generic\Traits\ReadOnlyEntity;
 
 }

--- a/Civi/Api4/FinancialTrxn.php
+++ b/Civi/Api4/FinancialTrxn.php
@@ -25,6 +25,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class FinancialTrxn extends Generic\DAOEntity {
-  use Generic\Traits\ReadOnly;
+  use Generic\Traits\ReadOnlyEntity;
 
 }

--- a/Civi/Api4/Generic/Traits/ReadOnlyEntity.php
+++ b/Civi/Api4/Generic/Traits/ReadOnlyEntity.php
@@ -14,7 +14,7 @@ namespace Civi\Api4\Generic\Traits;
 /**
  * Trait for Entities not intended to be publicly writable.
  */
-trait ReadOnly {
+trait ReadOnlyEntity {
 
   /**
    * Not intended to be used outside CiviCRM core code.

--- a/Civi/Api4/LineItem.php
+++ b/Civi/Api4/LineItem.php
@@ -18,6 +18,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class LineItem extends Generic\DAOEntity {
-  use Generic\Traits\ReadOnly;
+  use Generic\Traits\ReadOnlyEntity;
 
 }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -515,7 +515,7 @@ class ConformanceTest extends UnitTestCase implements HookInterface {
    * @return bool
    */
   protected function isReadOnly($entityClass) {
-    return in_array('ReadOnly', $entityClass::getInfo()['type'], TRUE);
+    return in_array('ReadOnlyEntity', $entityClass::getInfo()['type'], TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3043](https://lab.civicrm.org/dev/core/-/issues/3043)

Before
----------------------------------------
Crashes PHP 8.1+

After
----------------------------------------
No crash

Technical Details
----------------------------------------
The word 'readonly' is reserved as of php 8.1