### PR TITLE
dev/core#3057 - follow-up to fix civigrant info.xml version number in master

### DIFF
--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-11-11</releaseDate>
-  <version>5.47.beta1</version>
+  <version>5.48.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.47</ver>


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3057 and https://github.com/civicrm/civicrm-core/pull/22717
