### PR TITLE
Do not escape hierarchical select

### DIFF
--- a/templates/CRM/Activity/Import/Form/MapTable.tpl
+++ b/templates/CRM/Activity/Import/Form/MapTable.tpl
@@ -48,7 +48,7 @@
                     {if $wizard.currentStepName == 'Preview'}
                         {$mapper[$i]}
                     {else}
-                        {$form.mapper[$i].html}
+                        {$form.mapper[$i].html|smarty:nodefaults}
                     {/if}
                 </td>
 

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -98,7 +98,7 @@
                             {*/if*}
                         {/if}
                     {else}
-                        {$form.mapper[$i].html}
+                        {$form.mapper[$i].html|smarty:nodefaults}
                     {/if}
                 </td>
 

--- a/templates/CRM/Contact/Import/Form/Mapper.tpl
+++ b/templates/CRM/Contact/Import/Form/Mapper.tpl
@@ -15,7 +15,7 @@
    <dl>
      {section name=count start=1 loop=`$maxMapper`}
      {assign var='i' value=$smarty.section.count.index}
-       <dt>{$form.mapper[$i].label}</dt><dd>{$form.mapper[$i].html}<span class="tundra" id="id_map_mapper[{$i}]_1"><span id="id_mapper[{$i}]_1"></span></span><span class="tundra" id="id_map_mapper[{$i}]_2"><span id="id_mapper[{$i}]_2"></span></span><span class="tundra" id="id_map_mapper[{$i}]_3"><span id="id_mapper[{$i}]_3"></span></span></dd>
+       <dt>{$form.mapper[$i].label}</dt><dd>{$form.mapper[$i].html|smarty:nodefaults}<span class="tundra" id="id_map_mapper[{$i}]_1"><span id="id_mapper[{$i}]_1"></span></span><span class="tundra" id="id_map_mapper[{$i}]_2"><span id="id_mapper[{$i}]_2"></span></span><span class="tundra" id="id_map_mapper[{$i}]_3"><span id="id_mapper[{$i}]_3"></span></span></dd>
 
        {literal}
         <script type="text/javascript">

--- a/templates/CRM/Contribute/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contribute/Import/Form/MapTable.tpl
@@ -50,7 +50,7 @@
           {$mapper[$i]}
       {/if}
                     {else}
-                        {$form.mapper[$i].html}
+                        {$form.mapper[$i].html|smarty:nodefaults}
                     {/if}
                 </td>
 

--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -18,7 +18,7 @@
     </tr>
     <tr>
         <td class="label">{$form.extends.label}</td>
-        <td>{$form.extends.html} {help id="id-extends"}</td>
+        <td>{$form.extends.html|smarty:nodefaults} {help id="id-extends"}</td>
     </tr>
     <tr>
         <td class="label">{$form.weight.label}</td>

--- a/templates/CRM/Event/Import/Form/MapTable.tpl
+++ b/templates/CRM/Event/Import/Form/MapTable.tpl
@@ -46,7 +46,7 @@
                     {if $wizard.currentStepName == 'Preview'}
                         {$mapper[$i]}
                     {else}
-                        {$form.mapper[$i].html}
+                        {$form.mapper[$i].html|smarty:nodefaults}
                     {/if}
                 </td>
 

--- a/templates/CRM/Member/Import/Form/MapTable.tpl
+++ b/templates/CRM/Member/Import/Form/MapTable.tpl
@@ -46,7 +46,7 @@
                     {if $wizard.currentStepName == 'Preview'}
                         {$mapper[$i]}
                     {else}
-                        {$form.mapper[$i].html}
+                        {$form.mapper[$i].html|smarty:nodefaults}
                     {/if}
                 </td>
 

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -18,7 +18,7 @@
   <table class="form-layout-compressed">
     <tr class="crm-uf-field-form-block-field_name">
       <td class="label">{$form.field_name.label} {help id='field_name_0'}</td>
-      <td>{$form.field_name.html}<br />
+      <td>{$form.field_name.html|smarty:nodefaults}<br />
         <span class="description">&nbsp;{ts}Select the type of CiviCRM record and the field you want to include in this Profile.{/ts}</span></td>
     </tr>
     <tr class="crm-uf-field-form-block-label">


### PR DESCRIPTION


Overview
----------------------------------------
Do not escape hierarchical select

Before
----------------------------------------
Escaping applied to these quickform html hierarchical select elements, breaking the script

After
----------------------------------------
Elements marked for 'smarty:nodefaults' so escaping is not applied

Technical Details
----------------------------------------
We already have 'cutouts' in the escape function to not escape assigned html.
It isn't catching the hierarchical select elements - so I have marked a bunch
to not be escaped. I could have handled in 'escape' but I think tpl handling
is actually correct - the cutouts in the escape function was to get it to
a more manageable level

Comments
----------------------------------------
