### PR TITLE
Remove reference to undefined variable in CRM_Contact_Form_Inline_CommunicationPreferences

### DIFF
--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -42,15 +42,6 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
       $defaults['preferred_language'] = CRM_Utils_Array::key($defaults['preferred_language'], $languages);
     }
 
-    // CRM-7119: set preferred_language to default if unset
-    if (empty($defaults['preferred_language'])) {
-      if ($form->_action == CRM_Core_Action::ADD) {
-        if (($defContactLanguage = CRM_Core_I18n::getContactDefaultLanguage()) != FALSE) {
-          $defaults['preferred_language'] = $defContactLanguage;
-        }
-      }
-    }
-
     // CRM-19135: where CRM_Core_BAO_Contact::getValues() set label as a default value instead of reserved 'value',
     // the code is to ensure we always set default to value instead of label
     if (!empty($defaults['preferred_mail_format'])) {


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/20214 a change was introduced which means the inline communication form references a missing variable. The biggest impact of that is that your PHP log is likely to end up with something like this:

```
PHP Notice:  Trying to get property '_action' of non-object in ..
```

The `if` statement could never be true, and setting a default on an edit form (as opposed to a create form) doesn't make much sense. Therefore I propose this block of code is removed.


Before
----------------------------------------
PHP notice.

After
----------------------------------------
No PHP notice.
