### PR TITLE
Add basic contribution example base for contribution workflows

### DIFF
--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.ex.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.ex.php
@@ -1,0 +1,59 @@
+<?php
+
+use Civi\Api4\WorkflowMessage;
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+use Civi\WorkflowMessage\WorkflowMessageExample;
+
+/**
+ * Basic contribution example for contribution templates.
+ *
+ * @noinspection PhpUnused
+ * @noinspection UnknownInspectionInspection
+ */
+class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends WorkflowMessageExample {
+
+  /**
+   * Get the examples this class is able to deliver.
+   */
+  public function getExamples(): iterable {
+    $workflows = ['contribution_online_receipt', 'contribution_offline_receipt', 'contribution_invoice_receipt'];
+    foreach ($workflows as $workflow) {
+      yield [
+        'name' => 'workflow/' . $workflow . '/' . $this->getExampleName(),
+        'title' => ts('Completed Contribution'),
+        'tags' => ['preview'],
+        'workflow' => $workflow,
+      ];
+    }
+  }
+
+  /**
+   * Build an example to use when rendering the workflow.
+   *
+   * @param array $example
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function build(array &$example): void {
+    $workFlow = WorkflowMessage::get(TRUE)->addWhere('name', '=', $example['workflow'])->execute()->first();
+    $this->setWorkflowName($workFlow['name']);
+    $messageTemplate = new $workFlow['class']();
+    $this->addExampleData($messageTemplate);
+    $example['data'] = $this->toArray($messageTemplate);
+  }
+
+  /**
+   * Add relevant example data.
+   *
+   * @param \CRM_Contribute_WorkflowMessage_ContributionOfflineReceipt|\CRM_Contribute_WorkflowMessage_ContributionOnlineReceipt|\CRM_Contribute_WorkflowMessage_ContributionInvoiceReceipt $messageTemplate
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function addExampleData(GenericWorkflowMessage $messageTemplate): void {
+    $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
+    $messageTemplate->setContribution(\Civi\Test::example('entity/Contribution/Euro5990/completed'));
+  }
+
+}

--- a/Civi/WorkflowMessage/WorkflowMessageExample.php
+++ b/Civi/WorkflowMessage/WorkflowMessageExample.php
@@ -41,11 +41,31 @@ abstract class WorkflowMessageExample implements ExampleDataInterface {
   protected $wfName;
 
   /**
+   * Set the workflow name.
+   *
+   * The workflow name is the value in civicrm_message_template.workflow.
+   *
+   * @param string $workflowName
+   */
+  public function setWorkflowName(string $workflowName): void {
+    $this->wfName = $workflowName;
+  }
+
+  /**
    * Name for this example specifically.
    *
    * @var string
    */
   protected $exName;
+
+  /**
+   * Get the example name.
+   *
+   * @return string
+   */
+  public function getExampleName(): string {
+    return $this->exName;
+  }
 
   /**
    * WorkflowMessageExample constructor.


### PR DESCRIPTION
Overview
----------------------------------------
Add basic contribution example base for contribution workflows

The examples have very little exposed tokens so not much is visible - but
it is a start....



Before
----------------------------------------
Attempting to preview any of the contribution templates, with message admin extension enabled, gives an error

After
----------------------------------------
A preview page loads - there is not much to see as yet other than some contact data.

Technical Details
----------------------------------------
Note the Contribution tokens, unlike contact, don't take input of
already loaded data - fixing that will allow quite a lot more stuff to show up (at least where we are using tokens). That would be a good next step 

Comments
----------------------------------------
Note there is some caching so testing this & then pulling the patch & re-testing will not work I use

```
--- a/Civi/Test/ExampleDataLoader.php
+++ b/Civi/Test/ExampleDataLoader.php
@@ -40,7 +40,7 @@ class ExampleDataLoader {
       $cache = \CRM_Utils_Constant::value('CIVICRM_TEST') ? new \CRM_Utils_Cache_NoCache([]) : \Civi::cache('long');
       $cacheKey = \CRM_Utils_String::munge(__CLASS__);
       $this->metas = $cache->get($cacheKey);
-      if ($this->metas === NULL) {
+      if (1 || $this->metas === NULL) {
         $this->metas = $this->findMetas();
         $cache->set($cacheKey, $this->metas);
       }

```