### PR TITLE
CiviGrant - Declare API permissions

### DIFF
--- a/ext/civigrant/Civi/Api4/Grant.php
+++ b/ext/civigrant/Civi/Api4/Grant.php
@@ -23,4 +23,21 @@ namespace Civi\Api4;
  */
 class Grant extends Generic\DAOEntity {
 
+  public static function permissions() {
+    return [
+      'get' => [
+        'access CiviGrant',
+      ],
+      'delete' => [
+        'delete in CiviGrant',
+      ],
+      'create' => [
+        'edit grants',
+      ],
+      'update' => [
+        'edit grants',
+      ],
+    ];
+  }
+
 }

--- a/ext/civigrant/civigrant.php
+++ b/ext/civigrant/civigrant.php
@@ -69,6 +69,28 @@ function civigrant_civicrm_permission(&$permissions) {
 }
 
 /**
+ * Implements hook_civicrm_alterAPIPermissions().
+ *
+ * Set CiviGrant permissions for APIv3.
+ */
+function civigrant_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['grant'] = [
+    'get' => [
+      'access CiviGrant',
+    ],
+    'delete' => [
+      'delete in CiviGrant',
+    ],
+    'create' => [
+      'edit grants',
+    ],
+    'update' => [
+      'edit grants',
+    ],
+  ];
+}
+
+/**
  * Implements hook_civicrm_queryObjects().
  *
  * Adds query object for legacy screens like advanced search, search builder, etc.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes new SearchKit based CiviGrant contact summary tab, which was broken for non-admin users.

Before
----------------------------------------
For users without "administer CiviCRM" permission but with "access CiviGrant" permission, the Grants tab on the contact summary screen would appear blank.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
This allows the current user to access the grant api (e.g. through SearchKit) without needing the "administer CiviCRM" permission.

Comments
-----------
This is an unreleased 5.47 regression.
See discussion at https://lab.civicrm.org/dev/core/-/issues/3076