### PR TITLE
Fix pledge default on contribution page when the site has a WR for "contribution"

### DIFF
--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -267,7 +267,7 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       //set defaults for pledgeBlock values.
       $pledgeBlockParams = [
         'entity_id' => $this->_id,
-        'entity_table' => ts('civicrm_contribution_page'),
+        'entity_table' => 'civicrm_contribution_page',
       ];
       $pledgeBlockDefaults = [];
       CRM_Pledge_BAO_PledgeBlock::retrieve($pledgeBlockParams, $pledgeBlockDefaults);


### PR DESCRIPTION
Overview
----------------------------------------
Default on the pledge checkbox is not loaded when the site has WR for contribution => payment.

Before
----------------------------------------
Replicate on dmaster -

- Create a word replacement for contribution => payment.
- Enable pledge on a contribution page.
- On submit, the pledge checkbox is still loaded as disabled.

After
----------------------------------------
Fixed. The table should not be enclosed in ts().

Technical Details
----------------------------------------
Similar issue was fixed in https://github.com/civicrm/civicrm-core/pull/19238. This is on the configuration page and needs to be handled as well.

