### PR TITLE
Search Kit - Auto-enable during normal installation

### DIFF
--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ *
+ * This is an example plugin which manipulates the installation options.
+ *
+ * Note: The filename `Example.disabled.php` indicates that the example is
+ * a disabled. A real plugin must end in `*.civi-setup.php`.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.init', function (\Civi\Setup\Event\InitEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
+
+    // Activate some extensions during installation.
+    $e->getModel()->extensions[] = 'org.civicrm.search_kit';
+
+  });

--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -2,10 +2,7 @@
 /**
  * @file
  *
- * This is an example plugin which manipulates the installation options.
- *
- * Note: The filename `Example.disabled.php` indicates that the example is
- * a disabled. A real plugin must end in `*.civi-setup.php`.
+ * Choose some extensions to auto-install.
  */
 
 if (!defined('CIVI_SETUP')) {
@@ -16,7 +13,6 @@ if (!defined('CIVI_SETUP')) {
   ->addListener('civi.setup.init', function (\Civi\Setup\Event\InitEvent $e) {
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
 
-    // Activate some extensions during installation.
     $e->getModel()->extensions[] = 'org.civicrm.search_kit';
 
   });


### PR DESCRIPTION
Overview
----------------------------------------

Enables the extension "Search Kit" during installation.

Before
----------------------------------------

Not enabled

After
----------------------------------------

Enabled

Technical Details
----------------------------------------

This specifically goes through `civicrm-setup`. Unlike the legacy installers (which use `sql/civicrm_*.mysql`), the `civicrm-setup` can run the normal extension install routing (`hook_install`, etc).

Related resources:

* Example Plugin: https://github.com/totten/civicrm-core/blob/ea24d94a8b4ce29d0868dc3b6f9ee30c6a564b77/setup/plugins/init/Example.disabled.php
* Broad Issue (*Migration to civicrm-setup*): https://lab.civicrm.org/dev/core/-/issues/1615
* Many Words: https://docs.civicrm.org/dev/en/latest/framework/setup/

I wanted to `r-run` this on a local `civibuild`/`wp-demo` site. But if you want to manually test out installers, then it helps to disable auto-installers for manually testing the installer. Here was my process:

* Hack the local `buildkit/app/config/wp-demo/install.sh` to turn all the stuff which installs+configures Civi
* Run `civibuild reinstall wpmaster`
* Login. Navigate to WordPress "Plugins" page.
* Perform ordinary GUI install. 