### PR TITLE
Fix backward-compatability for new method in CRM_Contact_BAO_Query_Hook

### DIFF
--- a/CRM/Contact/BAO/Query/Hook.php
+++ b/CRM/Contact/BAO/Query/Hook.php
@@ -150,14 +150,22 @@ class CRM_Contact_BAO_Query_Hook {
   }
 
   /**
+   * This gives the opportunity for a single hook to return default fields.
+   *
+   * It only runs if no core components have defaults for this $mode.
+   * The expectation is that only one hook will handle this mode, so just
+   * the first one to return a value is used.
+   *
    * @param $mode
    * @return array|null
    */
   public function getDefaultReturnProperties($mode) {
-    foreach (self::getSearchQueryObjects() as $obj) {
-      $properties = $obj::defaultReturnProperties($mode);
-      if ($properties) {
-        return $properties;
+    foreach ($this->getSearchQueryObjects() as $obj) {
+      if (method_exists($obj, 'defaultReturnProperties')) {
+        $properties = $obj::defaultReturnProperties($mode);
+        if ($properties) {
+          return $properties;
+        }
       }
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
The method `getDefaultReturnProperties` was just added to `CRM_Contact_BAO_Query_Hook`, but some extensions do not yet implement it, and also do not extend that class so cannot inherit the default method.

This adds a guard around calling the new method to avoid crashes.

See discussion in https://github.com/civicrm/civicrm-core/pull/22064#issuecomment-1065574086