### PR TITLE
enforce required fields on Contact.duplicatecheck

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1602,10 +1602,16 @@ function _civicrm_api3_contact_getlist_output($result, $request) {
  * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_contact_duplicatecheck($params) {
+  if (!isset($params['match']) || !is_array($params['match'])) {
+    throw new \CiviCRM_API3_Exception('Duplicate check must include criteria to check against (missing or invalid $params[\'match\']).');
+  }
+  if (!isset($params['match']['contact_type']) || !is_string($params['match']['contact_type'])) {
+    throw new \CiviCRM_API3_Exception('Duplicate check must include a contact type. (missing or invalid $params[\'match\'][\'contact_type\'])');
+  }
   $dupes = CRM_Contact_BAO_Contact::getDuplicateContacts(
     $params['match'],
     $params['match']['contact_type'],
-    $params['rule_type'],
+    $params['rule_type'] ?? '',
     CRM_Utils_Array::value('exclude', $params, []),
     CRM_Utils_Array::value('check_permissions', $params),
     CRM_Utils_Array::value('dedupe_rule_id', $params)


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3065

Overview
----------------------------------------
Duplicate checking now requires arguments to be passed which previously were optional (at the BAO level).

Before
----------------------------------------
`cv api Contact.duplicatecheck` throws a fatal error when you don't pass required values.

After
----------------------------------------
Exceptions are thrown if you're missing match criteria or a contact type.  Rule type is once again optional.


Comments
----------------------------------------
This is a 5.46 regression; see #22394.

I checked all the other calls to `CRM_Contact_BAO_Contact::getDuplicateContacts()`.  This is the only one that can pass values that don't pass the strict type checking.