### PR TITLE
Avoid PHP notice on 'Manage Contribution Pages' screen

### DIFF
--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -456,9 +456,10 @@ ORDER BY is_active desc, title asc
     //get configure actions links.
     $configureActionLinks = self::configureActionLinks();
 
+    $contributions = [];
     while ($dao->fetch()) {
-      $contribution[$dao->id] = [];
-      CRM_Core_DAO::storeValues($dao, $contribution[$dao->id]);
+      $contributions[$dao->id] = [];
+      CRM_Core_DAO::storeValues($dao, $contributions[$dao->id]);
 
       // form all action links
       $action = array_sum(array_keys(self::actionLinks()));
@@ -486,7 +487,7 @@ ORDER BY is_active desc, title asc
 
       //build the configure links.
       $sectionsInfo = CRM_Utils_Array::value($dao->id, $contriPageSectionInfo, []);
-      $contribution[$dao->id]['configureActionLinks'] = CRM_Core_Action::formLink(self::formatConfigureLinks($sectionsInfo),
+      $contributions[$dao->id]['configureActionLinks'] = CRM_Core_Action::formLink(self::formatConfigureLinks($sectionsInfo),
         $action,
         array('id' => $dao->id),
         ts('Configure'),
@@ -497,7 +498,7 @@ ORDER BY is_active desc, title asc
       );
 
       //build the contributions links.
-      $contribution[$dao->id]['contributionLinks'] = CRM_Core_Action::formLink(self::contributionLinks(),
+      $contributions[$dao->id]['contributionLinks'] = CRM_Core_Action::formLink(self::contributionLinks(),
         $action,
         array('id' => $dao->id),
         ts('Contributions'),
@@ -508,7 +509,7 @@ ORDER BY is_active desc, title asc
       );
 
       //build the online contribution links.
-      $contribution[$dao->id]['onlineContributionLinks'] = CRM_Core_Action::formLink(self::onlineContributionLinks(),
+      $contributions[$dao->id]['onlineContributionLinks'] = CRM_Core_Action::formLink(self::onlineContributionLinks(),
         $action,
         array('id' => $dao->id),
         ts('Links'),
@@ -519,7 +520,7 @@ ORDER BY is_active desc, title asc
       );
 
       //build the normal action links.
-      $contribution[$dao->id]['action'] = CRM_Core_Action::formLink(self::actionLinks(),
+      $contributions[$dao->id]['action'] = CRM_Core_Action::formLink(self::actionLinks(),
         $action,
         array('id' => $dao->id),
         ts('more'),
@@ -530,12 +531,10 @@ ORDER BY is_active desc, title asc
       );
 
       //show campaigns on selector.
-      $contribution[$dao->id]['campaign'] = $allCampaigns[$dao->campaign_id] ?? NULL;
+      $contributions[$dao->id]['campaign'] = $allCampaigns[$dao->campaign_id] ?? NULL;
     }
 
-    if (isset($contribution)) {
-      $this->assign('rows', $contribution);
-    }
+    $this->assign('rows', $contributions);
   }
 
   public function search() {


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP notice on 'Manage Contribution Pages' screen.

Before
----------------------------------------
If no contribution pages exist, the notice `Undefined index: rows` occured. As shown in a WordPress environment, with query monitor catching and showing notices:

<img width="1440" alt="Screenshot 2022-01-29 at 15 55 13" src="https://user-images.githubusercontent.com/1931323/151667714-a3c52b61-b14f-402c-93d2-636e0c6fc9c7.png">

After
----------------------------------------
The `rows` smarty variable is always defined, defaulting to am empty array if no PCPs exist. As such the PHP notice has gone.

Additionally the variable `$contribution` has been pluralised for better readability.
