### PR TITLE
(dev/core#3045) ManagedEntities - Fix crash during upgrade

### DIFF
--- a/CRM/Core/BAO/Managed.php
+++ b/CRM/Core/BAO/Managed.php
@@ -34,6 +34,10 @@ class CRM_Core_BAO_Managed extends CRM_Core_DAO_Managed implements Civi\Test\Hoo
     }
     // When an entity is updated, update the timestamp in corresponding Managed record
     elseif ($event->action === 'edit' && $event->id && self::isApi4ManagedType($event->entity)) {
+      if (!array_key_exists('entity_modified_date', self::getSupportedFields())) {
+        // During upgrades this column may not exist yet
+        return;
+      }
       CRM_Core_DAO::executeQuery('UPDATE civicrm_managed SET entity_modified_date = CURRENT_TIMESTAMP WHERE entity_type = %1 AND entity_id = %2', [
         1 => [$event->entity, 'String'],
         2 => [$event->id, 'Integer'],


### PR DESCRIPTION
Overview
----------------------------------------
This prevents a potential crash when trying to update a column before it has been added by the upgrader

Fixes [dev/core#3045](https://lab.civicrm.org/dev/core/-/issues/3045)