### PR TITLE
CiviMail - Remove deprecated variable only used by Mosaico

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -50,11 +50,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'options' => ['limit' => 0],
       'sequential' => 1,
     ];
-    $groupNames = civicrm_api3('Group', 'get', $params + [
-      'is_active' => 1,
-      'check_permissions' => TRUE,
-      'return' => ['title', 'visibility', 'group_type', 'is_hidden'],
-    ]);
     $headerfooterList = civicrm_api3('MailingComponent', 'get', $params + [
       'is_active' => 1,
       'return' => [
@@ -97,8 +92,6 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'civiMails' => [],
       'campaignEnabled' => in_array('CiviCampaign', $config->enableComponents),
       'groupNames' => [],
-      // @todo this is not used in core. Remove once Mosaico no longer depends on it.
-      'testGroupNames' => $groupNames['values'],
       'headerfooterList' => $headerfooterList['values'],
       'mesTemplate' => $mesTemplate['values'],
       'emailAdd' => $emailAdd['values'],


### PR DESCRIPTION
Overview
----------------------------------------
Removes a variable unused in core, and no-longer used by Mosaico as of https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/481

Before
----------------------------------------
Deprecated variable present but not used in core.

After
----------------------------------------
Removed.

Technical Details
----------------------------------------
It was made moot by d1aefa39fa45d60ccd4f2e0ecdb382ae796c25ef

