### PR TITLE
Move HookInterface to \Civi\Core namespace

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -18,7 +18,7 @@
 /**
  *  Access Control List
  */
-class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL implements \Civi\Test\HookInterface {
+class CRM_ACL_BAO_ACL extends CRM_ACL_DAO_ACL implements \Civi\Core\HookInterface {
 
   /**
    * Available operations for  pseudoconstant.

--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -18,7 +18,7 @@
 /**
  * Class CRM_Campaign_BAO_Survey.
  */
-class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey implements Civi\Test\HookInterface {
+class CRM_Campaign_BAO_Survey extends CRM_Campaign_DAO_Survey implements Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -18,7 +18,7 @@
 /**
  * This class contains the functions for Case Type management.
  */
-class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Test\HookInterface {
+class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\HookInterface {
 
   /**
    * Static field for all the case information that we can potentially export.

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Test\HookInterface {
+class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Core\HookInterface {
 
   /**
    * SQL function used to format the phone_numeric field via trigger.

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contact_BAO_ContactType extends CRM_Contact_DAO_ContactType implements \Civi\Test\HookInterface {
+class CRM_Contact_BAO_ContactType extends CRM_Contact_DAO_ContactType implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Contact/BAO/RelationshipCache.php
+++ b/CRM/Contact/BAO/RelationshipCache.php
@@ -12,7 +12,7 @@
 /**
  * Class CRM_Contact_BAO_RelationshipCache.
  */
-class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCache implements \Civi\Test\HookInterface {
+class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCache implements \Civi\Core\HookInterface {
 
   /**
    * The "mappings" array defines the values to put into `civicrm_relationship_cache`

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -18,7 +18,7 @@ use Civi\Core\Event\PreEvent;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType implements \Civi\Test\HookInterface {
+class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -20,7 +20,7 @@ use Civi\Api4\Email;
 /**
  * This class contains functions for email handling.
  */
-class CRM_Core_BAO_Email extends CRM_Core_DAO_Email implements Civi\Test\HookInterface {
+class CRM_Core_BAO_Email extends CRM_Core_DAO_Email implements Civi\Core\HookInterface {
   use CRM_Contact_AccessTrait;
 
   /**

--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType implements \Civi\Core\HookInterface {
 
   /**
    * @var CRM_Core_DAO_LocationType|null

--- a/CRM/Core/BAO/Managed.php
+++ b/CRM/Core/BAO/Managed.php
@@ -18,7 +18,7 @@
 /**
  * This class contains functions for managed entities.
  */
-class CRM_Core_BAO_Managed extends CRM_Core_DAO_Managed implements Civi\Test\HookInterface {
+class CRM_Core_BAO_Managed extends CRM_Core_DAO_Managed implements Civi\Core\HookInterface {
 
   /**
    * Callback for hook_civicrm_post().

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -23,7 +23,7 @@ require_once 'Mail/mime.php';
 /**
  * Class CRM_Core_BAO_MessageTemplate.
  */
-class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -18,7 +18,7 @@
 /**
  * BAO object for crm_note table.
  */
-class CRM_Core_BAO_Note extends CRM_Core_DAO_Note implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_Note extends CRM_Core_DAO_Note implements \Civi\Core\HookInterface {
   use CRM_Core_DynamicFKAccessTrait;
 
   /**

--- a/CRM/Core/BAO/OptionGroup.php
+++ b/CRM/Core/BAO/OptionGroup.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi\Core\HookInterface {
 
   use CRM_Core_DynamicFKAccessTrait;
 

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -18,7 +18,7 @@
 /**
  * Class CRM_Core_BAO_WordReplacement.
  */
-class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implements \Civi\Test\HookInterface {
+class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Financial_BAO_FinancialAccount extends CRM_Financial_DAO_FinancialAccount implements \Civi\Test\HookInterface {
+class CRM_Financial_BAO_FinancialAccount extends CRM_Financial_DAO_FinancialAccount implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -17,7 +17,7 @@ use Civi\Api4\EntityFinancialAccount;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType implements \Civi\Test\HookInterface {
+class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType implements \Civi\Core\HookInterface {
 
   /**
    * Static cache holder of available financial types for this session

--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -18,7 +18,7 @@
 /**
  * This class contains payment processor related functions.
  */
-class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProcessor implements \Civi\Test\HookInterface {
+class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProcessor implements \Civi\Core\HookInterface {
   /**
    * Static holder for the default payment processor
    * @var object

--- a/CRM/Financial/BAO/PaymentProcessorType.php
+++ b/CRM/Financial/BAO/PaymentProcessorType.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Financial_BAO_PaymentProcessorType extends CRM_Financial_DAO_PaymentProcessorType implements \Civi\Test\HookInterface {
+class CRM_Financial_BAO_PaymentProcessorType extends CRM_Financial_DAO_PaymentProcessorType implements \Civi\Core\HookInterface {
 
   /**
    * Static holder for the default payment processor.

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus implements \Civi\Test\HookInterface {
+class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus implements \Civi\Core\HookInterface {
 
   /**
    * Retrieve DB object and copy to defaults array.

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implements \Civi\Test\HookInterface {
+class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implements \Civi\Core\HookInterface {
 
   /**
    * Static holder for the default Membership Type.

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -14,7 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implements Civi\Test\HookInterface {
+class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implements Civi\Core\HookInterface {
 
   /**
    * Takes an associative array and creates an instance object.

--- a/Civi/Core/Event/EventScanner.php
+++ b/Civi/Core/Event/EventScanner.php
@@ -67,7 +67,7 @@ class EventScanner {
 
     $listenerMap = [];
     // These 2 interfaces do the same thing; one is meant for unit tests and the other for runtime code
-    if (is_subclass_of($class, '\Civi\Test\HookInterface') || is_subclass_of($class, '\Civi\Core\HookInterface')) {
+    if (is_subclass_of($class, '\Civi\Core\HookInterface')) {
       $listenerMap = static::mergeListenerMap($listenerMap, static::findFunctionListeners($class, $self));
     }
     if (is_subclass_of($class, '\Symfony\Component\EventDispatcher\EventSubscriberInterface')) {

--- a/Civi/Core/Event/EventScanner.php
+++ b/Civi/Core/Event/EventScanner.php
@@ -66,8 +66,8 @@ class EventScanner {
     }
 
     $listenerMap = [];
-    // FIXME: Inteface misnomer
-    if (is_subclass_of($class, '\Civi\Test\HookInterface')) {
+    // These 2 interfaces do the same thing; one is meant for unit tests and the other for runtime code
+    if (is_subclass_of($class, '\Civi\Test\HookInterface') || is_subclass_of($class, '\Civi\Core\HookInterface')) {
       $listenerMap = static::mergeListenerMap($listenerMap, static::findFunctionListeners($class, $self));
     }
     if (is_subclass_of($class, '\Symfony\Component\EventDispatcher\EventSubscriberInterface')) {

--- a/Civi/Core/HookInterface.php
+++ b/Civi/Core/HookInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Civi\Core;
+
+/**
+ * Interface HookInterface
+ * @package Civi\Core
+ *
+ * This interface allows CRM_BAO classes to subscribe to hooks.
+ * Simply create an eponymous hook function (e.g. `hook_civicrm_post()`).
+ *
+ * ```
+ * class CRM_Foo_BAO_Bar implements \Civi\Core\HookInterface {
+ *   public function hook_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+ *     echo "Running hook_civicrm_post\n";
+ *   }
+ * }
+ * ```
+ *
+ * Similarly, to subscribe using Symfony-style listeners, create function with the 'on_' prefix:
+ *
+ * ```
+ * class CRM_Foo_BAO_Bar implements \Civi\Core\HookInterface {
+ *   public function on_civi_api_authorize(AuthorizeEvent $e): void {
+ *     echo "Running civi.api.authorize\n";
+ *   }
+ *   public function on_hook_civicrm_post(GenericHookEvent $e): void {
+ *     echo "Running hook_civicrm_post\n";
+ *   }
+ * }
+ * ```
+ *
+ * If you need more advanced registration abilities, consider using `Civi::dispatcher()`
+ * or `EventDispatcherInterface`.
+ *
+ * @see \Civi\Core\Event\EventScanner::findListeners
+ */
+interface HookInterface {
+}

--- a/Civi/Test/HookInterface.php
+++ b/Civi/Test/HookInterface.php
@@ -1,47 +1,6 @@
 <?php
 
-namespace Civi\Test;
-
-/**
- * Interface HookInterface
- * @package Civi\Test
- *
- * This interface allows you to subscribe to hooks as part of the test.
- * Simply create an eponymous hook function (e.g. `hook_civicrm_post()`).
- *
- * ```
- * class MyTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\HookInterface {
- *   public function hook_civicrm_post($op, $objectName, $objectId, &$objectRef) {
- *     echo "Running hook_civicrm_post\n";
- *   }
- * }
- * ```
- *
- * Similarly, to subscribe using Symfony-style listeners, create function with the 'on_' prefix:
- *
- * ```
- * class MyTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\HookInterface {
- *   public function on_civi_api_authorize(AuthorizeEvent $e): void {
- *     echo "Running civi.api.authorize\n";
- *   }
- *   public function on_hook_civicrm_post(GenericHookEvent $e): void {
- *     echo "Running hook_civicrm_post\n";
- *   }
- * }
- * ```
- *
- * At time of writing, there are a few limitations in how HookInterface is handled
- * by CiviTestListener:
- *
- *  - The test must execute in-process (aka HeadlessInterface; aka CIVICRM_UF==UnitTests).
- *    End-to-end tests (multi-process tests) are not supported.
- *  - Early bootstrap hooks (e.g. hook_civicrm_config) are not supported.
- *  - This does not support priorities or registering multiple listeners.
- *
- * If you need more advanced registration abilities, consider using `Civi::dispatcher()`
- * or `EventDispatcherInterface`.
- *
- * @see CiviTestListener
- */
-interface HookInterface {
-}
+// The interface `Civi\Test\HookInterface` was originally written for use in unit-tests.
+// It got promoted for use in more cases, but then the name became misleading.
+// Leave behind alias for backward compatibility.
+class_alias('Civi\Core\HookInterface', 'Civi\Test\HookInterface');


### PR DESCRIPTION
Overview
----------------------------------------
Places the `HookInterface` in a more central namespace to reflect the fact that it's now used for runtime code (originally it was just for unit tests).

Before
----------------------------------------
Class appears to be only meant for unit tests, but used in core code.
Code comment: `// FIXME: Interface misnomer`

After
----------------------------------------
Copied to core namespace. Old interface kept around for whatever is still using it.

Technical Details
----------------------------------------
This interface doesn't actually *do* anything, it's more like a tag. So I think this is a pretty safe change.