### PR TITLE
Cleanup on contribution view

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4271,6 +4271,9 @@ LIMIT 1;";
   /**
    * Get payment links as they relate to a contribution.
    *
+   * If a payment can be made then include a payment link & if a refund is appropriate
+   * then a refund link.
+   *
    * @param int $id
    * @param string $contributionStatus
    *
@@ -4279,10 +4282,9 @@ LIMIT 1;";
    *     -url
    *     -title
    *
-   * If a payment can be made then include a payment link & if a refund is appropriate
-   * then a refund link.
+   * @internal - not supported for use outside of core.
    */
-  protected static function getContributionPaymentLinks(int $id, string $contributionStatus): array {
+  public static function getContributionPaymentLinks(int $id, string $contributionStatus): array {
     if ($contributionStatus === 'Failed' || !CRM_Core_Permission::check('edit contributions')) {
       // In general the balance is the best way to determine if a payment can be added or not,
       // but not for Failed contributions, where we don't accept additional payments at the moment.

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4271,9 +4271,6 @@ LIMIT 1;";
   /**
    * Get payment links as they relate to a contribution.
    *
-   * If a payment can be made then include a payment link & if a refund is appropriate
-   * then a refund link.
-   *
    * @param int $id
    * @param string $contributionStatus
    *
@@ -4281,6 +4278,9 @@ LIMIT 1;";
    *   $actionLinks Links array containing:
    *     -url
    *     -title
+   *
+   * If a payment can be made then include a payment link & if a refund is appropriate
+   * then a refund link.
    */
   protected static function getContributionPaymentLinks(int $id, string $contributionStatus): array {
     if ($contributionStatus === 'Failed' || !CRM_Core_Permission::check('edit contributions')) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3634,7 +3634,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $info['transaction'] = self::getContributionTransactionInformation($contributionId, $contribution['financial_type_id']);
     }
 
-    $info['payment_links'] = self::getContributionPaymentLinks($id, $paymentBalance, $info['contribution_status']);
+    $info['payment_links'] = self::getContributionPaymentLinks($id, $info['contribution_status']);
     return $info;
   }
 
@@ -4275,7 +4275,6 @@ LIMIT 1;";
    * then a refund link.
    *
    * @param int $id
-   * @param float $balance
    * @param string $contributionStatus
    *
    * @return array
@@ -4283,7 +4282,7 @@ LIMIT 1;";
    *     -url
    *     -title
    */
-  protected static function getContributionPaymentLinks($id, $balance, $contributionStatus) {
+  protected static function getContributionPaymentLinks(int $id, string $contributionStatus): array {
     if ($contributionStatus === 'Failed' || !CRM_Core_Permission::check('edit contributions')) {
       // In general the balance is the best way to determine if a payment can be added or not,
       // but not for Failed contributions, where we don't accept additional payments at the moment.
@@ -4314,15 +4313,17 @@ LIMIT 1;";
         'title' => ts('Submit Credit Card payment'),
       ];
     }
-    $actionLinks[] = [
-      'url' => CRM_Utils_System::url('civicrm/payment', [
-        'action' => 'add',
-        'reset' => 1,
-        'id' => $id,
-        'is_refund' => 1,
-      ]),
-      'title' => ts('Record Refund'),
-    ];
+    if ($contributionStatus !== 'Pending') {
+      $actionLinks[] = [
+        'url' => CRM_Utils_System::url('civicrm/payment', [
+          'action' => 'add',
+          'reset' => 1,
+          'id' => $id,
+          'is_refund' => 1,
+        ]),
+        'title' => ts('Record Refund'),
+      ];
+    }
     return $actionLinks;
   }
 

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -55,6 +55,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     }
     $this->assign('is_template', $values['is_template']);
 
+    $noACL = FALSE;
     if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && $this->_action & CRM_Core_Action::VIEW) {
       $financialTypeID = CRM_Contribute_PseudoConstant::financialType($values['financial_type_id']);
       CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($id, 'view');
@@ -69,7 +70,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       }
     }
     elseif ($this->_action & CRM_Core_Action::VIEW) {
-      $this->assign('noACL', TRUE);
+      $noACL = TRUE;
     }
     CRM_Contribute_BAO_Contribution::resolveDefaults($values);
 
@@ -230,6 +231,77 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       $this->assign('component', 'contribution');
     }
     $this->assignPaymentInfoBlock($id);
