### PR TITLE
dev/core#3085 - Checkbox fields on profile admin page can't be unchecked

### DIFF
--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -29,7 +29,7 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
     $form->assign('advancedFieldsConverted', $entityFields);
 
     // should mapping be enabled for this group
-    $form->addElement('checkbox', 'is_map', ts('Enable mapping for this profile?'));
+    $form->addElement('advcheckbox', 'is_map', ts('Enable mapping for this profile?'));
 
     // should we allow updates on a exisitng contact
     $form->addRadio('is_update_dupe', ts('What to do upon duplicate match'), [ts('Issue warning and do not save'), ts('Update the matching contact'), ts('Allow duplicate contact to be created')]);
@@ -50,14 +50,14 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
     $form->addElement('select', 'add_contact_to_group', ts('Add contacts to a group?'), $group);
 
     // add CAPTCHA To this group ?
-    $form->addElement('checkbox', 'add_captcha', ts('Include reCAPTCHA?'));
+    $form->addElement('advcheckbox', 'add_captcha', ts('Include reCAPTCHA?'));
 
     // should we display an edit link
-    $form->addElement('checkbox', 'is_edit_link', ts('Include profile edit links in search results?'));
+    $form->addElement('advcheckbox', 'is_edit_link', ts('Include profile edit links in search results?'));
 
     // should we display a link to the website profile
     $config = CRM_Core_Config::singleton();
-    $form->addElement('checkbox', 'is_uf_link', ts('Include %1 user account information links in search results?', [1 => $config->userFramework]));
+    $form->addElement('advcheckbox', 'is_uf_link', ts('Include %1 user account information links in search results?', [1 => $config->userFramework]));
 
     // want to create cms user
     $session = CRM_Core_Session::singleton();

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -199,7 +199,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
 
     // is this group active ?
-    $this->addElement('checkbox', 'is_active', ts('Is this CiviCRM Profile active?'));
+    $this->addElement('advcheckbox', 'is_active', ts('Is this CiviCRM Profile active?'));
 
     $paneNames = [
       ts('Advanced Settings') => 'buildAdvanceSetting',
@@ -361,19 +361,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     }
     else {
       // get the submitted form values.
-      // Issue 3085 Cleared checkboxes don't appear in $params, so we look for
-      // elements starting with 'is', which indicates a boolean value, i.e.
-      // a check box. If such a field does not appear in $params, we set it
-      // to zero.
       $params = $this->controller->exportValues($this->_name);
-      foreach ($this->_elementIndex as $key => $value) {
-        if (str_starts_with($key, 'is')) {
-          if (!array_key_exists($key, $params)) {
-            $params[$key] = 0;
-          }
-        }
-
-      }
       if ($this->_action & (CRM_Core_Action::UPDATE)) {
         $params['id'] = $this->_id;
         // CRM-5284

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -361,12 +361,19 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
     }
     else {
       // get the submitted form values.
+      // Issue 3085 Cleared checkboxes don't appear in $params, so we look for
+      // elements starting with 'is', which indicates a boolean value, i.e.
+      // a check box. If such a field does not appear in $params, we set it
+      // to zero.
       $params = $this->controller->exportValues($this->_name);
+      foreach ($this->_elementIndex as $key => $value) {
+        if (str_starts_with($key, 'is')) {
+          if (!array_key_exists($key, $params)) {
+            $params[$key] = 0;
+          }
+        }
 
-      if (!array_key_exists('is_active', $params)) {
-        $params['is_active'] = 0;
       }
-
       if ($this->_action & (CRM_Core_Action::UPDATE)) {
         $params['id'] = $this->_id;
         // CRM-5284


### PR DESCRIPTION
Overview
----------------------------------------
This attempts to cure issue https://lab.civicrm.org/dev/core/-/issues/3085 where various checkboxes in profile settings, once checked, couldn't be cleared.

Before
----------------------------------------
Once you had checked a profile checkbox such as Map, it would not clear.

After
----------------------------------------
Checkboxes, once cleared, stay cleared.

Technical Details
----------------------------------------
Change 'checkbox' to 'advcheckbox' in ...civicrm-core/CRM/UF/Form/Group.php and AdvanceSetting.php. It is no longer necessary to check if $params['is_active'] exists, as advcheckbox makes sure it exists, even if cleared.

Comments
----------------------------------------
Thanks to @demeritcowboy for pointing out the advcheckbox fix.