### PR TITLE
(NFC) contributor-key.yml - Fix syntax error

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1092,8 +1092,8 @@
 - github      : nowszy
   name        : Pawel Nowak
 
--github       : pboling
- name         : Peter Boling 
+- github       : pboling
+  name         : Peter Boling
 
 - name        : Peter Bull
 


### PR DESCRIPTION
Before
--------

`civicredits.php` rejects data due to subtle syntax error

After
--------

`civicredits.php` accepts data