### PR TITLE
SearchKit - Fix multi-valued afform filters

### DIFF
--- a/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
+++ b/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
@@ -1,5 +1,6 @@
 <div af-fieldset="">
   <af-field name="source" />
+  <af-field name="contact_type" />
   <div class="af-container af-layout-inline">
     <af-field name="Contact_Email_contact_id_01.email" />
     <af-field name="Contact_Email_contact_id_01.location_type_id" defn="{input_attrs: {multiple: true}}" />

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -46,9 +46,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             'GROUP_CONCAT(DISTINCT Contact_Email_contact_id_01.email) AS GROUP_CONCAT_Contact_Email_contact_id_01_email',
           ],
           'orderBy' => [],
-          'where' => [
-            ['contact_type:name', '=', 'Individual'],
-          ],
+          'where' => [],
           'groupBy' => ['id'],
           'join' => [
             [
@@ -146,6 +144,12 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $params['filters'] = ['first_name' => 'tester2'];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertGreaterThan(1, $result->count());
+
+    // For a filter with options, ensure labels are set
+    $params['filters'] = ['contact_type' => ['Individual']];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertGreaterThan(1, $result->count());
+    $this->assertEquals(['Individual'], $result->labels);
 
     // Note that filters add a wildcard so the value `afform_test` matches all 3 sample contacts;
     // But the Afform markup contains `filters="{last_name: 'AfformTest'}"` which only matches 2.


### PR DESCRIPTION
Overview
----------------------------------------
Backports the regression fix from #23012 to the 5.47 branch.

Comments
-------------
IMO it's a bad-enough regression with a simple-enough fix to merit backporting.