### PR TITLE
APIv4 - remove unnecessary field from System::check

### DIFF
--- a/Civi/Api4/Action/System/Check.php
+++ b/Civi/Api4/Action/System/Check.php
@@ -84,13 +84,6 @@ class Check extends \Civi\Api4\Generic\BasicGetAction {
         'data_type' => 'String',
       ],
       [
-        'name' => 'severity',
-        'title' => 'Severity',
-        'description' => 'Psr\Log\LogLevel string',
-        'data_type' => 'String',
-        'options' => array_combine(\CRM_Utils_Check::getSeverityList(), \CRM_Utils_Check::getSeverityList()),
-      ],
-      [
         'name' => 'severity_id',
         'title' => 'Severity ID',
         'description' => 'Integer representation of Psr\Log\LogLevel',
@@ -100,7 +93,7 @@ class Check extends \Civi\Api4\Generic\BasicGetAction {
       [
         'name' => 'is_visible',
         'title' => 'is visible',
-        'description' => '0 if message has been hidden by the user',
+        'description' => 'FALSE if message has been hidden by the user',
         'data_type' => 'Boolean',
       ],
       [


### PR DESCRIPTION
Overview
----------------------------------------
Following on #22730, this removes the 'severity' field from the System::check api
because it's redundant with 'severity_id:name', and does not appear to be used anywhere.

Before
----------------------------------------
Redundant field exists. Not used in core. Probably not used outside of core.

After
----------------------------------------
Removed.