### PR TITLE
Enotice fix with priceset template

### DIFF
--- a/CRM/Price/Page/Set.php
+++ b/CRM/Price/Page/Set.php
@@ -109,6 +109,7 @@ class CRM_Price_Page_Set extends CRM_Core_Page {
     );
 
     // assign vars to templates
+    $this->assign('usedBy', FALSE);
     $this->assign('action', $action);
     $sid = CRM_Utils_Request::retrieve('sid', 'Positive',
       $this, FALSE, 0


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix with priceset template

Before
----------------------------------------
A PHP notice was thrown on the pricesets template (civicrm/admin/price). 

After
----------------------------------------
A default template variable is set, no notice occurs.

Comments
----------------------------------------
In this case it seemed best to set the default value early in the `run` method, and allow it to be later overwritten for the 1 fairly specific case where it is used.
