### PR TITLE
Fixes issue with duplicate is_billing on inline address forms.

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -66,6 +66,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
     CRM_Utils_Hook::pre($hook, 'Address', CRM_Utils_Array::value('id', $params), $params);
 
     CRM_Core_BAO_Block::handlePrimary($params, get_class());
+    CRM_Core_BAO_Block::handleBilling($params, get_class());
 
     // (prevent chaining 1 and 3) CRM-21214
     if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -176,12 +176,12 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     $address = CRM_Core_BAO_Address::getValues($entityBlock);
 
     $this->assertEquals($address[1]['contact_id'], $contactId);
-    $this->assertEquals($address[1]['is_primary'], 1, 'In line '. __LINE__);
-    $this->assertEquals($address[1]['is_billing'], 1, 'In line '. __LINE__);
+    $this->assertEquals($address[1]['is_primary'], 1, 'In line ' . __LINE__);
+    $this->assertEquals($address[1]['is_billing'], 1, 'In line ' . __LINE__);
 
     $this->assertEquals($address[2]['contact_id'], $contactId);
-    $this->assertEquals($address[2]['is_primary'], 0, 'In line '. __LINE__);
-    $this->assertEquals($address[2]['is_billing'], 0, 'In line '. __LINE__);
+    $this->assertEquals($address[2]['is_primary'], 0, 'In line ' . __LINE__);
+    $this->assertEquals($address[2]['is_billing'], 0, 'In line ' . __LINE__);
 
     $this->contactDelete($contactId);
   }
@@ -246,12 +246,12 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     // Validate both results, remember that the keys have been reset to 0 after usort
     $this->assertEquals($addresses[0]['contact_id'], $contactId);
-    $this->assertEquals($addresses[0]['is_primary'], 0, 'In line '. __LINE__);
-    $this->assertEquals($addresses[0]['is_billing'], 0, 'In line '. __LINE__);
+    $this->assertEquals($addresses[0]['is_primary'], 0, 'In line ' . __LINE__);
+    $this->assertEquals($addresses[0]['is_billing'], 0, 'In line ' . __LINE__);
 
     $this->assertEquals($addresses[1]['contact_id'], $contactId);
-    $this->assertEquals($addresses[1]['is_primary'], 1,'In line '. __LINE__);
-    $this->assertEquals($addresses[1]['is_billing'], 1,'In line '. __LINE__);
+    $this->assertEquals($addresses[1]['is_primary'], 1, 'In line ' . __LINE__);
+    $this->assertEquals($addresses[1]['is_billing'], 1, 'In line ' . __LINE__);
 
     $this->contactDelete($contactId);
   }


### PR DESCRIPTION
Overview
----------------------------------------
In the case that someone has 2 addresses registered, they can flag both of them as billing location via the inline address editing checkbox which I believe is wrong. This behaviour does not replicate when you edit the contact.
I am assuming that this is not an intended behaviour. Source Issue: https://lab.civicrm.org/dev/core/-/issues/3080

Before
----------------------------------------
No validation takes place when someone checks the "billing location" via the inline address editing which means that a contact can have multiple billing addresses.

After
----------------------------------------
There should be a validation while saving the inline address form to check if the checkbox is already being used in another address ID and if yes, it should not store the checkbox (or unset it).

