### PR TITLE
dev/core#3058 Fix missing offline Membership Renewal PDF invoice

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -627,7 +627,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         'membership_id' => $membership->id,
         'contribution_recur_id' => $contributionRecurID,
       ]);
-      CRM_Member_BAO_Membership::recordMembershipContribution($temporaryParams);
+      $contribution = CRM_Member_BAO_Membership::recordMembershipContribution($temporaryParams);
+      $this->_params['contribution_id'] = $contribution->id;
     }
 
     if (!empty($this->_params['send_receipt'])) {
@@ -708,6 +709,9 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         'from' => $receiptFrom,
         'toName' => $this->_contributorDisplayName,
         'toEmail' => $this->_contributorEmail,
+        'PDFFilename' => ts('receipt') . '.pdf',
+        'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
+        'contributionId' => $this->_params['contribution_id'],
         'isTest' => $this->_mode === 'test',
       ]
     );


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/3058

To reproduce:

* Enable Taxes and Invoicing (Administer > CiviContribute > CiviContribute Component Settings)
* Enable "Automatically email invoice when user purchases online"

Then go to a contact record

* Make sure the contact has an email address on their record (you probably want to update to your own email address)
* Add a Membership (without CC payment), record a payment (ex: cheque or whatever).

They should receive an email confirmation, with the invoice.pdf attached.

Now go back to their contact record, and renew the membership (again, no need for a CC payment). They will be emailed with a receipt, but the invoice.pdf will not be attached.

As a tangential issue: for taxes we have custom smarty (from the taxcalculator extension) that requires the `$contributionID` in the template. It works fine for the "offline new membership" but not for renewal, the variable is undefined.

I tried comparing the `submit` functions for `CRM/Membership/Form/Membership.php` vs `MembershipRenewal.php`, but it's not an easy one. They have a lot of similarities, but also major differences in how they process the contribution.

Before
----------------------------------------

Backend offline Membership Renewal does not attach the invoice PDF.

After
----------------------------------------

PDF attachment.

Technical Details
----------------------------------------

Fix based on the `Member.php` (offline new membership).

Comments
----------------------------------------

Had help from @eileenmcnaughton 