### PR TITLE
dev/core#3059 Regression fix - be tolerant with smarty money

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmMoney.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmMoney.php
@@ -25,9 +25,17 @@
  *
  * @return string
  *   formatted monetary amount
- *
- * @throws \CRM_Core_Exception
  */
 function smarty_modifier_crmMoney($amount, ?string $currency = NULL): string {
-  return Civi::format()->money($amount, $currency);
+  try {
+    return Civi::format()->money($amount, $currency);
+  }
+  catch (CRM_Core_Exception $e) {
+    // @todo escalate this to a deprecation notice. It turns out to be depressingly
+    // common for us to double process amount strings - if they are > 1000 then
+    // they wind up throwing an exception in the money function.
+    // It would be more correct to format in the smarty layer, only.
+    Civi::log()->warning('Invalid amount passed in as money - {money}', ['money' => $amount]);
+    return $amount;
+  }
 }

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -30,6 +30,8 @@ class Format {
    *
    * @return string
    *
+   * @throws \CRM_Core_Exception
+   *
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
    */
@@ -61,6 +63,7 @@ class Format {
    *   add any padding.
    *
    * @return string
+   * @throws \CRM_Core_Exception
    */
   public function number($amount, ?string $locale = NULL, array $attributes = [
     NumberFormatter::MIN_FRACTION_DIGITS => 0,
@@ -214,7 +217,7 @@ class Format {
     }
     // Verify the amount is a number or numeric string/object.
     // We cast to string because it can be a BigDecimal object.
-    elseif ($amount === TRUE || !is_numeric((string) $amount)) {
+    if ($amount === TRUE || !is_numeric((string) $amount)) {
       throw new \CRM_Core_Exception('Invalid value for type money');
     }
     return (string) $amount;


### PR DESCRIPTION


Overview
----------------------------------------
To replicate - create a custom field of type money - mine was against entity contribution.
Create a contribution (or whatever) with the field and give it a value greater than 1000.
Attempt to view - fatal error


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/152913887-d184df2c-817a-4772-9af3-beb3eff90cb7.png)

After
----------------------------------------
Loads

Technical Details
----------------------------------------
The issue is the php layer is formatting it to money -and the smarty does so again. By the second time a value > 999 is no longer valid (in US locale) and it fatals. I would expect this to be a problem in European locales for smaller values.

The fix makes seems comparible with the prior laxity. I have also already done an extended reports release which fixes the source issue in reports (ie formats only once...)

Comments
----------------------------------------
