### PR TITLE
(dev/core#3055) Fix dedupe check to not require elevated permissions

### DIFF
--- a/CRM/Utils/Check/Component/DedupeRules.php
+++ b/CRM/Utils/Check/Component/DedupeRules.php
@@ -22,7 +22,7 @@ class CRM_Utils_Check_Component_DedupeRules extends CRM_Utils_Check_Component {
    * @return string[]
    */
   private static function getContactTypesForRule($used) {
-    $dedupeRules = \Civi\Api4\DedupeRuleGroup::get()
+    $dedupeRules = \Civi\Api4\DedupeRuleGroup::get(FALSE)
       ->addSelect('contact_type')
       ->addGroupBy('contact_type')
       ->addWhere('used', '=', $used)


### PR DESCRIPTION
Overview
----------------------------------------

Forward port of @MegaphoneJon's #22703 from 5.46-stable to 5.47-rc.

See: https://lab.civicrm.org/dev/core/-/issues/3055
