### PR TITLE
[REF] Simplification in Contact::getValues

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -890,13 +890,12 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 
     unset($params['id']);
 
-    //get the block information for this contact
-    $entityBlock = ['contact_id' => $params['contact_id']];
-    $blocks = CRM_Core_BAO_Location::getValues($entityBlock, $microformat);
-    $defaults = array_merge($defaults, $blocks);
-    foreach ($blocks as $block => $value) {
-      $contact->$block = $value;
-    }
+    $contact->im = $defaults['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $params['contact_id']]);
+    $contact->email = $defaults['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $params['contact_id']]);
+    $contact->openid = $defaults['openid'] = CRM_Core_BAO_OpenID::getValues(['contact_id' => $params['contact_id']]);
+    $contact->phone = $defaults['phone'] = CRM_Core_BAO_Phone::getValues(['contact_id' => $params['contact_id']]);
+    $contact->address = $defaults['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $params['contact_id']], $microformat);
+    $contact->website = CRM_Core_BAO_Website::getValues($params, $defaults);
 
     if (!isset($params['noNotes'])) {
       $contact->notes = CRM_Core_BAO_Note::getValues($params, $defaults);
@@ -908,10 +907,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 
     if (!isset($params['noGroups'])) {
       $contact->groupContact = CRM_Contact_BAO_GroupContact::getValues($params, $defaults);
-    }
-
-    if (!isset($params['noWebsite'])) {
-      $contact->website = CRM_Core_BAO_Website::getValues($params, $defaults);
     }
 
     return $contact;
@@ -2616,7 +2611,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
    * @return CRM_Contact_BAO_Contact|null
    *   The found object or null
    */
-  public static function getValues(&$params, &$values) {
+  public static function getValues($params, &$values) {
     $contact = new CRM_Contact_BAO_Contact();
 
     $contact->copyValues($params);

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -76,7 +76,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact {
    * @return array
    *   (reference)   the values that could be potentially assigned to smarty
    */
-  public static function getValues(&$params, &$values) {
+  public static function getValues($params, &$values) {
     if (empty($params)) {
       return NULL;
     }

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -984,7 +984,7 @@ WHERE  relationship_type_id = " . CRM_Utils_Type::escape($type, 'Integer');
    * @return array
    *   (reference)   the values that could be potentially assigned to smarty
    */
-  public static function &getValues(&$params, &$values) {
+  public static function &getValues($params, &$values) {
     if (empty($params)) {
       return NULL;
     }

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -237,7 +237,7 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note implements \Civi\Test\HookInte
    *
    * @return array
    */
-  public static function &getValues(&$params, &$values, $numNotes = self::MAX_NOTES) {
+  public static function &getValues($params, &$values, $numNotes = self::MAX_NOTES) {
     if (empty($params)) {
       return NULL;
     }

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -122,7 +122,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
    *
    * @return array
    */
-  public static function &getValues(&$params = [], &$values = []) {
+  public static function &getValues($params = [], &$values = []) {
     $websites = [];
     $website = new CRM_Core_DAO_Website();
     $website->contact_id = $params['contact_id'];


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Simplification in Contact::getValues

Before
----------------------------------------
Erm - what does this mean?

![image](https://user-images.githubusercontent.com/336308/153695169-66ce4a77-f907-4368-8fbb-1aff00751bf0.png)

After
----------------------------------------
Ah - that's what it does 

![image](https://user-images.githubusercontent.com/336308/153695151-3f15b273-8139-4988-997e-eb7003c635da.png)

Technical Details
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/22757

The call to location::getValues takes more lines & is
less readable than just doing the thing.

Note that
1) I could not find any evidence of 'noWebsite' being passed in so I switched to
always add
2) the signature on website:getValues is slightly different (of course).
3) I found that the others that were receiving params as a reference were
not altering it so removed those pass-by-refs

Comments
----------------------------------------
