### PR TITLE
Avoid PHP undefined index notices on extension pages

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -246,7 +246,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       if (!empty($compat[$info->key]['obsolete'])) {
         continue;
       }
-      $row = (array) $info;
+      $row = self::fillMissingInfoKeys((array) $info);
       $row['id'] = $info->key;
       $row['upgradelink'] = '';
       $action = CRM_Core_Action::UPDATE;
@@ -330,7 +330,31 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
    * @return array
    */
   public static function createExtendedInfo(CRM_Extension_Info $obj) {
-    return CRM_Extension_System::createExtendedInfo($obj);
+    return self::fillMissingInfoKeys(CRM_Extension_System::createExtendedInfo($obj));
+  }
+
+  /**
+   * Extension templates expect certain keys to always be set, but these might be missing from the relevant info.xml files
+   * This ensures the expect keys are always set.
+   *
+   * @param array $info
+   * @return array
+   */
+  private static function fillMissingInfoKeys(array $info) {
+    $defaultKeys = [
+      'urls' => [],
+      'authors' => [],
+      'version' => '',
+      'description' => '',
+      'license' => '',
+      'releaseDate' => '',
+      'downloadUrl' => FALSE,
+      'compatibility' => FALSE,
+      'develStage' => FALSE,
+      'comments' => FALSE,
+    ];
+
+    return array_merge($defaultKeys, $info);
   }
 
 }

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -1,5 +1,5 @@
 <table class="crm-info-panel">
-    {if !empty($extension.urls)}
+    {if $extension.urls}
         {foreach from=$extension.urls key=label item=url}
             <tr><td class="label">{$label|escape}</td><td><a href="{$url|escape}">{$url|escape}</a></td></tr>
         {/foreach}
@@ -17,7 +17,7 @@
           {/foreach}
         </td>
     </tr>
-    {if !empty($extension.comments)}
+    {if $extension.comments}
     <tr>
       <td class="label">{ts}Comments{/ts}</td><td>{$extension.comments|escape}</td>
     </tr>
@@ -31,7 +31,7 @@
     <tr>
       <td class="label">{ts}License{/ts}</td><td>{$extension.license|escape}</td>
     </tr>
-    {if !empty($extension.develStage)}
+    {if $extension.develStage}
     <tr>
       <td class="label">{ts}Development stage{/ts}</td><td>{$extension.develStage|escape}</td>
     </tr>
@@ -54,12 +54,19 @@
     <tr>
         <td class="label">{ts}Compatible with{/ts}</td>
         <td>
-            {foreach from=$extension.compatibility.ver item=ver}
-                {$ver|escape} &nbsp;
-            {/foreach}
+            {if $extension.compatibility}
+                {foreach from=$extension.compatibility.ver item=ver}
+                    {$ver|escape} &nbsp;
+                {/foreach}
+            {/if}
         </td>
     </tr>
     <tr>
       <td class="label">{ts}Local path{/ts}</td><td>{if !empty($extension.path)}{$extension.path|escape}{/if}</td>
     </tr>
+    {if $extension.downloadUrl}
+    <tr>
+      <td class="label">{ts}Download location{/ts}</td><td>{$extension.downloadUrl|escape}</td>
+    </tr>
+    {/if}
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
On the extensions page (/civicrm/admin/extensions) various notices (undefined index) are thrown if the extension `info.xml` files are missing one or more keys. This adds a helper method to set relevant defaults for use in the twig files.

This also removes use of `empty()` in the `templates/CRM/Admin/Page/ExtensionDetails.tpl` template which is problematic with the new `CIVICRM_SMARTY_DEFAULT_ESCAPE`.

Before
----------------------------------------
Many PHP notices occur on the extension manager page:

<img width="1230" alt="Screenshot 2022-02-27 at 17 16 32" src="https://user-images.githubusercontent.com/1931323/155892437-a46fa43a-1a1c-4987-9d2f-6d2535a82557.png">


After
----------------------------------------
The bulk of these notices are removed (a `Undefined index: tabHeader` still occurs, but this is a problem common to many other pages). 
