### PR TITLE
[REF] Fix issue where spaces in payment_processor_type.name field cau…

### DIFF
--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -185,7 +185,7 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     $optAttributes = [];
     foreach ($paymentProcessors as $ppKey => $ppval) {
       if ($ppKey > 0) {
-        $optAttributes[$ppKey]['class'] = 'payment_processor_' . strtolower($this->_paymentProcessors[$ppKey]['payment_processor_type']);
+        $optAttributes[$ppKey]['class'] = 'payment_processor_' . strtolower(CRM_Utils_String::munge($this->_paymentProcessors[$ppKey]['payment_processor_type'], '_', 1000));
       }
       else {
         $optAttributes[$ppKey]['class'] = 'payment_processor_paylater';


### PR DESCRIPTION
…ses issues with class output on form

Overview
----------------------------------------
This fixes an issue raised by @KarinG in mattermost that if you install the iats extension then you will find that rather than having one class you get about 5 css classes outputed. 

Before
----------------------------------------
Multiple classes added when using a payment processor of type that has a space in the name

After
----------------------------------------
1 class outputted

ping @demeritcowboy @eileenmcnaughton @adixon 