### PR TITLE
SearchKit - Refresh contents after saving a popup when in a block/tab

### DIFF
--- a/ext/afform/core/templates/afform/contactSummary/AfformBlock.tpl
+++ b/ext/afform/core/templates/afform/contactSummary/AfformBlock.tpl
@@ -1,5 +1,5 @@
 <crm-angular-js modules="{$block.module}">
-  <div id="bootstrap-theme">
+  <form id="bootstrap-theme">
     <{$block.directive} options="{ldelim}contact_id: {$contactId}{rdelim}"></{$block.directive}>
-  </div>
+  </form>
 </crm-angular-js>

--- a/ext/afform/core/templates/afform/contactSummary/AfformTab.tpl
+++ b/ext/afform/core/templates/afform/contactSummary/AfformTab.tpl
@@ -1,5 +1,5 @@
 <crm-angular-js modules="{$tabValue.module}">
-  <div id="bootstrap-theme">
+  <form id="bootstrap-theme">
     <{$tabValue.directive} options="{ldelim}contact_id: {$contactId}{rdelim}"></{$tabValue.directive}>
-  </div>
+  </form>
 </crm-angular-js>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes SearchKit auto-refresh issue when creating or editing items via popup.

Before
----------------------------------------
- Enable CiviGrant extension
- Visit any contact summary screen
- Click the Grants tab and click on the New Grant button in that tab
- Fill in the required fields and save the new grant.
- Observe the list of grants in the tab does not refresh to show the newly created grant

After
----------------------------------------
Refreshes as expected

Technical Details
----------------------------------------
The auto-refresh depends on the search being inside a `<form>` element.