### PR TITLE
dev/core#3034

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -283,7 +283,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
         civicrm_api3('Attachment', 'create', [
           'entity_table' => 'civicrm_activity',
           'entity_id' => $activityId,
-          'name' => $fileName,
+          'name' => $fileName . '.' . $type,
           'mime_type' => $mimeType,
           'options' => [
             'move-file' => $tee->getFileName(),


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow up PR for #22532

Steps to reproduce
----------------------------------------

1. Create a case
2. Export document from this case
3. Check the activity Print/Meger document

Before
----------------------------------------

When creating a document from the manage case screen. The attachment at the activity has the file name of `.unknown`.

After
----------------------------------------

When creating a document from the manage case screen. The attachment at the activity has the file name of `CiviLetter.pdf`.

Comments
----------------------------------------

I also checked the other formats such as ODT and HTML and Word. All of them ended up with a filename attached to the activity with the name `.unknown`.
