### PR TITLE
Contact token should show contact's info instead of logged in contact

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2860,7 +2860,7 @@ ORDER BY civicrm_mailing.name";
         CRM_Core_Action::VIEW => [
           'name' => ts('View'),
           'url' => 'civicrm/mailing/view',
-          'qs' => "reset=1&id=%%mkey%%",
+          'qs' => "reset=1&id=%%mkey%%&cid=%%cid%%&cs=%%cs%%",
           'title' => ts('View Mailing'),
           'class' => 'crm-popup',
         ],
@@ -2884,6 +2884,7 @@ ORDER BY civicrm_mailing.name";
           'mid' => $values['mailing_id'],
           'cid' => $params['contact_id'],
           'mkey' => $mailingKey,
+          'cs' => CRM_Contact_BAO_Contact_Utils::generateChecksum($params['contact_id'], NULL, 'inf'),
         ],
         ts('more'),
         FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
When viewing sent mailings through the contact's mailing tab, tokens should resolve to the contact you are viewing.

Before
----------------------------------------
Contact token show logged in contact

After
----------------------------------------
Contact token show contact you are viewing


Comments
----------------------------------------
ping @colemanw @lcdservices 