### PR TITLE
 dev/core#3119 - Post-upgrade messages no longer being displayed

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -815,8 +815,9 @@ SET    version = '$version'
     $config = CRM_Core_Config::singleton();
     $config->userSystem->flush();
 
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, TRUE);
+    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
     // NOTE: triggerRebuild is FALSE becaues it will run again in a moment (via fixSchemaDifferences).
+    // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the Page. We reset later in doFinish().
 
     $versionCheck = new CRM_Utils_VersionCheck();
     $versionCheck->flushCache();
@@ -840,6 +841,7 @@ SET    version = '$version'
    * @return bool
    */
   public static function doFinish(): bool {
+    CRM_Core_Config::singleton()->cleanupCaches(TRUE);
     return TRUE;
   }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -841,7 +841,8 @@ SET    version = '$version'
    * @return bool
    */
   public static function doFinish(): bool {
-    CRM_Core_Config::singleton()->cleanupCaches(TRUE);
+    $session = CRM_Core_Session::singleton();
+    $session->reset(2);
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -195,7 +195,9 @@ class CRM_Upgrade_Incremental_Base {
     // Note: A good test-scenario is to install 5.45; enable logging and CiviGrant; disable searchkit+afform; then upgrade to 5.47.
     $schema = new CRM_Logging_Schema();
     $schema->fixSchemaDifferences();
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, TRUE);
+
+    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
+    // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the page. We reset later in doFinish().
 
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------

Backport @demeritcowboy's #22985 from 5.48-rc to 5.47-stable.

See also: https://lab.civicrm.org/dev/core/-/issues/3119
