### PR TITLE
Fix typo preventing uninstalling ckeditor4

### DIFF
--- a/ext/ckeditor4/CRM/Ckeditor4/Upgrader.php
+++ b/ext/ckeditor4/CRM/Ckeditor4/Upgrader.php
@@ -26,7 +26,7 @@ class CRM_Ckeditor4_Upgrader extends CRM_Ckeditor4_Upgrader_Base {
     foreach ($domains as $domain) {
       $currentSetting = \Civi::settings($domain['id'])->get('editor_id');
       if ($currentSetting === 'CKEditor') {
-        \Civi::setttings($domain['id'])->set('editor_id', 'Textarea');
+        \Civi::settings($domain['id'])->set('editor_id', 'Textarea');
       }
     }
     civicrm_api3('OptionValue', 'get', ['name' => 'CKEditor', 'api.option_value.delete' => ['id' => "\$value.id"]]);


### PR DESCRIPTION
Overview
----------------------------------------
Typo causes crash when uninstalling the ckeditor4 extension.