### PR TITLE
CiviGrant - Fix installation of dependencies during upgrade

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -116,14 +116,10 @@ class CRM_Core_ManagedEntities {
    * existing entities, and remove orphaned (stale) entities.
    *
    * @param bool $ignoreUpgradeMode
-   *
+   *   Unused.
    * @throws \CRM_Core_Exception
    */
   public function reconcile($ignoreUpgradeMode = FALSE) {
-    // Do not reconcile whilst we are in upgrade mode
-    if (CRM_Core_Config::singleton()->isUpgradeMode() && !$ignoreUpgradeMode) {
-      return;
-    }
     $this->loadDeclarations();
     if ($error = $this->validate($this->getDeclarations())) {
       throw new CRM_Core_Exception($error);

--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -75,6 +75,12 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
     $this->addTask('core-issue#2122 - Set the timezone to the default for existing Events', 'setEventTZDefault');
     $this->addTask('Drop CustomGroup UI_name_extends index', 'dropIndex', 'civicrm_custom_group', 'UI_name_extends');
     $this->addTask('Add CustomGroup UI_name index', 'addIndex', 'civicrm_custom_group', ['name'], 'UI');
+    if (CRM_Core_DAO::checkTableExists('civicrm_search_display')) {
+      $this->addTask('Add SearchDisplay.acl_bypass', 'addColumn',
+        'civicrm_search_display', 'acl_bypass',
+        "tinyint DEFAULT 0 COMMENT 'Skip permission checks and ACLs when running this display.'"
+      );
+    }
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -58,6 +58,9 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
   public function upgrade_5_47_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Migrate CiviGrant component to an extension', 'migrateCiviGrant');
+    if (CRM_Core_Component::isEnabled('CiviGrant')) {
+      $this->addExtensionTask('Enable CiviGrant dependencies', ['org.civicrm.search_kit', 'org.civicrm.afform']);
+    }
     $this->addTask('Add created_date to civicrm_relationship', 'addColumn', 'civicrm_relationship', 'created_date',
       "timestamp NOT NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'Relationship created date'"
     );


### PR DESCRIPTION
Overview
----------------------------------------

During the upgrade process the CiviGrant extension may be installed. This ensures its dependencies are also enabled.

Fixes https://lab.civicrm.org/dev/core/-/issues/3093. Alternative to #22861 and #22880.

(*Note: PR description filled-in after a couple rounds of editing. Reflects final form.*)

Before
----------------------------------------

The `FiveFortySeven` upgrade migrates CiviGrant data and _partially_ installs the `civigrant` extension. It does not activate dependencies like `afform` and `search_kit`.

This leaves the system in an inconsistent state and leads to errors.

After
----------------------------------------

The `FiveFortySeven` upgrade migrates CiviGrant and _fully_ installs the CiviGrant extension along with its dependencies (whatever they may be at time of execution; eg `afform` and `search_kit`).

Technical Details
----------------------------------------

The primary change is to split/move/expand the installation step:

* During the main body of the core schema updates, it migrates some core records and inserts a placeholder for `civicrm_extension`. This placeholder is inactive (`is_active=0`).
* After the core schema updates, it performs a full/standard installation. This enables dependencies and fires relevant hooks.

This requires some revisions in `CRM/Upgrade`. The `CRM/Upgrade` system builds a queue of upgrade-tasks (*specifically, a "priority queue" sorted on `(weight,id)`*). Moving the installation step requires setting the `weight` explicitly.
