### PR TITLE
Resolve docblock inaccuracy in CRM_Contribute_Form_Task_TaskTrait

### DIFF
--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -143,7 +143,7 @@ trait CRM_Contribute_Form_Task_TaskTrait {
   /**
    * Is only one entity being processed?
    *
-   * @return false
+   * @return bool
    */
   public function isSingle() {
     return count($this->getIDs()) === 1;


### PR DESCRIPTION
Overview
----------------------------------------
Resolve docblock inaccuracy in CRM_Contribute_Form_Task_TaskTrait.

This is a very minor thing, but `isSingle` returns a boolean dependant on the result of `$this->getIDs()`, rather than returning `false` every time.