### PR TITLE
Call to undefined function civicrm_api3_create_error() in civicrm/civ…

### DIFF
--- a/CRM/Core/Page/AJAX/Attachment.php
+++ b/CRM/Core/Page/AJAX/Attachment.php
@@ -62,6 +62,7 @@ class CRM_Core_Page_AJAX_Attachment {
         );
       }
       elseif ($file['error']) {
+        require_once 'api/v3/utils.php';
         $results[$key] = civicrm_api3_create_error("Upload failed (code=" . $file['error'] . ")");
       }
       else {


### PR DESCRIPTION
…icrm/CRM/Core/Page/AJAX/Attachment.php:65

Overview
----------------------------------------
Since WordPress 5.2 there is a built-in feature that detects when a plugin or theme causes a fatal error on your site, and notifies you with this automated email.

In this case, WordPress caught an error with one of your plugins, CiviCRM.

Error Details
=============
An error of type E_ERROR was caused in line 65 of the file /var/www/html/[.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Page/AJAX/Attachment.php](.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Page/AJAX/Attachment.php). Error message: Uncaught Error: Call to undefined function civicrm_api3_create_error() in /var/www/html/[.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Page/AJAX/Attachment.php:65](.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Page/AJAX/Attachment.php:65)
Stack trace:
#0 /var/www/html/[.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Page/AJAX/Attachment.php(35)](.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Page/AJAX/Attachment.php(35)): CRM_Core_Page_AJAX_Attachment::_attachFile()
#1 /var/www/html/[../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(278)](.../htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(278)): CRM_Core_Page_AJAX_Attachment::attachFile()
#2 /var/www/html/[site.com/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(68)](site.com/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(68)): CRM_Core_Invoke::runItem()
#3 /var/www/html/[site.com/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(36)](http://site.com/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(36)): CRM_Core_Invoke::_invoke()
#4 /var/www/html/[site.com/htdocs/wp-content/plugins/civicrm/civicrm.php(1172)](site.com/htdocs/wp-content/plugins/civicrm/civicrm.php(1172)): CRM_Core_Invoke::invoke()
#5 /var/www/html/[siteg.com/htdocs/wp-includes/class-wp-hook.php(303)](site.com/htdocs/wp-includes/class-wp-hook.php(303)): CiviCRM_For_WordPress->invoke() #

Before
----------------------------------------
In line 65, civicrm_api3_create_error function called without require it. That's why throwing error.

After
----------------------------------------
added require_once 'api/v3/utils.php'; before calling that function, so that issue minimized

