### PR TITLE
Redirect to Profile "create" screen when there is no Contact ID

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -96,7 +96,13 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
 
       // CRM-16784: If there is no ID then this can't be an 'edit'
       else {
-        CRM_Core_Error::statusBounce(ts('No user/contact ID was specified, so the Profile cannot be used in edit mode.'));
+        // Redirect to 'create' profile instead.
+        $gid = CRM_Utils_Request::retrieve('gid', 'Positive', $this);
+        $redirect = NULL;
+        if ($gid) {
+          $redirect = CRM_Utils_System::url('civicrm/profile/create', 'gid=' . $gid . '&reset=1');
+        }
+        CRM_Core_Error::statusBounce(ts('No user/contact ID was specified, so the Profile cannot be used in edit mode.'), $redirect);
       }
 
     }


### PR DESCRIPTION
Overview
----------------------------------------
Implements [this improvement proposal on Lab](https://lab.civicrm.org/dev/core/-/issues/3138).

Before
----------------------------------------
On Profile "edit" screens when there is no Contact ID, `statusBounce` redirects to the homepage of the site.

After
----------------------------------------
On Profile "edit" screens when there is no Contact ID, `statusBounce` redirects to the Profile "create" screen.