### PR TITLE
Afform - Ensure upgrade fully converts content blocks

### DIFF
--- a/ext/afform/core/CRM/Afform/Upgrader.php
+++ b/ext/afform/core/CRM/Afform/Upgrader.php
@@ -55,6 +55,9 @@ class CRM_Afform_Upgrader extends CRM_Afform_Upgrader_Base {
       }
       if (!empty($meta['entity_type'])) {
         $meta['type'] = 'block';
+        if ($meta['entity_type'] === '*') {
+          unset($meta['entity_type']);
+        }
       }
       file_put_contents($fileName, json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Minor follow-up from #23104 to fix a possible bug while upgrading Afform.

Technical Details
----------------------------------------
Ensures `{block: '*'}` doesn't get converted to `{entity_type: '*'}` because that's not a real entity type.

Comments
------------------
I haven't reproduced this bug personally, but I can see how it might happen, if you create a content-only block in 5.45 and then upgrade, you might get errors trying to edit it in 5.47+. This gives an extra safety check to prevent that.