### PR TITLE
APIv4 - Correctly return date-only custom field values without the time

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -338,6 +338,10 @@ class FormattingUtil {
         case 'Money':
         case 'Float':
           return (float) $value;
+
+        case 'Date':
+          // Strip time from date-only fields
+          return substr($value, 0, 10);
       }
     }
     return $value;


### PR DESCRIPTION
Overview
----------------------------------------
Tightens up APIv4 output formatting to ensure date-only custom fields do not return a value for time.

Before
----------------------------------------
Date-only custom fields would return the date plus `00:00:00` for the time.

After
----------------------------------------
Only date part returned.

Technical Details
----------------------------------------
This was causing the bug noted in https://github.com/civicrm/civicrm-core/pull/22358#issuecomment-1023530302 where Angular's field validation got very confused with a date-only field containing the extra time value.