### PR TITLE
Enotice fix in grumpy smarty mode

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -118,7 +118,8 @@ trait CRM_Contact_Form_Task_EmailTrait {
    * @throws \CRM_Core_Exception
    * @throws \API_Exception
    */
-  protected function traitPreProcess() {
+  protected function traitPreProcess(): void {
+    $this->addExpectedSmartyVariable('rows');
     if ($this->isSearchContext()) {
       // Currently only the contact email form is callable outside search context.
       parent::preProcess();


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix in grumpy smarty mode

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/158938709-07dc8094-319a-4f6a-866d-268173bfe645.png)

After
----------------------------------------
They are all still there .... except for the very bottom one...

Technical Details
----------------------------------------

Comments
----------------------------------------
