### PR TITLE
Avoid PHP notices on the UF settings page.

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -32,16 +32,21 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
     $this->_uf = $config->userFramework;
     $this->_settings['syncCMSEmail'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
 
-    if ($this->_uf == 'WordPress') {
-      $this->_settings['wpBasePage'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
-    }
+    $this->assign('wpBasePageEnabled', FALSE);
+    $this->assign('userFrameworkUsersTableNameEnabled', FALSE);
 
     $this->setTitle(
       ts('Settings - %1 Integration', [1 => $this->_uf])
     );
 
+    if ($this->_uf == 'WordPress') {
+      $this->_settings['wpBasePage'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+      $this->assign('wpBasePageEnabled', TRUE);
+    }
+
     if ($config->userSystem->is_drupal) {
       $this->_settings['userFrameworkUsersTableName'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+      $this->assign('userFrameworkUsersTableNameEnabled', TRUE);
     }
 
     // find out if drupal has its database prefixed
@@ -61,6 +66,8 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
         $drupal_prefix = $databases['default']['default']['prefix'];
       }
     }
+
+    $this->assign('tablePrefixes', FALSE);
 
     if ($config->userSystem->viewsExists() &&
       (

--- a/templates/CRM/Admin/Form/Setting/UF.tpl
+++ b/templates/CRM/Admin/Form/Setting/UF.tpl
@@ -13,12 +13,14 @@
 <div class="crm-block crm-form-block crm-uf-form-block">
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
       <table class="form-layout-compressed">
-         <tr class="crm-uf-form-block-userFrameworkUsersTableName">
+        {if $userFrameworkUsersTableNameEnabled}
+        <tr class="crm-uf-form-block-userFrameworkUsersTableName">
             <td class="label">{$form.userFrameworkUsersTableName.label}</td>
             <td>{$form.userFrameworkUsersTableName.html}</td>
         </tr>
-        {if !empty($form.wpBasePage)}
-         <tr class="crm-uf-form-block-wpBasePage">
+        {/if}
+        {if $wpBasePageEnabled}
+        <tr class="crm-uf-form-block-wpBasePage">
             <td class="label">{$form.wpBasePage.label}</td>
             <td>{$config->userFrameworkBaseURL}{$form.wpBasePage.html}
             <p class="description">{ts 1=$config->userFrameworkBaseURL}By default, CiviCRM will generate front-facing pages using the home page at %1 as its base. If you want to use a different template for CiviCRM pages, set the path here.{/ts}</p>


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP notices on the UF settings page.

This primarially benefits non Drupal environments,
specifically WordPress and Joomla.

Before
----------------------------------------
When viewing the "CMS Database Integration" (User Framework/ UF) page, a few PHP notices were generated. These were coming from within the compiled Smarty templates.

After
----------------------------------------
The PHP notices are no longer generated.