+
+    $searchKey = NULL;
+    if ($this->controller->_key) {
+      $searchKey = $this->controller->_key;
+    }
+    if ((
+        CRM_Core_Permission::check('edit_contributions')
+        && CRM_Core_Permission::check('edit contributions of type ' . $financialTypeID)
+        && !empty($canEdit)
+      ) || (CRM_Core_Permission::check('edit contributions') && $noACL)) {
+      $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=update&context={$context}";
+      if (($context === 'fulltext' || $context === 'search') && $searchKey) {
+        $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=update&context={$context}&key={$searchKey}";
+      }
+      $linkButtons[] = [
+        'title' => ts('Edit'),
+        'url' => 'civicrm/contact/view/contribution',
+        'qs' => $urlParams,
+        'icon' => 'fa-pencil',
+        'accesskey' => 'e',
+      ];
+      if (!empty($paymentButtonName)) {
+        $linkButtons[] = [
+          'title' => $paymentButtonName,
+          'url' => 'civicrm/payment',
+          'qs' => "action=add&reset=1&component=contribution&id={$id}&cid={$values['contact_id']}",
+          'icon' => 'fa-plus-circle',
+        ];
+      }
+    }
+
+    if ((
+        CRM_Core_Permission::check('delete in CiviContribute')
+        && CRM_Core_Permission::check('delete contributions of type ' . CRM_Contribute_PseudoConstant::financialType($financialTypeID))
+        && !empty($canDelete)
+      ) || (CRM_Core_Permission::check('delete in CiviContribute') && $noACL)) {
+      $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=delete&context={$context}";
+      if (($context === 'fulltext' || $context === 'search') && $searchKey) {
+        $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=delete&context={$context}&key={$searchKey}";
+      }
+      $linkButtons[] = [
+        'title' => ts('Delete'),
+        'url' => 'civicrm/contact/view/contribution',
+        'qs' => $urlParams,
+        'icon' => 'fa-trash',
+      ];
+    }
+
+    $pdfUrlParams = "reset=1&id={$id}&cid={$values['contact_id']}";
+    $emailUrlParams = "reset=1&id={$id}&cid={$values['contact_id']}&select=email";
+    if ($invoicing && empty($is_template)) {
+      if (($values['contribution_status'] != 'Refunded') && ($values['contribution_status'] != 'Cancelled')) {
+        $invoiceButtonText = ts('Download Invoice');
+      }
+      else {
+        $invoiceButtonText = ts('Download Invoice and Credit Note');
+      }
+      $linkButtons[] = [
+        'title' => $invoiceButtonText,
+        'url' => 'civicrm/contribute/invoice',
+        'qs' => $pdfUrlParams,
+        'icon' => 'fa-download',
+      ];
+      $linkButtons[] = [
+        'title' => ts('Email Invoice'),
+        'url' => 'civicrm/contribute/invoice/email',
+        'qs' => $emailUrlParams,
+        'icon' => 'fa-paper-plane',
+      ];
+    }
+    $this->assign('linkButtons', $linkButtons ?? []);
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -215,9 +215,11 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       if (($context === 'fulltext' || $context === 'search') && $searchKey) {
         $urlParams = "reset=1&id={$id}&cid={$values['contact_id']}&action=update&context={$context}&key={$searchKey}";
       }
