### PR TITLE
(dev/core#3416) authx - If `Authorization:` header is disabled, then ignore it.

### DIFF
--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -138,6 +138,7 @@ function authx_civicrm_config(&$config) {
  */
 function authx_civicrm_install() {
   _authx_civix_civicrm_install();
+
 }
 
 /**
@@ -165,6 +166,13 @@ function authx_civicrm_uninstall() {
  */
 function authx_civicrm_enable() {
   _authx_civix_civicrm_enable();
+  // If the system is already using HTTP `Authorization:` headers before installation/re-activation, then
+  // it's probably an extra/independent layer of security.
+  // Only activate support for `Authorization:` if this looks like a clean/amenable environment.
+  // @link https://github.com/civicrm/civicrm-core/pull/22837
+  if (empty($_SERVER['HTTP_AUTHORIZATION']) && NULL === Civi::settings()->getExplicit('authx_header_cred')) {
+    Civi::settings()->set('authx_header_cred', ['jwt', 'api_key']);
+  }
 }
 
 /**

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -13,7 +13,7 @@ Civi::dispatcher()->addListener('civi.invoke.auth', function($e) {
     return (new \Civi\Authx\Authenticator())->auth($e, ['flow' => 'xheader', 'cred' => $_SERVER['HTTP_X_CIVI_AUTH'], 'siteKey' => $siteKey]);
   }
 
-  if (!empty($_SERVER['HTTP_AUTHORIZATION'])) {
+  if (!empty($_SERVER['HTTP_AUTHORIZATION']) && !empty(Civi::settings()->get('authx_header_cred'))) {
     return (new \Civi\Authx\Authenticator())->auth($e, ['flow' => 'header', 'cred' => $_SERVER['HTTP_AUTHORIZATION'], 'siteKey' => $siteKey]);
   }
 

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -94,7 +94,7 @@ $_authx_settings = function() {
   $s['authx_legacyrest_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_legacyrest_user']['default'] = 'require';
   $s['authx_param_cred']['default'] = ['jwt', 'api_key'];
-  $s['authx_header_cred']['default'] = ['jwt', 'api_key'];
+  $s['authx_header_cred']['default'] = []; /* @see \authx_civicrm_install() */
   $s['authx_xheader_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_pipe_cred']['default'] = ['jwt', 'api_key'];
 

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -128,7 +128,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     // Phase 1: Request fails if this credential type is not enabled
     \Civi::settings()->set("authx_{$flowType}_cred", []);
     $response = $http->send($request);
-    $this->assertFailedDueToProhibition($response);
+    $this->assertNotAuthenticated($flowType === 'header' ? 'anon' : 'prohibit', $response);
 
     // Phase 2: Request succeeds if this credential type is enabled
     \Civi::settings()->set("authx_{$flowType}_cred", [$credType]);
@@ -159,7 +159,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     // Phase 1: Request fails if this credential type is not enabled
     \Civi::settings()->set("authx_{$flowType}_cred", []);
     $response = $http->send($request);
-    $this->assertFailedDueToProhibition($response);
+    $this->assertNotAuthenticated($flowType === 'header' ? 'anon' : 'prohibit', $response);
 
     // Phase 2: Request succeeds if this credential type is enabled
     \Civi::settings()->set("authx_{$flowType}_cred", [$credType]);
@@ -791,6 +791,28 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
 
   public function credNone($cid) {
     return NULL;
+  }
+
+  /**
+   * Assert that a request was not authenticated.
+   *
+   * @param string $mode
+   *   Expect that the  'prohibited' or 'anon'
+   * @param \Psr\Http\Message\ResponseInterface $response
+   */
+  private function assertNotAuthenticated(string $mode, $response) {
+    switch ($mode) {
+      case 'anon':
+        $this->assertAnonymousContact($response);
+        break;
+
+      case 'prohibit':
+        $this->assertFailedDueToProhibition($response);
+        break;
+
+      default:
+        throw new \RuntimeException("Invalid option: mode=$mode");
+    }
   }
 
   /**

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -366,6 +366,59 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
   }
 
   /**
+   * Suppose a deployment has two layers of authorization:
+   *
+   * (1) a generic/site-wide HTTP restriction (perhaps enforced by a reverse proxy)
+   * (2) anything/everything else (CMS/login-form/parameter/X-Civi-Auth stuff).
+   *
+   * Layer (1) has an `Authorization:` header that should be ignored by `authx`.
+   *
+   * This test submits both layer (1) and layer (2) credentials and ensures that authx respects
+   * the layer (2).
+   */
+  public function testIgnoredHeaderAuthorization() {
+    // We may submit some other credential - it will be used.
+    $flowType = 'param';
+    $credType = 'api_key';
+
+    \Civi::settings()->set("authx_header_cred", []);
+    \Civi::settings()->set("authx_{$flowType}_cred", [$credType]);
+
+    $http = $this->createGuzzle(['http_errors' => FALSE]);
+
+    // We submit both the irrelevant `Authorization:` and the relevant `?_authx=...` (DemoCID).
+    $request = $this->applyAuth($this->requestMyContact(), 'api_key', 'header', $this->getLebowskiCID());
+    $request = $this->applyAuth($request, $credType, $flowType, $this->getDemoCID());
+    // $request = $request->withAddedHeader('Authorization', $irrelevantAuthorization);
+    $response = $http->send($request);
+    $this->assertMyContact($this->getDemoCID(), $this->getDemoUID(), $credType, $flowType, $response);
+    if (!in_array('sendsExcessCookies', $this->quirks)) {
+      $this->assertNoCookies($response);
+    }
+  }
+
+  /**
+   * Similar to testIgnoredHeaderAuthorization(), but the Civi/CMS user is anonymous.
+   */
+  public function testIgnoredHeaderAuthorization_anon() {
+    $http = $this->createGuzzle(['http_errors' => FALSE]);
+
+    /** @var \Psr\Http\Message\RequestInterface $request */
+
+    // Variant 1: The `Authorization:` header is ignored (even if the content is totally fake/inauthentic).
+    \Civi::settings()->set("authx_header_cred", []);
+    $request = $this->requestMyContact()->withAddedHeader('Authorization', 'Basic ' . base64_encode("not:real"));
+    $response = $http->send($request);
+    $this->assertAnonymousContact($response);
+
+    // Variant 2: The `Authorization:` header is ignored (even if the content is sorta-real-ish for LebowskiCID).
+    \Civi::settings()->set("authx_header_cred", []);
+    $request = $this->applyAuth($this->requestMyContact(), 'api_key', 'header', $this->getLebowskiCID());
+    $response = $http->send($request);
+    $this->assertAnonymousContact($response);
+  }
+
+  /**
    * This consumer intends to make stateless requests with a handful of different identities,
    * but their browser happens to be cookie-enabled. Ensure that identities do not leak between requests.
    *

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -482,6 +482,8 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function testJwtMiddleware() {
+    \Civi::settings()->revert("authx_param_cred");
+
     // HTTP GET with a specific user. Choose flow automatically.
     $response = $this->createGuzzle()->get('civicrm/authx/id', [
       'authx_user' => $GLOBALS['_CV']['DEMO_USER'],


### PR DESCRIPTION
Overview
----------------------------------------

Suppose a deployment has two layers of authorization:

* (1) Some generic/site-wide HTTP basic check (perhaps to prevent search-engines from finding the site; perhaps enforced by a reverse proxy)
* (2) Some Civi or CMS credential (eg session-cookie, `?_authx`, or `X-Civi-Auth:`)

You would want to configure `authx` to ignore layer (1)'s `Authorization:` header -- while still checking some other layer (2) credential (eg `?_authx=Bearer+ASDF`). In this case, you would configure `authx` to disable header support (eg  `authx_header_cred=[]`).

This PR is based on the problem+solution reported by @davejenx via Mattermost. It adds test-coverage.

Before
----------------------------------------

You can configure  `authx_header_cred=[]`,  but requests are rejected because it still evaluates the `Authorization:` header.

After
----------------------------------------

It only evaluates `Authorization:` if it's enabled. If it's disabled, then it's ignored.

