### PR TITLE
Afform - Fix saving and editing entity blocks

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -193,7 +193,7 @@
       };
 
       this.getEntityDefn = function(entity) {
-        if (entity.type === 'Contact' && entity.data.contact_type) {
+        if (entity.type === 'Contact' && entity.data && entity.data.contact_type) {
           return editor.meta.entities[entity.data.contact_type];
         }
         return editor.meta.entities[entity.type];
@@ -203,12 +203,15 @@
       this.scrollToEntity = function(entityName) {
         var $canvas = $('#afGuiEditor-canvas-body'),
           $entity = $('.af-gui-container-type-fieldset[data-entity="' + entityName + '"]').first(),
+          scrollValue, maxScroll;
+        if ($entity.length) {
           // Scrolltop value needed to place entity's fieldset at top of canvas
-          scrollValue = $canvas.scrollTop() + ($entity.offset().top - $canvas.offset().top),
+          scrollValue = $canvas.scrollTop() + ($entity.offset().top - $canvas.offset().top);
           // Maximum possible scrollTop (height minus contents height, adjusting for padding)
           maxScroll = $('#afGuiEditor-canvas-body > *').height() - $canvas.height() + 20;
-        // Exceeding the maximum scrollTop breaks the animation so keep it under the limit
-        $canvas.animate({scrollTop: scrollValue > maxScroll ? maxScroll : scrollValue}, 500);
+          // Exceeding the maximum scrollTop breaks the animation so keep it under the limit
+          $canvas.animate({scrollTop: scrollValue > maxScroll ? maxScroll : scrollValue}, 500);
+        }
       };
 
       this.getAfform = function() {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -242,15 +242,14 @@
           layout: ctrl.node['#children']
         };
         if (ctrl.join) {
-          model.join = ctrl.join;
+          model.join_entity = ctrl.join;
         }
         if ($scope.block && $scope.block.original) {
           model.title = afGui.meta.blocks[$scope.block.original].title;
           model.name = afGui.meta.blocks[$scope.block.original].name;
-          model.block = afGui.meta.blocks[$scope.block.original].block;
         }
         else {
-          model.block = ctrl.getFieldEntityType();
+          model.entity_type = ctrl.getFieldEntityType();
         }
         dialogService.open('saveBlockDialog', '~/afGuiEditor/saveBlock.html', model, options)
           .then(function(block) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3120](https://lab.civicrm.org/dev/core/-/issues/3120)
Regression caused by #21218
Also fixes undefined variable errors when editing a block.

Before
----------------------------------------
Unable to save a block for an entity. Editor has console errors when editing blocks.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
This was caused by #21218 renaming a block property, but the "Save block" popup did not get updated.