### PR TITLE
Fix spelling mistake in function name, addMembershipToRealtedContacts should be addMembershipToRelatedContacts

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -607,7 +607,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     foreach ($sqls as $sql) {
       CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, TRUE);
     }
-    CRM_Dedupe_Merger::addMembershipToRealtedContacts($mainId);
+    CRM_Dedupe_Merger::addMembershipToRelatedContacts($mainId);
   }
 
   /**
@@ -1917,7 +1917,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function addMembershipToRealtedContacts($contactID) {
+  public static function addMembershipToRelatedContacts($contactID) {
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $contactID;
     $dao->is_test = 0;


### PR DESCRIPTION
Overview
----------------------------------------
Fix spelling mistake in function name, addMembershipToRealtedContacts should be addMembershipToRelatedContacts

Before
----------------------------------------
Function: addMembershipToRealtedContacts

After
----------------------------------------
Function: addMembershipToRelatedContacts

Technical Details
----------------------------------------
Spelling

Comments
----------------------------------------

Agileware Ref: CIVICRM-1924