### PR TITLE
Avoid trailing spaces in trigger output

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -314,14 +314,14 @@ class Container {
             'table' => 'civicrm_case_activity',
             'when' => 'AFTER',
             'event' => ['INSERT'],
-            'sql' => "\nUPDATE civicrm_case SET modified_date = CURRENT_TIMESTAMP WHERE id = NEW.case_id;\n",
+            'sql' => "UPDATE civicrm_case SET modified_date = CURRENT_TIMESTAMP WHERE id = NEW.case_id;",
           ],
           [
             'upgrade_check' => ['table' => 'civicrm_case', 'column' => 'modified_date'],
             'table' => 'civicrm_activity',
             'when' => 'BEFORE',
             'event' => ['UPDATE', 'DELETE'],
-            'sql' => "\nUPDATE civicrm_case SET modified_date = CURRENT_TIMESTAMP WHERE id IN (SELECT ca.case_id FROM civicrm_case_activity ca WHERE ca.activity_id = OLD.id);\n",
+            'sql' => "UPDATE civicrm_case SET modified_date = CURRENT_TIMESTAMP WHERE id IN (SELECT ca.case_id FROM civicrm_case_activity ca WHERE ca.activity_id = OLD.id);",
           ],
         ],
       ]

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -195,13 +195,13 @@ class TimestampTriggers {
         'table' => $relatedTableNames,
         'when' => 'AFTER',
         'event' => ['INSERT', 'UPDATE'],
-        'sql' => "\nUPDATE {$this->getTableName()} SET {$this->getModifiedDate()} = CURRENT_TIMESTAMP WHERE id = NEW.$contactRefColumn;\n",
+        'sql' => "UPDATE {$this->getTableName()} SET {$this->getModifiedDate()} = CURRENT_TIMESTAMP WHERE id = NEW.$contactRefColumn;",
       ];
       $info[] = [
         'table' => $relatedTableNames,
         'when' => 'AFTER',
         'event' => ['DELETE'],
-        'sql' => "\nUPDATE {$this->getTableName()} SET {$this->getModifiedDate()} = CURRENT_TIMESTAMP WHERE id = OLD.$contactRefColumn;\n",
+        'sql' => "UPDATE {$this->getTableName()} SET {$this->getModifiedDate()} = CURRENT_TIMESTAMP WHERE id = OLD.$contactRefColumn;",
       ];
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Avoid trailing spaces in trigger output

Before
----------------------------------------
When outputing triggers as text there are trailing spaces - which make the output a bit more of a pain to manage in git than they would be without trailing spaces

![image](https://user-images.githubusercontent.com/336308/160971872-cb03693d-5951-4ebf-afd9-7e14fc84799f.png)

After
----------------------------------------
The sql is all on one line in the case of the specified trigger. 

Technical Details
----------------------------------------
We don't need to worry about there NOT being a space & hence an sql error as the concatenation happens here https://github.com/civicrm/civicrm-core/blob/0a0896208e53671328b9fe0a43f8d53860465ea1/Civi/Core/SqlTriggers.php#L164

If there are mutliple statements they are separated here https://github.com/civicrm/civicrm-core/blob/0a0896208e53671328b9fe0a43f8d53860465ea1/Civi/Core/SqlTriggers.php#L160-L161

Because the concatenation adds spaces then putting in line breaks makes those spaces trailing.... or oddly at the start of a line.

![image](https://user-images.githubusercontent.com/336308/160978987-e5c08dc2-fcd7-46ad-96e2-e4668290d619.png)
 
![image](https://user-images.githubusercontent.com/336308/160978948-d3b43f8e-f467-471c-b634-d70502496d9c.png)

![image](https://user-images.githubusercontent.com/336308/160979015-9f4eed15-fd41-4cfd-8252-7d58f2c7754d.png)

![image](https://user-images.githubusercontent.com/336308/160979065-5e39295d-761e-4d59-84a5-7c1b83b652ac.png)

Comments
----------------------------------------
I did consider adding new lines so that ALL triggers would have new lines around them, rather than just removing them. However, I suspect that I am the only one who even cares as checking in triggers is an odd workflow and on balance I think being able to skim what each trigger is about is more useful

![image](https://user-images.githubusercontent.com/336308/160972338-54f3b5ea-5af5-4bda-a675-399b0d6600c4.png)
