### PR TITLE
Bypass grumpy mode for contribution search totals & criteria

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionTotals.tpl
+++ b/templates/CRM/Contribute/Page/ContributionTotals.tpl
@@ -13,10 +13,10 @@
 
     {if !empty($annual.count)}
         <tr>
-            <th class="contriTotalLeft right">{ts}Current Year-to-Date{/ts} &ndash; {$annual.amount}</th>
-            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg}</th>
-            {if $contributionSummary.cancel.amount}
+            <th class="contriTotalLeft right">{ts}Current Year-to-Date{/ts} &ndash; {$annual.amount|smarty:nodefaults}</th>
+            <th class="right"> &nbsp; {ts}# Completed Contributions{/ts} &ndash; {$annual.count|smarty:nodefaults}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Avg Amount{/ts} &ndash; {$annual.avg|smarty:nodefaults}</th>
+            {if $contributionSummary.cancel.amount|smarty:nodefaults}
                 <td>&nbsp;</td>
             {/if}
         </tr>
@@ -25,16 +25,16 @@
     {if $contributionSummary }
       <tr>
           {if $contributionSummary.total.amount}
-            <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount}</th>
-            <th class="right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count}</th>
-            <th class="right contriTotalRight"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg}</th>
+            <th class="contriTotalLeft right">{ts}Total{/ts} &ndash; {$contributionSummary.total.amount|smarty:nodefaults}</th>
+            <th class="right"> &nbsp; {ts}# Completed{/ts} &ndash; {$contributionSummary.total.count|smarty:nodefaults}</th>
+            <th class="right contriTotalRight"> &nbsp; {ts}Avg{/ts} &ndash; {$contributionSummary.total.avg|smarty:nodefaults}</th>
           {/if}
-          {if $contributionSummary.cancel.amount}
-            <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount}</th>
+          {if $contributionSummary.cancel.amount|smarty:nodefaults}
+            <th class="disabled right contriTotalRight"> &nbsp; {ts}Cancelled/Refunded{/ts} &ndash; {$contributionSummary.cancel.amount|smarty:nodefaults}</th>
           {/if}
       </tr>
-      {if $contributionSummary.soft_credit.count}
-        {include file="CRM/Contribute/Page/ContributionSoftTotals.tpl" softCreditTotals=$contributionSummary.soft_credit}
+      {if $contributionSummary.soft_credit.count|smarty:nodefaults}
+        {include file="CRM/Contribute/Page/ContributionSoftTotals.tpl" softCreditTotals=$contributionSummary.soft_credit|smarty:nodefaults}
       {/if}
     {/if}
 


### PR DESCRIPTION


Overview
----------------------------------------
Bypass grumpy mode for contribution totals

These are assigned to the template from php & have nbsp in them (for better or worse)

Also, only escape criteria once

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/153310903-aa2c2fc1-2dbe-4bcb-a8e4-bb8d149c34ee.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/153311539-fc683c9b-03b3-4163-b526-3ecd78c43c30.png)

Technical Details
----------------------------------------
Assuming currencies can't be hacked this assign is secure

Comments
----------------------------------------
