### PR TITLE
Allow API4 match to match an empty value

### DIFF
--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -142,7 +142,13 @@ abstract class AbstractSaveAction extends AbstractAction {
       $where = [];
       foreach ($record as $key => $val) {
         if (isset($val) && in_array($key, $this->match, TRUE)) {
-          $where[] = [$key, '=', $val];
+          if ($val === '' || is_null($val)) {
+            // If we want to match empty string we have to match on NULL/''
+            $where[] = [$key, 'IS EMPTY'];
+          }
+          else {
+            $where[] = [$key, '=', $val];
+          }
         }
       }
       if (count($where) === count($this->match)) {

--- a/tests/phpunit/api/v4/Action/SaveTest.php
+++ b/tests/phpunit/api/v4/Action/SaveTest.php
@@ -27,22 +27,20 @@ use Civi\Api4\Contact;
  */
 class SaveTest extends UnitTestCase {
 
-  public function testSaveWithMatchingCriteria() {
-    $records = [
-      ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
-      ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => 'def'],
-    ];
-
+  /**
+   * @dataProvider getMatchingCriteriaDataProvider
+   * @return void
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function testSaveWithMatchingCriteria($matchCriteria, $records, $changes, $expected) {
     $contacts = Contact::save(FALSE)
       ->setRecords($records)
       ->execute();
 
-    $records[0]['last_name'] = $records[1]['last_name'] = 'Changed';
-    $records[0]['external_identifier'] = 'ghi';
-
     $modified = Contact::save(FALSE)
-      ->setRecords($records)
-      ->setMatch(['first_name', 'external_identifier'])
+      ->setRecords($changes)
+      ->setMatch($matchCriteria)
       ->execute();
 
     $this->assertGreaterThan($contacts[0]['id'], $modified[0]['id']);
@@ -54,15 +52,55 @@ class SaveTest extends UnitTestCase {
       ->addWhere('id', 'IN', $ids)
       ->addOrderBy('id')
       ->execute();
-    $expected = [
-      // Original insert
-      ['id' => $contacts[0]['id'], 'first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
-      // Match+update
-      ['id' => $contacts[1]['id'], 'first_name' => 'Two', 'last_name' => 'Changed', 'external_identifier' => 'def'],
-      // Subsequent insert
-      ['id' => $modified[0]['id'], 'first_name' => 'One', 'last_name' => 'Changed', 'external_identifier' => 'ghi'],
-    ];
+
+    for ($index = 0; $index < count($expected); $index++) {
+      $expected[$index]['id'] = $contacts[0]['id'] + $index;
+    }
     $this->assertEquals($expected, (array) $get);
+  }
+
+  public function getMatchingCriteriaDataProvider() {
+    // data = [ match criteria, records, modifiedRecords, expected results ]
+    $data[] = [
+      ['first_name', 'external_identifier'],
+      [
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => 'def'],
+      ],
+      [
+        ['first_name' => 'One', 'last_name' => 'Changed', 'external_identifier' => 'ghi'],
+        ['first_name' => 'Two', 'last_name' => 'Changed', 'external_identifier' => 'def'],
+      ],
+      [
+        // Original insert
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+        // Match+update
+        ['first_name' => 'Two', 'last_name' => 'Changed', 'external_identifier' => 'def'],
+        // Subsequent insert
+        ['first_name' => 'One', 'last_name' => 'Changed', 'external_identifier' => 'ghi'],
+      ],
+    ];
+    // Test that we get a match on an empty string (eg. external_identifier => '')
+    $data[] = [
+      ['first_name', 'last_name', 'external_identifier'],
+      [
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => ''],
+      ],
+      [
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'ghi'],
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => ''],
+      ],
+      [
+        // Original insert
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+        // Match+update
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => ''],
+        // Subsequent insert
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'ghi'],
+      ],
+    ];
+    return $data;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The new matching functionality on X::save is nice but I found an issue that I find counterintuitive / confusing.

For example if you have some data to import and some has an external_identifier then you might match on first_name,last_name,external_identifier but if external_identifier is empty it won't match because it does external_identifier = '' and that's not the same as external_identifier IS NULL

ie. https://github.com/civicrm/civicrm-core/blob/master/Civi/Api4/Generic/AbstractSaveAction.php#L145

@colemanw said: Maybe patch that line to use the IS EMPTY operator if $val === ''?

Pending test to be added here: 
https://github.com/civicrm/civicrm-core/blob/db11224f49b015c1bfc031a0ad87ba7ed1bf499e/tests/phpunit/api/v4/Action/SaveTest.php#L45

Before
----------------------------------------
Matching on an empty string doesn't match.

Eg. match on: first_name='bob'; external_identifier=''; creates new record even if that exists.

After
----------------------------------------
Matching on an empty string matches.

Eg. match on: first_name='bob'; external_identifier=''; updates existing record.

Technical Details
----------------------------------------
This is particularly noticeable when doing imports.

Comments
----------------------------------------
@colemanw I've added a test now.