-      foreach (CRM_Contribute_BAO_Contribution::getContributionPaymentLinks($this->getID(), $contributionStatus) as $paymentButton) {
-        $paymentButton['icon'] = 'fa-plus-circle';
-        $linkButtons[] = $paymentButton;
+      if (!$contribution['is_template']) {
+        foreach (CRM_Contribute_BAO_Contribution::getContributionPaymentLinks($this->getID(), $contributionStatus) as $paymentButton) {
+          $paymentButton['icon'] = 'fa-plus-circle';
+          $linkButtons[] = $paymentButton;
+        }
       }
       $linkButtons[] = [
         'title' => ts('Edit'),
@@ -244,7 +246,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     $pdfUrlParams = "reset=1&id={$id}&cid={$values['contact_id']}";
     $emailUrlParams = "reset=1&id={$id}&cid={$values['contact_id']}&select=email";
     if (Civi::settings()->get('invoicing') && !$contribution['is_template']) {
-      if (($values['contribution_status'] != 'Refunded') && ($values['contribution_status'] != 'Cancelled')) {
+      if (($values['contribution_status'] !== 'Refunded') && ($values['contribution_status'] !== 'Cancelled')) {
         $invoiceButtonText = ts('Download Invoice');
       }
       else {
@@ -264,6 +266,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       ];
     }
     $this->assign('linkButtons', $linkButtons ?? []);
+    // These next 3 parameters are used to construct a url in PaymentInfo.tpl
     $this->assign('contactId', $values['contact_id']);
     $this->assign('componentId', $id);
     $this->assign('component', 'contribution');

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -178,17 +178,15 @@
       <td>{$thankyou_date|crmDate}</td>
     </tr>
   {/if}
+  <tr>
+    <td class='label'>{ts}Payment Summary{/ts}</td>
+    <td id='payment-info'></td>
+  </tr>
   {if empty($is_template)}
   <tr>
     <td class="label">{ts}Payment Details{/ts}</td>
     <td>{include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}</td>
   </tr>
-  {/if}
-  {if $addRecordPayment}
-    <tr>
-      <td class='label'>{ts}Payment Summary{/ts}</td>
-      <td id='payment-info'></td>
-    </tr>
   {/if}
 </table>
 
@@ -285,9 +283,7 @@
     </div>
   </fieldset>
 {/if}
-{if $addRecordPayment}
-  {include file="CRM/Contribute/Page/PaymentInfo.tpl" show='payments'}
-{/if}
+{include file="CRM/Contribute/Page/PaymentInfo.tpl" show='payments'}
 
 <div class="crm-submit-buttons">
   {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -10,44 +10,6 @@
 <div class="crm-block crm-content-block crm-contribution-view-form-block">
 <div class="action-link">
   <div class="crm-submit-buttons">
-    {if (call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && call_user_func(array('CRM_Core_Permission', 'check'), "edit contributions of type $financial_type") && !empty($canEdit)) ||
-    	(call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && $noACL)}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context"}
-      {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-        {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&key=$searchKey"}
-      {/if}
-      <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}" accesskey="e"><span>
-          <i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span>
-      </a>
-      {if !empty($paymentButtonName)}
-        <a class="button" href='{crmURL p="civicrm/payment" q="action=add&reset=1&component=`$component`&id=`$id`&cid=`$contact_id`"}'><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}{$paymentButtonName}{/ts}</a>
-      {/if}
-    {/if}
-    {if (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && call_user_func(array('CRM_Core_Permission', 'check'), "delete contributions of type $financial_type") && !empty($canDelete))     || (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && $noACL)}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context"}
-      {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-        {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&key=$searchKey"}
-      {/if}
-      <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}"><span>
-          <i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span>
-      </a>
-    {/if}
-    {assign var='pdfUrlParams' value="reset=1&id=$id&cid=$contact_id"}
-    {assign var='emailUrlParams' value="reset=1&id=$id&cid=$contact_id&select=email"}
-    {if $invoicing && empty($is_template)}
-      <div class="css_right">
-        <a class="button no-popup" href="{crmURL p='civicrm/contribute/invoice' q=$pdfUrlParams}">
-          <i class="crm-i fa-download" aria-hidden="true"></i>
-        {if $contribution_status != 'Refunded' && $contribution_status != 'Cancelled' }
-          {ts}Download Invoice{/ts}</a>
-        {else}
-          {ts}Download Invoice and Credit Note{/ts}</a>
-        {/if}
-        <a class="button" href="{crmURL p='civicrm/contribute/invoice/email' q=$emailUrlParams}">
-          <i class="crm-i fa-paper-plane" aria-hidden="true"></i>
-          {ts}Email Invoice{/ts}</a>
-      </div>
-    {/if}
     {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
 </div>
@@ -328,24 +290,6 @@
 {/if}
 
 <div class="crm-submit-buttons">
-  {if (call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && call_user_func(array('CRM_Core_Permission', 'check'), "edit contributions of type $financial_type") && $canEdit) ||
-    	(call_user_func(array('CRM_Core_Permission','check'), 'edit contributions') && $noACL)}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context"}
-    {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&key=$searchKey"}
-    {/if}
-    <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
-    {if $paymentButtonName}
-      <a class="button" href='{crmURL p="civicrm/payment" q="action=add&reset=1&component=`$component`&id=`$id`&cid=`$contact_id`"}'><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}{$paymentButtonName}{/ts}</a>
-    {/if}
-  {/if}
-  {if (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && call_user_func(array('CRM_Core_Permission', 'check'), "delete contributions of type $financial_type") && $canDelete)     || (call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') && $noACL)}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context"}
-    {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-      {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&key=$searchKey"}
-    {/if}
-    <a class="button" href="{crmURL p='civicrm/contact/view/contribution' q=$urlParams}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
-  {/if}
   {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This combines https://github.com/civicrm/civicrm-core/pull/22684 and https://github.com/civicrm/civicrm-core/pull/22588 and adds a couple of other consistency changes
- #22684 is a cleanup that moves acl logic to the financialacls extension
- #22588 moves button logic from the tpl to the php layer
- In addition this pr makes the payment/submit credit card payment/refund options the same as in the payment details block - it uses the same code to generate the list as the payment block. Understanding the logic for what & where bent my mind & was inconsistent with what we had otherwise settled on. I would also be ok with REMOVING them - since they are elsewhere on the form
- this pr makes the payment summary block always present and abov ethe payment details (it seemed confusing and based on things we've moved away from having them sometimes there)

Before
----------------------------------------
Pending 
![image](https://user-images.githubusercontent.com/336308/152484483-9eaacdf5-94f6-46e5-ab01-8a89d69042ff.png)

Completed
![image](https://user-images.githubusercontent.com/336308/152484448-fe35fd8e-f459-4ad3-a6fa-44c23ccfa6a8.png)


After
----------------------------------------
Pending 
![image](https://user-images.githubusercontent.com/336308/152484560-cdaef21e-9ca7-486c-a320-c7ea13840e8f.png)


Completed
![image](https://user-images.githubusercontent.com/336308/152483923-959ad160-925b-4bcc-8d11-827ce390fac2.png)


Technical Details
----------------------------------------
I feel like the is_template stuff should be a separate form class (which possibly extends or shares a parent with the contribution view for the bits of functionality that are shared) - but it's really the tpl which is going to be really hard to maintain if we don't separate them. That tpl separation can be done even if the template form is overloaded onto the same class

Comments
----------------------------------------
