### PR TITLE
CustomField - Remove redundant cache clear

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -146,9 +146,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField);
 
     CRM_Utils_System::flushCache();
-    // Flush caches is not aggressive about clearing the specific cache we know we want to clear
-    // so do it manually. Ideally we wouldn't need to clear others...
-    Civi::cache('metadata')->clear();
 
     return $customField;
   }
@@ -223,7 +220,6 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
 
     CRM_Utils_System::flushCache();
-    Civi::cache('metadata')->clear();
 
     foreach ($customFields as $index => $customField) {
       CRM_Utils_Hook::post(empty($records[$index]['id']) ? 'create' : 'edit', 'CustomField', $customField->id, $customField);


### PR DESCRIPTION
Overview
----------------------------------------
The metadata cache was getting cleared twice.

Technical Details
----------------------------------------
The comment suggests that CRM_Utils_System::flushCache() doesn't clear the metadata cache.
But it actually does.