### PR TITLE
Fix enotice, simplify text on Saved field mapping

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -145,7 +145,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
     $mappingArray = CRM_Core_BAO_Mapping::getMappings('Import Contact');
 
     $this->assign('savedMapping', $mappingArray);
-    $this->addElement('select', 'savedMapping', ts('Mapping Option'), ['' => ts('- select -')] + $mappingArray);
+    $this->addElement('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
     $js = ['onClick' => "buildSubTypes();buildDedupeRules();"];
     // contact types option
@@ -214,7 +214,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Core_Form {
       'fieldSeparator' => $config->fieldSeparator,
     ];
 
-    $this->assign('loadedMapping', $this->get('loadedMapping'));
     if ($this->get('loadedMapping')) {
       $defaults['savedMapping'] = $this->get('loadedMapping');
     }

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -36,7 +36,6 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     ];
 
     $loadedMapping = $this->get('loadedMapping');
-    $this->assign('loadedMapping', $loadedMapping);
     if ($loadedMapping) {
       $defaults['savedMapping'] = $loadedMapping;
     }

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -66,10 +66,9 @@ abstract class CRM_Import_Form_DataSource extends CRM_Core_Form {
     $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . static::IMPORT_ENTITY);
 
     $this->assign('savedMapping', $mappingArray);
-    $this->add('select', 'savedMapping', ts('Mapping Option'), ['' => ts('- select -')] + $mappingArray);
+    $this->add('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
     if ($loadedMapping = $this->get('loadedMapping')) {
-      $this->assign('loadedMapping', $loadedMapping);
       $this->setDefaults(['savedMapping' => $loadedMapping]);
     }
 

--- a/templates/CRM/Activity/Import/Form/DataSource.tpl
+++ b/templates/CRM/Activity/Import/Form/DataSource.tpl
@@ -43,7 +43,7 @@
         <tr>{include file="CRM/Core/Date.tpl"}</tr>
         {if $savedMapping}
         <tr class="crm-activity-import-uploadfile-form-block-savedMapping">
-        <td>{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</td>
+        <td>{$form.savedMapping.label}</td>
            <td>{$form.savedMapping.html}<br />
               <span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span>
 {/if}

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -77,7 +77,7 @@
 
         {if $savedMapping}
          <tr  class="crm-import-datasource-form-block-savedMapping">
-              <td class="label"><label for="savedMapping">{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</label></td>
+              <td class="label"><label for="savedMapping">{$form.savedMapping.label}</label></td>
               <td>{$form.savedMapping.html}<br />
       &nbsp;&nbsp;&nbsp;<span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span></td>
          </tr>

--- a/templates/CRM/Contribute/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contribute/Import/Form/DataSource.tpl
@@ -34,9 +34,9 @@
           <td>{$form.fieldSeparator.html}</td>
         </tr>
         <tr>{include file="CRM/Core/Date.tpl"}</tr>
-{if $savedMapping}
-      <tr> <td class="label">{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</td><td>{$form.savedMapping.html}<br /> <span class="description">{ts}Select a saved field mapping if this file format matches a previous import.{/ts}</span></tr>
-{/if}
+  {if $savedMapping}
+        <tr> <td class="label">{$form.savedMapping.label}</td><td>{$form.savedMapping.html}<br /> <span class="description">{ts}Select a saved field mapping if this file format matches a previous import.{/ts}</span></tr>
+  {/if}
     </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
  </div>

--- a/templates/CRM/Custom/Import/Form/DataSource.tpl
+++ b/templates/CRM/Custom/Import/Form/DataSource.tpl
@@ -64,7 +64,7 @@
   </tr>
   {if $savedMapping}
   <tr class="crm-custom-import-uploadfile-form-block-savedMapping">
-              <td class="label">{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</td>
+              <td class="label">{$form.savedMapping.label}</td>
               <td><span>{$form.savedMapping.html}</span> </td>
   </tr>
   <tr>

--- a/templates/CRM/Event/Import/Form/DataSource.tpl
+++ b/templates/CRM/Event/Import/Form/DataSource.tpl
@@ -64,7 +64,7 @@
   </tr>
   {if $savedMapping}
   <tr class="crm-event-import-uploadfile-form-block-savedMapping">
-              <td class="label">{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</dt>
+              <td class="label">{$form.savedMapping.label}</td>
               <td><span>{$form.savedMapping.html}</span> </td>
   </tr>
   <tr>

--- a/templates/CRM/Member/Import/Form/DataSource.tpl
+++ b/templates/CRM/Member/Import/Form/DataSource.tpl
@@ -53,7 +53,7 @@
        <tr class="crm-member-import-uploadfile-from-block-date">{include file="CRM/Core/Date.tpl"}</tr>
 {if $savedMapping}
        <tr  class="crm-member-import-uploadfile-from-block-savedMapping">
-         <td>{if $loadedMapping}{ts}Select a Different Field Mapping{/ts}{else}{ts}Load Saved Field Mapping{/ts}{/if}</td>
+         <td>{$form.savedMapping.label}</td>
          <td>{$form.savedMapping.html}<br />
            <span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>
          </td>


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotice, simplify text on Saved field mapping

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/161902503-ccb3d70a-914c-46d1-be69-8ce0d9767004.png)

![image](https://user-images.githubusercontent.com/336308/161902535-cf24f267-01c9-41eb-8970-0ad036a7e786.png)

IF I choose a mapping and click 'continue' and THEN go BACK from this screen
![image](https://user-images.githubusercontent.com/336308/161902713-e58e6786-4105-4717-88b2-c6dd541c851e.png)

the message changes slightly

![image](https://user-images.githubusercontent.com/336308/161902749-742c0067-a06e-4293-b8b3-40b2672592d6.png)


After
----------------------------------------
The same text is shown regardless of whether I have gone forwards & back or whether I have just loaded the page, no e-notice

![image](https://user-images.githubusercontent.com/336308/161902860-e305b6f8-62d3-40b5-99c5-99cf1abdd4cf.png)


Technical Details
----------------------------------------
The smarty `$loadedMapping` variable is determined in `postProcess` eg

![image](https://user-images.githubusercontent.com/336308/161903149-6de1a563-bfc1-4ce7-a7b2-7c41379ffd90.png)

It seems like a lot of code complexity to me for something that is very arguably clearer in a very particular flow. 

Switching to using the label from the quickform layer is much cleaner. I Could do the label magic in the quickform layer - but it just seems so arguable that it is even clearer that I removed it

Comments
----------------------------------------
