### PR TITLE
dev/core#3057 - Fix missing civigrant

### DIFF
--- a/distmaker/core-ext.txt
+++ b/distmaker/core-ext.txt
@@ -6,6 +6,7 @@
 
 afform
 authx
+civigrant
 contributioncancelactions
 ckeditor4
 eventcart

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-11-11</releaseDate>
-  <version>5.47</version>
+  <version>5.47.beta1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.47</ver>

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -211,7 +211,6 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
         'Event',
         'Participant',
         'Friend',
-        'Grant',
         'Mailing',
         'Membership',
         'MembershipBlock',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3057

Before
----------------------------------------
* civigrant is missing from the 5.47 tarball
* the testGetSiteStats should have been failing in master the last month, but because alpha sites are excluded from full stats it wasn't noticed. Now that 5.47 is beta it comes up.
* an update to info.xml was missed in the branching to 5.47

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
Assuming this is merged, then after it's upmerged will need another PR to update info.xml for master.
