### PR TITLE
[REF] Remove old require_once statements made obsolete by autoloader

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -414,7 +414,6 @@ class CRM_Core_Component {
         $infoFile = $crmFolderDir . "/{$subDir}/" . self::COMPONENT_INFO_CLASS . '.php';
         if (file_exists($infoFile)) {
           $infoClass = 'CRM_' . $subDir . '_' . self::COMPONENT_INFO_CLASS;
-          require_once str_replace('_', DIRECTORY_SEPARATOR, $infoClass) . '.php';
           $infoObject = new $infoClass(NULL, NULL, NULL);
           $components[$infoObject->info['name']] = $infoObject;
           unset($infoObject);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2129,7 +2129,6 @@ SELECT contact_id
    *   an object of type referenced by daoName
    */
   public static function commonRetrieveAll($daoName, $fieldIdName, $fieldId, &$details, $returnProperities = NULL) {
-    require_once str_replace('_', DIRECTORY_SEPARATOR, $daoName) . ".php";
     $object = new $daoName();
     $object->$fieldIdName = $fieldId;
 

--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -166,8 +166,6 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
     // get 'id' if present
     $id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
 
-    require_once str_replace('_', DIRECTORY_SEPARATOR, $this->getBAOName()) . ".php";
-
     if ($id) {
       if (!$this->checkPermission($id, NULL)) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to make changes to the record'));

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -247,7 +247,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     if ($parserClass[0] == 'CRM' &&
       count($parserClass) >= 3
     ) {
-      require_once str_replace('_', DIRECTORY_SEPARATOR, $parserName) . ".php";
       // ensure the functions exists
       if (method_exists($parserName, 'errorFileName') &&
         method_exists($parserName, 'saveFileName')


### PR DESCRIPTION
Overview
----------------------------------------
Removes unnecessary code leftover from PHP 4.

Technical Details
----------------------------------------
All of these `require_once` are requiring classes beginning with `CRM_`, which is definitely handled by our autoloader.