### PR TITLE
smarty/php notices on contribution view part 4

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -50,6 +50,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     $this->addExpectedSmartyVariables([
       'pricesetFieldsCount',
       'pcp_id',
+      'getTaxDetails',
       // currencySymbol maybe doesn't make sense but is probably old?
       'currencySymbol',
     ]);
@@ -153,6 +154,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     $values['note'] = array_values($noteValue);
 
     // show billing address location details, if exists
+    $values['billing_address'] = '';
     if (!empty($values['address_id'])) {
       $addressParams = ['id' => $values['address_id']];
       $addressDetails = CRM_Core_BAO_Address::getValues($addressParams, FALSE, 'id');

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1975,6 +1975,11 @@ SELECT IF( EXISTS(SELECT name FROM civicrm_contact_type WHERE name like %1), 1, 
       }
     }
     else {
+      $form->addExpectedSmartyVariables([
+        'multiRecordDisplay',
+        'groupId',
+        'skipTitle',
+      ]);
       $form->assign_by_ref("{$prefix}viewCustomData", $details);
       return $details;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Towards getting the test in https://github.com/civicrm/civicrm-core/pull/22865 to pass.

Before
----------------------------------------
On contribution view, notices about multiRecordDisplay, getTaxDetails, etc..

After
----------------------------------------
Still more notices, but this should be the last one needed for the test.

Technical Details
----------------------------------------


Comments
----------------------------------------

