### PR TITLE
Return array for setdefaults

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -611,11 +611,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   /**
    * This virtual function is used to set the default values of various form elements.
    *
-   * @return array|NULL
+   * @return array
    *   reference to the array of default values
    */
   public function setDefaultValues() {
-    return NULL;
+    return [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
TypeError: Argument 2 passed to CRM_Grant_BAO_Grant::retrieve() must be of the type array, null given, called in /var/www/html/drupal7/sites/all/modules/civicrm/ext/civigrant/CRM/Grant/Form/Grant.php on line 106 in CRM_Grant_BAO_Grant::retrieve() (line 75 of /var/www/html/drupal7/sites/all/modules/civicrm/ext/civigrant/CRM/Grant/BAO/Grant.php).

Alternate for https://github.com/civicrm/civicrm-core/pull/22947