### PR TITLE
(Regression) - fixed tags form field display on New/Edit contact screen

### DIFF
--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -14,17 +14,18 @@
 {/if}
     <table class="form-layout-compressed{if $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
       <tr>
-        {if $form.tag}
-          <td>
+        <td>
+          {if $form.tag}
             <div class="crm-section tag-section">
               {if !empty($title)}{$form.tag.label}<br>{/if}
               {$form.tag.html}
             </div>
-            {if $context NEQ 'profile'}
-              {include file="CRM/common/Tagset.tpl"}
-            {/if}
-          </td>
-        {/if}
+          {/if}
+          {if $context NEQ 'profile'}
+            {include file="CRM/common/Tagset.tpl"}
+          {/if}
+        </td>
+
         {if $form.group}
           <td>
             {if $groupElementType eq 'select'}


### PR DESCRIPTION
Overview
----------------------------------------
When all the tags belong to tagset and there are no standalone tags, the tag field is not displayed on New/Edit Contact Screen.

Before
----------------------------------------
Tags field not displayed on New/Edit Contact form

After
----------------------------------------
Tags field displayed on New/Edit Contact form