### PR TITLE
APIv4 Explorer - Add "copy" button to quicly copy code to clipboard

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -224,8 +224,14 @@
           </p>
         </div>
         <div ng-repeat="style in code[selectedTab.code]">
+          <button class="btn btn-xs btn-default pull-right" ng-click="$ctrl.copyCode('api4-code-' + selectedTab.code + '-' + style.name)">
+            <i class="crm-i fa-clipboard"></i>
+            {{:: ts('Copy') }}
+          </button>
           <label>{{:: style.label }}</label>
-          <div><pre class="prettyprint" ng-bind-html="style.code"></pre></div>
+          <div>
+            <pre class="prettyprint" id="api4-code-{{ selectedTab.code + '-' + style.name }}" ng-bind-html="style.code"></pre>
+          </div>
         </div>
       </div>
     </div>
@@ -261,7 +267,15 @@
       </div>
       <div class="panel-body">
         <div ng-show="selectedTab.result === 'result'">
-          <pre class="prettyprint" ng-repeat="code in result" ng-bind-html="code"></pre>
+          <div ng-repeat="code in result">
+            <div class="clearfix">
+              <button ng-if="$index" class="btn btn-xs btn-default pull-right" ng-click="$ctrl.copyCode('api4-result-' + $index)">
+                <i class="crm-i fa-clipboard"></i>
+                {{:: ts('Copy') }}
+              </button>
+            </div>
+            <pre class="prettyprint" id="api4-result-{{ $index }}" ng-bind-html="code"></pre>
+          </div>
         </div>
         <div ng-if="::perm.accessDebugOutput" ng-show="selectedTab.result === 'debug'">
           <pre ng-if="debug" class="prettyprint" ng-bind-html="debug"></pre>

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -116,6 +116,16 @@
       default: 'json'
     });
 
+    // Copy text to the clipboard
+    this.copyCode = function(domId) {
+      var node = document.getElementById(domId);
+      var range = document.createRange();
+      range.selectNode(node);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+      document.execCommand('copy');
+    };
+
     function ucfirst(str) {
       return str[0].toUpperCase() + str.slice(1);
     }
@@ -976,7 +986,7 @@
           break;
 
         case 'php':
-          $scope.result.push(prettyPrintOne((_.isArray(response.values) ? '(' + response.values.length + ') ' : '') + _.escape(phpFormat(response.values, 2, 2)), 'php', 1));
+          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2)) + ';', 'php', 1));
           break;
       }
     };


### PR DESCRIPTION
Overview
----------------------------------------
Makes it easy to select and copy generated code.

This also makes the "Export" action easier to use, a "Copy" button automatically selects text, and the PHP formatted code begins with "return" and ends with a semicolon, which can be copied directly into a `mgd.php` file.

Before
----------------------------------------
No copy button. PHP result missing a semicolon at the end.

After
----------------------------------------
Button automatically highlights (selects) code and copies it to the clipboard.
![image](https://user-images.githubusercontent.com/2874912/156933879-20cdd65d-50bd-48cb-93fd-e5a5ed8f38ed.png)
