### PR TITLE
SearchKit - Fix broken group-by caused by non-aggregated id column 

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -804,7 +804,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     }, $apiParams['select']);
     $additions = [];
     // Add primary key field if actions are enabled
-    if (!empty($this->display['settings']['actions']) || !empty($this->display['settings']['draggable'])) {
+    // (only needed for non-dao entities, as Api4SelectQuery will auto-add the id)
+    if (!in_array('DAOEntity', CoreUtil::getInfoItem($this->savedSearch['api_entity'], 'type')) &&
+      (!empty($this->display['settings']['actions']) || !empty($this->display['settings']['draggable']))
+    ) {
       $additions = CoreUtil::getInfoItem($this->savedSearch['api_entity'], 'primary_key');
     }
     // Add draggable column (typically "weight")

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -429,7 +429,7 @@
         }
         var arg = _.findWhere(searchMeta.parseExpr(col).args, {type: 'field'}) || {};
         // If the column is not a database field, no
-        if (!arg.field || !arg.field.entity || arg.field.type !== 'Field') {
+        if (!arg.field || !arg.field.entity || !_.includes(['Field', 'Custom'], arg.field.type)) {
           return false;
         }
         // If the column is used for a groupBy, no


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in SearchKit where using aggregation on a column other than `id` would cause the search to fail.
Also fixes missing custom field aggregation in the UI.

Fixes [dev/core#3143](https://lab.civicrm.org/dev/core/-/issues/3143)

Before
----------------------------------------
Doing e.g. an Activity search grouping by activity type would fail.
Custom fields not available for aggregation in the UI.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
Unit test added.