### PR TITLE
dev/core#3153 - Fix missing filter summary on CiviReports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3523,10 +3523,10 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
           }
         }
       }
-      else {
-        // Prevents an e-notice in statistics.tpl.
-        $statistics['filters'] = [];
-      }
+    }
+    // Prevents an e-notice in statistics.tpl.
+    if (!isset($statistics['filters'])) {
+      $statistics['filters'] = [];
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3153

Before
----------------------------------------
Filter summary missing at top of results table.

After
----------------------------------------
It's back.

Technical Details
----------------------------------------
Went missing in 5.45 because this overwrites it unless all the tables have filters: https://github.com/civicrm/civicrm-core/commit/6e1fbb97106366bd7a6dcd2ed4a7c81ae5363a09#diff-852cd33f516579b2034fcf492375f0dce1c4c96159b65fc13908bf4ef5448bc8R3518

Comments
----------------------------------------

