### PR TITLE
RestTest - Skip `testNotCMSUser_q` when it's not supported

### DIFF
--- a/tests/phpunit/E2E/Extern/AuthxRestTest.php
+++ b/tests/phpunit/E2E/Extern/AuthxRestTest.php
@@ -33,13 +33,8 @@ class E2E_Extern_AuthxRestTest extends E2E_Extern_BaseRestTest {
     return CRM_Utils_System::url('civicrm/ajax/rest', NULL, TRUE, NULL, FALSE, TRUE);
   }
 
-  public function apiTestCases() {
-    $r = parent::apiTestCases();
-    $r = array_filter($r, function($case) {
-      // The 'civicrm/ajax/rest' end-point does not support '?q' inputs.
-      return !isset($case[0]['q']);
-    });
-    return $r;
+  protected function isOldQSupported(): bool {
+    return FALSE;
   }
 
 }

--- a/tests/phpunit/E2E/Extern/BaseRestTest.php
+++ b/tests/phpunit/E2E/Extern/BaseRestTest.php
@@ -315,6 +315,9 @@ abstract class E2E_Extern_BaseRestTest extends CiviEndToEndTestCase {
    * a real user. Submit in "?q=civicrm/$entity/$action" notation
    */
   public function testNotCMSUser_q() {
+    if (!$this->isOldQSupported()) {
+      $this->markTestSkipped('rest.php?q=civicrm/ENTITY/ACTION is not supported here');
+    }
     $http = $this->createGuzzle(['http_errors' => FALSE]);
 
     //Create contact with api_key

--- a/tests/phpunit/E2E/Extern/BaseRestTest.php
+++ b/tests/phpunit/E2E/Extern/BaseRestTest.php
@@ -28,6 +28,21 @@ abstract class E2E_Extern_BaseRestTest extends CiviEndToEndTestCase {
   protected $adminContactId;
 
   /**
+   * Enable testing of `civicrm/{$entity}/{$action}` from APIv3 REST?
+   *
+   * The APIv3 REST end-point supported two notations:
+   *
+   * - `rest.php?entity=ENTITY&action=ACTION`
+   * - `rest.php?q=civicrm/ENTITY/ACTON`.
+   *
+   * The former better documentation, tooling, and compatibility. The latter is conflicted
+   * is some cases.
+   *
+   * @return bool
+   */
+  abstract protected function isOldQSupported(): bool;
+
+  /**
    * @param $apiResult
    * @param $cmpvar
    * @param string $prefix
@@ -201,6 +216,13 @@ abstract class E2E_Extern_BaseRestTest extends CiviEndToEndTestCase {
       // is_error
       0,
     );
+
+    if (!$this->isOldQSupported()) {
+      $cases = array_filter($cases, function($case) {
+        // The 'civicrm/ajax/rest' end-point does not support '?q' inputs.
+        return !isset($case[0]['q']);
+      });
+    }
 
     return $cases;
   }

--- a/tests/phpunit/E2E/Extern/LegacyRestTest.php
+++ b/tests/phpunit/E2E/Extern/LegacyRestTest.php
@@ -28,4 +28,8 @@ class E2E_Extern_LegacyRestTest extends E2E_Extern_BaseRestTest {
       ->getUrl('civicrm', 'extern/rest.php');
   }
 
+  protected function isOldQSupported(): bool {
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

The https://test.civicrm.org/job/CiviCRM-E2E-Matrix/ shows a test failure for `AuthxRestTest::testNotCMSUser_q` on `wp-demo` for v5.47+. The failure does not indicate a regression and can be skipped.

CC @kcristiano

Background
----------------------------------------

v5.47 split apart the E2E testing for APIv3 REST:
    
* `LegacyRestTest` extends `BaseRestTest` and targets `extern/rest.php`. It tests both: 
    * `extern/rest.php?entity=ENTITY&action=ACTION` (*typical, more portable format; encouraged by API Explorer for a long time*)
    * `extern/rest.php?q=civicrm/ENTITY/ACTION` (*older, less-documented format*)
* `AuthxRestTest` extends `BaseRestTest` and targets `civicrm/ajax/rest`. It only tests the typical format.
    * `civicrm/ajax/rest?entity=ENTITY&action=ACTION`
    * ~~`civicrm/ajax/rest?q=civicrm/ENTITY/ACTION` which equates to `q=civicrm/ajax/rest&q=civicrm/ENTITY/ACTION`~~ (*Skipped*)

Before
----------------------------------------

`AuthxRestTest` has a rule to skip testing of `civicrm/ajax/rest?q=civicrm/ENTITY/ACTION`

But the rule doesn't really skip all of them. `testNotCMSUser_q` is still running.

After
----------------------------------------

It really skips all of them.

