### PR TITLE
Fix apiv4 Contribution delete & all line items

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -184,9 +184,14 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * DeleteContribution() method
+   * Test contributions are deleted with assets in v3 and v4 api.@\
+   *
+   * @dataProvider versionThreeAndFour
+   *
+   * @param int $version
    */
-  public function testDeleteContribution() {
+  public function testDeleteContribution(int $version): void {
+    $this->_apiversion = $version;
     $contactId = $this->individualCreate();
 
     $params = [
@@ -203,19 +208,14 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
       'total_amount' => 200.00,
       'fee_amount' => 5,
       'net_amount' => 195,
-      'trxn_id' => '33ereerwww322323',
-      'invoice_id' => '33ed39c9e9ee6ef6031621ce0eafe6da70',
-      'thankyou_date' => '20080522',
       'sequential' => TRUE,
     ];
 
     $contribution = $this->callAPISuccess('Contribution', 'create', $params)['values'][0];
 
-    CRM_Contribute_BAO_Contribution::deleteContribution($contribution['id']);
-
-    $this->assertDBNull('CRM_Contribute_DAO_Contribution', $contribution['trxn_id'],
-      'id', 'trxn_id', 'Database check for deleted Contribution.'
-    );
+    $this->callAPISuccess('Contribution', 'delete', ['id' => $contribution['id']]);
+    $this->callAPISuccessGetCount('Contribution', [], 0);
+    $this->callAPISuccessGetCount('LineItem', [], 0);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix apiv4 Contribution delete & all line items


Before
----------------------------------------
1) Api v4 Contribution.delete was bypassing the BAO delete function and not deleing related entities
2) Line items were not being reliably deleted - since it is only deleting by entity_id + entity_table. The condition would never be right for memberships & would be unreliable when line items relate to more than one type. This would be long standing & mitigated by relative rarity of deleting contributions

After
----------------------------------------
Apiv4 calls a function which cleans up related. Lineitems to delete selected by contribution_id

test, 

Technical Details
----------------------------------------
I updated the BAO::delete test to call the 2 apis. I think we probably need to start to move our crud tests out of the api specific test suites as we are testing both APIs. BAO vs a new thing - I went with BAO. I'm happy to test the BAO function via the apis rather than directly

Comments
----------------------------------------
@colemanw another one