### PR TITLE
WIP ensure line items without price field id set doesn't cause problems

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -809,11 +809,17 @@ class CRM_Financial_BAO_Order {
     // a template contribution.
     $this->setLineItemCount(count($lineItems));
 
-    foreach ($lineItems as &$lineItem) {
-      // Set the price set id if not set above. Note that the above
-      // requires it for line retrieval but we want to fix that as it
-      // should not be required at that point.
-      $this->setPriceSetIDFromSelectedField($lineItem['price_field_id']);
+    foreach ($lineItems as $k => &$lineItem) {
+      if (empty($lineItem['price_field_id'])) {
+        $component = !empty($lineItem['membership_type_id']) ? 'membership' : 'contribution';
+        $this->setPriceSetToDefault($component);
+      }
+      else {
+        // Set the price set id if not set above. Note that the above
+        // requires it for line retrieval but we want to fix that as it
+        // should not be required at that point.
+        $this->setPriceSetIDFromSelectedField($lineItem['price_field_id']);
+      }
       // Set any pre-calculation to zero as we will calculate.
       $lineItem['tax_amount'] = 0;
       if ($this->isOverrideLineItemFinancialType($lineItem['financial_type_id']) !== FALSE) {


### PR DESCRIPTION
Addresses https://lab.civicrm.org/dev/core/-/issues/3150

Overview
----------------------------------------
A recent change (https://lab.civicrm.org/dev/core/-/commit/4df23f2a270c08bc42fd1ff93fcfe318ecdc0e19) causes CiviCRM to expect all line items to have a value for the `price_field_id`. In some workflows, a line item with a NULL `price_field_id` causes a back trace when browsing contributions and when processing new payment processor charges.

Before
----------------------------------------

Steps to reproduce (Note: I don't know how to "naturally" create a contribution with a line item that has a NULL `price_field_id` or even if it's possible):

1. Create a recurring contribution. 
2. Add a contribution record to it. 
3. Find the resulting line item and set the `price_field_id` to NULL.
4. Browse to the contact record and click the Contributions tab
5. Get a traceback:
```
[Symfony\Component\Debug\Exception\FatalThrowableError]                                                
  Type error: Argument 1 passed to CRM_Financial_BAO_Order::setPriceSetID() must be of the type int, null given, called in /var/www/powerbase/sites/all/modules/civicrm/CRM/Financial/BAO/Order.php on line   
  905 

```

[You have to open the console and open the ajax call in a new tab to see the traceback message.]

After
----------------------------------------

After changing the code to detect a NULL `price_field_id` and setting the default price set ID automatically, the problem is resolved.

Technical Details
----------------------------------------
It's not clear to me whether all line item really should have a price field id set (and it should be set to the default value for contributions or memberships depending on the line item itself) OR if CiviCRM should accomodate line items wihtout price field ids set.

This PR provides a test to demonstrate the problem and experiments with the accomodation approach to see what it would look like to gracefully handle that situation in at least one known worflow where a missing line item is found. 

Would it be better to have an upgrade script simply fill in the missing values in the `civicrm_line_item` table???

Comments
----------------------------------------

This problem has serious implications for payment processors. For example, with iATS, it can lead to [monthly recurring donors getting charged daily](https://github.com/iATSPayments/com.iatspayments.civicrm/issues/377).

