### PR TITLE
resolve TypeError: unsupported operand types: string + int;

### DIFF
--- a/templates/CRM/Price/Form/LineItem.tpl
+++ b/templates/CRM/Price/Form/LineItem.tpl
@@ -124,7 +124,8 @@
           {assign var="lineItemCount" value=0}
 
           {foreach from=$pcount item=p_count}
-            {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
+            {assign var="intPCount" value=$p_count.participant_count|intval}
+            {assign var="lineItemCount" value=$lineItemCount+$intPCount}
           {/foreach}
           {if $lineItemCount < 1 }
             {assign var="lineItemCount" value=1}

--- a/templates/CRM/Price/Page/LineItem.tpl
+++ b/templates/CRM/Price/Page/LineItem.tpl
@@ -111,7 +111,8 @@
         {assign var="lineItemCount" value=0}
 
         {foreach from=$pcount item=p_count}
-          {assign var="lineItemCount" value=$lineItemCount+$p_count.participant_count}
+          {assign var="intPCount" value=$p_count.participant_count|intval}
+          {assign var="lineItemCount" value=$lineItemCount+$intPCount}
         {/foreach}
         {if $lineItemCount < 1 }
           {assign var="lineItemCount" value=1}


### PR DESCRIPTION
Overview
----------------------------------------
resolve PHP 8 TypeError: Unsupported operand types: string + int in LineItem.tpl

Before
----------------------------------------
Editing a contribution for Event Fees, generates the error from the smarty tpl because participant count is apparently a string.

After
----------------------------------------
PHP8 compatible code.

Comments
----------------------------------------
There are probably other occurences of this type of problem but I have no idea how to root them out.
