### PR TITLE
Correctly document types for class consts

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -19,7 +19,7 @@ class CRM_Core_I18n {
   /**
    * Constants for communication preferences.
    *
-   * @var int
+   * @var string
    */
   const NONE = 'none', AUTO = 'auto';
 

--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -24,7 +24,14 @@ class CRM_Utils_Recent {
    *
    * @var string
    */
-  const MAX_ITEMS = 30, STORE_NAME = 'CRM_Utils_Recent';
+  const STORE_NAME = 'CRM_Utils_Recent';
+
+  /**
+   * Max number of recent items to store
+   *
+   * @var int
+   */
+  const MAX_ITEMS = 30;
 
   /**
    * The list of recently viewed items.

--- a/CRM/Utils/Sort.php
+++ b/CRM/Utils/Sort.php
@@ -29,14 +29,14 @@ class CRM_Utils_Sort {
    *
    * @var int
    */
-  const ASCENDING = 1, DESCENDING = 2, DONTCARE = 4,
+  const ASCENDING = 1, DESCENDING = 2, DONTCARE = 4;
 
-    /**
-     * The name for the sort GET/POST param
-     *
-     * @var string
-     */
-    SORT_ID = 'crmSID', SORT_DIRECTION = 'crmSortDirection', SORT_ORDER = 'crmSortOrder';
+  /**
+   * The name for the sort GET/POST param
+   *
+   * @var string
+   */
+  const SORT_ID = 'crmSID', SORT_DIRECTION = 'crmSortDirection', SORT_ORDER = 'crmSortOrder';
 
   /**
    * Name of the sort function. Used to isolate session variables


### PR DESCRIPTION
Overview
----------------------------------------
This PR ensures that the `@var` definitions for class consts are correct, and formatted in the correct way to be read by IDEs and other tools.

