### PR TITLE
APIv4 - Add tableName to Entity.get output

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -80,6 +80,10 @@ class Entity extends Generic\AbstractEntity {
           'description' => 'Class name for dao-based entities',
         ],
         [
+          'name' => 'table_name',
+          'description' => 'Name of sql table, if applicable',
+        ],
+        [
           'name' => 'primary_key',
           'data_type' => 'Array',
           'description' => 'Name of unique identifier field(s) (e.g. [id])',

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -153,6 +153,7 @@ abstract class AbstractEntity {
       $info['icon'] = $dao::$_icon;
       $info['label_field'] = $dao::$_labelField;
       $info['dao'] = $dao;
+      $info['table_name'] = $dao::$_tableName;
     }
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {
       $info['type'][] = self::stripNamespace($trait);

--- a/Civi/Api4/Provider/CustomEntityProvider.php
+++ b/Civi/Api4/Provider/CustomEntityProvider.php
@@ -35,6 +35,7 @@ class CustomEntityProvider {
         'name' => $fieldName,
         'title' => $group->title,
         'title_plural' => $group->title,
+        'table_name' => $group->table_name,
         'description' => ts('Custom group for %1', [1 => $baseEntity::getInfo()['title_plural']]),
         'paths' => [
           'view' => "civicrm/contact/view/cd?reset=1&gid={$group->id}&recId=[id]&multiRecordDisplay=single",

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -73,11 +73,7 @@ class CoreUtil {
    * @return string
    */
   public static function getTableName($entityName) {
-    if (strpos($entityName, 'Custom_') === 0) {
-      $customGroup = substr($entityName, 7);
-      return \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroup, 'table_name', 'name');
-    }
-    return AllCoreTables::getTableForEntityName($entityName);
+    return self::getInfoItem($entityName, 'table_name');
   }
 
   /**
@@ -87,15 +83,13 @@ class CoreUtil {
    * @return string|NULL
    */
   public static function getApiNameFromTableName($tableName) {
-    $entityName = AllCoreTables::getBriefName(AllCoreTables::getClassForTable($tableName));
-    // Real entities
-    if ($entityName) {
-      // Verify class exists
-      return self::getApiClass($entityName) ? $entityName : NULL;
+    $provider = \Civi::service('action_object_provider');
+    foreach ($provider->getEntities() as $entityName => $info) {
+      if (($info['table_name'] ?? NULL) === $tableName) {
+        return $entityName;
+      }
     }
-    // Multi-value custom group pseudo-entities
-    $customGroup = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $tableName, 'name', 'table_name');
-    return self::isCustomEntity($customGroup) ? "Custom_$customGroup" : NULL;
+    return NULL;
   }
 
   /**

--- a/tests/phpunit/api/v4/Utils/CoreUtilTest.php
+++ b/tests/phpunit/api/v4/Utils/CoreUtilTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Utils;
 
 use api\v4\UnitTestCase;
+use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\Utils\CoreUtil;
 
@@ -45,6 +46,11 @@ class CoreUtilTest extends UnitTestCase {
       ->addValue('title', uniqid())
       ->addValue('extends', 'Contact')
       ->addValue('is_multiple', TRUE)
+      ->addChain('fields', CustomField::save()
+        ->addDefault('html_type', 'Text')
+        ->addDefault('custom_group_id', '$id')
+        ->addRecord(['label' => 'MyField1'])
+      )
       ->execute()->first();
 
     $this->assertEquals('Custom_' . $multiGroup['name'], CoreUtil::getApiNameFromTableName($multiGroup['table_name']));


### PR DESCRIPTION
Overview
----------------------------------------
Adds another useful bit of output to APIv4 Entity.get. Improves flexibility for virtual entities.

Before
----------------------------------------
Relationship between entities and tables pretty much hard-coded.

After
----------------------------------------
More flexible, each entity can decide on its table name using dynamic logic if needed.

Comments
----------------------------------------
There is massive test coverage on this.