### PR TITLE
Remove unnecessary pass-by-ref

### DIFF
--- a/CRM/Activity/Import/Parser.php
+++ b/CRM/Activity/Import/Parser.php
@@ -59,7 +59,7 @@ abstract class CRM_Activity_Import_Parser extends CRM_Import_Parser {
   public function run(
     array $fileName,
     $separator,
-    &$mapper,
+    $mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $onDuplicate = self::DUPLICATE_SKIP,

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -152,7 +152,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   public function run(
     $fileName,
     $separator,
-    &$mapper,
+    $mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,

--- a/CRM/Custom/Import/Parser.php
+++ b/CRM/Custom/Import/Parser.php
@@ -59,7 +59,7 @@ abstract class CRM_Custom_Import_Parser extends CRM_Import_Parser {
   public function run(
     $fileName,
     $separator,
-    &$mapper,
+    $mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,

--- a/CRM/Event/Import/Parser.php
+++ b/CRM/Event/Import/Parser.php
@@ -61,7 +61,7 @@ abstract class CRM_Event_Import_Parser extends CRM_Import_Parser {
   public function run(
     $fileName,
     $separator,
-    &$mapper,
+    $mapper,
     $skipColumnHeader = FALSE,
     $mode = self::MODE_PREVIEW,
     $contactType = self::CONTACT_INDIVIDUAL,

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -150,7 +150,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Core_Form {
     $parser->setMaxLinesToProcess(100);
     $parser->run($fileName,
       $separator,
-      $mapper,
+      [],
       $skipColumnHeader,
       CRM_Import_Parser::MODE_MAPFIELD,
       $this->get('contactType')


### PR DESCRIPTION
Overview
----------------------------------------
Remove unnecessary pass-by-ref

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/162336955-4581dc79-8904-4b56-ae8e-ad47b3e3a4f6.png)


After
----------------------------------------
no more

Technical Details
----------------------------------------
Also stopped passing in a pass-by-ref variable in the function called from these places

![image](https://user-images.githubusercontent.com/336308/162337215-e88cdf04-34dd-4614-8555-7f7292b9a9e2.png)


Comments
----------------------------------------
Copy *& paste strikes again...