### PR TITLE
dev/core#3112 Clear caches to avoid error on upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -116,6 +116,9 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
       }
       CRM_Core_DAO::executeQuery("DELETE FROM civicrm_component WHERE name = 'CiviGrant'", [], TRUE, NULL, FALSE, FALSE);
     }
+    // Reload the civi cache here as 'table_name' may not be in the cached entities
+    // array generated in an earlier version retrieved via $cache->get('api4.entities.info', []);
+    Civi::cache('metadata')->flush();
 
     // There are existing records which should be managed by `civigrant`. To assign ownership, we need
     // placeholders in `civicrm_extension` and `civicrm_managed`.


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#3112 Clear caches to avoid error on upgrade. 

Before
----------------------------------------
Fatal error on upgrade if the metadata cache holds  a cached version of entity metadata with the table_name not populated

After
----------------------------------------
Cache refreshed first

Technical Details
----------------------------------------
There may be a better place for this - but at least here is is clear to the api call that
can fail without it .... if the metadata cache is populated from an earlier version the
table_name key may not exist & hence the api call fails with no table_name
in the from clause

Comments
----------------------------------------
@colemanw this addresses the issue I hit late last week