### PR TITLE
APIv4 Explorer - Adjust 'Index' field to fit better on narrow screens

### DIFF
--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -157,6 +157,10 @@
   width: 20em;
 }
 
+#bootstrap-theme.api4-explorer-page .form-control.api4-index {
+  width: 8em;
+}
+
 /* Another weird shoreditch fix */
 #bootstrap-theme .form-inline div.checkbox {
   margin-right: 1em;

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -26,8 +26,8 @@
   border-bottom-left-radius: 0;
   margin-bottom: 0;
 }
-#bootstrap-theme .panel-heading li>a {
-  background-color: #f1f1f18c
+#bootstrap-theme .panel-heading li > a {
+  background-color: #f1f1f18c;
 }
 #bootstrap-theme.api4-explorer-page .explorer-code-panel pre {
   min-height: 3.3em;


### PR DESCRIPTION
Overview
----------------------------------------
Makes the API Explorer header controls fit better on narrow screens.

Before
----------------------------------------
"Index" field unnecessarily wide, breaks narrow layouts.

![image](https://user-images.githubusercontent.com/2874912/162578839-591db0fa-1395-42d4-9f32-540953b91f3f.png)


After
----------------------------------------
Takes up a bit less space, better for narrow screens.

![image](https://user-images.githubusercontent.com/2874912/162578800-c1fb343f-ec2b-490d-b6e9-e49c6f3d995c.png)

Comments
----------------------------------------
@braders can you OK this one?