### PR TITLE
SearchKit - Fix "all selected" checkbox when selecting a single page …

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -21,7 +21,7 @@
 
       // Select all rows on the current page
       selectPage: function() {
-        this.allRowsSelected = true;
+        this.allRowsSelected = (this.rowCount <= this.results.length);
         this.selectedRows = _.uniq(_.pluck(this.results, 'key'));
       },
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup bugfix for #22906 - fixes the "all selected" checkbox when selecting a single page.

Before
----------------------------------------
When there is > 1 page of results, selecting "This page" results in a fully-checked box at the top, when it should have a line through it to indicate that not all results are selected.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/159568334-1508537f-faa5-400d-bfac-1ba982ddf843.png)