### PR TITLE
Afform - repeat block metadata update to fix errors when saving blocks

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -110,7 +110,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
       $joins = array_column(\CRM_Utils_Array::findAll($layout, 'af-join'), 'af-join');
       $entities = array_unique(array_merge($entities, $joins));
       $blockTags = array_unique(array_column(\CRM_Utils_Array::findAll($layout, function($el) use ($allAfforms) {
-        return in_array($el['#tag'], $allAfforms);
+        return isset($el['#tag']) && in_array($el['#tag'], $allAfforms);
       }), '#tag'));
       foreach ($blockTags as $blockTag) {
         if (!isset($info['blocks'][$blockTag])) {

--- a/ext/afform/core/CRM/Afform/Upgrader.php
+++ b/ext/afform/core/CRM/Afform/Upgrader.php
@@ -30,8 +30,17 @@ class CRM_Afform_Upgrader extends CRM_Afform_Upgrader_Base {
       $html = str_replace(array_keys($replacements), array_values($replacements), $html);
       file_put_contents($fileName, $html);
     }
+    $this->updateBlockMetadata($scanner);
 
-    // Update form metadata with new block property names
+    return TRUE;
+  }
+
+  /**
+   * Update form metadata with new block property names
+   * @param CRM_Afform_AfformScanner $scanner
+   */
+  private function updateBlockMetadata(CRM_Afform_AfformScanner $scanner): void {
+    $localDir = $scanner->getSiteLocalPath();
     $replacements = [
       'join' => 'join_entity',
       'block' => 'entity_type',
@@ -49,11 +58,10 @@ class CRM_Afform_Upgrader extends CRM_Afform_Upgrader_Base {
       }
       file_put_contents($fileName, json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
-    return TRUE;
   }
 
   /**
-   * Upgrade 1000 - install civicrm_afform_submission table
+   * Upgrade 1001 - install civicrm_afform_submission table
    * @return bool
    */
   public function upgrade_1001(): bool {
@@ -61,6 +69,19 @@ class CRM_Afform_Upgrader extends CRM_Afform_Upgrader_Base {
     if (!CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE 'civicrm_afform_submission'")) {
       $this->executeSqlFile('sql/auto_install.sql');
     }
+    return TRUE;
+  }
+
+  /**
+   * Upgrade 1002 - repeat block metadata update to fix errors when saving blocks
+   * @see #22963
+   * @return bool
+   */
+  public function upgrade_1002(): bool {
+    $this->ctx->log->info('Applying update 1002 - repeat block metadata update.');
+    $scanner = new CRM_Afform_AfformScanner();
+    $this->updateBlockMetadata($scanner);
+
     return TRUE;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #22963 - update any Afform blocks saved in error before the "Save Block" dialog was fixed.