### PR TITLE
(dev/core#3141) Membership should be listed chronologically by join d…

### DIFF
--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -29,6 +29,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $this->_contactId;
     $dao->is_test = 0;
+    $dao->orderBy('start_date DESC');
     $dao->find();
 
     while ($dao->fetch()) {


### PR DESCRIPTION
…ate, the most recent member since first

Overview
----------------------------------------
All memberships (active and inactive memberships) should be listed chronologically by join date, the most recent member since first.
This is followed on Membership dashboard but not Member tab or Member Userdashboard. The behavior should be consistent.

Before
----------------------------------------
![dmaster_member_dashboard](https://user-images.githubusercontent.com/3455173/160614011-2d9edb62-e2dd-4449-9cad-6bb92d6b148a.png)


After
----------------------------------------
fixed chronologically by join date on Userdashoard for active/inactive members
![Screenshot from 2022-03-30 11-00-08](https://user-images.githubusercontent.com/3455173/160757900-505fa397-b5ba-4800-9247-4456d81b538d.png)
