### PR TITLE
dev/core#3119 - Post-upgrade messages no longer being displayed

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -815,8 +815,9 @@ SET    version = '$version'
     $config = CRM_Core_Config::singleton();
     $config->userSystem->flush();
 
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, TRUE);
+    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
     // NOTE: triggerRebuild is FALSE becaues it will run again in a moment (via fixSchemaDifferences).
+    // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the Page. We reset later in doFinish().
 
     $versionCheck = new CRM_Utils_VersionCheck();
     $versionCheck->flushCache();
@@ -840,6 +841,7 @@ SET    version = '$version'
    * @return bool
    */
   public static function doFinish(): bool {
+    CRM_Core_Config::singleton()->cleanupCaches(TRUE);
     return TRUE;
   }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -841,7 +841,8 @@ SET    version = '$version'
    * @return bool
    */
   public static function doFinish(): bool {
-    CRM_Core_Config::singleton()->cleanupCaches(TRUE);
+    $session = CRM_Core_Session::singleton();
+    $session->reset(2);
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -195,7 +195,9 @@ class CRM_Upgrade_Incremental_Base {
     // Note: A good test-scenario is to install 5.45; enable logging and CiviGrant; disable searchkit+afform; then upgrade to 5.47.
     $schema = new CRM_Logging_Schema();
     $schema->fixSchemaDifferences();
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, TRUE);
+
+    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
+    // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the page. We reset later in doFinish().
 
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3119

Before
----------------------------------------
Note there isn't even the "Congratulations" message which is always present.

<img width="184" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/159130840-a05c8457-57fc-4097-857a-18ae99d1e2f3.png">

After
----------------------------------------
<img width="206" alt="Untitled3" src="https://user-images.githubusercontent.com/2967821/159130853-de32af92-7dc5-4f3e-b3e3-ef3b59b0e322.png">

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/22881 (in 5.47) the session clear got moved so that it now happens before it gets to the line where it retrieves session variables telling it that it's in upgrade mode and where to find the post-upgrade messages.

Comments
----------------------------------------
Doesn't affect `cv`, just the UI.

This does add yet another cache clear which slows down upgrades a bit. Previous additional cache clearing had already made it take longer than it used to. But anecdotally it seems common that people need to do additional cache clears anyway.