### PR TITLE
Release - Set version compatibility for core extensions when updating core

### DIFF
--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -79,12 +79,22 @@ updateFile("sql/test_data_second_domain.mysql", function ($content) use ($newVer
   return str_replace($oldVersion, $newVersion, $content);
 });
 
+// Update core extension info
 $infoXmls = findCoreInfoXml();
 foreach ($infoXmls as $infoXml) {
   updateXmlFile($infoXml, function (DOMDocument $dom) use ($newVersion) {
+    // Update extension version
     foreach ($dom->getElementsByTagName('version') as $tag) {
       /* @var \DOMNode $tag */
       $tag->textContent = $newVersion;
+    }
+    // Update compatability - set to major version of core
+    foreach ($dom->getElementsByTagName('compatibility') as $compat) {
+      /* @var \DOMNode $compat */
+      foreach ($compat->getElementsByTagName('ver') as $tag) {
+        /* @var \DOMNode $tag */
+        $tag->textContent = implode('.', array_slice(explode('.', $newVersion), 0, 2));
+      }
     }
   });
 }


### PR DESCRIPTION
Overview
----------------------------------------
When bumping the version of CiviCRM core, also bump the compatibility tag for each bundled extension.

Before
----------------------------------------
Core extensions have incorrect compatability version set, which might lead someone to believe that a later version of a core extension can be used on an earlier version of CiviCRM.

After
----------------------------------------
Always kept up-to-date.

Comments
-------------
Ping @totten 