### PR TITLE
stripslashes from json for REST requests

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -323,7 +323,7 @@ class CRM_Utils_REST {
     ];
 
     if (array_key_exists('json', $requestParams) && $requestParams['json'][0] == "{") {
-      $params = json_decode($requestParams['json'], TRUE);
+      $params = json_decode(stripslashes($requestParams['json']), TRUE);
       if ($params === NULL) {
         CRM_Utils_JSON::output([
           'is_error' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
I do not yet know if this is proper but it works for me. I think that depends on what is adding character escapes to the POST body.

We are using GravityForms webhook to subscribe contacts to a newsletter (`api.MailingEventSubscribe.create`).

When I dump the json in REST.php... I see that the double-quotes have been double-escaped: `{ \\"like\\": \\"this\\" }` and that causes `json_decode()` to return null and the request to be resolved with `Unable to decode supplied JSON.`.

I am not certain if the escapes are added in the request itself, or if PHP is escaping the values in `$_POST`.

I get the same scenario submitting the Gravity Form, or creating a request in insomnia (api dev client like Postman).

