### PR TITLE
Add in APIv4 Logging Entity

### DIFF
--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -56,13 +56,13 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
    *
    * @param array $params
    *   Array of name-value pairs of log table.
-   *
+   * @return CRM_Core_DAO_Log
    */
   public static function add(&$params) {
-
     $log = new CRM_Core_DAO_Log();
     $log->copyValues($params);
     $log->save();
+    return $log;
   }
 
   /**

--- a/Civi/Api4/Log.php
+++ b/Civi/Api4/Log.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Log
+ *
+ * @since 5.49
+ * @package Civi\Api4
+ */
+class Log extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnlyEntity;
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Exposes the `civicrm_log` table to APIv4.

This is a rebased version of #22117