### PR TITLE
Fix undeclared javascript variables

### DIFF
--- a/ang/crmMailing/RadioDate.js
+++ b/ang/crmMailing/RadioDate.js
@@ -62,22 +62,23 @@
             if (context === 'userInput' && $(this).val() === '' && $(this).siblings('.crm-form-date').val().length) {
               schedule.mode = 'at';
               schedule.datetime = '?';
-            } else { 
+            } else {
               var d = new Date(),
-              month = '' + (d.getMonth() + 1),
-              day = '' + d.getDate(),
-              year = d.getFullYear(),
-              hours = '' + d.getHours(),
-              minutes = '' + d.getMinutes();
-              var submittedDate = $(this).val();
+                month = '' + (d.getMonth() + 1),
+                day = '' + d.getDate(),
+                year = d.getFullYear(),
+                hours = '' + d.getHours(),
+                minutes = '' + d.getMinutes(),
+                submittedDate = $(this).val();
               if (month.length < 2) month = '0' + month;
               if (day.length < 2) day = '0' + day;
               if (hours.length < 2) hours = '0' + hours;
               if (minutes.length < 2) minutes = '0' + minutes;
-              date = [year, month, day].join('-');
-              time = [hours, minutes, "00"].join(':');
-              currentDate = date + ' ' + time;
-              var isInPast = (submittedDate.length && submittedDate.match(/^[0-9\-]+ [0-9\:]+$/) && isDateBefore(submittedDate, currentDate, 4*60*60*1000));
+              var
+                date = [year, month, day].join('-'),
+                time = [hours, minutes, "00"].join(':'),
+                currentDate = date + ' ' + time,
+                isInPast = (submittedDate.length && submittedDate.match(/^[0-9\-]+ [0-9\:]+$/) && isDateBefore(submittedDate, currentDate, 4*60*60*1000));
               ngModel.$setValidity('dateTimeInThePast', !isInPast);
               if (lastAlert && lastAlert.isOpen) {
                 lastAlert.close();

--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -253,7 +253,7 @@
               }
             },
             results: function(data) {
-              results = {
+              var results = {
                 children: $.map(data.values, function(obj) {
                   if('civicrm_mailing' === rcpAjaxState.entity) {
                     return obj["api.MailingRecipients.getcount"] > 0 ? {   id: obj.id + ' ' + rcpAjaxState.entity + ' ' + rcpAjaxState.type,
@@ -271,7 +271,7 @@
                   (rcpAjaxState.entity == 'civicrm_group'? 'Group' : 'Mailing'));
               }
 
-              more = data.more_results || !(rcpAjaxState.entity == 'civicrm_mailing' && rcpAjaxState.type == 'exclude');
+              var more = data.more_results || !(rcpAjaxState.entity == 'civicrm_mailing' && rcpAjaxState.type == 'exclude');
 
               if (more && !data.more_results) {
                 if (rcpAjaxState.type == 'include') {

--- a/ang/crmMailing/Templates.js
+++ b/ang/crmMailing/Templates.js
@@ -88,7 +88,7 @@
                   },
                   results: function(data) {
 
-                    results = {
+                    var results = {
                       children: $.map(data.values, function(obj) {
                         return { id: obj.id, text: obj.label };
                       })
@@ -98,7 +98,7 @@
                       results.text = ts('Message Templates');
                     }
 
-                    more = data.more_results;
+                    var more = data.more_results;
 
                     if (more && !data.more_results) {
                       rcpAjaxState.page_n += rcpAjaxState.page_i;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/494

Before
----------------------------------------
Javascript errors caused some functionality to break, notably the Mosaico *Recipients* widget.

After
----------------------------------------
All better.

Technical Details
----------------------------------------
These variables need to be declared with the `var` keyword, or it crashes some browsers.

@MegaphoneJon noted that you have to disable debug mode to see the error manifest. It probably depends on your browser too. My theory about that is that in debug mode, each js file is served separately, and these files do not include the `"use strict";` directive, but without debug mode the files all get cobbled together into one big js file, so if one of those said "use strict";` it would affect how the code in this file is treated.