### PR TITLE
Populate Template Params for Offline Event Confirmation Receipts

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1517,12 +1517,23 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $this->assign('amount', $eventAmount);
         }
 
+        // Assemble event info to send to the message template
+        $eventDetails = [];
+        $eventParams = ['id' => $params['event_id']];
+        CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails);
+        CRM_Event_BAO_Event::setOutputTimeZone($eventDetails);
+
+        $tplParams = [
+          'event' => $eventDetails,
+        ];
+
         $sendTemplateParams = [
           'groupName' => 'msg_tpl_workflow_event',
           'valueName' => 'event_offline_receipt',
           'contactId' => $contactID,
           'isTest' => !empty($this->_defaultValues['is_test']),
           'PDFFilename' => ts('confirmation') . '.pdf',
+          'tplParams' => $tplParams,
         ];
 
         // try to send emails only if email id is present

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1517,23 +1517,13 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $this->assign('amount', $eventAmount);
         }
 
-        // Assemble event info to send to the message template
-        $eventDetails = [];
-        $eventParams = ['id' => $params['event_id']];
-        CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails);
-        CRM_Event_BAO_Event::setOutputTimeZone($eventDetails);
-
-        $tplParams = [
-          'event' => $eventDetails,
-        ];
-
         $sendTemplateParams = [
           'groupName' => 'msg_tpl_workflow_event',
           'valueName' => 'event_offline_receipt',
           'contactId' => $contactID,
           'isTest' => !empty($this->_defaultValues['is_test']),
           'PDFFilename' => ts('confirmation') . '.pdf',
-          'tplParams' => $tplParams,
+          'tokenContext' => ['eventId' => $params['event_id'], 'participantId' => $this->_id],
         ];
 
         // try to send emails only if email id is present


### PR DESCRIPTION
Overview
----------------------------------------
This populates the event information in the tplParams variable for Offline Event Confirmation Receipts. 

Before
----------------------------------------
Event information not available in hook_civicrm_altermailparams for offline event confirmation receipts.


After
----------------------------------------
Event information available in hook_civicrm_altermailparams for offline event confirmation receipts.

Technical Details
----------------------------------------
Borrows from https://github.com/civicrm/civicrm-core/blob/1a247ef468d24f7b468bd5afa8d983aba50d9798/CRM/Event/Form/SelfSvcTransfer.php#L372
