### PR TITLE
Notice fixes in advanced search

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -55,6 +55,10 @@ class CRM_Contact_Form_Search_Criteria {
       }
     }
 
+    // Suppress e-notices for tag fields if not set...
+    $form->addOptionalQuickFormElement('tag_types_text');
+    $form->addOptionalQuickFormElement('tag_set');
+    $form->addOptionalQuickFormElement('all_tag_types');
     if ($form->_searchOptions['tags']) {
       // multiselect for categories
       $contactTags = CRM_Core_BAO_Tag::getTags();
@@ -82,7 +86,7 @@ class CRM_Contact_Form_Search_Criteria {
           $showAllTagTypes = TRUE;
         }
       }
-      $tagTypesText = implode(" or ", $tagsTypes);
+      $tagTypesText = implode(' or ', $tagsTypes);
       if ($showAllTagTypes) {
         $form->add('checkbox', 'all_tag_types', ts('Include tags used for %1', [1 => $tagTypesText]));
         $form->add('hidden', 'tag_types_text', $tagTypesText);

--- a/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
@@ -18,7 +18,6 @@
           {$field.label}
           {if !empty($fieldSpec.help)}
             {assign var=help value=$fieldSpec.help}
-            {capture assign=helpFile}{if $fieldSpec.help}{$fieldSpec.help}{else}''{/if}{/capture}
             {help id=$help.id file=$help.file}
           {/if}
           <br />


### PR DESCRIPTION
Overview
----------------------------------------
Fix smarty notices

Before
----------------------------------------
Smarty notices in grumpy mode
![image](https://user-images.githubusercontent.com/336308/158699275-bd93d35c-c374-47a8-96ed-59c5fd2df10d.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/158699054-92974e82-6dcc-440f-92cd-996fbeb083a2.png)

Help still works

![image](https://user-images.githubusercontent.com/336308/158699093-f2357cea-7884-4860-b074-b0cbddaa6b88.png)

Technical Details
----------------------------------------
This assign is never actually used anywhere
` {capture assign=helpFile}{if $fieldSpec.help}{$fieldSpec.help}{else}''{/if}{/capture}`
I think it was a good intention - we can see by the surrounding lines that `$help` should be an array

Comments
----------------------------------------