### PR TITLE
Optimise isCustomDateField

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -4762,19 +4762,20 @@ civicrm_relationship.start_date > {$today}
    * @param $fieldName
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws Exception
    */
   public static function isCustomDateField($fieldName) {
     if (($customFieldID = CRM_Core_BAO_CustomField::getKeyID($fieldName)) == FALSE) {
       return FALSE;
     }
     try {
-      $customFieldDataType = civicrm_api3('CustomField', 'getvalue', ['id' => $customFieldID, 'return' => 'data_type']);
+      $customFieldData = CRM_Core_BAO_CustomField::getFieldObject($customFieldID);
+      $customFieldDataType = $customFieldData->data_type;
       if ('Date' == $customFieldDataType) {
         return TRUE;
       }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (Exception $e) {
     }
     return FALSE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
In environments where there's a big number of smartgroups and some of them involve custom fields based on date, there's an api3 call that causes a bit of delay when the smartgroups are rebuilding their criteria.

Before
----------------------------------------
On an environment with more than 300 smartgroups (mixed criteria), I was getting an average of 250 seconds for the smartgroups to rebuild themselves (approx 100 smartgroups)

After
----------------------------------------
Using this patch, I was able to get an average of 20 second less on each pass (approx 220 seconds total)

Technical Details
----------------------------------------
We were using `$customFieldDataType = civicrm_api3('CustomField', 'getvalue', ['id' => $customFieldID, 'return' => 'data_type']);` to get the data type.
Suggested use of `$customFieldData = CRM_Core_BAO_CustomField::getFieldObject($customFieldID);` instead.

Comments
----------------------------------------
Assuming that we are slowing replacing APIv3, should we head this way using these functions or should we be using APIv4 instead?
