### PR TITLE
Centralise skipColumnHeader to one function (fixes notices, cleans code)

### DIFF
--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -24,8 +24,7 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
+    parent::preProcess();
     // Get the data from the session.
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
@@ -41,14 +40,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO->find(TRUE);
     }
     $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
-
-    if ($skipColumnHeader) {
-      $this->assign('skipColumnHeader', $skipColumnHeader);
-      $this->assign('rowDisplayCount', 3);
-    }
-    else {
-      $this->assign('rowDisplayCount', 2);
-    }
 
     if ($invalidRowCount) {
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Activity_Import_Parser';
@@ -92,7 +83,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
@@ -117,7 +107,7 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
     $parser->run($fileName, $separator,
       $mapperFields,
-      $skipColumnHeader,
+      $this->getSubmittedValue('skipColumnHeader'),
       CRM_Import_Parser::MODE_IMPORT,
       $onDuplicate,
       $this->get('statusID'),

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -108,7 +108,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     $showColNames = TRUE;
     if ('CRM_Import_DataSource_CSV' == $this->get('dataSource') &&
-      !$this->get('skipColumnHeader')
+      !$this->getSubmittedValue('skipColumnHeader')
     ) {
       $showColNames = FALSE;
     }

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -24,8 +24,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
+    parent::preProcess();
     //get the data from the session
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
@@ -43,14 +42,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO->find(TRUE);
     }
     $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
-
-    if ($skipColumnHeader) {
-      $this->assign('skipColumnHeader', $skipColumnHeader);
-      $this->assign('rowDisplayCount', 3);
-    }
-    else {
-      $this->assign('rowDisplayCount', 2);
-    }
 
     if ($invalidRowCount) {
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Contribute_Import_Parser_Contribution';
@@ -94,7 +85,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
@@ -129,7 +119,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
     $parser->run($fileName, $separator,
       $mapperFields,
-      $skipColumnHeader,
+      $this->getSubmittedValue('skipColumnHeader'),
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
       $onDuplicate,

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -13,8 +13,7 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @return void
    */
   public function preProcess() {
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
+    parent::preProcess();
     //get the data from the session
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
@@ -31,14 +30,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO->find(TRUE);
     }
     $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
-
-    if ($skipColumnHeader) {
-      $this->assign('skipColumnHeader', $skipColumnHeader);
-      $this->assign('rowDisplayCount', 3);
-    }
-    else {
-      $this->assign('rowDisplayCount', 2);
-    }
 
     if ($invalidRowCount) {
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . $this->_importParserUrl;
@@ -82,7 +73,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
@@ -109,7 +99,7 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
     $parser->run($fileName, $separator,
       $mapperFields,
-      $skipColumnHeader,
+      $this->getSubmittedValue('skipColumnHeader'),
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
       $onDuplicate

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -27,7 +27,7 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @return void
    */
   public function preProcess() {
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
+    parent::preProcess();
 
     //get the data from the session
     $dataValues = $this->get('dataValues');
@@ -44,14 +44,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO->find(TRUE);
     }
     $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
-
-    if ($skipColumnHeader) {
-      $this->assign('skipColumnHeader', $skipColumnHeader);
-      $this->assign('rowDisplayCount', 3);
-    }
-    else {
-      $this->assign('rowDisplayCount', 2);
-    }
 
     if ($invalidRowCount) {
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Event_Import_Parser';
@@ -95,7 +87,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
@@ -120,7 +111,7 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
     $parser->run($fileName, $separator,
       $mapperFields,
-      $skipColumnHeader,
+      $this->getSubmittedValue('skipColumnHeader'),
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
       $onDuplicate

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -21,7 +21,7 @@
  * TODO: CRM-11254 - if preProcess and postProcess functions can be reconciled between the 5 child classes,
  * those classes can be removed entirely and this class will not need to be abstract
  */
-abstract class CRM_Import_Form_Preview extends CRM_Core_Form {
+abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
 
   /**
    * Return a descriptive name for the page, used in wizard header.
@@ -30,6 +30,14 @@ abstract class CRM_Import_Form_Preview extends CRM_Core_Form {
    */
   public function getTitle() {
     return ts('Preview');
+  }
+
+  /**
+   * Assign common values to the template.
+   */
+  public function preProcess() {
+    $this->assign('skipColumnHeader', $this->getSubmittedValue('skipColumnHeader'));
+    $this->assign('rowDisplayCount', $this->getSubmittedValue('skipColumnHeader') ? 3 : 2);
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class helps the forms within the import flow access submitted & parsed values.
+ */
+class CRM_Import_Forms extends CRM_Core_Form {
+
+  /**
+   * Get the submitted value, accessing it from whatever form in the flow it is submitted on.
+   * @param string $fieldName
+   *
+   * @return mixed|null
+   */
+  public function getSubmittedValue(string $fieldName) {
+    $mappedValues = [
+      'skipColumnHeader' => 'DataSource',
+    ];
+    if (array_key_exists($fieldName, $mappedValues)) {
+      return $this->controller->exportValue($mappedValues[$fieldName], $fieldName);
+    }
+    return parent::getSubmittedValue($fieldName);
+
+  }
+
+}

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -27,8 +27,7 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @return void
    */
   public function preProcess() {
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
-
+    parent::preProcess();
     //get the data from the session
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
@@ -44,14 +43,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $mapDAO->find(TRUE);
     }
     $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
-
-    if ($skipColumnHeader) {
-      $this->assign('skipColumnHeader', $skipColumnHeader);
-      $this->assign('rowDisplayCount', 3);
-    }
-    else {
-      $this->assign('rowDisplayCount', 2);
-    }
 
     if ($invalidRowCount) {
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Member_Import_Parser_Membership';
@@ -96,7 +87,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-    $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
@@ -140,7 +130,7 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
     $parser->run($fileName, $separator,
       $mapperFields,
-      $skipColumnHeader,
+      $this->getSubmittedValue('skipColumnHeader'),
       CRM_Import_Parser::MODE_IMPORT,
       $this->get('contactType'),
       $onDuplicate,


### PR DESCRIPTION
Overview
----------------------------------------
Centralise skipColumnHeader to one function (fixes notices, cleans code)

Before
----------------------------------------
Notices & duplicated code on preview screen for import

After
----------------------------------------
Preview screen still handles the column headers (error is due to csv missing date data)

![image](https://user-images.githubusercontent.com/336308/162358007-b1a20951-5959-41be-a3e6-bd2fed504ce4.png)

Technical Details
----------------------------------------
This adds a parent class that allows the preview screen (and soon other screens in the flow) to access values submitted on the first screen in the flow - much of the confusion in this code is because of the way in which values are passed from form to form - however the quick form layer is already storing and caching this so we don't need another layer to pass the values on top

Comments
----------------------------------------
