### PR TITLE
Remove use of deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -193,7 +193,9 @@ class Download extends AbstractRunAction {
       $flag |= FILTER_FLAG_STRIP_HIGH;
     }
 
-    $filenameFallback = str_replace('%', '', filter_var($fileName, FILTER_SANITIZE_STRING, $flag));
+    /** @var string $filtered_name */
+    $filtered_name = filter_var($fileName, FILTER_UNSAFE_RAW, $flag);
+    $filenameFallback = str_replace('%', '', $filtered_name);
 
     $disposition = sprintf('attachment; filename="%s"', str_replace('"', '\\"', $filenameFallback));
     if ($fileName !== $filenameFallback) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove use of FILTER_SANITIZE_STRING, which is deprecated in PHP 8.1.0.

Before
----------------------------------------
Use of deprecated constant.

After
----------------------------------------
Replaced with constant which is not deprecated.

Technical Details
----------------------------------------
The docblock for the `getContentDisposition` method states that the method is copied from `\League\Csv\AbstractCsv::sendHeaders()`. Therefore I just copied the fix from the upstream library. They made the change several months ago, so I think it's safe to assume they didn't have issues with the fix: https://github.com/thephpleague/csv/commit/380f884922a6cdaaaaab3ad4bfc7d1d710af736e.