### PR TITLE
(dev/core#3106) Raise max# of editable websites (5 => 25)

### DIFF
--- a/CRM/Contact/Form/Inline/Website.php
+++ b/CRM/Contact/Form/Inline/Website.php
@@ -30,7 +30,7 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
    * No of website blocks for inline edit.
    * @var int
    */
-  private $_blockCount = 6;
+  private $_blockCount = 26;
 
   /**
    * Call preprocess.

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -21,7 +21,7 @@
     <tr>
       <td>{ts}Website{/ts}
         {help id="id-website" file="CRM/Contact/Form/Contact.hlp"}
-        {if $actualBlockCount lt 5 }
+        {if $actualBlockCount lt 25 }
           &nbsp;&nbsp;<span id="add-more-website" title="{ts}click to add more{/ts}"><a class="crm-hover-button action-item add-more-inline" href="#">{ts}add{/ts}</a></span>
         {/if}
       </td>


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3106

Overview
----------------------------------------
The max number of websites available to inline edit is 5.  Since "Websites" is also used to track folks' social media, it's pretty easy to exceed 5.  I think we should change it to 25.

Before
----------------------------------------
![Selection_1419](https://user-images.githubusercontent.com/1796012/157320610-1980cfe3-92b1-4ece-a80f-e8cbff72dd3a.png)

After
----------------------------------------
![Selection_1420](https://user-images.githubusercontent.com/1796012/157320623-a99ee94d-f7b4-4a1f-a554-804dc642d2ca.png)

Comments
----------------------------------------
You may be asking yourself, "Does anyone really need 25 websites per contact?"  The answer is "Yes".