### PR TITLE
[REF] Deprecate BAO_Contact::retrieve

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -868,6 +868,9 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
   /**
    * Fetch object based on array of properties.
    *
+   * @deprecated This is called from a few places but creates rather than solves
+   * complexity.
+   *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
    * @param array $defaults

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -254,15 +254,13 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           $this->_values = $values;
         }
         else {
-          $params = [
-            'id' => $this->_contactId,
-            'contact_id' => $this->_contactId,
-            'noRelationships' => TRUE,
-            'noNotes' => TRUE,
-            'noGroups' => TRUE,
-          ];
-
-          $contact = CRM_Contact_BAO_Contact::retrieve($params, $this->_values, TRUE);
+          CRM_Contact_BAO_Contact::getValues(['contact_id' => $this->_contactId], $this->_values);
+          $this->_values['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['openid'] = CRM_Core_BAO_OpenID::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['phone'] = CRM_Core_BAO_Phone::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $this->_contactId], TRUE);
+          CRM_Core_BAO_Website::getValues(['contact_id' => $this->_contactId], $this->_values);
           $this->set('values', $this->_values);
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
This removes 2 calls to BAO_Contact::retrieve and marks it as deprecated.

It is a surprisingly complex function and all the calls to it only use parts of what it
does - in general just having the code 'do the thing' is better.

In this case it turns out there is no need for the contact objects. There is
also some pretty funky handling for the location keys in the next section
so making it clearer what is in them should make it possible to simplify that....


Before
----------------------------------------
BAO_Contact::retrieve called - but with a bunch of pre-work to control the output

After
----------------------------------------
The functions actually called moved in

Technical Details
----------------------------------------
I have a follow up that builds on this

Comments
----------------------------------------
