### PR TITLE
BAO_Mailing::create - stop passing by reference

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1470,7 +1470,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public static function create(&$params) {
+  public static function create(array $params) {
 
     // CRM-#1843
     // If it is a mass sms, set url_tracking to false

--- a/CRM/Mailing/BAO/Spool.php
+++ b/CRM/Mailing/BAO/Spool.php
@@ -57,8 +57,7 @@ class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
       $params['body_html'] = htmlspecialchars($headerStr) . "\n\n" . $body;
       $params['subject'] = $headers['Subject'];
       $params['name'] = $headers['Subject'];
-      $ids = [];
-      $mailing = CRM_Mailing_BAO_Mailing::create($params, $ids);
+      $mailing = CRM_Mailing_BAO_Mailing::create($params);
 
       if (empty($mailing) || is_a($mailing, 'CRM_Core_Error')) {
         return PEAR::raiseError('Unable to create spooled mailing.');

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -167,7 +167,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
       $params['scheduled_date'] = CRM_Utils_Date::processDate($mailing->scheduled_date);
     }
 
-    CRM_Mailing_BAO_Mailing::create($params, $ids);
+    CRM_Mailing_BAO_Mailing::create($params);
 
     //when user perform mailing from search context
     //redirect it to search result CRM-3711


### PR DESCRIPTION
Overview
----------------------------------------
BAO_Mailing::create - stop passing by reference

Before
----------------------------------------
`$params` passed to BAO_Mailing::create as a reference

After
----------------------------------------
Not a reference

Technical Details
----------------------------------------
We have been removing this pass-by-refs on an ongoing basis. CRUD calls should use
the api but I checked the core calls and none are looking for anything altered in

I only found one extension in universe using the bao create (unsupported) to create mailings and it does not use params afterwards

Comments
----------------------------------------
