### PR TITLE
Add workflow template for offline event

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1499,7 +1499,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
                 }
               }
             }
-            $this->assign('totalTaxAmount', $totalTaxAmount);
             $this->assign('taxTerm', $this->getSalesTaxTerm());
             $this->assign('dataArray', $dataArray);
           }
@@ -1516,13 +1515,16 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $eventAmount = array_merge($eventAmount, $additionalParticipantDetails);
           $this->assign('amount', $eventAmount);
         }
-
+        $this->assign('totalTaxAmount', $totalTaxAmount ?? 0);
         $sendTemplateParams = [
-          'groupName' => 'msg_tpl_workflow_event',
-          'valueName' => 'event_offline_receipt',
+          'workflow' => 'event_offline_receipt',
           'contactId' => $contactID,
           'isTest' => !empty($this->_defaultValues['is_test']),
           'PDFFilename' => ts('confirmation') . '.pdf',
+          'modelProps' => [
+            'participantID' => $this->_id,
+            'eventID' => $params['event_id'],
+          ],
         ];
 
         // try to send emails only if email id is present

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -358,14 +358,16 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       $this->assign('isOnWaitlist', TRUE);
     }
     $this->assign('contactID', $this->_contactId);
-    $this->assign('participantID', $this->_participantId);
 
     $sendTemplateParams = [
-      'groupName' => 'msg_tpl_workflow_event',
-      'valueName' => 'event_offline_receipt',
+      'workflow' => 'event_offline_receipt',
       'contactId' => $this->_contactId,
       'isTest' => FALSE,
       'PDFFilename' => ts('confirmation') . '.pdf',
+      'modelProps' => [
+        'participantID' => $this->_participantId,
+        'eventID' => $params['event_id'],
+      ],
     ];
 
     // try to send emails only if email id is present

--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -175,10 +175,12 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
    *
    */
   protected function getExposedFields(): array {
-    return ['event_type_id',
+    return [
+      'event_type_id',
       'title',
       'id',
       'event_tz',
+      'pay_later_receipt',
       'start_date',
       'end_date',
       'summary',

--- a/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
+++ b/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Receipt sent when confirming a back office participation record.
+ *
+ * @support template-only
+ *
+ * @see CRM_Event_Form_Participant::submit()
+ * @see CRM_Event_Form_ParticipantFeeSelection::emailReceipt
+ */
+class CRM_Event_WorkflowMessage_EventOfflineReceipt extends GenericWorkflowMessage {
+  use CRM_Event_WorkflowMessage_ParticipantTrait;
+  public const WORKFLOW = 'event_offline_receipt';
+
+}

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -8,8 +8,15 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   /**
    * @var int
    *
-   * @scope tokenContext as participantId
+   * @scope tokenContext as participantId, tplParams as participantID
    */
-  public $participantId;
+  public $participantID;
+
+  /**
+   * @var int
+   *
+   * @scope tokenContext as eventId, tplParams as eventID
+   */
+  public $eventID;
 
 }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\Participant;
+
 /**
  *  Test CRM_Event_Form_Registration functions.
  *
@@ -22,18 +24,11 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
-   * Should financials be checked after the test but before tear down.
-   *
-   * @var bool
-   */
-  protected $isValidateFinancialsOnPostAssert = TRUE;
-
-  /**
    * Initial test of submit function.
    *
    * @throws \Exception
    */
-  public function testSubmit() {
+  public function testSubmit(): void {
     $form = $this->getForm();
     $form->submit([
       'register_date' => date('Ymd'),
@@ -262,8 +257,9 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    * @throws \Exception
    */
-  public function testParticipantOfflineReceipt($thousandSeparator) {
+  public function testParticipantOfflineReceipt(string $thousandSeparator): void {
     $this->setCurrencySeparators($thousandSeparator);
+    $this->swapMessageTemplateForTestTemplate('event_offline_receipt', 'text');
     $mut = new CiviMailUtils($this, TRUE);
     // Create an email associated with the logged in contact
     $loggedInContactID = $this->createLoggedInUser();
@@ -298,7 +294,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
 
     // Use the email created as the from email ensuring we are passing a numeric from to test dev/core#1069
     $this->setCurrencySeparators($thousandSeparator);
-    $form = $this->getForm(['is_monetary' => 1, 'financial_type_id' => 1]);
+    $form = $this->getForm(['is_monetary' => 1, 'financial_type_id' => 1, 'pay_later_receipt' => 'pay us']);
     $form->_mode = 'Live';
     $form->_quickConfig = TRUE;
     $form->_fromEmails = [
@@ -308,13 +304,24 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $submitParams = $this->getSubmitParamsForCreditCardPayment($paymentProcessorID);
     $submitParams['from_email_address'] = $email['id'];
     $form->submit($submitParams);
+    $participantID = Participant::get()->addWhere('event_id', '=', $this->getEventID())->execute()->first()['id'];
     //Check if type is correctly populated in mails.
     //Also check the string email is present not numeric from.
     $mut->checkMailLog([
+      'contactID:::' . $this->getContactID(),
+      'contact.id:::' . $this->getContactID(),
+      'eventID:::' . $this->getEventID(),
+      'event.id:::' . $this->getEventID(),
+      'participantID:::' . $participantID,
+      'participant.id:::' . $participantID,
       '<p>Test event type - 1</p>',
+      'event.title:::Annual CiviCRM meet',
+      'participant.status_id:name:::Registered',
       'testloggedinreceiptemail@civicrm.org',
+      'event.pay_later_receipt:::pay us',
       $this->formatMoneyInput(1550.55),
     ]);
+
     $this->callAPISuccess('Email', 'delete', ['id' => $email['id']]);
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -619,6 +619,7 @@ Emerald City, Maine 90210
 
 event.info_url :' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&reset=1&id=1
 event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1
+event.pay_later_receipt :
 event.custom_1 :my field
 ';
   }
@@ -904,6 +905,7 @@ December 21st, 2007
       '{event.location}' => 'Event Location',
       '{event.info_url}' => 'Event Info URL',
       '{event.registration_url}' => 'Event Registration URL',
+      '{event.pay_later_receipt}' => 'Pay Later Receipt Text',
       '{event.' . $this->getCustomFieldName('text') . '}' => 'Enter text here :: Group with field text',
     ];
   }

--- a/tests/templates/message_templates/event_offline_receipt_text.tpl
+++ b/tests/templates/message_templates/event_offline_receipt_text.tpl
@@ -1,0 +1,10 @@
+contactID:::{$contactID}
+eventID:::{$eventID}
+participantID:::{$participantID}
+contact.id:::{contact.id}
+event.id:::{event.id}
+participant.id:::{participant.id}
+event.title:::{event.title}
+participant.status_id:name:::{participant.status_id:name}
+email:::{$email}
+event.pay_later_receipt:::{event.pay_later_receipt}


### PR DESCRIPTION

Overview
----------------------------------------
Add workflow template for offline event

This locks in availability of participant and event tokens
along with the standard smarty variables of {contactID},
{participantID} and {eventID}

Before
----------------------------------------
Participant and Event ids & tokens not available to the template and hook (https://github.com/civicrm/civicrm-core/pull/22878 )

After
----------------------------------------
Tests ensure that participant & event ids work. Existing classes using the trait have tests in `CRM_Event_Form_SelfSvcUpdateTest` etc

Technical Details
----------------------------------------
This also removes the issets that cause failure with grumpy smarty mode

Comments
----------------------------------------