### PR TITLE
dev/core#3063 APIv3 - Fix numeric option matching

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2085,10 +2085,10 @@ function _civicrm_api3_validate_integer(&$params, $fieldName, &$fieldInfo, $enti
       }
     }
     if (
-    (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options']) || $fieldName === 'campaign_id')
-     // if it is already numeric AND it is an FK field we don't need to validate because
-     // sql will do that for us on insert (this also saves a big lookup)
-     && (!is_numeric($fieldValue) || empty($fieldInfo['FKClassName']))
+      (!empty($fieldInfo['pseudoconstant']) || !empty($fieldInfo['options']) || $fieldName === 'campaign_id')
+      // if it is already numeric AND it is an FK field we don't need to validate because
+      // sql will do that for us on insert (this also saves a big lookup)
+      && (!is_numeric($fieldValue) || !in_array($fieldName, ['campaign_id', 'payment_processor_id']))
     ) {
       $additional_lookup_params = [];
       if (strtolower($entity) === 'address' && $fieldName == 'state_province_id') {


### PR DESCRIPTION
Backports the important bit of #22740 with a workaround to avoid the pitfalls that made it a boondoggle.

Fixes [dev/core#3063](https://lab.civicrm.org/dev/core/-/issues/3063).

Before: Option matching was skipped for all FK fields if a numeric value was given
After: Only skipped for `campaign_id` and `payment_processor_id` fields

Added `payment_processor_id` to the exception for the sake of this backport to make it pass tests.