### PR TITLE
[REF] Rename SoftDeleteEntity -> SoftDeleteActionTrait

### DIFF
--- a/Civi/Api4/Action/Contact/Delete.php
+++ b/Civi/Api4/Action/Contact/Delete.php
@@ -17,7 +17,7 @@ namespace Civi\Api4\Action\Contact;
  * @inheritDoc
  */
 class Delete extends \Civi\Api4\Generic\DAODeleteAction {
-  use \Civi\Api4\Generic\Traits\SoftDeleteEntity;
+  use \Civi\Api4\Generic\Traits\SoftDeleteActionTrait;
 
   /**
    * @param $items

--- a/Civi/Api4/Generic/Traits/SoftDeleteActionTrait.php
+++ b/Civi/Api4/Generic/Traits/SoftDeleteActionTrait.php
@@ -12,11 +12,11 @@
 namespace Civi\Api4\Generic\Traits;
 
 /**
- * This trait is used by entities with a "move to trash" option.
+ * This trait is used by delete actions with a "move to trash" option.
  * @method $this setUseTrash(bool $useTrash) Pass FALSE to force delete and bypass trash
  * @method bool getUseTrash()
  */
-trait SoftDeleteEntity {
+trait SoftDeleteActionTrait {
 
   /**
    * Should $ENTITY be moved to the trash instead of permanently deleted?


### PR DESCRIPTION
Overview
----------------------------------------
2nd attempt to correctly name this trait.

Before
----------------------------------------
In #22662 it was renamed to `SoftDeleteEntity` but that's incorrect, this trait is used by action classes not entity classes.

After
----------------------------------------
Now named `SoftDeleteActionTrait` for consistency with other action traits, e.g. `ArrayQueryActionTrait`, `DAOActionTrait`, `CustomValueActionTrait`.
