### PR TITLE
Remove bad use of PHP assert, removed in PHP 8.0

### DIFF
--- a/CRM/Case/Form/Activity/LinkCases.php
+++ b/CRM/Case/Form/Activity/LinkCases.php
@@ -99,15 +99,22 @@ class CRM_Case_Form_Activity_LinkCases {
     $errors = [];
 
     $linkCaseId = $values['link_to_case_id'] ?? NULL;
-    assert('is_numeric($linkCaseId)');
+
+    if (!CRM_Utils_Rule::positiveInteger($linkCaseId) || $linkCaseId == 0) {
+      // We can't just return $errors because when the page reloads the
+      // entityref widget throws an error before the page can display the error.
+      // It seems ok with other invalid values, just not 0, but both are equally invalid.
+      CRM_Core_Error::statusBounce(ts('The linked case ID is invalid.'));
+    }
+
     if ($linkCaseId == CRM_Utils_Array::first($form->_caseId)) {
-      $errors['link_to_case'] = ts('Please select some other case to link.');
+      $errors['link_to_case_id'] = ts('Please select some other case to link.');
     }
 
     // do check for existing related cases.
     $relatedCases = $form->get('relatedCases');
     if (is_array($relatedCases) && array_key_exists($linkCaseId, $relatedCases)) {
-      $errors['link_to_case'] = ts('Selected case is already linked.');
+      $errors['link_to_case_id'] = ts('Selected case is already linked.');
     }
 
     return empty($errors) ? TRUE : $errors;


### PR DESCRIPTION
Overview
----------------------------------------
Using a string as the assertion passed to assert() is deprecated since PHP 7.2 and removed since PHP 8.0. 
See https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L350-L354

Given that `assert` is a reasonably obscure function and should only be used for debugging purposes, this PR replaces the usage of `assert` with a more standard `formRule` check. 

Before
----------------------------------------
Use of `assert` which should be avoided, and won't work as expected as of PHP 8.0.

After
----------------------------------------
Use of `assert` gone.

Comments
----------------------------------------
I wasn't 100% sure if the validation was actually needed in `formRule` or if the parent class would automatically validate based on the field type. I veered to the side of too much validation is better than not enough.
