### PR TITLE
Contribution Pages: alias userID to contactID, fixes org renewal with checksum and mid

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -128,6 +128,10 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   public $_contactID;
 
+  /**
+   * Kept only for backwards compatibility. Alias for _contactID
+   * @var int
+   */
   protected $_userID;
 
   /**
@@ -230,22 +234,20 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @throws \Exception
    */
   public function preProcess() {
-
     // current contribution page id
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     $this->_ccid = CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
+
     if (!$this->_id) {
       // seems like the session is corrupted and/or we lost the id trail
       // lets just bump this to a regular session error and redirect user to main page
       $this->controller->invalidKeyRedirect();
     }
+
     $this->_emailExists = $this->get('emailExists');
-
-    // this was used prior to the cleverer this_>getContactID - unsure now
-    $this->_userID = CRM_Core_Session::getLoggedInContactID();
-
-    $this->_contactID = $this->_membershipContactID = $this->getContactID();
+    $this->_userID = $this->_contactID = $this->_membershipContactID = $this->getContactID();
     $this->_mid = NULL;
+
     if ($this->_contactID) {
       $this->_mid = CRM_Utils_Request::retrieve('mid', 'Positive', $this);
       if ($this->_mid) {


### PR DESCRIPTION
Overview
----------------------------------------

Organisational membership renewal is a bit of a challenge. One can send a Scheduled Reminder to the individual related to an organisation, with the checksum/cid of the individual, and if their relationship to the org allows it, they can view the organisation and renew on-behalf.

However, the contribution page does not show any information about the membership being renewed.

Form have a way around that: we can pass the little-known `mid` URL argument (membership ID), but it only works if the user is logged-in (and not with a checksum). This [membershiprenewallink](https://lab.civicrm.org/extensions/membershiprenewallink/) extension by Jaap is pretty useful for that.

Looking at the code, there is a `userID` and `contactID` var, with a mysterious comment about it:

> "this was used prior to the cleverer this_>getContactID - unsure now"

I can't see a good reason to distinguish between a logged-in user, and a checksum user.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/158458140-d530b87e-fff4-4a7f-b02b-a686c81aa8e7.png)

Passing the `mid` as an URL argument will cause a fatal error, because it checks against the `$this->_contactID`, which is NULL if we used a checksum.

After
----------------------------------------

Using the `mid` in the URL, we can now select the membership to renew, and everything works as expected:

![image](https://user-images.githubusercontent.com/254741/158458380-9a507662-09bd-4e1e-94e5-daa3fdd2ca00.png)

