### PR TITLE
Enable APIv4 export action on UFGroup and UFField.

### DIFF
--- a/Civi/Api4/UFField.php
+++ b/Civi/Api4/UFField.php
@@ -22,5 +22,6 @@ namespace Civi\Api4;
  */
 class UFField extends Generic\DAOEntity {
   use Generic\Traits\SortableEntity;
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/UFGroup.php
+++ b/Civi/Api4/UFGroup.php
@@ -19,5 +19,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class UFGroup extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
With these little changes the export action is available on the UFGroup and UFField Entities. 


Before
----------------------------------------
The export action is not available in APIv4 on the UFField or UFGroup entities.

After
----------------------------------------
The export action is available.

Technical Details
----------------------------------------
None.

Comments
----------------------------------------

It still needs a tweak because UFField exports `field_name` which hard codes a custom
field's id instead of `field_name:name` - but I think it's a good first
step.
