### PR TITLE
dev/translation#38 Fix multilingual triggers for when fields default to an empty string

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -522,19 +522,19 @@ class CRM_Core_I18n_Schema {
       $trigger = [];
 
       foreach ($hash as $column => $_) {
-        $trigger[] = "IF NEW.{$column}_{$locale} IS NOT NULL THEN";
+        $trigger[] = "IF NEW.{$column}_{$locale} IS NOT NULL AND NEW.{$column}_{$locale} != '' THEN";
         foreach ($locales as $old) {
-          $trigger[] = "IF NEW.{$column}_{$old} IS NULL THEN SET NEW.{$column}_{$old} = NEW.{$column}_{$locale}; END IF;";
+          $trigger[] = "IF NEW.{$column}_{$old} IS NULL OR NEW.{$column}_{$old} = '' THEN SET NEW.{$column}_{$old} = NEW.{$column}_{$locale}; END IF;";
         }
         foreach ($locales as $old) {
-          $trigger[] = "ELSEIF NEW.{$column}_{$old} IS NOT NULL THEN";
+          $trigger[] = "ELSEIF NEW.{$column}_{$old} IS NOT NULL AND NEW.{$column}_{$old} != '' THEN";
           foreach (array_merge($locales, [
             $locale,
           ]) as $loc) {
             if ($loc == $old) {
               continue;
             }
-            $trigger[] = "IF NEW.{$column}_{$loc} IS NULL THEN SET NEW.{$column}_{$loc} = NEW.{$column}_{$old}; END IF;";
+            $trigger[] = "IF NEW.{$column}_{$loc} IS NULL OR NEW.{$column}_{$loc} = '' THEN SET NEW.{$column}_{$loc} = NEW.{$column}_{$old}; END IF;";
           }
         }
         $trigger[] = 'END IF;';

--- a/tests/phpunit/CRM/Core/I18n/SchemaTest.php
+++ b/tests/phpunit/CRM/Core/I18n/SchemaTest.php
@@ -114,4 +114,11 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     }
   }
 
+  public function testMultilingualCustomFieldCreation() {
+    $this->enableMultilingual();
+    CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
+    $id = $this->customGroupCreate()['id'];
+    $this->customFieldCreate(['custom_group_id' => $id]);
+  }
+
 }


### PR DESCRIPTION
https://lab.civicrm.org/dev/translation/-/issues/38

and follow-up to #20767

Overview
----------------------------------------

As an admin:

- enable multilingual
- add a second language
- create a custom field set
- then add two fields.

CiviCRM will crash on the second field, because duplicate key on the label, because the are two labels that have an empty string, since the triggers did not update the other languages correctly;

Technical Details
----------------------------------------

In older CivICRM versions, fields such as `civicrm_custom_field.label_en_US` would be `DEFAULT NULL`. These days it seems to `DEFAULT ''`. This broke the triggers.

Comments
----------------------------------------

This has been broken for over 6 months. It's not clear if it's specific to some MySQL/MariaDB versions. I don't really understand the details of the conversation. I tested on MariaDB 10.3.

Fixed with help from @samuelsov and @shaneonabike, and re-used the test by @MegaphoneJon in #20753.