### PR TITLE
Stop passing settings into getTaxLabel

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -129,10 +129,6 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
             else {
               $labelClass = 'price_set_field-label';
             }
-            // show tax rate with amount
-            $invoiceSettings = Civi::settings()->get('contribution_invoice_settings');
-            $taxTerm = Civi::settings()->get('tax_term');
-            $displayOpt = $invoiceSettings['tax_display_settings'] ?? NULL;
 
             foreach ($fieldValues['options'] as $optionId => $optionVal) {
               if (CRM_Utils_Array::value('visibility_id', $optionVal) != array_search('public', $visibility) &&
@@ -143,7 +139,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
 
               $values['feeBlock']['isDisplayAmount'][$fieldCnt] = $fieldValues['is_display_amounts'] ?? NULL;
               if (Civi::settings()->get('invoicing') && isset($optionVal['tax_amount'])) {
-                $values['feeBlock']['value'][$fieldCnt] = CRM_Price_BAO_PriceField::getTaxLabel($optionVal, 'amount', $displayOpt, $taxTerm, $eventCurrency);
+                $values['feeBlock']['value'][$fieldCnt] = CRM_Price_BAO_PriceField::getTaxLabel($optionVal, 'amount', $eventCurrency);
                 $values['feeBlock']['tax_amount'][$fieldCnt] = $optionVal['tax_amount'];
               }
               else {

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -390,7 +390,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
               $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
             }
             if (isset($taxAmount) && $invoicing) {
-              $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . self::getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm);
+              $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . self::getTaxLabel($opt, $valueFieldName);
             }
             else {
               $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
@@ -488,7 +488,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           if ($field->is_display_amounts) {
             $opt['label'] .= '&nbsp;-&nbsp;';
             if (isset($taxAmount) && $invoicing) {
-              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm);
+              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
             }
             else {
               $opt['label'] = $opt['label'] . CRM_Utils_Money::format($opt[$valueFieldName]);
@@ -550,7 +550,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             }
             $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>&nbsp;-&nbsp;';
             if (isset($taxAmount) && $invoicing) {
-              $opt['label'] .= self::getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm);
+              $opt['label'] .= self::getTaxLabel($opt, $valueFieldName);
             }
             else {
               $opt['label'] .= CRM_Utils_Money::format($opt[$valueFieldName]);
@@ -826,20 +826,18 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
    * @param array $opt
    * @param string $valueFieldName
    *   Amount.
-   * @param string $displayOpt
-   *   Tax display setting option.
-   *
-   * @param string $taxTerm
    * @param string|null $currency
    *
    * @return string
    *   Tax label for custom field.
    */
-  public static function getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm, $currency = NULL) {
-    if ($displayOpt == 'Do_not_show') {
+  public static function getTaxLabel($opt, $valueFieldName, $currency = NULL) {
+    $taxTerm = Civi::settings()->get('tax_term');
+    $displayOpt = Civi::settings()->get('tax_display_settings');
+    if ($displayOpt === 'Do_not_show') {
       $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount'], $currency);
     }
-    elseif ($displayOpt == 'Inclusive') {
+    elseif ($displayOpt === 'Inclusive') {
       $label = CRM_Utils_Money::format($opt[$valueFieldName] + $opt['tax_amount'], $currency);
       $label .= '<span class="crm-price-amount-tax"> ' . ts('(includes %1 of %2)', [1 => $taxTerm, 2 => CRM_Utils_Money::format($opt['tax_amount'], $currency)]) . '</span>';
     }


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing settings into getTaxLabel

Before
----------------------------------------
`CRM_Price_BAO_PriceField::getTaxLabel` is called from 2 places in the code. In both places the values passed into the function as `$displayOpt` and ` $taxTerm` are just the settings. In one place these are only retrieved to be passed into this function

 ` public static function getTaxLabel($opt, $valueFieldName, $displayOpt, $taxTerm, $currency = NULL) {`

After
----------------------------------------
Settings don't need to be passed around.... removed from the function signature


Technical Details
----------------------------------------

Comments
----------------------------------------
