### PR TITLE
Remove use of overrideDefaultCurrency method from eventInfo page.

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -58,6 +58,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
 
     //retrieve event information
     $params = ['id' => $this->_id];
+    $values = ['event' => NULL];
     CRM_Event_BAO_Event::retrieve($params, $values['event']);
 
     if (!$values['event']['is_active']) {
@@ -84,9 +85,11 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
 
     $values['event']['event_tz'] = CRM_Core_SelectValues::timezone()[$values['event']['event_tz']];
 
+    $eventCurrency = CRM_Utils_Array::value('currency', $values['event'], $config->defaultCurrency);
+    $this->assign('eventCurrency', $eventCurrency);
+
     // show event fees.
     if ($this->_id && !empty($values['event']['is_monetary'])) {
-      CRM_Contribute_BAO_Contribution_Utils::overrideDefaultCurrency($values['event']);
 
       //CRM-10434
       $discountId = CRM_Core_BAO_Discount::findSet($this->_id, 'civicrm_event');
@@ -145,7 +148,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
 
               $values['feeBlock']['isDisplayAmount'][$fieldCnt] = $fieldValues['is_display_amounts'] ?? NULL;
               if (Civi::settings()->get('invoicing') && isset($optionVal['tax_amount'])) {
-                $values['feeBlock']['value'][$fieldCnt] = CRM_Price_BAO_PriceField::getTaxLabel($optionVal, 'amount', $displayOpt, $taxTerm);
+                $values['feeBlock']['value'][$fieldCnt] = CRM_Price_BAO_PriceField::getTaxLabel($optionVal, 'amount', $displayOpt, $taxTerm, $eventCurrency);
                 $values['feeBlock']['tax_amount'][$fieldCnt] = $optionVal['tax_amount'];
               }
               else {

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -830,21 +830,22 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
    *   Tax display setting option.
    *
    * @param string $taxTerm
+   * @param string|null $currency
    *
    * @return string
    *   Tax label for custom field.
    */
-  public static function getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm) {
+  public static function getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm, $currency = NULL) {
     if ($displayOpt == 'Do_not_show') {
-      $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount']);
+      $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount'], $currency);
     }
     elseif ($displayOpt == 'Inclusive') {
-      $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount']);
-      $label .= '<span class="crm-price-amount-tax"> ' . ts('(includes %1 of %2)', [1 => $taxTerm, 2 => CRM_Utils_Money::format($opt['tax_amount'])]) . '</span>';
+      $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount'], $currency);
+      $label .= '<span class="crm-price-amount-tax"> ' . ts('(includes %1 of %2)', [1 => $taxTerm, 2 => CRM_Utils_Money::format($opt['tax_amount'], $currency)]) . '</span>';
     }
     else {
-      $label = CRM_Utils_Money::format($opt[$valueFieldName]);
-      $label .= '<span class="crm-price-amount-tax"> + ' . CRM_Utils_Money::format($opt['tax_amount']) . ' ' . $taxTerm . '</span>';
+      $label = CRM_Utils_Money::format($opt[$valueFieldName], $currency);
+      $label .= '<span class="crm-price-amount-tax"> + ' . CRM_Utils_Money::format($opt['tax_amount'], $currency) . ' ' . $taxTerm . '</span>';
     }
 
     return $label;

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -190,16 +190,16 @@
                         {* Skip price field label for quick_config price sets since it duplicates $event.fee_label *}
                       {else}
                       <tr>
-                          <td class="{$lClass} crm-event-label">{$feeBlock.label.$idx}</td>
-                          {if $isPriceSet & $feeBlock.isDisplayAmount.$idx}
-            <td class="fee_amount-value right">
-                              {if $feeBlock.tax_amount && $feeBlock.tax_amount.$idx}
-          {$feeBlock.value.$idx}
-                              {else}
-                {$feeBlock.value.$idx|crmMoney}
-                              {/if}
-            </td>
-                          {/if}
+                        <td class="{$lClass} crm-event-label">{$feeBlock.label.$idx}</td>
+                        {if $isPriceSet & $feeBlock.isDisplayAmount.$idx}
+                          <td class="fee_amount-value right">
+                            {if $feeBlock.tax_amount && $feeBlock.tax_amount.$idx}
+                              {$feeBlock.value.$idx}
+                            {else}
+                              {$feeBlock.value.$idx|crmMoney:$eventCurrency}
+                            {/if}
+                          </td>
+                        {/if}
                       </tr>
                       {/if}
                   {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Updates the civicrm/event/info route to show the current currency in multi-currencies setups.

Before
----------------------------------------
As discussed in https://lab.civicrm.org/dev/core/-/issues/2930#note_66911, `CRM_Contribute_BAO_Contribution_Utils::overrideDefaultCurrency` does not work correctly with the new money functions recently introduced in https://github.com/civicrm/civicrm-core/commit/386fe6c224674035d073d308af48de53b3937882 and https://github.com/civicrm/civicrm-core/commit/d6d93aa4646ba00fc7a40b9496325c0ee2199a56.

Whilst there is a good argument for updating `CRM_Contribute_BAO_Contribution_Utils::overrideDefaultCurrency` to work with the new functions for backwards compatiability, I think moving away from overriding the default currency is a cleaner long-term solution.

After
----------------------------------------
The `overrideDefaultCurrency` method is no longer used on the eventInfo page, and the correct currency is used, even if the event and default currencies are different.

The getTaxLabel method has been updated to accept a new optional currency argument, in order to facilitate this change.

Comments
----------------------------------------
I've kept this PR minimal to start, and so have just focussed on this single eventInfo page - other pages can be handled through follow up PRs. 