### PR TITLE
dev/core#3132 Ensure that contacts are not placed in null island if g…

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1313,7 +1313,10 @@ SELECT is_primary,
     // core#2379 - Limit geocode length to 14 characters to avoid validation error on save in UI.
     foreach (['geo_code_1', 'geo_code_2'] as $geocode) {
       if ($params[$geocode] ?? FALSE) {
-        $params[$geocode] = (float) substr($params[$geocode], 0, 14);
+        // ensure that if the geocoding provider (Google, OSM etc) has returned the string 'null' because they can't geocode, ensure that contacts are not placed on null island 0,0
+        if ($params[$geocode] !== 'null') {
+          $params[$geocode] = (float) substr($params[$geocode], 0, 14);
+        }
       }
     }
     return $providerExists;

--- a/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
+++ b/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+class CRM_Utils_Geocode_TestProvider {
+
+  public static function format(&$values, $stateName = FALSE) {
+    if ($values['street_address'] == 'Does not exist') {
+      $values['geo_code_1'] = $values['geo_code_2'] = 'null';
+    }
+  }
+
+}

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -627,4 +627,27 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->callAPISuccess('Address', 'create', ['id' => $secondAddress['id'], 'contact_id' => $contactIdB, 'master_id' => $firstAddress['id']]);
   }
 
+  /**
+   * Ensure that when geocoding fails and geocoders return the string 'null' that it is not translated into int 0 for geo_code_1 and geo_code_2 which would place the contact on null island (0,0)
+   */
+  public function testGeocodingAddress(): void {
+    $this->callAPISuccess('Setting', 'create', ['geoProvider' => 'TestProvider']);
+    $cid = $this->individualCreate();
+    $r = $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $cid,
+      'location_type_id' => 1,
+      // Trigger geocoding to return 'null's for geo_code_1 and geo_code_2
+      'street_address' => 'Does not exist',
+      'city' => 'Hereville',
+      //'US',
+      'country_id' => 'US',
+      // 'California',
+      'state_province_id' => 'California',
+      'postal_code' => '94100',
+    ]);
+    $createdAddress = $this->callAPISuccess('Address', 'get', ['id' => $r['id']])['values'][$r['id']];
+    // If we have stored NULL values, then geo_code_1 should not be returned.
+    $this->assertFalse(isset($createdAddress['geo_code_1']));
+  }
+
 }


### PR DESCRIPTION
…eocoders return 'null' string for geocodes

Overview
----------------------------------------
This fixes a problem where by geocoders such as [google](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Geocode/Google.php#L136) return the string 'null' which is then treated as a truthy value in the if on L1315 and there for the geo_code fields get set to 0 instead of NULL in the database 

Before
----------------------------------------
geo_code_1 and geo_code_2 get set to 0 and contacts are placed on null island

After
----------------------------------------
Contacts are not placed on null island

ping @johntwyman @eileenmcnaughton 