### PR TITLE
dev/core#3077 use BAO::add when creating case roles/relationships

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -245,7 +245,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     $dao->copyValues($params);
     // only create a relationship if it does not exist
     if (!$dao->find(TRUE)) {
-      $dao->save();
+      CRM_Contact_BAO_Relationship::add($params);
     }
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Use CRM_Contact_BAO_Relationship::add() to create a case role rather than direct DAO insert.

Before
----------------------------------------
When a case is created, roles/relationships were added using a direct DAO insert, which bypassed the pre/post hooks.

After
----------------------------------------
Use the BAO layer to create the relationships.

