### PR TITLE
dev/core#2122 - Upgrade scripts for revert event timezones

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -323,7 +323,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
         ],
       ],
       [
-        'version' => '5.48.beta1',
+        'version' => '5.48.beta2',
         'upgrade_descriptor' => ts('Revert time zone for Event dates'),
         'templates' => [
           ['name' => 'event_online_receipt', 'type' => 'html'],

--- a/CRM/Upgrade/Incremental/php/FiveFortyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortyEight.php
@@ -21,6 +21,42 @@
  */
 class CRM_Upgrade_Incremental_php_FiveFortyEight extends CRM_Upgrade_Incremental_Base {
 
+  use CRM_Upgrade_Incremental_php_TimezoneRevertTrait;
+
+  /**
+   * Compute any messages which should be displayed beforeupgrade.
+   *
+   * Note: This function is called iteratively for each incremental upgrade step.
+   * There must be a concrete step (eg 'X.Y.Z.mysql.tpl' or 'upgrade_X_Y_Z()').
+   *
+   * @param string $preUpgradeMessage
+   * @param string $rev
+   *   a version number, e.g. '4.4.alpha1', '4.4.beta3', '4.4.0'.
+   * @param null $currentVer
+   */
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
+    if ($rev === '5.48.beta2') {
+      $preUpgradeMessage .= $this->createEventTzPreUpgradeMessage();
+    }
+  }
+
+  /**
+   * Compute any messages which should be displayed after upgrade.
+   *
+   * Note: This function is called iteratively for each incremental upgrade step.
+   * There must be a concrete step (eg 'X.Y.Z.mysql.tpl' or 'upgrade_X_Y_Z()').
+   *
+   * @param string $postUpgradeMessage
+   *   alterable.
+   * @param string $rev
+   *   an intermediate version; note that setPostUpgradeMessage is called repeatedly with different $revs.
+   */
+  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev): void {
+    if ($rev === '5.48.beta2') {
+      $postUpgradeMessage .= $this->createEventTzPostUpgradeMessage();
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *
@@ -46,6 +82,17 @@ class CRM_Upgrade_Incremental_php_FiveFortyEight extends CRM_Upgrade_Incremental
     $this->addTask('Add "retry_interval" to "civicrm_queue"', 'addColumn', 'civicrm_queue', 'retry_interval',
       "int NULL COMMENT 'Number of seconds to wait before retrying a failed execution.'"
     );
+  }
+
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_5_48_beta2($rev): void {
+    // $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addEventTzTasks();
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
+++ b/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Circa v5.47.x-5.48.x, the `civicrm_event.event_tz` columns were introduced. But there were still
+ * significant issues.
+ *
+ * This rollsback the schema changes. The same logic should be used for various upgrade-paths
+ * involving 5.47.x or 5.48.x, so it helps to use a trait shared by them.
+ */
+trait CRM_Upgrade_Incremental_php_TimezoneRevertTrait {
+
+  public function createEventTzPreUpgradeMessage(): string {
+    if (self::areEventsUsingTimestamp() && self::areThereAnyCiviEvents()) {
+      return '<div><span>' . ts('CiviEvent Timezones') . '</span><ul><li>' . ts('It is important that you run this upgrade under a user account that has the same CMS timezone setting as the user account that originally ran the upgrade to 5.47. Your timezone is %1. <a %2>(Learn more...)</a>', [
+        1 => CRM_Core_Config::singleton()->userSystem->getTimeZoneString(),
+        2 => 'target="_blank" href="https://civicrm.org/redirect/event-timezone-5.47"',
+      ]) . '</li></ul></div>';
+    }
+    return '';
+  }
+
+  public function createEventTzPostUpgradeMessage(): string {
+    // Note that setPostUpgradeMessage is called at the start of the step,
+    // before its queued tasks run, so we are examining the database
+    // before updating the fields.
+    if (self::areThereAnyCiviEvents() && self::areEventsUsingTimestamp()) {
+      return '<div><span>' . ts('CiviEvent Timezones') . '</span><ul><li>' . ts('Please check your CiviEvents for the correct time. <a %1>(Learn more...)</a>', [1 => 'target="_blank" href="https://civicrm.org/redirect/event-timezone-5.47"']) . '</li></ul></div>';
+    }
+    return '';
+  }
+
+  public function addEventTzTasks(): void {
+    if (self::areEventsUsingTimestamp()) {
+      $this->addTask('Add temporary backup start_date to civicrm_event', 'addColumn', 'civicrm_event', 'start_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+      $this->addTask('Add temporary backup end_date to civicrm_event', 'addColumn', 'civicrm_event', 'end_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+      $this->addTask('Add temporary backup registration_start_date to civicrm_event', 'addColumn', 'civicrm_event', 'registration_start_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+      $this->addTask('Add temporary backup registration_end_date to civicrm_event', 'addColumn', 'civicrm_event', 'registration_end_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+      $this->addTask('Fill Backup Event Dates', 'fillBackupEventDates');
+      $this->addTask('Revert Event Dates', 'revertEventDates');
+    }
+  }
+
+  /**
+   * dev/core#2122 - keep a copy of converted dates
+   * In theory we could skip this step if logging is enabled, but (a) people
+   * might turn off logging before running upgrades, and (b) there may not be a
+   * complete record anyway. People can drop the new column if they don't need
+   * it.
+   * @param \CRM_Queue_TaskContext $ctx
+   * @return bool
+   */
+  public static function fillBackupEventDates(CRM_Queue_TaskContext $ctx): bool {
+    // We only run if the field is timestamp, so don't need to check about that.
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_event SET start_date_ts_bak = start_date, end_date_ts_bak = end_date, registration_start_date_ts_bak = registration_start_date, registration_end_date_ts_bak = registration_end_date');
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_event CHANGE COLUMN event_tz event_tz_bak text NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+    return TRUE;
+  }
+
+  /**
+   * dev/core#2122 - undo timestamp conversion from 5.47
+   * @param \CRM_Queue_TaskContext $ctx
+   * @return bool
+   */
+  public static function revertEventDates(CRM_Queue_TaskContext $ctx): bool {
+    // We only run if the field is timestamp, so don't need to check about that.
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `start_date` datetime DEFAULT NULL COMMENT 'Date and time that event starts.'");
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `end_date` datetime DEFAULT NULL COMMENT 'Date and time that event ends. May be NULL if no defined end date/time'");
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `registration_start_date` datetime DEFAULT NULL COMMENT 'Date and time that online registration starts.'");
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `registration_end_date` datetime DEFAULT NULL COMMENT 'Date and time that online registration ends.'");
+    return TRUE;
+  }
+
+  /**
+   * Check if civicrm_event start_date is a timestamp.
+   * @return bool
+   */
+  private static function areEventsUsingTimestamp(): bool {
+    $dao = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM civicrm_event LIKE 'start_date'");
+    if ($dao->fetch()) {
+      return (strtolower($dao->Type) === 'timestamp');
+    }
+    return FALSE;
+  }
+
+  /**
+   * Are there any events in the system?
+   * @return bool
+   */
+  private static function areThereAnyCiviEvents(): bool {
+    return (bool) CRM_Core_DAO::singleValueQuery('SELECT COUNT(id) FROM civicrm_event');
+  }
+
+  /**
+   * Return the event_tz that is used most often. The idea being that if they
+   * didn't change too much after upgrading to 5.47 this will be the timezone
+   * of the account that was used to do the original upgrade to 5.47.
+   * @return string
+   */
+  private static function getMajorityTimezone(): string {
+    $dao = CRM_Core_DAO::executeQuery('SELECT event_tz, COUNT(event_tz) AS cnt FROM civicrm_event GROUP BY event_tz ORDER BY COUNT(event_tz) DESC LIMIT 1');
+    if ($dao->fetch()) {
+      return $dao->event_tz;
+    }
+    // This shouldn't happen, because our function only gets called if there is
+    // at least one event in the system.
+    return '';
+  }
+
+}

--- a/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
+++ b/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
@@ -95,10 +95,20 @@ trait CRM_Upgrade_Incremental_php_TimezoneRevertTrait {
    */
   public static function revertEventDates(CRM_Queue_TaskContext $ctx): bool {
     // We only run if the field is timestamp, so don't need to check about that.
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `start_date` datetime DEFAULT NULL COMMENT 'Date and time that event starts.'");
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `end_date` datetime DEFAULT NULL COMMENT 'Date and time that event ends. May be NULL if no defined end date/time'");
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `registration_start_date` datetime DEFAULT NULL COMMENT 'Date and time that online registration starts.'");
-    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_event` MODIFY COLUMN `registration_end_date` datetime DEFAULT NULL COMMENT 'Date and time that online registration ends.'");
+
+    // The original 5.47.alpha1 upgrade was executed with SQL helpers in CRM_Utils_File, which use
+    // a separate DSN/session. We need to use the same interface so that the `@@time_zone` is consistent
+    // with the prior update.
+
+    $sql = "ALTER TABLE `civicrm_event`
+      MODIFY COLUMN `start_date` datetime DEFAULT NULL COMMENT 'Date and time that event starts.',
+      MODIFY COLUMN `end_date` datetime DEFAULT NULL COMMENT 'Date and time that event ends. May be NULL if no defined end date/time',
+      MODIFY COLUMN `registration_start_date` datetime DEFAULT NULL COMMENT 'Date and time that online registration starts.',
+      MODIFY COLUMN `registration_end_date` datetime DEFAULT NULL COMMENT 'Date and time that online registration ends.';";
+
+    $upgrade = new CRM_Upgrade_Form();
+    $upgrade->source($sql, TRUE);
+
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
+++ b/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
@@ -22,11 +22,9 @@ trait CRM_Upgrade_Incremental_php_TimezoneRevertTrait {
     if (self::areEventsUsingTimestamp() && self::areThereAnyCiviEvents()) {
       $timezoneStats = $this->getTimezoneStats();
       return '<div><span>' . ts('CiviEvent Timezone Rollback') . '</span><ul><li>'
-        . ts('The upgrade will rollback recent changes involving CiviEvent timezones.')
+        . ts('CiviEvent v5.47.0 briefly introduced new timezone functionality. This will be removed, and times will be converted back to their old format.')
         . '</li><li>'
-        . ts('This requires converting CiviEvent times. After conversion, <em>CiviEvent times may be skewed</em>.')
-        . '</li><li>'
-        . ts('To prevent or fix skewed times, please review <a %1>CiviEvent v5.47 Timezone Notice</a>.', [
+        . ts('Unfortunately, <em>CiviEvent times may be inaccurate</em>. To prevent or fix inaccuracies, please review <a %1>CiviEvent v5.47 Timezone Notice</a>.', [
           1 => 'target="_blank" href="https://civicrm.org/redirect/event-timezone-5.47"',
         ])
         . '</li><li>'

--- a/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
+++ b/CRM/Upgrade/Incremental/php/TimezoneRevertTrait.php
@@ -63,13 +63,22 @@ trait CRM_Upgrade_Incremental_php_TimezoneRevertTrait {
 
   public function addEventTzTasks(): void {
     if (self::areEventsUsingTimestamp()) {
-      $this->addTask('Add temporary backup start_date to civicrm_event', 'addColumn', 'civicrm_event', 'start_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
-      $this->addTask('Add temporary backup end_date to civicrm_event', 'addColumn', 'civicrm_event', 'end_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
-      $this->addTask('Add temporary backup registration_start_date to civicrm_event', 'addColumn', 'civicrm_event', 'registration_start_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
-      $this->addTask('Add temporary backup registration_end_date to civicrm_event', 'addColumn', 'civicrm_event', 'registration_end_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
-      $this->addTask('Backup CiviEvent times', 'fillBackupEventDates');
-      $this->addTask('Revert CiviEvent times', 'revertEventDates');
-      $this->addTask('Adapt CiviEvent times', 'convertModifiedEvents');
+      $actions = getenv('CIVICRM_TZ_REVERT')
+        ? explode(',', getenv('CIVICRM_TZ_REVERT'))
+        : ['backup', 'revert', 'adapt'];
+      if (in_array('backup', $actions)) {
+        $this->addTask('Add temporary backup start_date to civicrm_event', 'addColumn', 'civicrm_event', 'start_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+        $this->addTask('Add temporary backup end_date to civicrm_event', 'addColumn', 'civicrm_event', 'end_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+        $this->addTask('Add temporary backup registration_start_date to civicrm_event', 'addColumn', 'civicrm_event', 'registration_start_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+        $this->addTask('Add temporary backup registration_end_date to civicrm_event', 'addColumn', 'civicrm_event', 'registration_end_date_ts_bak', "timestamp NULL DEFAULT NULL COMMENT 'For troubleshooting upgrades post 5.47. Can drop this column if no issues.'");
+        $this->addTask('Backup CiviEvent times', 'fillBackupEventDates');
+      }
+      if (in_array('revert', $actions)) {
+        $this->addTask('Revert CiviEvent times', 'revertEventDates');
+      }
+      if (in_array('adapt', $actions)) {
+        $this->addTask('Adapt CiviEvent times', 'convertModifiedEvents');
+      }
     }
   }
 

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-02-11</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-01-02</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.47</ver>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-11-11</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.47</ver>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-05-23</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.39</ver>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-12</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.32</ver>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-03</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-07</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-27</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.30</ver>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-05</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-07-21</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-07-25</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:hidden</tag>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-06-12</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-23</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-13</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-03</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-01-06</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-28</releaseDate>
-  <version>5.48.beta1</version>
+  <version>5.48.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -2935,7 +2935,7 @@ UNLOCK TABLES;
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
 INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES
- (1,'Default Domain Name',NULL,'5.48.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+ (1,'Default Domain Name',NULL,'5.48.beta2',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -908,4 +908,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.48.beta1';
+UPDATE civicrm_domain SET version = '5.48.beta2';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.48.beta1</version_no>
+  <version_no>5.48.beta2</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------
This goes along with PR https://github.com/civicrm/civicrm-core/pull/22930 and is not really standalone, but I've separated it out since it is the most likely part to get merge-conflicted or need some tweaking.

Note the steps are re-runnable since it won't do anything if the field is datetime. For this to all work it also needs a backport of the 5.47 parts of this PR into the 5.47.3 branch. Then:

* <5.47 to 5.47.3 - it would NOT run the 5.47.3 backport script because the field will still be datetime because the other PR removes the 5.47.alpha1 steps. It's like nothing ever happened.
* <5.47 to 5.48 - it would run neither script for the same reasons
* 5.47.1 to 5.47.3 - it would run the 5.47.3 script
* 5.47.1 to 5.48 - it would run the 5.47.3 script and NOT run the 5.48.beta1 script because when it hits the 5.48 script the field will be datetime.
* 5.47.3 to 5.48 - it would not run the 5.48.beta1 script because the field will be datetime at that point (for both upgrades and new installs of 5.47.3)

I've done some testing. To realistically test the "upgrade-x-to-5.47.3-and-stop-there" path you would use the 5.47 backport at https://github.com/civicrm/civicrm-core/pull/22946

Before
----------------------------------------


After
----------------------------------------


Technical Details
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2122

Comments
----------------------------------------
If you had upgraded to 5.47, then for troubleshooting purposes it creates some backup fields with what the values were before "fixing", as suggested in chat.
