### PR TITLE
Fix undefined index by making sure that is_template is always defined

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -280,14 +280,14 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->assignPremiumProduct($this->_id);
       $this->buildValuesAndAssignOnline_Note_Type($this->_id, $this->_values);
     }
+    if (!isset($this->_values['is_template'])) {
+      $this->_values['is_template'] = FALSE;
+    }
+    $this->assign('is_template', $this->_values['is_template']);
 
     // when custom data is included in this page
     if (!empty($_POST['hidden_custom'])) {
       $this->applyCustomData('Contribution', $this->getFinancialTypeID(), $this->_id);
-    }
-
-    if (!empty($this->_values['is_template'])) {
-      $this->assign('is_template', TRUE);
     }
 
     $this->_lineItems = [];


### PR DESCRIPTION
Overview
----------------------------------------
The value of `$this->_values['is_template']` is checked in various places but may not be defined. Fix that.

Before
----------------------------------------
`$this->_values['is_template']` not always defined.

After
----------------------------------------
`$this->_values['is_template']` always defined.

Technical Details
----------------------------------------
If the form is not editing a template contribution this won't be set in the form.

Comments
----------------------------------------

