### PR TITLE
[WIP] Event registrations confirmation receipt with multiple participants: add a heading for Participant 1

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -342,6 +342,14 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'payment_or_refund_notification', 'type' => 'text'],
         ],
       ],
+      [
+        'version' => '5.48.beta2',
+        'upgrade_descriptor' => ts('Include Participant heading for 1st Participant'),
+        'templates' => [
+          ['name' => 'event_online_receipt', 'type' => 'html'],
+          ['name' => 'event_online_receipt', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -430,7 +430,7 @@
 
      {/if} {* End of conditional section for Paid events *}
 
-
+<tr><th {$headerStyle}>{ts}Participant Information - Participant 1{/ts}</th></tr>
 {if !empty($customPre)}
 {foreach from=$customPre item=customPr key=i}
    <tr> <th {$headerStyle}>{$customPre_grouptitle.$i}</th></tr>
@@ -461,7 +461,7 @@
 
 {if !empty($customProfile)}
 {foreach from=$customProfile.profile item=eachParticipant key=participantID}
-     <tr><th {$headerStyle}>{ts 1=$participantID+2}Participant %1{/ts} </th></tr>
+     <tr><th {$headerStyle}>{ts 1=$participantID+2}Participant Information - Participant %1{/ts} </th></tr>
      {foreach from=$eachParticipant item=eachProfile key=pid}
      <tr><th {$headerStyle}>{$customProfile.title.$pid}</th></tr>
      {foreach from=$eachProfile item=val key=field}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -227,6 +227,11 @@ You were registered by: {$payer.name}
 {/if}
 {/if} {* End of conditional section for Paid events *}
 
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
+
+{ts}Participant Information - Participant 1{/ts}
+
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 {if !empty($customPre)}
 {foreach from=$customPre item=customPr key=i}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
@@ -245,7 +250,6 @@ You were registered by: {$payer.name}
 {if !empty($customPost)}
 {foreach from=$customPost item=customPos key=j}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
-
 {$customPost_grouptitle.$j}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 


### PR DESCRIPTION
# Overview

CiviCRM Events, when registering multiple participants the template: Events - Registration Confirmation and Receipt does not have a heading for Participant 1.  Has a heading that starts from Participant 2.

This makes it hard to identify which fields are for the first Participant since the fields immediately follow the Event receipt detail. And then the next heading is simply Participant 2 which implies there should have been a Participant 1.

The Event Registration (off-line) template does have a Participant 1 heading.

# How to test this PR

1. Set up an Event and **enable** the option, Online Registration, **Register multiple participants?**
2. View the Event Registration page for the Event
3. Register a person and 2 other additional participants
4. Check the email received for the registrant
5. The email should now list Participant 1 and their details, then Participant 2 and Participant 3 details

# Before

Participant 1 details have no heading.

# After

Participant 1 details have a heading. Heading wording is aligned with the Event Registration (off-line) template for consistency.

# Comments

Agileware Ref: CIVICRM-1960