### PR TITLE
core#1836 - restrict scheduled reminder 'Also Include' to non-events

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -228,8 +228,17 @@
 
       // CRM-14070 Hide limit-to when entity is activity
       function showHideLimitTo() {
+        // '1' is the value of "Activity" in the entity select box.
         $('#limit_to', $form).toggle(!($('#entity_0', $form).val() == '1'));
         if ($('#entity_0', $form).val() != '1' || !($('#entity_0').length)) {
+          // Some Event entity is selected.
+          if (['2', '3', '5'].includes($('#entity_0', $form).val())) {
+            $('#limit_to option[value="0"]', $form).attr('disabled','disabled').removeAttr('selected');
+          }
+          else {
+            $('#limit_to option[value="0"]', $form).removeAttr('disabled');
+          }
+          // Anything but Activity is selected.
           if ($('#limit_to', $form).val() == '') {
             $('tr.recipient:visible, #recipientList, #recipient, a.recipient').hide();
             $('a.limit_to').show();
@@ -241,6 +250,7 @@
           $("label[for='recipient']").text('{/literal}{$recipientLabels.other}{literal}');
         }
         else {
+          // Activity is selected.
           $('#recipient, a.recipient').show()
           $('#recipient').css("margin-left", "-2px");
           $('a.limit_to').hide();


### PR DESCRIPTION
Overview
----------------------------------------
This is a rewrite of #20425.  As @magnolia61 pointed out - it was a good idea, and I'm not sure why I closed the PR.  It was probably accidental, because the issue is still a problem.

Before
----------------------------------------
In Scheduled Reminders, you can select "Also Include" recipients with event reminders, even though that's [broken](https://github.com/civicrm/civicrm-core/pull/17641#issuecomment-664094558).

After
----------------------------------------
You can't select "Also Include" on event reminders.  If you selected "Also Include" that choice is removed.

Comments
----------------------------------------
@magnolia61 you seemed to have an interest in this?

For testing purposes - it's best to bring up a site that has the patch and one that doesn't in adjoining tabs, and observe the difference in behavior when the same options are selected.