### PR TITLE
Unhide message admin UI

### DIFF
--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -16,9 +16,6 @@
   </urls>
   <releaseDate>2021-06-12</releaseDate>
   <version>5.47.alpha1</version>
-  <tags>
-    <tag>mgmt:hidden</tag>
-  </tags>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.43</ver>


### PR DESCRIPTION
Overview
----------------------------------------
Unhide message admin UI

Before
----------------------------------------
Message admin extension ships with CiviCRM but not visible in the extensions screen

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/151252713-cc685132-bd85-42d3-8078-dd5f338d9e3d.png)

Technical Details
----------------------------------------
The extension works - it has a bug that I need to log - but I don't think being bug-free is a criteria - just not insanely alpha

Comments
----------------------------------------
