### PR TITLE
Respect zero value

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -113,7 +113,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     // Default weight & value
     $fieldValues = ['option_group_id' => $this->_gid];
     foreach (['weight', 'value'] as $field) {
-      if (empty($defaults[$field])) {
+      if (!isset($defaults[$field]) || $defaults[$field] === '') {
         $defaults[$field] = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_OptionValue', $fieldValues, $field);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
If the value or weight for the option value is set to 0, the edit screen still recalculates the value or weight. 