### PR TITLE
APIv4 - Ensure only declared fields are returned from BasicGet actions

### DIFF
--- a/Civi/Api4/Action/Setting/GetFields.php
+++ b/Civi/Api4/Action/Setting/GetFields.php
@@ -32,7 +32,7 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
     $filter = $names ? ['name' => $names] : [];
     $settings = \Civi\Core\SettingsMetadata::getMetadata($filter, $this->domainId, $this->loadOptions);
     $getReadonly = $this->_isFieldSelected('readonly');
-    foreach ($settings as $index => $setting) {
+    foreach ($settings as &$setting) {
       // Unserialize default value
       if (!empty($setting['serialize']) && !empty($setting['default']) && is_string($setting['default'])) {
         $setting['default'] = \CRM_Core_DAO::unSerializeField($setting['default'], $setting['serialize']);
@@ -43,13 +43,18 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
       if ($getReadonly) {
         $setting['readonly'] = \Civi::settings()->getMandatory($setting['name']) !== NULL;
       }
-      // Filter out deprecated properties
-      $settings[$index] = array_intersect_key($setting, array_column($this->fields(), NULL, 'name'));
     }
     return $settings;
   }
 
+  /**
+   * Returns overridden list of fields for 'get', 'revert' & 'set' actions.
+   * @return string[][]
+   */
   public function fields() {
+    if (!in_array($this->action, ['get', 'revert', 'set'], TRUE)) {
+      return parent::fields();
+    }
     return [
       [
         'name' => 'name',

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -123,6 +123,7 @@ class BasicGetFieldsAction extends BasicGetAction {
         }
       }
     }
+    $fieldProps = array_column($this->fields(), 'name', 'name');
     // Unless this is an internal getFields call, filter out @internal properties
     $internalProps = $isInternal ? [] : array_filter(array_column($this->fields(), '@internal', 'name'));
     foreach ($values as &$field) {
@@ -141,7 +142,7 @@ class BasicGetFieldsAction extends BasicGetAction {
       if (isset($defaults['options'])) {
         $field['options'] = $this->formatOptionList($field['options']);
       }
-      $field = array_diff_key($field, $internalProps);
+      $field = array_intersect_key(array_diff_key($field, $internalProps), $fieldProps);
     }
   }
 

--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -110,8 +110,7 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
       'data_type' => 'Integer',
     ];
     $fields[] = [
-      'name' => 'custom_group_id',
-      'data_type' => 'Integer',
+      'name' => 'custom_group',
     ];
     $fields[] = [
       'name' => 'sql_filters',

--- a/Civi/Api4/Setting.php
+++ b/Civi/Api4/Setting.php
@@ -58,4 +58,13 @@ class Setting extends Generic\AbstractEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @inheritDoc
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['primary_key'] = ['name'];
+    return $info;
+  }
+
 }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -209,24 +209,26 @@ class FormattingUtil {
           self::applyFormatters($result, $fieldName, $field, $value);
           $dataType = NULL;
         }
