### PR TITLE
Manage Contribution page, the link to "Online Contribution (Test-drive)" is an admin-only URL to register in the backend, should be a frontend URL

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Tab.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Tab.tpl
@@ -16,7 +16,7 @@
                  <div class="crm-contribpage-links-list-inner">
                    <ul>
                             <li><a class="crm-contribpage-contribution" href="{crmURL p='civicrm/contribute/add' q="reset=1&action=add&context=standalone"}">{ts}New Contribution{/ts}</a></li>
-                            <li><a class="crm-contribution-test" href="{crmURL p='civicrm/contribute/transact' q="reset=1&action=preview&id=`$contributionPageID`"}">{ts}Online Contribution (Test-drive){/ts}</a></li>
+                            <li><a class="crm-contribution-test" href="{crmURL p='civicrm/contribute/transact' q="reset=1&action=preview&id=`$contributionPageID`" fe='true'}">{ts}Online Contribution (Test-drive){/ts}</a></li>
                             <li><a class="crm-contribution-live" href="{crmURL p='civicrm/contribute/transact' q="reset=1&id=`$contributionPageID`" fe='true'}" target="_blank">{ts}Online Contribution (Live){/ts}</a></li>
                 </ul>
                  </div>


### PR DESCRIPTION
Overview
----------------------------------------
Manage Contribution page, the link to "Online Contribution (Test-drive)" is an admin-only URL to register in the backend, should be a frontend URL.

Before
----------------------------------------
"Online Contribution (Test-drive)" URL links to the CiviCRM administration backend, shows Contribution Page in **backend** theme.

After
----------------------------------------
"Online Contribution (Test-drive)" URL links to the CiviCRM frontend, shows Contribution Page in **frontend** theme.

Technical Details
----------------------------------------
Simple change.

Comments
----------------------------------------
Same logic as per https://github.com/civicrm/civicrm-core/pull/22669

A key objective of performing a "test drive" of the **Contribution page** workflow is to verify that the process is working correctly and to confirm that the user experience is correct. Therefore using an admin-only URL **negates this objective**, because the user experience you are testing is **fundamentally different** to what users who do not have backend access to CiviCRM will experience. Change to using a front-end URL for "test drive" so you can test what **end users will experience**.

Agileware Ref: CIVICRM-1923