### PR TITLE
Clean return values for dummy payment processor

### DIFF
--- a/CRM/Core/Payment/Dummy.php
+++ b/CRM/Core/Payment/Dummy.php
@@ -126,10 +126,6 @@ class CRM_Core_Payment_Dummy extends CRM_Core_Payment {
       }
     }
 
-    // We shouldn't do this but it saves us changing the `testPayNowPayment` test to actually test the contribution
-    // like it should.
-    $result = array_merge($params, $result);
-
     return $result;
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -105,7 +105,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     );
 
     // Make sure that certain parameters are set on return from processConfirm
-    $this->assertEquals('Campaign Contribution', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $processConfirmResult['financial_type_id']));
+    $this->assertEquals('Campaign Contribution', CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'financial_type_id', $processConfirmResult['contribution']->financial_type_id));
 
     // Based on the processed contribution, complete transaction which update the contribution status based on payment result.
     if (!empty($processConfirmResult['contribution'])) {


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/financial/-/issues/141

Before
----------------------------------------
Dummy payment processor merges input values with return values to make tests work.

After
----------------------------------------
Dummy payment processor only returns values it is meant to return and tests work properly.

Technical Details
----------------------------------------


Comments
----------------------------------------
