### PR TITLE
Fix property declarations

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
@@ -22,19 +22,19 @@ class CRM_Contribute_Form_Contribution_MainTest extends CiviUnitTestCase {
    * The id of the contribution page.
    * @var int
    */
-  private int $contributionPageId;
+  private $contributionPageId;
 
   /**
    * The id of the contribution page's payment processor.
    * @var int
    */
-  private int $paymentProcessorId;
+  private $paymentProcessorId;
 
   /**
    * The price set of the contribution page.
    * @var int
    */
-  private int $priceSetId;
+  private $priceSetId;
 
   /**
    * Clean up DB.


### PR DESCRIPTION
Overview
----------------------------------------
Fix property declarations

Before
----------------------------------------
```  
private int $contributionPageId;
```

After
----------------------------------------
```
  private $contributionPageId;

```

Technical Details
----------------------------------------
I think this property hinting must work on some php versions & not others - recently added by @MegaphoneJon & fails locally for me

Comments
----------------------------------------

