### PR TITLE
Cleanup unnecessary variables

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -154,11 +154,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
    *   the result of this processing
    */
   public function summary(&$values) {
-    $erroneousField = NULL;
-    $response = $this->setActiveFieldValues($values, $erroneousField);
+    $this->setActiveFieldValues($values);
 
-    $params = &$this->getActiveFieldParams();
-    $errorMessage = NULL;
+    $params = $this->getActiveFieldParams();
 
     //for date-Formats
     $errorMessage = implode('; ', $this->formatDateFields($params));


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup unnecessary variables

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/161895838-e0aff658-b240-40e5-9b1f-1bf6e6b467fa.png)

`$errorneousField` is not used again in the function and defaults to NULL

![image](https://user-images.githubusercontent.com/336308/161895599-bc527c5e-0ae3-4166-9ee1-469115b2a219.png)


After
----------------------------------------
poof


Technical Details
----------------------------------------

Comments
----------------------------------------
