### PR TITLE
dev/core#3056 - Crash with search builder if civigrant not enabled and have admin rights

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -148,6 +148,14 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
   protected $_openedPanes = [];
 
+  public function __construct($state = NULL, $action = CRM_Core_Action::NONE, $method = 'post', $name = NULL) {
+    parent::__construct($state, $action, $method, $name);
+    // Because this is a static variable, reset it in case it got changed elsewhere.
+    // Should only come up during unit tests.
+    // Note the only subclass that seems to set this does it in preprocess (custom searches)
+    self::$_selectorName = 'CRM_Contact_Selector';
+  }
+
   /**
    * Explicitly declare the entity api name.
    */

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -760,7 +760,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Test\Ho
       }
     }
     if (($mappingType == 'Search Builder') || ($exportMode == CRM_Export_Form_Select::GRANT_EXPORT)) {
-      if (CRM_Core_Permission::check('access CiviGrant')) {
+      if (method_exists('CRM_Grant_BAO_Grant', 'exportableFields') && CRM_Core_Permission::check('access CiviGrant')) {
         $fields['Grant'] = CRM_Grant_BAO_Grant::exportableFields();
         unset($fields['Grant']['grant_contact_id']);
         if ($mappingType == 'Search Builder') {

--- a/tests/phpunit/CRM/Core/InvokeTest.php
+++ b/tests/phpunit/CRM/Core/InvokeTest.php
@@ -51,4 +51,18 @@ class CRM_Core_InvokeTest extends CiviUnitTestCase {
     ob_end_clean();
   }
 
+  public function testOpeningSearchBuilder(): void {
+    $_SERVER['REQUEST_URI'] = 'civicrm/contact/search/builder?reset=1';
+    $_GET['q'] = 'civicrm/contact/search/builder';
+    $_GET['reset'] = 1;
+
+    $item = CRM_Core_Invoke::getItem([$_GET['q']]);
+    ob_start();
+    CRM_Core_Invoke::runItem($item);
+    $contents = ob_get_clean();
+
+    unset($_GET['reset']);
+    $this->assertRegExp('/form.+id="Builder" class="CRM_Contact_Form_Search_Builder/', $contents);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3056

Search Builder, as in Search -> Search Builder (civicrm/contact/search/builder), crashes if CiviGrant not enabled and you are an admin or have access CiviGrant permission still.

Before
----------------------------------------
1. Disable the CiviGrant extension if not already disabled.
1. Log in as e.g. drupal user 1
1. Go to search builder, or try to edit the criteria you have for an existing smart group based on search builder.
1. Error: Class 'CRM_Grant_BAO_Grant' not found in CRM_Core_BAO_Mapping::addComponentFields() (line 764 of ...\CRM\Core\BAO\Mapping.php).

After
----------------------------------------
Ok

Technical Details
----------------------------------------
CiviGrant was moved to an extension in 5.47. Search builder still references it.

Comments
----------------------------------------
It looks like 5.47 hasn't branched yet so putting against master. I'll rebase if it branches first.