### PR TITLE
Mark AJAX methods as static

### DIFF
--- a/CRM/Campaign/Page/AJAX.php
+++ b/CRM/Campaign/Page/AJAX.php
@@ -349,7 +349,7 @@ class CRM_Campaign_Page_AJAX {
     CRM_Utils_System::civiExit();
   }
 
-  public function processVoterData() {
+  public static function processVoterData() {
     $status = NULL;
     $operation = CRM_Utils_Type::escape($_POST['operation'], 'String');
     if ($operation == 'release') {
@@ -477,7 +477,7 @@ class CRM_Campaign_Page_AJAX {
     CRM_Utils_JSON::output(['status' => $status]);
   }
 
-  public function campaignGroups() {
+  public static function campaignGroups() {
     $surveyId = CRM_Utils_Request::retrieve('survey_id', 'Positive',
       CRM_Core_DAO::$_nullObject, FALSE, NULL, 'POST'
     );
@@ -621,7 +621,7 @@ class CRM_Campaign_Page_AJAX {
    * This function uses the deprecated v1 datatable api and needs updating. See CRM-16353.
    * @deprecated
    */
-  public function surveyList() {
+  public static function surveyList() {
     //get the search criteria params.
     $searchCriteria = CRM_Utils_Request::retrieve('searchCriteria', 'String', CRM_Core_DAO::$_nullObject, FALSE, NULL, 'POST');
     $searchParams = explode(',', $searchCriteria);
@@ -726,7 +726,7 @@ class CRM_Campaign_Page_AJAX {
    * This function uses the deprecated v1 datatable api and needs updating. See CRM-16353.
    * @deprecated
    */
-  public function petitionList() {
+  public static function petitionList() {
     //get the search criteria params.
     $searchCriteria = CRM_Utils_Request::retrieve('searchCriteria', 'String', CRM_Core_DAO::$_nullObject, FALSE, NULL, 'POST');
     $searchParams = explode(',', $searchCriteria);

--- a/CRM/UF/Page/AJAX.php
+++ b/CRM/UF/Page/AJAX.php
@@ -24,7 +24,7 @@ class CRM_UF_Page_AJAX {
    * Function the check whether the field belongs.
    * to multi-record custom set
    */
-  public function checkIsMultiRecord() {
+  public static function checkIsMultiRecord() {
     $customId = $_GET['customId'];
 
     $isMultiple = CRM_Core_BAO_CustomField::isMultiRecordField($customId);


### PR DESCRIPTION
Overview
----------------------------------------
Mark AJAX methods as static.

Before
----------------------------------------
When using CiviCRM, errors like the below will be logged (depending on the version of PHP in use, and what error configuration is in use):

```
PHP Deprecated:  Non-static method CRM_Campaign_Page_AJAX::campaignGroups() should not be called statically
```

This happens because `CRM_Utils_REST` uses `call_user_func([$params['className'], $params['fnName']], $params)`. When a callable takes a string as the first array item, the function is assumed to be static (https://www.php.net/manual/en/language.types.callable.php).

After
----------------------------------------
All ajax methods are marked as static.

These methods are only used in an ajax context. Note that most ajax methods where already marked as static.