### PR TITLE
Add deprecation notice to APIv3 Explorer

### DIFF
--- a/templates/CRM/Admin/Page/APIExplorer.tpl
+++ b/templates/CRM/Admin/Page/APIExplorer.tpl
@@ -218,7 +218,16 @@
   }
   {/literal}
 </style>
-
+<div class="messages status no-popup">
+  <p>
+    {icon icon="fa-info-circle"}{/icon}
+    <strong>{ts}Deprecation Notice{/ts}</strong>
+  </p>
+  <p>
+    {ts}APIv3 is the legacy version of CiviCRM's API. While still supported, it is not recommended for use in new projects.{/ts}
+    <a href="{crmURL p='civicrm/api4'}">{icon icon="fa-hand-o-right"}{/icon} {ts}Switch to APIv4{/ts}</a>
+  </p>
+</div>
 <div class="crm-block crm-content-block">
 <div id="mainTabContainer">
   <ul>


### PR DESCRIPTION
Overview
----------------------------------------
Informs users that APIv3 is no longer recommended for new projects.

![image](https://user-images.githubusercontent.com/2874912/155034022-a2b26d03-10f3-4c16-9d1b-3cb43d406e6c.png)

Comments
----------
According to the [Developer Docs](https://docs.civicrm.org/dev/en/latest/api/#api-versions), "v4 is recommended for all new projects".