### PR TITLE
SearchKit - Improve import UI to handle update & preview the import

### DIFF
--- a/ang/crmDialog.js
+++ b/ang/crmDialog.js
@@ -40,35 +40,27 @@
         var $dialog = this;
         $dialog.buttons = [];
 
-        $dialog.close = function (result) {
+        $dialog.close = function(result) {
           dialogService.close($dialog.name, result);
         };
 
-        $dialog.cancel = function (result) {
+        $dialog.cancel = function() {
           dialogService.cancel($dialog.name);
         };
 
         $dialog.loadButtons = function() {
           var buttons = [];
           angular.forEach($dialog.buttons, function (crmDialogButton) {
-            var button = _.pick(crmDialogButton, ['id', 'icons', 'text']);
-            button.click = function () {
-              crmDialogButton.onClick();
+            var button = _.pick(crmDialogButton, ['icons', 'text', 'disabled']);
+            button.click = function() {
+              $scope.$apply(crmDialogButton.onClick);
             };
             buttons.push(button);
           });
           dialogService.setButtons($dialog.name, buttons);
-          $dialog.toggleButtons();
         };
 
-        $dialog.toggleButtons = function() {
-          angular.forEach($dialog.buttons, function (crmDialogButton) {
-            $('#' + crmDialogButton.id).prop('disabled', crmDialogButton.disabled);
-          });
-        };
-
-        $timeout(function(){
-          $dialog.loadButtons();
+        $timeout(function() {
           $('.ui-dialog:last input:not([disabled]):not([type="submit"]):first').focus();
         });
 
@@ -79,8 +71,6 @@
       }
     };
   });
-
-  var idNum = 1;
 
   // Ex: <crm-dialog-button text="ts('Do it')" icons="{primary: 'fa-foo'}" on-click="doIt()" />
   angular.module('crmDialog').component('crmDialogButton', {
@@ -97,12 +87,10 @@
       var $ctrl = this;
       $ctrl.$onInit = function() {
         $ctrl.crmDialog.buttons.push(this);
+        $scope.$watch('$ctrl.disabled', $ctrl.crmDialog.loadButtons);
+        $scope.$watch('$ctrl.text', $ctrl.crmDialog.loadButtons);
+        $scope.$watch('$ctrl.icons', $ctrl.crmDialog.loadButtons);
       };
-      $ctrl.id = 'crmDialogButton_' + (idNum++);
-
-      $scope.$watch('$ctrl.disabled', function() {
-        $ctrl.crmDialog.toggleButtons();
-      });
     }
   });
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
@@ -49,9 +49,13 @@
         var data = [];
         _.each(ctrl.types, function(type) {
           if (type.enabled) {
-            _.each(type.values, function(values) {
-              data.push([type.entity, 'create', {values: values}]);
-            });
+            var params = {records: type.values};
+            // Afform always matches on 'name', no need to add it to the API 'save' params
+            if (type.entity !== 'Afform') {
+              // Group and SavedSearch match by 'name', SearchDisplay also matches by 'saved_search_id'.
+              params.match = type.entity === 'SearchDisplay' ? ['name', 'saved_search_id'] : ['name'];
+            }
+            data.push([type.entity, 'save', params]);
           }
         });
         ctrl.output = JSON.stringify(data, null, 2);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -9,31 +9,116 @@
 
       this.values = '';
 
