### PR TITLE
dev/core#3142 - Contact form and summary page completely broken

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -254,7 +254,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           $this->_values = $values;
         }
         else {
-          CRM_Contact_BAO_Contact::getValues(['contact_id' => $this->_contactId], $this->_values);
+          CRM_Contact_BAO_Contact::getValues(['id' => $this->_contactId, 'contact_id' => $this->_contactId], $this->_values);
           $this->_values['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $this->_contactId]);
           $this->_values['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $this->_contactId]);
           $this->_values['openid'] = CRM_Core_BAO_OpenID::getValues(['contact_id' => $this->_contactId]);

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -150,7 +150,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
 
     $params['contact_id'] = $this->_contactId;
 
-    CRM_Contact_BAO_Contact::getValues($params, $defaults);
+    CRM_Contact_BAO_Contact::getValues(array_merge(['id' => $this->_contactId], $params), $defaults);
     $defaults['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $params['contact_id']]);
     $defaults['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $params['contact_id']]);
     $defaults['openid'] = CRM_Core_BAO_OpenID::getValues(['contact_id' => $params['contact_id']]);
@@ -158,7 +158,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $defaults['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $params['contact_id']], TRUE);
     CRM_Core_BAO_Website::getValues($params, $defaults);
     // Copy employer fields to the current_employer keys.
-    if (($defaults['contact_type'] === 'Individual') && $defaults['employer_id'] && $defaults['organization_name']) {
+    if (($defaults['contact_type'] === 'Individual') && !empty($defaults['employer_id']) && !empty($defaults['organization_name'])) {
       $defaults['current_employer'] = $defaults['organization_name'];
       $defaults['current_employer_id'] = $defaults['employer_id'];
     }

--- a/tests/phpunit/CRM/Core/InvokeTest.php
+++ b/tests/phpunit/CRM/Core/InvokeTest.php
@@ -65,4 +65,30 @@ class CRM_Core_InvokeTest extends CiviUnitTestCase {
     $this->assertRegExp('/form.+id="Builder" class="CRM_Contact_Form_Search_Builder/', $contents);
   }
 
+  public function testContactSummary(): void {
+    $cid = $this->individualCreate([
+      'first_name' => 'ContactPage',
+      'last_name' => 'Summary',
+      'do_not_phone' => 1,
+      'gender_id' => 'Male',
+    ]);
+    $_SERVER['REQUEST_URI'] = "civicrm/contact/view?cid={$cid}&reset=1";
+    $_GET['q'] = 'civicrm/contact/view';
+    $_GET['reset'] = $_REQUEST['reset'] = 1;
+    $_GET['cid'] = $_REQUEST['cid'] = $cid;
+
+    $item = CRM_Core_Invoke::getItem([$_GET['q']]);
+    ob_start();
+    CRM_Core_Invoke::runItem($item);
+    $contents = ob_get_clean();
+
+    unset($_GET['q'], $_REQUEST['q']);
+    unset($_GET['reset'], $_REQUEST['reset']);
+    unset($_GET['cid'], $_REQUEST['cid']);
+
+    $this->assertStringContainsString("<div class=\"crm-content crm-contact_type_label\">\n      Individual\n    </div>", $contents);
+    $this->assertStringContainsString("<div class=\"crm-content crm-contact-privacy_values font-red upper\">\n                  Do not phone<br/>                                                                                              </div>", $contents);
+    $this->assertStringContainsString("<div class=\"crm-content crm-contact-gender_display\">Male</div>", $contents);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3142

Before
----------------------------------------
Open any contact summary page. Everyone is an Organization and all the fields are blank.

Edit any existing contact. All the fields are blank.

After
----------------------------------------
Better.

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/22966

Comments
----------------------------------------
Has test
