### PR TITLE
dev/drupal#171 - Allow guzzle 7 for drupal 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     "pear/net_smtp": "1.9.*",
     "pear/net_socket": "1.0.*",
     "pear/mail": "^1.4",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.3 || ^7.3",
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.13.3",


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/171

Before
----------------------------------------
Can't download civi files on drupal 10 using composer.

After
----------------------------------------
Still can't, but not because of guzzle.

Technical Details
----------------------------------------
Drupal 10 requires guzzle 7.

Note the lock file is still the same lock file. So all other cms's will still get the same guzzle 6, even drupal 9 but there it's not because of the lock file but because it's own requirement is guzzle 6.

Comments
----------------------------------------
I did some testing, listed here: https://lab.civicrm.org/dev/drupal/-/issues/171#note_68130. Note that was with drupal 9 and a fudged install to allow it to have guzzle 7, because civi can't be installed on drupal 10, but I could see it was using the guzzle 7 files. Grepping, there is no weirdo usage of guzzle in core, and the signatures for basic Guzzle\Client usage haven't changed, so it all seems to still work.