### PR TITLE
Remove unused private variables

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -23,8 +23,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
   protected $_mapperKeys;
 
   private $_contactIdIndex;
-  private $_totalAmountIndex;
-  private $_contributionTypeIndex;
 
   protected $_mapperSoftCredit;
   //protected $_mapperPhoneType;
@@ -97,8 +95,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
 
     // FIXME: we should do this in one place together with Form/MapField.php
     $this->_contactIdIndex = -1;
-    $this->_totalAmountIndex = -1;
-    $this->_contributionTypeIndex = -1;
 
     $index = 0;
     foreach ($this->_mapperKeys as $key) {
@@ -107,13 +103,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Contribute_Import_Pa
           $this->_contactIdIndex = $index;
           break;
 
-        case 'total_amount':
-          $this->_totalAmountIndex = $index;
-          break;
-
-        case 'financial_type':
-          $this->_contributionTypeIndex = $index;
-          break;
       }
       $index++;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused private variables

Before
----------------------------------------
Private variables are set but never used

![image](https://user-images.githubusercontent.com/336308/162085905-9f47712c-cadd-45fd-885d-64a05b4e3e04.png)

![image](https://user-images.githubusercontent.com/336308/162085965-3198d143-aac1-4ce1-b7f9-36510ac278dd.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
As they are private we can be confident they can't be used from elsewhere. 

I think the intent was to validate them as required fields - but the goal here is to clean up stuff that isn't doing anything - not to recover it's long lost intent

Comments
----------------------------------------
