### PR TITLE
Afform Gui - Fix selecting html element of text box

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
@@ -1,7 +1,7 @@
 <li ng-click="$event.stopPropagation()">
   <div class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Style:') }}</label>
-    <select class="form-control" ng-model="node['#tag']" title="{{:: ts('Text style') }}">
+    <select class="form-control" ng-model="$ctrl.node['#tag']" title="{{:: ts('Text style') }}">
       <option ng-repeat="(opt, label) in tags" value="{{ opt }}">{{ label }}</option>
     </select>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an Afform GUI regression where setting the tag of a text element was broken.

Before
----------------------------------------
Note the "Style" select is not working.

![image](https://user-images.githubusercontent.com/2874912/158025765-b4dde986-26d3-4d77-9df3-05da3ac61b68.png)


After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/2874912/158025728-6f09fc41-2884-45d5-9353-5e73fd67dd74.png)

