### PR TITLE
Fix inaccuracy in docblock for method calculateBaseScheduleDate

### DIFF
--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -464,8 +464,8 @@ WHERE  civicrm_pledge.id = %2
    *
    * @param array $params
    *
-   * @return array
-   *   Next scheduled date as an array
+   * @return string
+   *   Next scheduled date in the format YmdHis
    */
   public static function calculateBaseScheduleDate(&$params) {
     $date = [];


### PR DESCRIPTION
Overview
----------------------------------------
The method `CRM_Pledge_BAO_PledgePayment::calculateBaseScheduleDate` returns the result of a call to `date` which is always a string. Therefore the documented return type of array cannot be correct.

`CRM_Pledge_BAO_PledgePayment::calculateBaseScheduleDate` is only called from a single place in core, and I have also checked that the returned value is treated as a string.

Before
----------------------------------------
Inaccurate docblock comment.

After
----------------------------------------
(more) accurate docblock comment.
