### PR TITLE
Add event id to template params so it can be received by altermailparams

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1523,6 +1523,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           'contactId' => $contactID,
           'isTest' => !empty($this->_defaultValues['is_test']),
           'PDFFilename' => ts('confirmation') . '.pdf',
+          'tplParams' => ['event' => [
+            'id' => $params['event_id'],
+          ]],
         ];
 
         // try to send emails only if email id is present


### PR DESCRIPTION
Overview
----------------------------------------
Makes the event id available in hook_civicrm_alterMailParams for system generated offline event receipts.

Before
----------------------------------------
When using hook_civicrm_alterMailParams to alter the offline event confirmation receipt the event id 
**is not** available

After
----------------------------------------
When using hook_civicrm_alterMailParams to alter the offline event confirmation receipt the event id **is** available


