### PR TITLE
RecurForms test fixes

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/RecurForms.php
+++ b/tests/phpunit/CRM/Contribute/Form/RecurForms.php
@@ -15,6 +15,11 @@
 class CRM_Contribute_Form_RecurForms extends CiviUnitTestCase {
 
   /**
+   * @var int
+   */
+  protected $paymentProcessorId;
+
+  /**
    * Get contact id.
    *
    *  return int
@@ -31,17 +36,18 @@ class CRM_Contribute_Form_RecurForms extends CiviUnitTestCase {
    */
   public function addContribution(): void {
     $this->paymentProcessorId = $this->processorCreate();
-    $this->callAPISuccess('Order', 'create', [
+    $order = $this->callAPISuccess('Order', 'create', [
       'contact_id' => $this->getContactID(),
       'contribution_recur_id' => $this->getContributionRecurID(),
       'financial_type_id' => 'Donation',
       'total_amount' => 10,
       'contribution_page_id' => $this->getContributionPageID(),
-      'api.Payment.create' => [
-        'total_amount' => 10,
-        'payment_processor_id' => $this->paymentProcessorId,
-        'is_send_contribution_notification' => FALSE,
-      ],
+    ]);
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $order['id'],
+      'total_amount' => 10,
+      'payment_processor_id' => $this->paymentProcessorId,
+      'is_send_contribution_notification' => FALSE,
     ]);
   }
 
@@ -58,6 +64,7 @@ class CRM_Contribute_Form_RecurForms extends CiviUnitTestCase {
         'installments' => 12,
         'frequency_interval' => 1,
         'frequency_unit' => 'month',
+        'payment_processor_id' => $this->paymentProcessorId,
       ])['id'];
     }
     return $this->ids['ContributionRecur'][0];


### PR DESCRIPTION
Overview
----------------------------------------
Found via #21895 

Before
----------------------------------------
Tests not setting payment_processor_id on contribution recur so defaults to "manual".

After
----------------------------------------
Tests setting payment_processor_id on contribution recur so uses the one we actually chose.

Technical Details
----------------------------------------

Comments
----------------------------------------
@demeritcowboy 
