### PR TITLE
SearchKit - Add icon support

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -235,7 +235,7 @@
   $(function() {
     // Shoehorn in a non-angular widget for picking icons
     $('#crm-container').append('<div style="display:none"><input id="af-gui-icon-picker"></div>');
-    CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').done(function() {
+    CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').then(function() {
       $('#af-gui-icon-picker').crmIconPicker();
     });
     // Add css classes while dragging

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -135,7 +135,7 @@ class Admin {
           $entity['links'] = array_values($links);
         }
         $getFields = civicrm_api4($entity['name'], 'getFields', [
-          'select' => ['name', 'title', 'label', 'description', 'type', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'entity', 'fk_entity', 'readonly', 'operators', 'nullable'],
+          'select' => ['name', 'title', 'label', 'description', 'type', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'entity', 'fk_entity', 'readonly', 'operators', 'suffixes', 'nullable'],
           'where' => [['name', 'NOT IN', ['api_key', 'hash']]],
           'orderBy' => ['label'],
         ]);

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -400,7 +400,7 @@
   // Shoehorn in a non-angular widget for picking icons
   $(function() {
     $('#crm-container').append('<div style="display:none"><input id="crm-search-admin-icon-picker"></div>');
-    CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').done(function() {
+    CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').then(function() {
       $('#crm-search-admin-icon-picker').crmIconPicker();
     });
   });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -501,7 +501,7 @@
           prefix = typeof prefix === 'undefined' ? '' : prefix;
           _.each(fields, function(field) {
             var item = {
-              id: prefix + field.name + (field.options ? suffix : ''),
+              id: prefix + field.name + (field.suffixes && _.includes(field.suffixes, suffix.replace(':', '')) ? suffix : ''),
               text: field.label,
               description: field.description
             };

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -51,4 +51,5 @@
     {{:: ts('In-Place Edit') }}
   </label>
 </div>
+<search-admin-icons item="col"></search-admin-icons>
 <search-admin-css-rules label="{{:: ts('Style') }}" item="col" default="col.key"></search-admin-css-rules>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
@@ -23,8 +23,8 @@
   <label>{{:: ts('If') }}</label>
   <input class="form-control collapsible-optgroups" ng-model="clause[1]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(clause)" />
   <crm-search-condition ng-if="clause[1]" clause="clause" field="$ctrl.getField(clause[1])" offset="2" option-key="'name'" format="$ctrl.format" class="form-group"></crm-search-condition>
-  <button type="button" class="btn-xs btn-danger-outline" ng-click="$ctrl.item.cssRules.splice($index);" title="{{:: ts('Remove style') }}">
-    <i class="crm-i fa-ban"></i>
+  <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.item.cssRules.splice($index, 1);" title="{{:: ts('Remove style') }}">
+    <i class="crm-i fa-times"></i>
   </button>
 </div>
 <div class="form-inline" ng-if="$ctrl.showMore()" title="{{:: ts('Set background color or text style based on a field value') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.component.js
@@ -1,0 +1,103 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('searchAdminIcons', {
+    bindings: {
+      item: '<'
+    },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/crmSearchAdmin/displays/common/searchAdminIcons.html',
+    controller: function($scope, $element, $timeout, searchMeta) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.getField = searchMeta.getField;
+
+      this.fields = function() {
+        var allFields = ctrl.crmSearchAdmin.getAllFields(':name', ['Field', 'Custom', 'Extra', 'Pseudo']);
+        return {
+          results: ctrl.crmSearchAdmin.getSelectFields().concat(allFields)
+        };
+      };
+
+      function initWidgets() {
+        CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmIconPicker.js').then(function() {
+          $('.crm-search-admin-field-icon > input.crm-icon-picker[ng-model]', $element).crmIconPicker();
+        });
+      }
+
+      this.$onInit = function() {
+        $element.on('hidden.bs.dropdown', function() {
+          $timeout(function() {
+            ctrl.menuOpen = false;
+          });
+        });
+        var allFields = ctrl.crmSearchAdmin.getAllFields(':icon'),
+          entityLabel = searchMeta.getEntity(ctrl.crmSearchAdmin.savedSearch.api_entity).title;
+        // Gather all fields with an icon
+        function getIconFields(iconFields, group, i) {
+          if (group.children) {
+            // Use singular title for main entity
+            entityLabel = i ? group.text : entityLabel;
+            _.transform(group.children, function(iconFields, field) {
+              if (field.id && _.endsWith(field.id, 'icon')) {
+                field.text = entityLabel + ' - ' + field.text;
+                iconFields.push(field);
+              }
+            }, iconFields);
+          }
+        }
+        ctrl.iconFields = _.transform(allFields, getIconFields, []);
+        ctrl.iconFieldMap = _.indexBy(ctrl.iconFields, 'id');
+        $timeout(initWidgets);
+      };
+
+      this.onSelectField = function(clause) {
+        if (clause[0]) {
+          clause[1] = '=';
+          clause.length = 2;
+        } else {
+          clause.length = 0;
+        }
+      };
+
+      this.addIcon = function(field) {
+        ctrl.item.icons = ctrl.item.icons || [];
+        if (field) {
+          ctrl.item.icons.push({field: field, side: 'left'});
+        }
+        else {
+          searchMeta.pickIcon().then(function(icon) {
+            if (icon) {
+              ctrl.item.icons.push({icon: icon, side: 'left', if: []});
+              $timeout(initWidgets);
+            }
+          });
+        }
+      };
+
+      this.pickIcon = function(index) {
+        var item = ctrl.item.icons[index];
+        searchMeta.pickIcon().then(function(icon) {
+          if (icon) {
+            item.icon = icon;
+            delete item.field;
+            item.if = item.if || [];
+            $timeout(initWidgets);
+          }
+        });
+      };
+
+      this.setIconField = function(field, index) {
+        var item = ctrl.item.icons[index];
+        delete item.icon;
+        delete item.if;
+        item.field = field;
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.html
@@ -1,0 +1,51 @@
+<div class="form-inline" ng-repeat="icon in $ctrl.item.icons">
+  <label>{{:: ts('Icon') }}</label>
+  <div class="input-group">
+    <div class="input-group-btn">
+      <button type="button" ng-click="$ctrl.menuOpen = true" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span>{{ icon.field ? $ctrl.iconFieldMap[icon.field].text : ts('Choose...') }}</span> <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" ng-if="$ctrl.menuOpen">
+        <li ng-repeat="field in $ctrl.iconFields">
+          <a href ng-click="$ctrl.setIconField(field.id, $parent.$index)">{{:: field.text }}</a>
+        </li>
+        <li class="divider" ng-show="$ctrl.iconFields.length" role="separator"></li>
+        <li>
+          <a href ng-click="$ctrl.pickIcon($index)">{{:: ts('Choose Icon...') }}</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="form-group crm-search-admin-field-icon" ng-if="icon.icon">
+    <input required ng-model="icon.icon" class="form-control crm-icon-picker">
+  </div>
+  <select class="form-control" ng-model="icon.side" title="{{:: ts('Show icon on left or right side of the field') }}">
+    <option value="left">{{:: ts('Align left') }}</option>
+    <option value="right">{{:: ts('Align right') }}</option>
+  </select>
+  <div class="form-group" ng-if="icon.if">
+    <label>{{:: ts('If') }}</label>
+    <input class="form-control collapsible-optgroups" ng-model="icon.if[0]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(icon.if)" />
+    <crm-search-condition ng-if="icon.if[0]" clause="icon.if" field="$ctrl.getField(icon.if[0])" offset="1" option-key="'name'" format="$ctrl.format" class="form-group"></crm-search-condition>
+  </div>
+  <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.item.icons.splice($index, 1);" title="{{:: ts('Remove icon') }}">
+    <i class="crm-i fa-times"></i>
+  </button>
+</div>
+<div class="form-inline" title="{{:: ts('Add icon(s) to this column') }}">
+  <label>{{:: ts('Icon') }}</label>
+  <div class="btn-group">
+    <button type="button" ng-click="$ctrl.menuOpen = true" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <span>{{ $ctrl.item.icons && $ctrl.item.icons.length ? ts('Add') : ts('None') }}</span> <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" ng-if="$ctrl.menuOpen">
+      <li ng-repeat="field in $ctrl.iconFields">
+        <a href ng-click="$ctrl.addIcon(field.id)">{{:: field.text }}</a>
+      </li>
+      <li class="divider" ng-show="$ctrl.iconFields.length" role="separator"></li>
+      <li>
+        <a href ng-click="$ctrl.addIcon()">{{:: ts('Choose Icon...') }}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,11 +1,14 @@
 <crm-search-display-editable row="row" col="colData" do-save="$ctrl.runSearch([apiCall], {}, row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
 <span ng-if="::!colData.links" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
+  <i ng-repeat="icon in colData.icons" ng-if="icon.side === 'left'" class="crm-i {{:: icon['class'] }}"></i>
   {{:: $ctrl.formatFieldValue(colData) }}
+  <i ng-repeat="icon in colData.icons" ng-if="icon.side === 'right'" class="crm-i {{:: icon['class'] }}"></i>
 </span>
 <span ng-if="::colData.links">
   <span ng-repeat="link in colData.links">
     <a target="{{:: link.target }}" href="{{:: link.url }}">
-      {{:: link.text }}</a><span ng-if="!$last">,
+      <i ng-repeat="icon in colData.icons" ng-if="icon.side === 'left'" class="crm-i {{:: icon['class'] }}"></i>
+      {{:: link.text }}<i ng-repeat="icon in colData.icons" ng-if="icon.side === 'right'" class="crm-i {{:: icon['class'] }}"></i></a><span ng-if="!$last">,
     </span>
   </span>
 </span>

--- a/js/jquery/jquery.crmIconPicker.js
+++ b/js/jquery/jquery.crmIconPicker.js
@@ -27,8 +27,9 @@
       }
 
       var $input = $(this),
+        classes = ($input.attr('class') || '').replace('crm-icon-picker', ''),
         $button = $('<a class="crm-icon-picker-button" href="#" />').button().removeClass('ui-corner-all').attr('title', $input.attr('title')),
-        $style = $('<select class="crm-form-select"></select>'),
+        $style = $('<select class="crm-form-select"></select>').addClass(classes),
         options = [
           {key: 'fa-rotate-90', value: ts('Rotate right')},
           {key: 'fa-rotate-270', value: ts('Rotate left')},
@@ -90,7 +91,8 @@
             '<div class="icon-ctrls crm-clearfix">' +
             '<input class="crm-form-text" name="search" placeholder="&#xf002"/>' +
             '<select class="crm-form-select"></select>' +
-            '<button type="button" class="cancel" title=""><i class="crm-i fa-ban" aria-hidden="true"></i> ' + ts('No icon') + '</button>' +
+            // Add "No Icon" button unless field is required
+            ($input.is('[required]') ? '' : '<button type="button" class="cancel" title=""><i class="crm-i fa-ban" aria-hidden="true"></i> ' + ts('No icon') + '</button>') +
             '</div>' +
             '<div class="icons"></div>'
           );


### PR DESCRIPTION
Overview
----------------------------------------
This allows each column to have one or more icons, based on a field value or a conditional rule.

Before
----------------------------------------
No icons in search displays.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/160124219-df0c8ad1-7b2f-49c3-b601-11b2d16140fb.png)

Technical Details
----------------------------------------
Supplemented by #22996 which helps SearchKit accurately know what fields contain an icon.
