### PR TITLE
Add spinners to 'Estimating...' in CiviMail

### DIFF
--- a/ang/crmMailing/BlockRecipients.html
+++ b/ang/crmMailing/BlockRecipients.html
@@ -9,7 +9,7 @@
     ng-required="true" />
     <a crm-icon="fa-wrench" ng-click="editOptions(mailing)" class="crm-hover-button" title="{{:: ts('Edit Recipient Options') }}"></a>
     <div ng-style="{display: permitRecipientRebuild ? '' : 'inline-block'}">
-      <button ng-click="rebuildRecipients()" ng-show="permitRecipientRebuild" class="crm-button" title="{{:: ts('Click to refresh recipient count') }}">{{getRecipientsEstimate()}}</button>
-      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{:: ts('Preview a List of Recipients') }}" style="font-weight: bold;">{{getRecipientCount()}}</a>
+      <button ng-click="rebuildRecipients()" ng-show="permitRecipientRebuild" class="crm-button" title="{{:: ts('Click to refresh recipient count') }}" ng-bind-html="getRecipientsEstimate()"></button>
+      <a ng-click="previewRecipients()" class="crm-hover-button" title="{{:: ts('Preview a List of Recipients') }}" style="font-weight: bold;" ng-bind-html="getRecipientCount()"></a>
     </div>
 </div>

--- a/ang/crmMailing/EditRecipCtrl.js
+++ b/ang/crmMailing/EditRecipCtrl.js
@@ -25,7 +25,7 @@
     $scope.getRecipientsEstimate = function() {
       var ts = $scope.ts;
       if ($scope.recipients === null) {
-        return ts('Estimating...');
+        return ts('Estimating') + ' <i class="fa fa-spinner fa-spin"></i>';
       }
       if ($scope.recipients === 0) {
         return ts('Estimate recipient count');
@@ -45,7 +45,7 @@
         return ts('(unknown)');
       }
       else {
-        return $scope.permitRecipientRebuild ? ts('(unknown)') : ts('Estimating...');
+        return $scope.permitRecipientRebuild ? ts('(unknown)') : ts('Estimating') + ' <i class="fa fa-spinner fa-spin"></i>';
       }
     };
 


### PR DESCRIPTION
Overview
----------------------------------------
Tiny UI tweak to add a spinner to the 'Estimating' text in a mailing. 

Before
----------------------------------------
Static button says 'Estimating...'. On large mailings this is a little unnerving for users when it takes a while.

After
----------------------------------------
![2022-03-12_19-34-32](https://user-images.githubusercontent.com/28389118/158032371-e516c82e-0aa5-4c8c-b043-586f86fafb14.gif)

Technical Details
----------------------------------------
This also updates the 'Refresh Recipient Count' button. This is hard to test at time of writing, as I think that setting [isn't working](https://lab.civicrm.org/dev/core/-/issues/3115).
