### PR TITLE
Fix incorrect use of icon argument for crmButton function

### DIFF
--- a/templates/CRM/Admin/Page/Navigation.tpl
+++ b/templates/CRM/Admin/Page/Navigation.tpl
@@ -20,7 +20,7 @@
 
   <div class="crm-block crm-content-block">
     <div id="new-menu-item">
-      {crmButton p="civicrm/admin/menu" q="action=add&reset=1" id="newMenuItem" icon="crm-i fa-plus-circle" style="margin-left: 6px;"}{ts}Add Menu Item{/ts}{/crmButton}
+      {crmButton p="civicrm/admin/menu" q="action=add&reset=1" id="newMenuItem" icon="plus-circle" style="margin-left: 6px;"}{ts}Add Menu Item{/ts}{/crmButton}
     </div>
     <div class="spacer"></div>
     <div style="padding-left: 48px;"><img src="{$config->resourceBase}i/logo_sm.png" /></div>

--- a/templates/CRM/Badge/Page/Layout.tpl
+++ b/templates/CRM/Badge/Page/Layout.tpl
@@ -48,7 +48,7 @@
 
       {if $action ne 1 and $action ne 2}
         <div class="action-link">
-          {crmButton q="action=add&reset=1" id="newbadge-layout" icon="crm-i fa-plus-circle"}{ts}New Badge Layout{/ts}{/crmButton}
+          {crmButton q="action=add&reset=1" id="newbadge-layout" icon="plus-circle"}{ts}New Badge Layout{/ts}{/crmButton}
         </div>
       {/if}
     </div>

--- a/templates/CRM/Batch/Form/Search.tpl
+++ b/templates/CRM/Batch/Form/Search.tpl
@@ -22,7 +22,7 @@
   </table>
 </div>
 <div class="action-link">
-  {crmButton accesskey="N" p="civicrm/batch/add" q="reset=1&action=add" id="newBatch" icon="crm-i fa-plus-circle"}{ts}New Data Entry Batch{/ts}{/crmButton}<br/>
+  {crmButton accesskey="N" p="civicrm/batch/add" q="reset=1&action=add" id="newBatch" icon="plus-circle"}{ts}New Data Entry Batch{/ts}{/crmButton}<br/>
 </div>
 <table class="crm-batch-selector">
   <thead>

--- a/templates/CRM/Campaign/Form/Search/Campaign.tpl
+++ b/templates/CRM/Campaign/Form/Search/Campaign.tpl
@@ -15,7 +15,7 @@
     {ts}None found.{/ts}
   </div>
   <div class="action-link">
-    {crmButton p="civicrm/campaign/add" q="reset=1" icon="crm-i fa-plus-circle" h=0}{ts}Add Campaign{/ts}{/crmButton}
+    {crmButton p="civicrm/campaign/add" q="reset=1" icon="plus-circle" h=0}{ts}Add Campaign{/ts}{/crmButton}
   </div>
 {elseif $buildSelector}
 
@@ -52,7 +52,7 @@
   </table>
 {else}
   <div class="action-link">
-    {crmButton p="civicrm/campaign/add" q="reset=1" icon="crm-i fa-plus-circle" h=0}{ts}Add Campaign{/ts}{/crmButton}
+    {crmButton p="civicrm/campaign/add" q="reset=1" icon="plus-circle" h=0}{ts}Add Campaign{/ts}{/crmButton}
   </div>
 {* build search form here *}
 

--- a/templates/CRM/Campaign/Page/SurveyType.tpl
+++ b/templates/CRM/Campaign/Page/SurveyType.tpl
@@ -4,7 +4,7 @@
 {else}
 {if $rows}
 <div class="action-link">
-  {crmButton p=$addSurveyType.0 q=$addSurveyType.1 icon="crm-i fa-plus-circle"}{ts 1=$GName}Add %1{/ts}{/crmButton}
+  {crmButton p=$addSurveyType.0 q=$addSurveyType.1 icon="plus-circle"}{ts 1=$GName}Add %1{/ts}{/crmButton}
 </div>
 
 <div id={$gName}>
@@ -41,7 +41,7 @@
         </table>
         {/strip}
         <div class="action-link">
-          {crmButton p=$addSurveyType.0 q=$addSurveyType.1 icon="crm-i fa-plus-circle"}{ts 1=$GName}Add %1{/ts}{/crmButton}
+          {crmButton p=$addSurveyType.0 q=$addSurveyType.1 icon="plus-circle"}{ts 1=$GName}Add %1{/ts}{/crmButton}
         </div>
 
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix incorrect use of icon argument for crmButton function

Before
----------------------------------------
Recently a handful of button icons have looked a bit off:

<img width="190" alt="Screenshot 2022-04-09 at 09 42 03" src="https://user-images.githubusercontent.com/1931323/162564032-69ca4af5-905a-4fca-b844-5051a2a09ad2.png">

After
----------------------------------------
Correct icon restored:

<img width="190" alt="Screenshot 2022-04-09 at 09 42 27" src="https://user-images.githubusercontent.com/1931323/162564045-02f5991a-9b13-4e72-8359-41082012ac1f.png">

Technical Details
----------------------------------------
It turns out a handful of buttons were using the `icon` argument of the `crmButton` function wrong, but that this had actually been working fine for the last 7 years. However, commit 45c304a3b2bd7d6313751c4f9828f85eeb61a88c started styling `crm-i-*` classes, which broke styling on the incorrectly specified icons.