### PR TITLE
Fix display of Child Groups on Manage Groups screen

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -254,7 +254,7 @@
                 appendHTML += '<td class="{/literal}{$editableClass}{literal} crmf-description">' + (val.description || '') + "</td>";
                 appendHTML += "<td>" + val.group_type + "</td>";
                 appendHTML += '<td class="{/literal}{$editableClass}{literal} crmf-visibility" data-type="select">' + val.visibility + "</td>";
-                if (showOrgInfo) {
+                if (showOrgInfo != "0") {
                   appendHTML += "<td>" + val.org_info + "</td>";
                 }
                 appendHTML += "<td>" + val.links + "</td>";


### PR DESCRIPTION
Overview
----------------------------------------
This PR addresses [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/3071).

Since #22084 Child Groups incorrectly show an extra table cell on Manage Groups screen when CiviCRM is not in Multisite mode. This PR fixes it.