### PR TITLE
Do not default escape 'create new' links

### DIFF
--- a/templates/CRM/Block/CreateNew.tpl
+++ b/templates/CRM/Block/CreateNew.tpl
@@ -33,7 +33,7 @@
             {if $short.shortCuts}
               <ul>
                 {foreach from=$short.shortCuts item=shortCut}
-                  <li><a href="{$shortCut.url}" class="crm-{$shortCut.ref}">{$shortCut.title}</a></li>
+                  <li><a href="{$shortCut.url}" class="crm-{$shortCut.ref}">{$shortCut.title|smarty:nodefaults}</a></li>
                 {/foreach}
               </ul>
             {/if}


### PR DESCRIPTION

Overview
----------------------------------------
Do not default escape 'create new' links

Before
----------------------------------------
The links that appear when you hover over Contribution, Event, Membership in the create new block have broken html if smarty grumpy mode is enabled

![image](https://user-images.githubusercontent.com/336308/158937837-42cf2390-fef6-4287-b7d1-3f887f1470cb.png)

After
----------------------------------------
The strings are marked do not escape

These are assigned from the various Info::creatNewShortcut and contain html
so should not be escaped in grumpy mode. This block is
largely only in drupal 7 & is only code-assigned

Technical Details
----------------------------------------

Comments
----------------------------------------
