### PR TITLE
(NFC) LoggingDetailTest - Improve reliability of test

### DIFF
--- a/tests/phpunit/CRM/Report/Form/Contact/LoggingDetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Contact/LoggingDetailTest.php
@@ -22,8 +22,14 @@ class CRM_Report_Form_Contact_LoggingDetailTest extends CiviReportTestCase {
 
   public function setUp(): void {
     parent::setUp();
+
+    // Setup logging. This may create a series of backfilled log records.
     $this->callAPISuccess('Setting', 'create', ['logging' => TRUE]);
     $this->quickCleanup($this->_tablesToTruncate);
+
+    // The test needs to create+read some log records. We want this to have a new/separate `log_conn_id`.
+    unset(\Civi::$statics['CRM_Utils_Request']['id']);
+    CRM_Core_DAO::init(CIVICRM_DSN);
   }
 
   public function tearDown(): void {


### PR DESCRIPTION
Overview
----------------------------------------

Improve test reliability.

This was discussed/investigated on Mattermost among @demeritcowboy, @seamuslee001, and me. Investigation starts around https://chat.civicrm.org/civicrm/pl/ti75i31u9frq9kfgxef5qfko3y

Before
-----------------

If you run this test repeatedly, it may alternately pass and fail.  The percentage of passes-vs-fails can vary widely (depending on the computer where you execute).

For example, on `test-3`, I observed a fairly high probability of test-failure (*failure in roughly 3/4 invocations*).

After
-----------------

On the same system, it passes consistently (*no failures after 15 invocations*).
