### PR TITLE
CiviGrant - Don't return grant fields as contact fields

### DIFF
--- a/ext/civigrant/CRM/Grant/BAO/Query.php
+++ b/ext/civigrant/CRM/Grant/BAO/Query.php
@@ -17,12 +17,16 @@ use CRM_Grant_ExtensionUtil as E;
 class CRM_Grant_BAO_Query extends CRM_Contact_BAO_Query_Interface {
 
   /**
-   * Get grant fields.
+   * Unused.
+   *
+   * This function is meant to return extra contact fields, but grants are not contacts.
    *
    * @return array
    */
   public function &getFields() {
-    return CRM_Grant_BAO_Grant::exportableFields();
+    $fields = [];
+    return $fields;
+    // return CRM_Grant_BAO_Grant::exportableFields();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes grant fields appearing in the export wizard when they shouldn't.
See https://lab.civicrm.org/dev/core/-/issues/3069

Before
----------------------------------------
- Run a search
- Select Export action
- Select fields
- Grant fields show up as contact fields

After
----------------------------------------
They don't

Comments
--------------------
I thought this would break something as the `getFields` function seemed like it was needed for something or other to do with searches. But Advanced Search Grants tab still works, and so does Find Grants. So maybe it's safe to remove.