### PR TITLE
dev/core#3072 - Put contribution dates in message template back to not including time

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1154,7 +1154,7 @@ Price Field - Price Field 1        1    $100.00       $100.00
     $strings = [
       'Total Tax Amount : $' . $this->formatMoneyInput(1000.00),
       'Total Amount : $' . $this->formatMoneyInput(11000.00),
-      'Date Received: April 21st, 2015',
+      'Date Received: 04/21/2015',
       'Paid By: Check',
       'Check Number: 12345',
     ];
@@ -1213,7 +1213,7 @@ Price Field - Price Field 1        1    $100.00       $100.00
     $strings = [
       'Total Tax Amount : $' . $this->formatMoneyInput(2000),
       'Total Amount : $' . $this->formatMoneyInput(22000.00),
-      'Date Received: April 21st, 2015',
+      'Date Received: 04/21/2015',
       'Paid By: Check',
       'Check Number: 12345',
       'Financial Type: Donation',

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -157,7 +157,7 @@
         {ts}Date Received{/ts}
        </td>
        <td {$valueStyle}>
-         {contribution.receive_date}
+         {contribution.receive_date|crmDate:"shortdate"}
        </td>
       </tr>
      {/if}
@@ -168,7 +168,7 @@
         {ts}Receipt Date{/ts}
        </td>
        <td {$valueStyle}>
-         {contribution.receipt_date}
+         {contribution.receipt_date|crmDate:"shortdate"}
        </td>
       </tr>
      {/if}

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -49,10 +49,10 @@
 {/if}
 {ts}Total Amount{/ts} : {contribution.total_amount}
 {if '{contribution.receive_date}'}
-{ts}Date Received{/ts}: {contribution.receive_date}
+{ts}Date Received{/ts}: {contribution.receive_date|crmDate:"shortdate"}
 {/if}
 {if '{contribution.receipt_date}'}
-{ts}Receipt Date{/ts}: {contribution.receipt_date}
+{ts}Receipt Date{/ts}: {contribution.receipt_date|crmDate:"shortdate"}
 {/if}
 {if '{contribution.payment_instrument_id}' and empty($formValues.hidden_CreditCard)}
 {ts}Paid By{/ts}: {contribution.payment_instrument_id:label}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3072

Before
----------------------------------------
In 5.47, the contribution dates in the offline message template started including the time. Before that they didn't.

After
----------------------------------------
Back to pre-5.47 output.

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/22560/files#diff-fd5668d5492e5f0ec55b7f8a10eccfa4ea9de249e4cf2383a2e0d36dbd92ebe0R154

Comments
----------------------------------------
The above commit only updated it for new installs. So have done the same but have put it against 5.48 since otherwise new 5.48 installs will have the time included.
