### PR TITLE
Core#2918 Implement new UI for configuring dedupe rule usage.

### DIFF
--- a/CRM/Contact/Form/DedupeRules.php
+++ b/CRM/Contact/Form/DedupeRules.php
@@ -40,6 +40,9 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
       CRM_Utils_System::permissionDenied();
       CRM_Utils_System::civiExit();
     }
+
+    Civi::resources()->addScriptFile('civicrm', 'js/crm.dedupeRules.js');
+
     $this->_options = CRM_Core_SelectValues::getDedupeRuleTypes();
     $this->_rgid = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
 
@@ -65,6 +68,8 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
       $this->_defaults['is_reserved'] = $rgDao->is_reserved;
       $this->assign('isReserved', $rgDao->is_reserved);
       $this->assign('ruleName', $rgDao->name);
+      $this->assign('ruleUsed', CRM_Core_SelectValues::getDedupeRuleTypes()[$rgDao->used]);
+      $this->assign('canChangeUsage', $rgDao->used === 'General');
       $ruleDao = new CRM_Dedupe_DAO_DedupeRule();
       $ruleDao->dedupe_rule_group_id = $this->_rgid;
       $ruleDao->find();
@@ -75,6 +80,11 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
         $this->_defaults["weight_$count"] = $ruleDao->rule_weight;
         $count++;
       }
