### PR TITLE
SearchKit - Add 'merge contacts' task

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -132,10 +132,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $this->assign('flip', $flipUrl);
 
       $this->prev = $this->next = NULL;
-      foreach ([
-        'prev',
-        'next',
-      ] as $position) {
+      foreach (['prev', 'next'] as $position) {
         if (!empty($pos[$position])) {
           if ($pos[$position]['id1'] && $pos[$position]['id2']) {
             $rowParams = array_merge($urlParams, [
@@ -145,9 +142,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
               'mergeId' => $pos[$position]['mergeId'],
             ]);
             $this->$position = CRM_Utils_System::url('civicrm/contact/merge', $rowParams);
-            $this->assign($position, $this->$position);
           }
         }
+        $this->assign($position, $this->$position);
       }
 
       // get user info of other contact.
@@ -157,9 +154,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       if ($otherUfId) {
         // @todo also calculate & assign url here & get it out of getRowsElementsAndInfo as it is form layer functionality.
         $otherUser = $config->userSystem->getUser($this->_oid);
-        $this->assign('otherUfId', $otherUfId);
-        $this->assign('otherUfName', $otherUser ? $otherUser['name'] : NULL);
       }
+      $this->assign('otherUfId', $otherUfId);
+      $this->assign('otherUfName', $otherUser ? $otherUser['name'] : NULL);
 
       $cmsUser = $mainUfId && $otherUfId;
       $this->assign('user', $cmsUser);
@@ -199,12 +196,11 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $assignedRows = $rowsElementsAndInfo['rows'];
       foreach ($assignedRows as $index => $assignedRow) {
         // prevent smarty notices.
-        if (!array_key_exists('main', $assignedRow)) {
-          $assignedRows[$index]['main'] = NULL;
-        }
-        if (!array_key_exists('other', $assignedRow)) {
-          $assignedRows[$index]['other'] = NULL;
-        }
+        $assignedRows[$index] += [
+          'main' => NULL,
+          'other' => NULL,
+          'location_entity' => NULL,
+        ];
       }
       $this->assign('rows', $assignedRows);
 
@@ -265,7 +261,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       'type' => 'next',
       'name' => $this->next ? ts('Merge and go to Next Pair') : ts('Merge'),
       'isDefault' => TRUE,
-      'icon' => $this->next ? 'fa-play-circle' : 'check',
+      'icon' => $this->next ? 'fa-play-circle' : 'fa-check',
     ];
 
     if ($this->next || $this->prev) {
@@ -326,15 +322,15 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
     if (!empty($formValues['_qf_Merge_submit'])) {
       $urlParams['action'] = "update";
-      CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind',
+      CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/dedupefind',
         $urlParams
       ));
     }
-    if (!empty($formValues['_qf_Merge_done'])) {
-      CRM_Utils_System::redirect($contactViewUrl);
+    elseif (!empty($formValues['_qf_Merge_done'])) {
+      CRM_Core_Session::singleton()->pushUserContext($contactViewUrl);
     }
 
-    if ($this->next && $this->_mergeId) {
+    elseif ($this->next && $this->_mergeId) {
       $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $this->_gid, json_decode($this->criteria, TRUE), TRUE, $this->limit);
 
       $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
@@ -351,12 +347,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         $urlParams['oid'] = $pos['next']['id2'];
         $urlParams['mergeId'] = $pos['next']['mergeId'];
         $urlParams['action'] = 'update';
-        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/merge', $urlParams));
+        CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/merge', $urlParams));
       }
     }
-
-    // Perhaps never reached.
-    CRM_Utils_System::redirect($contactViewUrl);
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -24,6 +24,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
    * @throws \API_Exception
    */
   public function _run(\Civi\Api4\Generic\Result $result) {
+    // Adding checkPermissions filters out actions the user is not allowed to perform
     $entity = Entity::get($this->checkPermissions)->addWhere('name', '=', $this->entity)
       ->addSelect('name', 'title_plural')
       ->setChain(['actions' => ['$name', 'getActions', ['where' => [['name', 'IN', ['update', 'delete']]]], 'name']])
@@ -107,6 +108,17 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
             ],
           ];
         }
+      }
+      if (!$this->checkPermissions || \CRM_Core_Permission::check(['merge duplicate contacts', 'delete contacts'])) {
+        $tasks[$entity['name']]['contact.merge'] = [
+          'title' => E::ts('Dedupe - Merge 2 Contacts'),
+          'number' => '=== 2',
+          'icon' => 'fa-compress',
+          'crmPopup' => [
+            'path' => "'civicrm/contact/merge'",
+            'query' => '{reset: 1, cid: ids[0], oid: ids[1], action: "update"}',
+          ],
+        ];
       }
     }
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
@@ -42,6 +42,15 @@
         return $scope.$eval('' + ctrl.ids.length + action.number);
       };
 
+      this.getActionTitle = function(action) {
+        if (ctrl.isActionAllowed(action)) {
+          return ctrl.ids.length ?
+            ts('Perform action on %1 %2', {1: ctrl.ids.length, 2: ctrl.entityInfo[ctrl.ids.length === 1 ? 'title' : 'title_plural']}) :
+            ts('Perform action on all %1', {1: ctrl.entityInfo.title_plural});
+        }
+        return ts('Selected number must be %1', {1: action.number.replace('===', '')});
+      };
+
       this.doAction = function(action) {
         if (!ctrl.isActionAllowed(action)) {
           return;

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.html
@@ -1,14 +1,20 @@
-<div class="btn-group" title="{{:: ts('Perform action on selected items.') }}">
-  <button type="button" ng-disabled="$ctrl.displayController.loading || !$ctrl.displayController.results.length" ng-click="$ctrl.getTasks()" class="btn dropdown-toggle btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<div class="btn-group">
+  <button type="button"
+    ng-disabled="$ctrl.displayController.loading || !$ctrl.displayController.results.length"
+    ng-click="$ctrl.getTasks()"
+    class="btn dropdown-toggle btn-default"
+    title="{{:: ts('Perform action on selected items.') }}"
+    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+  >
     <i class="crm-i fa-pencil"></i>
     {{:: ts('Action') }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu">
-    <li ng-class="{disabled: !$ctrl.isActionAllowed(action)}" ng-repeat="action in $ctrl.tasks">
-      <a href ng-click="$ctrl.doAction(action)"><i class="fa {{:: action.icon }}"></i> {{:: action.title }}</a>
+    <li ng-class="{disabled: !$ctrl.isActionAllowed(action)}" ng-repeat="action in $ctrl.tasks" title="{{ $ctrl.getActionTitle(action) }}">
+      <a href ng-click="$ctrl.doAction(action)"><i class="crm-i {{:: action.icon }}"></i> {{:: action.title }}</a>
     </li>
     <li class="disabled" ng-if="!$ctrl.tasks">
-      <a href><i class="fa fa-spinner fa-spin"></i></a>
+      <a href><i class="crm-i fa-spinner fa-spin"></i></a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Allows duplicate contacts to be merged from SearchKit.

Before
----------------------------------------
No option to merge contacts.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/153778690-5597865a-5e7f-41ee-bcfc-0fddb1ab176e.png)

![image](https://user-images.githubusercontent.com/2874912/153778761-bec79016-e72d-44b7-bba9-f592c1cbf85f.png)


Technical Details
----------------------------------------
Included some cleanup in the Dedupe form to make it work better with ajax, and fixed some (but not all) of the undefined template variables).