### PR TITLE
Fix regression with flexible merging of contact information

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2750,6 +2750,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
         // Add this value to the table rows
         $rows["move_location_{$blockName}_{$count}"]['other'] = $displayValue;
+        $rows["move_location_{$blockName}_{$count}"]['location_entity'] = $blockName;
 
         // CRM-17556 Only display 'main' contact value if it's the same location + type
         // Look it up from main values...
@@ -2777,7 +2778,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
               // Set this value as the default against the 'other' contact value
               $rows["move_location_{$blockName}_{$count}"]['main'] = $mainValueCheck[$blockInfo['displayField']];
               $rows["move_location_{$blockName}_{$count}"]['main_is_primary'] = $mainValueCheck['is_primary'] ?? 0;
-              $rows["move_location_{$blockName}_{$count}"]['location_entity'] = $blockName;
               $mainContactBlockId = $mainValueCheck['id'];
               break;
             }


### PR DESCRIPTION
Overview
----------------------------------------

Ping @eileenmcnaughton 

The merging screen should allow users to check contact information already on the 'master' record, when taking across values from the 'other'.

This allows users to check what information already exists, and set the new information as 'primary' or as a different 'type' if required.

This commit https://github.com/civicrm/civicrm-core/commit/86b14b5914cd8966b7a878ec9f7599d5b41651b7 caused a regression whereby the drop-down menus to browse contact information on the 'master' record are not shown if there is not a matching piece of contact information on the 'master' record.

This can be fixed with a simple move of one line of code - setting the location entity type regardless of whether there are values present on the master record.

This is difficult to implement tests for because it is not part of the merging logic itself, but part of the hideous legacy logic which builds the merging form - which doesn't have any test coverage at the moment (and makes heavy use of JS).

Before
----------------------------------------

No drop-downs displayed, if the master record doesn't have matching contact info (eg: 'Home email' on other record, 'Work email' on master record).

![image](https://user-images.githubusercontent.com/5212601/152784036-0d9f661c-9fb4-43f0-a8dd-aa9a8147d284.png)

After
----------------------------------------

Drop-downs are displayed correctly, allowing users to browse contact information, and change type / set primary where needed.

![image](https://user-images.githubusercontent.com/5212601/152784300-6241a60f-4609-412e-ba8a-48679ae73515.png)


