### PR TITLE
dev/core#3028 - For invalid greetings, return '' instead of failing

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3543,7 +3543,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
       'contact_type' => $contact->contact_type,
       'greeting_type' => $greetingType,
     ];
-    return CRM_Core_PseudoConstant::greeting($filter)[$contact->{$idField}];
+    return CRM_Core_PseudoConstant::greeting($filter)[$contact->{$idField}] ?? '';
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Fix crash when re-generating greetings for invalid data.

As mentioned in the ticket, I was able to reproduce by hacking at the SQL:

```sql
update civicrm_contact set postal_greeting_id = 999 where id = 200;
```

I think a plausible, organic scenario for this would be:

1. Add a new `postal_greeting` (*Ex: INSERT INTO civicrm_option_value ... ("My Greeting",123,...)*)
2. Update a `Contact` to use the new greeting. (*Ex: Set `postal_greeting_id=123`*)
3. Delete the `postal_greeting`. (*Ex: The contact now has an invalid `postal_greeting_id==123`.*)
4. Perform some action that requires recalculating the greeting. (*Ex: Merge the contact with another contact.*)

See: https://lab.civicrm.org/dev/core/-/issues/3028

Before
----------------------------------------

Recalculating the greeting leads to a type error:

```
TypeError: Return value of CRM_Contact_BAO_Contact::getTemplateForGreeting() 
must be of the type string, null returned in CRM_Contact_BAO_Contact::getTemplateForGreeting()
(line 3509 of /var/www/vhosts/xyz/webroot/sites/all/modules/civicrm/CRM/Contact/BAO/Contact.php).
```

After
----------------------------------------

No crash. The greeting value is blank (which is a common form omission, if you look at other paths in the context).