### PR TITLE
split sql select into two selects for performance reasons

### DIFF
--- a/CRM/Mailing/Event/BAO/Unsubscribe.php
+++ b/CRM/Mailing/Event/BAO/Unsubscribe.php
@@ -223,7 +223,29 @@ WHERE  email = %2
       CRM_Contact_BAO_GroupContactCache::check(array_merge($groupIds, $baseGroupIds));
     }
 
-    $groupsSQL = "
+    /* https://lab.civicrm.org/dev/core/-/issues/3031
+     * When 2 separate tables are referenced in an OR clause the index will be used on one & not the other. At the sql
+     * level we usually deal with this by using UNION to join the 2 queries together - the patch is doing the same thing at
+     * the php level & probably as a result performs better than the original not-that-bad OR clause did & likely similarly to
+     * how a UNION would work.
+     */
+    $groupsCachedSQL = "
+            SELECT      grp.id as group_id,
+                        grp.title as title,
+                        grp.frontend_title as frontend_title,
+                        grp.frontend_description as frontend_description,
+                        grp.description as description,
+                        grp.saved_search_id as saved_search_id
+            FROM        civicrm_group grp
+            LEFT JOIN   civicrm_group_contact_cache gcc
+                ON      gcc.group_id = grp.id
+            WHERE       grp.is_hidden = 0
+                        $groupIdClause
+                AND     ((grp.saved_search_id is not null AND gcc.contact_id = %1)
+                            $baseGroupClause
+                        ) GROUP BY grp.id";
+
+    $groupsAddedSQL = "
             SELECT      grp.id as group_id,
                         grp.title as title,
                         grp.frontend_title as frontend_title,
@@ -233,33 +255,40 @@ WHERE  email = %2
             FROM        civicrm_group grp
             LEFT JOIN   civicrm_group_contact gc
                 ON      gc.group_id = grp.id
-            LEFT JOIN     civicrm_group_contact_cache gcc
-                ON      gcc.group_id = grp.id
             WHERE       grp.is_hidden = 0
                         $groupIdClause
-                AND     ((grp.saved_search_id is not null AND gcc.contact_id = %1)
-                            OR  (gc.contact_id = %1
+                AND     ((gc.contact_id = %1
                                 AND gc.status = 'Added')
                             $baseGroupClause
                         ) GROUP BY grp.id";
     $groupsParams = [
       1 => [$contact_id, 'Positive'],
     ];
-    $do = CRM_Core_DAO::executeQuery($groupsSQL, $groupsParams);
+    $doCached = CRM_Core_DAO::executeQuery($groupsCachedSQL, $groupsParams);
+    $doAdded = CRM_Core_DAO::executeQuery($groupsAddedSQL, $groupsParams);
 
     if ($return) {
       $returnGroups = [];
-      while ($do->fetch()) {
-        $returnGroups[$do->group_id] = [
-          'title' => !empty($do->frontend_title) ? $do->frontend_title : $do->title,
-          'description' => !empty($do->frontend_description) ? $do->frontend_description : $do->description,
+      while ($doCached->fetch()) {
+        $returnGroups[$doCached->group_id] = [
+          'title' => !empty($doCached->frontend_title) ? $doCached->frontend_title : $doCached->title,
+          'description' => !empty($doCached->frontend_description) ? $doCached->frontend_description : $doCached->description,
+        ];
+      }
+      while ($doAdded->fetch()) {
+        $returnGroups[$doAdded->group_id] = [
+          'title' => !empty($doAdded->frontend_title) ? $doAdded->frontend_title : $doAdded->title,
+          'description' => !empty($doAdded->frontend_description) ? $doAdded->frontend_description : $doAdded->description,
         ];
       }
       return $returnGroups;
     }
     else {
-      while ($do->fetch()) {
-        $groups[$do->group_id] = !empty($do->frontend_title) ? $do->frontend_title : $do->title;
+      while ($doCached->fetch()) {
+        $groups[$doCached->group_id] = !empty($doCached->frontend_title) ? $doCached->frontend_title : $doCached->title;
+      }
+      while ($doAdded->fetch()) {
+        $groups[$doAdded->group_id] = !empty($doAdded->frontend_title) ? $doAdded->frontend_title : $doAdded->title;
       }
     }
     $transaction = new CRM_Core_Transaction();


### PR DESCRIPTION
Overview
----------------------------------------
As per https://lab.civicrm.org/dev/core/-/issues/3031

Traced to some sql in CRM/Mailing/Event/BAO/Unsubscribe.php which was executing when checking whether a contact was subscribed to one or more groups.

Before
----------------------------------------
On sites with a reasonably large number of contacts and mail enabled smart groups.
Very high CPU and delays when viewing mail-enabled smart groups on a contact.
Very high CPU when running some system jobs (e.g. bounce processing).

After
----------------------------------------
Somewhat improved.

Technical Details
----------------------------------------
As per the issue discussion, the sql is much more efficient when split into two separate queries in place of the existing OR, presumably due to the ability of mysql to use (internal) caches.

Comments
----------------------------------------
There may be other related issues due to the use of smart groups for mailings, I can still see some load with these activities when the smart group caches are rebuilt.
