### PR TITLE
Afform - Easier layout creation with predefined container styles and built-in title

### DIFF
--- a/ang/crmUI.css
+++ b/ang/crmUI.css
@@ -1,0 +1,24 @@
+/* CSS rules for Angular module "crmUI" */
+
+/* In-place edit  */
+.crm-container [crm-ui-editable] {
+  padding-left: 2px;
+  border: 2px dashed transparent;
+}
+.crm-container [crm-ui-editable]:hover,
+.crm-container [crm-ui-editable]:focus {
+  border: 2px dashed #d1d1d1;
+  cursor: pointer;
+  background-color: white !important;
+  color: initial !important;
+}
+.crm-container span[crm-ui-editable] {
+  display: inline-block !important;
+  padding-right: 2px;
+  min-height: 1em;
+  min-width: 3em;
+}
+.crm-container [crm-ui-editable]:empty:before {
+  content: attr(placeholder);
+  color: #9a9a9a;
+}

--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -6,6 +6,7 @@ return [
   'ext' => 'civicrm',
   'js' => ['ang/crmUi.js'],
   'partials' => ['ang/crmUi'],
+  'css' => ['ang/crmUI.css'],
   'requires' => array_merge(
     [
       'crmResource',

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -1107,8 +1107,10 @@
       };
     })
 
-    // Editable text using ngModel & html5 contenteditable
-    // Usage: <span crm-ui-editable ng-model="my.data">{{ my.data }}</span>
+    // Single-line editable text using ngModel & html5 contenteditable
+    // Supports a `placeholder` attribute which shows up if empty and no `default-value`.
+    // The `default-value` attribute will force a value if empty (mutually-exclusive with `placeholder`).
+    // Usage: <span crm-ui-editable ng-model="model.text" placeholder="Enter text"></span>
     .directive("crmUiEditable", function() {
       return {
         restrict: "A",
@@ -1150,7 +1152,7 @@
             scope.$apply(read);
           });
 
-          element.attr('contenteditable', 'true').addClass('crm-editable-enabled');
+          element.attr('contenteditable', 'true');
         }
       };
     })

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -249,6 +249,7 @@ class AfformAdminMeta {
         'element' => [
           '#tag' => 'fieldset',
           'af-fieldset' => NULL,
+          'class' => 'af-container',
           'af-title' => E::ts('Enter title'),
           '#children' => [],
         ],

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -249,17 +249,8 @@ class AfformAdminMeta {
         'element' => [
           '#tag' => 'fieldset',
           'af-fieldset' => NULL,
-          '#children' => [
-            [
-              '#tag' => 'legend',
-              'class' => 'af-text',
-              '#children' => [
-                [
-                  '#text' => E::ts('Enter title'),
-                ],
-              ],
-            ],
-          ],
+          'af-title' => E::ts('Enter title'),
+          '#children' => [],
         ],
       ],
     ];

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -204,6 +204,13 @@ body.af-gui-dragging {
   margin-top: 10px;
 }
 
+/* Card style */
+#afGuiEditor .af-gui-container.af-container-style-pane {
+  box-shadow: 1px 2px 8px 1px rgb(0, 0, 0, .3);
+  background: linear-gradient(to bottom, #f2f2f2 0 22px, transparent 22px 100%) no-repeat;
+  border-radius: 4px;
+}
+
 #afGuiEditor af-gui-container,
 #afGuiEditor af-gui-markup,
 #afGuiEditor af-gui-field,

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -142,7 +142,8 @@
   font-family: "Courier New", Courier, monospace;
   font-size: 12px;
 }
-#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-bar {
+#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-bar,
+#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container-title span:empty {
   opacity: 0;
 }
 #afGuiEditor-canvas [ui-sortable] .af-gui-bar {
@@ -153,11 +154,13 @@
   left: 0;
   padding-left: 15px;
 }
-#afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-bar {
+#afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-bar,
+#afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-container-title span:empty {
   opacity: 1;
   transition: opacity .2s;
 }