-        // Evaluate pseudoconstant suffixes
-        $suffix = strrpos($fieldName, ':');
-        if ($suffix) {
-          $fieldOptions[$fieldName] = $fieldOptions[$fieldName] ?? self::getPseudoconstantList($field, $fieldName, $result, $action);
-          $dataType = NULL;
-        }
-        if ($fieldExpr->supportsExpansion) {
-          if (!empty($field['serialize']) && is_string($value)) {
-            $value = \CRM_Core_DAO::unSerializeField($value, $field['serialize']);
+        if ($value !== NULL) {
+          // Evaluate pseudoconstant suffixes
+          $suffix = strrpos($fieldName, ':');
+          if ($suffix) {
+            $fieldOptions[$fieldName] = $fieldOptions[$fieldName] ?? self::getPseudoconstantList($field, $fieldName, $result, $action);
+            $dataType = NULL;
           }
-          if (isset($fieldOptions[$fieldName])) {
-            $value = self::replacePseudoconstant($fieldOptions[$fieldName], $value);
+          if ($fieldExpr->supportsExpansion) {
+            if (!empty($field['serialize']) && is_string($value)) {
+              $value = \CRM_Core_DAO::unSerializeField($value, $field['serialize']);
+            }
+            if (isset($fieldOptions[$fieldName])) {
+              $value = self::replacePseudoconstant($fieldOptions[$fieldName], $value);
+            }
           }
-        }
-        // Keep track of contact types for self::contactFieldsToRemove
-        if ($value && isset($field['entity']) && $field['entity'] === 'Contact' && $field['name'] === 'contact_type') {
-          $prefix = strrpos($fieldName, '.');
-          $contactTypePaths[$prefix ? substr($fieldName, 0, $prefix + 1) : ''] = $value;
+          // Keep track of contact types for self::contactFieldsToRemove
+          if ($value && isset($field['entity']) && $field['entity'] === 'Contact' && $field['name'] === 'contact_type') {
+            $prefix = strrpos($fieldName, '.');
+            $contactTypePaths[$prefix ? substr($fieldName, 0, $prefix + 1) : ''] = $value;
+          }
         }
         $result[$key] = self::convertDataType($value, $dataType);
       }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -265,7 +265,12 @@ class FormattingUtil {
     }
     // Fallback for option lists that exist in the api but not the BAO
     if (!isset($options) || $options === FALSE) {
-      $options = civicrm_api4($field['entity'], 'getFields', ['action' => $action, 'loadOptions' => ['id', $valueType], 'where' => [['name', '=', $field['name']]]])[0]['options'] ?? NULL;
+      $options = civicrm_api4($field['entity'], 'getFields', [
+        'checkPermissions' => FALSE,
+        'action' => $action,
+        'loadOptions' => ['id', $valueType],
+        'where' => [['name', '=', $field['name']]],
+      ])[0]['options'] ?? NULL;
       $options = $options ? array_column($options, $valueType, 'id') : $options;
     }
     if (is_array($options)) {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -162,10 +162,10 @@ class BasicActionsTest extends UnitTestCase implements HookInterface {
 
   public function testBatchFrobnicate() {
     $objects = [
-      ['group' => 'one', 'color' => 'red', 'number' => 10],
-      ['group' => 'one', 'color' => 'blue', 'number' => 20],
-      ['group' => 'one', 'color' => 'green', 'number' => 30],
-      ['group' => 'two', 'color' => 'blue', 'number' => 40],
+      ['group' => 'one', 'color' => 'red', 'size' => 10],
+      ['group' => 'one', 'color' => 'blue', 'size' => 20],
+      ['group' => 'one', 'color' => 'green', 'size' => 30],
+      ['group' => 'two', 'color' => 'blue', 'size' => 40],
     ];
     $this->replaceRecords($objects);
 
@@ -432,6 +432,29 @@ class BasicActionsTest extends UnitTestCase implements HookInterface {
     catch (\API_Exception $createError) {
     }
     $this->assertStringContainsString('Illegal expression', $createError->getMessage());
+  }
+
+  public function testGetReturnValues(): void {
+    $records = [
+      ['shape' => 'round', 'not_a_real_field' => 'not allowed!'],
+      ['shape' => 'square', 'not_a_real_field' => 'not allowed!'],
+    ];
+    $this->replaceRecords($records);
+
+    // Fields not declared in the MockBasicEntity::getFields should not be returned
+    $results = MockBasicEntity::get(FALSE)
+      ->execute();
+    $this->assertEquals('round', $results[0]['shape']);
+    $this->assertArrayNotHasKey('not_a_real_field', $results[0]);
+    $this->assertArrayNotHasKey('not_a_real_field', $results[1]);
+
+    // Still should not be returned, even if selected
+    $results = MockBasicEntity::get(FALSE)
+      ->addSelect('shape', 'not_a_real_field')
+      ->execute();
+    $this->assertEquals('round', $results[0]['shape']);
+    $this->assertArrayNotHasKey('not_a_real_field', $results[0]);
+    $this->assertArrayNotHasKey('not_a_real_field', $results[1]);
   }
 
 }

--- a/tests/phpunit/api/v4/Mock/Api4/Action/MockBasicEntity/BatchFrobnicate.php
+++ b/tests/phpunit/api/v4/Mock/Api4/Action/MockBasicEntity/BatchFrobnicate.php
@@ -27,12 +27,12 @@ class BatchFrobnicate extends \Civi\Api4\Generic\BasicBatchAction {
   protected function doTask($item) {
     return [
       'identifier' => $item['identifier'],
-      'frobnication' => $item['number'] * $item['number'],
+      'frobnication' => $item['size'] * $item['size'],
     ];
   }
 
   protected function getSelect() {
-    return ['identifier', 'number'];
+    return ['identifier', 'size'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #22754 this ensures that APIv4 only returns fields declared in getFields, even if they are selected.

Before
----------------------------------------
APIv4 `Extension.get` would return declared fields by default, but you could add others to the `SELECT` clause and they would be returned.

After
----------------------------------------
Only declared fields are ever returned.