### PR TITLE
dev/core#3126 - CiviReport statistics appearing twice on page

### DIFF
--- a/templates/CRM/Report/Form.tpl
+++ b/templates/CRM/Report/Form.tpl
@@ -44,7 +44,7 @@
     {/if}
     <br />
     {*Statistics at the bottom of the page*}
-    {include file="CRM/Report/Form/Statistics.tpl" top="false" bottom=true}
+    {include file="CRM/Report/Form/Statistics.tpl" top=false bottom=true}
 
     {include file="CRM/Report/Form/ErrorMessage.tpl"}
   </div>

--- a/templates/CRM/Report/Form/Contact/Detail.tpl
+++ b/templates/CRM/Report/Form/Contact/Detail.tpl
@@ -180,7 +180,7 @@
 
         {if !$section }
             {*Statistics at the bottom of the page*}
-            {include file="CRM/Report/Form/Statistics.tpl" top="false" bottom=true}
+            {include file="CRM/Report/Form/Statistics.tpl" top=false bottom=true}
         {/if}
     {/if}
     {include file="CRM/Report/Form/ErrorMessage.tpl"}

--- a/templates/CRM/Report/Form/Contribute/DeferredRevenue.tpl
+++ b/templates/CRM/Report/Form/Contribute/DeferredRevenue.tpl
@@ -43,7 +43,7 @@
 
   <br />
   {*Statistics at the bottom of the page*}
-  {include file="CRM/Report/Form/Statistics.tpl" top="false" bottom=true}
+  {include file="CRM/Report/Form/Statistics.tpl" top=false bottom=true}
 
   {include file="CRM/Report/Form/ErrorMessage.tpl"}
 </div>

--- a/templates/CRM/Report/Form/Event/Income.tpl
+++ b/templates/CRM/Report/Form/Event/Income.tpl
@@ -70,7 +70,7 @@
         </div>
         {if !$section }
             {*Statistics at the bottom of the page*}
-            {include file="CRM/Report/Form/Statistics.tpl" top="false" bottom=true}
+            {include file="CRM/Report/Form/Statistics.tpl" top=false bottom=true}
         {/if}
     {/if}
     {include file="CRM/Report/Form/ErrorMessage.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3126

Before
----------------------------------------
CiviReport statistics appearing twice on page

After
----------------------------------------
Once

Technical Details
----------------------------------------
String "false" is always true in smarty.

Comments
----------------------------------------
Have put against 5.48 since was introduced in 5.45 in https://github.com/civicrm/civicrm-core/pull/22070
