### PR TITLE
[REF] APIv4 - Rename trait 'SoftDelete' to 'SoftDeleteEntity'

### DIFF
--- a/Civi/Api4/Action/Contact/Delete.php
+++ b/Civi/Api4/Action/Contact/Delete.php
@@ -17,7 +17,7 @@ namespace Civi\Api4\Action\Contact;
  * @inheritDoc
  */
 class Delete extends \Civi\Api4\Generic\DAODeleteAction {
-  use \Civi\Api4\Generic\Traits\SoftDelete;
+  use \Civi\Api4\Generic\Traits\SoftDeleteEntity;
 
   /**
    * @param $items

--- a/Civi/Api4/Generic/Traits/SoftDeleteEntity.php
+++ b/Civi/Api4/Generic/Traits/SoftDeleteEntity.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Generic\Traits;
  * @method $this setUseTrash(bool $useTrash) Pass FALSE to force delete and bypass trash
  * @method bool getUseTrash()
  */
-trait SoftDelete {
+trait SoftDeleteEntity {
 
   /**
    * Should $ENTITY be moved to the trash instead of permanently deleted?


### PR DESCRIPTION
Overview
----------------------------------------
Simple file rename for consistency with other traits

Before
----------------------------------------
APIv4 has some "ability" traits, named:
- ManagedEntity
- SortableEntity
- ReadOnlyEntity
- SoftDelete

After
----------------------------------------
- SoftDeleteEntity