### PR TITLE
APiv4 - Add Extension.get

### DIFF
--- a/Civi/Api4/Extension.php
+++ b/Civi/Api4/Extension.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Extensions - add-on modules extend the functionality of CiviCRM.
+ *
+ * @see https://docs.civicrm.org/user/en/latest/introduction/extensions/
+ * @searchable secondary
+ * @since 5.48
+ * @package Civi\Api4
+ */
+class Extension extends Generic\AbstractEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetAction
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new Generic\BasicGetAction(__CLASS__, __FUNCTION__, function($action) {
+      $statuses = \CRM_Extension_System::singleton()->getManager()->getStatuses();
+      $mapper = \CRM_Extension_System::singleton()->getMapper();
+      $result = [];
+      foreach ($statuses as $key => $status) {
+        try {
+          $obj = $mapper->keyToInfo($key);
+          $info = \CRM_Extension_System::createExtendedInfo($obj);
+          $result[] = $info;
+        }
+        catch (\CRM_Extension_Exception $ex) {
+          \Civi::log()->error(sprintf('Failed to read extension (%1). Please refresh the extension list.', [1 => $key]));
+        }
+      }
+      return $result;
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(static::getEntityName(), __FUNCTION__, function() {
+      return [
+        [
+          'name' => 'key',
+          'description' => 'Long, unique extension identifier',
+        ],
+        [
+          'name' => 'file',
+          'description' => 'Short, unique extension identifier',
+        ],
+        [
+          'name' => 'label',
+          'description' => 'User-facing extension title',
+        ],
+        [
+          'name' => 'description',
+          'description' => 'Additional information about the extension',
+        ],
+        [
+          'name' => 'version',
+          'description' => 'Current version number (string)',
+        ],
+        [
+          'name' => 'tags',
+          'data_type' => 'Array',
+          'description' => "Tags which characterize the extension's purpose or functionality",
+        ],
+        [
+          'name' => 'status',
+          'description' => 'Extension enabled/disabled/uninstalled status',
+          'options' => [
+            \CRM_Extension_Manager::STATUS_UNINSTALLED => ts('Uninstalled'),
+            \CRM_Extension_Manager::STATUS_DISABLED => ts('Disabled'),
+            \CRM_Extension_Manager::STATUS_INSTALLED => ts('Enabled'),
+            \CRM_Extension_Manager::STATUS_DISABLED_MISSING => ts('Disabled (Missing)'),
+            \CRM_Extension_Manager::STATUS_INSTALLED_MISSING => ts('Enabled (Missing)'),
+          ],
+        ],
+      ];
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['title'] = ts('Extension');
+    $info['title_plural'] = ts('Extensions');
+    $info['primary_key'] = ['key'];
+    $info['label_field'] = 'label';
+    return $info;
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/ExtensionTest.php
+++ b/tests/phpunit/api/v4/Entity/ExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use api\v4\UnitTestCase;
+use Civi\Api4\Extension;
+
+/**
+ * @group headless
+ */
+class ExtensionTest extends UnitTestCase {
+
+  public function testGet() {
+    $moduleTest = Extension::get(FALSE)
+      ->addWhere('key', '=', 'test.extension.manager.moduletest')
+      ->execute()->single();
+    $this->assertEquals('test_extension_manager_moduletest', $moduleTest['label']);
+    $this->assertEquals(['mock'], $moduleTest['tags']);
+
+    $moduleTest = Extension::get(FALSE)
+      ->addWhere('file', '=', 'moduletest')
+      ->execute()->single();
+    $this->assertEquals('test_extension_manager_moduletest', $moduleTest['label']);
+    $this->assertEquals(['mock'], $moduleTest['tags']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Ports the Extension.get API to v4.

Before
----------------------------------------
Extension API in v3 only.

After
----------------------------------------
APIv4 now exists for Extensions, but only get action so far.

![image](https://user-images.githubusercontent.com/2874912/153966812-03d1319e-7f80-4495-9f4f-4ceebc7e6413.png)

Comments
----------------------------------------
I've learned that adding anything non-essential to a new API can bite you in the butt later. So this new api only supports the 'get' action as a first step, and that action returns a limited subset of what's returned by `CRM_Extension_System::createExtendedInfo` - just the stuff that's really useful and not likely to be deprecated anytime soon.

This new API returns only the short version of the key (e.g. `search_kit` *not* `org.civicrm.search_kit`), as the long version is deprecated we might as well omit it altogether.

I wasn't entirely sure what to do with the `name` and `label` properties. It seems like the intention was that `label` would be a localized version of the `name`, but I don't see any code in the extension system to actually translate the string to localize the `label`, it appears to be copied from `name` as-is:
https://github.com/civicrm/civicrm-core/blob/fa3fdebc3e31c604a323d819fd10cc893ca59d50/CRM/Extension/Info.php#L182

Nevertheless this new API dutifully returns `label` (but not `name`, because it's redundant and likely to get confused with `key`). IDK maybe someday labels will get translated?