### PR TITLE
(dev/core#3065) Enforce required fields on Contact.duplicatecheck (5.46)

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1602,10 +1602,16 @@ function _civicrm_api3_contact_getlist_output($result, $request) {
  * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_contact_duplicatecheck($params) {
+  if (!isset($params['match']) || !is_array($params['match'])) {
+    throw new \CiviCRM_API3_Exception('Duplicate check must include criteria to check against (missing or invalid $params[\'match\']).');
+  }
+  if (!isset($params['match']['contact_type']) || !is_string($params['match']['contact_type'])) {
+    throw new \CiviCRM_API3_Exception('Duplicate check must include a contact type. (missing or invalid $params[\'match\'][\'contact_type\'])');
+  }
   $dupes = CRM_Contact_BAO_Contact::getDuplicateContacts(
     $params['match'],
     $params['match']['contact_type'],
-    $params['rule_type'],
+    $params['rule_type'] ?? '',
     CRM_Utils_Array::value('exclude', $params, []),
     CRM_Utils_Array::value('check_permissions', $params),
     CRM_Utils_Array::value('dedupe_rule_id', $params)


### PR DESCRIPTION
Overview
----------------------------------------

Backport #22741 from 5.47-rc to 5.46-stable.

See also: https://lab.civicrm.org/dev/core/-/issues/3065