### PR TITLE
5.46.0 - Run some autocleaning on release notes

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -26,6 +26,15 @@ Released February 3, 2022
 - **[Credits](release-notes/5.46.0.md#credits)**
 - **[Feedback](release-notes/5.46.0.md#feedback)**
 
+## CiviCRM 5.45.3
+
+Released February 3, 2022
+
+- **[Synopsis](release-notes/5.45.3.md#synopsis)**
+- **[Bugs resolved](release-notes/5.45.3.md#bugs)**
+- **[Credits](release-notes/5.45.3.md#credits)**
+- **[Feedback](release-notes/5.45.3.md#feedback)**
+
 ## CiviCRM 5.45.2
 
 Released January 28, 2022

--- a/release-notes.md
+++ b/release-notes.md
@@ -17,7 +17,7 @@ Other resources for identifying changes are:
 
 ## CiviCRM 5.46.0
 
-Released February 2, 2022
+Released February 3, 2022
 
 - **[Synopsis](release-notes/5.46.0.md#synopsis)**
 - **[Features](release-notes/5.46.0.md#features)**

--- a/release-notes/5.45.3.md
+++ b/release-notes/5.45.3.md
@@ -1,0 +1,39 @@
+# CiviCRM 5.45.3
+
+Released February 3, 2022
+
+- **[Synopsis](#synopsis)**
+- **[Bugs resolved](#bugs)**
+- **[Credits](#credits)**
+- **[Feedback](#feedback)**
+
+## <a name=synopsis></a>Synopsis
+
+| *Does this version...?*                                         |          |
+| --------------------------------------------------------------- | -------- |
+| Change the database schema?                                     | no       |
+| Alter the API?                                                  | no       |
+| Require attention to configuration options?                     | no       |
+| **Fix problems installing or upgrading to a previous version?** | **yes**  |
+| Introduce features?                                             | no       |
+| Fix bugs?                                                       | no       |
+
+## <a name=bugs></a>Bugs resolved
+
+* **_Managed Entities_: Fix crash during upgrade ([dev/core#3045](https://lab.civicrm.org/dev/core/-/issues/3045): [#22642](https://github.com/civicrm/civicrm-core/pull/22642))**
+
+    The configurations affected by this issue could not be positively identified. However, affected users reported that the patch fixed the issue.
+
+## <a name=credits></a>Credits
+
+This release was developed by the following authors and reviewers:
+
+CiviCoop - Jaap Jansma; CiviCRM - Coleman Watts, Tim Otten; JMA Consulting - Seamus Lee;
+Third Sector Design - William Mortada, Kurund Jalmi; Wikimedia Foundation - Eileen
+McNaughton
+
+## <a name=feedback></a>Feedback
+
+These release notes are edited by Tim Otten and Andie Hunt.  If you'd like to
+provide feedback on them, please login to https://chat.civicrm.org/civicrm and
+contact `@agh1`.

--- a/release-notes/5.46.0.md
+++ b/release-notes/5.46.0.md
@@ -1,6 +1,6 @@
 # CiviCRM 5.46.0
 
-Released February 2, 2022
+Released February 3, 2022
 
 - **[Synopsis](#synopsis)**
 - **[Features](#features)**

--- a/release-notes/5.46.0.md
+++ b/release-notes/5.46.0.md
@@ -13,13 +13,13 @@ Released February 2, 2022
 
 | *Does this version...?*                                         |         |
 |:--------------------------------------------------------------- |:-------:|
-| Fix security vulnerabilities?                                   |         |
-| Change the database schema?                                     |         |
-| Alter the API?                                                  |         |
+| Fix security vulnerabilities?                                   | no      |
+| Change the database schema?                                     | no      |
+| Alter the API?                                                  | yes     |
 | Require attention to configuration options?                     |         |
-| Fix problems installing or upgrading to a previous version?     |         |
-| Introduce features?                                             |         |
-| Fix bugs?                                                       |         |
+| Fix problems installing or upgrading to a previous version?     | no      |
+| Introduce features?                                             | yes     |
+| Fix bugs?                                                       | yes     |
 
 ## <a name="features"></a>Features
 

--- a/release-notes/5.46.0.md
+++ b/release-notes/5.46.0.md
@@ -117,7 +117,7 @@ Released February 2, 2022
 
 - **SearchKit - Allow functions in the WHERE clause ([22241](https://github.com/civicrm/civicrm-core/pull/22241))**
 
-- **SearchKit - Import/Export saved search configuration ([22229](https://github.com/civicrm/civicrm-core/pull/22229))**ß
+- **SearchKit - Import/Export saved search configuration ([22229](https://github.com/civicrm/civicrm-core/pull/22229))**
 
 - **SearchKit - Facilitate popup forms ([22490](https://github.com/civicrm/civicrm-core/pull/22490))**
 

--- a/release-notes/5.46.0.md
+++ b/release-notes/5.46.0.md
@@ -29,57 +29,57 @@ Released February 3, 2022
 
 ## <a name="bugs"></a>Bugs resolved
 
-- **dev/financial#57 Hide recur trxn_id if it matches recur processor_id ([21916](https://github.com/civicrm/civicrm-core/pull/21916))**
+- **(dev/financial#57) Hide recur trxn_id if it matches recur processor_id ([21916](https://github.com/civicrm/civicrm-core/pull/21916))**
 
-- **dev/report#90 - Don't crash search_kit on upgrade from 5.35 ([22375](https://github.com/civicrm/civicrm-core/pull/22375))**
+- **(dev/report#90) Don't crash SearchKit on upgrade from 5.35 ([22375](https://github.com/civicrm/civicrm-core/pull/22375))**
 
-- **fixes report#93: SearchKit shows broken external URLs ([22437](https://github.com/civicrm/civicrm-core/pull/22437))**
+- **(dev/report#93) SearchKit shows broken external URLs ([22437](https://github.com/civicrm/civicrm-core/pull/22437))**
 
-- **dev/drupal#169 - Fix namespacing in kcfinder ([338](https://github.com/civicrm/civicrm-packages/pull/338))**
+- **(dev/drupal#169) Fix namespacing in KCFinder ([338](https://github.com/civicrm/civicrm-packages/pull/338))**
 
-- **dev/drupal#172 - module status used incorrectly in drupal 8 to determine which modules to care about for managed entities ([22350](https://github.com/civicrm/civicrm-core/pull/22350))**
+- **(dev/drupal#172) Module status used incorrectly in Drupal 8 to determine which modules to care about for managed entities ([22350](https://github.com/civicrm/civicrm-core/pull/22350))**
 
-- **dev/drupal#172 - Deprecated function call in Drupal 9.3 ([22337](https://github.com/civicrm/civicrm-core/pull/22337))**
+- **(dev/drupal#172) Deprecated function call in Drupal 9.3 ([22337](https://github.com/civicrm/civicrm-core/pull/22337))**
 
 ### Core CiviCRM
 
-- **dev/core#567 Add test shell ([22275](https://github.com/civicrm/civicrm-core/pull/22275))**
+- **(dev/core#567) Add test shell ([22275](https://github.com/civicrm/civicrm-core/pull/22275))**
 
-- **(dev/core#1615) wp-cli - Perform CLI installations using Civi\Setup ([264](https://github.com/civicrm/civicrm-wordpress/pull/264))**
+- **(dev/core#1615) WP-CLI - Perform CLI installations using Civi\Setup ([264](https://github.com/civicrm/civicrm-wordpress/pull/264))**
 
-- **dev/core#2752 Allow financial_trxns to be viewed ([21178](https://github.com/civicrm/civicrm-core/pull/21178))**
+- **(dev/core#2752) Allow financial_trxns to be viewed ([21178](https://github.com/civicrm/civicrm-core/pull/21178))**
 
-- **dev/core#2752  Use acl, not blanket permissions on FinancialAccount, FinancialType, EntityFinancialAccount ([21181](https://github.com/civicrm/civicrm-core/pull/21181))**
+- **(dev/core#2752)  Use ACL, not blanket permissions on FinancialAccount, FinancialType, EntityFinancialAccount ([21181](https://github.com/civicrm/civicrm-core/pull/21181))**
 
-- **dev/core#2773 Add an ACL to demo data ([22377](https://github.com/civicrm/civicrm-core/pull/22377))**
+- **(dev/core#2773) Add an ACL to demo data ([22377](https://github.com/civicrm/civicrm-core/pull/22377))**
 
-- **dev/core#2825 - Make source contact required for activities on the form ([22243](https://github.com/civicrm/civicrm-core/pull/22243))**
+- **(dev/core#2825) Make source contact required for activities on the form ([22243](https://github.com/civicrm/civicrm-core/pull/22243))**
 
-- **dev/core#2927 - Avoid warnings for is_dir() when open_basedir is in effect ([22107](https://github.com/civicrm/civicrm-core/pull/22107))**
+- **(dev/core#2927) Avoid warnings for is_dir() when open_basedir is in effect ([22107](https://github.com/civicrm/civicrm-core/pull/22107))**
 
-- **(dev/core#2962) get contact id for the mailing along with display nam… ([22096](https://github.com/civicrm/civicrm-core/pull/22096))**
+- **(dev/core#2962) Get contact ID for the mailing along with display nam… ([22096](https://github.com/civicrm/civicrm-core/pull/22096))**
 
-- **dev/core#2977 - For custom group creation, flip the default display settings ([22244](https://github.com/civicrm/civicrm-core/pull/22244))**
+- **(dev/core#2977) For custom group creation, flip the default display settings ([22244](https://github.com/civicrm/civicrm-core/pull/22244))**
 
-- **(dev/core#2979) remove the limit of 15 max values for multiple values… ([22214](https://github.com/civicrm/civicrm-core/pull/22214))**
+- **(dev/core#2979) Remove the limit of 15 max values for multiple values… ([22214](https://github.com/civicrm/civicrm-core/pull/22214))**
 
-- **dev/core#2982 - Deprecated warnings for money formatting in Repeat Contributions CiviReport ([22217](https://github.com/civicrm/civicrm-core/pull/22217))**
+- **(dev/core#2982) Deprecated warnings for money formatting in Repeat Contributions CiviReport ([22217](https://github.com/civicrm/civicrm-core/pull/22217))**
 
-- **dev/core#2984 - Clarify API error when component is disabled ([22231](https://github.com/civicrm/civicrm-core/pull/22231))**
+- **(dev/core#2984) Clarify API error when component is disabled ([22231](https://github.com/civicrm/civicrm-core/pull/22231))**
 
-- **dev/core#2996 Increment php recommndations ([22265](https://github.com/civicrm/civicrm-core/pull/22265))**
+- **(dev/core#2996) Increment PHP recommndations ([22265](https://github.com/civicrm/civicrm-core/pull/22265))**
 
-- **dev/core#3001 escape single quotes when rendering tokens in html format ([22387](https://github.com/civicrm/civicrm-core/pull/22387))**
+- **(dev/core#3001) Escape single quotes when rendering tokens in html format ([22387](https://github.com/civicrm/civicrm-core/pull/22387))**
 
-- **dev/core#3001 escape single quotes when rendering tokens in html format ([22285](https://github.com/civicrm/civicrm-core/pull/22285))**
+- **(dev/core#3001) Escape single quotes when rendering tokens in html format ([22285](https://github.com/civicrm/civicrm-core/pull/22285))**
 
 - **(dev/core#3012) Expose email on hold as filter for report ([22357](https://github.com/civicrm/civicrm-core/pull/22357))**
 
-- **dev/core#3026 - 5.46 version of 22478 ([22479](https://github.com/civicrm/civicrm-core/pull/22479))**
+- **(dev/core#3026) 5.46 version of 22478 ([22479](https://github.com/civicrm/civicrm-core/pull/22479))**
 
-- **dev/core#3028 - For invalid greetings, return '' instead of failing ([22650](https://github.com/civicrm/civicrm-core/pull/22650))**
+- **(dev/core#3028) For invalid greetings, return '' instead of failing ([22650](https://github.com/civicrm/civicrm-core/pull/22650))**
 
-- **[dev/core#3029] Avoid risking a TypeError when evaluating tokens for non-existent custom fields ([22537](https://github.com/civicrm/civicrm-core/pull/22537))**
+- **(dev/core#3029) Avoid risking a TypeError when evaluating tokens for non-existent custom fields ([22537](https://github.com/civicrm/civicrm-core/pull/22537))**
 
 - **Extensions - Add dependency status check ([22640](https://github.com/civicrm/civicrm-core/pull/22640))**
 
@@ -95,7 +95,7 @@ Released February 3, 2022
 
 - **APIv4 - Set default status when creating GroupContact record ([22322](https://github.com/civicrm/civicrm-core/pull/22322))**
 
-- **Apiv4 - Make Groups a managed entity, fix 'null' bugs in BAO_Group ([22228](https://github.com/civicrm/civicrm-core/pull/22228))**
+- **APIv4 - Make Groups a managed entity, fix 'null' bugs in BAO_Group ([22228](https://github.com/civicrm/civicrm-core/pull/22228))**
 
 - **APIv4 - Set 'activity_type_id' to required ([22359](https://github.com/civicrm/civicrm-core/pull/22359))**
 
@@ -135,7 +135,7 @@ Released February 3, 2022
 
 - **Add system status check for missing dedupe rules ([22369](https://github.com/civicrm/civicrm-core/pull/22369))**
 
-- **Use new money formatting util for smarty formatting ([22309](https://github.com/civicrm/civicrm-core/pull/22309))**
+- **Use new money formatting util for Smarty formatting ([22309](https://github.com/civicrm/civicrm-core/pull/22309))**
 
 - **Improve accessibility - associate label and fields ([22361](https://github.com/civicrm/civicrm-core/pull/22361))**
 
@@ -171,7 +171,7 @@ Released February 3, 2022
 
 - **Add system status warning to display scheduled job failures ([21762](https://github.com/civicrm/civicrm-core/pull/21762))**
 
-- **Fix input type for smarty number formatting (more forgiving)
+- **Fix input type for Smarty number formatting (more forgiving)
   ([22429](https://github.com/civicrm/civicrm-core/pull/22429))**
 
 - **Ensure getDuplicateContacts always returns an array
@@ -189,7 +189,7 @@ Released February 3, 2022
 - **Do not escape showHideBlocks by default
   ([22371](https://github.com/civicrm/civicrm-core/pull/22371))**
 
-- **Fix notices on acl page
+- **Fix notices on ACL page
   ([22370](https://github.com/civicrm/civicrm-core/pull/22370))**
 
 - **Fix PropertyBag setRecurInstallments to accept 0
@@ -234,7 +234,7 @@ Released February 3, 2022
 - **Do not default-escape weight field on order
   ([22256](https://github.com/civicrm/civicrm-core/pull/22256))**
 
-- **Move require_once for smarty modifier due to order issues
+- **Move require_once for Smarty modifier due to order issues
   ([22252](https://github.com/civicrm/civicrm-core/pull/22252))**
 
 - **Contact/BAO/Query.php: fix searching for whitespace
@@ -252,7 +252,7 @@ Released February 3, 2022
 - **[Smarty variables] remove isset from merge screen
   ([22193](https://github.com/civicrm/civicrm-core/pull/22193))**
 
-- **[Smarty variables] Fix overzealous escaping with smarty default escaping
+- **[Smarty variables] Fix overzealous escaping with Smarty default escaping
   ([22194](https://github.com/civicrm/civicrm-core/pull/22194))**
 
 - **[Smarty variables]  Remove issets relating to auto_renew
@@ -264,7 +264,7 @@ Released February 3, 2022
 - **Smarty modifier - stop using isset to check taxTerm
   ([22323](https://github.com/civicrm/civicrm-core/pull/22323))**
 
-- **E-notice fix (smarty)
+- **E-notice fix (Smarty)
   ([22308](https://github.com/civicrm/civicrm-core/pull/22308))**
 
 ## CiviCampaign
@@ -331,7 +331,7 @@ Released February 3, 2022
 - **Remove handling for always-truthy var being false
   ([22260](https://github.com/civicrm/civicrm-core/pull/22260))**
 
-- **Remove unnecessary id attribute.
+- **Remove unnecessary ID attribute.
   ([22347](https://github.com/civicrm/civicrm-core/pull/22347))**
 
 - **Remove never passed variables
@@ -367,53 +367,53 @@ Released February 3, 2022
 - **(REF) CRM/Upgrade - Remove unused entrypoint `verifyPreDBstate()`
   ([22237](https://github.com/civicrm/civicrm-core/pull/22237))**
 
-- **[REF] Remove more params that are unused now function is not shared
+- **(REF) Remove more params that are unused now function is not shared
   ([22261](https://github.com/civicrm/civicrm-core/pull/22261))**
 
-- **[REF] Duplicate function to allow us to work it out of the code
+- **(REF) Duplicate function to allow us to work it out of the code
   ([22254](https://github.com/civicrm/civicrm-core/pull/22254))**
 
-- **[REF] Minor parameter simplification
+- **(REF) Minor parameter simplification
   ([22253](https://github.com/civicrm/civicrm-core/pull/22253))**
 
-- **[REF] Add in getVersion override for Drupal 8/9 to support cv testing and
+- **(REF) Add in getVersion override for Drupal 8/9 to support cv testing and
   also cv vars:show picking up the right CMS version
   ([22220](https://github.com/civicrm/civicrm-core/pull/22220))**
 
-- **[Ref] Add getter for priceSetID and use full form flow
+- **(REF) Add getter for priceSetID and use full form flow
   ([22267](https://github.com/civicrm/civicrm-core/pull/22267))**
 
-- **[REF] Afform - Use APIv4 for managed dashboard
+- **(REF) Afform - Use APIv4 for managed dashboard
   ([22213](https://github.com/civicrm/civicrm-core/pull/22213))**
 
-- **[REF] Remove handling for relationshipID
+- **(REF) Remove handling for relationshipID
   ([22391](https://github.com/civicrm/civicrm-core/pull/22391))**
 
-- **REF - Use `CRM_Contact_BAO_ContactType::basicTypes()` instead of hardcoded
+- **(REF) Use `CRM_Contact_BAO_ContactType::basicTypes()` instead of hardcoded
   lists ([22389](https://github.com/civicrm/civicrm-core/pull/22389))**
 
-- **[REF] move code into the function
+- **(REF) Move code into the function
   ([22288](https://github.com/civicrm/civicrm-core/pull/22288))**
 
-- **[REF] Remove now non-variable variables from previously shared code
+- **(REF) Remove now non-variable variables from previously shared code
   ([22284](https://github.com/civicrm/civicrm-core/pull/22284))**
 
-- **[REF] Duplicate & unshare processFormContribution
+- **(REF) Duplicate & unshare processFormContribution
   ([22276](https://github.com/civicrm/civicrm-core/pull/22276))**
 
-- **[REF] Stop passing this as form, set in function
+- **(REF) Stop passing this as form, set in function
   ([22287](https://github.com/civicrm/civicrm-core/pull/22287))**
 
-- **[REF] Deprecated old getContributionStatuses
+- **(REF) Deprecated old getContributionStatuses
   ([22345](https://github.com/civicrm/civicrm-core/pull/22345))**
 
-- **[REF] Simplify getContributionStatuses
+- **(REF) Simplify getContributionStatuses
   ([22280](https://github.com/civicrm/civicrm-core/pull/22280))**
 
-- **[REF] Upgrade JQuery UI to 1.13.0
+- **(REF) Upgrade jQuery UI to 1.13.0
   ([22583](https://github.com/civicrm/civicrm-core/pull/22583))**
 
-- **[REF] Further cleanup on employer create
+- **(REF) Further cleanup on employer create
   ([22390](https://github.com/civicrm/civicrm-core/pull/22390))**
 
 - **HookTest - Fix execution on PHP 8
@@ -434,34 +434,34 @@ Released February 3, 2022
 - **(NFC) Cleanup test class
   ([22384](https://github.com/civicrm/civicrm-core/pull/22384))**
 
-- **[NFC] - Try to work around failing tests
+- **(NFC) Try to work around failing tests
   ([22269](https://github.com/civicrm/civicrm-core/pull/22269))**
 
-- **[NFC] Cleanup in Authorize.net test class
+- **(NFC) Cleanup in Authorize.net test class
   ([22272](https://github.com/civicrm/civicrm-core/pull/22272))**
 
-- **[NFC] isDir unit test fails on php 7 'min' matrix
+- **(NFC) isDir unit test fails on PHP 7 'min' matrix
   ([22418](https://github.com/civicrm/civicrm-core/pull/22418))**
 
 - **(NFC) APIv4: Add help info for multi-record custom field sets
   ([22257](https://github.com/civicrm/civicrm-core/pull/22257))**
 
-- **[NFC] Test cleanup
+- **(NFC) Test cleanup
   ([22251](https://github.com/civicrm/civicrm-core/pull/22251))**
 
-- **[NFC] Minor cleanup in test class
+- **(NFC) Minor cleanup in test class
   ([22249](https://github.com/civicrm/civicrm-core/pull/22249))**
 
-- **NFC - Cleanup messy boilerplate
+- **(NFC) Cleanup messy boilerplate
   ([22224](https://github.com/civicrm/civicrm-core/pull/22224))**
 
-- **NFC - Delete boilerplate comments and empty functions from upgrade classes
+- **(NFC) Delete boilerplate comments and empty functions from upgrade classes
   ([22226](https://github.com/civicrm/civicrm-core/pull/22226))**
 
-- **[NFC] CRM_Core_Exception incorrectly called without message
+- **(NFC) CRM_Core_Exception incorrectly called without message
   ([22339](https://github.com/civicrm/civicrm-core/pull/22339))**
 
-- **[NFC] docblock improvements to Import_Field classes
+- **(NFC) Docblock improvements to Import_Field classes
   ([22360](https://github.com/civicrm/civicrm-core/pull/22360))**
 
 ## <a name="credits"></a>Credits


### PR DESCRIPTION
Overview
----------------------------------------

This is another pass at the release notes for 5.46. It includes a few tiny edits (the first 3 commits) and then one big automated edit (the last commit; generated by https://gist.github.com/totten/acff49e6dd77947349a1df26d5002003).

Comments
----------------------------------------

@agh1 @alifrumin I wasn't sure if #22678 implied that there would be a second pass, but we're close to release-time, so I ran some pro-forma search/replace as another pass. It's just some superficial changes - nowhere near as good as the copyediting (categorization/crosslinks/etc) that y'all do.

If you do have another branch in-progress, please continue and send it up. They might not get into the `5.46.0` tag per se, but they'll be visible for web-users and future tarballs. (If there are any conflicts with this branch, just ignore/discard/override anything I've done. It's easy to re-run the auto-cleanup.)