### PR TITLE
Refresh entity list after updating custom group

### DIFF
--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -164,6 +164,10 @@ class ActionObjectProvider implements EventSubscriberInterface, ProviderInterfac
     return $entities;
   }
 
+  public function flushEntities(): void {
+    \Civi::cache('metadata')->delete('api4.entities.info');
+  }
+
   /**
    * @param \Civi\Api4\Generic\AbstractEntity $className
    * @param array $entities

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -407,6 +407,8 @@ class Container {
     $dispatcher->addListener('civi.api4.validate', $aliasMethodEvent('civi.api4.validate', 'getEntityName'), 100);
     $dispatcher->addListener('civi.api4.authorizeRecord', $aliasMethodEvent('civi.api4.authorizeRecord', 'getEntityName'), 100);
     $dispatcher->addListener('civi.api4.entityTypes', ['\Civi\Api4\Provider\CustomEntityProvider', 'addCustomEntities'], 100);
+    // CustomEntityProvider (^^^) copies CustomGroup data to ActionObjectProvider, which caches it. Updates should propagate.
+    $dispatcher->addListenerService('hook_civicrm_post::CustomGroup', ['action_object_provider', 'flushEntities']);
 
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);

--- a/tests/phpunit/api/v4/Action/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValueTest.php
@@ -263,4 +263,36 @@ class CustomValueTest extends BaseCustomValueTest {
     $this->assertEquals(0, count($result));
   }
 
+  /**
+   * Whenever a CustomGroup toggles the `is_multiple` flag, the entity-list should be updated.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testEntityRefresh() {
+    $groupName = uniqid('groupc');
+
+    $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    CustomGroup::create(FALSE)
+      ->addValue('title', $groupName)
+      ->addValue('extends', 'Contact')
+      ->addValue('is_multiple', FALSE)
+      ->execute();
+
+    $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    CustomGroup::update(FALSE)
+      ->addWhere('name', '=', $groupName)
+      ->addValue('is_multiple', TRUE)
+      ->execute();
+    $this->assertContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    CustomGroup::update(FALSE)
+      ->addWhere('name', '=', $groupName)
+      ->addValue('is_multiple', FALSE)
+      ->execute();
+    $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

The CustomGroups are used to generate virtual entities (if they set `is_multiple`). Toggling `is_multiple` should cause the virtual entity to be added or removed.

(Ping @colemanw - I noticed this while testing one of the other recent PRs about APIv4/CustomGroups.)

Reproduction steps
----------------------------------------

1. Create a custom data group. Leave default `is_multiple=0`.
2. View "API Explorer". Look for the virtual entity. (It's not there. Properly so.)
3. Edit custom data group. Change to `is_multiple=1`.
4. Reload "API Explorer". Look for the virtual entity.

Before
----------------------------------------

The entity does not appear. You have to do a system-flush.

After
----------------------------------------

The entity does appear.

Comments
----------------------------------------

Another possible resolution: sprinkle `Civi::cache('metadata')->flush()` in more places (like `CRM_Custom_Form_Group`?).  It seems kind of like a mess no matter what you do - eg there are 3x cache collections with metadata about custom fields (ie `fields`, `customData`, `metadata`), and they're each flushed at different times. 
