### PR TITLE
Fix dedupe check to not require elevated permissions

### DIFF
--- a/CRM/Utils/Check/Component/DedupeRules.php
+++ b/CRM/Utils/Check/Component/DedupeRules.php
@@ -22,7 +22,7 @@ class CRM_Utils_Check_Component_DedupeRules extends CRM_Utils_Check_Component {
    * @return string[]
    */
   private static function getContactTypesForRule($used) {
-    $dedupeRules = \Civi\Api4\DedupeRuleGroup::get()
+    $dedupeRules = \Civi\Api4\DedupeRuleGroup::get(FALSE)
       ->addSelect('contact_type')
       ->addGroupBy('contact_type')
       ->addWhere('used', '=', $used)


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3055

Overview
----------------------------------------
If you allow a non-admin user to run `System.check` (as I do in [Megaphone Monitoring](https://github.com/MegaphoneJon/com.megaphonetech.monitoring/blob/master/monitoring.php#L9)) then the API call fails on 5.46 due to the new "dedupe rule group" check.

Before
----------------------------------------
`Authorization Failed`.

After
----------------------------------------
API call is successful.

Comments
----------------------------------------
Since Dedupe Rule Group data isn't sensitive, and most folks would need "Administer CiviCRM" to run this check, bypassing the permission check feels like an innocuous change.

Pinging @braders as the author of the check to ensure they don't see anything objectionable in this.
