### PR TITLE
dev/core#3066 - Check CiviPledge is enabled before disconnecting pledge payments

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -507,6 +507,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution {
     CRM_Contribute_BAO_ContributionSoft::processSoftContribution($params, $contribution);
 
     if (!empty($params['id']) && !empty($params['contribution_status_id'])
+      && CRM_Core_Component::isEnabled('CiviPledge')
     ) {
       self::disconnectPledgePaymentsIfCancelled((int) $params['id'], CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id']));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes error documented by [dev/core#3066](https://lab.civicrm.org/dev/core/-/issues/3066).

Before
----------------------------------------
APIv4 calls were made even if the PledgePayment API was not available and `Civi\API\Exception\NotImplementedException` was thrown.

After
----------------------------------------
`CRM_Contribute_BAO_Contribution::disconnectPledgePaymentsIfCancelled()` is skipped if CiviPledge is disabled.

Comments
----------------------------------------
If this is backported, please note that `CRM_Core_Component::isEnabled()` is not available in the current release (5.46.x) or the ESR.
