### PR TITLE
Improve field accessibility in legacycustomsearches

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -308,7 +308,7 @@ WHERE      t.table_name = 'Activity' AND
       }
     }
 
-    $form->add('select', 'table', ts('Tables'), $tables);
+    $form->add('select', 'table', ts('in...'), $tables);
 
     $form->assign('csID', $form->get('csid'));
 

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -14,11 +14,11 @@
       <table class="form-layout-compressed">
         <tr>
           <td>
-            <label>{$form.text.label}</label>
+            {$form.text.label}
             {$form.text.html}
           </td>
           <td>
-            <label>{ts}in...{/ts}</label>
+            {$form.table.label}
             {$form.table.html}
           </td>
           <td>{$form.buttons.html} {help id="id-fullText"}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Improve field accessibility in legacycustomsearches

Before
----------------------------------------

1. First label was double nested (`<label><label>...</label></label>`)
2. Second field had no accessible label

After
----------------------------------------
Accessibility improved.

Comments
----------------------------------------
I appreciate that the legacy searches are on their way out, but it felt appropriate to fix as its such a small change.
