### PR TITLE
(NFC) tests/phpunit/CRM/Queue - Add common `@group`

### DIFF
--- a/tests/phpunit/CRM/Queue/Queue/SqlTest.php
+++ b/tests/phpunit/CRM/Queue/Queue/SqlTest.php
@@ -14,6 +14,7 @@
  * work. For example, the createItem() interface supports
  * priority-queueing.
  * @group headless
+ * @group queue
  */
 class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -12,6 +12,7 @@
 /**
  * Ensure that various queue implementations comply with the interface
  * @group headless
+ * @group queue
  */
 class CRM_Queue_QueueTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Queue/RunnerTest.php
+++ b/tests/phpunit/CRM/Queue/RunnerTest.php
@@ -12,6 +12,7 @@
 /**
  * Ensure that various queue implementations comply with the interface
  * @group headless
+ * @group queue
  */
 class CRM_Queue_RunnerTest extends CiviUnitTestCase {
 


### PR DESCRIPTION
Overview
----------------------------------------

Small tweak that organizes some tests under `@group queue`.

This is handier for quickly running a bunch of tests that touch on the queue subsystem.

Comments
----------------------------------------

As it stands in this revision, it's slightly unnecessary to do `phpunit --group queue` because you can do `phpunit tests/phpunit/CRM/Queue`. However, subsequent revisions will add more tests that don't live in the same folder (eg they live in `tests/phpunit/api/v4`). 