### PR TITLE
dev/core#2866 Remove preferred_mail_format from email trait

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -145,9 +145,6 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
       }
     }
 
-    if (array_key_exists('preferred_mail_format', $fields) && empty($fields['preferred_mail_format'])) {
-      $errors['preferred_mail_format'] = ts('Please select an email format preferred by this contact.');
-    }
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -192,7 +192,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
       // get the details for all selected contacts ( to, cc and bcc contacts )
       $allContactDetails = civicrm_api3('Contact', 'get', [
         'id' => ['IN' => $this->_allContactIds],
-        'return' => ['sort_name', 'email', 'do_not_email', 'is_deceased', 'on_hold', 'display_name', 'preferred_mail_format'],
+        'return' => ['sort_name', 'email', 'do_not_email', 'is_deceased', 'on_hold', 'display_name'],
         'options' => ['limit' => 0],
       ])['values'];
 


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#2866 Remove preferred_mail_format from email trait

Before
----------------------------------------
Value is fetched but somewhere around this https://lab.civicrm.org/dev/core/-/commit/f91d65f3c50e6567b5357e0ae7f80431151e05b7
it became unused

After
----------------------------------------
Not fetched

Technical Details
----------------------------------------

Comments
----------------------------------------
