### PR TITLE
Fix smarty notices in membership dashboard

### DIFF
--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -86,51 +86,61 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
       $membershipSummary[$key]['premonth']['new'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipJoins($key, $preMonth, $preMonthEnd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['premonth']['renew'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipRenewals($key, $preMonth, $preMonthEnd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['premonth']['total'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $preMonth, $preMonthEnd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['month']['new'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipJoins($key, $monthStart, $ymd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['month']['renew'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipRenewals($key, $monthStart, $ymd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['month']['total'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $monthStart, $ymd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['year']['new'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipJoins($key, $yearStart, $ymd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['year']['renew'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipRenewals($key, $yearStart, $ymd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['year']['total'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $yearStart, $ymd),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['current']['total'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipCount($key, $current),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['total']['total'] = array('count' => CRM_Member_BAO_Membership::getMembershipCount($key, $ymd));
@@ -139,21 +149,25 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
       $membershipSummary[$key]['premonth_owner']['premonth_owner'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $preMonth, $preMonthEnd, 0, 1),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['month_owner']['month_owner'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $monthStart, $ymd, 0, 1),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['year_owner']['year_owner'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $yearStart, $ymd, 0, 1),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['current_owner']['current_owner'] = array(
         'count' => CRM_Member_BAO_Membership::getMembershipCount($key, $current, 0, 1),
         'name' => $value,
+        'url' => FALSE,
       );
 
       $membershipSummary[$key]['total_owner']['total_owner'] = array('count' => CRM_Member_BAO_Membership::getMembershipCount($key, $ymd, 0, 1));
@@ -210,38 +224,47 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
 
     $totalCount['premonth']['new'] = array(
       'count' => $newCountPreMonth,
+      'url' => FALSE,
     );
 
     $totalCount['premonth']['renew'] = array(
       'count' => $renewCountPreMonth,
+      'url' => FALSE,
     );
 
     $totalCount['premonth']['total'] = array(
       'count' => $totalCountPreMonth,
+      'url' => FALSE,
     );
 
     $totalCount['month']['new'] = array(
       'count' => $newCountMonth,
+      'url' => FALSE,
     );
 
     $totalCount['month']['renew'] = array(
       'count' => $renewCountMonth,
+      'url' => FALSE,
     );
 
     $totalCount['month']['total'] = array(
       'count' => $totalCountMonth,
+      'url' => FALSE,
     );
 
     $totalCount['year']['new'] = array(
       'count' => $newCountYear,
+      'url' => FALSE,
     );
 
     $totalCount['year']['renew'] = array(
       'count' => $renewCountYear,
+      'url' => FALSE,
     );
 
     $totalCount['year']['total'] = array(
       'count' => $totalCountYear,
+      'url' => FALSE,
     );
 
     $totalCount['current']['total'] = array(
@@ -272,32 +295,38 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     //LCD add owner values
     $totalCount['premonth_owner']['premonth_owner'] = array(
       'count' => $totalCountPreMonth_owner,
+      'url' => FALSE,
       //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=$preMonth&end=$preMonthEnd&owner=1"),
     );
 
     $totalCount['month_owner']['month_owner'] = array(
       'count' => $totalCountMonth_owner,
+      'url' => FALSE,
       //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=$monthStart&end=$ymd&owner=1"),
     );
 
     $totalCount['year_owner']['year_owner'] = array(
       'count' => $totalCountYear_owner,
+      'url' => FALSE,
       //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=$yearStart&end=$ymd&owner=1"),
     );
 
     $totalCount['current_owner']['current_owner'] = array(
       'count' => $totalCountCurrent_owner,
+      'url' => FALSE,
       //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&owner=1"),
     );
 
     $totalCount['total_owner']['total_owner'] = array(
       'count' => $totalCountTotal_owner,
+      'url' => FALSE,
       //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&owner=1"),
     );
 
     if (!$isCurrentMonth) {
       $totalCount['total_owner']['total_owner'] = array(
         'count' => $totalCountTotal_owner,
+        'url' => FALSE,
         //  'url' => CRM_Utils_System::url('civicrm/member/search', "reset=1&force=1&membership_status_id=$status&start=&end=$ymd&owner=1"),
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix smarty notices in membership dashboard.

Before
----------------------------------------
On visiting the membership dashboard, many PHP notices were logged. (as shown in a WordPress environment running query monitor):

<img width="1440" alt="Screenshot 2022-01-29 at 12 13 06" src="https://user-images.githubusercontent.com/1931323/151660621-21ee373f-6de0-475f-9784-9c779e3fc9ea.png">


After
----------------------------------------
The notices have gone (most of them anyway!)

<img width="1440" alt="Screenshot 2022-01-29 at 12 12 38" src="https://user-images.githubusercontent.com/1931323/151660645-9858fa06-09d7-4e50-9ea2-bd508efcffde.png">

Comments
----------------------------------------
If the GET query param `date` is used to show a specific period, then there a couple of remaining notices related to `url` that I could not track down. However, I suspect the `date` GET param is largely unknown, so I didn't spend too much time looking into this.
