### PR TITLE
(dev/mail#107) CiviMail - Fix validation error (5.49)

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1654,12 +1654,22 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   /**
    * @deprecated
    *   This is used by CiviMail but will be made redundant by FlexMailer.
-   * @param CRM_Mailing_DAO_Mailing $mailing
+   * @param CRM_Mailing_DAO_Mailing|array $mailing
    *   The mailing which may or may not be sendable.
    * @return array
    *   List of error messages.
    */
   public static function checkSendable($mailing) {
+    if (is_array($mailing)) {
+      $params = $mailing;
+      $mailing = new \CRM_Mailing_BAO_Mailing();
+      $mailing->id = $params['id'] ?? NULL;
+      if ($mailing->id) {
+        $mailing->find(TRUE);
+      }
+      $mailing->copyValues($params);
+    }
+
     $errors = [];
     foreach (['subject', 'name', 'from_name', 'from_email'] as $field) {
       if (empty($mailing->{$field})) {


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a new/inaccurate validation error in CiviMail.

ping @eileenmcnaughton 

See also: 
* https://civicrm.stackexchange.com/questions/41654/after-upgrade-to-civicrm-5-48-0-all-submissions-say-mailing-cannot-be-sent-th
* https://lab.civicrm.org/dev/mail/-/issues/107

Steps to reproduce:
----------------------------------------

- Disable Flexmailer
- Use web UI
- Create a new mailing
- Fill out fields
- Submit mailing

Before
----------------------------------------

The "Submit" action raises an error:

> Mailing cannot be sent. There are missing or invalid fields (subject,name,from_name,from_email,body).

After
----------------------------------------

The "Submit" works.

Comments
----------------------------------------

The issue is that the validator is being called with a different data-structure (ie it was originally written for a Mailing DAO record - but now receives a partial Mailing array record). This patch is a side-port of the patch used on Flexmailer during 5.48 dev (7e0fcd9d1073493a953b46caad225498e470f546), and it allows the validator to accept either DAO or array.