### PR TITLE
Title as label rather than [object object] on card icons

### DIFF
--- a/templates/CRM/Core/BillingBlock.js
+++ b/templates/CRM/Core/BillingBlock.js
@@ -10,7 +10,7 @@
   function civicrm_billingblock_creditcard_helper() {
     $(function() {
       $.each(CRM.config.creditCardTypes, function(key, val) {
-        var html = '<a href="#" data-card_type=" + key + " title="' + val + '" class="crm-credit_card_type-icon-' + val.css_key + '"><span>' + val.label + '</span></a>';
+        var html = '<a href="#" data-card_type=" + key + " title="' + val.label + '" class="crm-credit_card_type-icon-' + val.css_key + '"><span>' + val.label + '</span></a>';
         $('.crm-credit_card_type-icons').append(html);
 
         $('.crm-credit_card_type-icon-' + val.css_key).click(function() {


### PR DESCRIPTION
Overview
----------------------------------------
Use the label for the `title` attribute rather than `[object object]` when rendering credit card icons on payment forms.

Before
----------------------------------------
On hovering over a credit card icon, you currently see this, due to some bad JS:

<img width="353" alt="Screenshot 2022-02-05 at 17 01 05" src="https://user-images.githubusercontent.com/1931323/152651200-0b1c3288-ef56-4a41-9e5c-b88cf80e6b7d.png">


After
----------------------------------------
The card provider label is used instead (Visa, AMEX etc)
