### PR TITLE
Set default values to avoid notices when rendering (event templates screen)

### DIFF
--- a/CRM/Admin/Page/EventTemplate.php
+++ b/CRM/Admin/Page/EventTemplate.php
@@ -85,16 +85,19 @@ class CRM_Admin_Page_EventTemplate extends CRM_Core_Page_Basic {
       CRM_Core_DAO::storeValues($eventTemplate, $allEventTemplates[$eventTemplate->id]);
 
       //get listing types.
+      $allEventTemplates[$eventTemplate->id]['participant_listing'] = ts('Disabled');
       if ($eventTemplate->participant_listing_id) {
         $allEventTemplates[$eventTemplate->id]['participant_listing'] = $participantListings[$eventTemplate->participant_listing_id];
       }
 
       //get participant role
+      $allEventTemplates[$eventTemplate->id]['participant_role'] = '';
       if ($eventTemplate->default_role_id) {
         $allEventTemplates[$eventTemplate->id]['participant_role'] = $participantRoles[$eventTemplate->default_role_id];
       }
 
       //get event type.
+      $allEventTemplates[$eventTemplate->id]['event_type'] = '';
       if (isset($eventTypes[$eventTemplate->event_type_id])) {
         $allEventTemplates[$eventTemplate->id]['event_type'] = $eventTypes[$eventTemplate->event_type_id];
       }


### PR DESCRIPTION
Overview
----------------------------------------
Set default values to avoid notices when rendering (event templates screen)

Before
----------------------------------------
On the manage event templates screen, if an event template had participant listings disabled (i.e. no value set), then a notice would be thrown from the Smarty template. 

<img width="1440" alt="Screenshot 2022-01-29 at 18 27 19" src="https://user-images.githubusercontent.com/1931323/151672980-186227f8-85dc-45aa-8eb8-41c64892d165.png">

After
----------------------------------------
No notice is thrown.

Additionally, the "Participant listing" column now contains the text "Disabled", rather than an empty cell, which matches the language used on the edit form.

Comments
----------------------------------------
Default values have also been added for `participant_role` and `event_type`. These are required fields and so should always be set, however as there are `if` around where these keys are set it feels like it doesn't hurt to add the fallback values - it could catch edge-cases where event templates have been created through the API, or through poorly behaved extensions for example.
