### PR TITLE
(dev/core#3136) Incorporate the domain id in the log file nomenclature to hel…

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -689,7 +689,12 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       else {
         $hash = '';
       }
-      $fileName = $config->configAndLogDir . 'CiviCRM.' . $prefixString . $hash . 'log';
+
+      $domainPrefix = '';
+      if (is_multisite()) {
+        $domainPrefix = CIVICRM_DOMAIN_ID . '_';
+      }
+      $fileName = $config->configAndLogDir . 'CiviCRM.' . $domainPrefix . $prefixString . $hash . 'log';
 
       // Roll log file monthly or if greater than our threshold.
       // Size-based rotation introduced in response to filesize limits on


### PR DESCRIPTION
…p locate the file easily

Overview
----------------------------------------
If you have loads of domains, it gets harder to locate the correct log file. Incorporating the domain id in the log file name will make it simpler.

Before
----------------------------------------
Harder to locate the domain specific file.

After
----------------------------------------
Nomenclature reflects the domain id making it easier to locate.