### PR TITLE
APIv4 - Get dynamic list of entity types

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -35,7 +35,7 @@ class Entity extends Generic\AbstractEntity {
    * @return Generic\BasicGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {
-    return (new Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function() {
+    return (new Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function(Generic\BasicGetFieldsAction $getFields) {
       return [
         [
           'name' => 'name',
@@ -53,15 +53,7 @@ class Entity extends Generic\AbstractEntity {
           'name' => 'type',
           'data_type' => 'Array',
           'description' => 'Base class for this entity',
-          'options' => [
-            'AbstractEntity' => 'AbstractEntity',
-            'DAOEntity' => 'DAOEntity',
-            'CustomValue' => 'CustomValue',
-            'BasicEntity' => 'BasicEntity',
-            'SortableEntity' => 'SortableEntity',
-            'ManagedEntity' => 'ManagedEntity',
-            'EntityBridge' => 'EntityBridge',
-          ],
+          'options' => $getFields->getLoadOptions() ? self::getEntityTypes() : TRUE,
         ],
         [
           'name' => 'description',
@@ -158,6 +150,22 @@ class Entity extends Generic\AbstractEntity {
     return [
       'default' => ['access CiviCRM'],
     ];
+  }
+
+  /**
+   * Collect the 'type' values from every entity.
+   *
+   * @return array
+   */
+  private static function getEntityTypes() {
+    $provider = \Civi::service('action_object_provider');
+    $entityTypes = [];
+    foreach ($provider->getEntities() as $entity) {
+      foreach ($entity['type'] ?? [] as $type) {
+        $entityTypes[$type] = $type;
+      }
+    }
+    return $entityTypes;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Switches APIv4 Entity.get to dynamically fetch a list of entity types instead of using a hardcoded list.

Before
----------------------------------------
Hardcoded list, can't be influenced by extensions.

After
----------------------------------------
Any new type of entity added by an extension will be included.