### PR TITLE
Don't throw PHP notice when rendering dedupefind template.

### DIFF
--- a/CRM/Contact/Form/DedupeFind.php
+++ b/CRM/Contact/Form/DedupeFind.php
@@ -41,9 +41,11 @@ class CRM_Contact_Form_DedupeFind extends CRM_Admin_Form {
     $groupList = ['' => ts('- All Contacts -')] + CRM_Core_PseudoConstant::nestedGroup();
 
     $this->add('select', 'group_id', ts('Select Group'), $groupList, FALSE, ['class' => 'crm-select2 huge']);
-    if (Civi::settings()->get('dedupe_default_limit')) {
-      $this->add('text', 'limit', ts('No of contacts to find matches for '));
-    }
+    $this->add('text', 'limit', ts('No of contacts to find matches for '));
+
+    // To improve usability for smaller sites, we don't show the limit field unless a default limit has been set.
+    $this->assign('limitShown', (bool) Civi::settings()->get('dedupe_default_limit'));
+
     $this->addButtons([
       [
         'type' => 'next',

--- a/templates/CRM/Contact/Form/DedupeFind.tpl
+++ b/templates/CRM/Contact/Form/DedupeFind.tpl
@@ -20,10 +20,12 @@
        <td class="label">{$form.group_id.label}</td>
        <td>{$form.group_id.html}</td>
      </tr>
-       <tr class="crm-dedupe-find-form-block-limit">
-        <td class="label">{$form.limit.label}</td>
-        <td>{$form.limit.html}</td>
-       </tr>
+     {if $limitShown}
+        <tr class="crm-dedupe-find-form-block-limit">
+          <td class="label">{$form.limit.label}</td>
+          <td>{$form.limit.html}</td>
+        </tr>
+      {/if}
    </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Don't throw PHP notice when rendering dedupefind template.

Before
----------------------------------------
A number of notices occured from the Smarty template when finding duplicate contacts:

<img width="1440" alt="Screenshot 2022-02-05 at 13 27 50" src="https://user-images.githubusercontent.com/1931323/152644074-4c33cff5-b603-4a6f-a73f-d2f7dd3d4387.png">

_These only occur if no default dedupe limit `dedupe_default_limit` is set_

After
----------------------------------------
The notices related to the limit field no longer occur. (Note there is still a `Undefined index: gid`, which appears to be coming from a slightly different template).

Technical Details
----------------------------------------
I was slightly confused by the logic around when the "No of contacts to find matches for" should be shown. It appears that it is only shown if a default limit is set, presumably in order to avoid showing unnecessary fields to administrators of smaller networks.

The visibility is now controlled by a new template variable `limitShown`, which uses the same logic as is currently in place. One benefit of this change is that it is now possible for site owners to ensure the limit field is shown or hidden regardless of the global setting, by setting the `limitShown` variable within `hook_civicrm_buildForm`.
