### PR TITLE
fixes core#3090 - logging detail report SQL syntax error on relationship type ID changes

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1384,7 +1384,7 @@ LIKE %1
    *
    * @param string $daoName
    *   Name of the DAO (Example: CRM_Contact_DAO_Contact to retrieve value from a contact).
-   * @param int $searchValue
+   * @param mixed $searchValue
    *   Value of the column you want to search by.
    * @param string $returnColumn
    *   Name of the column you want to GET the value of.
@@ -1398,7 +1398,7 @@ LIKE %1
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getFieldValue($daoName, $searchValue, $returnColumn = 'name', $searchColumn = 'id', $force = FALSE) {
+  public static function getFieldValue(string $daoName, $searchValue, string $returnColumn = 'name', string $searchColumn = 'id', bool $force = FALSE) {
     if (
       empty($searchValue) ||
       trim(strtolower($searchValue)) == 'null'

--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -477,7 +477,7 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
    * @return string
    */
   private function convertForeignKeyValuesToLabels(string $fkClassName, string $field, int $keyval): string {
-    if (property_exists($fkClassName, '_labelField')) {
+    if (property_exists($fkClassName, '_labelField') && $fkClassName::$_labelField) {
       $labelValue = CRM_Core_DAO::getFieldValue($fkClassName, $keyval, $fkClassName::$_labelField);
       // Not sure if this should use ts - there's not a lot of context (`%1 (id: %2)`) - and also the similar field labels above don't use ts.
       return "{$labelValue} (id: {$keyval})";


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3090

Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3090.

Before
----------------------------------------
`DB Error: Syntax error`.

After
----------------------------------------
Returns expected data.

Technical Details
----------------------------------------
`property_exists($fkClassName, '_labelField') will return `TRUE` for any class that extends `CRM_Core_DAO`, since the property exists in `CRM_Core_DAO`.  However, the `getFieldValue` will fail if passed a `NULL` value.

Comments
----------------------------------------
For extra giggles I'm adding strict type checking on `getFieldValue()` on the grounds that this will cause a SQL error anyway and this will let us catch errors during PHPunit testing.  That said, the `$searchValue` argument is listed as `int` which is only true if your search column contains ints.
