### PR TITLE
dev/core#3112 Clear caches to avoid error on upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -126,6 +126,9 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
       }
       CRM_Core_DAO::executeQuery("DELETE FROM civicrm_component WHERE name = 'CiviGrant'", [], TRUE, NULL, FALSE, FALSE);
     }
+    // Reload the civi cache here as 'table_name' may not be in the cached entities
+    // array generated in an earlier version retrieved via $cache->get('api4.entities.info', []);
+    Civi::cache('metadata')->flush();
 
     // There are existing records which should be managed by `civigrant`. To assign ownership, we need
     // placeholders in `civicrm_extension` and `civicrm_managed`.


### PR DESCRIPTION
Overview
-------------
Backports #22932 to 5.47


Technical Details
----------------------------------------

There may be a better place for this - but at least here is is clear to the api call that
can fail without it .... if the metadata cache is populated from an earlier version the
table_name key may not exist & hence the api call fails with no table_name
in the from clause
