### PR TITLE
dev/core#2866 Ignore preferred mail format when sending message

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -15,7 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Api4\Email;
 use Civi\Api4\MessageTemplate;
 use Civi\WorkflowMessage\WorkflowMessage;
 
@@ -397,20 +396,6 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
     // send the template, honouring the target user’s preferences (if any)
     $sent = FALSE;
     if (!empty($params['toEmail'])) {
-      // @todo - consider whether we really should be loading
-      // this based on 'the first email in the db that matches'.
-      // when we likely have the contact id. OTOH people probably barely
-      // use preferredMailFormat these days - the good fight against html
-      // emails was lost a decade ago...
-      $preferredMailFormatArray = Email::get(FALSE)->addWhere('email', '=', $params['toEmail'])->addSelect('contact_id.preferred_mail_format')->execute()->first();
-      $preferredMailFormat = $preferredMailFormatArray['contact_id.preferred_mail_format'] ?? 'Both';
-
-      if ($preferredMailFormat === 'HTML') {
-        $params['text'] = NULL;
-      }
-      if ($preferredMailFormat === 'Text') {
-        $params['html'] = NULL;
-      }
 
       $config = CRM_Core_Config::singleton();
       if ($isAttachPDF) {

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -46,36 +46,6 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check detection of contact's preferred mail.
-   *
-   * - ie if text then no html output is sent.
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   */
-  public function testSendTemplateNoHtml(): void {
-    $contactId = $this->individualCreate([
-      'preferred_mail_format' => 'Text',
-      'first_name' => 'Mary',
-      'email' => 'mary_anderson@civicrm.org',
-    ]);
-    $mut = new CiviMailUtils($this, TRUE);
-    CRM_Core_BAO_MessageTemplate::sendTemplate(
-      [
-        'contactId' => $contactId,
-        'from' => 'admin@example.com',
-        'toEmail' => 'mary_anderson@civicrm.org',
-        'messageTemplate' => [
-          'msg_subject' => 'My subject',
-          'msg_text' => 'My text',
-          'msg_html' => 'My html',
-        ],
-      ]
-    );
-    $mut->checkMailLog(['My text', 'My subject'], ['My html']);
-  }
-
-  /**
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2866 Ignore preferred mail format when sending message

Before
----------------------------------------
preferred mail format dicates whether html or text messages are sent

After
----------------------------------------
Both are sent, the choice of which to show is left to the email client

Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/2866 the idea of only sending one is outdated

Comments
----------------------------------------
