### PR TITLE
Subscription Amount change not respected in Paypal

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -305,6 +305,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $input['paymentStatus'] = $this->retrieve('payment_status', 'String', FALSE);
     $input['invoice'] = $this->retrieve('invoice', 'String', TRUE);
     $input['amount'] = $this->retrieve('mc_gross', 'Money', FALSE);
+    $input['total_amount'] = $this->retrieve('mc_gross', 'Money', FALSE);
     $input['reasonCode'] = $this->retrieve('ReasonCode', 'String', FALSE);
 
     $lookup = [

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -194,14 +194,14 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     }
 
     if (!$recur) {
-      if ($contribution->total_amount != $input['amount']) {
+      if ($contribution->total_amount != $input['total_amount']) {
         Civi::log()->debug('PayPalIPN: Amount values dont match between database and IPN request. (ID: ' . $contribution->id . ').');
         echo "Failure: Amount values dont match between database and IPN request<p>";
         return;
       }
     }
     else {
-      $contribution->total_amount = $input['amount'];
+      $contribution->total_amount = $input['total_amount'];
     }
 
     // check if contribution is already completed, if so we ignore this ipn
@@ -304,7 +304,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $billingID = CRM_Core_BAO_LocationType::getBilling();
     $input['paymentStatus'] = $this->retrieve('payment_status', 'String', FALSE);
     $input['invoice'] = $this->retrieve('invoice', 'String', TRUE);
-    $input['amount'] = $this->retrieve('mc_gross', 'Money', FALSE);
     $input['total_amount'] = $this->retrieve('mc_gross', 'Money', FALSE);
     $input['reasonCode'] = $this->retrieve('ReasonCode', 'String', FALSE);
 


### PR DESCRIPTION
Overview
----------------------------------------
When the subscription amount is changed in Paypal from $50.00 to $80.00, Civi still creates a subsequent contribution of $50.00 upon IPN call. The repeattransaction expects total_amount to get passed into the params if the contribution api want's to update the amount.

Before
----------------------------------------
The subsequent contribution amount was set to the previous contribution amount.

After
----------------------------------------
The subsequent contribution amount is set to the new amount.