### PR TITLE
Replace incorrect class comment

### DIFF
--- a/CRM/Activity/Form/Task/AddToTag.php
+++ b/CRM/Activity/Form/Task/AddToTag.php
@@ -16,9 +16,8 @@
  */
 
 /**
- * This class provides the functionality to delete a group of
- * contacts. This class provides functionality for the actual
- * addition of contacts to groups.
+ * This class provides the functionality to tag a group of
+ * activities (or a single activity)
  */
 class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
 


### PR DESCRIPTION
Overview
----------------------------------------
The class comment was wrong, and clearly a copy-paste from an earlier class. Replace with something more suitable.
