### PR TITLE
Link to Google Maps over HTTPs

### DIFF
--- a/templates/CRM/Contact/Form/Task/Map/Google.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/Google.tpl
@@ -89,7 +89,7 @@
     function gpopUp() {
   var from   = document.getElementById('from').value;
   var to     = document.getElementById('to').value;
-  var URL    = "http://maps.google.com/maps?saddr=" + from + "&daddr=" + to;
+  var URL    = "https://maps.google.com/maps?saddr=" + from + "&daddr=" + to;
   day = new Date();
   id  = day.getTime();
   eval("page" + id + " = window.open(URL, '" + id + "', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=780,height=640,left = 202,top = 100');");

--- a/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
@@ -163,7 +163,7 @@
     function gpopUp() {
         var from   = document.getElementById('from').value;
         var to     = document.getElementById('to').value;
-        var URL    = "http://maps.google.com/maps?saddr=" + from + "&daddr=" + to;
+        var URL    = "https://maps.google.com/maps?saddr=" + from + "&daddr=" + to;
         day = new Date();
         id  = day.getTime();
         eval("page" + id + " = window.open(URL, '" + id + "', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=780,height=640,left = 202,top = 100');");


### PR DESCRIPTION
Overview
----------------------------------------
Link to Google Maps over HTTPs.

These links contain address information, and so including this data in unsecured http requests could be considered data exposure. It's 2022, HTTPS has been widespread for years, I can see no downside to this.

Before
----------------------------------------
Google maps was linked to over http.

After
----------------------------------------
Google maps was linked to over https.

Comments
----------------------------------------
This affects the "Get Directions FROM" function when viewing an address by map.
