### PR TITLE
WordPress - Display site-theme/decorations on error screens

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -204,9 +204,11 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     CRM_Core_Error::debug_var('Fatal Error Details', $error, TRUE, TRUE, '', PEAR_LOG_ERR);
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
+    $exit = TRUE;
     if ($config->initialized) {
       $content = $template->fetch('CRM/common/fatal.tpl');
       echo CRM_Utils_System::theme($content);
+      $exit = CRM_Utils_System::exitAfterFatal();
     }
     else {
       echo "Sorry. A non-recoverable error has occurred. The error trace below might help to resolve the issue<p>";
@@ -217,7 +219,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       exit;
     }
     $runOnce = TRUE;
-    self::abend(CRM_Core_Error::FATAL_ERROR);
+    self::abend(CRM_Core_Error::FATAL_ERROR, $exit);
   }
 
   /**
@@ -442,9 +444,10 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
 
     echo CRM_Utils_System::theme($content);
+    $exit = CRM_Utils_System::exitAfterFatal();
 
     // fin
-    self::abend(CRM_Core_Error::FATAL_ERROR);
+    self::abend(CRM_Core_Error::FATAL_ERROR, $exit);
   }
 
   /**
@@ -999,12 +1002,15 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * Terminate execution abnormally.
    *
    * @param string $code
+   * @param bool $exit
    */
