### PR TITLE
Afform - Fix regression editing a content block with no entity type

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -153,8 +153,8 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     }
 
     if ($info['definition']['type'] === 'block') {
-      $blockEntity = $info['definition']['join_entity'] ?? $info['definition']['entity_type'];
-      if ($blockEntity !== '*') {
+      $blockEntity = $info['definition']['join_entity'] ?? $info['definition']['entity_type'] ?? NULL;
+      if ($blockEntity) {
         $entities[] = $blockEntity;
       }
       $scanBlocks($info['definition']['layout']);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -76,7 +76,7 @@
 
         else if (editor.getFormType() === 'block') {
           editor.layout['#children'] = editor.afform.layout;
-          editor.blockEntity = editor.afform.join_entity || editor.afform.entity_type;
+          editor.blockEntity = editor.afform.join_entity || editor.afform.entity_type || '*';
           $scope.entities[editor.blockEntity] = backfillEntityDefaults({
             type: editor.blockEntity,
             name: editor.blockEntity,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an error when trying to edit a block which consists of only markup and no entity fields.

Before
----------------------------------------
1. Create a container with some text or rich text elements inside
2. Save container as a new block
3. Go back to the main afform_admin screen, on the blocks tab hit "edit"
4. Error

After
----------------------------------------
4. Works