### PR TITLE
(REF) CRM_Queue_Task - Tighter signature

### DIFF
--- a/CRM/Queue/Task.php
+++ b/CRM/Queue/Task.php
@@ -47,10 +47,10 @@ class CRM_Queue_Task {
    *   (CRM_Queue_TaskContext).
    * @param array $arguments
    *   Serializable, extra arguments to pass to the callback (in order).
-   * @param string $title
+   * @param string|null $title
    *   A printable string which describes this task.
    */
-  public function __construct($callback, $arguments, $title = NULL) {
+  public function __construct($callback, array $arguments = [], ?string $title = NULL) {
     $this->callback = $callback;
     $this->arguments = $arguments;
     $this->title = $title;


### PR DESCRIPTION
Overview
----------------------------------------

This slightly tightens the signature of `CRM_Queue_Task` so that it provides clearer errors when used incorrectly.

Before
----------------------------------------

No PHP type-checking

After
----------------------------------------

More PHP type-checking
