### PR TITLE
Avoid PHP notices from smarty on pricefield table

### DIFF
--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -148,11 +148,11 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
         }
       }
 
-      if ($priceFieldBAO->active_on == '0000-00-00 00:00:00') {
+      if (!isset($priceField[$priceFieldBAO->id]['active_on']) || $priceFieldBAO->active_on == '0000-00-00 00:00:00') {
         $priceField[$priceFieldBAO->id]['active_on'] = '';
       }
 
-      if ($priceFieldBAO->expire_on == '0000-00-00 00:00:00') {
+      if (!isset($priceField[$priceFieldBAO->id]['expire_on']) || $priceFieldBAO->expire_on == '0000-00-00 00:00:00') {
         $priceField[$priceFieldBAO->id]['expire_on'] = '';
       }
 
@@ -230,8 +230,13 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
     );
 
     if ($this->_sid) {
+      $usedByDefaults = [
+        'civicrm_event' => FALSE,
+        'civicrm_event' => FALSE,
+        'civicrm_contribution_page' => FALSE,
+      ];
       $usedBy = CRM_Price_BAO_PriceSet::getUsedBy($this->_sid);
-      $this->assign('usedBy', $usedBy);
+      $this->assign('usedBy', array_merge($usedByDefaults, $usedBy));
       $this->_isSetReserved = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_sid, 'is_reserved');
       $this->assign('isReserved', $this->_isSetReserved);
 


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP notices from smarty on pricefield table. Specifically:

- Default the active and expires dates to an empty string if they are not set.
- Always set each possible `usedBy` key to false, setting the `true` keys from `CRM_Price_BAO_PriceSet::getUsedBy`.

Before
----------------------------------------
PHP notices in civicrm/admin/price/field page.

After
----------------------------------------
The PHP notices have gone.
