### PR TITLE
Avoid null column showing on groups search page

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -91,7 +91,7 @@
       <th data-data="description" data-orderable="false" cell-class="crm-group-description crmf-description {$editableClass}" class='crm-group-description'>{ts}Description{/ts}</th>
       <th data-data="group_type" cell-class="crm-group-group_type" class='crm-group-group_type'>{ts}Group Type{/ts}</th>
       <th data-data="visibility" cell-class="crm-group-visibility crmf-visibility {$editableClass}" cell-data-type="select" class='crm-group-visibility'>{ts}Visibility{/ts}</th>
-      {if !empty($showOrgInfo)}
+      {if $showOrgInfo}
         <th data-data="org_info" data-orderable="false" cell-class="crm-group-org_info" class='crm-group-org_info'>{ts}Organization{/ts}</th>
       {/if}
       <th data-data="links" data-orderable="false" cell-class="crm-group-group_links" class='crm-group-group_links'>&nbsp;</th>
@@ -186,7 +186,7 @@
     // show hide children
     var context = $('#crm-main-content-wrapper');
     $('table.crm-group-selector', context).on( 'click', 'span.show-children', function(){
-      var showOrgInfo = {/literal}{if $showOrgInfo}"{$showOrgInfo}"{else}"0"{/if}{literal};
+      var showOrgInfo = {/literal}{if $showOrgInfo}true{else}false{/if}{literal};
       var rowID = $(this).parents('tr').prop('id');
       var parentRow = rowID.split('_');
       var parent_id = parentRow[1];


### PR DESCRIPTION
Overview
----------------------------------------
Avoid null column showing on groups search page.

Before
----------------------------------------
Currently, if you setup a child group (e.g. a mailing group) and then try to view that group, an extra column is shown with the text content "null". For example, as seen on dmaster:

<img width="1043" alt="Screenshot 2022-02-07 at 20 20 28" src="https://user-images.githubusercontent.com/1931323/152865354-30fae2a1-f356-492e-b32b-e3dc71ffd91e.png">


After
----------------------------------------
The extra "null" column does not appear:

<img width="1033" alt="Screenshot 2022-02-07 at 20 24 56" src="https://user-images.githubusercontent.com/1931323/152866058-6d92ae19-fab0-43e7-8df0-eb50cc5ac7a2.png">

Technical Details
----------------------------------------
The group search page had some JavaScript checking whether "0" or "1" were truthy. As both were strings both were truthy. Therefore, now a proper boolean is used which works correctly.

Comments
----------------------------------------
I belive the extra column is intended to show the organisation in a multisite setup. I don't have such a site to hand to test with, so whilst I'm reasonably confident it might be nice for someone to sense-check it all looks good from that angle.

I've also removed the `empty()` check whilst I'm here as it's problamatic with the new escaping mode. `$showOrgInfo` appears to always be set to either `true` or `false`.
