### PR TITLE
Flush the metadata cache when the domain is edited

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -81,9 +81,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
       $this, FALSE, 'view'
     );
-    //location blocks.
-    $location = new CRM_Contact_Form_Location();
-    $location->preProcess($this);
+    CRM_Contact_Form_Location::preProcess($this);
   }
 
   /**

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -21,7 +21,7 @@ class CRM_Contact_Form_Location {
    *
    * @param CRM_Core_Form $form
    */
-  public static function preProcess(&$form) {
+  public static function preProcess($form) {
     $form->_addBlockName = CRM_Utils_Request::retrieve('block', 'String');
     $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive');
 

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -33,6 +33,9 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * @param CRM_Core_DAO_Domain $domain
    */
   public static function onPostSave($domain) {
+    // We want to clear out any cached tokens.
+    // Editing a domain is so rare we can risk being heavy handed.
+    Civi::cache('metadata')->clear();
     Civi::$statics[__CLASS__]['current'] = NULL;
   }
 
@@ -147,8 +150,9 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * @param int $id
    *
    * @return CRM_Core_DAO_Domain
+   * @throws \CRM_Core_Exception
    */
-  public static function edit($params, $id) {
+  public static function edit($params, $id): CRM_Core_DAO_Domain {
     $params['id'] = $id;
     return self::writeRecord($params);
   }

--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -31,7 +31,7 @@
 
     <h3>{ts}Default Organization Address{/ts}</h3>
         <div class="description">{ts 1=&#123;domain.address&#125;}CiviMail mailings must include the sending organization's address. This is done by putting the %1 token in either the body or footer of the mailing. This token may also be used in regular 'Email - send now' messages and in other Message Templates. The token is replaced by the address entered below when the message is sent.{/ts}</div>
-        {include file="CRM/Contact/Form/Edit/Address.tpl"}
+        {include file="CRM/Contact/Form/Edit/Address.tpl" masterAddress='' parseStreetAddress=''}
     <h3>{ts}Organization Contact Information{/ts}</h3>
         <div class="description">{ts}You can also include general email and/or phone contact information in mailings.{/ts} {help id="additional-contact"}</div>
         <table class="form-layout-compressed">

--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -11,7 +11,7 @@
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller*}
 {* @var $blockId Contains the current address block id, and assigned in the  CRM/Contact/Form/Location.php file *}
 
-{if $title and $className eq 'CRM_Contact_Form_Contact'}
+{if $className eq 'CRM_Contact_Form_Contact' && $title}
 <div id="addressBlockId" class="crm-accordion-wrapper crm-address-accordion collapsed">
  <div class="crm-accordion-header">
     {$title}

--- a/templates/CRM/Contact/Form/Edit/Address/address_name.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/address_name.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if !empty($form.address.$blockId.name)}
+{if array_key_exists('name', $form.address.$blockId)}
   <tr>
       <td colspan="2">
         {$form.address.$blockId.name.label} {help id="id-address-name" file="CRM/Contact/Form/Contact.hlp"}<br />


### PR DESCRIPTION

Overview
----------------------------------------
Flush the metadata cache when the domain is edited

Before
----------------------------------------
Editing the domain to have a street address will not result in the {domain.address} token being usable until the metadata cache has aged out

After
----------------------------------------
The cache is flushed on editing the domain (at least through the form UI)

Technical Details
----------------------------------------

Comments
----------------------------------------
