### PR TITLE
Follow up fix on removing preferred_mail_format

### DIFF
--- a/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
@@ -38,12 +38,6 @@
       </div>
     </div>
     {/if}
-    <div class="crm-summary-row">
-      <div class="crm-label">{ts}Email Format{/ts}</div>
-      <div class="crm-content crm-contact-preferred_mail_format">
-        {$preferred_mail_format}
-      </div>
-    </div>
     {if $communication_style_display}
     <div class="crm-summary-row">
       <div class="crm-label">{ts}Communication Style{/ts}</div>


### PR DESCRIPTION
Overview
----------------------------------------
Follow up fix on removing preferred_mail_format

Before
----------------------------------------
Deprecated preferred_mail_format is present (or at least a notice) on communication preferences

After
----------------------------------------
poof

Technical Details
----------------------------------------
As pointed out by @demeritcowboy https://github.com/civicrm/civicrm-core/pull/22635#issuecomment-1040367448

Comments
----------------------------------------
