### PR TITLE
CiviGrant - Ensure dependencies are installed

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -99,6 +99,9 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
     $civiGrantEnabled = CRM_Core_Component::isEnabled('CiviGrant');
     if ($civiGrantEnabled) {
       CRM_Core_BAO_ConfigSetting::disableComponent('CiviGrant');
+      // Install CiviGrant extension dependencies
+      CRM_Extension_System::singleton()->getManager()
+        ->install(['org.civicrm.search_kit', 'org.civicrm.afform']);
     }
     $civiGrantId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Component', 'CiviGrant', 'id', 'name');
     if ($civiGrantId) {


### PR DESCRIPTION
Overview
----------------------------------------
During the upgrade process the CiviGrant extension may be installed. This ensures its dependencies are also enabled.

Fixes https://lab.civicrm.org/dev/core/-/issues/3093