### PR TITLE
Fix the "since" version for api v4 Mailing and MailingJob

### DIFF
--- a/Civi/Api4/Mailing.php
+++ b/Civi/Api4/Mailing.php
@@ -17,7 +17,7 @@ namespace Civi\Api4;
  *
  * @searchable secondary
  * @see https://docs.civicrm.org/user/en/latest/email/what-is-civimail/
- * @since 5.47
+ * @since 5.48
  * @package Civi\Api4
  */
 class Mailing extends Generic\DAOEntity {

--- a/Civi/Api4/MailingJob.php
+++ b/Civi/Api4/MailingJob.php
@@ -20,7 +20,7 @@ use Civi\Api4\Generic\Traits\ReadOnlyEntity;
  * @searchable none
  *
  * @see https://docs.civicrm.org/user/en/latest/email/what-is-civimail/
- * @since 5.47
+ * @since 5.48
  * @package Civi\Api4
  */
 class MailingJob extends Generic\DAOEntity {


### PR DESCRIPTION
Overview
----------------------------------------
This was just merged, but it says `@since 5.47`.

https://github.com/civicrm/civicrm-core/blob/5.47/Civi/Api4/Mailing.php gives a 404.