### PR TITLE
dev/core#3085 - Checkbox fields on profile admin page can't be unchecked

### DIFF
--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -361,12 +361,19 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     }
     else {
       // get the submitted form values.
+      // Issue 3085 Cleared checkboxes don't appear in $params, so we look for
+      // elements starting with 'is', which indicates a boolean value, i.e.
+      // a check box. If such a field does not appear in $params, we set it
+      // to zero.
       $params = $this->controller->exportValues($this->_name);
+      foreach ($this->_elementIndex as $key => $value) {
+        if (str_starts_with($key, 'is')) {
+          if (!array_key_exists($key, $params)) {
+            $params[$key] = 0;
+          }
+        }
 
-      if (!array_key_exists('is_active', $params)) {
-        $params['is_active'] = 0;
       }
-
       if ($this->_action & (CRM_Core_Action::UPDATE)) {
         $params['id'] = $this->_id;
         // CRM-5284


### PR DESCRIPTION
Overview
----------------------------------------
This relates to [Issue 3085](https://lab.civicrm.org/dev/core/-/issues/3085), where once a checkbox  was set in _Profiles -> Settings-> Advanced_, it would not remained cleared; next time you looked at the profile, it was still set.

Before
----------------------------------------
The checkboxes remained set when you reopened the profile settings.

After
----------------------------------------
The check boxes remain cleared after you clear them and save the profile.

Technical Details
----------------------------------------
We loop through $this->_elementIndex. If the key starts with 'is' it is a Boolean value. Cleared checkboxes do not have their keys in $params, so we check if $params has such a key, and if it does not, we create it with a value of zero.

Comments
----------------------------------------
@jaapjansma asked for this PR.
