### PR TITLE
APIv4 - Fix typo in Entity.getFields

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -81,7 +81,7 @@ class Entity extends Generic\AbstractEntity {
         ],
         [
           'name' => 'primary_key',
-          'type' => 'Array',
+          'data_type' => 'Array',
           'description' => 'Name of unique identifier field(s) (e.g. [id])',
         ],
         [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a typo that caused test failures when I tried to tighten up strictness about what fields should be returned.

Before
----------------------------------------
Wrong key

After
----------------------------------------
Correct

Technical Details
------------
In `getFields`, "type" refers to the type of field, not the type of data it contains. In retrospect, it probably should have been called `field_type`.