### PR TITLE
During upgrade log that it ran the sql when there is just a sql file and no corresponding task

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -754,6 +754,7 @@ SET    version = '$version'
       $versionObject->$phpFunctionName($rev, $originalVer, $latestVer);
     }
     else {
+      $ctx->log->info("Upgrade DB to $rev: SQL");
       $upgrade->processSQL($rev);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Doesn't always log if SQL task ran.

Before
----------------------------------------
Doesn't log if SQL task ran when there is only a .tpl file and not a corresponding runSQL php task.

After
----------------------------------------
Logs

Technical Details
----------------------------------------


Comments
----------------------------------------
I checked and it doesn't double-log it if there is also a corresponding php task.
