### PR TITLE
Re-fix enotice on templateSelected

### DIFF
--- a/templates/CRM/Mailing/Form/InsertTokens.tpl
+++ b/templates/CRM/Mailing/Form/InsertTokens.tpl
@@ -25,13 +25,20 @@ var isMailing    = false;
   text_message = "mailing_format";
   isMailing = false;
   {/literal}
-  {elseif $form.formClass eq 'CRM_SMS_Form_Upload' || $form.formClass eq 'CRM_Contact_Form_Task_SMS'}
+{elseif $form.formClass eq 'CRM_SMS_Form_Upload' || $form.formClass eq 'CRM_Contact_Form_Task_SMS'}
   {literal}
   prefix = "SMS";
   text_message = "sms_text_message";
   isMailing = true;
   {/literal}
-  {else}
+  {if $templateSelected}
+    {literal}
+      if ( document.getElementsByName(prefix + "saveTemplate")[0].checked ) {
+        document.getElementById(prefix + "template").selectedIndex = {/literal}{$templateSelected}{literal};
+      }
+    {/literal}
+  {/if}
+{else}
   {literal}
   text_message = "text_message";
   html_message = (cj("#edit-html-message-value").length > 0) ? "edit-html-message-value" : "html_message";
@@ -45,13 +52,6 @@ var isMailing    = false;
   {/literal}
 {/if}
 
-{if !empty($templateSelected)}
-  {literal}
-  if ( document.getElementsByName(prefix + "saveTemplate")[0].checked ) {
-    document.getElementById(prefix + "template").selectedIndex = {/literal}{$templateSelected}{literal};
-  }
-{/literal}
-{/if}
 {literal}
 
 /**


### PR DESCRIPTION

Overview
----------------------------------------
Re-fix enotice on templateSelected

Before
----------------------------------------
This becomes an enotice if grumpy smarty mode is enabled - resulting in test fails

After
----------------------------------------
The templateSelected is only checked for the sms form - this is the only form that assigns it

![image](https://user-images.githubusercontent.com/336308/159581776-3af58755-8d6c-405f-9305-1ff204316847.png)


Technical Details
----------------------------------------
The empty check on templateSelected was added to stop tests failing on a smarty notice.

However, this still causes a smarty notice (and test fails) in grumpy smarty mode.

Hence this re-fixes in by moving the check to only be done for the from
(the sms Upload form) that assigns it

Comments
----------------------------------------
