### PR TITLE
Copy Clear value in batch update process for radio button field

### DIFF
--- a/templates/CRM/common/batchCopy.tpl
+++ b/templates/CRM/common/batchCopy.tpl
@@ -36,8 +36,15 @@
       // select, checkbox, radio, date fields, text, textarea, multi-select
       // wysiwyg editor, advanced multi-select ( to do )
       if ( elementType == 'radio' ) {
-        firstElementValue = elementId.filter(':checked').eq(0).val();
-        elementId.filter("[value='" + firstElementValue + "']").prop("checked",true).change();
+        var firstElementId    = $('.crm-copy-fields tr:first-child [name^="field["][name*="[' + fname +']"][type!=hidden]');
+        firstElementValue = firstElementId.filter(':checked').eq(0).val();
+        // if radio button is uncheck then unset all the fields.
+        if (typeof firstElementValue == 'undefined') {
+          elementId.prop("checked", false).change().siblings('a.crm-clear-link').trigger('click');
+        }
+        else {
+          elementId.filter("[value='" + firstElementValue + "']").prop("checked", true).change();
+        }
       }
       else if ( elementType == 'checkbox' ) {
         // handle checkbox


### PR DESCRIPTION
Overview
----------------------------------------
Unable to select clear value for all contact using copy to all functionality under batch update contact using profile.
Before

----------------------------------------
If you profile contain radio button and same profile is used in contact batch update process.
Radio button field dispaly with clear button.  If Admin do not want to update or touch these field , so you click  clear button and click on copy to all. Here functionality does not work.


https://user-images.githubusercontent.com/377735/158135311-ff1ddf54-7fb8-4e04-b5b4-566b95fc91dc.mp4


After
----------------------------------------
You can copy clear value to all rows.
