### PR TITLE
Add support for financial account custom fields

### DIFF
--- a/CRM/Financial/BAO/FinancialAccount.php
+++ b/CRM/Financial/BAO/FinancialAccount.php
@@ -97,6 +97,10 @@ class CRM_Financial_BAO_FinancialAccount extends CRM_Financial_DAO_FinancialAcco
     $financialAccount->copyValues($params);
     $financialAccount->save();
 
+    if (!empty($params['custom']) && is_array($params['custom'])) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], static::$_tableName, $financialAccount->id, $op);
+    }
+
     // invoke post hook
     $op = 'create';
     if (!empty($params['id'])) {

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -19,6 +19,7 @@
  * This class generates form components for Financial Account
  */
 class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
+  use CRM_Core_Form_EntityFormTrait;
 
   /**
    * Flag if its a AR account type.
@@ -28,10 +29,23 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
   protected $_isARFlag = FALSE;
 
   /**
+   * Explicitly declare the entity api name.
+   *
+   * @return string
+   */
+  public function getDefaultEntity() {
+    return 'FinancialAccount';
+  }
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
     parent::preProcess();
+
+    // Add custom data to form
+    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'FinancialAccount', $this->_id);
+    CRM_Custom_Form_CustomData::buildQuickForm($this);
 
     if ($this->_id) {
       $params = [
@@ -101,6 +115,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
       }
     }
 
+    $this->addCustomDataToForm();
     if ($this->_action == CRM_Core_Action::UPDATE &&
       CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $this->_id, 'is_reserved')
     ) {
@@ -159,6 +174,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
    */
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
+    $defaults = array_merge($defaults, CRM_Custom_Form_CustomData::setDefaultValues($this));
     if ($this->_action & CRM_Core_Action::ADD) {
       $defaults['contact_id'] = CRM_Core_BAO_Domain::getDomain()->contact_id;
     }
@@ -180,6 +196,7 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
     else {
       // store the submitted values in an array
       $params = $this->exportValues();
+      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($this->_submitValues, $this->_id, 'FinancialAccount');
 
       if ($this->_action & CRM_Core_Action::UPDATE) {
         $params['id'] = $this->_id;

--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -76,6 +76,9 @@
       </td>
     </tr>
   </table>
+  <div id="financial_account_custom_field_extension_section" class="crm-accordion-wrapper crm-financial-account-panel">
+  {include file="CRM/Custom/Form/CustomData.tpl"}
+  </div>
 {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="botttom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
The FinancialAccount entity almost but doesn't quite have support for custom fields.

Before
----------------------------------------
Can't save or display custom field data for financial accounts.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
The BAO change is all that's necessary to support FinancialAccount custom fields in API4 - I almost put the rest in an extension, but the code is well-abstracted and so why not add support in core.

Comments
----------------------------------------
You'll need to add FinancialAccount to the `cg_extend_objects` option group.  `cv api OptionValue.create label='Financial Accounts' name='civicrm_financial_account' value='FinancialAccount' option_group_id='cg_extend_objects'` will do the trick.