### PR TITLE
Mailing Report: do not recalculate the recipients when the count is zero

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -83,20 +83,6 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
   private $_domain = NULL;
 
   /**
-   * @deprecated
-   *
-   * @param int $mailingID
-   *
-   * @return int
-   */
-  public static function getRecipientsCount($mailingID) {
-    //rebuild the recipients
-    self::getRecipients($mailingID);
-
-    return civicrm_api3('MailingRecipients', 'getcount', ['mailing_id' => $mailingID]);
-  }
-
-  /**
    * This function retrieve recipients of selected mailing groups.
    *
    * @param int $mailingID
@@ -2032,16 +2018,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['jobs'][] = $row;
     }
 
-    $newTableSize = CRM_Mailing_BAO_Recipients::mailingSize($mailing_id);
-
-    // we need to do this for backward compatibility, since old mailings did not
-    // use the mailing_recipients table
-    if ($newTableSize > 0) {
-      $report['event_totals']['queue'] = $newTableSize;
-    }
-    else {
-      $report['event_totals']['queue'] = self::getRecipientsCount($mailing_id);
-    }
+    $report['event_totals']['queue'] = CRM_Mailing_BAO_Recipients::mailingSize($mailing_id);
 
     if (!empty($report['event_totals']['queue'])) {
       $report['event_totals']['delivered_rate'] = (100.0 * $report['event_totals']['delivered']) / $report['event_totals']['queue'];


### PR DESCRIPTION
Overview
----------------------------------------

Removes backwards compatibility for mailings created more than 11 years ago.

Lets say I delete `civicrm_mailing_recipient` data for old mailings, because the table is huge, but then I go and view an old mailing, CiviCRM will recalculate the recipients. This is an odd behaviour for mailings that are completed/archived. Very often, the data will not be accurate, after such as long time (search criteria for smartgroups will not generate the same set of results).

For example, I had a mailing from 2015 for which I deleted data. Before deleting, it had around 200 recipients. After deleting, and because of the recalculation, the mailing now had over 400 recipients. Sure, I could avoid deleting old data, or just delete the mailing, but I am working on an extension which helps with archiving data for old mailings.

Rather than add complexity here (check the mailing status), it feels safe to remove this old code, after 11 years.

Before
----------------------------------------

When the `civicrm_mailing_recipient` data has been deleted, mailing report shows an incorrect count of recipients.

After
----------------------------------------

When the `civicrm_mailing_recipient` data has been deleted, mailing report shows 0 recipients.

Technical Details
----------------------------------------

The behaviour was added here: https://github.com/civicrm/civicrm-svn/commit/b80ac2e8f5a2802ff985925c72a85f8dc90ca842

Comments
----------------------------------------

The topic of mailing archiving has come up very often, but it's usually simpler to keep the data, or delete the mailing. I would like to create an extension which provides a compromise.

* https://civicrm.stackexchange.com/questions/28483/best-way-to-cleanup-civimail-database-tables
* https://forum.civicrm.org/index.php%3Ftopic=6079.0.html