### PR TITLE
Afform - reset managed entities when deleting a dashlet

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -667,6 +667,7 @@ class CRM_Core_ManagedEntities {
 
   protected function loadManagedEntityActions(): void {
     $managedEntities = Managed::get(FALSE)->addSelect('*')->execute();
+    $this->managedActions = [];
     foreach ($managedEntities as $managedEntity) {
       $key = "{$managedEntity['module']}_{$managedEntity['name']}_{$managedEntity['entity_type']}";
       // Set to 'delete' - it will be overwritten below if it is to be updated.

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Civi\Api4\Action\Afform;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * @inheritDoc
+ * @package Civi\Api4\Action\Afform
+ */
+class Revert extends \Civi\Api4\Generic\BasicBatchAction {
+
+  /**
+   * @var bool
+   */
+  private $flushManaged = FALSE;
+
+  /**
+   * @var bool
+   */
+  private $flushMenu = FALSE;
+
+  /**
+   * Revert every record, and flush caches at the end.
+   *
+   * @inheritDoc
+   */
+  protected function processBatch(Result $result, array $items) {
+    parent::processBatch($result, $items);
+
+    // We may have changed list of files covered by the cache.
+    _afform_clear();
+
+    if ($this->flushManaged) {
+      // FIXME: more targeted reconciliation
+      \CRM_Core_ManagedEntities::singleton()->reconcile();
+    }
+    if ($this->flushMenu) {
+      \CRM_Core_Menu::store();
+    }
+  }
+
+  /**
+   * Revert (delete) a record.
+   *
+   * @inheritDoc
+   */
+  protected function doTask($item) {
+    /** @var \CRM_Afform_AfformScanner $scanner */
+    $scanner = \Civi::service('afform_scanner');
+    $files = [
+      \CRM_Afform_AfformScanner::METADATA_FILE,
+      \CRM_Afform_AfformScanner::LAYOUT_FILE,
+    ];
+
+    foreach ($files as $file) {
+      $metaPath = $scanner->createSiteLocalPath($item['name'], $file);
+      if (file_exists($metaPath)) {
+        if (!@unlink($metaPath)) {
+          throw new \API_Exception("Failed to remove afform overrides in $file");
+        }
+      }
+    }
+
+    $original = (array) $scanner->getMeta($item['name']);
+
+    // If the dashlet setting changed, managed entities must be reconciled
+    if (
+      (empty($item['is_dashlet']) !== empty($original['is_dashlet'])) ||
+      ($item['is_dashlet'] && ($item['title'] ?? '') !== ($original['title'] ?? ''))
+    ) {
+      $this->flushManaged = TRUE;
+    }
+
+    // If the server_route changed, reset menu cache
+    if (($item['server_route'] ?? '') !== ($original['server_route'] ?? '')) {
+      $this->flushMenu = TRUE;
+    }
+
+    return $item;
+  }
+
+  /**
+   * Adds extra return params so caches can be conditionally flushed.
+   *
+   * @return string[]
+   */
+  protected function getSelect() {
+    return ['name', 'title', 'is_dashlet', 'server_route'];
+  }
+
+}

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -2,7 +2,6 @@
 
 namespace Civi\Api4;
 
-use Civi\Api4\Generic\BasicBatchAction;
 use Civi\Api4\Generic\BasicGetFieldsAction;
 
 /**
@@ -105,33 +104,11 @@ class Afform extends Generic\AbstractEntity {
 
   /**
    * @param bool $checkPermissions
-   * @return Generic\BasicBatchAction
+   * @return Action\Afform\Revert
    */
   public static function revert($checkPermissions = TRUE) {
-    return (new BasicBatchAction('Afform', __FUNCTION__, function($item, BasicBatchAction $action) {
-      $scanner = \Civi::service('afform_scanner');
-      $files = [
-        \CRM_Afform_AfformScanner::METADATA_FILE,
-        \CRM_Afform_AfformScanner::LAYOUT_FILE,
-      ];
-
-      foreach ($files as $file) {
-        $metaPath = $scanner->createSiteLocalPath($item['name'], $file);
-        if (file_exists($metaPath)) {
-          if (!@unlink($metaPath)) {
-            throw new \API_Exception("Failed to remove afform overrides in $file");
-          }
-        }
-      }
-
-      // We may have changed list of files covered by the cache.
-      _afform_clear();
-
-      // FIXME if `server_route` changes, then flush the menu cache.
-      // FIXME if asset-caching is enabled, then flush the asset cache
-
-      return $item;
-    }))->setCheckPermissions($checkPermissions);
+    return (new Action\Afform\Revert('Afform', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -65,19 +65,18 @@ trait AfformSaveTrait {
       return ($item[$field] ?? NULL) !== ($orig[$field] ?? NULL);
     };
 
-    if ($isChanged('is_dashlet')) {
-      // FIXME: more targetted reconciliation
-      \CRM_Core_ManagedEntities::singleton()->reconcile();
-    }
-    elseif (array_key_exists('is_dashlet', (array) $orig) && $orig['is_dashlet'] && $isChanged('title')) {
-      // FIXME: more targetted reconciliation
+    // If the dashlet setting changed, managed entities must be reconciled
+    if (
+      $isChanged('is_dashlet') ||
+      (!empty($meta['is_dashlet']) && $isChanged('title'))
+    ) {
+      // FIXME: more targeted reconciliation
       \CRM_Core_ManagedEntities::singleton()->reconcile();
     }
 
     // Right now, permission-checks are completely on-demand.
     if ($isChanged('server_route') /* || $isChanged('permission') */) {
       \CRM_Core_Menu::store();
-      \CRM_Core_BAO_Navigation::resetNavigation();
     }
 
     $item['module_name'] = _afform_angular_module_name($item['name'], 'camel');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3122](https://lab.civicrm.org/dev/core/-/issues/3122)

Before
----------------------------------------
Deleting an afform does not delete the related dashlet

After
----------------------------------------
Now it does

Technical Details
----------------------------------------
It wasn't as simple as adding a cache clear in the revert function, because if multiple afforms were being reverted at once, that would be very slow clearing the cache each time. So I refactored the `BasicBatchAction` to allow the cache to be cleared after the whole batch is processed.