### PR TITLE
Expose payment processor error from PaymentProcessor.pay

### DIFF
--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -123,7 +123,8 @@ function civicrm_api3_payment_processor_pay($params) {
     if (empty($code)) {
       $code = 'EXTERNAL_FAILURE';
     }
-    throw new API_Exception('Payment failed', $code, $errorData, $e);
+    $message = $e->getMessage() ?? 'Payment Failed';
+    throw new API_Exception($message, $code, $errorData, $e);
   }
   return civicrm_api3_create_success(array($result), $params);
 }


### PR DESCRIPTION
https://lab.civicrm.org/dev/financial/-/issues/191

Overview
----------------------------------------
`PaymentProcessor.pay` returns the same message - `Payment Failed` - no matter the cause.  This makes it impossible to tell the user why their credit card was declined.

### Steps to Replicate
* Install the dummy processor.
* Submit `PaymentProcessor.pay` with an expiration date in 2021 or earlier.
 * Alternatively, create a Webform, install WFC, and submit your payment that way.

I don't know if there's a good reason for this or not. @KarinG has expressed interest to me in bubbling up the message from the payment processor.

Before
----------------------------------------
`Invalid expiry date`

After
----------------------------------------
`Payment failed`

Technical Details
----------------------------------------
Not really, this is pretty straightforward.