### PR TITLE
Notices on import - consolidate mapping variables

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -84,14 +84,13 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
       // Get an array of the name values for mapping fields associated with this mapping_id.
       $mappingName = CRM_Core_BAO_Mapping::getMappingFieldValues($savedMapping, 'name');
 
-      $this->assign('loadedMapping', $savedMapping);
       $this->set('loadedMapping', $savedMapping);
 
       $params = ['id' => $savedMapping];
       $temp = [];
       $mappingDetails = CRM_Core_BAO_Mapping::retrieve($params, $temp);
 
-      $this->assign('savedName', $mappingDetails->name);
+      $this->assign('savedMappingName', $mappingDetails->name);
 
       $this->add('hidden', 'mappingId', $savedMapping);
 

--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -39,9 +39,8 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO = new CRM_Core_DAO_Mapping();
       $mapDAO->id = $mappingId;
       $mapDAO->find(TRUE);
-      $this->assign('loadedMapping', $mappingId);
-      $this->assign('savedName', $mapDAO->name);
     }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
 
     if ($skipColumnHeader) {
       $this->assign('skipColumnHeader', $skipColumnHeader);

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -49,9 +49,8 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO = new CRM_Core_DAO_Mapping();
       $mapDAO->id = $mappingId;
       $mapDAO->find(TRUE);
-      $this->assign('loadedMapping', $mappingId);
-      $this->assign('savedName', $mapDAO->name);
     }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
 
     $this->assign('rowDisplayCount', 2);
 

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -41,9 +41,8 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO = new CRM_Core_DAO_Mapping();
       $mapDAO->id = $mappingId;
       $mapDAO->find(TRUE);
-      $this->assign('loadedMapping', $mappingId);
-      $this->assign('savedName', $mapDAO->name);
     }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
 
     if ($skipColumnHeader) {
       $this->assign('skipColumnHeader', $skipColumnHeader);

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -29,9 +29,8 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO = new CRM_Core_DAO_Mapping();
       $mapDAO->id = $mappingId;
       $mapDAO->find(TRUE);
-      $this->assign('loadedMapping', $mappingId);
-      $this->assign('savedName', $mapDAO->name);
     }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
 
     if ($skipColumnHeader) {
       $this->assign('skipColumnHeader', $skipColumnHeader);

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -104,11 +104,6 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       //mapping is to be loaded from database
 
-      $params = array('id' => $savedMapping);
-      $temp = [];
-      $mappingDetails = CRM_Core_BAO_Mapping::retrieve($params, $temp);
-
-      $this->assign('loadedMapping', $mappingDetails->name);
       $this->set('loadedMapping', $savedMapping);
 
       $getMappingName = new CRM_Core_DAO_Mapping();
@@ -119,7 +114,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
         $mapperName = $getMappingName->name;
       }
 
-      $this->assign('savedName', $mapperName);
+      $this->assign('savedMappingName', $mapperName);
 
       $this->add('hidden', 'mappingId', $savedMapping);
 

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -42,9 +42,8 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO = new CRM_Core_DAO_Mapping();
       $mapDAO->id = $mappingId;
       $mapDAO->find(TRUE);
-      $this->assign('loadedMapping', $mappingId);
-      $this->assign('savedName', $mapDAO->name);
     }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
 
     if ($skipColumnHeader) {
       $this->assign('skipColumnHeader', $skipColumnHeader);

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -157,8 +157,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Core_Form {
 
       $mappingName = (string) civicrm_api3('Mapping', 'getvalue', ['id' => $savedMappingID, 'return' => 'name']);
       $this->set('loadedMapping', $savedMapping);
-      $this->assign('loadedMapping', $mappingName);
-      $this->assign('savedName', $mappingName);
       $this->add('hidden', 'mappingId', $savedMappingID);
 
       $this->addElement('checkbox', 'updateMapping', ts('Update this field mapping'), NULL);
@@ -166,7 +164,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Core_Form {
       $this->add('text', 'saveMappingName', ts('Name'));
       $this->add('text', 'saveMappingDesc', ts('Description'));
     }
-
+    $this->assign('savedMappingName', $mappingName ?? NULL);
     $this->addElement('checkbox', 'saveMapping', $saveDetailsName, NULL, ['onclick' => "showSaveDetails(this)"]);
   }
 

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -117,11 +117,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       //mapping is to be loaded from database
 
-      $params = array('id' => $savedMapping);
-      $temp = [];
-      $mappingDetails = CRM_Core_BAO_Mapping::retrieve($params, $temp);
-
-      $this->assign('loadedMapping', $mappingDetails->name);
       $this->set('loadedMapping', $savedMapping);
 
       $getMappingName = new CRM_Core_DAO_Mapping();
@@ -132,7 +127,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
         $mapperName = $getMappingName->name;
       }
 
-      $this->assign('savedName', $mapperName);
+      $this->assign('savedMappingName', $mapperName);
 
       $this->add('hidden', 'mappingId', $savedMapping);
 

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -42,9 +42,8 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO = new CRM_Core_DAO_Mapping();
       $mapDAO->id = $mappingId;
       $mapDAO->find(TRUE);
