### PR TITLE
Fixed fatal error on edit grant

### DIFF
--- a/ext/civigrant/CRM/Grant/Form/Grant.php
+++ b/ext/civigrant/CRM/Grant/Form/Grant.php
@@ -92,7 +92,7 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
    */
   public function setDefaultValues() {
 
-    $defaults = parent::setDefaultValues();
+    $defaults = parent::setDefaultValues() ?? [];
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       return $defaults;


### PR DESCRIPTION
Overview
----------------------------------------
TypeError: Argument 2 passed to CRM_Grant_BAO_Grant::retrieve() must be of the type array, null given, called in /var/www/html/drupal7/sites/all/modules/civicrm/ext/civigrant/CRM/Grant/Form/Grant.php on line 106 in CRM_Grant_BAO_Grant::retrieve() (line 75 of /var/www/html/drupal7/sites/all/modules/civicrm/ext/civigrant/CRM/Grant/BAO/Grant.php).