### PR TITLE
Remove broken call to function_exists in CRM_Utils_String::isUtf8

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -329,21 +329,8 @@ class CRM_Utils_String {
    * @return bool
    */
   public static function isUtf8($str) {
-    if (!function_exists(mb_detect_encoding)) {
-      // eliminate all white space from the string
-      $str = preg_replace('/\s+/', '', $str);
-
-      // pattern stolen from the php.net function documentation for
-      // utf8decode();
-      // comment by JF Sebastian, 30-Mar-2005
-      return preg_match('/^([\x00-\x7f]|[\xc2-\xdf][\x80-\xbf]|\xe0[\xa0-\xbf][\x80-\xbf]|[\xe1-\xec][\x80-\xbf]{2}|\xed[\x80-\x9f][\x80-\xbf]|[\xee-\xef][\x80-\xbf]{2}|f0[\x90-\xbf][\x80-\xbf]{2}|[\xf1-\xf3][\x80-\xbf]{3}|\xf4[\x80-\x8f][\x80-\xbf]{2})*$/', $str);
-      // ||
-      // iconv('ISO-8859-1', 'UTF-8', $str);
-    }
-    else {
-      $enc = mb_detect_encoding($str, ['UTF-8'], TRUE);
-      return ($enc !== FALSE);
-    }
+    $enc = mb_detect_encoding($str, ['UTF-8'], TRUE);
+    return ($enc !== FALSE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix call to `function_exists` in `CRM_Utils_String::isUtf8`

Before
----------------------------------------
In the line `if (!function_exists(mb_detect_encoding))`, `mb_detect_encoding` was being treated as a constant - `mb_detect_encoding` is not a constant, and `function_exists` expects a string.

After
----------------------------------------
Valid PHP code.

Comments
----------------------------------------
Given that this mistake has been unnoticed for a decade I did strongly suspect that the method `isUtf8` should be deprecated, and in time removed - it seems unlikely that it is in widespread use.

However, the method is referenced from `CRM_Utils_String::isAscii` which is in use elsewhere in CiviCRM core. Given this, I was not sure if it was appropriate to deprecate `isUtf8` whilst `isAscii` is still using it...
