### PR TITLE
SearchKit - Use crmDialogButtons for task popups

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks.ang.php
+++ b/ext/search_kit/ang/crmSearchTasks.ang.php
@@ -13,7 +13,7 @@ return [
     'css/crmSearchTasks.css',
   ],
   'basePages' => [],
-  'requires' => ['crmUi', 'crmUtil', 'dialogService', 'api4', 'checklist-model'],
+  'requires' => ['crmUi', 'crmUtil', 'dialogService', 'api4', 'checklist-model', 'crmDialog'],
   'settingsFactory' => ['\Civi\Search\Actions', 'getActionSettings'],
   'permissions' => ['edit groups', 'administer reserved groups'],
 ];

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskDelete.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskDelete.html
@@ -1,21 +1,13 @@
-<div id="bootstrap-theme">
+<div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form ng-controller="crmSearchTaskDelete as $ctrl">
     <p><strong>{{:: ts('Are you sure you want to delete %1 %2?', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
     <hr />
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Deleting %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="Delete" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="delete" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
     </div>
-    <hr />
-    <div class="buttons text-right">
-      <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger" ng-hide="$ctrl.run">
-        <i class="crm-i fa-times"></i>
-        {{:: ts('Cancel') }}
-      </button>
-      <button ng-click="$ctrl.start()" class="btn btn-primary" ng-disabled="$ctrl.run">
-        <i class="crm-i fa-{{ $ctrl.run ? 'spin fa-spinner' : 'trash' }}"></i>
-        {{:: ts('Delete %1', {1: $ctrl.entityTitle}) }}
-      </button>
-    </div>
+
+    <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>
+    <crm-dialog-button text="ts('Delete %1', {1: $ctrl.entityTitle})" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-trash'}" on-click="$ctrl.start()" disabled="$ctrl.run" ></crm-dialog-button>
   </form>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskDownload.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskDownload.html
@@ -1,4 +1,4 @@
-<div id="bootstrap-theme">
+<div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form ng-controller="crmSearchTaskDownload as $ctrl">
     <p>
       <strong ng-if="$ctrl.ids.length">{{:: ts('Download %1 %2', {1: $ctrl.ids.length, 2: $ctrl.entityTitle}) }}</strong>
@@ -20,16 +20,8 @@
         <div class="progress-bar progress-bar-striped active" role="progressbar" ng-style="{width: '' + $ctrl.progress + '%'}"></div>
       </div>
     </div>
-    <hr />
-    <div class="buttons text-right">
-      <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger" ng-hide="$ctrl.run">
-        <i class="crm-i fa-times"></i>
-        {{:: ts('Cancel') }}
-      </button>
-      <button ng-click="$ctrl.download()" class="btn btn-primary" ng-disabled="$ctrl.run">
-        <i class="crm-i fa-{{ $ctrl.run ? 'spin fa-spinner' : 'download' }}"></i>
-        {{:: ts('Download') }}
-      </button>
-    </div>
+
+    <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>
+    <crm-dialog-button text="ts('Download')" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-download'}" on-click="$ctrl.download()" disabled="$ctrl.run" ></crm-dialog-button>
   </form>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
@@ -1,4 +1,4 @@
-<div id="bootstrap-theme">
+<div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form ng-controller="crmSearchTaskTag as $ctrl">
     <div class="form-radios">
       <label ng-class="{disabled: !!$ctrl.run}">
@@ -42,16 +42,8 @@
       <h5>{{:: $ctrl.action === 'save' ? ts('Adding tags...') : ts('Removing tags...') }}</h5>
       <crm-search-batch-runner entity="'EntityTag'" action="{{ $ctrl.action }}" id-field="entity_id" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
     </div>
-    <hr />
-    <div class="buttons text-right">
-      <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger" ng-hide="$ctrl.run">
-        <i class="crm-i fa-times"></i>
-        {{:: ts('Cancel') }}
-      </button>
-      <button ng-click="$ctrl.saveTags()" class="btn btn-primary" ng-disabled="$ctrl.run || !$ctrl.selection.length">
-        <i class="crm-i fa-{{ $ctrl.run ? 'spin fa-spinner' : 'check' }}"></i>
-        {{ $ctrl.action === 'save' ? ts('Add tags') : ts('Remove tags') }}
-      </button>
-    </div>
+
+    <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>
+    <crm-dialog-button text="$ctrl.action === 'save' ? ts('Add tags') : ts('Remove tags')" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-check'}" on-click="$ctrl.saveTags()" disabled="$ctrl.run || !$ctrl.selection.length" ></crm-dialog-button>
   </form>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
@@ -1,4 +1,4 @@
-<div id="bootstrap-theme">
+<div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form name="crmSearchTaskUpdateForm" ng-controller="crmSearchTaskUpdate as $ctrl">
     <p><strong>{{:: ts('Update the %1 selected %2 with the following values:', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
     <div class="form-inline" ng-repeat="clause in $ctrl.values" >
@@ -10,18 +10,10 @@
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Updating %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="Update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
     </div>
-    <hr />
-    <div class="buttons text-right">
-      <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger" ng-hide="$ctrl.run">
-        <i class="crm-i fa-times"></i>
-        {{:: ts('Cancel') }}
-      </button>
-      <button ng-click="$ctrl.save()" class="btn btn-primary" ng-disabled="!$ctrl.values.length || $ctrl.run || !crmSearchTaskUpdateForm.$valid">
-        <i class="crm-i fa-{{ $ctrl.run ? 'spin fa-spinner' : 'check' }}"></i>
-        {{:: ts('Update %1', {1: $ctrl.entityTitle}) }}
-      </button>
-    </div>
+
+    <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>
+    <crm-dialog-button text="ts('Update %1', {1: $ctrl.entityTitle})" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-check'}" on-click="$ctrl.save()" disabled="!$ctrl.values.length || $ctrl.run || !crmSearchTaskUpdateForm.$valid" ></crm-dialog-button>
   </form>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Updates the buttons in SearchKit action popups to use standard dialog button formatting.

Before
----------------------------------------
Ad-hoc buttons inserted into the body of the dialog. This runs the risk that the buttons can scroll out of view.
![image](https://user-images.githubusercontent.com/2874912/154703779-a73927f9-2502-4a01-b19f-4d18ed4e7020.png)


After
----------------------------------------
Buttons fixed to the bottom of the dialog.
![image](https://user-images.githubusercontent.com/2874912/154703367-ba28f756-c4e3-4f28-bf37-97a4bbceb18e.png)


Technical Details
----------------------------------------
Uses new `crmDialog` and `crmDialogButton` directives.
