### PR TITLE
(NFC) release-notes/5.46.0.md - Re-apply auto-cleanups

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -28,7 +28,7 @@ Released March 2, 2022
 
 ## CiviCRM 5.46.0
 
-Released February 2, 2022
+Released February 3, 2022
 
 - **[Synopsis](release-notes/5.46.0.md#synopsis)**
 - **[Features](release-notes/5.46.0.md#features)**

--- a/release-notes/5.46.0.md
+++ b/release-notes/5.46.0.md
@@ -1,6 +1,6 @@
 # CiviCRM 5.46.0
 
-Released February 2, 2022
+Released February 3, 2022
 
 - **[Synopsis](#synopsis)**
 - **[Features](#features)**

--- a/release-notes/5.46.0.md
+++ b/release-notes/5.46.0.md
@@ -44,16 +44,16 @@ Released February 3, 2022
 
   Adds a email on hold filter to reports.
 
-- **Increment recommended php version
+- **Increment recommended PHP version
   ([dev/core#2996](https://lab.civicrm.org/dev/core/-/issues/2996):
   [22265](https://github.com/civicrm/civicrm-core/pull/22265))**
 
-  Changes the minimum php version to 7.3 and the recommended php version to 7.4.
+  Changes the minimum PHP version to 7.3 and the recommended PHP version to 7.4.
 
 - **APIv4 Explorer - Make selected language and format bookmarkable
   ([22233](https://github.com/civicrm/civicrm-core/pull/22233))**
 
-  The APIv4 explorer already places params in the url for easy bookmarking.
+  The APIv4 explorer already places params in the URL for easy bookmarking.
   This extends it to work for the selected language tab and the selected output
   format.
 
@@ -103,7 +103,7 @@ Released February 3, 2022
 - **Afform - UI and contextual titles for search displays
   ([22319](https://github.com/civicrm/civicrm-core/pull/22319))**
 
-  Makes it easy to create drilldown search displays, passing in a url arg to
+  Makes it easy to create drilldown search displays, passing in a URL arg to
   specify a category/container. E.g. "Custom fields in group X", "Option values
   for Individual Prefix", "Email addresses for Bob Smith".
 
@@ -154,7 +154,7 @@ Released February 3, 2022
   [21178](https://github.com/civicrm/civicrm-core/pull/21178) and
   [21181](https://github.com/civicrm/civicrm-core/pull/21181))**
 
-  Allows financial_trxns to be viewed and use acl, not blanket permissions on
+  Allows financial_trxns to be viewed and use ACL, not blanket permissions on
   FinancialAccount, FinancialType, EntityFinancialAccount.
 
 - **Demo sample data - Add in some mixed currency contributions
@@ -189,7 +189,7 @@ Released February 3, 2022
   [22107](https://github.com/civicrm/civicrm-core/pull/22107))**
 
 - **Removes the limit of 15 max values for multiple values can also
-  be retrieved from url in reports
+  be retrieved from URL in reports
   ([dev/core#2979](https://lab.civicrm.org/dev/core/-/issues/2979):
   [22214](https://github.com/civicrm/civicrm-core/pull/22214))**
 
@@ -216,7 +216,7 @@ Released February 3, 2022
   ([dev/core#2924](https://lab.civicrm.org/dev/core/-/issues/2924):
   [22322](https://github.com/civicrm/civicrm-core/pull/22322))**
 
-- **Apiv4 - Make Groups a managed entity, fix 'null' bugs in BAO_Group
+- **APIv4 - Make Groups a managed entity, fix 'null' bugs in BAO_Group
   ([22228](https://github.com/civicrm/civicrm-core/pull/22228))**
 
 - **APIv4 - Set 'activity_type_id' to required
@@ -252,7 +252,7 @@ Released February 3, 2022
   ([dev/report#90](https://lab.civicrm.org/dev/report/-/issues/90):
   [22375](https://github.com/civicrm/civicrm-core/pull/22375))**
 
-  Don't crash search_kit on upgrade from 5.35.
+  Don't crash SearchKit on upgrade from 5.35.
 
 - **DedupeRules - Translate contact type labels, respect enabled contact types
   ([22383](https://github.com/civicrm/civicrm-core/pull/22383))**
@@ -282,7 +282,7 @@ Released February 3, 2022
 - **ExtensionUpgrades - Skip trying to upgrade missing dependencies
   ([22623](https://github.com/civicrm/civicrm-core/pull/22623))**
 
-- **Fix input type for smarty number formatting (more forgiving)
+- **Fix input type for Smarty number formatting (more forgiving)
   ([22429](https://github.com/civicrm/civicrm-core/pull/22429))**
 
 - **Ensure getDuplicateContacts always returns an array
@@ -300,7 +300,7 @@ Released February 3, 2022
 - **Do not escape showHideBlocks by default
   ([22371](https://github.com/civicrm/civicrm-core/pull/22371))**
 
-- **Fix notices on acl page
+- **Fix notices on ACL page
   ([22370](https://github.com/civicrm/civicrm-core/pull/22370))**
 
 - **Fix PropertyBag setRecurInstallments to accept 0
@@ -345,13 +345,13 @@ Released February 3, 2022
 - **Do not default-escape weight field on order
   ([22256](https://github.com/civicrm/civicrm-core/pull/22256))**
 
-- **Move require_once for smarty modifier due to order issues
+- **Move require_once for Smarty modifier due to order issues
   ([22252](https://github.com/civicrm/civicrm-core/pull/22252))**
 
 - **Contact/BAO/Query.php: fix searching for whitespace
   ([22240](https://github.com/civicrm/civicrm-core/pull/22240))**
 
-- **Use new money formatting util for smarty formatting
+- **Use new money formatting util for Smarty formatting
   ([22309](https://github.com/civicrm/civicrm-core/pull/22309))**
 
 - **Smarty variables]  Remove another isset - deferredFinancialType
@@ -366,7 +366,7 @@ Released February 3, 2022
 - **[Smarty variables] remove isset from merge screen
   ([22193](https://github.com/civicrm/civicrm-core/pull/22193))**
 
-- **[Smarty variables] Fix overzealous escaping with smarty default escaping
+- **[Smarty variables] Fix overzealous escaping with Smarty default escaping
   ([22194](https://github.com/civicrm/civicrm-core/pull/22194))**
 
 - **[Smarty variables]  Remove issets relating to auto_renew
@@ -378,7 +378,7 @@ Released February 3, 2022
 - **Smarty modifier - stop using isset to check taxTerm
   ([22323](https://github.com/civicrm/civicrm-core/pull/22323))**
 
-- **E-notice fix (smarty)
+- **E-notice fix (Smarty)
   ([22308](https://github.com/civicrm/civicrm-core/pull/22308))**
 
 ## CiviCampaign
@@ -478,7 +478,7 @@ Released February 3, 2022
 - **SearchKit - Tweak export explorer link icon + format
   ([22300](https://github.com/civicrm/civicrm-core/pull/22300))**
 
-- **Expose contact id in getContactInfo method in
+- **Expose contact ID in getContactInfo method in
   CRM/Mailing/Event/BAO/Queue.php
   ([dev/core#2962](https://lab.civicrm.org/dev/core/-/issues/2962):
   [22096](https://github.com/civicrm/civicrm-core/pull/22096))**
@@ -513,7 +513,7 @@ Released February 3, 2022
 - **Remove handling for always-truthy var being false
   ([22260](https://github.com/civicrm/civicrm-core/pull/22260))**
 
-- **Remove unnecessary id attribute.
+- **Remove unnecessary ID attribute.
   ([22347](https://github.com/civicrm/civicrm-core/pull/22347))**
 
 - **Remove never passed variables
@@ -549,53 +549,53 @@ Released February 3, 2022
 - **(REF) CRM/Upgrade - Remove unused entrypoint `verifyPreDBstate()`
   ([22237](https://github.com/civicrm/civicrm-core/pull/22237))**
 
-- **[REF] Remove more params that are unused now function is not shared
+- **(REF) Remove more params that are unused now function is not shared
   ([22261](https://github.com/civicrm/civicrm-core/pull/22261))**
 
-- **[REF] Duplicate function to allow us to work it out of the code
+- **(REF) Duplicate function to allow us to work it out of the code
   ([22254](https://github.com/civicrm/civicrm-core/pull/22254))**
 
-- **[REF] Minor parameter simplification
+- **(REF) Minor parameter simplification
   ([22253](https://github.com/civicrm/civicrm-core/pull/22253))**
 
-- **[REF] Add in getVersion override for Drupal 8/9 to support cv testing and
+- **(REF) Add in getVersion override for Drupal 8/9 to support cv testing and
   also cv vars:show picking up the right CMS version
   ([22220](https://github.com/civicrm/civicrm-core/pull/22220))**
 
-- **[Ref] Add getter for priceSetID and use full form flow
+- **(REF) Add getter for priceSetID and use full form flow
   ([22267](https://github.com/civicrm/civicrm-core/pull/22267))**
 
-- **[REF] Afform - Use APIv4 for managed dashboard
+- **(REF) Afform - Use APIv4 for managed dashboard
   ([22213](https://github.com/civicrm/civicrm-core/pull/22213))**
 
-- **[REF] Remove handling for relationshipID
+- **(REF) Remove handling for relationshipID
   ([22391](https://github.com/civicrm/civicrm-core/pull/22391))**
 
-- **REF - Use `CRM_Contact_BAO_ContactType::basicTypes()` instead of hardcoded
+- **(REF) Use `CRM_Contact_BAO_ContactType::basicTypes()` instead of hardcoded
   lists ([22389](https://github.com/civicrm/civicrm-core/pull/22389))**
 
-- **[REF] move code into the function
+- **(REF) Move code into the function
   ([22288](https://github.com/civicrm/civicrm-core/pull/22288))**
 
-- **[REF] Remove now non-variable variables from previously shared code
+- **(REF) Remove now non-variable variables from previously shared code
   ([22284](https://github.com/civicrm/civicrm-core/pull/22284))**
 
-- **[REF] Duplicate & unshare processFormContribution
+- **(REF) Duplicate & unshare processFormContribution
   ([22276](https://github.com/civicrm/civicrm-core/pull/22276))**
 
-- **[REF] Stop passing this as form, set in function
+- **(REF) Stop passing this as form, set in function
   ([22287](https://github.com/civicrm/civicrm-core/pull/22287))**
 
-- **[REF] Deprecated old getContributionStatuses
+- **(REF) Deprecated old getContributionStatuses
   ([22345](https://github.com/civicrm/civicrm-core/pull/22345))**
 
-- **[REF] Simplify getContributionStatuses
+- **(REF) Simplify getContributionStatuses
   ([22280](https://github.com/civicrm/civicrm-core/pull/22280))**
 
-- **[REF] Upgrade JQuery UI to 1.13.0
+- **(REF) Upgrade jQuery UI to 1.13.0
   ([22583](https://github.com/civicrm/civicrm-core/pull/22583))**
 
-- **[REF] Further cleanup on employer create
+- **(REF) Further cleanup on employer create
   ([22390](https://github.com/civicrm/civicrm-core/pull/22390))**
 
 - **HookTest - Fix execution on PHP 8
@@ -616,34 +616,34 @@ Released February 3, 2022
 - **(NFC) Cleanup test class
   ([22384](https://github.com/civicrm/civicrm-core/pull/22384))**
 
-- **[NFC] - Try to work around failing tests
+- **(NFC) Try to work around failing tests
   ([22269](https://github.com/civicrm/civicrm-core/pull/22269))**
 
-- **[NFC] Cleanup in Authorize.net test class
+- **(NFC) Cleanup in Authorize.net test class
   ([22272](https://github.com/civicrm/civicrm-core/pull/22272))**
 
-- **[NFC] isDir unit test fails on php 7 'min' matrix
+- **(NFC) isDir unit test fails on PHP 7 'min' matrix
   ([22418](https://github.com/civicrm/civicrm-core/pull/22418))**
 
 - **(NFC) APIv4: Add help info for multi-record custom field sets
   ([22257](https://github.com/civicrm/civicrm-core/pull/22257))**
 
-- **[NFC] Test cleanup
+- **(NFC) Test cleanup
   ([22251](https://github.com/civicrm/civicrm-core/pull/22251))**
 
-- **[NFC] Minor cleanup in test class
+- **(NFC) Minor cleanup in test class
   ([22249](https://github.com/civicrm/civicrm-core/pull/22249))**
 
-- **NFC - Cleanup messy boilerplate
+- **(NFC) Cleanup messy boilerplate
   ([22224](https://github.com/civicrm/civicrm-core/pull/22224))**
 
-- **NFC - Delete boilerplate comments and empty functions from upgrade classes
+- **(NFC) Delete boilerplate comments and empty functions from upgrade classes
   ([22226](https://github.com/civicrm/civicrm-core/pull/22226))**
 
-- **[NFC] CRM_Core_Exception incorrectly called without message
+- **(NFC) CRM_Core_Exception incorrectly called without message
   ([22339](https://github.com/civicrm/civicrm-core/pull/22339))**
 
-- **[NFC] docblock improvements to Import_Field classes
+- **(NFC) Docblock improvements to Import_Field classes
   ([22360](https://github.com/civicrm/civicrm-core/pull/22360))**
 
 ## <a name="credits"></a>Credits


### PR DESCRIPTION
Overview
----------------------------------------

This combines together @alifrumin's recent updates to the release notes (#22813) and my earlier/interim cleanups from #22700 (https://gist.github.com/totten/acff49e6dd77947349a1df26d5002003).

