### PR TITLE
dev/core#3028 - For invalid greetings, return '' instead of failing

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3512,7 +3512,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
       'contact_type' => $contact->contact_type,
       'greeting_type' => $greetingType,
     ];
-    return CRM_Core_PseudoConstant::greeting($filter)[$contact->{$idField}];
+    return CRM_Core_PseudoConstant::greeting($filter)[$contact->{$idField}] ?? '';
   }
 
   /**


### PR DESCRIPTION
Backport #22650 from 5.46-rc to 5.45-stable.