### PR TITLE
🪲 🪳 Bug Fix: The option "Enable multiple bulk email address for a contact" does not apply when editing a Contact, only works for inline edit of email addresses

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -71,7 +71,7 @@ class CRM_Contact_Form_Edit_Email {
       //Bulkmail checkbox
       $form->assign('multipleBulk', $multipleBulk);
       $js = ['id' => 'Email_' . $blockId . '_IsBulkmail', 'aria-label' => ts('Bulk Mailing for Email %1?', [1 => $blockId])];
-      if (!$blockEdit) {
+      if (!$blockEdit && !$multipleBulk) {
         $js['onClick'] = 'singleSelect( this.id );';
       }
       $form->addElement('advcheckbox', "email[$blockId][is_bulkmail]", NULL, '', $js);


### PR DESCRIPTION
Overview
----------------------------------------
The option "Enable multiple bulk email address for a contact" does not apply when editing a Contact, only works for inline edit of email addresses. Bulk Email checkbox forces singular selection.

To reproduce this bug, first enable the option, **Enable multiple bulk email address for a contact.**

1. Go to CiviMail Component Settings
2. Check the option, **Enable multiple bulk email address for a contact.**
3. Click **Save**

Then perform the following tests:
1. Edit a Contact and try to select more than one email address for the bulk mailing
2. Use the in-line edit and try to select more than one email address for the bulk mailing

![image](https://user-images.githubusercontent.com/58866555/162848321-6ffcabbe-d394-4a5d-bc4a-6ab5987c9da9.png)

Before
----------------------------------------
The option "Enable multiple bulk email address for a contact" does NOT work when editing a Contact.

![image](https://user-images.githubusercontent.com/58866555/161210543-844d0759-b292-4702-a5f0-05207342198b.png)


After
----------------------------------------
The option "Enable multiple bulk email address for a contact" does work when editing a Contact.

![image](https://user-images.githubusercontent.com/58866555/161210561-a68f4f1c-04d6-4112-ae0a-f43cc6a6a88d.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
Agileware Ref: CIVICRM-1958
