### PR TITLE
Fix OptionValue BAO to call pre/post hooks to prevent force-reset of managed option values

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -155,6 +155,9 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
       $params['option_group_id'], 'name', 'id'
     );
 
+    $op = $id ? 'edit' : 'create';
+    CRM_Utils_Hook::pre($op, 'OptionValue', $id, $params);
+
     // action is taken depending upon the mode
     $optionValue = new CRM_Core_DAO_OptionValue();
     $optionValue->copyValues($params);
@@ -217,6 +220,8 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
     $optionValue->id = $id;
     $optionValue->save();
     CRM_Core_PseudoConstant::flush();
+
+    CRM_Utils_Hook::post($op, 'OptionValue', $id, $optionValue);
 
     // Create relationship for payment instrument options
     if (!empty($params['financial_account_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the worst part of the bug reported in https://lab.civicrm.org/dev/core/-/issues/3161 - in which all user-changes to CiviGrant option values were periodically force-reverted by the managed entity system.

Before
----------------------------------------
Any changes to grant-status option values would be reverted during the next upgrade or cache clear.

After
----------------------------------------
Changes persist.

Technical Details
----------------------------------------
Managed entities rely on `pre/post` hooks being called in order to track whether an entity has been modified. Without those hooks `OptionValues` were being force-reverted by the managed system even when the 'update' mode was set to 'unmodified', which is supposed to defer to user modifications.
