### PR TITLE
ManagedEntities - Allow "match" param to convert existing records to …

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -311,22 +311,30 @@ class CRM_Core_ManagedEntities {
    *   Entity specification (per hook_civicrm_managedEntities).
    */
   protected function insertNewEntity($todo) {
-    if ($todo['params']['version'] == 4) {
-      $todo['params']['checkPermissions'] = FALSE;
+    $params = $todo['params'];
+    // APIv4
+    if ($params['version'] == 4) {
+      $params['checkPermissions'] = FALSE;
+      // Use "save" instead of "create" action to accommodate a "match" param
+      $params['records'] = [$params['values']];
+      unset($params['values']);
+      $result = civicrm_api4($todo['entity_type'], 'save', $params);
+      $id = $result->first()['id'];
     }
-
-    $result = civicrm_api($todo['entity_type'], 'create', ['debug' => TRUE] + $todo['params']);
-    if (!empty($result['is_error'])) {
-      $this->onApiError($todo['entity_type'], 'create', $todo['params'], $result);
+    // APIv3
+    else {
+      $result = civicrm_api($todo['entity_type'], 'create', $params);
+      if (!empty($result['is_error'])) {
+        $this->onApiError($todo['entity_type'], 'create', $params, $result);
+      }
+      $id = $result['id'];
     }
 
     $dao = new CRM_Core_DAO_Managed();
     $dao->module = $todo['module'];
     $dao->name = $todo['name'];
     $dao->entity_type = $todo['entity_type'];
-    // A fatal error will result if there is no valid id but if
-    // this is v4 api we might need to access it via ->first().
-    $dao->entity_id = $result['id'] ?? $result->first()['id'];
+    $dao->entity_id = $id;
     $dao->cleanup = $todo['cleanup'] ?? NULL;
     $dao->save();
   }
@@ -382,6 +390,8 @@ class CRM_Core_ManagedEntities {
     elseif ($doUpdate && $todo['params']['version'] == 4) {
       $params = ['checkPermissions' => FALSE] + $todo['params'];
       $params['values']['id'] = $dao->entity_id;
+      // 'match' param doesn't apply to "update" action
+      unset($params['match']);
       civicrm_api4($dao->entity_type, 'update', $params);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This can help ease the pain of declaring managed entities which may or may not already exist - now they can be matched by name or other unique identifier.

Before
----------------------------------------
An increasingly common scenario is to want to use the `CiviCRM_Managed` subsystem to declare entities which were previously created in some other way. For example, an extension may have inserted a record into the database during the install process. Later on, it seems like a good idea to move it into a `.mgd.php` file instead, but what to do about existing sites which have already run the installer?

After
----------------------------------------
Setting the `match` param will cause `CiviCRM_Managed` to look for an existing record before inserting a new one.
