### PR TITLE
dev/financial#186 Do not display partially paid & partially refunded for selection on edit

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -2052,7 +2052,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       return CRM_Contribute_BAO_Contribution_Utils::getPendingCompleteFailedAndCancelledStatuses();
     }
     $statusNames = CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate');
-    $statusNamesToUnset = [
+    $statusNamesToUnset = array_diff([
       // For records which represent a data template for a recurring
       // contribution that may not yet have a payment. This status should not
       // be available from forms. 'Template' contributions should only be created
@@ -2060,15 +2060,15 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       // is_template field set to 1. This status excludes them from reports
       // that are still ignorant of the is_template field.
       'Template',
-    ];
+      'Partially paid',
+      'Pending refund',
+    ], [$this->getPreviousContributionStatus()]);
     switch ($this->getPreviousContributionStatus()) {
       case 'Completed':
         // [CRM-17498] Removing unsupported status change options.
         $statusNamesToUnset = array_merge($statusNamesToUnset, [
           'Pending',
           'Failed',
-          'Partially paid',
-          'Pending refund',
         ]);
         break;
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/financial#186 Do not display partially paid & partially refunded for selection on edit

Before
----------------------------------------
When editing a pending contribution it is possible to select 'Partially paid' or 'Partially refunded' as the new contribution status - however, this was not intended as the way people would reach these statuses - the Add Payment/refund functionality should be used

![image](https://user-images.githubusercontent.com/336308/161165211-b1039f62-44b7-4b8f-89df-4f5a66f611cf.png)


After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
I'm pretty sure these were actually removed at one point and got over-added
back because the original fix over-removed them - ie it took them out
when the contribution's current status was 'Partially paid' etc,
making a no-save change impossible


Comments
----------------------------------------
