### PR TITLE
SearchKit - Customizable "No Results" text

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -28,6 +28,10 @@
   </div>
   <search-admin-css-rules label="{{:: ts('Row Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
   <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+  <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the table is empty.') }}">
+    <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+    <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+  </div>
 </fieldset>
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -64,11 +64,24 @@
         this.initializeDisplay($scope, $element);
         // Keep tab counts up-to-date - put rowCount in current tab if there are no other filters
         $scope.$watch('$ctrl.rowCount', function(val) {
-          if (typeof val === 'number' && angular.equals(['has_base'], _.keys(ctrl.filters))) {
+          if (typeof val === 'number' && angular.equals(['has_base'], getActiveFilters())) {
             ctrl.tabCount = val;
           }
         });
+        // Customize the noResultsText
+        $scope.$watch('$ctrl.filters', function() {
+          ctrl.settings.noResultsText = (angular.equals(['has_base'], getActiveFilters())) ?
+            ts('Welcome to Search Kit. Click the New Search button above to start composing your first search.') :
+            ts('No Saved Searches match filter criteria.');
+        }, true);
       };
+
+      // Get the names of in-use filters
+      function getActiveFilters() {
+        return _.keys(_.pick(ctrl.filters, function(val) {
+          return val !== null && (val === true || val === false || val.length);
+        }));
+      }
 
       this.onPostRun.push(function(result) {
         _.each(result, function(row) {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -11,7 +11,7 @@
 <tr ng-if="$ctrl.rowCount === 0">
   <td colspan="{{ $ctrl.settings.columns.length + 2 }}">
     <p class="alert alert-info text-center">
-      {{:: ts('None Found') }}
+      {{ $ctrl.settings.noResultsText || ts('None Found') }}
     </p>
   </td>
 </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Allows the "None Found" text to be configured when a table displays no results.
Customizes the text for the SearchKit admin screen.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/153894540-d20ab4ac-14ff-4aca-ab37-667baea39cb8.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/153894425-7d81fc3f-bc80-4f72-a300-3e26f84107cd.png)
