### PR TITLE
Fix submit handling of thousands when creating data entry batch

### DIFF
--- a/CRM/Batch/Form/Batch.php
+++ b/CRM/Batch/Form/Batch.php
@@ -9,10 +9,14 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Batch;
+
 /**
  * This class generates form components for batch entry.
  */
 class CRM_Batch_Form_Batch extends CRM_Admin_Form {
+
+  protected $submittableMoneyFields = ['total'];
 
   /**
    * PreProcess function.
@@ -26,6 +30,8 @@ class CRM_Batch_Form_Batch extends CRM_Admin_Form {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
@@ -69,35 +75,35 @@ class CRM_Batch_Form_Batch extends CRM_Admin_Form {
 
   /**
    * Process the form submission.
+   *
+   * @throws \API_Exception
    */
-  public function postProcess() {
-    $params = $this->controller->exportValues($this->_name);
+  public function postProcess(): void {
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Core_Session::setStatus("", ts("Batch Deleted"), "success");
+      CRM_Core_Session::setStatus('', ts('Batch Deleted'), 'success');
       CRM_Batch_BAO_Batch::deleteBatch($this->_id);
       return;
     }
 
-    if ($this->_id) {
-      $params['id'] = $this->_id;
-    }
-    else {
-      $session = CRM_Core_Session::singleton();
-      $params['created_id'] = $session->get('userID');
-      $params['created_date'] = CRM_Utils_Date::processDate(date("Y-m-d"), date("H:i:s"));
-    }
+    $batchID = Batch::save(FALSE)->setRecords([
+      [
+        // Always create with data entry status.
+        'status_id:name' => 'Data Entry',
+        'id' => $this->_id,
+        'title' => $this->getSubmittedValue('title'),
+        'description' => $this->getSubmittedValue('description'),
+        'type_id' => $this->getSubmittedValue('type_id'),
+        'total' => $this->getSubmittedValue('total'),
+        'item_count' => $this->getSubmittedValue('item_count'),
+      ],
+    ])->execute()->first()['id'];
 
-    // always create with data entry status
-    $params['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_BAO_Batch', 'status_id', 'Data Entry');
-    $batch = CRM_Batch_BAO_Batch::create($params);
-
-    // redirect to batch entry page.
-    $session = CRM_Core_Session::singleton();
+    // Redirect to batch entry page.
     if ($this->_action & CRM_Core_Action::ADD) {
-      $session->replaceUserContext(CRM_Utils_System::url('civicrm/batch/entry', "id={$batch->id}&reset=1&action=add"));
+      CRM_Core_Session::singleton()->replaceUserContext(CRM_Utils_System::url('civicrm/batch/entry', "id={$batchID}&reset=1&action=add"));
     }
     else {
-      $session->replaceUserContext(CRM_Utils_System::url('civicrm/batch/entry', "id={$batch->id}&reset=1"));
+      CRM_Core_Session::singleton()->replaceUserContext(CRM_Utils_System::url('civicrm/batch/entry', "id={$batchID}&reset=1"));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix submit handling of thousands when creating data entry batch

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/153961984-cbb35036-f418-468c-8d6f-a85c1a9eff9f.png)

When creating a new batch entering the total batch amount with  a comma (eg. 5,000.00) results in the amount being truncated

After
----------------------------------------
Saves correctly

Technical Details
----------------------------------------
Note I tested & the apiv4 does fine at handling created_id & created_date so I removed that from the form

Comments
----------------------------------------
I noticed some other issues around this flow - I think I have another PR open for the enotices so I kept this PR tightly constrained to post process