### PR TITLE
Format money in custom fields once, on the tpl layer

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1918,6 +1918,7 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
               'field_data_type' => $properties['data_type'] ?? NULL,
               'field_value' => CRM_Core_BAO_CustomField::displayValue($values['data'], $properties['id'], $entityId),
               'options_per_line' => $properties['options_per_line'] ?? NULL,
+              'data' => $values['data'],
             ];
             // editable = whether this set contains any non-read-only fields
             if (!isset($details[$groupID][$values['id']]['editable'])) {

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -63,7 +63,7 @@
                       <td class="label">{$element.field_title}</td>
                       {if $element.field_data_type == 'Money'}
                         {if $element.field_type == 'Text'}
-                          <td class="html-adjust">{$element.field_value|crmMoney}</td>
+                          <td class="html-adjust">{$element.data|crmMoney}</td>
                         {else}
                           <td class="html-adjust">{$element.field_value}</td>
                         {/if}


### PR DESCRIPTION


Overview
----------------------------------------
Format money in custom fields once, on the tpl layer

Further to https://github.com/civicrm/civicrm-core/pull/22727 - this attempts to address the double formatting issue

Before
----------------------------------------
Formatted in the php layer AND the tpl layer

After
----------------------------------------
Only formatted in the tpl layer

Technical Details
----------------------------------------
This ensures the raw value is available to the template layer and uses it
rather than the formatted value for money display.

It rather feels it would be better to separate out this view use case in case
there are others hidden in there - but I think this tpl is only
used with this assign

Comments
----------------------------------------
