### PR TITLE
Don't lose search criteria for smart group built with search builder

### DIFF
--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -197,7 +197,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
         $mappingOperator[$mapping->grouping][$mapping->column_number] = $mapping->operator;
       }
 
-      if (!empty($mapping->value)) {
+      if (isset($mapping->value)) {
         $mappingValue[$mapping->grouping][$mapping->column_number] = $mapping->value;
       }
     }
@@ -935,7 +935,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
           $defaults["operator[$x][$i]"] = $mappingOperator[$x][$i] ?? NULL;
         }
 
-        if (CRM_Utils_Array::value($i, CRM_Utils_Array::value($x, $mappingValue))) {
+        if (isset($mappingValue[$x][$i])) {
           $defaults["value[$x][$i]"] = $mappingValue[$x][$i] ?? NULL;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Consider a smart group with yes/no criteria, e.g. Do Not Email and Deceased. If you go to 'Edit' the search criteria and it rebuilds the search builder the final values (yes/no) are lost and go back to 'Select'

![screenshot_1_1635221149](https://user-images.githubusercontent.com/10171921/160480828-da07f2d2-54fd-4020-9add-1cad43840e33.png)

I'm not sure if it's all yes/no fields or what the cause is but it seems to store the value correctly until you go back to edit and then they are lost - this could cause someone to then update the smart group criteria without realising they've lost values
