### PR TITLE
Dedupe - Fix redirecting to contact after merge

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -326,11 +326,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         $urlParams
       ));
     }
-    elseif (!empty($formValues['_qf_Merge_done'])) {
-      CRM_Core_Session::singleton()->pushUserContext($contactViewUrl);
-    }
-
-    elseif ($this->next && $this->_mergeId) {
+    elseif ($this->next && $this->_mergeId && empty($formValues['_qf_Merge_done'])) {
       $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $this->_gid, json_decode($this->criteria, TRUE), TRUE, $this->limit);
 
       $join = CRM_Dedupe_Merger::getJoinOnDedupeTable();
@@ -349,6 +345,9 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         $urlParams['action'] = 'update';
         CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/merge', $urlParams));
       }
+    }
+    else {
+      CRM_Core_Session::singleton()->pushUserContext($contactViewUrl);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3135](https://lab.civicrm.org/dev/core/-/issues/3135)

Before
----------------------------------------
1. user does a search from basic search, advanced search etc
2. user selects 2 contacts & chooses the action to merge them
3. user submits the screen to merge them
4. *user incorrectly redirected back to the search*

After
----------------------------------------
4. user redirected to the single resulting contact

Technical Details
----------------------------------------
The final redirect was accidentally changed by a6f2a80ffbddfc0788199ec824b8aff46ccd1542

Comments
--------------------------
Turns out this comment was incorrect and a final "catch-all" else is needed
https://github.com/civicrm/civicrm-core/blob/e8cf95b40d52d51a29036078c997082c7f4a0653/CRM/Contact/Form/Merge.php#L358-L359
