### PR TITLE
[NFC] Batch entry - Avoid warnings when performing math on empty string.

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -425,7 +425,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
 
     $batchTotal = 0;
     foreach ($params['field'] as $key => $value) {
-      $batchTotal += $value['total_amount'];
+      $batchTotal += ($value['total_amount'] ?: 0);
 
       //validate for soft credit fields
       if (!empty($params['soft_credit_contact_id'][$key]) && empty($params['soft_credit_amount'][$key])) {


### PR DESCRIPTION
Overview
----------------------------------------
Cast value to int before performing math on batch data entry screen. This avoids a PHP warning if one or more of the rows have been accedentially missed.

Before
----------------------------------------
If one or more rows are missing an amount then PHP warnings occur:

<img width="1129" alt="Screenshot 2022-02-06 at 17 22 13" src="https://user-images.githubusercontent.com/1931323/152692914-e0d9f75a-2307-419c-aea6-144e3c619d4e.png">

After
----------------------------------------
No PHP warning occurs. Validation still works as expected.