### PR TITLE
Avoid PHP notices on activity form

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -364,12 +364,14 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       );
     }
 
+    $activityTypeDescription = NULL;
     if ($this->_activityTypeId) {
-      // Set activity type name and description to template.
       list($this->_activityTypeName, $activityTypeDescription) = CRM_Core_BAO_OptionValue::getActivityTypeDetails($this->_activityTypeId);
-      $this->assign('activityTypeName', $this->_activityTypeName);
-      $this->assign('activityTypeDescription', $activityTypeDescription);
     }
+
+    // Set activity type name and description to template.
+    $this->assign('activityTypeName', $this->_activityTypeName ?? FALSE);
+    $this->assign('activityTypeDescription', $activityTypeDescription ?? FALSE);
 
     // set user context
     $urlParams = $urlString = NULL;
@@ -1235,6 +1237,9 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    * For the moment this is just pulled from preProcess
    */
   public function assignActivityType() {
+    // Default array with required key for Smarty template
+    $activityTypeNameAndLabel = ['machineName' => FALSE];
+
     if ($this->_activityTypeId) {
       $activityTypeDisplayLabels = $this->getActivityTypeDisplayLabels();
       if ($activityTypeDisplayLabels[$this->_activityTypeId]) {
@@ -1242,7 +1247,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
         // At the moment this is duplicating other code in this section, but refactoring in small steps.
         $activityTypeObj = new CRM_Activity_BAO_ActivityType($this->_activityTypeId);
-        $this->assign('activityTypeNameAndLabel', $activityTypeObj->getActivityType());
+        $activityTypeNameAndLabel = $activityTypeObj->getActivityType();
       }
       // Set title.
       if (isset($activityTypeDisplayLabels)) {
@@ -1262,6 +1267,8 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         }
       }
     }
+
+    $this->assign('activityTypeNameAndLabel', $activityTypeNameAndLabel);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP notices on activity form.

This ensures that fallback values are set, so that notices are not thrown when `activity.tpl` does `{if}` checks on `$activityTypeDescription` and `$activityTypeNameAndLabel.machineName`.

Before
----------------------------------------
When creating a new activity (/civicrm/activity) a handful of PHP notices were generated from within Smarty templates. 

After
----------------------------------------
No notices generated by core on this form.
