### PR TITLE
Add case ID and make subject optional for case detail report

### DIFF
--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -56,9 +56,13 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
             'no_display' => TRUE,
             'required' => TRUE,
           ],
+          'case_id' => [
+            'title' => ts('Case ID'),
+            'type' => CRM_Utils_Type::T_INT,
+          ],
           'subject' => [
             'title' => ts('Subject'),
-            'required' => TRUE,
+            'default' => TRUE,
           ],
           'start_date' => [
             'title' => ts('Start Date'),


### PR DESCRIPTION
Overview
----------------------------------------
Allow to display case ID on the "Case detail" report.
Make the subject optional for display.

Before
----------------------------------------
No case ID visible. Subject always visible.

After
----------------------------------------
Allow to display case ID on the "Case detail" report.
Make the subject optional for display.

Technical Details
----------------------------------------


Comments
----------------------------------------

