### PR TITLE
dev/core#3083 getNonDeductibleAmountFromPriceSet should take into account the financial type of the price field option

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1759,7 +1759,7 @@ WHERE     ct.id = cp.financial_type_id AND
   /**
    * Get the financial type info for the given id.
    *
-   * @param int $financialTypeID
+   * @param int $financialTypeId
    *   Financial type Id.
    * @return \Civi\Api4\Generic\Result
    *

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1499,7 +1499,8 @@ WHERE       ps.id = %1
         $financialType = \CRM_Price_BAO_PriceSet::getFinancialType($options['financial_type_id']);
         if ($financialType['is_deductible']) {
           $nonDeductibleAmount += $options['non_deductible_amount'] * $options['qty'];
-        } else {
+        }
+        else {
           $nonDeductibleAmount += $options['line_total'];
         }
       }
@@ -1754,7 +1755,6 @@ WHERE     ct.id = cp.financial_type_id AND
       }
     }
   }
-
 
   /**
    * Get the financial type info for the given id.

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1760,14 +1760,14 @@ WHERE     ct.id = cp.financial_type_id AND
    * Get the financial type info for the given id.
    *
    * @param int $financialTypeID
-   *
+   *   Financial type Id.
    * @return \Civi\Api4\Generic\Result
    *
    * @throws \API_Exception
    */
-  protected static function getFinancialType(int $financial_type_id): array {
+  protected static function getFinancialType(int $financialTypeId): array {
     return FinancialType::get(FALSE)
-      ->addWhere('id', '=', ($financial_type_id))
+      ->addWhere('id', '=', ($financialTypeId))
       ->execute()
       ->first();
   }


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/3083