### PR TITLE
[NFC] Update 5.47 release notes synopsis to warn that it requires attention to configuration options

### DIFF
--- a/release-notes/5.47.0.md
+++ b/release-notes/5.47.0.md
@@ -16,7 +16,7 @@ Released March 4, 2022
 | Fix security vulnerabilities?                                   |   no    |
 | **Change the database schema?**                                 | **yes** |
 | **Alter the API?**                                              | **yes** |
-| Require attention to configuration options?                     |   no    |
+| **Require attention to configuration options?**                 | **yes** |
 | Fix problems installing or upgrading to a previous version?     |   no    |
 | **Introduce features?**                                         | **yes** |
 | **Fix bugs?**                                                   | **yes** |


### PR DESCRIPTION
Overview
----------------------------------------
This updates the 5.47 release notes to warn people that 5.47 requires attention to configuration options. I am specifically thinking of the CiviEvent timezone issues.