+      var checkInput = _.debounce(function() {
+        $scope.$apply(function() {
+          if (!ctrl.values) {
+            ctrl.checking = false;
+            return;
+          }
+          try {
+            var apiCalls = JSON.parse(ctrl.values),
+              allowedEntities = ['SavedSearch', 'SearchDisplay', 'Group'];
+            if (CRM.crmSearchAdmin.afformEnabled) {
+              allowedEntities.push('Afform');
+            }
+            // Get entity titles for use in status message
+            var getCalls = {
+              Entity: ['Entity', 'get', {
+                select: ['title', 'title_plural'],
+                where: [['name', 'IN', allowedEntities]]
+              }, 'name']
+            };
+            // Get count of existing matches for each import entity
+            _.each(apiCalls, function (apiCall) {
+              var entity = apiCall[0];
+              if (apiCall[1] !== 'save' || ('chain' in apiCall[2] && !_.isEmpty(apiCall[2].chain))) {
+                throw ts('Unsupported API action: only "save" is allowed.');
+              }
+              if (!_.includes(allowedEntities, entity)) {
+                throw ts('Unsupported API entity "' + entity + '".');
+              }
+              if (entity in getCalls) {
+                throw ts('Duplicate API entity "' + entity + '".');
+              }
+              var names = _.map(apiCall[2].records, 'name'),
+                where = [['name', 'IN', names]];
+              if (entity === 'SearchDisplay') {
+                where.push(['saved_search_id.name', '=', apiCall[2].records[0]['saved_search_id.name']]);
+              }
+              if (names.length) {
+                getCalls[entity] = [entity, 'get', {select: ['row_count'], where: where}];
+              }
+            });
+            if (_.keys(getCalls).length < 2) {
+              throw ts('No records to import.');
+            }
+            crmApi4(getCalls)
+              .then(function (results) {
+                ctrl.checking = false;
+                ctrl.error = '';
+                ctrl.preview = '';
+                _.each(allowedEntities, function (entity) {
+                  if (results[entity]) {
+                    var info = results.Entity[entity],
+                      count = getCalls[entity][2].where[0][2].length,
+                      existing = results[entity].count,
+                      saveCall = _.findWhere(apiCalls, {0: entity});
+                    // Unless it's an afform, the api save params must include `match` or an update is not possible
+                    if (existing && entity !== 'Afform' && (!saveCall[2].match || !saveCall[2].match.length)) {
+                      ctrl.error += ' ' + ts('Cannot create %1 %2 because an existing one with the same name already exists.', {
+                        1: existing,
+                        2: existing === 1 ? info.title : info.title_plural
+                      });
+                      ctrl.error += ' ' + ts('To update existing records, include "match" in the API params.');
+                    } else if (existing) {
+                      ctrl.preview += ' ' + ts('%1 existing %2 will be updated.', {
+                        1: existing,
+                        2: existing === 1 ? info.title : info.title_plural
+                      });
+                    }
+                    if (existing < count) {
+                      ctrl.preview += ' ' + ts('%1 new %2 will be created.', {
+                        1: count - existing,
+                        2: (count - existing) === 1 ? info.title : info.title_plural
+                      });
+                    }
+                  }
+                });
+              }, function (error) {
+                ctrl.running = false;
+                ctrl.error = error.error_message;
+                ctrl.checking = false;
+              });
+          } catch (e) {
+            ctrl.error = e;
+            ctrl.checking = false;
+          }
+        });
+      }, 500);
+
+      this.onChangeInput = function() {
+        ctrl.checking = true;
+        ctrl.error = '';
+        ctrl.preview = null;
+        checkInput();
+      };
+
       this.run = function() {
         ctrl.running = true;
-        try {
-          var apiCalls = JSON.parse(ctrl.values);
-          _.each(apiCalls, function(apiCall) {
-            if (apiCall[1] !== 'create' || ('chain' in apiCall[2] && !_.isEmpty(apiCall[2].chain))) {
-              throw ts('Unsupported API action: only "create" is allowed.');
-            }
+        ctrl.preview = null;
+        var apiCalls = JSON.parse(ctrl.values);
+        crmApi4(apiCalls)
+          .then(function(result) {
+            CRM.alert(
+              result.length === 1 ? ts('1 record successfully imported.') : ts('%1 records successfully imported.', {1: results.length}),
+              ts('Saved'),
+              'success'
+            );
+            dialogService.close('crmSearchAdminImport');
+          }, function(error) {
+            ctrl.running = false;
+            ctrl.error = ts('Processing Error:') + ' ' + error.error_message;
           });
-          crmApi4(apiCalls)
-            .then(function(result) {
-              CRM.alert(
-                result.length === 1 ? ts('1 record successfully imported.') : ts('%1 records successfully imported.', {1: results.length}),
-                ts('Saved'),
-                'success'
-              );
-              dialogService.close('crmSearchAdminImport');
-            }, function(error) {
-              ctrl.running = false;
-              alert(ts('Processing Error') + "\n" + error.error_message);
-            });
-        } catch(e) {
-          ctrl.running = false;
-          alert(ts('Input Error') + "\n" + e);
-        }
       };
     }
   });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.html
