### PR TITLE
Grumpy smarty - Never escape 'initHideBoxes'

### DIFF
--- a/templates/CRM/Activity/Import/Form/MapField.tpl
+++ b/templates/CRM/Activity/Import/Form/MapField.tpl
@@ -24,7 +24,7 @@
  <br />
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
- {$initHideBoxes}
+ {$initHideBoxes|smarty:nodefaults}
 {literal}
 <script type="text/javascript" >
 if ( document.getElementsByName("saveMapping")[0].checked ) {

--- a/templates/CRM/Contact/Form/Search/Builder.tpl
+++ b/templates/CRM/Contact/Form/Search/Builder.tpl
@@ -52,5 +52,5 @@
 {/if}
 </div>
 {/if}
-{$initHideBoxes}
+{$initHideBoxes|smarty:nodefaults}
 {include file="CRM/Form/validate.tpl"}

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -34,6 +34,6 @@ if ( document.getElementsByName("saveMapping")[0].checked ) {
 </script>
 
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
- {$initHideBoxes}
+ {$initHideBoxes|smarty:nodefaults}
 
 </div>

--- a/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
@@ -69,5 +69,5 @@
   </script>
 {/if}
 {if $action ne 2 or $showOption eq true}
-  {$initHideBoxes}
+  {$initHideBoxes|smarty:nodefaults}
 {/if}

--- a/templates/CRM/Contribute/Import/Form/MapField.tpl
+++ b/templates/CRM/Contribute/Import/Form/MapField.tpl
@@ -22,7 +22,7 @@
  {include file="CRM/Contribute/Import/Form/MapTable.tpl}
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
- {$initHideBoxes}
+ {$initHideBoxes|smarty:nodefaults}
 </div>
 {literal}
 <script type="text/javascript" >

--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -73,7 +73,7 @@
       {crmButton p='civicrm/admin/custom/group/field' q="action=browse&reset=1&gid=$gid" icon="th-list"}{ts}Custom Fields for this Set{/ts}{/crmButton}
     </div>
 {/if}
-{if !empty($initHideBlocks)}{$initHideBlocks}{/if}
+{if !empty($initHideBlocks|smarty:nodefaults)}{$initHideBoxes|smarty:nodefaults}{/if}
 {literal}
 <script type="text/Javascript">
 CRM.$(function($) {

--- a/templates/CRM/Event/Import/Form/MapField.tpl
+++ b/templates/CRM/Event/Import/Form/MapField.tpl
@@ -38,7 +38,7 @@
      </td>
    </tr>
  </table>
- {$initHideBoxes}
+ {$initHideBoxes|smarty:nodefaults}
 </div>
 {literal}
 <script type="text/javascript" >

--- a/templates/CRM/Member/Import/Form/MapField.tpl
+++ b/templates/CRM/Member/Import/Form/MapField.tpl
@@ -23,7 +23,7 @@
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
- {$initHideBoxes}
+ {$initHideBoxes|smarty:nodefaults}
 {literal}
 <script type="text/javascript" >
 if ( document.getElementsByName("saveMapping")[0].checked ) {

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -70,7 +70,7 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 
-{$initHideBoxes}
+{$initHideBoxes|smarty:nodefaults}
 
 {literal}
 <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
Never escape 'initHideBoxes'

Before
----------------------------------------
civicrm/admin/uf/group/field/add?reset=1&action=add&gid=14

![image](https://user-images.githubusercontent.com/336308/159186336-f5a67457-f70c-45bf-9b2a-0529e5333352.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
InitHideBoxes is js - fugly as this is we shouldn't escape it - there is
a world in which we would re-write it out of existence but not this one....

Comments
----------------------------------------
