### PR TITLE
Update unit test to use exception

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -373,7 +373,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     $contactId = $params['cid'];
 
     $filter = NULL;
-    if ($params['context'] == 'membership' && !empty($params['entityID']) && $contactId) {
+    if ($params['context'] === 'membership' && !empty($params['entityID']) && $contactId) {
       $filter = " AND cc.id IN (SELECT contribution_id FROM civicrm_membership_payment WHERE membership_id = {$params['entityID']})";
     }
 
@@ -398,6 +398,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    * @param array $dTParams
    *
    * @return array
+   * @throws \CRM_Core_Exception
    */
   public static function getSoftContributionList($contact_id, $filter = NULL, $isTest = 0, &$dTParams = NULL) {
     $config = CRM_Core_Config::singleton();
@@ -468,7 +469,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     $dTParams['total'] = CRM_Core_DAO::singleValueQuery('SELECT FOUND_ROWS()');
     $result = [];
     while ($cs->fetch()) {
-      $result[$cs->id]['amount'] = CRM_Utils_Money::format($cs->amount, $cs->currency);
+      $result[$cs->id]['amount'] = Civi::format()->money($cs->amount, $cs->currency);
       $result[$cs->id]['currency'] = $cs->currency;
       $result[$cs->id]['contributor_id'] = $cs->contributor_id;
       $result[$cs->id]['contribution_id'] = $cs->contribution_id;

--- a/CRM/Contribute/Page/AJAX.php
+++ b/CRM/Contribute/Page/AJAX.php
@@ -37,11 +37,6 @@ class CRM_Contribute_Page_AJAX {
     $params += CRM_Core_Page_AJAX::validateParams($requiredParameters, $optionalParameters);
 
     $softCreditList = CRM_Contribute_BAO_ContributionSoft::getSoftContributionSelector($params);
-
-    if (!empty($_GET['is_unit_test'])) {
-      return $softCreditList;
-    }
-
     CRM_Utils_JSON::output($softCreditList);
   }
 

--- a/tests/phpunit/CRM/Contribute/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Contribute/Page/AjaxTest.php
@@ -15,72 +15,59 @@
  */
 class CRM_Contribute_Page_AjaxTest extends CiviUnitTestCase {
 
-  protected $_params = [];
-
+  /**
+   * Setup for test.
+   */
   public function setUp(): void {
     parent::setUp();
-
-    $this->_fields = ['amount', 'sct_label'];
-
     $this->_params = [
       'page' => 1,
       'rp' => 50,
       'offset' => 0,
       'rowCount' => 50,
       'sort' => NULL,
-      'is_unit_test' => TRUE,
     ];
     $softContactParams = [
       'first_name' => 'soft',
       'last_name' => 'Contact',
     ];
-    $this->_softContactId = $this->individualCreate($softContactParams);
+    $this->ids['Contact']['SoftCredit'] = $this->individualCreate($softContactParams);
 
-    //create three sample contacts
+    // Create three sample contacts.
     foreach ([0, 1, 2] as $seq) {
-      $this->_primaryContacts[] = $this->individualCreate([], $seq);
+      $this->individualCreate([], $seq);
     }
   }
 
   /**
-   * Test retrieve Soft Contribution through AJAX
+   * Cleanup after test.
    */
-  public function testGetSoftContributionSelector() {
-    $softTypes = [3, 2, 5];
-    $amounts = ['100', '600', '150'];
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
 
-    // create sample soft contribution for contact
-    foreach ($this->_primaryContacts as $seq => $contactId) {
-      $this->callAPISuccess('Contribution', 'create', [
-        'contact_id' => $contactId,
-        'receive_date' => date('Ymd'),
-        'total_amount' => $amounts[$seq],
-        'financial_type_id' => 1,
-        'non_deductible_amount' => '10',
-        'contribution_status_id' => 1,
-        'soft_credit' => [
-          '1' => [
-            'contact_id' => $this->_softContactId,
-            'amount' => $amounts[$seq],
-            'soft_credit_type_id' => $softTypes[$seq],
-          ],
-        ],
-      ]);
-    }
+  /**
+   * Test retrieve Soft Contribution through AJAX.
+   */
+  public function testGetSoftContributionSelector(): void {
+    $softCreditList = $amountSortedList = $softTypeSortedList = [];
+    $this->createThreeSoftCredits();
 
     $_GET = array_merge($this->_params,
       [
-        'cid' => $this->_softContactId,
+        'cid' => $this->ids['Contact']['SoftCredit'],
         'context' => 'contribution',
       ]
     );
-    $softCreditList = CRM_Contribute_Page_AJAX::getSoftContributionRows();
-
-    foreach ($this->_fields as $columnName) {
-      $_GET['columns'][] = [
-        'data' => $columnName,
-      ];
+    try {
+      CRM_Contribute_Page_AJAX::getSoftContributionRows();
     }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $softCreditList = $e->errorData;
+    }
+
+    $_GET['columns'] = [['data' => 'amount'], ['data' => 'sct_label']];
     // get the results in descending order
     $_GET['order'] = [
       '0' => [
@@ -88,36 +75,44 @@ class CRM_Contribute_Page_AjaxTest extends CiviUnitTestCase {
         'dir' => 'desc',
       ],
     ];
-    $amountSortedList = CRM_Contribute_Page_AJAX::getSoftContributionRows();
+    try {
+      CRM_Contribute_Page_AJAX::getSoftContributionRows();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $amountSortedList = $e->errorData;
+    }
 
     $this->assertEquals(3, $softCreditList['recordsTotal']);
     $this->assertEquals(3, $amountSortedList['recordsTotal']);
-    rsort($amounts);
-    foreach ($amounts as $key => $amount) {
-      $amount = CRM_Utils_Money::format($amount, 'USD');
-      $this->assertEquals($amount, $amountSortedList['data'][$key]['amount']);
-    }
+
+    $this->assertEquals('$600.00', $amountSortedList['data'][0]['amount']);
+    $this->assertEquals('$150.00', $amountSortedList['data'][1]['amount']);
+    $this->assertEquals('$100.00', $amountSortedList['data'][2]['amount']);
 
     // sort with soft credit types
     $_GET['order'][0]['column'] = 1;
-    foreach ($softTypes as $id) {
-      $softLabels[] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', $id);
+    try {
+      CRM_Contribute_Page_AJAX::getSoftContributionRows();
     }
-    rsort($softLabels);
-    $softTypeSortedList = CRM_Contribute_Page_AJAX::getSoftContributionRows();
-    foreach ($softLabels as $key => $labels) {
-      $this->assertEquals($labels, $softTypeSortedList['data'][$key]['sct_label']);
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $softTypeSortedList = $e->errorData;
     }
+
+    $this->assertEquals('Workplace Giving', $softTypeSortedList['data'][0]['sct_label']);
+    $this->assertEquals('Solicited', $softTypeSortedList['data'][1]['sct_label']);
+    $this->assertEquals('In Memory of', $softTypeSortedList['data'][2]['sct_label']);
   }
 
   /**
-   * Test retrieve Soft Contribution For Membership
+   * Test retrieve Soft Contribution For Membership.
    */
-  public function testGetSoftContributionForMembership() {
-    //Check soft credit for membership
-    $memParams = [
-      'contribution_contact_id' => $this->_primaryContacts[0],
-      'contact_id' => $this->_softContactId,
+  public function testGetSoftContributionForMembership(): void {
+    $softCreditList = [];
+    $this->createThreeSoftCredits();
+    // Check soft credit for membership.
+    $membershipParams = [
+      'contribution_contact_id' => $this->ids['Contact']['individual_0'],
+      'contact_id' => $this->ids['Contact']['SoftCredit'],
       'contribution_status_id' => 1,
       'financial_type_id' => 2,
       'status_id' => 1,
@@ -125,22 +120,70 @@ class CRM_Contribute_Page_AjaxTest extends CiviUnitTestCase {
       'receive_date' => '2018-06-08',
       'soft_credit' => [
         'soft_credit_type_id' => 11,
-        'contact_id' => $this->_softContactId,
+        'contact_id' => $this->ids['Contact']['SoftCredit'],
       ],
     ];
+    $membershipID = $this->contactMembershipCreate($membershipParams);
     $_GET = array_merge($this->_params,
       [
-        'cid' => $this->_softContactId,
+        'cid' => $this->ids['Contact']['SoftCredit'],
         'context' => 'membership',
-        'entityID' => $this->contactMembershipCreate($memParams),
+        'entityID' => $membershipID,
       ]
     );
 
-    $softCreditList = CRM_Contribute_Page_AJAX::getSoftContributionRows();
+    try {
+      CRM_Contribute_Page_AJAX::getSoftContributionRows();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $softCreditList = $e->errorData;
+    }
     $this->assertEquals(1, $softCreditList['recordsTotal']);
     $this->assertEquals('Gift', $softCreditList['data'][0]['sct_label']);
-    $this->assertEquals('$ 100.00', $softCreditList['data'][0]['amount']);
+    $this->assertEquals('$100.00', $softCreditList['data'][0]['amount']);
     $this->assertEquals('Member Dues', $softCreditList['data'][0]['financial_type']);
+  }
+
+  /**
+   * Create three soft credits against different contacts.
+   */
+  private function createThreeSoftCredits(): void {
+    $credits = [
+      [
+        'contact_id' => $this->ids['Contact']['individual_0'],
+        'soft_credit_type_id' => 3,
+        'amount' => 100,
+      ],
+      [
+        'contact_id' => $this->ids['Contact']['individual_1'],
+        'soft_credit_type_id' => 2,
+        'amount' => 600,
+      ],
+      [
+        'contact_id' => $this->ids['Contact']['individual_2'],
+        'soft_credit_type_id' => 5,
+        'amount' => 150,
+      ],
+    ];
+    // Create sample soft contribution for contact.
+    foreach ($credits as $index => $credit) {
+      $this->callAPISuccess('Contribution', 'create', [
+        'contact_id' => $credit['contact_id'],
+        // The assumption is the last to be created will have a later time.
+        'receive_date' => ' + ' . $index . ' minutes',
+        'total_amount' => $credit['amount'],
+        'financial_type_id' => 1,
+        'non_deductible_amount' => '10',
+        'contribution_status_id' => 1,
+        'soft_credit' => [
+          '1' => [
+            'contact_id' => $this->ids['Contact']['SoftCredit'],
+            'amount' => $credit['amount'],
+            'soft_credit_type_id' => $credit['soft_credit_type_id'],
+          ],
+        ],
+      ]);
+    }
   }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
Update unit test to use exception
Note that this also updates the money formatting on the contributionSoft list

Before
----------------------------------------
old 'is_unit_test' check

After
----------------------------------------
Uses premature exception. 

Also switches formatting to use `Civi::format` - this is already done in some higher volume places so this one shouldn't raise any eyebrows

Technical Details
----------------------------------------


Comments
----------------------------------------