@@ -1,14 +1,21 @@
 <div id="bootstrap-theme" crm-dialog="crmSearchAdminImport">
-  <div class="alert alert-info">
-    <p>
-      <i class="crm-i fa-info-circle"></i>
-      {{:: ts('Search configuration copied from the "Export" action can be pasted here.') }}
-    </p>
-    <p>
-      {{:: ts('Note: a Saved Search with the same name must not already exist.') }}
-    </p>
+  <div class="alert alert-info" ng-if="!$ctrl.checking && !$ctrl.error && !$ctrl.preview">
+    <i class="crm-i fa-info-circle"></i>
+    {{:: ts('Search configuration copied from the "Export" action can be pasted here.') }}
   </div>
-  <textarea id="crm-search-admin-export-output-code" class="form-control" ng-model="$ctrl.values" rows="15"></textarea>
-  <crm-dialog-button text="ts('Import')" icons="{primary: 'fa-save'}" on-click="$ctrl.run()" disabled="$ctrl.running || !$ctrl.values" />
+  <div class="alert alert-info" ng-if="$ctrl.checking || $ctrl.running">
+    <i class="crm-i fa-spinner fa-pulse"></i>
+    {{ $ctrl.checking ? ts('Checking input...') : ts('Importing Saved Search...') }}
+  </div>
+  <div class="alert alert-danger" ng-if="$ctrl.error">
+    <i class="crm-i fa-exclamation-triangle"></i>
+    {{ $ctrl.error }}
+  </div>
+  <div class="alert alert-success" ng-if="$ctrl.preview && !$ctrl.error">
+    <i class="crm-i fa-check-circle-o"></i>
+    {{ $ctrl.preview }}
+  </div>
+  <textarea id="crm-search-admin-export-output-code" class="form-control" ng-model="$ctrl.values" ng-change="$ctrl.onChangeInput()" ng-disabled="$ctrl.running" rows="15"></textarea>
+  <crm-dialog-button text="ts('Import')" icons="{primary: $ctrl.running ? 'fa-spinner fa-spin' : 'fa-save'}" on-click="$ctrl.run()" disabled="$ctrl.running || $ctrl.error || !$ctrl.preview" />
   <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="crmSearchAdminImport.cancel()" disabled="$ctrl.running" />
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -73,6 +73,10 @@
       this.onPostRun.push(function(result) {
         _.each(result, function(row) {
           row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
+          // If main entity doesn't exist, no can edit
+          if (!row.data['api_entity:label']) {
+            row.permissionToEdit = false;
+          }
           // Saves rendering cycles to not show an empty menu of search displays
           if (!row.data.display_name) {
             row.openDisplayMenu = false;
@@ -177,6 +181,10 @@
               }),
               searchMeta.fieldToColumn('api_entity:label', {
                 label: ts('For'),
+                empty_value: ts('Missing'),
+                cssRules: [
+                  ['font-italic', 'api_entity:label', 'IS EMPTY']
+                ]
               }),
               {
                 type: 'include',


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit has an import/export SavedSearch feature which allows you to copy/paste api code in JSON format. This PR enables update as well as create, and improves that UI to give better user feedback about what will happen when the import is run.

Before
----------------------------------------
Export used 'create' api action, and import could only handle creating new records.
If you try to import an existing SavedSearch, you'd get this:

![image](https://user-images.githubusercontent.com/2874912/152472639-6a74d9e2-bf6a-40c6-8bf4-29bf33d9aeda.png)

After
----------------------------------------
Export uses 'save' action, which can either create or update.
Before running the import, it tells you exactly what will happen:

![image](https://user-images.githubusercontent.com/2874912/152472872-8bdb6ff9-565f-45cd-8108-bc045716dc3b.png)

Comments
---------------
@eileenmcnaughton raised this during a round of testing.

