### PR TITLE
REF - Switch to using new `CRM_Core_Component::isEnabled()`

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2067,8 +2067,7 @@ AND cl.modified_id  = c.id
       'is_current_revision',
       'activity_is_deleted',
     ];
-    $config = CRM_Core_Config::singleton();
-    if (!in_array('CiviCampaign', $config->enableComponents)) {
+    if (!CRM_Core_Component::isEnabled('CiviCampaign')) {
       $skipFields[] = 'activity_engagement_level';
     }
 

--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -90,8 +90,7 @@ class CRM_Activity_Task extends CRM_Core_Task {
         ],
       ];
 
-      $config = CRM_Core_Config::singleton();
-      if (in_array('CiviCase', $config->enableComponents)) {
+      if (CRM_Core_Component::isEnabled('CiviCase')) {
         if (CRM_Core_Permission::check('access all cases and activities') ||
           CRM_Core_Permission::check('access my cases and activities')
         ) {

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -269,8 +269,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
 
     // If CiviCase enabled AND "Add" mode OR "edit" mode for non-reserved activities, only allow user to pick Core or CiviCase component.
     // FIXME: Each component should define whether adding new activity types is allowed.
-    $config = CRM_Core_Config::singleton();
-    if ($this->_gName == 'activity_type' && in_array("CiviCase", $config->enableComponents) &&
+    if ($this->_gName == 'activity_type' && CRM_Core_Component::isEnabled("CiviCase") &&
       (($this->_action & CRM_Core_Action::ADD) || !$isReserved)
     ) {
       $caseID = CRM_Core_Component::getComponentID('CiviCase');

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -294,7 +294,7 @@ Order By  camp.title";
    * @return bool
    */
   public static function isCampaignEnable(): bool {
-    return in_array('CiviCampaign', CRM_Core_Config::singleton()->enableComponents, TRUE);
+    return CRM_Core_Component::isEnabled('CiviCampaign');
   }
 
   /**

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -34,8 +34,7 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case {
    * @return bool
    */
   public static function enabled() {
-    $config = CRM_Core_Config::singleton();
-    return in_array('CiviCase', $config->enableComponents);
+    return CRM_Core_Component::isEnabled('CiviCase');
   }
 
   /**

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3268,7 +3268,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
     $componentName = $menuOptions['component'] ?? NULL;
 
     // if component action - make sure component is enable.
-    if ($componentName && !in_array($componentName, CRM_Core_Config::singleton()->enableComponents)) {
+    if ($componentName && !CRM_Core_Component::isEnabled($componentName)) {
       return FALSE;
     }
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -266,7 +266,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
 
-    if (in_array('CiviPledge', CRM_Core_Config::singleton()->enableComponents) && !$this->_formType) {
+    if (CRM_Core_Component::isEnabled('CiviPledge') && !$this->_formType) {
       $this->preProcessPledge();
     }
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -520,8 +520,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->set('productID', $productID);
       $this->set('option', $option);
     }
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviMember', $config->enableComponents) && empty($this->_ccid)) {
+    if (CRM_Core_Component::isEnabled('CiviMember') && empty($this->_ccid)) {
       if (isset($params['selectMembership']) &&
         $params['selectMembership'] !== 'no_thanks'
       ) {

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -426,8 +426,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     //don't build pledge block when mid is passed
     if (!$this->_mid && empty($this->_ccid)) {
-      $config = CRM_Core_Config::singleton();
-      if (in_array('CiviPledge', $config->enableComponents) && !empty($this->_values['pledge_block_id'])) {
+      if (CRM_Core_Component::isEnabled('CiviPledge') && !empty($this->_values['pledge_block_id'])) {
         CRM_Pledge_BAO_PledgeBlock::buildPledgeBlock($this);
       }
     }

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -526,7 +526,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       'amount_level',
     ];
 
-    $config = CRM_Core_Config::singleton();
     if (isset($this->_values['is_recur']) && !empty($this->_paymentProcessor['is_recur'])) {
       $this->assign('is_recur_enabled', 1);
       $vars = array_merge($vars, [
@@ -537,9 +536,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       ]);
     }
 
-    if (in_array('CiviPledge', $config->enableComponents) &&
-      CRM_Utils_Array::value('is_pledge', $this->_params) == 1
+    if (CRM_Core_Component::isEnabled('CiviPledge') &&
+      !empty($this->_params['is_pledge'])
     ) {
+      // TODO: Assigned variable appears to be unused
       $this->assign('pledge_enabled', 1);
 
       $vars = array_merge($vars, [

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -152,8 +152,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     ]);
 
     //CiviPledge fields.
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviPledge', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviPledge')) {
       $this->assign('civiPledge', TRUE);
       $this->addElement('checkbox', 'is_pledge_active', ts('Pledges'),
         NULL, ['onclick' => "showHideAmountBlock( this, 'is_pledge_active' ); return showHideByValue('is_pledge_active',true,'pledgeFields','table-row','radio',false);"]

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -299,15 +299,11 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
       return $controller->run();
     }
     elseif ($action & CRM_Core_Action::UPDATE) {
-      $config = CRM_Core_Config::singleton();
-
       // assign vars to templates
       $this->assign('id', $id);
       $this->assign('title', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage', $id, 'title'));
       $this->assign('is_active', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage', $id, 'is_active'));
-      if (in_array('CiviMember', $config->enableComponents)) {
-        $this->assign('CiviMember', TRUE);
-      }
+      $this->assign('CiviMember', CRM_Core_Component::isEnabled('CiviMember'));
     }
     elseif ($action & CRM_Core_Action::COPY) {
       // @todo Unused local variable can be safely removed.

--- a/CRM/Contribute/StateMachine/ContributionPage.php
+++ b/CRM/Contribute/StateMachine/ContributionPage.php
@@ -34,8 +34,6 @@ class CRM_Contribute_StateMachine_ContributionPage extends CRM_Core_StateMachine
     $session = CRM_Core_Session::singleton();
     $session->set('singleForm', FALSE);
 
-    $config = CRM_Core_Config::singleton();
-
     $this->_pages = [
       'CRM_Contribute_Form_ContributionPage_Settings' => NULL,
       'CRM_Contribute_Form_ContributionPage_Amount' => NULL,
@@ -48,7 +46,7 @@ class CRM_Contribute_StateMachine_ContributionPage extends CRM_Core_StateMachine
       'CRM_Contribute_Form_ContributionPage_Widget' => NULL,
     ];
 
-    if (!in_array("CiviMember", $config->enableComponents)) {
+    if (!CRM_Core_Component::isEnabled('CiviMember')) {
       unset($this->_pages['CRM_Member_Form_MembershipBlock']);
     }
 

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -142,8 +142,6 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
    */
   public static function checkPermission($permissions, $operator) {
     if ($permissions) {
-      $config = CRM_Core_Config::singleton();
-
       static $allComponents;
       if (!$allComponents) {
         $allComponents = CRM_Core_Component::getNames();
@@ -170,9 +168,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
 
         //hack to determine if it's a component related permission
         if ($componentName) {
-          if (!in_array($componentName, $config->enableComponents) ||
-            !CRM_Core_Permission::check($key)
-          ) {
+          if (!CRM_Core_Component::isEnabled($componentName) || !CRM_Core_Permission::check($key)) {
             $showDashlet = FALSE;
             if ($operator == 'AND') {
               return $showDashlet;

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -368,9 +368,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
         $componentName = CRM_Core_Permission::getComponentName($key);
 
         if ($componentName) {
-          if (!in_array($componentName, CRM_Core_Config::singleton()->enableComponents) ||
-            !CRM_Core_Permission::check($key)
-          ) {
+          if (!CRM_Core_Component::isEnabled($componentName) || !CRM_Core_Permission::check($key)) {
             $showItem = FALSE;
             if ($operator == 'AND') {
               return FALSE;

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3455,8 +3455,7 @@ SELECT  group_id
    */
   public static function isProfileDoubleOptin() {
     // check for double optin
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviMail', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviMail')) {
       return Civi::settings()->get('profile_double_optin');
     }
     return FALSE;
@@ -3467,8 +3466,7 @@ SELECT  group_id
    */
   public static function isProfileAddToGroupDoubleOptin() {
     // check for add to group double optin
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviMail', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviMail')) {
       return Civi::settings()->get('profile_add_to_group_double_optin');
     }
     return FALSE;

--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -326,8 +326,6 @@ class CRM_Core_Block {
    * Create the list of options to create New objects for the application and format is as a block.
    */
   private static function setTemplateShortcutValues() {
-    $config = CRM_Core_Config::singleton();
-
     static $shortCuts = [];
 
     if (!($shortCuts)) {
@@ -349,14 +347,12 @@ class CRM_Core_Block {
 
       $components = CRM_Core_Component::getEnabledComponents();
 
-      if (!empty($config->enableComponents)) {
+      if ($components) {
         // check if we can process credit card contribs
         $newCredit = CRM_Core_Config::isEnabledBackOfficeCreditCardPayments();
 
-        foreach ($components as $componentName => $obj) {
-          if (in_array($componentName, $config->enableComponents)) {
-            $obj->creatNewShortcut($shortCuts, $newCredit);
-          }
+        foreach ($components as $obj) {
+          $obj->creatNewShortcut($shortCuts, $newCredit);
         }
       }
 

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -220,8 +220,7 @@ abstract class CRM_Core_Component_Info {
    *   true if component is enabled, false if not
    */
   public function isEnabled() {
-    $config = CRM_Core_Config::singleton();
-    return in_array($this->info['name'], $config->enableComponents, TRUE);
+    return CRM_Core_Component::isEnabled($this->info['name']);
   }
 
   /**

--- a/CRM/Core/Form/ShortCode.php
+++ b/CRM/Core/Form/ShortCode.php
@@ -53,8 +53,6 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
    * Build form data. Can be modified via hook_civicrm_preProcess.
    */
   public function preProcess() {
-    $config = CRM_Core_Config::singleton();
-
     $this->components['user-dashboard'] = [
       'label' => ts("User Dashboard"),
       'select' => NULL,
@@ -73,7 +71,7 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
       ],
     ];
 
-    if (in_array('CiviContribute', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviContribute')) {
       $this->components['contribution'] = [
         'label' => ts("Contribution Page"),
         'select' => [
@@ -92,7 +90,7 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
       ];
     }
 
-    if (in_array('CiviEvent', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviEvent')) {
       $this->components['event'] = [
         'label' => ts("Event Page"),
         'select' => [
@@ -103,7 +101,7 @@ class CRM_Core_Form_ShortCode extends CRM_Core_Form {
       ];
     }
 
-    if (in_array('CiviCampaign', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviCampaign')) {
       $this->components['petition'] = [
         'label' => ts("Petition"),
         'select' => [

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -423,9 +423,7 @@ class CRM_Core_Permission {
    *   Access to specified $module is granted.
    */
   public static function access($module, $checkPermission = TRUE, $requireAllCasesPermOnCiviCase = FALSE) {
-    $config = CRM_Core_Config::singleton();
-
-    if (!in_array($module, $config->enableComponents)) {
+    if (!CRM_Core_Component::isEnabled($module)) {
       return FALSE;
     }
 

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -88,10 +88,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviEvent', $config->enableComponents)) {
-      $this->assign('CiviEvent', TRUE);
-    }
+    $this->assign('CiviEvent', CRM_Core_Component::isEnabled('CiviEvent'));
     CRM_Core_Form_RecurringEntity::preProcess('civicrm_event');
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add', 'REQUEST');
@@ -354,8 +351,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
         [1 => CRM_Utils_Array::value('title', CRM_Utils_Array::value($subPage, $this->get('tabHeader')), $className)]
       ), $this->getTitle(), 'success');
 
-      $config = CRM_Core_Config::singleton();
-      if (in_array('CiviCampaign', $config->enableComponents)) {
+      if (CRM_Core_Component::isEnabled('CiviCampaign')) {
         $values = $this->controller->exportValues($this->_name);
         $newCampaignID = $values['campaign_id'] ?? NULL;
         $eventID = $values['id'] ?? NULL;

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -41,7 +41,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       }
     }
 
-    $config = CRM_Core_Config::singleton();
     $session = CRM_Core_Session::singleton();
     $contactID = $session->get('userID');
 
@@ -95,7 +94,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
     $crmMailingSettings = [
       'templateTypes' => CRM_Mailing_BAO_Mailing::getTemplateTypes(),
       'civiMails' => [],
-      'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
+      'campaignEnabled' => CRM_Core_Component::isEnabled('CiviCampaign'),
       'groupNames' => [],
       // @todo this is not used in core. Remove once Mosaico no longer depends on it.
       'testGroupNames' => $groupNames['values'],

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -4399,9 +4399,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    */
   public function addCampaignFields($entityTable = 'civicrm_contribution', $groupBy = FALSE, $orderBy = FALSE, $filters = TRUE) {
     // Check if CiviCampaign is a) enabled and b) has active campaigns
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array('CiviCampaign', $config->enableComponents);
-    if ($campaignEnabled) {
+    if (CRM_Core_Component::isEnabled('CiviCampaign')) {
       $getCampaigns = CRM_Campaign_BAO_Campaign::getPermissionedCampaigns(NULL, NULL, FALSE, FALSE, TRUE);
       // If we have a campaign, build out the relevant elements
       if (!empty($getCampaigns['campaigns'])) {

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -700,8 +700,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
    */
   public static function formRule($fields, $files, $self) {
     $errors = [];
-    $config = CRM_Core_Config::singleton();
-    if (in_array("CiviCase", $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviCase')) {
       $componentId = CRM_Core_Component::getComponentID('CiviCase');
       $caseActivityTypes = CRM_Core_OptionGroup::values('activity_type', TRUE, FALSE, FALSE, " AND v.component_id={$componentId}");
       if (!empty($fields['activity_type_id_value']) && is_array($fields['activity_type_id_value']) && empty($fields['include_case_activities_value'])) {

--- a/CRM/Report/Page/InstanceList.php
+++ b/CRM/Report/Page/InstanceList.php
@@ -134,7 +134,6 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
 
     $dao = CRM_Core_DAO::executeQuery($sql, $queryParams);
 
-    $config = CRM_Core_Config::singleton();
     $rows = [];
     $url = 'civicrm/report/instance';
     $my_reports_grouping = 'My';
@@ -143,7 +142,7 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
         continue;
       }
 
-      $enabled = in_array("Civi{$dao->compName}", $config->enableComponents);
+      $enabled = CRM_Core_Component::isEnabled("Civi{$dao->compName}");
       if ($dao->compName == 'Contact' || $dao->compName == $dao->grouping) {
         $enabled = TRUE;
       }

--- a/CRM/Report/Page/TemplateList.php
+++ b/CRM/Report/Page/TemplateList.php
@@ -68,10 +68,9 @@ LEFT  JOIN civicrm_component comp
 
     $dao = CRM_Core_DAO::executeQuery($sql);
     $rows = [];
-    $config = CRM_Core_Config::singleton();
     while ($dao->fetch()) {
       if ($dao->component_name != 'Contact' && $dao->component_name != $dao->grouping &&
-        !in_array("Civi{$dao->component_name}", $config->enableComponents)
+        !CRM_Core_Component::isEnabled("Civi{$dao->component_name}")
       ) {
         continue;
       }

--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -96,7 +96,7 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
    * @throws \Civi\API\Exception\NotImplementedException
    */
   public static function migrateCiviGrant(CRM_Queue_TaskContext $ctx): bool {
-    $civiGrantEnabled = in_array('CiviGrant', Civi::settings()->get('enable_components'), TRUE);
+    $civiGrantEnabled = CRM_Core_Component::isEnabled('CiviGrant');
     if ($civiGrantEnabled) {
       CRM_Core_BAO_ConfigSetting::disableComponent('CiviGrant');
     }

--- a/CRM/Upgrade/Incremental/php/FiveThirteen.php
+++ b/CRM/Upgrade/Incremental/php/FiveThirteen.php
@@ -23,9 +23,7 @@ class CRM_Upgrade_Incremental_php_FiveThirteen extends CRM_Upgrade_Incremental_B
    *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
    */
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev) {
-    $config = CRM_Core_Config::singleton();
-    $campaignEnabled = in_array("CiviCampaign", $config->enableComponents);
-    if ($rev == '5.13.alpha1' && $campaignEnabled) {
+    if ($rev == '5.13.alpha1' && CRM_Core_Component::isEnabled('CiviCampaign')) {
       $postUpgradeMessage .= '<br /><br />' . ts("If you have created a report based on the Mailing Summary Report template and it outputs or filters on campaigns, You will need to go back to that report and re-save the report after selecting and or setting the campaign filters up again");
     }
   }

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -39,8 +39,7 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
         ]);
       }
 
-      $config = CRM_Core_Config::singleton();
-      if (in_array('CiviCase', $config->enableComponents)) {
+      if (CRM_Core_Component::isEnabled('CiviCase')) {
         // Do dry-run to get warning messages.
         $messages = self::_changeCaseTypeLabelToName(TRUE);
         foreach ($messages as $message) {
@@ -62,8 +61,7 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
       "tinyint(4) DEFAULT '0' COMMENT 'Shows this is a template for recurring contributions.'", FALSE, '5.20.alpha1');
     $this->addTask('Add order_reference field to civicrm_financial_trxn', 'addColumn', 'civicrm_financial_trxn', 'order_reference',
       "varchar(255) COMMENT 'Payment Processor external order reference'", FALSE, '5.20.alpha1');
-    $config = CRM_Core_Config::singleton();
-    if (in_array('CiviCase', $config->enableComponents)) {
+    if (CRM_Core_Component::isEnabled('CiviCase')) {
       $this->addTask('Change direction of autoassignees in case type xml', 'changeCaseTypeAutoassignee');
       $this->addTask('Change labels back to names in case type xml', 'changeCaseTypeLabelToName');
     }

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -251,9 +251,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
       return $messages;
     }
 
-    $config = CRM_Core_Config::singleton();
-
-    if (in_array('CiviMail', $config->enableComponents) &&
+    if (CRM_Core_Component::isEnabled('CiviMail') &&
       CRM_Core_BAO_MailSettings::defaultDomain() == "EXAMPLE.ORG"
     ) {
       $message = new CRM_Utils_Check_Message(

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -53,7 +53,7 @@ class RelationshipCache extends Generic\AbstractEntity {
         'description' => ts('One or more related contacts'),
       ],
     ];
-    if (in_array('CiviCase', \Civi::settings()->get('enable_components'), TRUE)) {
+    if (\CRM_Core_Component::isEnabled('CiviCase')) {
       $info['bridge']['case_id'] = [
         'to' => 'far_contact_id',
         'label' => ts('Case Roles'),

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -92,9 +92,7 @@ class SpecGatherer {
       if (array_key_exists('contactType', $DAOField) && $spec->getValue('contact_type') && $DAOField['contactType'] != $spec->getValue('contact_type')) {
         continue;
       }
-      if (!empty($DAOField['component']) &&
-        !in_array($DAOField['component'], \Civi::settings()->get('enable_components'), TRUE)
-      ) {
+      if (!empty($DAOField['component']) && !\CRM_Core_Component::isEnabled($DAOField['component'])) {
         continue;
       }
       if ($DAOField['name'] == 'is_active' && empty($DAOField['default'])) {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Case.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Case.php
@@ -29,8 +29,7 @@ class CRM_Contact_Form_Search_Custom_FullText_Case extends CRM_Contact_Form_Sear
    * @return bool
    */
   public function isActive() {
-    $config = CRM_Core_Config::singleton();
-    return in_array('CiviCase', $config->enableComponents);
+    return CRM_Core_Component::isEnabled('CiviCase');
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Contribution.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Contribution.php
@@ -29,9 +29,8 @@ class CRM_Contact_Form_Search_Custom_FullText_Contribution extends CRM_Contact_F
    * @return bool
    */
   public function isActive() {
-    $config = CRM_Core_Config::singleton();
-    return in_array('CiviContribute', $config->enableComponents) &&
-    CRM_Core_Permission::check('access CiviContribute');
+    return CRM_Core_Component::isEnabled('CiviContribute') &&
+      CRM_Core_Permission::check('access CiviContribute');
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Membership.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Membership.php
@@ -29,9 +29,8 @@ class CRM_Contact_Form_Search_Custom_FullText_Membership extends CRM_Contact_For
    * @return bool
    */
   public function isActive() {
-    $config = CRM_Core_Config::singleton();
-    return in_array('CiviMember', $config->enableComponents) &&
-    CRM_Core_Permission::check('access CiviMember');
+    return CRM_Core_Component::isEnabled('CiviMember') &&
+      CRM_Core_Permission::check('access CiviMember');
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Participant.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Participant.php
@@ -29,9 +29,8 @@ class CRM_Contact_Form_Search_Custom_FullText_Participant extends CRM_Contact_Fo
    * @return bool
    */
   public function isActive() {
-    $config = CRM_Core_Config::singleton();
-    return in_array('CiviEvent', $config->enableComponents) &&
-    CRM_Core_Permission::check('view event participants');
+    return CRM_Core_Component::isEnabled('CiviEvent') &&
+      CRM_Core_Permission::check('view event participants');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up code which checks if a component is enabled, using the new utility function created by @eileenmcnaughton in #22567

Technical Details
----------------------------------------
Switches more verbose array searches to the new utility function.