### PR TITLE
Remove unused parameter, pass-by-ref

### DIFF
--- a/CRM/Contact/Form/Inline/Email.php
+++ b/CRM/Contact/Form/Inline/Email.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Inline_Email extends CRM_Contact_Form_Inline {
     $email = new CRM_Core_BAO_Email();
     $email->contact_id = $this->_contactId;
 
-    $this->_emails = CRM_Core_BAO_Block::retrieveBlock($email, NULL);
+    $this->_emails = CRM_Core_BAO_Block::retrieveBlock($email);
 
     // Check if this contact has a first/last/organization/household name
     if ($this->_contactType == 'Individual') {

--- a/CRM/Contact/Form/Inline/IM.php
+++ b/CRM/Contact/Form/Inline/IM.php
@@ -42,7 +42,7 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
     $im = new CRM_Core_BAO_IM();
     $im->contact_id = $this->_contactId;
 
-    $this->_ims = CRM_Core_BAO_Block::retrieveBlock($im, NULL);
+    $this->_ims = CRM_Core_BAO_Block::retrieveBlock($im);
   }
 
   /**

--- a/CRM/Contact/Form/Inline/OpenID.php
+++ b/CRM/Contact/Form/Inline/OpenID.php
@@ -42,7 +42,7 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
     $openid = new CRM_Core_BAO_OpenID();
     $openid->contact_id = $this->_contactId;
 
-    $this->_openids = CRM_Core_BAO_Block::retrieveBlock($openid, NULL);
+    $this->_openids = CRM_Core_BAO_Block::retrieveBlock($openid);
   }
 
   /**

--- a/CRM/Contact/Form/Inline/Phone.php
+++ b/CRM/Contact/Form/Inline/Phone.php
@@ -42,7 +42,7 @@ class CRM_Contact_Form_Inline_Phone extends CRM_Contact_Form_Inline {
     $phone = new CRM_Core_BAO_Phone();
     $phone->contact_id = $this->_contactId;
 
-    $this->_phones = CRM_Core_BAO_Block::retrieveBlock($phone, NULL);
+    $this->_phones = CRM_Core_BAO_Block::retrieveBlock($phone);
   }
 
   /**

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -54,7 +54,7 @@ class CRM_Core_BAO_Block {
       if (!$block->contact_id) {
         throw new CRM_Core_Exception('Invalid Contact ID parameter passed');
       }
-      $blocks = self::retrieveBlock($block, $blockName);
+      $blocks = self::retrieveBlock($block);
     }
     else {
       $blockIds = self::getBlockIds($blockName, NULL, $params);
@@ -67,7 +67,7 @@ class CRM_Core_BAO_Block {
       foreach ($blockIds as $blockId) {
         $block = new $BAOString();
         $block->id = $blockId['id'];
-        $getBlocks = self::retrieveBlock($block, $blockName);
+        $getBlocks = self::retrieveBlock($block);
         $blocks[$count++] = array_pop($getBlocks);
       }
     }
@@ -81,13 +81,11 @@ class CRM_Core_BAO_Block {
    *
    * @param Object $block
    *   Typically a Phone|Email|IM|OpenID object.
-   * @param string $blockName
-   *   Name of the above object.
    *
    * @return array
    *   Array of $block objects.
    */
-  public static function retrieveBlock(&$block, $blockName) {
+  public static function retrieveBlock($block) {
     // we first get the primary location due to the order by clause
     $block->orderBy('is_primary desc, id');
     $block->find();


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused parameter, pass-by-ref

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/153537492-1eaeb4ec-fb7f-4cff-8204-db491931ff7f.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/153537466-af55397e-9001-42c0-91df-7cbe6ee1b8b8.png)

Technical Details
----------------------------------------
I checked all core places that they were using the return value rather than the pass-by-ref (which would be inherently un-useful anyway as it would hold only the last value

Comments
----------------------------------------

