### PR TITLE
Add 'plural' support for the ts function in JavaScript

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -15,6 +15,9 @@ CRM._ = _;
 function ts(text, params) {
   "use strict";
   var d = (params && params.domain) ? ('strings::' + params.domain) : null;
+  if (params && params.plural && params.count > 1) {
+    text = params.plural;
+  }
   if (d && CRM[d] && CRM[d][text]) {
     text = CRM[d][text];
   }


### PR DESCRIPTION
Overview
----------------------------------------

Adds support for the `plural` argument to the `ts` function, which is also available in PHP.

Technical Details
----------------------------------------

Makes it possible to use this syntax:

```
ts('Eat %count banana?', {count: model.ids.length, plural: 'Eat %count bananas?'}) }}
```