-#afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar {
+#afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar,
+#afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-container-title span:empty {
   background-color: #d7e6ff;
   opacity: 1;
   transition: opacity .1s;
@@ -263,7 +266,8 @@ body.af-gui-dragging {
 }
 /* Fix button colors when bar is highlighted */
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button > span,
-#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > span {
+#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > span,
+#afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-node-title {
   color: white;
 }
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button:hover > span,
@@ -380,6 +384,12 @@ body.af-gui-dragging {
   margin-left: 5px;
   margin-right: 20px;
   position: relative;
+}
+#afGuiEditor .af-gui-container-title {
+  top: -21px;
+}
+#afGuiEditor .af-gui-container-title span:empty {
+  font-weight: lighter;
 }
 
 #afGuiEditor .af-gui-field-required:after {

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -96,6 +96,7 @@
 #afGuiEditor .crm-editable-enabled:hover:not(:focus) {
   border: 2px dashed grey !important;
 }
+/* Undo Shoreditch add-ons */
 #afGuiEditor .crm-editable-enabled:before,
 #afGuiEditor .crm-editable-enabled:after {
   content: '';

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -56,6 +56,16 @@
         return str ? _.unique(_.trim(str).split(/\s+/g)) : [];
       }
 
+      // Check if a node has class(es)
+      function hasClass(node, className) {
+        if (!node['class']) {
+          return false;
+        }
+        var classes = splitClass(node['class']),
+          classNames = className.split(' ');
+        return _.intersection(classes, classNames).length === classNames.length;
+      }
+
       function modifyClasses(node, toRemove, toAdd) {
         var classes = splitClass(node['class']);
         if (toRemove) {
@@ -64,7 +74,11 @@
         if (toAdd) {
           classes = _.unique(classes.concat(splitClass(toAdd)));
         }
-        node['class'] = classes.join(' ');
+        if (classes.length) {
+          node['class'] = classes.join(' ');
+        } else if ('class' in node) {
+          delete node['class'];
+        }
       }
 
       return {
@@ -202,6 +216,7 @@
         },
 
         splitClass: splitClass,
+        hasClass: hasClass,
         modifyClasses: modifyClasses,
         getStyles: getStyles,
         setStyle: setStyle,

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -135,7 +135,7 @@
           // Create a new af-fieldset container for the entity
           var fieldset = _.cloneDeep(afGui.meta.elements.fieldset.element);
           fieldset['af-fieldset'] = type + num;
-          fieldset['#children'][0]['#children'][0]['#text'] = meta.label + ' ' + num;
+          fieldset['af-title'] = meta.label + ' ' + num;
           // Add boilerplate contents
           _.each(meta.boilerplate, function (tag) {
             fieldset['#children'].push(tag);
@@ -274,6 +274,7 @@
         var fieldset = {
           '#tag': 'div',
           'af-fieldset': '',
+          'af-title': display.label,
           '#children': [
             {
               '#tag': display.tag,

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemCollapsible.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemCollapsible.component.js
@@ -1,0 +1,43 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  // Menu item to control the border property of a node
+  angular.module('afGuiEditor').component('afGuiMenuItemCollapsible', {
+    templateUrl: '~/afGuiEditor/afGuiMenuItemCollapsible.html',
+    bindings: {
+      node: '='
+    },
+    controller: function($scope, afGui) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
+        ctrl = this;
+
+      this.isCollapsible = function() {
+        return afGui.hasClass(ctrl.node, 'af-collapsible');
+      };
+
+      this.isCollapsed = function() {
+        return afGui.hasClass(ctrl.node, 'af-collapsible af-collapsed');
+      };
+
+      this.toggleCollapsible = function() {
+        // Node must have a title to be collapsible
+        if (ctrl.isCollapsible() || !ctrl.node['af-title']) {
+          afGui.modifyClasses(ctrl.node, 'af-collapsible af-collapsed');
+        } else {
+          afGui.modifyClasses(ctrl.node, null, 'af-collapsible');
+        }
+      };
+
+      this.toggleCollapsed = function() {
+        if (ctrl.isCollapsed()) {
+          afGui.modifyClasses(ctrl.node, 'af-collapsed');
+        } else {
+          afGui.modifyClasses(ctrl.node, null, 'af-collapsed');
+        }
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemCollapsible.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemCollapsible.html
@@ -1,0 +1,8 @@
+<label ng-class="{disabled: !$ctrl.node['af-title']}" ng-click="$ctrl.toggleCollapsible(); $event.stopPropagation();" title="{{ $ctrl.node['af-title'] ? ts('Allow user to collapse this to only show title') : ts('Must have a title to be collapsible') }}">
+  <i class="crm-i fa-{{ $ctrl.isCollapsible() ? 'check-' : '' }}square-o"></i>
+  {{:: ts('Collapsible') }}
+</label>
+<a href ng-click="$ctrl.toggleCollapsed(); $event.stopPropagation();" class="btn btn-sm btn-default" ng-class="{invisible: !$ctrl.isCollapsible()}">
+  <i class="crm-i fa-caret-{{ $ctrl.isCollapsed() ? 'right' : 'down' }}"></i>
+  {{ $ctrl.isCollapsed() ? ts('Closed') : ts('Open') }}
+</a>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.component.js
@@ -1,0 +1,31 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  // Menu item to control the border property of a node
+  angular.module('afGuiEditor').component('afGuiMenuItemStyle', {
+    templateUrl: '~/afGuiEditor/afGuiMenuItemStyle.html',
+    bindings: {
+      node: '='
+    },
+    controller: function($scope, afGui) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
+        ctrl = this;
+
+      // Todo: Make this an option group so other extensions can add to it
+      this.styles = [
+        {name: 'af-container-style-pane', label: ts('Panel Pane')}
+      ];
+
+      $scope.getSetStyle = function(style) {
+        var options = _.map(ctrl.styles, 'name');
+        if (arguments.length) {
+          afGui.modifyClasses(ctrl.node, options, style);
+        }
+        return _.intersection(afGui.splitClass(ctrl.node['class']), options)[0] || '';
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.html
@@ -1,0 +1,7 @@
+<div class="af-gui-field-select-in-dropdown form-inline" ng-click="$event.stopPropagation()">
+  <label>{{:: ts('Style:') }}</label>
+  <select class="form-control" ng-model="getSetStyle" ng-model-options="{getterSetter: true}">
+    <option value="">{{:: ts('None') }}</option>
+    <option ng-repeat="style in $ctrl.styles" value="{{:: style.name }}">{{:: style.label }}</option>
+  </select>
+</div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -31,6 +31,7 @@
   </div>
 </li>
 <li><af-gui-menu-item-collapsible ng-if="!block" node="$ctrl.node" class="af-gui-field-select-in-dropdown form-inline"></af-gui-menu-item-collapsible></li>
+<li><af-gui-menu-item-style node="$ctrl.node"></af-gui-menu-item-style></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
 <li role="separator" class="divider"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -1,5 +1,5 @@
-<li ng-if="!$ctrl.node['af-fieldset'] && !block.layout"><a href ng-click="saveBlock()">{{:: ts('Save as block') }}</a></li>
-<li ng-if="!$ctrl.node['af-fieldset'] && !block.layout" role="separator" class="divider"></li>
+<li ng-if="$ctrl.canSaveAsBlock()"><a href ng-click="saveBlock()">{{:: ts('Save as block') }}</a></li>
+<li ng-if="$ctrl.canSaveAsBlock()" role="separator" class="divider"></li>
 <li ng-if="tags[$ctrl.node['#tag']]">
   <div class="af-gui-field-select-in-dropdown form-inline" ng-click="$event.stopPropagation()">
     {{:: ts('Element:') }}

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -30,6 +30,7 @@
     </div>
   </div>
 </li>
+<li><af-gui-menu-item-collapsible ng-if="!block" node="$ctrl.node" class="af-gui-field-select-in-dropdown form-inline"></af-gui-menu-item-collapsible></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
 <li role="separator" class="divider"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -122,6 +122,12 @@
         }
       };
 
+      this.getCollapsibleIcon = function() {
+        if (afGui.hasClass(ctrl.node, 'af-collapsible')) {
+          return afGui.hasClass(ctrl.node, 'af-collapsed') ? 'fa-caret-right' : 'fa-caret-down';
+        }
+      };
+
       // Sets min value for af-repeat as a string, returns it as an int
       $scope.getSetMin = function(val) {
         if (arguments.length) {
@@ -330,6 +336,33 @@
           types = ['af-container', 'af-text', 'af-button', 'af-markup'],
           type = _.intersection(types, classes);
         return type.length ? type[0].replace('af-', '') : null;
+      };
+
+      this.getSetTitle = function(value) {
+        if (arguments.length) {
+          if (value.length) {
+            ctrl.node['af-title'] = value;
+          } else {
+            delete ctrl.node['af-title'];
+            // With no title, cannot be collapsible
+            afGui.modifyClasses(ctrl.node, 'af-collapsible af-collapsed');
+          }
+        }
+        return ctrl.node['af-title'];
+      };
+
+      this.getToolTip = function() {
+        var text = '', nodeType;
+        if (!$scope.block) {
+          nodeType = ctrl.getNodeType(ctrl.node);
+          if (nodeType === 'fieldset') {
+            text = ctrl.editor.getEntity(ctrl.entityName).label;
+          } else if (nodeType === 'searchFieldset') {
+            text = ts('Search Display');
+          }
+          text += ' ' + $scope.tags[ctrl.node['#tag']];
+        }
+        return text;
       };
 
       this.removeElement = function(element) {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -1,15 +1,12 @@
-<div class="af-gui-bar" ng-if="$ctrl.node['#tag']" ng-click="selectEntity()" >
-  <div ng-if="!$ctrl.loading" class="form-inline">
-    <span ng-if="$ctrl.getNodeType($ctrl.node) == 'fieldset'">{{ $ctrl.editor.getEntity($ctrl.entityName).label }}</span>
-    <span ng-if="$ctrl.getNodeType($ctrl.node) == 'searchFieldset'">{{:: ts('Search Display') }}</span>
+<div class="af-gui-bar {{ block ? 'af-gui-block-bar' : '' }}" ng-if="$ctrl.node['#tag']" ng-click="selectEntity()" >
+  <div ng-if="!$ctrl.loading" class="form-inline" title="{{ $ctrl.getToolTip() }}">
     <span ng-if="block">{{ $ctrl.join ? ts($ctrl.join) + ':' : ts('Block:') }}</span>
-    <span ng-if="!block">{{ tags[$ctrl.node['#tag']] }}</span>
-    <select ng-if="block" ng-model="block.directive" ng-change="selectBlockDirective()">
+    <select ng-if="block" ng-model="block.directive" ng-change="selectBlockDirective()" title="{{:: ts('Select block') }}">
       <option value="">{{:: ts('Custom') }}</option>
       <option ng-value="option.id" ng-repeat="option in block.options track by option.id">{{ option.text }}</option>
     </select>
-    <button type="button" class="btn btn-default btn-xs" ng-if="block && !block.layout" ng-click="saveBlock()">{{:: ts('Save...') }}</button>
-    <div class="btn-group pull-right">
+    <button type="button" class="btn btn-default btn-xs" ng-if="block && !block.layout" ng-click="saveBlock()" title="{{:: ts('Save block') }}">{{:: ts('Save...') }}</button>
+    <div class="btn-group pull-right" title="">
       <af-gui-container-multi-toggle ng-if="!ctrl.loading && ($ctrl.join || $ctrl.node['af-repeat'])" entity="$ctrl.getFieldEntityType()" class="btn-group"></af-gui-container-multi-toggle>
       <div class="btn-group" af-gui-menu>
         <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
@@ -21,6 +18,10 @@
   </div>
   <div ng-if="$ctrl.loading"><i class="crm-i fa-spin fa-spinner"></i></div>
 </div>
+<label class="af-gui-node-title af-gui-container-title af-gui-text-h3" ng-if="$ctrl.node['#tag'] && !block" title="{{:: ts('Container title') }}">
+  <i class="crm-i {{ $ctrl.getCollapsibleIcon() }}"></i>
+  <span placeholder="{{:: ts('No title') }}" crm-ui-editable ng-model="$ctrl.getSetTitle" ng-model-options="{getterSetter: true}"></span>
+</label>
 <div ng-if="!$ctrl.loading" ui-sortable="$ctrl.sortableOptions" ui-sortable-update="$ctrl.editor.onDrop" ng-model="getSetChildren" ng-model-options="{getterSetter: true}" class="af-gui-layout {{ getLayout() }}">
   <div ng-repeat="item in getSetChildren()" >
     <div ng-switch="$ctrl.getNodeType(item)">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -25,14 +25,14 @@
 <div ng-if="!$ctrl.loading" ui-sortable="$ctrl.sortableOptions" ui-sortable-update="$ctrl.editor.onDrop" ng-model="getSetChildren" ng-model-options="{getterSetter: true}" class="af-gui-layout {{ getLayout() }}">
   <div ng-repeat="item in getSetChildren()" >
     <div ng-switch="$ctrl.getNodeType(item)">
-      <af-gui-container ng-switch-when="fieldset" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-fieldset af-gui-container-type-{{ item['#tag'] }}" ng-class="{'af-entity-selected': isSelectedFieldset(item['af-fieldset'])}" entity-name="item['af-fieldset']" data-entity="{{ item['af-fieldset'] }}" ></af-gui-container>
-      <af-gui-container ng-switch-when="container" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-container-type-{{ item['#tag'] }}" entity-name="$ctrl.entityName" data-entity="{{ $ctrl.getDataEntity() }}" ></af-gui-container>
+      <af-gui-container ng-switch-when="fieldset" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-fieldset af-gui-container-type-{{ item['#tag'] + ' ' + item['class'] }}" ng-class="{'af-entity-selected': isSelectedFieldset(item['af-fieldset'])}" entity-name="item['af-fieldset']" data-entity="{{ item['af-fieldset'] }}" ></af-gui-container>
+      <af-gui-container ng-switch-when="container" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-container-type-{{ item['#tag'] + ' ' + item['class'] }}" entity-name="$ctrl.entityName" data-entity="{{ $ctrl.getDataEntity() }}" ></af-gui-container>
       <af-gui-container ng-switch-when="join" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container" join="item['af-join']" entity-name="$ctrl.entityName + '-join-' + item['af-join']" data-entity="{{ $ctrl.entityName + '-join-' + item['af-join'] }}" ></af-gui-container>
       <af-gui-field ng-switch-when="field" node="item" delete-this="$ctrl.removeElement(item)" ></af-gui-field>
       <af-gui-text ng-switch-when="text" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-element af-gui-text" ></af-gui-text>
       <af-gui-markup ng-switch-when="markup" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-markup" ></af-gui-markup>
       <af-gui-button ng-switch-when="button" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-element af-gui-button" ></af-gui-button>
-      <af-gui-container ng-switch-when="searchFieldset" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-fieldset af-gui-container-type-{{ item['#tag'] }}" ng-class="{'af-entity-selected': isSelectedSearchFieldset(item)}" data-entity="{{ getSearchKey(item) }}" ></af-gui-container>
+      <af-gui-container ng-switch-when="searchFieldset" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-fieldset af-gui-container-type-{{ item['#tag'] + ' ' + item['class'] }}" ng-class="{'af-entity-selected': isSelectedSearchFieldset(item)}" data-entity="{{ getSearchKey(item) }}" ></af-gui-container>
       <af-gui-search-display ng-switch-when="searchDisplay" node="item" class="af-gui-element"></af-gui-search-display>
     </div>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -25,7 +25,7 @@
   <div ng-repeat="item in getSetChildren()" >
     <div ng-switch="$ctrl.getNodeType(item)">
       <af-gui-container ng-switch-when="fieldset" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-fieldset af-gui-container-type-{{ item['#tag'] }}" ng-class="{'af-entity-selected': isSelectedFieldset(item['af-fieldset'])}" entity-name="item['af-fieldset']" data-entity="{{ item['af-fieldset'] }}" ></af-gui-container>
-      <af-gui-container ng-switch-when="container" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-container-type-{{ item['#tag'] }}" entity-name="$ctrl.entityName" data-entity="{{ $ctrl.entityName }}" ></af-gui-container>
+      <af-gui-container ng-switch-when="container" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container af-gui-container-type-{{ item['#tag'] }}" entity-name="$ctrl.entityName" data-entity="{{ $ctrl.getDataEntity() }}" ></af-gui-container>
       <af-gui-container ng-switch-when="join" node="item" delete-this="$ctrl.removeElement(item)" style="{{ item.style }}" class="af-gui-container" join="item['af-join']" entity-name="$ctrl.entityName + '-join-' + item['af-join']" data-entity="{{ $ctrl.entityName + '-join-' + item['af-join'] }}" ></af-gui-container>
       <af-gui-field ng-switch-when="field" node="item" delete-this="$ctrl.removeElement(item)" ></af-gui-field>
       <af-gui-text ng-switch-when="text" node="item" delete-this="$ctrl.removeElement(item)" class="af-gui-element af-gui-text" ></af-gui-text>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchContainer-menu.html
@@ -6,6 +6,7 @@
     </select>
   </div>
 </li>
+<li><af-gui-menu-item-collapsible node="$ctrl.node" class="af-gui-field-select-in-dropdown form-inline"></af-gui-menu-item-collapsible></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
 <li role="separator" class="divider"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchContainer-menu.html
@@ -7,6 +7,7 @@
   </div>
 </li>
 <li><af-gui-menu-item-collapsible node="$ctrl.node" class="af-gui-field-select-in-dropdown form-inline"></af-gui-menu-item-collapsible></li>
+<li><af-gui-menu-item-style node="$ctrl.node"></af-gui-menu-item-style></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
 <li role="separator" class="divider"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
@@ -1,6 +1,6 @@
 <li ng-click="$event.stopPropagation()">
   <div class="af-gui-field-select-in-dropdown">
-    <label>{{:: ts('Style:') }}</label>
+    <label>{{:: ts('Element:') }}</label>
     <select class="form-control" ng-model="$ctrl.node['#tag']" title="{{:: ts('Text style') }}">
       <option ng-repeat="(opt, label) in tags" value="{{ opt }}">{{ label }}</option>
     </select>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
@@ -13,7 +13,7 @@
         ctrl = this;
 
       $scope.tags = {
-        p: ts('Normal Text'),
+        p: ts('Paragraph'),
         legend: ts('Fieldset Legend'),
         h1: ts('Heading 1'),
         h2: ts('Heading 2'),

--- a/ext/afform/core/ang/af/afTitle.directive.js
+++ b/ext/afform/core/ang/af/afTitle.directive.js
@@ -1,0 +1,28 @@
+(function(angular, $, _) {
+  "use strict";
+  angular.module('af').directive('afTitle', function() {
+    return {
+      restrict: 'A',
+      bindToController: {
+        title: '@afTitle'
+      },
+      controller: function($scope, $element) {
+        var ctrl = this;
+
+        $scope.$watch(function() {return ctrl.title;}, function(text) {
+          var tag = $element.is('fieldset') ? 'legend' : 'h4',
+            $title = $element.children(tag + '.af-title');
+          if (!$title.length) {
+            $title = $('<' + tag + ' class="af-title" />').prependTo($element);
+            if ($element.hasClass('af-collapsible')) {
+              $title.click(function() {
+                $element.toggleClass('af-collapsed');
+              });
+            }
+          }
+          $title.text(text);
+        });
+      }
+    };
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -30,3 +30,20 @@ af-form {
   top: 0;
   right: 0;
 }
+
+/* Collapsible containers */
+.af-collapsible > .af-title {
+  cursor: pointer;
+}
+.af-collapsible > .af-title:before {
+  font-family: "FontAwesome";
+  display: inline-block;
+  width: 1em;
+  content: "\f0d7";
+}
+.af-collapsible.af-collapsed > .af-title:before {
+  content: "\f0da";
+}
+.af-collapsible.af-collapsed > .af-title + * {
+  display: none;
+}

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -8,6 +8,7 @@ a.af-api4-action-idle {
 
 .af-container.af-layout-cols {
   display: flex;
+  flex-wrap: wrap;
 }
 .af-container.af-layout-cols > * {
   flex: 1;
@@ -17,6 +18,14 @@ a.af-api4-action-idle {
   margin-right: .5em;
   vertical-align: top;
 }
+.af-container.af-layout-cols > .af-title {
+  flex: 0 0 100%;
+}
+.af-container.af-layout-inline > .af-title {
+  display: block;
+  width: 100%;
+}
+
 af-form {
   display: block;
 }
@@ -46,4 +55,28 @@ af-form {
 }
 .af-collapsible.af-collapsed > .af-title + * {
   display: none;
+}
+
+/* Card style */
+#bootstrap-theme .af-container-style-pane {
+  background-color: white;
+  border-radius: 4px;
+  box-shadow: 1px 2px 8px 1px rgba(0, 0, 0, 0.3);
+  margin: 10px;
+  padding: 5px;
+}
+#bootstrap-theme .af-container-style-pane > .af-title {
+  background-color: #70716b;
+  color: white;
+  padding: 5px;
+  border-radius: 4px 4px 0 0;
+  position: relative;
+  top: -5px;
+  left: -5px;
+  width: calc(100% + 10px);
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+#bootstrap-theme .af-container-style-pane.af-collapsed > .af-title {
+  margin-bottom: 0;
 }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -135,10 +135,11 @@
       };
 
       this.addDisplay = function(type) {
-        var count = _.filter(ctrl.savedSearch.displays, {type: type}).length;
+        var count = _.filter(ctrl.savedSearch.displays, {type: type}).length,
+          searchLabel = ctrl.savedSearch.label || searchMeta.getEntity(ctrl.savedSearch.api_entity).title_plural;
         ctrl.savedSearch.displays.push({
           type: type,
-          label: ctrl.displayTypes[type].label + (count ? ' ' + (++count) : '')
+          label: searchLabel + ' ' + ctrl.displayTypes[type].label + ' ' + (count + 1),
         });
         $scope.selectTab('display_' + (ctrl.savedSearch.displays.length - 1));
       };

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -201,6 +201,7 @@
 #bootstrap-theme.crm-search .crm-editable-enabled:hover:not(:focus) {
   border: 2px dashed grey !important;
 }
+/* Undo Shoreditch add-ons */
 #bootstrap-theme.crm-search .crm-editable-enabled:before,
 #bootstrap-theme.crm-search .crm-editable-enabled:after {
   content: '';


### PR DESCRIPTION
Overview
----------------------------------------
This makes layouts easier to make, by adding predefined "Panel Pane" and "Collapsible" styles which can be applied to any container element. It also makes container titles easier to work with, and fixes some issues with saving blocks.

Before
----------------------------------------
No predefined style for creating a dashboard dashlet or collapsible fieldset.

After
----------------------------------------
Any container can be given a title and styled as a panel pane and/or collapsible:

![image](https://user-images.githubusercontent.com/2874912/159072803-76904aea-1c05-409a-a643-526f575a9192.png)

This gives a nice-looking dashboard:

![image](https://user-images.githubusercontent.com/2874912/159072964-8817d5b2-0a87-4389-b974-db3415ce5fb1.png)
