### PR TITLE
OptionValue - Allow duplicate values across different groupings

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -209,6 +209,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
         $dao->domain_id = $optionValue->domain_id;
       }
       $dao->option_group_id = $params['option_group_id'];
+      $dao->grouping = $params['grouping'] ?? NULL;
       if ($dao->find(TRUE)) {
         throw new CRM_Core_Exception('Value already exists in the database');
       }


### PR DESCRIPTION
Overview
----------------------------------------
When creating an option value, take `grouping` into consideration when enforcing unique values.

Before
--------------------
The OptionValue BAO enforces unique values per group and per domain, but doesn't consider grouping. Identical values with different groupings are rejected.

After
-----------
Identical values with different groupings are allowed.
