### PR TITLE
First recurring payment (paypal ipn) - remove redundant status set, start_date change

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -133,19 +133,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       echo 'Failure: Invalid parameters<p>';
       return;
     }
-    if ($first) {
-      $recur->start_date = $now;
-    }
-    else {
-      $recur->modified_date = $now;
-    }
-
-    // make sure the contribution status is not done
-    // since order of ipn's is unknown
-    if ($recur->contribution_status_id != $contributionStatuses['Completed']) {
-      $recur->contribution_status_id = $contributionStatuses['In Progress'];
-    }
-    $recur->save();
 
     if (!$first) {
       // check if this contribution transaction is already processed

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\ContributionRecur;
+
 /**
  * Class CRM_Core_Payment_PayPalProIPNTest
  * @group headless
@@ -123,6 +125,11 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
     $paypalIPN->main();
+    $recur = ContributionRecur::get()
+      ->addWhere('contact_id', '=', $this->_contactID)
+      ->addSelect('contribution_status_id:name')
+      ->execute()->first();
+    $this->assertEquals('In Progress', $recur['contribution_status_id:name']);
     $mut->checkMailLog(['https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_subscr-find'], ['civicrm/contribute/unsubscribe', 'civicrm/contribute/updatebilling']);
     $mut->stop();
     $contribution1 = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $this->_contributionID]);


### PR DESCRIPTION
Overview
----------------------------------------
First recurring payment (paypal ipn) - remove redundant status set, set start_date centrally

Before
----------------------------------------
The paypal IPN code updates the contribution status id from 'Pending' to 'In Progress' on the first payment. This is redundant as it is later done in `BAO_ContributionRecur::updateOnNewPayment ` and incorrect as it is using the wrong option group (contribution vs contribution recur status options) - and the test shows it is done with these lines removed

On removing this the only 'reason' for the `$recur->save()` here is to update the start date to the current date when updating from 'Pending' to 'In Progress' - I feel like if this is worth doing it should be done in the  `BAO_ContributionRecur::updateOnNewPayment ` such that it is consistent

After
----------------------------------------
update to recurring removed from the PaypalIPN

Per discussion I originally wanted to centralise this but settled on removal as ... it's complicated

Technical Details
----------------------------------------
@mattwire @KarinG @adixon - I'm inclined to think it would ALSO be OK not to update the start date in paypal since it barely changes from the initial date if you disagree with always updating the civicrm_contribution_recur.start_date field when the first contribution in the series is completed 

Comments
----------------------------------------
