### PR TITLE
Refresh entity list after updating custom group (self_hook_*) 

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -18,7 +18,15 @@
 /**
  * Business object for managing custom data groups.
  */
-class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup {
+class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi\Core\HookInterface {
+
+  /**
+   * @param \Civi\Core\Event\PostEvent $e
+   * @see CRM_Utils_Hook::post()
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
+    Civi::cache('metadata')->flush();
+  }
 
   /**
    * Takes an associative array and creates a custom group object.

--- a/tests/phpunit/api/v4/Action/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Action/CustomValueTest.php
@@ -263,4 +263,36 @@ class CustomValueTest extends BaseCustomValueTest {
     $this->assertEquals(0, count($result));
   }
 
+  /**
+   * Whenever a CustomGroup toggles the `is_multiple` flag, the entity-list should be updated.
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testEntityRefresh() {
+    $groupName = uniqid('groupc');
+
+    $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    CustomGroup::create(FALSE)
+      ->addValue('title', $groupName)
+      ->addValue('extends', 'Contact')
+      ->addValue('is_multiple', FALSE)
+      ->execute();
+
+    $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    CustomGroup::update(FALSE)
+      ->addWhere('name', '=', $groupName)
+      ->addValue('is_multiple', TRUE)
+      ->execute();
+    $this->assertContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+
+    CustomGroup::update(FALSE)
+      ->addWhere('name', '=', $groupName)
+      ->addValue('is_multiple', FALSE)
+      ->execute();
+    $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

The CustomGroups are used to generate virtual entities (if they set `is_multiple`). Toggling `is_multiple`
should cause the virtual entity to be added or removed.

This is an alternative variant of #22843.

Reproduction steps
----------------------------------------

1. Create a custom data group. Leave default `is_multiple=0`.
2. View "API Explorer". Look for the virtual entity. (It's not there. Properly so.)
3. Edit custom data group. Change to `is_multiple=1`.
4. Reload "API Explorer". Look for the virtual entity.

Before
----------------------------------------

The entity does not appear. You have to do a system-flush.

After
----------------------------------------

The entity does appear.