### PR TITLE
Avoid e-notices on pages with tabs

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -719,7 +719,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // our ensured variables get blown away, so we need to set them even if
     // it's already been initialized.
     self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
-
+    self::$_template->addExpectedTabHeaderKeys();
   }
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -199,6 +199,8 @@ class CRM_Core_Page {
     $pageTemplateFile = $this->getHookedTemplateFileName();
     self::$_template->assign('tplFile', $pageTemplateFile);
 
+    self::$_template->addExpectedTabHeaderKeys();
+
     // invoke the pagRun hook, CRM-3906
     CRM_Utils_Hook::pageRun($this);
 

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -203,6 +203,26 @@ class CRM_Core_Smarty extends Smarty {
   }
 
   /**
+   * Avoid e-notices on pages with tabs,
+   * by ensuring tabHeader items contain the necessary keys
+   */
+  public function addExpectedTabHeaderKeys(): void {
+    $defaults = [
+      'class' => '',
+      'extra' => '',
+      'icon' => FALSE,
+      'count' => FALSE,
+      'template' => FALSE,
+    ];
+
+    $tabs = $this->get_template_vars('tabHeader');
+    foreach ((array) $tabs as $i => $tab) {
+      $tabs[$i] = array_merge($defaults, $tab);
+    }
+    $this->assign('tabHeader', $tabs);
+  }
+
+  /**
    * Fetch a template (while using certain variables)
    *
    * @param string $resource_name


### PR DESCRIPTION
Overview
----------------------------------------
Avoid e-notices on pages with tabs,  by ensuring tabHeader items contain the necessary keys.
   
Before
----------------------------------------
On pages with tabs (manage event, campaign conduce survey, etc) e-notices were frequently triggered from within `TabHeader.tpl`. These resulted from `TabHeader.tpl` trying to read `tabHeader` keys from each top-level array item.  

After
----------------------------------------
The `tabHeader` array is re-assigned in `CRM_Core_Form` and `CRM_Core_Page` just before the template is rendered, with all keys defined for each `tabHeader` tab array.

Technical Details
----------------------------------------
This could have been resolved by changing the arrays assigned to `tabHeader` within induvidual pages. However, this centralises the logic incase new array keys are added in future, and will ensure notices are not caused by any extensions using `TabHeader.tpl`.