-  protected static function abend($code) {
+  protected static function abend($code, $exit = TRUE) {
     // do a hard rollback of any pending transactions
     // if we've come here, its because of some unexpected PEAR errors
     CRM_Core_Transaction::forceRollbackIfEnabled();
-    CRM_Utils_System::civiExit($code);
+    if ($exit) {
+      CRM_Utils_System::civiExit($code);
+    }
   }
 
   /**

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -208,7 +208,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     if ($config->initialized) {
       $content = $template->fetch('CRM/common/fatal.tpl');
       echo CRM_Utils_System::theme($content);
-      $exit = CRM_Utils_System::exitAfterFatal();
+      $exit = CRM_Utils_System::shouldExitAfterFatal();
     }
     else {
       echo "Sorry. A non-recoverable error has occurred. The error trace below might help to resolve the issue<p>";
@@ -219,7 +219,13 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       exit;
     }
     $runOnce = TRUE;
-    self::abend(CRM_Core_Error::FATAL_ERROR, $exit);
+
+    if ($exit) {
+      self::abend(CRM_Core_Error::FATAL_ERROR);
+    }
+    else {
+      self::inpageExceptionDisplay(CRM_Core_Error::FATAL_ERROR);
+    }
   }
 
   /**
@@ -444,10 +450,14 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
 
     echo CRM_Utils_System::theme($content);
-    $exit = CRM_Utils_System::exitAfterFatal();
+    $exit = CRM_Utils_System::shouldExitAfterFatal();
 
-    // fin
-    self::abend(CRM_Core_Error::FATAL_ERROR, $exit);
+    if ($exit) {
+      self::abend(CRM_Core_Error::FATAL_ERROR);
+    }
+    else {
+      self::inpageExceptionDisplay(CRM_Core_Error::FATAL_ERROR);
+    }
   }
 
   /**
@@ -1001,15 +1011,43 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   /**
    * Terminate execution abnormally.
    *
-   * @param string $code
-   * @param bool $exit
+   * @param int $code
    */
-  protected static function abend($code, $exit = TRUE) {
+  protected static function abend($code) {
     // do a hard rollback of any pending transactions
     // if we've come here, its because of some unexpected PEAR errors
     CRM_Core_Transaction::forceRollbackIfEnabled();
-    if ($exit) {
-      CRM_Utils_System::civiExit($code);
+    CRM_Utils_System::civiExit($code);
+  }
+
+  /**
+   * Show in-page exception
+   * For situations where where calling abend will block the ability for a branded error screen
+   *
+   * Although the host page will run past this point, CiviCRM should not,
+   * therefore we trigger the civi.exit events
+   *
+   * @param string $code
+   */
+  protected static function inpageExceptionDisplay($code) {
+    // do a hard rollback of any pending transactions
+    // if we've come here, its because of some unexpected PEAR errors
+    CRM_Core_Transaction::forceRollbackIfEnabled();
+
+    if ($code > 0 && !headers_sent()) {
+      http_response_code(500);
+    }
+
+    // move things to CiviCRM cache as needed
+    CRM_Core_Session::storeSessionObjects();
+
+    if (Civi\Core\Container::isContainerBooted()) {
+      Civi::dispatcher()->dispatch('civi.core.exit');
+    }
+
+    $userSystem = CRM_Core_Config::singleton()->userSystem;
+    if (is_callable([$userSystem, 'onCiviExit'])) {
+      $userSystem->onCiviExit();
     }
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -38,6 +38,7 @@
  * @method static array synchronizeUsers() Create CRM contacts for all existing CMS users.
  * @method static void appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
  * @method static void alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
+ * @method static exitAfterFatal() Should the current execution exit after a fatal error?
  */
 class CRM_Utils_System {
 

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1102,9 +1102,11 @@ abstract class CRM_Utils_System_Base {
   /**
    * Should the current execution exit after a fatal error?
    * This is the appropriate functionality in most cases.
+   *
+   * @internal
    * @return bool
    */
-  public function exitAfterFatal() {
+  public function shouldExitAfterFatal() {
     return TRUE;
   }
 

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1099,4 +1099,13 @@ abstract class CRM_Utils_System_Base {
     return [];
   }
 
+  /**
+   * Should the current execution exit after a fatal error?
+   * This is the appropriate functionality in most cases.
+   * @return bool
+   */
+  public function exitAfterFatal() {
+    return TRUE;
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1481,9 +1481,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * In WordPress, it is not usually possible to trigger theming outside of the WordPress theme process,
    * meaning that in order to render an error inside the theme we cannot exit on error.
    *
+   * @internal
    * @return bool
    */
-  public function exitAfterFatal() {
+  public function shouldExitAfterFatal() {
     $ret = TRUE;
     if (!is_admin() && !wp_doing_ajax()) {
       $ret = FALSE;

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -602,6 +602,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   public function permissionDenied() {
     status_header(403);
+    global $civicrm_wp_title;
+    $civicrm_wp_title = ts('You do not have permission to access this page.');
     throw new CRM_Core_Exception(ts('You do not have permission to access this page.'));
   }
 
@@ -1471,6 +1473,23 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   public function showPasswordFieldWhenAdminCreatesUser() {
     return !$this->isUserRegistrationPermitted();
+  }
+
+  /**
+   * Should the current execution exit after a fatal error?
+   *
+   * In WordPress, it is not usually possible to trigger theming outside of the WordPress theme process,
+   * meaning that in order to render an error inside the theme we cannot exit on error.
+   *
+   * @return bool
+   */
+  public function exitAfterFatal() {
+    $ret = TRUE;
+    if (!is_admin() && !wp_doing_ajax()) {
+      $ret = FALSE;
+    }
+
+    return apply_filters('civicrm_exit_after_fatal', $ret);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This builds on the previous work completed by @seamuslee001 in https://github.com/civicrm/civicrm-core/pull/20206, but addresses some concerns with the original approach.

This new approach keeps the use of `CRM_Core_Exception`, ensuring that existing logging and hooks are not lost. As WordPress does not have a generic `theme()` function to theme a generic error message we need to ensure that the execution does not `exit` to allow the error message to be dropped into the page content - demonstated with a couple of default themes:

<img width="933" alt="Screenshot 2022-02-20 at 16 27 47" src="https://user-images.githubusercontent.com/1931323/154852977-5b8afc01-8538-43f5-bef8-7bcd8f263f47.png">

<img width="1035" alt="Screenshot 2022-02-20 at 16 28 22" src="https://user-images.githubusercontent.com/1931323/154853010-ea51578c-47d0-4489-95db-8b798372acea.png">


Before
----------------------------------------
Previously a completely unbranded, and minimally styled error page was used:
<img width="1440" alt="Screenshot 2022-02-20 at 16 29 36" src="https://user-images.githubusercontent.com/1931323/154853081-5afdb09a-0fd6-4763-ba67-03b0ed72cd3b.png">

After
----------------------------------------
The error message is embedded in the post content, as demonstrated in the screnshots above.

Technical Details
----------------------------------------
There may be some (legitimate) concerns about not calling `exit` after an error, which is fair - consideration should be given to whether I'm missing anything when reviewing this.

I did wonder if the `$civicrm_wp_title` variable should be set within the `CRM_Core_Error` method to avoid leaking information when exceptions happen which don't pass through the `permissionDenied` method. Ultimately I decided this probably wasn't a big risk, but it would be good to check no one else disagrees here.

This can be tested in two ways:
 - Manually trigger an exception on the page you are viewing by adding `throw new CRM_Core_Exception('This is a test exception')` to the relevant form. (unless you know of a specific route which causes a legitimate exception).
 - Visit a page you don't have permissions to view in order to trigger the `permissionDenied` method.