### PR TITLE
Dev/core#2524 Fix seriazliation parameter exception in APIv3

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -82,6 +82,10 @@ class CRM_Core_DAO extends DB_DataObject {
     QUERY_FORMAT_NO_QUOTES = 2,
 
     /**
+     * No serialization.
+     */
+    SERIALIZE_NONE = 0,
+    /**
      * Serialized string separated by and bookended with VALUE_SEPARATOR
      */
     SERIALIZE_SEPARATOR_BOOKEND = 1,

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1136,6 +1136,7 @@ class CRM_Core_SelectValues {
    */
   public static function fieldSerialization() {
     return [
+      CRM_Core_DAO::SERIALIZE_NONE => 'none',
       CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND => 'separator_bookend',
       CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED => 'separator_trimmed',
       CRM_Core_DAO::SERIALIZE_JSON => 'json',

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -407,6 +407,9 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
     ];
     $daoInfo = new ReflectionClass('CRM_Core_DAO');
     foreach ($daoInfo->getConstants() as $constant => $val) {
+      if ($constant === 'SERIALIZE_NONE') {
+        continue;
+      }
       if ($constant === 'SERIALIZE_JSON' || $constant === 'SERIALIZE_PHP') {
         $constants[] = [$val, array_merge($simpleData, $complexData)];
       }

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -73,10 +73,10 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     ];
 
     $customField = $this->callAPIAndDocument('custom_field', 'create', $params, __FUNCTION__, __FILE__);
-    $params['id'] = $customField['id'];
-    $customField = $this->callAPISuccess('custom_field', 'create', $params);
+    $customField['label'] = 'Name2';
+    $customFieldEdited = $this->callAPISuccess('custom_field', 'create', $customField);
 
-    $this->assertNotNull($customField['id']);
+    $this->assertNotNull($customFieldEdited['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the "'0' is not a valid option for field serialize" exception in APIv3.
0 is a valid, default value set in the DB.
This allows passing whole custom field data as a parameter
to the custom field update method without getting an exception.

https://lab.civicrm.org/dev/core/-/issues/2524