### PR TITLE
Fix double encoding of document title on Contact view form

### DIFF
--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -193,7 +193,7 @@
     function refreshTitle() {
       var contactName = $('.crm-summary-display_name').text();
       contactName = $.trim(contactName);
-      document.title = $('title').html().replace(oldName, contactName);
+      document.title = document.title.replace(oldName, contactName);
       oldName = contactName;
     }
     $('#contactname-block').on('load', refreshTitle);


### PR DESCRIPTION
Overview
----------------------------------------

The main contact view page incorrectly sets the `document.title` property, passing in html-encoded data where plain text is required.

Before
----------------------------------------

Page titles that include special characters, e.g. ampersands (&) get mangled as soon as the page's Javascript runs.

In this screencast you can see (if you stare long enough) that while loading, the site name correctly comes up (CiviCRM | People & Planet), and when it is replaced to add the contact name ("Me & You"), the rest of the site name gets mangled (Me & You | People **&amp;** Planet)

![fix-ampersands](https://user-images.githubusercontent.com/870343/157839512-8c64a2ba-5be9-4b2a-a2da-bfcb5c415802.gif)


After
----------------------------------------

The site name is not mangled. Also, I moved away from making jQuery find the first `<title>` element in favour of simply using `document.title`, which we're relying on anyway and of course has been supported since ... ever.


Technical Details
----------------------------------------

Plaintext should be provided as a value to `document.title`.

Note that this does not affect *contact names* with ampersands; they worked fine. It's just about the original page title that Civi modifies when a contact is loaded.

