### PR TITLE
SearchKit - Fix joins when RelationshipCache is base search entity

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -240,7 +240,7 @@ class Admin {
         $bridge = in_array('EntityBridge', $entity['type']) ? $entity['name'] : NULL;
 
         // Non-bridge joins directly between 2 entities
-        if (!$bridge) {
+        if ($entity['searchable'] !== 'bridge') {
           foreach ($references as $reference) {
             $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
             if (
@@ -288,7 +288,7 @@ class Admin {
           }
         }
         // Bridge joins go through an intermediary table
-        elseif (!empty($entity['bridge'])) {
+        if ($bridge && !empty($entity['bridge'])) {
           foreach ($entity['bridge'] as $targetKey => $bridgeInfo) {
             $baseKey = $bridgeInfo['to'];
             $reference = self::getReference($targetKey, $references);

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -61,6 +61,10 @@ class AdminTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
       $relationshipJoins[0]['defaults']
     );
 
+    $relationshipCacheJoins = $joins['RelationshipCache'];
+    $this->assertCount(4, $relationshipCacheJoins);
+    $this->assertEquals(['RelationshipType', 'Contact', 'Contact', 'Case'], array_column($relationshipCacheJoins, 'entity'));
+
     $eventParticipantJoins = \CRM_Utils_Array::findAll($joins['Event'], [
       'entity' => 'Participant',
       'alias' => 'Event_Participant_event_id',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing joins when basing the search on "Related Contacts"

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/160950062-b60fb26c-546a-4958-8b47-488eb5728743.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/160949990-b8d16728-669a-4a5e-90f4-cb018ddd8822.png)


Technical Details
-------------------------------
The problem with the `if/else` logic checking for normal/bridge entities, is that `RelationshipCache` is *both* - it can be a primary search entity and it also acts as a bridge between related contacts. So I changed it from `if/else` to `if/if` and now it works :)