### PR TITLE
Fixes for smarty grumpy mode with membership

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -212,6 +212,12 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
       ->addSetting(['setting' => ['monetaryDecimalPoint' => CRM_Core_Config::singleton()->monetaryDecimalPoint]]);
 
     $this->assign('defaultCurrencySymbol', CRM_Core_BAO_Country::defaultCurrencySymbol());
+    // This could be updated to TRUE in the formRule
+    $this->addExpectedSmartyVariable('batchAmountMismatch');
+    // It is unclear where this is otherwise assigned but the template expects it.
+    $this->addExpectedSmartyVariable('contactFields');
+    // The not-always-present refresh button.
+    $this->addOptionalQuickFormElement('_qf_Batch_refresh');
   }
 
   /**
@@ -462,8 +468,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     if (!empty($errors)) {
       return $errors;
     }
-
-    $self->assign('batchAmountMismatch', FALSE);
     return TRUE;
   }
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -503,6 +503,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       'skipDisplay' => 0,
       'data_type' => CRM_Utils_Type::getDataTypeFromFieldMetadata($fieldMetaData),
       'bao' => $fieldMetaData['bao'] ?? NULL,
+      'html_type' => $fieldMetaData['html']['type'] ?? NULL,
     ];
 
     $formattedField = CRM_Utils_Date::addDateMetadataToField($fieldMetaData, $formattedField);

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -159,6 +159,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
     $this->assign('context', $this->_context);
     $this->assign('membershipMode', $this->_mode);
+    $this->assign('newCredit', CRM_Core_Config::isEnabledBackOfficeCreditCardPayments());
     $this->allMembershipTypeDetails = CRM_Member_BAO_Membership::buildMembershipTypeValues($this, [], TRUE);
     foreach ($this->allMembershipTypeDetails as $index => $membershipType) {
       if ($membershipType['auto_renew']) {
@@ -237,10 +238,8 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     $this->assign('recurProcessor', json_encode($this->_recurPaymentProcessors));
     // Build the form for auto renew. This is displayed when in credit card mode or update mode.
     // The reason for showing it in update mode is not that clear.
+    $this->assign('allowAutoRenew', $this->_mode && !empty($this->_recurPaymentProcessors));
     if ($this->_mode || ($this->_action & CRM_Core_Action::UPDATE)) {
-      if (!empty($this->_recurPaymentProcessors)) {
-        $this->assign('allowAutoRenew', TRUE);
-      }
 
       $autoRenewElement = $this->addElement('checkbox', 'auto_renew', ts('Membership renewed automatically'),
         NULL, ['onclick' => "showHideByValue('auto_renew','','send-receipt','table-row','radio',true); showHideNotice( );"]

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -234,7 +234,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         CRM_Core_Error::statusBounce(ts("This Membership is linked to a contribution. You must have 'delete in CiviContribute' permission in order to delete this record."));
       }
     }
-
+    $mems_by_org = [];
     if ($this->_action & CRM_Core_Action::ADD) {
       if ($this->_contactID) {
         //check whether contact has a current membership so we can alert user that they may want to do a renewal instead
@@ -249,7 +249,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
           foreach ($cMemTypes as $memTypeID) {
             $memberorgs[$memTypeID] = CRM_Member_BAO_MembershipType::getMembershipType($memTypeID)['member_of_contact_id'];
           }
-          $mems_by_org = [];
           foreach ($contactMemberships as $mem) {
             $mem['member_of_contact_id'] = $memberorgs[$mem['membership_type_id']] ?? NULL;
             if (!empty($mem['membership_end_date'])) {
@@ -272,7 +271,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
             );
             $mems_by_org[$mem['member_of_contact_id']] = $mem;
           }
-          $this->assign('existingContactMemberships', $mems_by_org);
         }
       }
       else {
@@ -287,6 +285,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         $resources->addSetting(['existingMems' => $passthru]);
       }
     }
+    $this->assign('existingContactMemberships', $mems_by_org);
 
     if (!$this->_memType) {
       $params = CRM_Utils_Request::exportValues();
@@ -377,10 +376,7 @@ DESC limit 1");
     if (empty($defaults['join_date'])) {
       $defaults['join_date'] = CRM_Utils_Time::date('Y-m-d');
     }
-
-    if (!empty($defaults['membership_end_date'])) {
-      $this->assign('endDate', $defaults['membership_end_date']);
-    }
+    $this->assign('endDate', $defaults['membership_end_date'] ?? NULL);
 
     return $defaults;
   }

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -102,7 +102,7 @@
              </div>
           {else}
             <div class="compressed crm-grid-cell">
-              {$form.field.$rowNumber.$n.html}
+              {$form.field.$rowNumber.$n.html|smarty:nodefaults}
               {if $fields.$n.html_type eq 'File' && !empty($form.field.$rowNumber.$fieldName.value.size)}
                 {ts}Attached{/ts}: {$form.field.$rowNumber.$fieldName.value.name}
               {/if}

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -85,7 +85,7 @@
               {help id="override_membership_type"}
             </span>
           </td>
-          <td id="mem_type_id-editable"><span id='mem_type_id'>{$form.membership_type_id.html}</span>
+          <td id="mem_type_id-editable"><span id='mem_type_id'>{$form.membership_type_id.html|smarty:nodefaults}</span>
             {if $hasPriceSets}
               <span id='totalAmountORPriceSet'> {ts}OR{/ts}</span>
               <span id='selectPriceSet'>{$form.price_set_id.html}</span>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -61,7 +61,7 @@
       </tr>
       <tr id="membershipOrgType" class="crm-member-membershiprenew-form-block-renew_org_name hiddenElement">
         <td class="label">{$form.membership_type_id.label}</td>
-        <td>{$form.membership_type_id.html}
+        <td>{$form.membership_type_id.html|smarty:nodefaults}
           {if $member_is_test} {ts}(test){/ts}{/if}<br/>
           <span class="description">{ts}Select Membership Organization and then Membership Type.{/ts}</span>
         </td>


### PR DESCRIPTION


Overview
----------------------------------------
Fix escaping, notices in grumpy mode

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/153526465-62e5a137-8bed-49db-a084-52d65e8140ec.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/153526433-35bfbf09-124c-4903-b818-587bfd0a03ca.png)


Technical Details
----------------------------------------
Generally we bypass escaping for qf html elements in CRM_Core_Smarty
pretty bluntly but these bypass that. Probably ideally we
would actually escape all qf html in the end anyway.


Comments
----------------------------------------
