### PR TITLE
Fix copy button float in APIv4 Explorer

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -224,11 +224,13 @@
           </p>
         </div>
         <div ng-repeat="style in code[selectedTab.code]">
-          <button class="btn btn-xs btn-default pull-right" ng-click="$ctrl.copyCode('api4-code-' + selectedTab.code + '-' + style.name)">
-            <i class="crm-i fa-clipboard"></i>
-            {{:: ts('Copy') }}
-          </button>
-          <label>{{:: style.label }}</label>
+          <div class="clearfix">
+            <button class="btn btn-xs btn-default pull-right" ng-click="$ctrl.copyCode('api4-code-' + selectedTab.code + '-' + style.name)">
+              <i class="crm-i fa-clipboard"></i>
+              {{:: ts('Copy') }}
+            </button>
+            <label>{{:: style.label }}</label>
+          </div>
           <div>
             <pre class="prettyprint" id="api4-code-{{ selectedTab.code + '-' + style.name }}" ng-bind-html="style.code"></pre>
           </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a misalignment in the new copy button on some themes.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/159099545-f0d9d883-1aa6-422b-a272-33716d27f41e.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/159099522-7141fbc9-e052-4392-a220-95c94f166665.png)

