### PR TITLE
Emit deprecated warning for typo version of hook_civicrm_links

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -394,9 +394,6 @@ class CRM_Core_Block {
     }
 
     $values = [];
-    foreach ($shortCuts as $key => $short) {
-      $values[$key] = self::setShortCutValues($short);
-    }
 
     // Deprecated hook with typo.  Please don't use this!
     CRM_Utils_Hook::links('create.new.shorcuts',
@@ -404,6 +401,13 @@ class CRM_Core_Block {
       CRM_Core_DAO::$_nullObject,
       $values
     );
+    if ($values) {
+      CRM_Core_Error::deprecatedWarning('hook_civicrm_links "create.new.shorcuts" deprecated in favor of "create.new.shortcuts"');
+    }
+
+    foreach ($shortCuts as $key => $short) {
+      $values[$key] = self::setShortCutValues($short);
+    }
 
     // Hook that enables extensions to add user-defined links
     CRM_Utils_Hook::links('create.new.shortcuts',


### PR DESCRIPTION
Overview
----------------------------------------
The context string 'create.new.shorcuts' was deprecated in 2018.
This adds a noisy warning to ensure extension devs update their code.
