### PR TITLE
dev/core#3095 Permit setting of format_locale, prefer if set

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -32,6 +32,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     'inheritLocale' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'lcMessages' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'legacyEncoding' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
+    'format_locale' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'monetaryThousandSeparator' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'monetaryDecimalPoint' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
     'moneyformat' => CRM_Core_BAO_Setting::LOCALIZATION_PREFERENCES_NAME,
@@ -43,11 +44,9 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $config = CRM_Core_Config::singleton();
-
     $this->setTitle(ts('Settings - Localization'));
 
-    $warningTitle = json_encode(ts("Warning"));
+    $warningTitle = json_encode(ts('Warning'));
     $defaultLocaleOptions = CRM_Admin_Form_Setting_Localization::getDefaultLocaleOptions();
 
     if (CRM_Core_I18n::isMultiLingual()) {

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -257,7 +257,7 @@ class CRM_Core_I18n {
     // Hacking in for now since the is probably the most important use-case for
     // money formatting in an English speaking non-US locale based on any reasonable
     // metric.
-    $return['en_NZ'] = ts('English - New Zealand');
+    $return['en_NZ'] = ts('English (New Zealand)');
     return $return;
   }
 

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -240,6 +240,21 @@ class CRM_Core_I18n {
   }
 
   /**
+   * Get the options available for format locale.
+   *
+   * Note the pseudoconstant can't be used as the key is the name not the value.
+   *
+   * @return array
+   */
+  public static function getLocaleOptions(): array {
+    $values = CRM_Core_OptionValue::getValues(['name' => 'languages'], $optionValues, 'label', TRUE);
+    foreach ($values as $value) {
+      $return[$value['name']] = $value['label'];
+    }
+    return $return;
+  }
+
+  /**
    * Return the available UI languages
    * @return array|string
    *   array(string languageCode => string languageName) if !$justCodes

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -246,9 +246,10 @@ class CRM_Core_I18n {
    *
    * @return array
    */
-  public static function getLocaleOptions(): array {
+  public static function getFormatLocales(): array {
     $values = CRM_Core_OptionValue::getValues(['name' => 'languages'], $optionValues, 'label', TRUE);
     $return = [];
+    $return[NULL] = ts('Inherit from language');
     foreach ($values as $value) {
       $return[$value['name']] = $value['label'];
     }

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -248,9 +248,15 @@ class CRM_Core_I18n {
    */
   public static function getLocaleOptions(): array {
     $values = CRM_Core_OptionValue::getValues(['name' => 'languages'], $optionValues, 'label', TRUE);
+    $return = [];
     foreach ($values as $value) {
       $return[$value['name']] = $value['label'];
     }
+    // Sorry not sorry.
+    // Hacking in for now since the is probably the most important use-case for
+    // money formatting in an English speaking non-US locale based on any reasonable
+    // metric.
+    $return['en_NZ'] = ts('English - New Zealand');
     return $return;
   }
 

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -43,7 +43,7 @@ class Format {
       $currency = Civi::settings()->get('defaultCurrency');
     }
     if (!isset($locale)) {
-      $locale = CRM_Core_I18n::getLocale();
+      $locale = Civi::settings()->get('format_locale') ?? CRM_Core_I18n::getLocale();
     }
     $money = Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
     $formatter = $this->getMoneyFormatter($currency, $locale);
@@ -150,7 +150,7 @@ class Format {
    * we are looking at how to manage an 'opt in'
    */
   protected function isUseSeparatorSettings(): bool {
-    return !CRM_Utils_Constant::value('IGNORE_SEPARATOR_CONFIG');
+    return !Civi::settings()->get('format_locale') && !CRM_Utils_Constant::value('IGNORE_SEPARATOR_CONFIG');
   }
 
   /**

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -409,6 +409,28 @@ return [
       'callback' => 'CRM_Core_I18n::languages',
     ],
   ],
+  'format_locale' => [
+    'group_name' => 'Localization Preferences',
+    'group' => 'localization',
+    'name' => 'format_locale',
+    'type' => 'String',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
+    'html_attributes' => [
+      'multiple' => 0,
+      'class' => 'crm-select2',
+    ],
+    'default' => NULL,
+    'add' => '5.47',
+    'title' => ts('Formatting locale'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => NULL,
+    'pseudoconstant' => [
+      'callback' => 'CRM_Core_I18n::getLocaleOptions',
+    ],
+    'description' => ts('Locale to use when formatting money (and in future dates). This replaces thousandsSeparator & decimalSeparator & moneyFormat settings.'),
+  ],
   'uiLanguages' => [
     'group_name' => 'Localization Preferences',
     'group' => 'localization',

--- a/settings/Localization.setting.php
+++ b/settings/Localization.setting.php
@@ -417,7 +417,6 @@ return [
     'quick_form_type' => 'Select',
     'html_type' => 'Select',
     'html_attributes' => [
-      'multiple' => 0,
       'class' => 'crm-select2',
     ],
     'default' => NULL,
@@ -427,7 +426,7 @@ return [
     'is_contact' => 0,
     'help_text' => NULL,
     'pseudoconstant' => [
-      'callback' => 'CRM_Core_I18n::getLocaleOptions',
+      'callback' => 'CRM_Core_I18n::getFormatLocales',
     ],
     'description' => ts('Locale to use when formatting money (and in future dates). This replaces thousandsSeparator & decimalSeparator & moneyFormat settings.'),
   ],

--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -49,10 +49,15 @@
               <span class="description">{$settings_fields.contact_default_language.description}</span>
             </td>
           </tr>
-            <tr class="crm-localization-form-block-defaultCurrency">
-                <td class="label">{$form.defaultCurrency.label} {help id='defaultCurrency' title=$form.defaultCurrency.label}</td>
-                <td>{$form.defaultCurrency.html}</td>
-            </tr>
+          <tr class="crm-localization-form-block-defaultCurrency">
+            <td class="label">{$form.defaultCurrency.label} {help id='defaultCurrency' title=$form.defaultCurrency.label}</td>
+            <td>{$form.defaultCurrency.html}</td>
+          </tr>
+          <tr class="crm-localization-form-block-format_locale">
+            <td class="label">{$form.format_locale.label}</td>
+            <td>{$form.format_locale.html}<br />
+              <span class="description">{ts}Locale to use when formatting money (and in future dates). This replaces thousandsSeparator & decimalSeparator settings.{/ts}</span></td>
+          </tr>
             <tr class="crm-localization-form-block-monetaryThousandSeparator">
                 <td class="label">{$form.monetaryThousandSeparator.label}</td>
                 <td>{$form.monetaryThousandSeparator.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Many sites in Australia, Canada and NZ use 'en_US' as the site language - as there is no practical difference and if the language files are not present then there is no actual option. However, in CiviCRM 5.47 this is used for displaying currency too - and it is non optimal

Before
----------------------------------------
No option to change language (in some cases)
![image](https://user-images.githubusercontent.com/336308/156669775-340aa09a-f5f5-4a85-a7c8-f80644ed42d9.png)

And for my 'Canadian' site....

![image](https://user-images.githubusercontent.com/336308/156669942-1814bae3-b615-4fee-9c1f-5d8b0b6ae04b.png)



After
----------------------------------------
Can set format locale & once set....


![image](https://user-images.githubusercontent.com/336308/156669703-0dd90955-8075-400a-8819-3c403f97e74e.png)

![image](https://user-images.githubusercontent.com/336308/156669654-83f6a7f8-f835-45ba-ae62-f0313744b301.png)


Technical Details
----------------------------------------
This is a minimal patch to address https://lab.civicrm.org/dev/core/-/issues/3095
in time for 5.47. With this set it is possible to change the format locale to
English, Canada or English, Australian (erm & sorta NZ!)
and the currency will only be displayed before dollar amounts NOT of that
currency.

This should be enough to mitigate that regression feeling but missing are
1) fixing the admin form to hide irrelevant settings if format_locale is set
2) the psuedoconstant is cludgey - existing stuff doesn't seem to work so
I added a function - also - if we ARE going to use this option group we
should .... add NZ to it

Comments
----------------------------------------
