### PR TITLE
dev/core#3104 - Crash when viewing a contact page - Call to undefined method CRM_Contact_Page_View_Summary::addExpectedSmartyVariables()

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -519,4 +519,25 @@ class CRM_Core_Page {
     return "<i$attribString></i>$sr";
   }
 
+  /**
+   * Add an expected smarty variable to the array.
+   *
+   * @param string $elementName
+   */
+  public function addExpectedSmartyVariable(string $elementName): void {
+    $this->expectedSmartyVariables[] = $elementName;
+  }
+
+  /**
+   * Add an expected smarty variable to the array.
+   *
+   * @param array $elementNames
+   */
+  public function addExpectedSmartyVariables(array $elementNames): void {
+    foreach ($elementNames as $elementName) {
+      // Duplicates don't actually matter....
+      $this->addExpectedSmartyVariable($elementName);
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Crash when viewing a contact summary.

Before
----------------------------------------
Call to undefined method CRM_Contact_Page_View_Summary::addExpectedSmartyVariables()

After
----------------------------------------
ok

Technical Details
----------------------------------------
While trying to clean up smarty/php notices on forms in https://github.com/civicrm/civicrm-core/pull/22894 I added a call to the function but that block also gets called on CRM_Core_Pages, which doesn't have the function.

Comments
----------------------------------------
Copied it from CRM_Core_Form.
