### PR TITLE
Enotice fix - membership search

### DIFF
--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -43,7 +43,7 @@
         </td>
     {/if}
     <td class="crm-membership-type crm-membership-type_{$row.membership_type}">
-        {$row.membership_type}{if $row.is_test} ({ts}test{/ts}){/if}
+        {$row.membership_type}
         {if $row.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
     </td>
     <td class="crm-membership-join_date">{$row.membership_join_date|truncate:10:''|crmDate}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix - membership search

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/162357364-a0cec667-88aa-404c-bf60-32863d76ba61.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/162357501-40cdd309-2c5f-4992-a24c-5dbb2bf920e9.png)

![image](https://user-images.githubusercontent.com/336308/162357381-0487f7f6-67d8-4225-b787-9554bac40328.png)

Technical Details
----------------------------------------
The row variable is 'members_is_test', is_test is never true - even when the (test) has been added - which it seems the php layer is doing)

Comments
----------------------------------------
