### PR TITLE
Only acl line items based on contribution

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1268,4 +1268,19 @@ WHERE li.contribution_id = %1";
     ];
   }
 
+  /**
+   * Add contribution id select where.
+   *
+   * This overrides the parent to PREVENT additional entity_id based
+   * clauses being added. Additional filters joining on the participant
+   * and membership tables just seem too non-performant.
+   *
+   * @inheritDoc
+   */
+  public function addSelectWhereClause(): array {
+    $clauses['contribution_id'] = CRM_Utils_SQL::mergeSubquery('Contribution');
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Only acl line items based on contribution

Before
----------------------------------------
ACL query on line items joins enitty_id to multiple tables

After
----------------------------------------
ONLY acls contributions

Technical Details
----------------------------------------
The query becomes insane if we allow membership, participant ids to bubble up here

Note this extra join is only in master so only affects master

Comments
----------------------------------------
@MegaphoneJon can you test it with the other