### PR TITLE
SearchKit - Fix multi-valued afform filters

### DIFF
--- a/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
+++ b/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
@@ -1,5 +1,6 @@
 <div af-fieldset="">
   <af-field name="source" />
+  <af-field name="contact_type" />
   <div class="af-container af-layout-inline">
     <af-field name="Contact_Email_contact_id_01.email" />
     <af-field name="Contact_Email_contact_id_01.location_type_id" defn="{input_attrs: {multiple: true}}" />

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1014,22 +1014,28 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     if (!empty($field['options'])) {
       $options = civicrm_api4($field['entity'], 'getFields', [
         'loadOptions' => TRUE,
+        'checkPermissions' => FALSE,
         'where' => [['name', '=', $field['name']]],
       ])->first()['options'] ?? [];
-      if (!empty($options[$value])) {
-        $this->filterLabels[] = $options[$value];
+      foreach ((array) $value as $val) {
+        if (!empty($options[$val])) {
+          $this->filterLabels[] = $options[$val];
+        }
       }
     }
     elseif (!empty($field['fk_entity'])) {
       $idField = CoreUtil::getIdFieldName($field['fk_entity']);
       $labelField = CoreUtil::getInfoItem($field['fk_entity'], 'label_field');
       if ($labelField) {
-        $record = civicrm_api4($field['fk_entity'], 'get', [
-          'where' => [[$idField, '=', $value]],
+        $records = civicrm_api4($field['fk_entity'], 'get', [
+          'checkPermissions' => $this->checkPermissions,
+          'where' => [[$idField, 'IN', (array) $value]],
           'select' => [$labelField],
-        ])->first() ?? NULL;
-        if (isset($record[$labelField])) {
-          $this->filterLabels[] = $record[$labelField];
+        ]);
+        foreach ($records as $record) {
+          if (isset($record[$labelField])) {
+            $this->filterLabels[] = $record[$labelField];
+          }
         }
       }
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -46,9 +46,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             'GROUP_CONCAT(DISTINCT Contact_Email_contact_id_01.email) AS GROUP_CONCAT_Contact_Email_contact_id_01_email',
           ],
           'orderBy' => [],
-          'where' => [
-            ['contact_type:name', '=', 'Individual'],
-          ],
+          'where' => [],
           'groupBy' => ['id'],
           'join' => [
             [
@@ -146,6 +144,12 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $params['filters'] = ['first_name' => 'tester2'];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertGreaterThan(1, $result->count());
+
+    // For a filter with options, ensure labels are set
+    $params['filters'] = ['contact_type' => ['Individual']];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertGreaterThan(1, $result->count());
+    $this->assertEquals(['Individual'], $result->labels);
 
     // Note that filters add a wildcard so the value `afform_test` matches all 3 sample contacts;
     // But the Afform markup contains `filters="{last_name: 'AfformTest'}"` which only matches 2.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a SearchKit regression causing multi-select afform filters to stop working.

Before
----------------------------------------
- Create a search for e.g. Activities
- Add it to a Form
- Add a multi-select filter e.g. Activity Type
- Visit the form and try using the filter. It will return no results.

After
----------------------------------------
Fixed, test coverage added.

Technical Details
----------------------------------------
Multi-select search filters stopped working as of 007167dfb90eaaeb0c76f2c9e5b0327f0b3e22e9 due to the label lookup assuming single-valued input. This fix adds a test for getting labels with multi-valued filter input.