### PR TITLE
Don't perform event timezone check if CiviEvent is disabled

### DIFF
--- a/CRM/Utils/Check/Component/Event.php
+++ b/CRM/Utils/Check/Component/Event.php
@@ -6,6 +6,13 @@
 class CRM_Utils_Check_Component_Event extends CRM_Utils_Check_Component {
 
   /**
+   * @inheritDoc
+   */
+  public function isEnabled() {
+    return CRM_Core_Component::isEnabled('CiviEvent');
+  }
+
+  /**
    * Check events have timezone set.
    *
    * @return CRM_Utils_Check_Message[]


### PR DESCRIPTION
Overview
----------------------------------------
The new timezone check in 5.47 fails if you don't have CiviEvent enabled.

Before
----------------------------------------
`API Exception: Event API is not available because CiviEvent component is disabled while checking events for timezones.` in System Status.

After
----------------------------------------
No error.

Comments
----------------------------------------
This error message was impressively accurate for being dynamically generated, well done APIv4.