+    }
+    else {
+      $this->_defaults['used'] = 'General';
+      $this->assign('ruleUsed', CRM_Core_SelectValues::getDedupeRuleTypes()['General']);
+      $this->assign('canChangeUsage', TRUE);
     }
     $supported = CRM_Dedupe_BAO_DedupeRuleGroup::supportedFields($this->_contactType);
     if (is_array($supported)) {
@@ -96,7 +106,7 @@ class CRM_Contact_Form_DedupeRules extends CRM_Admin_Form {
       'objectExists', ['CRM_Dedupe_DAO_DedupeRuleGroup', $this->_rgid, 'title']
     );
 
-    $this->addField('used', ['label' => ts('Usage')], TRUE);
+    $this->add('hidden', 'used');
     $reserved = $this->addField('is_reserved', ['label' => ts('Reserved?')]);
     if (!empty($this->_defaults['is_reserved'])) {
       $reserved->freeze();

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3926,3 +3926,23 @@ span.crm-status-icon {
 .crm-search-display-grid-layout-5 {
   grid-template-columns: repeat(5, 1fr);
 }
+
+/* Dedupe rules */
+.crm-dedupe-rules-form-block-used div {
+  max-width: 800px;
+}
+.crm-dedupe-rules-form-block-used p:first-child {
+  margin-top: 0;
+}
+.dedupe-rules-dialog [type=radio] {
+  margin-top: 4px;
+}
+.dedupe-rules-dialog p:first-child {
+  margin-top: 0;
+}
+.dedupe-rules-dialog input[type=radio] {
+  float: left;
+}
+.dedupe-rules-dialog label > * {
+  margin-left: 30px;
+}

--- a/js/crm.dedupeRules.js
+++ b/js/crm.dedupeRules.js
@@ -1,0 +1,48 @@
+// https://civicrm.org/licensing
+
+CRM.$(function($) {
+  function updateDisplay() {
+    var used = $('[name=used]').val();
+    var inputParent = $('[name=usedDialog][value=' + used + ']').closest('div');
+    var title = inputParent.find('.dedupe-rules-dialog-title').text();
+    var desc = inputParent.find('.dedupe-rules-dialog-desc').text();
+    $('.js-dedupe-rules-current').text(title);
+    $('.js-dedupe-rules-desc').text(desc);
+  }
+  function setInitial() {
+    var used = $('[name=used]').val();
+    $('[name=usedDialog][value=' + used + ']').prop('checked', true);
+    updateDisplay();
+  }
+  function setSaveValue() {
+    var dialogVal = $('[name=usedDialog]:checked').val();
+    $('[name=used]').val(dialogVal);
+    updateDisplay();
+  }
+  function openDialog() {
+    var dialog = $('.dedupe-rules-dialog');
+    dialog.dialog({
+      title: dialog.attr('data-title'),
+      width: 800,
+      buttons: [
+        {
+          text: dialog.attr('data-button-close'),
+          icon: 'fa-close',
+          click: function() {
+            dialog.dialog('close');
+          }
+        },
+        {
+          text: dialog.attr('data-button-update'),
+          icon: 'fa-check',
+          click: function() {
+            setSaveValue();
+            dialog.dialog('close');
+          }
+        }
+      ]
+    });
+  }
+  setInitial();
+  $('.js-dedupe-rules-change').on('click', openDialog);
+});

--- a/templates/CRM/Contact/Form/DedupeRules.tpl
+++ b/templates/CRM/Contact/Form/DedupeRules.tpl
@@ -25,8 +25,14 @@
         </td>
     </tr>
     <tr class="crm-dedupe-rules-form-block-used">
-        <td class="label">{$form.used.label}</td>
-        <td>{$form.used.html} {help id="id-rule-used"}</td>
+        <td class="label">{ts}Usage{/ts}</td>
+        <td>
+          <div>
+            <p><strong>{ts}Currently set to: {/ts}<span class='js-dedupe-rules-current'></span></strong></p>
+            <p class='js-dedupe-rules-desc'></p>
+            <p><button class='crm-button js-dedupe-rules-change' type='button' {if NOT $canChangeUsage} disabled title='{ts 1=$ruleUsed}To change the usage for this rule, please configure another rule as %1{/ts}'{/if}>{ts}Change usage{/ts}</button></p>
+          </div>
+        </td>
      </tr>
      <tr class="crm-dedupe-rules-form-block-is_reserved">
         <td class="label">{$form.is_reserved.label}</td>
@@ -96,4 +102,30 @@
     </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>
+
+<div class='dedupe-rules-dialog' data-title='{ts escape='js'}Change usage{/ts}' data-button-close='{ts escape='js'}Close{/ts}' data-button-update='{ts escape='js'}Update{/ts}' hidden>
+  <p>{ts}CiviCRM includes three types of dedupe rule. <strong>You can only configure one 'Unsupervised' and one 'Supervised' rule for each contact type, but you can configure any number of additional 'General' rules to provide other criteria to scan for possible duplicates.</strong>{/ts}</p>
+  <p>{ts}Selecting 'Unsupervised' or 'Supervised' will convert the previously configured rule of that type to 'General'.{/ts}</p>
+  <div>
+    <label>
+      <input type="radio" name="usedDialog" value="Unsupervised">
+      <p><strong class='dedupe-rules-dialog-title'>{ts}Unsupervised{/ts}</strong></p>
+      <p class='dedupe-rules-dialog-desc'>{ts}The 'Unsupervised' rule for each contact type is automatically used when new contacts are created through online registrations including Events, Membership, Contributions and Profile pages. They are also selected by default when you Import contacts. They are generally configured with a narrow definition of what constitutes a duplicate.{/ts}</p>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="radio" name="usedDialog" value="Supervised">
+      <p><strong class='dedupe-rules-dialog-title'>{ts}Supervised{/ts}</strong></p>
+      <p class='dedupe-rules-dialog-desc'>{ts}The 'Supervised' rule for each contact type is automatically used to check for possible duplicates when contacts are added or edited via the user interface. Supervised Rules should be configured with a broader definition of what constitutes a duplicate.{/ts}</p>
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="radio" name="usedDialog" value="General">
+      <p><strong class='dedupe-rules-dialog-title'>{ts}General{/ts}</strong></p>
+      <p class='dedupe-rules-dialog-desc'>{ts}You can configure any number of 'General' rules, to provide other criteria to scan for possible duplicates.{/ts}</p>
+    </label>
+  </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This implements the new UI proposed and discussed in Core#2918.

Before
----------------------------------------
Currently the UI for configuring dedupe rules allows the usage to be selected from a list of radio options:

<img width="930" alt="Screenshot 2022-02-20 at 14 55 17" src="https://user-images.githubusercontent.com/1931323/154848701-af376aec-441a-4d8b-99ca-29b5262ae687.png">

This is problematic for multiple reasons:

- It allows a situation where no supervised or unsupervised rule exists (A system check to warn against this was added in https://github.com/civicrm/civicrm-core/pull/22369).
- It incorrectly suggests that multiple supervised or unsupervised rules can be configured.
- The help text is somewhat squeezed into the helptext popup.


After
----------------------------------------
The UI is now driven through a popup allowing much more context into the available options:
<img width="1192" alt="Screenshot 2022-02-20 at 14 58 18" src="https://user-images.githubusercontent.com/1931323/154848841-84c4c5be-20c7-4c83-9092-a350ab86b84d.png">

It is no longer possible to change the usage for supervised and unsupervised rules - the "change usage" button is disabled, and the `title` attribute set to read "To change the usage for this rule, please configure another rule as Supervised":

<img width="633" alt="Screenshot 2022-02-20 at 14 59 08" src="https://user-images.githubusercontent.com/1931323/154848916-b30c370d-ab8a-445e-bb1b-52165828e593.png">

Comments
----------------------------------------
Minor CSS adjustments have been made, which will affect non-default themes. However, without the CSS changes the functionality is still perfectly usable, so this shouldn't be a big issue.
