### PR TITLE
dev/core#3094 - Crash on contribution view when don't have event/participant permissions

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -90,26 +90,30 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       }
     }
 
-    $participantLineItems = \Civi\Api4\LineItem::get()
-      ->addSelect('entity_id', 'participant.role_id:label', 'participant.fee_level', 'participant.contact_id', 'contact.display_name')
-      ->addJoin('Participant AS participant', 'LEFT', ['participant.id', '=', 'entity_id'])
-      ->addJoin('Contact AS contact', 'LEFT', ['contact.id', '=', 'participant.contact_id'])
-      ->addWhere('entity_table', '=', 'civicrm_participant')
-      ->addWhere('contribution_id', '=', $id)
-      ->execute();
+    try {
+      $participantLineItems = \Civi\Api4\LineItem::get()
+        ->addSelect('entity_id', 'participant.role_id:label', 'participant.fee_level', 'participant.contact_id', 'contact.display_name')
+        ->addJoin('Participant AS participant', 'LEFT', ['participant.id', '=', 'entity_id'])
+        ->addJoin('Contact AS contact', 'LEFT', ['contact.id', '=', 'participant.contact_id'])
+        ->addWhere('entity_table', '=', 'civicrm_participant')
+        ->addWhere('contribution_id', '=', $id)
+        ->execute();
+    }
+    catch (API_Exception $e) {
+      // likely don't have permission for events/participants
+      $participantLineItems = [];
+    }
 
     $associatedParticipants = FALSE;
-    if ($participantLineItems->count()) {
-      foreach ($participantLineItems as $participant) {
-        $associatedParticipants[] = [
-          'participantLink' => CRM_Utils_System::url('civicrm/contact/view/participant',
-            "action=view&reset=1&id={$participant['entity_id']}&cid={$participant['participant.contact_id']}&context=home"
-          ),
-          'participantName' => $participant['contact.display_name'],
-          'fee' => implode(', ', $participant['participant.fee_level']),
-          'role' => implode(', ', $participant['participant.role_id:label']),
-        ];
-      }
+    foreach ($participantLineItems as $participant) {
+      $associatedParticipants[] = [
+        'participantLink' => CRM_Utils_System::url('civicrm/contact/view/participant',
+          "action=view&reset=1&id={$participant['entity_id']}&cid={$participant['participant.contact_id']}&context=home"
+        ),
+        'participantName' => $participant['contact.display_name'],
+        'fee' => implode(', ', $participant['participant.fee_level']),
+        'role' => implode(', ', $participant['participant.role_id:label']),
+      ];
     }
     $this->assign('associatedParticipants', $associatedParticipants);
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @group headless
+ */
+class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
+
+  /**
+   * Test that can still view a contribution without full permissions.
+   */
+  public function testContributionViewLimitedPermissions() {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'access all custom data',
+      'edit all contacts',
+      'access CiviContribute',
+      'edit contributions',
+      'delete in CiviContribute',
+    ];
+    $contact_id = $this->individualCreate();
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $contact_id,
+      'financial_type_id' => 'Donation',
+      'total_amount' => '10',
+    ]);
+
+    $_SERVER['REQUEST_URI'] = "civicrm/contact/view/contribution?reset=1&action=view&id={$contribution['id']}&cid={$contact_id}";
+    $_GET['q'] = $_REQUEST['q'] = 'civicrm/contact/view/contribution';
+    $_GET['reset'] = $_REQUEST['reset'] = 1;
+    $_GET['action'] = $_REQUEST['action'] = 'view';
+    $_GET['id'] = $_REQUEST['id'] = $contribution['id'];
+    $_GET['cid'] = $_REQUEST['cid'] = $contact_id;
+
+    $item = CRM_Core_Invoke::getItem(['civicrm/contact/view/contribution']);
+    ob_start();
+    CRM_Core_Invoke::runItem($item);
+    $contents = ob_get_clean();
+
+    unset($_GET['q'], $_REQUEST['q']);
+    unset($_GET['reset'], $_REQUEST['reset']);
+    unset($_GET['action'], $_REQUEST['action']);
+    unset($_GET['id'], $_REQUEST['id']);
+    unset($_GET['cid'], $_REQUEST['cid']);
+
+    $this->assertRegExp('/Contribution Total:\s+\$10\.00/', $contents);
+    $this->assertStringContainsString('Mr. Anthony Anderson II', $contents);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3094

Before
----------------------------------------
Crash with API_Exception: "Invalid field 'participant.contact_id'" when viewing any contribution if you don't have participant permissions.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
Participant info was added to contribution view in https://github.com/civicrm/civicrm-core/pull/22732

Comments
----------------------------------------
Has test

Can see the test fail at https://test.civicrm.org/job/CiviCRM-Core-PR/47318/testReport/junit/(root)/CRM_Contribute_Form_ContributionViewTest/testContributionViewLimitedPermissions/ where I had only pushed the test and not the fix yet.

CRM_Contribute_Form_ContributionViewTest::testContributionViewLimitedPermissions
API_Exception: Invalid field 'participant.contact_id'

```
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Query/Api4SelectQuery.php:668
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Query/Api4SelectQuery.php:613
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Query/Api4SelectQuery.php:513
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Query/Api4SelectQuery.php:425
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Query/Api4SelectQuery.php:762
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Query/Api4SelectQuery.php:125
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Generic/DAOGetAction.php:112
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Generic/DAOGetAction.php:101
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Provider/ActionObjectProvider.php:69
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/API/Kernel.php:149
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/Civi/Api4/Generic/AbstractAction.php:234
/home/jenkins/bknix-dfl/build/core-22865-7v4ph/web/sites/all/modules/civicrm/CRM/Contribute/Form/ContributionView.php:99
```