### PR TITLE
(REF) CRM_Queue_Queue_* - Retain a copy of `$queueSpec`

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -26,21 +26,24 @@ abstract class CRM_Queue_Queue {
   private $_name;
 
   /**
+   * @var array{name: string, type: string, runner: string, batch_limit: int, lease_time: ?int, retry_limit: int, retry_interval: ?int}
+   * @see \CRM_Queue_Service::create()
+   */
+  protected $queueSpec;
+
+  /**
    * Create a reference to queue. After constructing the queue, one should
    * usually call createQueue (if it's a new queue) or loadQueue (if it's
    * known to be an existing queue).
    *
-   * @param array $queueSpec
-   *   Array with keys:
-   *   - type: string, required, e.g. "interactive", "immediate", "stomp",
-   *     "beanstalk"
-   *   - name: string, required, e.g. "upgrade-tasks"
-   *   - reset: bool, optional; if a queue is found, then it should be
-   *     flushed; default to TRUE
-   *   - (additional keys depending on the queue provider).
+   * @param array{name: string, type: string, runner: string, batch_limit: int, lease_time: ?int, retry_limit: int, retry_interval: ?int} $queueSpec
+   *   Ex: ['name' => 'my-import', 'type' => 'SqlParallel']
+   *   The full definition of queueSpec is defined in CRM_Queue_Service.
+   * @see \CRM_Queue_Service::create()
    */
   public function __construct($queueSpec) {
     $this->_name = $queueSpec['name'];
+    $this->queueSpec = $queueSpec;
   }
 
   /**
@@ -50,6 +53,16 @@ abstract class CRM_Queue_Queue {
    */
   public function getName() {
     return $this->_name;
+  }
+
+  /**
+   * Get a property from the queueSpec.
+   *
+   * @param string $field
+   * @return mixed|null
+   */
+  public function getSpec(string $field) {
+    return $this->queueSpec[$field] ?? NULL;
   }
 
   /**

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -72,6 +72,8 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->queue = $this->queueService->create($queueSpec);
     $this->assertDBQuery(0, 'SELECT count(*) FROM civicrm_queue');
     $this->assertTrue($this->queue instanceof CRM_Queue_Queue);
+    $this->assertEquals($queueSpec['name'], $this->queue->getSpec('name'));
+    $this->assertEquals($queueSpec['type'], $this->queue->getSpec('type'));
 
     $this->queue->createItem([
       'test-key' => 'a',


### PR DESCRIPTION
Overview
----------------------------------------

Queue objects are constructed with an array-based specification (`$queueSpec`). This patch prepares for defining and using more queue-level properties.

Before
----------------------------------------

Suppose you want to define a queue-level property like `retry_interval`. It would make sense to add this to the queue-spec:

```php
$queue = CRM_Queue_Service::singleton()->create([
  'name' => 'foo',
  'type' => 'bar',
  'retry_interval' => 600,
]);
```

However, the `retry_interval` would be forgotten - so when it came to time to schedule a retry, the value is unavailable.

After
----------------------------------------

You can get any field from the `$queueSpec`, eg

```php
$queue->getSpec('retry_interval');
```

