### PR TITLE
dev/user-interface#45 Show associated participants on contributionView form

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -94,6 +94,29 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       }
     }
 
+    $participantLineItems = \Civi\Api4\LineItem::get()
+      ->addSelect('entity_id', 'participant.role_id:label', 'participant.fee_level', 'participant.contact_id', 'contact.display_name')
+      ->addJoin('Participant AS participant', 'LEFT', ['participant.id', '=', 'entity_id'])
+      ->addJoin('Contact AS contact', 'LEFT', ['contact.id', '=', 'participant.contact_id'])
+      ->addWhere('entity_table', '=', 'civicrm_participant')
+      ->addWhere('contribution_id', '=', $id)
+      ->execute();
+
+    $associatedParticipants = FALSE;
+    if ($participantLineItems->count()) {
+      foreach ($participantLineItems as $participant) {
+        $associatedParticipants[] = [
+          'participantLink' => CRM_Utils_System::url('civicrm/contact/view/participant',
+            "action=view&reset=1&id={$participant['entity_id']}&cid={$participant['participant.contact_id']}&context=home"
+          ),
+          'participantName' => $participant['contact.display_name'],
+          'fee' => implode(', ', $participant['participant.fee_level']),
+          'role' => implode(', ', $participant['participant.role_id:label']),
+        ];
+      }
+    }
+    $this->assign('associatedParticipants', $associatedParticipants);
+
     $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', NULL, $id, 0, $values['financial_type_id'] ?? NULL,
       NULL, TRUE, NULL, FALSE, CRM_Core_Permission::VIEW);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree, FALSE, NULL, NULL, NULL, $id);

--- a/templates/CRM/Contribute/Form/ContributionView.tpl
+++ b/templates/CRM/Contribute/Form/ContributionView.tpl
@@ -87,6 +87,14 @@
         {/if}
     </td>
   </tr>
+  {if $associatedParticipants}
+    <tr>
+      <td class="label">{ts}Associated participants{/ts}</td>
+      <td>
+        {include file="CRM/Contribute/Form/ContributionViewAssociatedParticipants.tpl" associatedParticipants=$associatedParticipants}
+      </td>
+    </tr>
+  {/if}
   {if $invoicing && $tax_amount}
     <tr>
       <td class="label">{ts 1=$taxTerm}Total %1 Amount{/ts}</td>

--- a/templates/CRM/Contribute/Form/ContributionViewAssociatedParticipants.tpl
+++ b/templates/CRM/Contribute/Form/ContributionViewAssociatedParticipants.tpl
@@ -1,0 +1,16 @@
+<table>
+  <tbody>
+    <tr class="columnheader">
+      <th>{ts}Participant{/ts}</th>
+      <th>{ts}Role{/ts}</th>
+      <th>{ts}Fee{/ts}</th>
+    </tr>
+    {foreach from=$associatedParticipants item="participant"}
+      <tr>
+        <td><a href='{$participant.participantLink}'>{$participant.participantName|escape}</a></td></td>
+        <td>{$participant.role|escape}</td>
+        <td>{$participant.fee|escape}</td>
+      </tr>
+    {/foreach}
+  </tbody>
+</table>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/user-interface#45](https://lab.civicrm.org/dev/user-interface/-/issues/45#note_69360). Show associated participants on contributionView form.

As outlined on GitLab this introduces a way to navigate to participants from the contribution view:

![Screenshot_2022-02-04_at_08 53 53](https://user-images.githubusercontent.com/1931323/153079914-b13d3256-e36d-41e9-abe5-36b8069cf76b.png)

This is done by reading the associated participants from the contribution line items using API4. If this is successfully reviewed I'll consider implementing similar functionality to list the purchased membership(s) on the view contribution screen. This should make the contribution view much more useful for CiviCRM users.
