### PR TITLE
Issue 3085

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ sql/dummy_processor.mysql
 distmaker/distmaker.conf
 distmaker/out
 /tmp
+/nbproject/private/

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -361,11 +361,20 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     }
     else {
       // get the submitted form values.
+      // Issue 3085 Cleared checkboxes don't appear in $params, so we look for
+      // elements starting with 'is', which indicates a boolean value, i.e.
+      // a check box. If such a field does not appear in $params, we set it
+      // to zero.
       $params = $this->controller->exportValues($this->_name);
+      foreach ($this->_elementIndex as $key => $value) {
+        if (str_starts_with($key, 'is')) {
+          if (!array_key_exists($key, $params)) {
+            $params[$key] = 0;
+          }
+        }
 
-      if (!array_key_exists('is_active', $params)) {
-        $params['is_active'] = 0;
       }
+     
 
       if ($this->_action & (CRM_Core_Action::UPDATE)) {
         $params['id'] = $this->_id;


### PR DESCRIPTION
Overview
----------------------------------------
This relates to [Issue 3085](https://lab.civicrm.org/dev/core/-/issues/3085) where cleared checkboxes in Profile Advanced settings would not clear.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._
Once a checkbox option such as mapping was set, clearing it made no difference, when you opened the settings again, they remained set.
After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._
When you clear the checkbox and save the profile, the checkbox remains cleard.
Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._
A foreach of the $this->_elementIndex looks for keys starting with 'is'. If the key does not appear in $params, it is inserted with a value of 0.
Comments
----------------------------------------
_Anything else you would like the reviewer to note_
This PR was requested by [@jaapjansma](https://lab.civicrm.org/jaapjansma)