### PR TITLE
Update composer.json for composer 2.2 allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
   "config": {
     "platform": {
       "php": "7.2"
+    },
+    "allow-plugins": {
+      "civicrm/composer-compile-plugin": true,
+      "civicrm/composer-downloads-plugin": true,
+      "cweagans/composer-patches": true
     }
   },
   "require": {


### PR DESCRIPTION
Overview
----------------------------------------
Running `composer install` with composer v2.2 outputs:

> For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
> You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.

Before
----------------------------------------
Dire warning

After
----------------------------------------
Just the usual composer issues.

Technical Details
----------------------------------------
This won't help drupal 8 - people will have to script it themselves or if running manually press 'y'. But will prevent problems for drupal 7 builds like on the demo sites.

Comments
----------------------------------------
I think the PR test runs might be using a lower version so you don't see it in the output there.
