### PR TITLE
Civi\Api4\Queue - Allow use with hook_managed

### DIFF
--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -22,6 +22,8 @@ namespace Civi\Api4;
  */
 class Queue extends \Civi\Api4\Generic\DAOEntity {
 
+  use Generic\Traits\ManagedEntity;
+
   /**
    * @return array
    */


### PR DESCRIPTION
Overview
----------------------------------------

Flag the entity `Queue` so that it can be used with `hook_managed`.

Before
----------------------------------------

Not allowed

After
----------------------------------------

Allowed

Comments
----------------------------------------

This was useful in evaluating/demo'ing #22690 and will be useful in a successor.

I'm not really sure that this merits its own test-coverage. I don't think we do explicit coverage of this for other entities...