### PR TITLE
Fix notices on Task.tpl (grumpy mode)

### DIFF
--- a/templates/CRM/Contact/Form/Task.tpl
+++ b/templates/CRM/Contact/Form/Task.tpl
@@ -12,7 +12,7 @@
 {if $isSelectedContacts}
 <div id="popupContainer">
   <div class="crm-block crm-form-block crm-search-form-block">
-    <table id="selectedRecords-{if !empty($group)}{$group.id}{/if}" class="display crm-copy-fields crm-sortable">
+    <table id="selectedRecords-" class="display crm-copy-fields crm-sortable">
       <thead>
       <tr class="columnheader">
         <th class="contact_details">{ts}Name{/ts}</th>
@@ -56,8 +56,8 @@
     });
 
     var count = 0; var columns = ''; var sortColumn = '';
-    $('#selectedRecords-{/literal}{$group.id}{literal} th').each(function() {
-      if ($(this).attr('class') == 'contact_details') {
+    $('#selectedRecords- th').each(function() {
+      if ($(this).attr('class') === 'contact_details') {
         sortColumn += '[' + count + ', "asc" ],';
         columns += '{"sClass": "contact_details"},';
       }


### PR DESCRIPTION

Overview
----------------------------------------
Fix notices on Task.tpl (grumpy mode)

Note the screen is accessing by doing a task from contact search. The data table in question is the one you get when clicking on 'view selected contacts'

![image](https://user-images.githubusercontent.com/336308/159576220-baa92e98-3f05-49f3-9628-d46b30282635.png)

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/159575929-09624bc5-4c14-42a9-8f9f-f7fb07bf798a.png)



After
----------------------------------------
poof

Technical Details
----------------------------------------
The addition of group.id to this id dates back to
https://github.com/civicrm/civicrm-core/pull/3191

- a huge PR which attempted to block collisions on the data table id per
https://issues.civicrm.org/jira/browse/CRM-14636

However, I could find no evidence that 'group' would ever be assigned here
and as a rather large PR I suspect there was a bit of pattern replacement
beyond what was confirmed....

Removing 'group' means the selector becomes 'selectedRecords-' - which is
what it is in practice anyway since group is not assigned. This is possibly
accidentally unique anyway because of the trailing '-'

Comments
----------------------------------------
