### PR TITLE
CiviCRM Event, the link to "On-line Registration (Test Drive)" is an admin-only URL to register in the backend, should be a frontend URL

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Tab.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Tab.tpl
@@ -19,7 +19,7 @@
                     <li><a class="crm-event-participant" href="{crmURL p='civicrm/participant/add' q="reset=1&action=add&context=standalone&eid=`$id`"}">{ts}Register Participant{/ts}</a></li>
                        <li><a class="crm-event-info" href="{crmURL p='civicrm/event/info' q="reset=1&id=`$id`" fe='true'}" target="_blank">{ts}Event Info{/ts}</a></li>
                     {if $isOnlineRegistration}
-                        <li><a class="crm-event-test" href="{crmURL p='civicrm/event/register' q="reset=1&action=preview&id=`$id`"}">{ts}Online Registration (Test-drive){/ts}</a></li>
+                        <li><a class="crm-event-test" href="{crmURL p='civicrm/event/register' q="reset=1&action=preview&id=`$id`" fe='true'}">{ts}Online Registration (Test-drive){/ts}</a></li>
                                <li><a class="crm-event-live" href="{crmURL p='civicrm/event/register' q="reset=1&id=`$id`" fe='true'}" target="_blank">{ts}Online Registration (Live){/ts}</a></li>
                     {/if}
                 </ul>


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Event, the link to "On-line Registration (Test Drive)" is an admin-only URL to register in the backend, should be a frontend URL; does not make sense to show a backend registration.

Before
----------------------------------------
"On-line Registration (Test Drive)" URL links to the CiviCRM administration backend, shows Event Registration in administration theme.

After
----------------------------------------
"On-line Registration (Test Drive)" URL links to the CiviCRM frontend, shows Event Registration in frontend theme.

Technical Details
----------------------------------------
Simple change.

Comments
----------------------------------------
A key objective of performing a "test drive" of the event registration workflow is to verify that the process is working correctly and to confirm that the user experience is correct. Therefore using an admin-only URL negates this objective, because the user experience you are testing is fundamentally different to what users who do not have backend access to CiviCRM will experience. Change to using a front-end URL for "test drive" so you can test what end users will experience.

Agileware Ref: CIVICRM-1921
