### PR TITLE
Add paymentstatus helpers for doPayment and separate return params

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1366,14 +1366,12 @@ abstract class CRM_Core_Payment {
   public function doPayment(&$params, $component = 'contribute') {
     $propertyBag = \Civi\Payment\PropertyBag::cast($params);
     $this->_component = $component;
-    $statuses = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate');
 
     // If we have a $0 amount, skip call to processor and set payment_status to Completed.
     // Conceivably a processor might override this - perhaps for setting up a token - but we don't
     // have an example of that at the moment.
     if ($propertyBag->getAmount() == 0) {
-      $result['payment_status_id'] = array_search('Completed', $statuses);
-      $result['payment_status'] = 'Completed';
+      $result = $this->setStatusPaymentCompleted([]);
       return $result;
     }
 
@@ -1381,8 +1379,7 @@ abstract class CRM_Core_Payment {
       CRM_Core_Error::deprecatedFunctionWarning('doPayment', 'doTransferCheckout');
       $result = $this->doTransferCheckout($params, $component);
       if (is_array($result) && !isset($result['payment_status_id'])) {
-        $result['payment_status_id'] = array_search('Pending', $statuses);
-        $result['payment_status'] = 'Pending';
+        $result = $this->setStatusPaymentPending($result);
       }
     }
     else {
@@ -1391,12 +1388,10 @@ abstract class CRM_Core_Payment {
       if (is_array($result) && !isset($result['payment_status_id'])) {
         if (!empty($params['is_recur'])) {
           // See comment block.
-          $result['payment_status_id'] = array_search('Pending', $statuses);
-          $result['payment_status'] = 'Pending';
+          $result = $this->setStatusPaymentPending($result);
         }
         else {
-          $result['payment_status_id'] = array_search('Completed', $statuses);
-          $result['payment_status'] = 'Completed';
+          $result = $this->setStatusPaymentCompleted($result);
         }
       }
     }
@@ -1405,6 +1400,30 @@ abstract class CRM_Core_Payment {
       throw new PaymentProcessorException(CRM_Core_Error::getMessages($result));
     }
     return $result;
+  }
+
+  /**
+   * Set the payment status to Pending
+   * @param \Civi\Payment\PropertyBag|array $params
+   *
+   * @return array
+   */
+  protected function setStatusPaymentPending($params) {
+    $params['payment_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
+    $params['payment_status'] = 'Pending';
+    return $params;
+  }
+
+  /**
+   * Set the payment status to Completed
+   * @param \Civi\Payment\PropertyBag|array $params
+   *
+   * @return array
+   */
+  protected function setStatusPaymentCompleted($params) {
+    $params['payment_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+    $params['payment_status'] = 'Completed';
+    return $params;
   }
 
   /**

--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -184,13 +184,13 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     // fetch available contribution statuses
     $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
 
+    $result = [];
     // check for application errors
     // TODO:
     // AVS, CVV2, CAVV, and other verification results
     switch ($response_fields[0]) {
       case self::AUTH_REVIEW:
-        $params['payment_status_id'] = array_search('Pending', $contributionStatus);
-        $params['payment_status'] = 'Pending';
+        $result = $this->setStatusPaymentPending($result);
         break;
 
       case self::AUTH_ERROR:
@@ -203,13 +203,12 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
 
       default:
         // Success
-        $params['trxn_id'] = !empty($response_fields[6]) ? $response_fields[6] : $this->getTestTrxnID();
-        $params['payment_status_id'] = array_search('Completed', $statuses);
-        $params['payment_status'] = 'Completed';
+        $result['trxn_id'] = !empty($response_fields[6]) ? $response_fields[6] : $this->getTestTrxnID();
+        $result = $this->setStatusPaymentCompleted($result);
         break;
     }
 
-    return $params;
+    return $result;
   }
 
   /**

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -558,8 +558,8 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
 
     $trxnDetails = [
       'trxn_id' => $result['trxn_id'],
-      'trxn_date' => $result['now'],
-      'currency' => $result['currencyID'] ?? NULL,
+      'trxn_date' => $params['receive_date'] ?? date('YmdHis'),
+      'currency' => $params['currencyID'],
     ];
     return $trxnDetails;
   }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/financial/-/issues/141

Before
----------------------------------------
No helper function to set payment status.
authorizenet returned input params which may be array or propertybag and contains a lot of data that should not be returned.

After
----------------------------------------
Helper functions to set payment status.
authorizenet returns the agreed values as an array.

Technical Details
----------------------------------------
The helper functions have been used in mjwshared library for some time now. It will eventually allow us to fully remove `payment_status_id` in the future if we want to if all payment processors start using these helpers.

Updated authorizenet to use the agreed set of return parameters instead of returning entire input params which may be an array or propertyBag.

Comments
----------------------------------------
