### PR TITLE
Event Location fixes

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -88,7 +88,7 @@
             dataType: 'json',
             success: function(data) {
               var selectLocBlockId = $('#loc_event_id').val();
-              // Only change state when options are loaded
+              // Only change state when options are loaded.
               if (data.address_1_state_province_id) {
                 var defaultState = data.address_1_state_province_id;
                 $('#address_1_state_province_id', $form).one('crmOptionsUpdated', function() {
@@ -100,7 +100,8 @@
                 if ( i == 'count_loc_used' ) {
                   if ( ((selectLocBlockId == locBlockId) && data.count_loc_used > 1) ||
                     ((selectLocBlockId != locBlockId) && data.count_loc_used > 0) ) {
-                    displayMessage(data.count_loc_used);
+                    // Counts retrieved via AJAX are already "other" Event counts.
+                    displayMessage(parseInt(data.count_loc_used) + 1);
                   } else {
                     displayMessage(0);
                   }
@@ -117,12 +118,12 @@
           var createNew = document.getElementsByName("location_option")[0].checked;
           if (createNew) {
             $('#existingLoc', $form).hide();
-            //clear all location fields values.
+            // Clear all location fields values.
             if (clear !== false) {
               $(":input[id *= 'address_1_'], :input[id *= 'email_1_'], :input[id *= 'phone_1_']", $form).val("").change();
               {/literal}{if $config->defaultContactCountry}
               {if $config->defaultContactStateProvince}
-              // Set default state once options are loaded
+              // Set default state once options are loaded.
               var defaultState = {$config->defaultContactStateProvince}
               {literal}
                 $('#address_1_state_province_id', $form).one('crmOptionsUpdated', function() {
@@ -147,9 +148,14 @@
         showLocFields(false);
 
         function displayMessage(count) {
-          if (count) {
-            var msg = {/literal}'{ts escape="js" 1="%1"}This location is used by %1 other events. Modifying location information will change values for all events.{/ts}'{literal};
-            $('#locUsedMsg', $form).text(ts(msg, {1: count})).addClass('status');
+          if (parseInt(count) > 1) {
+            var otherCount = parseInt(count) - 1;
+            if (otherCount > 1) {
+              var msg = {/literal}'{ts escape="js" 1="%1"}This location is used by %1 other events. Modifying location information will change values for all events.{/ts}'{literal};
+            } else {
+              var msg = {/literal}'{ts escape="js" 1="%1"}This location is used by %1 other event. Modifying location information will also change values for that event.{/ts}'{literal};
+            }
+            $('#locUsedMsg', $form).text(ts(msg, {1: otherCount})).addClass('status');
           } else {
             $('#locUsedMsg', $form).text(' ').removeClass('status');
           }


### PR DESCRIPTION
Overview
----------------------------------------
The PR goes part way to addressing the issues raised in [this Lab ticket](https://lab.civicrm.org/dev/core/-/issues/2103).

Before
----------------------------------------
The issues are succinctly summarised in the OP and [in this comment](https://lab.civicrm.org/dev/core/-/issues/2103#note_66827):

After
----------------------------------------
* LocBlocks are not duplicated
* Address, Email and Phone records are not duplicated
* The "This location is used by..." warning shows correct values
* The "This location is used by..." warning is pluralised

Comments
----------------------------------------
I have not tested the results of this PR in all possible scenarios but offer it as an improvement on the status quo and a basis for further refinement. I have liberally commented the code in case the changes affect other workflows, e.g. #18586, #18488, #13534 and others I've probably missed.

Not addressed
----------------------------------------
* "It is not easy to see what other events use that location."
* "Consider whether [the displayed count] is all events, or just active and/or future events"
* "Maybe include a link to search for events using that location"

There is also the question of what happens when, say, an Email field is cleared... is the intent to _delete_ the Email record, or should the record remain as is currently the case?