### PR TITLE
Queues - Add support for using persistent queues

### DIFF
--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -79,6 +79,9 @@ class CRM_Queue_Service {
    *   - reset: bool, optional; if a queue is found, then it should be
    *     flushed; default to TRUE
    *   - (additional keys depending on the queue provider).
+   *   - is_persistent: bool, optional; if true, then this queue is loaded from `civicrm_queue` list
+   *   - is_autorun: bool, optional; if true, then this queue will be auto-scanned
+   *     by background task-runners
    *
    * @return CRM_Queue_Queue
    */
@@ -87,6 +90,9 @@ class CRM_Queue_Service {
       return $this->queues[$queueSpec['name']];
     }
 
+    if (!empty($queueSpec['is_persistent'])) {
+      $queueSpec = $this->findCreateQueueSpec($queueSpec);
+    }
     $queue = $this->instantiateQueueObject($queueSpec);
     $exists = $queue->existsQueue();
     if (!$exists) {
@@ -104,6 +110,36 @@ class CRM_Queue_Service {
   }
 
   /**
+   * Find/create the queue-spec. Specifically:
+   *
+   * - If there is a stored queue, use its spec.
+   * - If there is no stored queue, and if we have enough information, then create queue.
+   *
+   * @param array $queueSpec
+   * @return array
+   *   Updated queueSpec.
+   * @throws \CRM_Core_Exception
+   */
+  protected function findCreateQueueSpec(array $queueSpec): array {
+    $storageFields = ['type', 'is_autorun'];
+    $dao = new CRM_Queue_DAO_Queue();
+    $dao->name = $queueSpec['name'];
+    if ($dao->find(TRUE)) {
+      return array_merge($queueSpec, CRM_Utils_Array::subset($dao->toArray(), $storageFields));
+    }
+
+    if (empty($queueSpec['type'])) {
+      throw new \CRM_Core_Exception(sprintf('Failed to find or create persistent queue "%s". Missing field "%s".',
+        $queueSpec['name'], 'type'));
+    }
+    $queueSpec = array_merge(['is_autorun' => FALSE], $queueSpec);
+    $dao->copyValues($queueSpec);
+    $dao->insert();
+
+    return $queueSpec;
+  }
+
+  /**
    * Look up an existing queue.
    *
    * @param array $queueSpec
@@ -111,12 +147,16 @@ class CRM_Queue_Service {
    *   - type: string, required, e.g. `Sql`, `SqlParallel`, `Memory`
    *   - name: string, required, e.g. "upgrade-tasks"
    *   - (additional keys depending on the queue provider).
+   *   - is_persistent: bool, optional; if true, then this queue is loaded from `civicrm_queue` list
    *
    * @return CRM_Queue_Queue
    */
   public function load($queueSpec) {
     if (is_object($this->queues[$queueSpec['name']] ?? NULL)) {
       return $this->queues[$queueSpec['name']];
+    }
+    if (!empty($queueSpec['is_persistent'])) {
+      $queueSpec = $this->findCreateQueueSpec($queueSpec);
     }
     $queue = $this->instantiateQueueObject($queueSpec);
     $queue->loadQueue();

--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -74,8 +74,7 @@ class CRM_Queue_Service {
    *
    * @param array $queueSpec
    *   Array with keys:
-   *   - type: string, required, e.g. "interactive", "immediate", "stomp",
-   *    "beanstalk"
+   *   - type: string, required, e.g. `Sql`, `SqlParallel`, `Memory`
    *   - name: string, required, e.g. "upgrade-tasks"
    *   - reset: bool, optional; if a queue is found, then it should be
    *     flushed; default to TRUE
@@ -109,8 +108,7 @@ class CRM_Queue_Service {
    *
    * @param array $queueSpec
    *   Array with keys:
-   *   - type: string, required, e.g. "interactive", "immediate", "stomp",
-   *     "beanstalk"
+   *   - type: string, required, e.g. `Sql`, `SqlParallel`, `Memory`
    *   - name: string, required, e.g. "upgrade-tasks"
    *   - (additional keys depending on the queue provider).
    *
@@ -130,8 +128,7 @@ class CRM_Queue_Service {
    * Convert a queue "type" name to a class name.
    *
    * @param string $type
-   *   E.g. "interactive", "immediate", "stomp", "beanstalk".
-   *
+   *   - type: string, required, e.g. `Sql`, `SqlParallel`, `Memory`
    * @return string
    *   Class-name
    */

--- a/Civi.php
+++ b/Civi.php
@@ -124,7 +124,7 @@ class Civi {
    */
   public static function queue(string $name, array $params = []): CRM_Queue_Queue {
     $defaults = ['reset' => FALSE, 'is_persistent' => TRUE];
-    $params = array_merge($defaults, ['name' => $name], $params);
+    $params = array_merge($defaults, $params, ['name' => $name]);
     return CRM_Queue_Service::singleton()->create($params);
   }
 

--- a/Civi.php
+++ b/Civi.php
@@ -108,18 +108,24 @@ class Civi {
   /**
    * Fetch a queue object.
    *
+   * Note: Historically, `CRM_Queue_Queue` objects were not persistently-registered. Persistence
+   * is now encouraged. This facade has a bias towards persistently-registered queues.
+   *
    * @param string $name
-   *   Name of the queue.
-   *   The queue must be persistent (stored in `civicrm_queue`).
+   *   The name of a persistent/registered queue (stored in `civicrm_queue`)
+   * @param array{type: string, is_autorun: bool, reset: bool, is_persistent: bool} $params
+   *   Specification for a queue.
+   *   This is not required for accessing an existing queue.
+   *   Specify this if you wish to auto-create the queue or to include advanced options (eg `reset`).
+   *   Example: ['type' => 'SqlParallel']
+   *   Defaults: ['reset'=>FALSE, 'is_persistent'=>TRUE, 'is_autorun'=>FALSE]
    * @return \CRM_Queue_Queue
    * @see \CRM_Queue_Service
    */
-  public static function queue(string $name): CRM_Queue_Queue {
-    return CRM_Queue_Service::singleton()->create([
-      'name' => $name,
-      'reset' => FALSE,
-      'is_persistent' => TRUE,
-    ]);
+  public static function queue(string $name, array $params = []): CRM_Queue_Queue {
+    $defaults = ['reset' => FALSE, 'is_persistent' => TRUE];
+    $params = array_merge($defaults, ['name' => $name], $params);
+    return CRM_Queue_Service::singleton()->create($params);
   }
 
   /**

--- a/Civi.php
+++ b/Civi.php
@@ -106,6 +106,23 @@ class Civi {
   }
 
   /**
+   * Fetch a queue object.
+   *
+   * @param string $name
+   *   Name of the queue.
+   *   The queue must be persistent (stored in `civicrm_queue`).
+   * @return \CRM_Queue_Queue
+   * @see \CRM_Queue_Service
+   */
+  public static function queue(string $name): CRM_Queue_Queue {
+    return CRM_Queue_Service::singleton()->create([
+      'name' => $name,
+      'reset' => FALSE,
+      'is_persistent' => TRUE,
+    ]);
+  }
+
+  /**
    * Obtain the formatting object.
    *
    * @return \Civi\Core\Format

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -255,6 +255,32 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     }
   }
 
+  public function testFacadeAutoCreate() {
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_queue');
+    $q1 = Civi::queue('testFacadeAutoCreate_q1', [
+      'type' => 'Sql',
+    ]);
+    $q2 = Civi::queue('testFacadeAutoCreate_q2', [
+      'type' => 'SqlParallel',
+    ]);
+    $q1Reload = Civi::queue('testFacadeAutoCreate_q1', [
+      /* q1 already exists, so it doesn't matter what type you give. */
+      'type' => 'ZoombaroombaFaketypeGoombapoompa',
+    ]);
+    $this->assertDBQuery(2, 'SELECT count(*) FROM civicrm_queue');
+    $this->assertInstanceOf('CRM_Queue_Queue_Sql', $q1);
+    $this->assertInstanceOf('CRM_Queue_Queue_SqlParallel', $q2);
+    $this->assertInstanceOf('CRM_Queue_Queue_Sql', $q1Reload);
+
+    try {
+      Civi::queue('testFacadeAutoCreate_q3' /* missing type */);
+      $this->fail('Queue lookup should fail. There is neither pre-existing registration nor new details.');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertRegExp(';Missing field "type";', $e->getMessage());
+    }
+  }
+
   /**
    * Test that queue content is reset when reset=>TRUE
    *

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -27,13 +27,13 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $queueSpecs[] = [
       [
         'type' => 'Sql',
-        'name' => 'test-queue',
+        'name' => 'test-queue-sql',
       ],
     ];
     $queueSpecs[] = [
       [
         'type' => 'Memory',
-        'name' => 'test-queue',
+        'name' => 'test-queue-mem',
       ],
     ];
     $queueSpecs[] = [
@@ -56,7 +56,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
   public function tearDown(): void {
     CRM_Utils_Time::resetTime();
 
-    $tablesToTruncate = ['civicrm_queue_item'];
+    $tablesToTruncate = ['civicrm_queue_item', 'civicrm_queue'];
     $this->quickCleanup($tablesToTruncate);
     parent::tearDown();
   }
@@ -68,7 +68,9 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
    * @param $queueSpec
    */
   public function testBasicUsage($queueSpec) {
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_queue');
     $this->queue = $this->queueService->create($queueSpec);
+    $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_queue');
     $this->assertTrue($this->queue instanceof CRM_Queue_Queue);
 
     $this->queue->createItem([


### PR DESCRIPTION
Overview
----------------------------------------

Updates the programmatic APIs to make it easier to work with persistent queues, eg

```php
// Load and instantiate a queue from `civicrm_queue`. (If missing, throw error.)
$queue = Civi::queue('my-queue');

// Load and instantiate a queue from `civicrm_queue`. (If missing, auto-create.)
$queue = Civi::queue('my-queue', ['type' => 'SqlParallel', 'is_autorun' => TRUE]);
````

Contributes towards https://lab.civicrm.org/dev/core/-/issues/1304.
Extracted and modified from #22325.

cc @eileenmcnaughton @artfulrobot 

Before
----------------------------------------

Support for persistent queue objects was recently added, but it's slightly disconnected. The APIs for storing queue metadata and [instantiating queue-objects](https://docs.civicrm.org/dev/en/latest/framework/queues/) are separate. This creates a persistent queue by calling both:

```php
// Create a persistent `civicrm_queue` record
Civi\Api4\Queue::create(0)
  ->setValues([
    'name' => 'my-own-queue', 
    'type' => 'Sql',
    'is_autorun' => TRUE,
  ])
  ->execute();

// Instantiate a CRM_Queue_Queue object
$queue = CRM_Queue_Service::singleton()->create([
  'type'  => 'Sql',
  'name'  => 'my-own-queue',
  'reset' => TRUE,
]);
```

Similarly, this combines them to load an existing queue:

```php
// Load a queue
$queueSpec = Civi\Api4\Queue::get(0)
  ->addWhere('name', '=', $name)
  ->execute()
  ->single();
$queue = CRM_Queue_Service::singleton()->load($queueSpec);
```

After
----------------------------------------

As before, you can create a persistent queue with `Civi\Api4\Queue::create()`. But once it's created, all the other calls can be replaced by:

```php
$queue = Civi::queue($name);
```

Technical Details
-------------------------------------

`Civi::queue()` is a just a wrapper for `CRM_Queue_Service`. If you have existing code that uses `CRM_Queue_Service`, you can continue with that, and you can enable load-save behavior by adding the `is_persistent` flag, eg

```php
$queue = CRM_Queue_Service::singleton()->create([
  'type'  => 'Sql',
  'name'  => 'my-own-queue',
  'is_persistent' => TRUE,
  'is_autorun' => TRUE,
  'reset' => FALSE,
]);
```