### PR TITLE
Avoid PHP notices in activity search

### DIFF
--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -249,6 +249,9 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
         if (isset($result->$property)) {
           $row[$property] = $result->$property;
         }
+        else {
+          $row[$property] = NULL;
+        }
       }
 
       $contactId = $row['contact_id'] ?? NULL;
@@ -273,6 +276,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
         $row['activity_type'] = CRM_Core_TestEntity::appendTestText($row['activity_type']);
       }
       $row['mailingId'] = '';
+      $row['recipients'] = '';
       if (
         $accessCiviMail &&
         ($mailingIDs === TRUE || in_array($result->source_record_id, $mailingIDs)) &&

--- a/tests/phpunit/CRM/Activity/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Form/SearchTest.php
@@ -64,6 +64,10 @@ class CRM_Activity_Form_SearchTest extends CiviUnitTestCase {
         'campaign' => NULL,
         'campaign_id' => NULL,
         'repeat' => '',
+        'contact_sub_type' => NULL,
+        'activity_campaign_id' => NULL,
+        'activity_engagement_level' => NULL,
+        'recipients' => '',
       ],
     ], $rows);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Avoids PHP notices when rendering activity search results (civicrm/activity/search)

Before
----------------------------------------
Notices such as:
```
Undefined index: activity_subject
Undefined index: recipients
```
(both repeated many times per pages dependant on the search results).

After
----------------------------------------
Notices no longer occur.

Comments
----------------------------------------
I did wonder if `recipients` should be set to `null`, but decided to go with consistency with `mailingId`. 

Additionally the template (`templates/CRM/Activity/Form/Selector.tpl`) contains a `{elseif $row.recipients}` which I can't see would ever be reached by core. I did think about simply removing this elseif, but decided it was safer to keep it incase any extensions are relying on this bit of the template.

```
{if $row.mailingId}
  <a href="{$row.mailingId}" title="{ts}View Mailing Report{/ts}">{$row.recipients}</a>
{elseif $row.recipients}
  {row.recipients}
{elseif !$row.target_contact_name}
  ...
```
