### PR TITLE
(POC) Fix integration with MySQL `time_zone`

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -755,10 +755,9 @@ abstract class CRM_Utils_System_Base {
    * Set timezone in mysql so that timestamp fields show the correct time.
    */
   public function setMySQLTimeZone() {
-    $timeZoneOffset = $this->getTimeZoneOffset();
-    if ($timeZoneOffset) {
-      $sql = "SET time_zone = '$timeZoneOffset'";
-      CRM_Core_DAO::executequery($sql);
+    $timeZone = $this->getTimeZoneString();
+    if ($timeZone) {
+      CRM_Core_DAO::executequery('SET time_zone = %1', [1 => [$timeZone, 'String']]);
     }
   }
 
@@ -766,6 +765,7 @@ abstract class CRM_Utils_System_Base {
    * Get timezone from CMS.
    *
    * @return string|false|null
+   * @deprecated
    */
   public function getTimeZoneOffset() {
     $timezone = $this->getTimeZoneString();

--- a/tests/phpunit/E2E/Core/TimezoneTest.php
+++ b/tests/phpunit/E2E/Core/TimezoneTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace E2E\Core;
+
+/**
+ * If the UF-integration configures PHP and MySQL with equivalent
+ * timezone options, then they will agree on how to convert to/from
+ * universal time.
+ *
+ * @package E2E\Core
+ * @group e2e
+ */
+class TimezoneTest extends \CiviEndToEndTestCase {
+
+  /**
+   * @var array
+   *   Example contact record.
+   */
+  protected static $who;
+
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+    static::$who = civicrm_api4('Contact', 'create', [
+      'values' => [
+        'contact_type' => 'Individual',
+        'first_name' => 'David',
+        'last_name' => 'Whittaker',
+      ],
+    ])->first();
+  }
+
+  public static function tearDownAfterClass(): void {
+    civicrm_api4('Contact', 'delete', [
+      'where' => [['id', '=', static::$who['id']]],
+    ]);
+    parent::tearDownAfterClass();
+  }
+
+  public function getDates(): array {
+    $dates = [];
+    $n = 0;
+    foreach ([2020, 2022, 2024] as $year) {
+      foreach (range(1, 12) as $month) {
+        foreach ([1, 16, 28] as $day) {
+          $date = sprintf('%04d-%02d-%02d %02d:%02d:00', $year, $month, $day, 13, ($n++) % 60);
+          $dates[$date] = [$date];
+        }
+      }
+    }
+    return $dates;
+  }
+
+  /**
+   *
+   * @dataProvider getDates
+   */
+  public function testEpochConversion(string $date): void {
+    $phpEpoch = strtotime($date);
+    $sqlEpoch = (int) \CRM_Core_DAO::singleValueQuery('SELECT UNIX_TIMESTAMP(%1)', [
+      1 => [$date, 'String'],
+    ]);
+    $this->assertEquals($phpEpoch, $sqlEpoch, "Mismatched epochs for $date: php($phpEpoch) != sql($sqlEpoch)");
+  }
+
+  /**
+   * @param string $date
+   * @throws \API_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
+   * @dataProvider getDates
+   */
+  public function testWriteRead(string $date): void {
+    \CRM_Core_DAO::executeQuery('UPDATE civicrm_contact SET modified_date = FROM_UNIXTIME(%1) WHERE id = %2', [
+      1 => [strtotime($date), 'Integer'],
+      2 => [static::$who['id'], 'Positive'],
+    ]);
+    $api3 = civicrm_api3('Contact', 'get', [
+      'id' => static::$who['id'],
+      'return' => 'modified_date',
+    ]);
+    $api3 = $api3['values'][static::$who['id']];
+    $api4 = civicrm_api4('Contact', 'get', [
+      'where' => [['id', '=', static::$who['id']]],
+      'select' => ['modified_date'],
+    ])->single();
+
+    $this->assertEquals($date, $api4['modified_date'], 'Api3 value should match original');
+    $this->assertEquals($date, $api3['modified_date'], 'Api4 value should match original');
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

The simplest possible patch that fixes DST bugs - plus an E2E test. 

(This would contribute toward https://lab.civicrm.org/dev/core/-/issues/3152 approach `#1`. Contrast with #23091.)

Before
----------------------------------------

* MySQL `TIMESTAMP`s appear incorrect when viewing across DST boundaries.
* Runs on most MySQL servers, regardless of whether [timezone data is loaded](https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html)

After
----------------------------------------

* MySQL `TIMESTAMP`s appear correct, even when viewing across DST boundaries.
* Requires that [MySQL timezone data is loaded](https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html)

Comments
----------------------------------------

Posting as a PR so that there's something clear/tangible to reference in the Gitlab discussion.
