### PR TITLE
Recent update to {receipt_text} token gives warning in system check after upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -334,6 +334,14 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'payment_or_refund_notification', 'type' => 'text'],
         ],
       ],
+      [
+        'version' => '5.48.alpha1',
+        'upgrade_descriptor' => ts('Replace {receipt_text_renewal} with {receipt_text}'),
+        'templates' => [
+          ['name' => 'membership_offline_receipt', 'type' => 'html'],
+          ['name' => 'membership_offline_receipt', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/22736 the token was changed but the message templates aren't updated.

Before
----------------------------------------
Warning in system status checks about outdated tokens after upgrade.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

