### PR TITLE
(dev/core#2122) CiviEvent - Add pre-upgrade warning

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -35,7 +35,7 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
     if ($rev === '5.47.alpha1' && version_compare($currentVer, '5.47', '<')) {
       // Note: This warning should only exist within a few patch releases of 5.47. Do not merge-forward.
-      $prose = ts('<strong>CiviEvent users may have migration problems with v%1.</strong> CiviEvent users should consider v5.46 instead. <a %2>More information</a>', [
+      $prose = ts('<strong>CiviEvent users may have migration problems with v%1.</strong> CiviEvent users should consider v5.46 instead. <a %2>(Learn more...)</a>', [
         1 => CRM_Utils_System::version(),
         2 => 'target="_blank" href="https://civicrm.org/redirect/event-timezone-5.47"',
       ]);

--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -33,6 +33,14 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
    * @param null $currentVer
    */
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
+    if ($rev === '5.47.alpha1' && version_compare($currentVer, '5.47', '<')) {
+      // Note: This warning should only exist within a few patch releases of 5.47. Do not merge-forward.
+      $prose = ts('<strong>CiviEvent users may have migration problems with v%1.</strong> CiviEvent users should consider v5.46 instead. <a %2>More information</a>', [
+        1 => CRM_Utils_System::version(),
+        2 => 'target="_blank" href="https://civicrm.org/redirect/event-timezone-5.47"',
+      ]);
+      $preUpgradeMessage = '<p>' . $prose . '</p>' . $preUpgradeMessage;
+    }
     if ($rev === '5.47.alpha1') {
       $count = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact WHERE preferred_mail_format != "Both"');
       if ($count) {

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.23</ver>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-02-11</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-11-11</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.47</ver>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-05-23</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.39</ver>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-12</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.32</ver>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-03</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-07</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-27</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.30</ver>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-05</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-07-21</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-07-25</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:hidden</tag>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-06-12</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-23</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-13</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-03</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-01-06</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.38</ver>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-28</releaseDate>
-  <version>5.47.1</version>
+  <version>5.47.2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -2941,7 +2941,7 @@ UNLOCK TABLES;
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
 INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES
- (1,'Default Domain Name',NULL,'5.47.1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+ (1,'Default Domain Name',NULL,'5.47.2',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -909,4 +909,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.47.1';
+UPDATE civicrm_domain SET version = '5.47.2';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.47.1</version_no>
+  <version_no>5.47.2</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------

Add pre-upgrade warning about the current CiviEvent/timezone issues. 

cc @agh1 @KarinG @demeritcowboy @seamuslee001 

https://lab.civicrm.org/dev/core/-/issues/2122

After
----------------------------------------

<img width="1243" alt="Screen Shot 2022-03-16 at 5 55 50 PM" src="https://user-images.githubusercontent.com/1336047/158715343-7284186a-426c-44ba-9960-b096ffe1cda6.png">
