### PR TITLE
E-notice fix on pdfLetter

### DIFF
--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -92,7 +92,7 @@
  <div class="crm-accordion-body">
    <div class="helpIcon" id="helphtml">
      <input class="crm-token-selector big" data-field="html_message" />
-     {help id="id-token-html" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp"}
+     {help id="id-token-html" file="CRM/Contact/Form/Task/Email.hlp"}
    </div>
     <div class="clear"></div>
     <div class='html'>


### PR DESCRIPTION

Overview
----------------------------------------
E-notice fix on pdfLetter 

Reached by choosing task print/merge letter from search results.

This drives the help text next to the token selector and neither
variable seem to impact on the help popup working....

Before
----------------------------------------
notice in smarty grumpy mode

After
----------------------------------------
Still works...

![image](https://user-images.githubusercontent.com/336308/159579471-d905c84a-bb47-4058-a489-32128bf73672.png)

![image](https://user-images.githubusercontent.com/336308/159579505-67965855-f5db-49b2-92b8-87944de39256.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
