### PR TITLE
Fix issues with PHP GetText and 0 length files

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -561,7 +561,7 @@ class CRM_Core_I18n {
           // phpgettext
           $mo_file = $path . DIRECTORY_SEPARATOR . 'l10n' . DIRECTORY_SEPARATOR . $this->locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . $domain . '.mo';
           $streamer = new FileReader($mo_file);
-          $this->_extensioncache[$key] = new gettext_reader($streamer);
+          $this->_extensioncache[$key] = $streamer->length() ? new gettext_reader($streamer) : NULL;
         }
       }
       catch (CRM_Extension_Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------
I've recently setup a site with en_US and pt_BR languages. However most extensions don't have pt_BR available and, using l10nupdate extension, I end up with a lot of 0 length mo files.

That shouldn't be a problem but I've found that on some servers (in this case a Ubuntu/Plesk server on PHP7.4) the following happens:
1. Enable l10nupdate extension and perform initial download of translation files (eg. browse to extensions page in CiviCRM).
2. Now try to do anything in CiviCRM that tries to access an extension translation.
3. PHP process hangs with 100% CPU usage and eventually times out.

Before
----------------------------------------
See description above.

After
----------------------------------------
PHP process does not timeout and does not use 100% CPU.

Technical Details
----------------------------------------
Instead of passing the file to `gettext_reader` if it exists we only pass the file if it is not empty (length > 0). This instantly resolves the problem on the above server and has no negative impact (ie. a 0 byte file can never contain translations so we don't need to invoke gettext at all.

Comments
----------------------------------------
