### PR TITLE
Remove reference to undefined variable

### DIFF
--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -29,14 +29,14 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
    * @return CRM_Price_DAO_PriceFieldValue
    */
   public static function add($params) {
+    $fieldValueBAO = self::writeRecord($params);
+
     if (!empty($params['is_default'])) {
       $priceFieldID = $params['price_field_id'] ?? CRM_Core_DAO::getFieldValue('CRM_Price_BAO_PriceFieldValue', $fieldValueBAO->id, 'price_field_id');
-      $query = 'UPDATE civicrm_price_field_value SET is_default = 0 WHERE  price_field_id = %1';
-      $p = [1 => [$priceFieldID, 'Integer']];
+      $query = 'UPDATE civicrm_price_field_value SET is_default = 0 WHERE price_field_id = %1 and id != %2';
+      $p = [1 => [$priceFieldID, 'Integer'], 2 => [$fieldValueBAO->id, 'Integer']];
       CRM_Core_DAO::executeQuery($query, $p);
     }
-
-    $fieldValueBAO = self::writeRecord($params);
 
     // Reset the cached values in this function.
     CRM_Price_BAO_PriceField::getOptions(CRM_Utils_Array::value('price_field_id', $params), FALSE, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
In `CRM_Price_BAO_PriceFieldValue::add`, `$fieldValueBAO->id` was read before `$fieldValueBAO` is defined; this can obviously not work.

The variable was defined prior to commit 50a890fd3e748a0356722f9da5a1f300f6322621 2 years ago, which swapped the order of operations. This change restores the original order of operations, but ensures that the default is set correctly. See https://github.com/civicrm/civicrm-core/pull/17960 for more context for the original problem from 2 years prior.

This only impacts extensions which might be using `CRM_Price_BAO_PriceFieldValue`; core calls to `CRM_Price_BAO_PriceFieldValue::add` always pass in the `price_field_id` meaning the faulty code was never reached.
