### PR TITLE
Fix deleting afforms when deleting saved search

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -509,7 +509,7 @@ function afform_civicrm_pre($op, $entity, $id, &$params) {
       ->execute();
   }
   // When deleting a savedSearch, delete any Afforms which use the default display
-  if ($entity === 'SearchDisplay' && $op === 'delete') {
+  elseif ($entity === 'SavedSearch' && $op === 'delete') {
     $search = \Civi\Api4\SavedSearch::get(FALSE)
       ->addSelect('name')
       ->addWhere('id', '=', $id)

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -239,6 +239,12 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $this->assertCount(1, $refs);
     $this->assertEquals('Afform', $refs[0]['type']);
 
+    SearchDisplay::delete(FALSE)
+      ->addWhere('name', '=', 'TestDisplayToDelete')
+      ->execute();
+
+    $this->assertCount(1, Afform::get(FALSE)->addWhere('name', 'CONTAINS', 'TestAfformToDelete')->execute());
+
     SavedSearch::delete(FALSE)
       ->addWhere('name', '=', 'TestSearchToDelete')
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
A typo in the code was preventing afforms from being deleted with a corresponding saved search,
and may have led to afforms being deleted incorrectly!

Before
----------------------------------------
When embedding the "Default Display" of a SavedSeach in an Afform, the afform was not being deleted along with the SavedSearch.
The code looks like it might have been deleting other afforms by accident though, as the wrong ids were being looked up to delete.

After
----------------------------------------
Works correctly, test coverage added.