### PR TITLE
dev/financial#201 Do not add pledge statuses to Contribution statuses

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -431,8 +431,6 @@ VALUES
   (@option_group_id_cs, '{ts escape="sql"}Pending{/ts}'    , 2, 'Pending'    , NULL, 0, 0, 2, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_cs, '{ts escape="sql"}Cancelled{/ts}'  , 3, 'Cancelled'  , NULL, 0, 0, 3, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_cs, '{ts escape="sql"}Failed{/ts}'     , 4, 'Failed'     , NULL, 0, 0, 4, NULL, 0, 1, 1, NULL, NULL, NULL),
-  (@option_group_id_cs, '{ts escape="sql"}In Progress{/ts}', 5, 'In Progress', NULL, 0, 0, 5, NULL, 0, 1, 1, NULL, NULL, NULL),
-  (@option_group_id_cs, '{ts escape="sql"}Overdue{/ts}'    , 6, 'Overdue'    , NULL, 0, 0, 6, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_cs, '{ts escape="sql"}Refunded{/ts}'   , 7, 'Refunded'   , NULL, 0, 0, 7, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_cs, '{ts escape="sql"}Partially paid{/ts}', 8, 'Partially paid', NULL, 0, 0, 8, NULL, 0, 1, 1, NULL, NULL, NULL),
   (@option_group_id_cs, '{ts escape="sql"}Pending refund{/ts}', 9, 'Pending refund', NULL, 0, 0, 9, NULL, 0, 1, 1, NULL, NULL, NULL),


### PR DESCRIPTION


Overview
----------------------------------------
Do not add pledge statuses to Contribution statuses on new installs

Historically Pledge statues, recurring contribution statuses and contribution statuses shared
one option group. When they were split out the pledge ones remained in the contribution status group.

This removes them from the contribution status group on install

Before
----------------------------------------
New installs of CiviCRM have contribution status 'Overdue' and 'In progress' - but there is no appropriate logic for them

After
----------------------------------------
The statuses are not adde don new installs

Technical Details
----------------------------------------
This doesn't touch existing installs. Options for existing installs

1) do nothing
2) add a status check & suggest people disable them if they exist and are not used (downside is this adds an ongoing performance cost to the status checks - esp on larger sites - although slow status checks can be disabled through the api)
3) add a one-off notice in the upgrade script if sites not are using these statuses but they are active
4) remove the statuses in an upgrade script if not in use
5) disable the statuses in an upgrade script if not in use

Comments
----------------------------------------
