### PR TITLE
Do not default-escape upgrade linkes + Enotice fix on Extension screen

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -347,14 +347,18 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       'version' => '',
       'description' => '',
       'license' => '',
+      'path' => '',
       'releaseDate' => '',
       'downloadUrl' => FALSE,
       'compatibility' => FALSE,
       'develStage' => FALSE,
       'comments' => FALSE,
     ];
-
-    return array_merge($defaultKeys, $info);
+    $info = array_merge($defaultKeys, $info);
+    foreach ($info['authors'] as &$author) {
+      $author = array_merge(['homepage' => ''], $author);
+    }
+    return $info;
   }
 
 }

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -17,7 +17,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
       </thead>
       <tbody>
         {foreach from=$remoteExtensionRows key=extKey item=row}
-        {if !empty($localExtensionRows[$extKey])}
+        {if array_key_exists($extKey, $localExtensionRows)}
           {continue}
         {/if}
         <tr id="addnew-row_{$row.file}" class="crm-extensions crm-extensions_{$row.file}">

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -22,8 +22,8 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         <tr id="extension-{$row.file|escape}" class="crm-entity crm-extension-{$row.file|escape}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label|escape}</strong><br/>{$row.description|escape}
-              {if $extAddNewEnabled && array_key_exists($extKey, $remoteExtensionRows) && $remoteExtensionRows[$extKey].upgradelink}
-                <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink}</div>
+              {if $extAddNewEnabled && array_key_exists($extKey, $remoteExtensionRows) && $remoteExtensionRows[$extKey].upgradelink|smarty:nodefaults}
+                <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink|smarty:nodefaults}</div>
               {/if}
           </td>
           <td class="crm-extensions-status">{$row.statusLabel} </td>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -22,7 +22,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         <tr id="extension-{$row.file|escape}" class="crm-entity crm-extension-{$row.file|escape}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
               <a class="collapsed" href="#"></a>&nbsp;<strong>{$row.label|escape}</strong><br/>{$row.description|escape}
-              {if $extAddNewEnabled && !empty($remoteExtensionRows[$extKey]) && $remoteExtensionRows[$extKey].upgradelink}
+              {if $extAddNewEnabled && array_key_exists($extKey, $remoteExtensionRows) && $remoteExtensionRows[$extKey].upgradelink}
                 <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink}</div>
               {/if}
           </td>


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix on Extension screen

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/160735615-0daab56d-66f6-423e-8a05-f3236d8edb33.png)
![image](https://user-images.githubusercontent.com/336308/160734069-9fa0fa89-4f71-45e3-8fa2-434017ff26ba.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/160735680-eeee1bcc-b234-4e52-ac00-16e158030126.png)

![image](https://user-images.githubusercontent.com/336308/160734086-fbefb529-1800-4c8b-baf6-4eb5f68a79dd.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
