### PR TITLE
No longer install the Contribution Cancel Actions, CiviCRM Core Extension by default on new CiviCRM sites

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1780,7 +1780,6 @@ INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_act
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'greenwich', 'Theme: Greenwich', 'Theme: Greenwich', 'greenwich', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'eventcart', 'Event cart', 'Event cart', 'eventcart', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'financialacls', 'Financial ACLs', 'Financial ACLs', 'financialacls', 1);
-INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'contributioncancelactions', 'Contribution cancel actions', 'Contribution cancel actions', 'contributioncancelactions', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'recaptcha', 'reCAPTCHA', 'reCAPTCHA', 'recaptcha', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'ckeditor4', 'CKEditor4', 'CKEditor4', 'ckeditor4', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'legacycustomsearches', 'Custom search framework', 'Custom search framework', 'legacycustomsearches', 1);


### PR DESCRIPTION
Overview
----------------------------------------
No longer install the Contribution Cancel Actions, CiviCRM Core Extension by default on new CiviCRM sites.
See https://lab.civicrm.org/dev/core/-/issues/2517

Before
----------------------------------------
Contribution Cancel Actions, extension installed by default on new CiviCRM sites.

After
----------------------------------------
Contribution Cancel Actions, extension NOT installed by default on new CiviCRM sites.

Technical Details
----------------------------------------

Comments
----------------------------------------
Because @eileenmcnaughton said:
> I think the next step in deprecating the extension is to remove it from the sql that installs in on new CiviCRM installs. I would merge a PR that did that if I saw one

Rebased copy of https://github.com/civicrm/civicrm-core/pull/21673

Agileware Ref: CIVICRM-1851