### PR TITLE
CiviGrant - Remove upgrade that adds removed option value

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -137,13 +137,6 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
             'name' => 'CiviGrant',
           ],
         ],
-        'OptionGroup_contact_view_options_OptionValue_CiviGrant' => [
-          'entity' => 'OptionValue',
-          'values' => [
-            'option_group_id:name' => 'contact_view_options',
-            'name' => 'CiviGrant',
-          ],
-        ],
         'OptionGroup_mapping_type_OptionValue_Export Grant' => [
           'entity' => 'OptionValue',
           'values' => [


### PR DESCRIPTION
Overview
----------------------------------------
Followup from #23105 - removes unnecessary upgrade step.

Technical Details
----------------------------------------
This removes an upgrade step from 5.47. 

This is safe to remove from the 5.48 branch because the managed entity has also been removed from 5.48.

It's safe to keep in the 5.47 branch because the Managed system will remove it eventually due to the managed entity being removed.