### PR TITLE
Test cleanup, deprecate ContributionSoft::retrieve

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -186,6 +186,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
    * @deprecated
    */
   public static function retrieve($params, &$defaults) {
+    CRM_Core_Error::deprecatedFunctionWarning('apiv4');
     return self::commonRetrieve(self::class, $params, $defaults);
   }
 


### PR DESCRIPTION
This removes the only call to ContributionSoft::retrieve that I could
find in core, hence I added a deprecation notice to the function.

There could be some extension uses - although it would never have
been supported to call this rather than the api

