### PR TITLE
[REF] Switch OptionGroup BAO to use new centralized logic to make name from title

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2028,14 +2028,13 @@ WHERE  id IN ( %1, %2 )
         )
       ) {
         // first create an option group for this custom group
-        $optionGroup = new CRM_Core_DAO_OptionGroup();
-        $optionGroup->name = "{$params['column_name']}_" . date('YmdHis');
-        $optionGroup->title = $params['label'];
-        $optionGroup->is_active = 1;
-        // Don't set reserved as it's not a built-in option group and may be useful for other custom fields.
-        $optionGroup->is_reserved = 0;
-        $optionGroup->data_type = $dataType;
-        $optionGroup->save();
+        $customGroupTitle = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $params['custom_group_id'], 'title');
+        $optionGroup = CRM_Core_DAO_OptionGroup::writeRecord([
+          'title' => "$customGroupTitle :: {$params['label']}",
+          // Don't set reserved as it's not a built-in option group and may be useful for other custom fields.
+          'is_reserved' => 0,
+          'data_type' => $dataType,
+        ]);
         $params['option_group_id'] = $optionGroup->id;
         if (!empty($params['option_value']) && is_array($params['option_value'])) {
           foreach ($params['option_value'] as $k => $v) {

--- a/CRM/Core/BAO/OptionGroup.php
+++ b/CRM/Core/BAO/OptionGroup.php
@@ -59,8 +59,8 @@ class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup implements \Civi
    * @param array $ids
    *   Reference array contains the id.
    *
-   *
-   * @return object
+   * @deprecated
+   * @return CRM_Core_DAO_OptionGroup
    */
   public static function add(&$params, $ids = []) {
     if (empty($params['id']) && !empty($ids['optionGroup'])) {

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -43,12 +43,14 @@ class CRM_Utils_String {
   public static function titleToVar($title, $maxLength = 31) {
     $variable = self::munge($title, '_', $maxLength);
 
+    // FIXME: nothing below this line makes sense. The above call to self::munge will always
+    // return a safe string of the correct length, so why are we now checking if it's a safe
+    // string of the correct length?
     if (CRM_Utils_Rule::title($variable, $maxLength)) {
       return $variable;
     }
 
-    // if longer than the maxLength lets just return a substr of the
-    // md5 to prevent errors downstream
+    // FIXME: When would this ever be reachable?
     return substr(md5($title), 0, $maxLength);
   }
 

--- a/api/v3/OptionGroup.php
+++ b/api/v3/OptionGroup.php
@@ -37,9 +37,12 @@ function civicrm_api3_option_group_get($params) {
  * @return array
  */
 function civicrm_api3_option_group_create($params) {
-  $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'OptionGroup');
+  // Use deprecated BAO method in APIv3 for legacy support. APIv4 uses new writeRecords method.
+  $bao = CRM_Core_BAO_OptionGroup::add($params);
   civicrm_api('option_value', 'getfields', ['version' => 3, 'cache_clear' => 1]);
-  return $result;
+  $values = [];
+  _civicrm_api3_object_to_array($bao, $values[$bao->id]);
+  return civicrm_api3_create_success($values, $params, 'OptionGroup', 'create', $bao);
 }
 
 /**

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -203,7 +203,7 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     $optionGroup = $this->callAPISuccess('option_group', 'getsingle', [
       'id' => $optionGroupID,
     ]);
-    $this->assertEquals('Country', $optionGroup['title']);
+    $this->assertEquals('select_test_group :: Country', $optionGroup['title']);
     $optionValueCount = $this->callAPISuccess('option_value', 'getcount', [
       'option_group_id' => $optionGroupID,
     ]);

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -423,6 +423,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
       'Profile',
       'Payment',
       'Order',
+      'OptionGroup',
       'MailingGroup',
       'Logging',
     ];

--- a/tests/phpunit/api/v4/Action/CreateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CreateCustomValueTest.php
@@ -59,7 +59,7 @@ class CreateCustomValueTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $this->assertEquals('Color', $optionGroup['title']);
+    $this->assertEquals('MyContactFields :: Color', $optionGroup['title']);
 
     $createdOptionValues = OptionValue::get(FALSE)
       ->addWhere('option_group_id', '=', $optionGroupId)


### PR DESCRIPTION
Overview
----------------------------------------
Refactors OptionGroup code to use centralized logic from #22570 

Before
----------------------------------------
Some artistically creative code in OptionGroup BAO to make a name from the title.

After
----------------------------------------
OptionGroup BAO `add` function deprecated, which triggers APIv4 to use `writeRecords()` with its centralized logic for creating name from title.
APIv3 kept the same to minimize impact on existing code.

Notes
----------------------------------------
I stumbled into this because I was writing a unit test which created two custom field groups with the same named fields in both groups. The current "artistic" approach to creating a unique name was to append a timestamp to it, but in a unit test the fields are created at the same time, so this didn't work.
I decided to do this refactor to move things in a more standardized direction; it required extending the `CRM_Core_DAO::makeNameFromLabel` function to handle titles as well as labels, and to cope better with the maxlength of the `name` field.