### PR TITLE
REF Cleanup activity getBespokeTokens()

### DIFF
--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -101,16 +101,13 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
   protected function getBespokeTokens(): array {
     $tokens = [];
     if (CRM_Core_Component::isEnabled('CiviCase')) {
-      $tokens['case_id'] = ts('Activity Case ID');
-      return [
-        'case_id' => [
-          'title' => ts('Activity Case ID'),
-          'name' => 'case_id',
-          'type' => 'calculated',
-          'options' => NULL,
-          'data_type' => 'Integer',
-          'audience' => 'user',
-        ],
+      $tokens['case_id'] = [
+        'title' => ts('Activity Case ID'),
+        'name' => 'case_id',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'Integer',
+        'audience' => 'user',
       ];
     }
     return $tokens;


### PR DESCRIPTION
Overview
----------------------------------------
This line is never used:
`$tokens['case_id'] = ts('Activity Case ID');`

Before
----------------------------------------
Extra line that is never used.

After
----------------------------------------
`$tokens['case_id']` only defined once.

Technical Details
----------------------------------------
Note I specified it like this instead of just doing return [..] because it makes it much easier to apply patches such as eg. https://github.com/mattwire/civicrm-core/commit/67eb50679090e79236526809a93b23562489cbdf

Comments
----------------------------------------
