### PR TITLE
resolve "Failed to load about:blank, with network status code 301"

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -220,6 +220,7 @@ class CRM_Utils_PDF_Utils {
     $snappy->setOption("margin-right", $margins[2] . $margins[0]);
     $snappy->setOption("margin-bottom", $margins[3] . $margins[0]);
     $snappy->setOption("margin-left", $margins[4] . $margins[0]);
+    $snappy->setOption('enable-local-file-access', true);
     $pdf = $snappy->getOutputFromHtml($html);
     if ($output) {
       return $pdf;

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -223,11 +223,12 @@ class CRM_Utils_PDF_Utils {
     try {
       // address https://github.com/mileszs/wicked_pdf/pull/920
       $snappy->setOption('enable-local-file-access', TRUE);
-    } catch (\InvalidArgumentException $x) {
+    }
+    catch (\InvalidArgumentException $x) {
       // must be wkhtmltopdf v <=0.12.5
       // so, fine...
     }
-    
+
     $pdf = $snappy->getOutputFromHtml($html);
     if ($output) {
       return $pdf;

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -220,7 +220,7 @@ class CRM_Utils_PDF_Utils {
     $snappy->setOption("margin-right", $margins[2] . $margins[0]);
     $snappy->setOption("margin-bottom", $margins[3] . $margins[0]);
     $snappy->setOption("margin-left", $margins[4] . $margins[0]);
-    $snappy->setOption('enable-local-file-access', true);
+    $snappy->setOption('enable-local-file-access', TRUE);
     $pdf = $snappy->getOutputFromHtml($html);
     if ($output) {
       return $pdf;

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -220,7 +220,14 @@ class CRM_Utils_PDF_Utils {
     $snappy->setOption("margin-right", $margins[2] . $margins[0]);
     $snappy->setOption("margin-bottom", $margins[3] . $margins[0]);
     $snappy->setOption("margin-left", $margins[4] . $margins[0]);
-    $snappy->setOption('enable-local-file-access', TRUE);
+    try {
+      // address https://github.com/mileszs/wicked_pdf/pull/920
+      $snappy->setOption('enable-local-file-access', TRUE);
+    } catch (\InvalidArgumentException $x) {
+      // must be wkhtmltopdf v <=0.12.5
+      // so, fine...
+    }
+    
     $pdf = $snappy->getOutputFromHtml($html);
     if ($output) {
       return $pdf;


### PR DESCRIPTION

Overview
----------------------------------------
Generating invoices generates an error: https://pastebin.com/JMBxq3bv

"Failed to load about:blank, with network status code 301"

This apparently is a known problem:

https://stackoverflow.com/questions/63119774/laravel-snappy-returning-failed-to-load-aboutblank-with-network-status-code-30

Technical Details
----------------------------------------
`CRM_Utils_PDF_Utils::_html2pdf_wkhtmltopdf`

`$snappy->setOption('enable-local-file-access', true);`