-      $this->assign('loadedMapping', $mappingId);
-      $this->assign('savedName', $mapDAO->name);
     }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
 
     if ($skipColumnHeader) {
       $this->assign('skipColumnHeader', $skipColumnHeader);

--- a/templates/CRM/Activity/Import/Form/MapTable.tpl
+++ b/templates/CRM/Activity/Import/Form/MapTable.tpl
@@ -13,13 +13,13 @@
  <div id="map-field">
     {strip}
     <table>
-    {if $loadedMapping}
-        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedName}Saved Field Mapping: %1{/ts}</td></tr>
+    {if $savedMappingName}
+      <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
     {/if}
         <tr class="columnheader">
             {section name=rows loop=$rowDisplayCount}
        {if $skipColumnHeader }
-                   { if $smarty.section.rows.iteration == 1 }
+                   {if $smarty.section.rows.iteration == 1}
                      <th>{ts}Column Headers{/ts}</th>
                    {else}
                      <th>{ts 1=$smarty.section.rows.iteration}Import Data (row %1){/ts}</th>
@@ -61,7 +61,7 @@
     {if $wizard.currentStepName != 'Preview'}
     <div>
 
-      {if $loadedMapping}
+      {if $savedMappingName}
           <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
       {/if}
       <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -13,8 +13,8 @@
  <div id="map-field">
     {strip}
     <table class="selector">
-    {if $loadedMapping}
-        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedName}Saved Field Mapping: %1{/ts}</td></tr>
+    {if $savedMappingName}
+        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
     {/if}
         <tr class="columnheader">
       {if $showColNames}
@@ -23,7 +23,7 @@
           {assign var="totalRowsDisplay" value=$rowDisplayCount}
       {/if}
             {section name=rows loop=$totalRowsDisplay}
-                { if $smarty.section.rows.iteration == 1 and $showColNames}
+                {if $smarty.section.rows.iteration == 1 and $showColNames}
                   <td>{ts}Column Names{/ts}</td>
                 {elseif $showColNames}
                   <td>{ts 1=$smarty.section.rows.iteration-1}Import Data (row %1){/ts}</td>
@@ -111,7 +111,7 @@
     {if $wizard.currentStepName != 'Preview'}
     <div>
 
-      {if $loadedMapping}
+      {if $savedMappingName}
           <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
       {/if}
       <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>

--- a/templates/CRM/Contribute/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contribute/Import/Form/MapTable.tpl
@@ -12,13 +12,13 @@
  <div id="map-field">
     {strip}
     <table>
-    {if $loadedMapping}
-        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedName}Saved Field Mapping: %1{/ts}</td></tr>
-    {/if}
+      {if $savedMappingName}
+        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
+      {/if}
         <tr class="columnheader">
             {section name=rows loop=$rowDisplayCount}
        {if $skipColumnHeader }
-                   { if $smarty.section.rows.iteration == 1 }
+                   {if $smarty.section.rows.iteration == 1}
                      <th>{ts}Column Headers{/ts}</th>
                    {else}
                      <th>{ts 1=$smarty.section.rows.iteration}Import Data (row %1){/ts}</th>
@@ -63,7 +63,7 @@
     {if $wizard.currentStepName != 'Preview'}
     <div>
 
-      {if $loadedMapping}
+      {if $savedMappingName}
           <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
       {/if}
       <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>

--- a/templates/CRM/Event/Import/Form/MapTable.tpl
+++ b/templates/CRM/Event/Import/Form/MapTable.tpl
@@ -12,8 +12,8 @@
 <div id="map-field">
     {strip}
     <table>
-    {if $loadedMapping}
-        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedName}Saved Field Mapping: %1{/ts}</td></tr>
+    {if $savedMappingName}
+        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
     {/if}
         <tr class="columnheader">
             {section name=rows loop=$rowDisplayCount}
@@ -59,7 +59,7 @@
     {if $wizard.currentStepName != 'Preview'}
     <div>
 
-      {if $loadedMapping}
+      {if $savedMappingName}
           <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
       {/if}
       <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>

--- a/templates/CRM/Member/Import/Form/MapTable.tpl
+++ b/templates/CRM/Member/Import/Form/MapTable.tpl
@@ -12,8 +12,8 @@
  <div id="map-field">
     {strip}
     <table>
-    {if $loadedMapping}
-        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedName}Saved Field Mapping: %1{/ts}</td></tr>
+    {if $savedMappingName}
+        <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
     {/if}
         <tr class="columnheader">
             {section name=rows loop=$rowDisplayCount}
@@ -59,7 +59,7 @@
     {if $wizard.currentStepName != 'Preview'}
     <div>
 
-      {if $loadedMapping}
+      {if $savedMappingName}
           <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
       {/if}
       <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>


### PR DESCRIPTION

Overview
----------------------------------------
Notices on import - consolidate mapping variables

This consolidates 2 variables mappingName and loadedMapping into
one (savedMappingName) - loadedMapping is only ever used as
a boolean so presence or otherwise of savedMappingName is enough.

This addresses enotices and simplifies the code

Before
----------------------------------------
Lotsa notices

After
----------------------------------------
Less notices...

Mapping name still shown
![image](https://user-images.githubusercontent.com/336308/162060825-9c53fc5a-5dd4-439a-8659-25f420fa1941.png)
 
and on preview

![image](https://user-images.githubusercontent.com/336308/162060918-0c57e0d3-e9e1-440f-958f-19968373bcc0.png)


Technical Details
----------------------------------------


Comments
----------------------------------------

