### PR TITLE
(dev/core#1304) Queues - Allow background worker to drive tasks via APIv4

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -165,6 +165,17 @@ abstract class CRM_Queue_Queue {
   abstract public function deleteItem($item);
 
   /**
+   * Get the full data for an item.
+   *
+   * This is a passive peek - it does not claim/steal/release anything.
+   *
+   * @param int|string $id
+   *   The unique ID of the task within the queue.
+   * @return CRM_Queue_DAO_QueueItem|object|null $dao
+   */
+  abstract public function fetchItem($id);
+
+  /**
    * Return an item that could not be processed.
    *
    * @param object $item

--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -20,6 +20,8 @@
  */
 abstract class CRM_Queue_Queue {
 
+  const DEFAULT_LEASE_TIME = 3600;
+
   /**
    * @var string
    */
@@ -137,13 +139,13 @@ abstract class CRM_Queue_Queue {
   /**
    * Get the next item.
    *
-   * @param int $lease_time
-   *   Seconds.
-   *
+   * @param int|null $lease_time
+   *   Hold a lease on the claimed item for $X seconds.
+   *   If NULL, inherit a default.
    * @return object
    *   with key 'data' that matches the inputted data
    */
-  abstract public function claimItem($lease_time = 3600);
+  abstract public function claimItem($lease_time = NULL);
 
   /**
    * Get the next item, even if there's an active lease
@@ -154,7 +156,7 @@ abstract class CRM_Queue_Queue {
    * @return object
    *   with key 'data' that matches the inputted data
    */
-  abstract public function stealItem($lease_time = 3600);
+  abstract public function stealItem($lease_time = NULL);
 
   /**
    * Remove an item from the queue.

--- a/CRM/Queue/Queue/BatchQueueInterface.php
+++ b/CRM/Queue/Queue/BatchQueueInterface.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Variation on CRM_Queue_Queue which can claim/release/delete items in batches.
+ */
+interface CRM_Queue_Queue_BatchQueueInterface {
+
+  /**
+   * Get a batch of queue items.
+   *
+   * @param int $limit
+   *   Maximum number of records to claim
+   * @param int|null $lease_time
+   *   Hold a lease on the claimed item for $X seconds.
+   *   If NULL, inherit a default.
+   * @return object
+   *   with key 'data' that matches the inputted data
+   */
+  public function claimItems(int $limit, ?int $lease_time = NULL): array;
+
+  /**
+   * Remove items from the queue.
+   *
+   * @param array $items
+   *   The item returned by claimItem.
+   */
+  public function deleteItems(array $items): void;
+
+  /**
+   * Get the full data for multiple items.
+   *
+   * This is a passive peek - it does not claim/steal/release anything.
+   *
+   * @param array $ids
+   *   The unique IDs of the tasks within the queue.
+   * @return array
+   */
+  public function fetchItems(array $ids): array;
+
+  /**
+   * Return an item that could not be processed.
+   *
+   * @param array $items
+   *   The items returned by claimItem.
+   */
+  public function releaseItems(array $items): void;
+
+}

--- a/CRM/Queue/Queue/Memory.php
+++ b/CRM/Queue/Queue/Memory.php
@@ -204,7 +204,13 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
    *   The item returned by claimItem.
    */
   public function releaseItem($item) {
-    unset($this->releaseTimes[$item->id]);
+    if (empty($this->queueSpec['retry_interval'])) {
+      unset($this->releaseTimes[$item->id]);
+    }
+    else {
+      $nowEpoch = CRM_Utils_Time::getTimeRaw();
+      $this->releaseTimes[$item->id] = $nowEpoch + $this->queueSpec['retry_interval'];
+    }
   }
 
 }

--- a/CRM/Queue/Queue/Memory.php
+++ b/CRM/Queue/Queue/Memory.php
@@ -117,13 +117,15 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
   /**
    * Get and remove the next item.
    *
-   * @param int $leaseTime
-   *   Seconds.
-   *
+   * @param int|null $leaseTime
+   *   Hold a lease on the claimed item for $X seconds.
+   *   If NULL, inherit a queue default (`$queueSpec['lease_time']`) or system default (`DEFAULT_LEASE_TIME`).
    * @return object
    *   Includes key 'data' that matches the inputted data.
    */
-  public function claimItem($leaseTime = 3600) {
+  public function claimItem($leaseTime = NULL) {
+    $leaseTime = $leaseTime ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
+
     // foreach hits the items in order -- but we short-circuit after the first
     foreach ($this->items as $id => $data) {
       $nowEpoch = CRM_Utils_Time::getTimeRaw();
@@ -149,13 +151,15 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
   /**
    * Get the next item.
    *
-   * @param int $leaseTime
-   *   Seconds.
-   *
+   * @param int|null $leaseTime
+   *   Hold a lease on the claimed item for $X seconds.
+   *   If NULL, inherit a queue default (`$queueSpec['lease_time']`) or system default (`DEFAULT_LEASE_TIME`).
    * @return object
    *   With key 'data' that matches the inputted data.
    */
-  public function stealItem($leaseTime = 3600) {
+  public function stealItem($leaseTime = NULL) {
+    $leaseTime = $leaseTime ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
+
     // foreach hits the items in order -- but we short-circuit after the first
     foreach ($this->items as $id => $data) {
       $nowEpoch = CRM_Utils_Time::getTimeRaw();

--- a/CRM/Queue/Queue/Memory.php
+++ b/CRM/Queue/Queue/Memory.php
@@ -169,6 +169,19 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
   }
 
   /**
+   * Get the full data for an item.
+   *
+   * This is a passive peek - it does not claim/steal/release anything.
+   *
+   * @param int|string $id
+   *   The unique ID of the task within the queue.
+   * @return CRM_Queue_DAO_QueueItem|object|null $dao
+   */
+  public function fetchItem($id) {
+    return $this->items[$id] ?? NULL;
+  }
+
+  /**
    * Return an item that could not be processed.
    *
    * @param CRM_Core_DAO $item

--- a/CRM/Queue/Queue/SqlParallel.php
+++ b/CRM/Queue/Queue/SqlParallel.php
@@ -37,13 +37,14 @@ class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue {
   /**
    * Get the next item.
    *
-   * @param int $lease_time
-   *   Seconds.
-   *
+   * @param int|null $lease_time
+   *   Hold a lease on the claimed item for $X seconds.
+   *   If NULL, inherit a queue default (`$queueSpec['lease_time']`) or system default (`DEFAULT_LEASE_TIME`).
    * @return object
    *   With key 'data' that matches the inputted data.
    */
-  public function claimItem($lease_time = 3600) {
+  public function claimItem($lease_time = NULL) {
+    $lease_time = $lease_time ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
 
     $result = NULL;
     $dao = CRM_Core_DAO::executeQuery('LOCK TABLES civicrm_queue_item WRITE;');
@@ -90,13 +91,15 @@ class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue {
   /**
    * Get the next item, even if there's an active lease
    *
-   * @param int $lease_time
-   *   Seconds.
-   *
+   * @param int|null $lease_time
+   *   Hold a lease on the claimed item for $X seconds.
+   *   If NULL, inherit a queue default (`$queueSpec['lease_time']`) or system default (`DEFAULT_LEASE_TIME`).
    * @return object
    *   With key 'data' that matches the inputted data.
    */
-  public function stealItem($lease_time = 3600) {
+  public function stealItem($lease_time = NULL) {
+    $lease_time = $lease_time ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
+
     $sql = "
       SELECT id, queue_name, submit_time, release_time, run_count, data
       FROM civicrm_queue_item

--- a/CRM/Queue/Queue/SqlParallel.php
+++ b/CRM/Queue/Queue/SqlParallel.php
@@ -12,7 +12,7 @@
 /**
  * A queue implementation which stores items in the CiviCRM SQL database
  */
-class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue {
+class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue implements CRM_Queue_Queue_BatchQueueInterface {
 
   use CRM_Queue_Queue_SqlTrait;
 
@@ -35,29 +35,32 @@ class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue {
   }
 
   /**
-   * Get the next item.
-   *
-   * @param int|null $lease_time
-   *   Hold a lease on the claimed item for $X seconds.
-   *   If NULL, inherit a queue default (`$queueSpec['lease_time']`) or system default (`DEFAULT_LEASE_TIME`).
-   * @return object
-   *   With key 'data' that matches the inputted data.
+   * @inheritDoc
    */
   public function claimItem($lease_time = NULL) {
-    $lease_time = $lease_time ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
+    $items = $this->claimItems(1, $lease_time);
+    return $items[0] ?? NULL;
+  }
 
-    $result = NULL;
+  /**
+   * @inheritDoc
+   */
+  public function claimItems(int $limit, ?int $lease_time = NULL): array {
+    $lease_time = $lease_time ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
+    $limit = $this->getSpec('batch_limit') ? min($limit, $this->getSpec('batch_limit')) : $limit;
+
     $dao = CRM_Core_DAO::executeQuery('LOCK TABLES civicrm_queue_item WRITE;');
     $sql = "SELECT id, queue_name, submit_time, release_time, run_count, data
         FROM civicrm_queue_item
         WHERE queue_name = %1
               AND (release_time IS NULL OR release_time < %2)
         ORDER BY weight ASC, id ASC
-        LIMIT 1
+        LIMIT %3
       ";
     $params = [
       1 => [$this->getName(), 'String'],
       2 => [CRM_Utils_Time::getTime(), 'Timestamp'],
+      3 => [$limit, 'Integer'],
     ];
     $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, 'CRM_Queue_DAO_QueueItem');
     if (is_a($dao, 'DB_Error')) {
@@ -65,22 +68,22 @@ class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue {
       CRM_Core_Error::fatal();
     }
 
-    if ($dao->fetch()) {
+    $result = [];
+    while ($dao->fetch()) {
+      $result[] = (object) [
+        'id' => $dao->id,
+        'data' => unserialize($dao->data),
+        'queue_name' => $dao->queue_name,
+        'run_count' => 1 + (int) $dao->run_count,
+      ];
+    }
+    if ($result) {
       $nowEpoch = CRM_Utils_Time::getTimeRaw();
-      $dao->run_count++;
-      CRM_Core_DAO::executeQuery("UPDATE civicrm_queue_item SET release_time = %1, run_count = %3 WHERE id = %2", [
-        '1' => [date('YmdHis', $nowEpoch + $lease_time), 'String'],
-        '2' => [$dao->id, 'Integer'],
-        '3' => [$dao->run_count, 'Integer'],
+      $sql = CRM_Utils_SQL::interpolate('UPDATE civicrm_queue_item SET release_time = @RT, run_count = 1+run_count WHERE id IN (#ids)', [
+        'RT' => date('YmdHis', $nowEpoch + $lease_time),
+        'ids' => CRM_Utils_Array::collect('id', $result),
       ]);
-
-      // (Comment by artfulrobot Sep 2019: Not sure what the below comment means, should be removed/clarified?)
-      // work-around: inconsistent date-formatting causes unintentional breakage
-      #        $dao->submit_time = date('YmdHis', strtotime($dao->submit_time));
-      #        $dao->release_time = date('YmdHis', $nowEpoch + $lease_time);
-      #        $dao->save();
-      $dao->data = unserialize($dao->data);
-      $result = $dao;
+      CRM_Core_DAO::executeQuery($sql);
     }
 
     $dao = CRM_Core_DAO::executeQuery('UNLOCK TABLES;');

--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -95,6 +95,26 @@ trait CRM_Queue_Queue_SqlTrait {
   }
 
   /**
+   * Get the full data for an item.
+   *
+   * This is a passive peek - it does not claim/steal/release anything.
+   *
+   * @param int|string $id
+   *   The unique ID of the task within the queue.
+   * @return CRM_Queue_DAO_QueueItem|object|null $dao
+   */
+  public function fetchItem($id) {
+    $dao = new CRM_Queue_DAO_QueueItem();
+    $dao->id = $id;
+    $dao->queue_name = $this->getName();
+    if (!$dao->find(TRUE)) {
+      return NULL;
+    }
+    $dao->data = unserialize($dao->data);
+    return $dao;
+  }
+
+  /**
    * Return an item that could not be processed.
    *
    * @param CRM_Core_DAO $dao

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -26,9 +26,9 @@
  *   This is used by some CLI upgrades.
  *
  * This runner is not appropriate for all queues or workloads, so you might choose or create
- * a different runner. For example, `CRM_Queue_Autorunner` is geared toward background task lists.
+ * a different runner. For example, `CRM_Queue_TaskRunner` is geared toward background task lists.
  *
- * @see CRM_Queue_Autorunner
+ * @see CRM_Queue_TaskRunner
  */
 class CRM_Queue_Runner {
 

--- a/CRM/Queue/TaskRunner.php
+++ b/CRM/Queue/TaskRunner.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * `CRM_Queue_TaskRunner`  a list tasks from a queue. It is designed to supported background
+ * tasks which run automatically.
+ *
+ * This runner is not appropriate for all queues or workloads, so you might choose or create
+ * a different runner. For example, `CRM_Queue_Runner` is geared toward background task lists.
+ *
+ * @see CRM_Queue_Runner
+ */
+class CRM_Queue_TaskRunner {
+
+  /**
+   * @param \CRM_Queue_Queue $queue
+   * @param $item
+   * @return string
+   *   One of the following:
+   *    - 'ok': Task executed normally. Removed from queue.
+   *    - 'retry': Task encountered an error. Will try again later.
+   *    - 'delete': Task encountered an error. Will not try again later. Removed from queue.
+   *    - 'abort': Task encountered an error. Will not try again later. Stopped the queue.
+   * @throws \API_Exception
+   */
+  public function run(CRM_Queue_Queue $queue, $item): string {
+    $this->assertType($item->data, ['CRM_Queue_Task'], 'Cannot run. Invalid task given.');
+
+    /** @var \CRM_Queue_Task $task */
+    $task = $item->data;
+
+    /** @var string $outcome One of 'ok', 'retry', 'delete', 'abort' */
+
+    if (is_numeric($queue->getSpec('retry_limit')) && $item->run_count > 1 + $queue->getSpec('retry_limit')) {
+      \Civi::log()->debug("Skipping exhausted task: " . $task->title);
+      $outcome = $queue->getSpec('error');
+      $exception = new \API_Exception(sprintf('Skipping exhausted task after %d tries: %s', $item->run_count, print_r($task, 1)), 'queue_retry_exhausted');
+    }
+    else {
+      \Civi::log()->debug("Running task: " . $task->title);
+      try {
+        $runResult = $task->run($this->createContext($queue));
+        $outcome = $runResult ? 'ok' : $queue->getSpec('error');
+        $exception = ($outcome === 'ok') ? NULL : new \API_Exception('Queue task returned false', 'queue_false');
+      }
+      catch (\Exception $e) {
+        $outcome = $queue->getSpec('error');
+        $exception = $e;
+      }
+
+      if (in_array($outcome, ['delete', 'abort']) && $this->isRetriable($queue, $item)) {
+        $outcome = 'retry';
+      }
+    }
+
+    if ($outcome !== 'ok') {
+      \CRM_Utils_Hook::queueTaskError($queue, $item, $outcome, $exception);
+    }
+
+    if ($outcome === 'ok') {
+      $queue->deleteItem($item);
+      return $outcome;
+    }
+
+    $logDetails = [
+      'id' => $queue->getName() . '#' . $item->id,
+      'task' => CRM_Utils_Array::subset((array) $task, ['title', 'callback', 'arguments']),
+      'outcome' => $outcome,
+      'message' => $exception ? $exception->getMessage() : NULL,
+      'exception' => $exception,
+    ];
+
+    switch ($outcome) {
+      case 'retry':
+        \Civi::log('queue')->error('Task "{id}" failed and should be retried. {message}', $logDetails);
+        $queue->releaseItem($item);
+        break;
+
+      case 'delete':
+        \Civi::log('queue')->error('Task "{id}" failed and will be deleted. {message}', $logDetails);
+        $queue->deleteItem($item);
+        break;
+
+      case 'abort':
+        \Civi::log('queue')->error('Task "{id}" failed. Queue processing aborted. {message}', $logDetails);
+        $queue->setStatus('aborted');
+        $queue->releaseItem($item); /* Sysadmin might inspect, fix, and then resume. Item should be accessible. */
+        break;
+
+      default:
+        \Civi::log('queue')->critical('Unrecognized outcome for task "{id}": {outcome}', $logDetails);
+        break;
+    }
+
+    return $outcome;
+  }
+
+  /**
+   * @param \CRM_Queue_Queue $queue
+   * return CRM_Queue_TaskContext;
+   */
+  private function createContext(\CRM_Queue_Queue $queue): \CRM_Queue_TaskContext {
+    $taskCtx = new \CRM_Queue_TaskContext();
+    $taskCtx->queue = $queue;
+    $taskCtx->log = \CRM_Core_Error::createDebugLogger();
+    return $taskCtx;
+  }
+
+  private function assertType($object, array $types, string $message) {
+    foreach ($types as $type) {
+      if ($object instanceof  $type) {
+        return;
+      }
+    }
+    throw new \Exception($message);
+  }
+
+  private function isRetriable(\CRM_Queue_Queue $queue, $item): bool {
+    return property_exists($item, 'run_count')
+      && is_numeric($queue->getSpec('retry_limit'))
+      && $queue->getSpec('retry_limit') + 1 > $item->run_count;
+  }
+
+}

--- a/Civi/Api4/Action/Queue/ClaimItems.php
+++ b/Civi/Api4/Action/Queue/ClaimItems.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Queue;
+
+use Civi\Api4\Generic\Traits\SelectParamTrait;
+
+/**
+ * Claim an item from the queue.  Returns zero or one items.
+ *
+ * @method ?string setQueue
+ * @method $this setQueue(?string $queue)
+ */
+class ClaimItems extends \Civi\Api4\Generic\AbstractAction {
+
+  use SelectParamTrait;
+
+  /**
+   * Name of the target queue.
+   *
+   * @var string|null
+   */
+  protected $queue;
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $this->select = empty($this->select) ? ['id', 'data', 'queue'] : $this->select;
+    $queue = $this->queue();
+    if (!$queue->isActive()) {
+      return;
+    }
+
+    $isBatch = $queue instanceof \CRM_Queue_Queue_BatchQueueInterface;
+    $limit = $queue->getSpec('batch_limit') ?: 1;
+    if ($limit > 1 && !$isBatch) {
+      throw new \API_Exception(sprintf('Queue "%s" (%s) does not support batching.', $queue->getName(), get_class($queue)));
+      // Note 1: Simply looping over `claimItem()` is unlikley to help the consumer b/c
+      // drivers like Sql+Memory are linear+blocking.
+      // Note 2: The default is batch_limit=1. So someone has specifically chosen an invalid configuration...
+    }
+    $items = $isBatch ? $queue->claimItems($limit) : [$queue->claimItem()];
+
+    foreach ($items as $item) {
+      if ($item) {
+        $result[] = $this->convertItemToStub($item);
+      }
+    }
+  }
+
+  /**
+   * @param \CRM_Queue_DAO_QueueItem|\stdClass $item
+   * @return array
+   */
+  protected function convertItemToStub(object $item): array {
+    $array = [];
+    foreach ($this->select as $field) {
+      switch ($field) {
+        case 'id':
+          $array['id'] = $item->id;
+          break;
+
+        case 'data':
+          $array['data'] = (array) $item->data;
+          break;
+
+        case 'queue':
+          $array['queue'] = $this->queue;
+          break;
+
+      }
+    }
+    return $array;
+  }
+
+  protected function queue(): \CRM_Queue_Queue {
+    if (empty($this->queue)) {
+      throw new \API_Exception('Missing required parameter: $queue');
+    }
+    return \Civi::queue($this->queue);
+  }
+
+}

--- a/Civi/Api4/Action/Queue/RunItems.php
+++ b/Civi/Api4/Action/Queue/RunItems.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Civi\Api4\Action\Queue;
+
+/**
+ * Run an enqueued item (task).
+ *
+ * You must either:
+ *
+ * - (a) Give the target queue-item specifically (`setItem()`). Useful if you called `claimItem()` separately.
+ * - (b) Give the name of the queue from which to find an item (`setQueue()`).
+ *
+ * Note: If you use `setItem()`, the inputted will be validated (refetched) to ensure authenticity of all details.
+ *
+ * Returns 0 or 1 records which indicate the outcome of running the chosen task.
+ *
+ * ```php
+ * $todo = Civi\Api4\Queue::claimItem()->setQueue($item)->setLeaseTime(600)->execute()->single();
+ * $result = Civi\Api4\Queue::runItem()->setItem($todo)->execute()->single();
+ * assert(in_array($result['outcome'], ['ok', 'retry', 'fail']))
+ *
+ * $result = Civi\Api4\Queue::runItem()->setQueue('foo')->execute()->first();
+ * assert(in_array($result['outcome'], ['ok', 'retry', 'fail']))
+ * ```
+ *
+ * Valid outcomes are:
+ * - 'ok': Task executed normally. Removed from queue.
+ * - 'retry': Task encountered an error. Will try again later.
+ * - 'fail': Task encountered an error. Will not try again later. Removed from queue.
+ *
+ * @method $this setItem(?array $item)
+ * @method ?array getItem()
+ * @method ?string setQueue
+ * @method $this setQueue(?string $queue)
+ */
+class RunItems extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Previously claimed item - which should now be released.
+   *
+   * @var array|null
+   *   Fields: {id: scalar, queue: string}
+   */
+  protected $items;
+
+  /**
+   * Name of the target queue.
+   *
+   * @var string|null
+   */
+  protected $queue;
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    if (!empty($this->items)) {
+      $this->validateItemStubs();
+      $queue = \Civi::queue($this->items[0]['queue']);
+      $ids = \CRM_Utils_Array::collect('id', $this->items);
+      if (count($ids) > 1 && !($queue instanceof \CRM_Queue_Queue_BatchQueueInterface)) {
+        throw new \API_Exception("runItems: Error: Running multiple items requires BatchQueueInterface");
+      }
+      if (count($ids) > 1) {
+        $items = $queue->fetchItems($ids);
+      }
+      else {
+        $items = [$queue->fetchItem($ids[0])];
+      }
+    }
+    elseif (!empty($this->queue)) {
+      $queue = \Civi::queue($this->queue);
+      if (!$queue->isActive()) {
+        return;
+      }
+      $items = $queue instanceof \CRM_Queue_Queue_BatchQueueInterface
+        ? $queue->claimItems($queue->getSpec('batch_limit') ?: 1)
+        : [$queue->claimItem()];
+    }
+    else {
+      throw new \API_Exception("runItems: Requires either 'queue' or 'item'.");
+    }
+
+    if (empty($items)) {
+      return;
+    }
+
+    $outcomes = [];
+    \CRM_Utils_Hook::queueRun($queue, $items, $outcomes);
+    if (empty($outcomes)) {
+      throw new \API_Exception(sprintf('Failed to run queue items (name=%s, runner=%s, itemCount=%d, outcomeCount=%d)',
+        $queue->getName(), $queue->getSpec('runner'), count($items), count($outcomes)));
+    }
+    foreach ($items as $itemPos => $item) {
+      $result[] = ['outcome' => $outcomes[$itemPos], 'item' => $this->createItemStub($item)];
+    }
+  }
+
+  private function validateItemStubs(): void {
+    $queueNames = [];
+    if (!isset($this->items[0])) {
+      throw new \API_Exception("Queue items must be given as numeric array.");
+    }
+    foreach ($this->items as $item) {
+      if (empty($item['queue'])) {
+        throw new \API_Exception("Queue item requires property 'queue'.");
+      }
+      if (empty($item['id'])) {
+        throw new \API_Exception("Queue item requires property 'id'.");
+      }
+      $queueNames[$item['queue']] = 1;
+    }
+    if (count($queueNames) > 1) {
+      throw new \API_Exception("Queue items cannot be mixed. Found queues: " . implode(', ', array_keys($queueNames)));
+    }
+  }
+
+  private function createItemStub($item): array {
+    return ['id' => $item->id, 'queue' => $item->queue_name];
+  }
+
+}

--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -10,6 +10,9 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Action\Queue\ClaimItems;
+use Civi\Api4\Action\Queue\RunItems;
+
 /**
  * Track a list of durable/scannable queues.
  *
@@ -31,7 +34,34 @@ class Queue extends \Civi\Api4\Generic\DAOEntity {
     return [
       'meta' => ['access CiviCRM'],
       'default' => ['administer queues'],
+      'runItem' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
     ];
+  }
+
+  /**
+   * Claim an item from the queue. Returns zero or one items.
+   *
+   * Note: This is appropriate for persistent, auto-run queues.
+   *
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Queue\ClaimItems
+   */
+  public static function claimItems($checkPermissions = TRUE) {
+    return (new ClaimItems(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * Run an item from the queue.
+   *
+   * Note: This is appropriate for persistent, auto-run queues.
+   *
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Queue\RunItems
+   */
+  public static function runItems($checkPermissions = TRUE) {
+    return (new RunItems(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
 }

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -134,11 +134,13 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->assertEquals(3, $this->queue->numberOfItems());
     $item = $this->queue->claimItem();
     $this->assertEquals('a', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->queue->deleteItem($item);
 
     $this->assertEquals(2, $this->queue->numberOfItems());
     $item = $this->queue->claimItem();
     $this->assertEquals('b', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->queue->deleteItem($item);
 
     $this->queue->createItem([
@@ -148,11 +150,13 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->assertEquals(2, $this->queue->numberOfItems());
     $item = $this->queue->claimItem();
     $this->assertEquals('c', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->queue->deleteItem($item);
 
     $this->assertEquals(1, $this->queue->numberOfItems());
     $item = $this->queue->claimItem();
     $this->assertEquals('d', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->queue->deleteItem($item);
 
     $this->assertEquals(0, $this->queue->numberOfItems());
@@ -174,12 +178,14 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
 
     $item = $this->queue->claimItem();
     $this->assertEquals('a', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->assertEquals(1, $this->queue->numberOfItems());
     $this->queue->releaseItem($item);
 
     $this->assertEquals(1, $this->queue->numberOfItems());
     $item = $this->queue->claimItem();
     $this->assertEquals('a', $item->data['test-key']);
+    $this->assertEquals(2, $item->run_count);
     $this->queue->deleteItem($item);
 
     $this->assertEquals(0, $this->queue->numberOfItems());
@@ -203,6 +209,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
 
     $item = $this->queue->claimItem();
     $this->assertEquals('a', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->assertEquals(1, $this->queue->numberOfItems());
     // forget to release
 
@@ -215,6 +222,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     CRM_Utils_Time::setTime('2012-04-01 2:00:03');
     $item3 = $this->queue->claimItem();
     $this->assertEquals('a', $item3->data['test-key']);
+    $this->assertEquals(2, $item3->run_count);
     $this->assertEquals(1, $this->queue->numberOfItems());
     $this->queue->deleteItem($item3);
 
@@ -238,6 +246,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
 
     $item = $this->queue->claimItem();
     $this->assertEquals('a', $item->data['test-key']);
+    $this->assertEquals(1, $item->run_count);
     $this->assertEquals(1, $this->queue->numberOfItems());
     // forget to release
 
@@ -249,6 +258,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     // but stealItem works
     $item3 = $this->queue->stealItem();
     $this->assertEquals('a', $item3->data['test-key']);
+    $this->assertEquals(2, $item3->run_count);
     $this->assertEquals(1, $this->queue->numberOfItems());
     $this->queue->deleteItem($item3);
 

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -1,0 +1,409 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Queue;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @group headless
+ * @group queue
+ */
+class QueueTest extends Api4TestBase {
+
+  protected function setUp(): void {
+    \Civi::$statics[__CLASS__] = [
+      'doSomethingResult' => TRUE,
+      'doSomethingLog' => [],
+      'onHookQueueRunLog' => [],
+    ];
+    parent::setUp();
+  }
+
+  /**
+   * Setup a queue with a line of back-to-back tasks.
+   *
+   * The first task runs normally. The second task fails at first, but it is retried, and then
+   * succeeds.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testBasicLinearPolling() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queue = \Civi::queue($queueName, [
+      'type' => 'Sql',
+      'runner' => 'task',
+      'error' => 'delete',
+      'retry_limit' => 2,
+      'retry_interval' => 4,
+    ]);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['first']
+    ));
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['second']
+    ));
+
+    // Get item #1. Run it. Finish it.
+    $first = Queue::claimItems()->setQueue($queueName)->execute()->single();
+    $this->assertCallback('doSomething', ['first'], $first);
+    $this->assertEquals(0, count(Queue::claimItems()->setQueue($queueName)->execute()), 'Linear queue should not return more items while first item is pending.');
+    $firstResult = Queue::runItems(0)->setItems([$first])->execute()->single();
+    $this->assertEquals('ok', $firstResult['outcome']);
+    $this->assertEquals($first['id'], $firstResult['item']['id']);
+    $this->assertEquals($first['queue'], $firstResult['item']['queue']);
+    $this->assertEquals(['first_ok'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    // Get item #2. Run it - but fail!
+    $second = Queue::claimItems()->setQueue($queueName)->execute()->single();
+    $this->assertCallback('doSomething', ['second'], $second);
+    \Civi::$statics[__CLASS__]['doSomethingResult'] = FALSE;
+    $secondResult = Queue::runItems(0)->setItems([$second])->execute()->single();
+    \Civi::$statics[__CLASS__]['doSomethingResult'] = TRUE;
+    $this->assertEquals('retry', $secondResult['outcome']);
+    $this->assertEquals(['first_ok', 'second_err'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    // Item #2 is delayed... it'll take a few seconds to come up...
+    $waitCount = $this->waitFor(1.0, 10, function() use ($queueName, &$retrySecond): bool {
+      $retrySecond = Queue::claimItems()->setQueue($queueName)->execute()->first();
+      return !empty($retrySecond);
+    });
+    $this->assertTrue($waitCount > 0, 'Failed task should not become available immediately. It should take a few seconds.');
+    $this->assertCallback('doSomething', ['second'], $retrySecond);
+    $retrySecondResult = Queue::runItems(0)->setItems([$retrySecond])->execute()->single();
+    $this->assertEquals('ok', $retrySecondResult['outcome']);
+    $this->assertEquals(['first_ok', 'second_err', 'second_ok'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    // All done.
+    $this->assertEquals(0, $queue->numberOfItems());
+  }
+
+  public function testBasicParallelPolling() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+    $queue = \Civi::queue($queueName, ['type' => 'SqlParallel', 'runner' => 'task', 'error' => 'delete']);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['first']
+    ));
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['second']
+    ));
+
+    $first = Queue::claimItems()->setQueue($queueName)->execute()->single();
+    $second = Queue::claimItems()->setQueue($queueName)->execute()->single();
+
+    $this->assertCallback('doSomething', ['first'], $first);
+    $this->assertCallback('doSomething', ['second'], $second);
+
+    // Just for fun, let's run these tasks in opposite order.
+
+    Queue::runItems(0)->setItems([$second])->execute();
+    $this->assertEquals(['second_ok'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    Queue::runItems(0)->setItems([$first])->execute();
+    $this->assertEquals(['second_ok', 'first_ok'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    $this->assertEquals(0, $queue->numberOfItems());
+  }
+
+  /**
+   * Create a parallel queue. Claim and execute tasks as batches.
+   *
+   * Batches are executed via `hook_civicrm_queueRun_{runner}`.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testBatchParallelPolling() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+    \Civi::dispatcher()->addListener('hook_civicrm_queueRun_testStuff', [$this, 'onHookQueueRun']);
+    $queue = \Civi::queue($queueName, [
+      'type' => 'SqlParallel',
+      'runner' => 'testStuff',
+      'error' => 'delete',
+      'batch_limit' => 3,
+    ]);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    for ($i = 0; $i < 7; $i++) {
+      \Civi::queue($queueName)->createItem(['thingy' => $i]);
+    }
+
+    $result = Queue::runItems(0)->setQueue($queueName)->execute();
+    $this->assertEquals(3, count($result));
+    $this->assertEquals([0, 1, 2], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][0]);
+
+    $result = Queue::runItems(0)->setQueue($queueName)->execute();
+    $this->assertEquals(3, count($result));
+    $this->assertEquals([3, 4, 5], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][1]);
+
+    $result = Queue::runItems(0)->setQueue($queueName)->execute();
+    $this->assertEquals(1, count($result));
+    $this->assertEquals([6], \Civi::$statics[__CLASS__]['onHookQueueRunLog'][2]);
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::queueRun()
+   */
+  public function onHookQueueRun(GenericHookEvent $e): void {
+    \Civi::$statics[__CLASS__]['onHookQueueRunLog'][] = array_map(
+      function($item) {
+        return $item->data['thingy'];
+      },
+      $e->items
+    );
+
+    foreach ($e->items as $itemKey => $item) {
+      $e->outcomes[$itemKey] = 'ok';
+      $e->queue->deleteItem($item);
+    }
+  }
+
+  public function testSelect() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_parallel';
+    $queue = \Civi::queue($queueName, ['type' => 'SqlParallel', 'runner' => 'task', 'error' => 'delete']);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['first']
+    ));
+
+    $first = Queue::claimItems()->setQueue($queueName)->setSelect(['id', 'queue'])->execute()->single();
+    $this->assertTrue(is_numeric($first['id']));
+    $this->assertEquals($queueName, $first['queue']);
+    $this->assertFalse(isset($first['data']));
+  }
+
+  public function testEmptyPoll() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queue = \Civi::queue($queueName, ['type' => 'Sql', 'runner' => 'task', 'error' => 'delete']);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    $startResult = Queue::claimItems()->setQueue($queueName)->execute();
+    $this->assertEquals(0, $startResult->count());
+  }
+
+  public function getErrorModes(): array {
+    return [
+      'delete' => ['delete'],
+      'abort' => ['abort'],
+    ];
+  }
+
+  /**
+   * Add a task which is never going to succeed. Try it multiple times (until we run out
+   * of retries).
+   *
+   * @param string $errorMode
+   *   Either 'delete' or 'abort'
+   * @dataProvider getErrorModes
+   */
+  public function testRetryWithPoliteExhaustion(string $errorMode) {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queue = \Civi::queue($queueName, [
+      'type' => 'Sql',
+      'runner' => 'task',
+      'error' => $errorMode,
+      'retry_limit' => 2,
+      'retry_interval' => 1,
+    ]);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['nogooddirtyscoundrel']
+    ));
+
+    \Civi::$statics[__CLASS__]['doSomethingResult'] = FALSE;
+    $outcomes = [];
+    $this->waitFor(0.5, 15, function() use ($queueName, &$outcomes) {
+      $claimed = Queue::claimItems(0)->setQueue($queueName)->execute()->first();
+      if (!$claimed) {
+        return FALSE;
+      }
+      $result = Queue::runItems(0)->setItems([$claimed])->execute()->first();
+      $outcomes[] = $result['outcome'];
+      return ($result['outcome'] !== 'retry');
+    });
+
+    $this->assertEquals(['retry', 'retry', $errorMode], $outcomes);
+    $this->assertEquals(
+      ['nogooddirtyscoundrel_err', 'nogooddirtyscoundrel_err', 'nogooddirtyscoundrel_err'],
+      \Civi::$statics[__CLASS__]['doSomethingLog']
+    );
+
+    $expectActive = ['delete' => TRUE, 'abort' => FALSE];
+    $this->assertEquals($expectActive[$errorMode], $queue->isActive());
+  }
+
+  /**
+   * Add a task. The task-running agent is a bit delinquent... so it forgets the first
+   * few tasks. But the third one works!
+   */
+  public function testRetryWithDelinquencyAndSuccess() {
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queue = \Civi::queue($queueName, [
+      'type' => 'Sql',
+      'runner' => 'task',
+      'error' => 'delete',
+      'retry_limit' => 2,
+      'retry_interval' => 0,
+      'lease_time' => 1,
+    ]);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['playinghooky']
+    ));
+    $this->assertEquals(1, $queue->numberOfItems());
+
+    $claim1 = $this->waitForClaim(0.5, 5, $queueName);
+    // Oops, don't do anything with claim #1!
+    $this->assertEquals(1, $queue->numberOfItems());
+    $this->assertEquals([], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    $claim2 = $this->waitForClaim(0.5, 5, $queueName);
+    // Oops, don't do anything with claim #2!
+    $this->assertEquals(1, $queue->numberOfItems());
+    $this->assertEquals([], \Civi::$statics[__CLASS__]['doSomethingLog']);
+
+    $claim3 = $this->waitForClaim(0.5, 5, $queueName);
+    $this->assertEquals(1, $queue->numberOfItems());
+    $result = Queue::runItems(0)->setItems([$claim3])->execute()->first();
+    $this->assertEquals(0, $queue->numberOfItems());
+    $this->assertEquals(['playinghooky_ok'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+    $this->assertEquals('ok', $result['outcome']);
+  }
+
+  /**
+   * Add a task which is never going to succeed. The task fails every time, and eventually
+   * we either delete it or abort the queue.
+   *
+   * @param string $errorMode
+   *   Either 'delete' or 'abort'
+   * @dataProvider getErrorModes
+   */
+  public function testRetryWithEventualFailure(string $errorMode) {
+    \Civi::$statics[__CLASS__]['doSomethingResult'] = FALSE;
+
+    $queueName = 'QueueTest_' . md5(random_bytes(32)) . '_linear';
+    $queue = \Civi::queue($queueName, [
+      'type' => 'Sql',
+      'runner' => 'task',
+      'error' => $errorMode,
+      'retry_limit' => 2,
+      'retry_interval' => 0,
+      'lease_time' => 1,
+    ]);
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    \Civi::queue($queueName)->createItem(new \CRM_Queue_Task(
+      [QueueTest::class, 'doSomething'],
+      ['playinghooky']
+    ));
+    $this->assertEquals(1, $queue->numberOfItems());
+
+    $claimAndRun = function($expectOutcome, $expectEndCount) use ($queue, $queueName) {
+      $claim = $this->waitForClaim(0.5, 5, $queueName);
+      $this->assertEquals(1, $queue->numberOfItems());
+      $result = Queue::runItems(0)->setItems([$claim])->execute()->first();
+      $this->assertEquals($expectEndCount, $queue->numberOfItems());
+      $this->assertEquals($expectOutcome, $result['outcome']);
+    };
+
+    $claimAndRun('retry', 1);
+    $claimAndRun('retry', 1);
+    switch ($errorMode) {
+      case 'delete':
+        $claimAndRun('delete', 0);
+        $this->assertEquals(TRUE, $queue->isActive());
+        break;
+
+      case 'abort':
+        $claimAndRun('abort', 1);
+        $this->assertEquals(FALSE, $queue->isActive());
+        break;
+    }
+
+    $this->assertEquals(['playinghooky_err', 'playinghooky_err', 'playinghooky_err'], \Civi::$statics[__CLASS__]['doSomethingLog']);
+  }
+
+  public static function doSomething(\CRM_Queue_TaskContext $ctx, string $something) {
+    $ok = \Civi::$statics[__CLASS__]['doSomethingResult'];
+    \Civi::$statics[__CLASS__]['doSomethingLog'][] = $something . ($ok ? '_ok' : '_err');
+    return $ok;
+  }
+
+  protected function assertCallback($expectMethod, $expectArgs, $actualTask) {
+    $this->assertEquals([QueueTest::class, $expectMethod], $actualTask['data']['callback'], 'Claimed task should have expected method');
+    $this->assertEquals($expectArgs, $actualTask['data']['arguments'], 'Claimed task should have expected arguments');
+  }
+
+  protected function waitForClaim(float $interval, float $timeout, string $queueName): ?array {
+    $claims = [];
+    $this->waitFor($interval, $timeout, function() use ($queueName, &$claims) {
+      $claimed = Queue::claimItems(0)->setQueue($queueName)->execute()->first();
+      if (!$claimed) {
+        return FALSE;
+      }
+      $claims[] = $claimed;
+      return TRUE;
+    });
+    return $claims[0] ?? NULL;
+  }
+
+  /**
+   * Repeatedly check $condition until it returns true (or until we exhaust timeout).
+   *
+   * @param float $interval
+   *   Seconds to wait between checks.
+   * @param float $timeout
+   *   Total maximum seconds to wait across all checks.
+   * @param callable $condition
+   *   The condition to check.
+   * @return int
+   *   Total number of intervals we had to wait/sleep.
+   */
+  protected function waitFor(float $interval, float $timeout, callable $condition): int {
+    $end = microtime(TRUE) + $timeout;
+    $interval *= round($interval * 1000 * 1000);
+    $waitCount = 0;
+    $ready = $condition();
+    while (!$ready && microtime(TRUE) <= $end) {
+      usleep($interval);
+      $waitCount++;
+      $ready = $condition();
+    }
+    $this->assertTrue($ready, 'Wait condition not met');
+    return $waitCount;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This adds two APIs, `Queue.claimItems` and `Queue.runItems`. These APIs may be used by background agents to reserve and execute tasks in a persistent queue. This PR is a major step towards providing *generic* support for background processing. 

As described in previous PRs (esp #22812), application-developers can specify queue behavior by setting various options, eg:

```php
$queue = Civi::queue('my-stuff', [
  'type' => 'SqlParallel',    // Multiple workers may claim concurrent tasks from this queue
  'runner' => 'myStuff',      // Execute tasks via `hook_civicrm_queueRun_myStuff`
  'lease_time' => 3600,       // If task doesn't succeed within 60min, assume it failed.
  'batch_limit' => 5,         // Grab batches of 0-5 items.
  'retry_limit' => 2,         // If a task fails, it may be retried (twice).
  'retry_interval' => 600,    // If a task fails, try again after 10min.
  'error' => 'abort',         // If a task repeatedly has unhandled exceptions, then stop queue from running new tasks
]);
$queue->createItem(...);
$queue->createItem(...);
$queue->createItem(...);
```

Background agents call the `Queue.runItems` API (and/or `Queue.claimItems`). The `Queue` API respects the options from above. Tasks may be executed like so:

```bash
# Example 1: Claim and run a task - single API call, bash
cv api4 Queue.runItems queue=my-stuff
```
```php
# Example 2: Claim and run a task - single API call, PHP
$outcomes = \Civi\Api4\Queue::runItems(0)>setQueue('my-stuff')->execute();
```
```php
# Example 3: Claim and run a task - two API calls, PHP
$claims = (array) \Civi\Api4\Queue::claimItems(0)->setQueue('my-stuff')->execute();
if ($claims) {
  $outcomes =  \Civi\Api4\Queue::runItems(0)->setItems($claims)->execute();
}
```

Cross-Reference
----------------

* Contributes toward https://lab.civicrm.org/dev/core/-/issues/1304. 
* Provides an API for use by [coworker](https://lab.civicrm.org/dev/coworker).
* Replaces #22690. This revisions differs in a few ways:
    * Adds support for batched queue operations (eg "claim up to 10 items to work on as a batch")
    * Adds several queue-level configuration options (per #22812 - `runner`, `lease_time`, `batch_limit`, `retry_limit`). 
    * Relaxes the requirement for using `CRM_Queue_Task`. You may still fill a queue with tasks, but you may also fill queues with bespoke `array()` data.
    * Adds `hook_queueRun_{runner}` as a way to run queued items with bespoke and/or batched data.

Before
----------------------------------------

The `CRM_Queue` allows you to build a queue or task-list. It encourages task-running in the foreground but not in the background:

* __Foreground__: If you want to run tasks in the foreground, then use the AJAX-based `CRM_Queue_Runner`. (Note: [it was primarily tuned for executing database upgrades in the web UI](https://github.com/civicrm/civicrm-core/blob/47cd9404f4622a5b7f9e92c0a91982a0b7c94231/CRM/Queue/Runner.php#L13-L27).)
* __Background__: If you want to run tasks in the background, then you must create a new agent and use various APIs to poll+evaluate the queues. (This is what some extensions do.) Anyone who deploys must take extra steps to configure their agent.

After
----------------------------------------

You may still use all the same patterns as before. Additionally, you may *register a queue* that will run in the background. The `Queue.runItems` API executes them. Here are a few examples:

* [(gist) Example extension "queuex". Queue with tasks, executed 1-by-1 (Minimalist)](https://gist.github.com/totten/168f15ccf7a1ab14a6a8b695f33074e8)
* [(gist) Example extension "queuex". Queue with tasks, executed 1-by-1. (w/extra API examples.)](https://gist.github.com/totten/3e29142090ca26f92b6d94ee7b2cacd9)
* [(gist) Example extension "queuex". Queue with basic arrays, fetched in batches. (w/extra API examples.)](https://gist.github.com/totten/27b16b8b1fc78a6e582c7f2e8ded964a)

Technical Details
----------------------------------------

The present PR only adds the `Queue` APIs (*building-blocks*) -- there must also be some *agent* that uses the APIs. Here are a few ways to create an agent:

* __Bare mininum__: Manually setup cron jobs or CLI scripts for each queue.
     ```bash
    cv api4 Queue.runItems queue=my-stuff
    ```
* __Generic agent (pseudocode)__: Implement a generic agent that calls `Queue.get +w 'runner IS NOT EMPTY'` and then `Queue.runItems`. Here is pseudocode: https://gist.github.com/totten/d7a7e29de238b7892d49366966787759
* __Generic agent (implementation)__: Use https://lab.civicrm.org/dev/coworker. This is an in-development implementation of that pseudocode above. It defines a number of options (such as configuring #workers and limiting the #tasks each worker handles). The current revision uses [API pipe](https://github.com/civicrm/civicrm-core/pull/22262) for low-latency execution -- but it also aims to support REST API for broader compatibility.

Further notes:

* __Background error handling__: For database upgrades running in the foreground, an error will cause the whole queue to stop - and it will ask the user for instruction. But if you send tasks to run in the background, then there is no active user to ask. Instead, you need some policy to decide how to handle the error. This PR includes two mechanisms for error-handling:
    * __Retry Policy__: The retry policy specifies whether (and how) to retry tasks. This example will retry up to 4 times (at intervals of 10 minutes, aka 600 seconds). If it still doesn't succeed, then it is considered failed.
        ```php
        $q = Civi::queue('my-stuff', [
          'type' => 'SqlParallel',
          'retry_limit' => 4,
          'retry_interval' => 600,
          'error' => 'delete',
        ]);
        $q->createItem(new CRM_Queue_Task('queuex_hello', [123]));
        ```
    * __Error Hook__: When a task encounters an error, it fires `hook_civicrm_queueTaskError()`. You can use this hook to inspect the error, to enqueue an alternative action, to send a notification, etc. The following example discriminates based on the specific error - for some errors, it retries; for others, it gives up:
        ```php
        function example_civicrm_queueTaskError($queue, $item, &$outcome, $exception) {
          if (preg_match(';Email server unavailable;', $exception->getMessage()) {
            $outcome = 'retry'; // Maybe worth trying again.
          }
          else {
            $outcome = 'fail';
          }
        }
* __1 Step/2 Step__: The examples show how to run a task with 1-step (`runItems()`) or 2-steps (`claimItems()`+`runItems()`). Why? The 1-step protocol is more convenient in some cases (eg `cv api4 Queue.runItems...`). However, in `coworker`s architecture, the 2-step allows it to better balance work across multiple processes.
