### PR TITLE
Remove deprecated language construct

### DIFF
--- a/ext/afform/admin/afform_admin.civix.php
+++ b/ext/afform/admin/afform_admin.civix.php
@@ -91,9 +91,9 @@ function _afform_admin_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/afform/core/afform.civix.php
+++ b/ext/afform/core/afform.civix.php
@@ -91,9 +91,9 @@ function _afform_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/afform/html/afform_html.civix.php
+++ b/ext/afform/html/afform_html.civix.php
@@ -91,9 +91,9 @@ function _afform_html_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/afform/mock/afform_mock.civix.php
+++ b/ext/afform/mock/afform_mock.civix.php
@@ -91,9 +91,9 @@ function _afform_mock_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/authx/authx.civix.php
+++ b/ext/authx/authx.civix.php
@@ -91,9 +91,9 @@ function _authx_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/civigrant/civigrant.civix.php
+++ b/ext/civigrant/civigrant.civix.php
@@ -91,9 +91,9 @@ function _civigrant_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/ckeditor4/ckeditor4.civix.php
+++ b/ext/ckeditor4/ckeditor4.civix.php
@@ -91,9 +91,9 @@ function _ckeditor4_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/contributioncancelactions/contributioncancelactions.civix.php
+++ b/ext/contributioncancelactions/contributioncancelactions.civix.php
@@ -91,9 +91,9 @@ function _contributioncancelactions_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/eventcart/eventcart.civix.php
+++ b/ext/eventcart/eventcart.civix.php
@@ -91,9 +91,9 @@ function _eventcart_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/ewaysingle/ewaysingle.civix.php
+++ b/ext/ewaysingle/ewaysingle.civix.php
@@ -91,9 +91,9 @@ function _ewaysingle_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/financialacls/financialacls.civix.php
+++ b/ext/financialacls/financialacls.civix.php
@@ -91,9 +91,9 @@ function _financialacls_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/flexmailer/flexmailer.civix.php
+++ b/ext/flexmailer/flexmailer.civix.php
@@ -91,9 +91,9 @@ function _flexmailer_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/greenwich/greenwich.civix.php
+++ b/ext/greenwich/greenwich.civix.php
@@ -91,9 +91,9 @@ function _greenwich_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/legacycustomsearches/legacycustomsearches.civix.php
+++ b/ext/legacycustomsearches/legacycustomsearches.civix.php
@@ -91,9 +91,9 @@ function _legacycustomsearches_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/message_admin/message_admin.civix.php
+++ b/ext/message_admin/message_admin.civix.php
@@ -91,9 +91,9 @@ function _message_admin_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/oauth-client/oauth_client.civix.php
+++ b/ext/oauth-client/oauth_client.civix.php
@@ -91,9 +91,9 @@ function _oauth_client_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/payflowpro/payflowpro.civix.php
+++ b/ext/payflowpro/payflowpro.civix.php
@@ -91,9 +91,10 @@ function _payflowpro_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__
+    . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/recaptcha/recaptcha.civix.php
+++ b/ext/recaptcha/recaptcha.civix.php
@@ -91,9 +91,9 @@ function _recaptcha_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/search_kit/search_kit.civix.php
+++ b/ext/search_kit/search_kit.civix.php
@@ -91,9 +91,9 @@ function _search_kit_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
+++ b/ext/sequentialcreditnotes/sequentialcreditnotes.civix.php
@@ -91,9 +91,9 @@ function _sequentialcreditnotes_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/tests/extensions/shimmy/shimmy.civix.php
+++ b/tests/extensions/shimmy/shimmy.civix.php
@@ -98,9 +98,9 @@ function _shimmy_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/tools/extensions/org.civicrm.angularex/angularex.civix.php
+++ b/tools/extensions/org.civicrm.angularex/angularex.civix.php
@@ -91,9 +91,9 @@ function _angularex_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/tools/extensions/org.civicrm.demoqueue/demoqueue.civix.php
+++ b/tools/extensions/org.civicrm.demoqueue/demoqueue.civix.php
@@ -7,9 +7,9 @@
  * @param $config
  */
 function _demoqueue_civix_civicrm_config(&$config) {
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {


### PR DESCRIPTION

Overview
----------------------------------------
Remove deprecated language construct

Per https://github.com/totten/civix/pull/235 this language construct
appears to be getting more noisy about being bad....

Before
----------------------------------------
Seeing notices like PHP Notice: Only variables should be assigned by reference in /srv/civi-sites/wmff/civicrm/ext/greenwich/greenwich.civix.php on line 94

After
----------------------------------------
poof

Technical Details
----------------------------------------
I expect this is a version dependent thing - I don't seem to see it all the time.

Comments
----------------------------------------
