### PR TITLE
Restrict allowed uploads - contact image

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -811,7 +811,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     CRM_Contact_Form_Location::buildQuickForm($this);
 
     // add attachment
-    $this->addField('image_URL', ['maxlength' => '255', 'label' => ts('Browse/Upload Image')]);
+    $this->addField('image_URL', ['maxlength' => '255', 'label' => ts('Browse/Upload Image'), 'accept' => 'image/png, image/jpeg, image/gif']);
 
     // add the dedupe button
     $this->addElement('xbutton',


### PR DESCRIPTION
Overview
----------------------------------------
Restrict allowed uploads - contact image

Before
----------------------------------------
The image upload for contacts accepted any file type. However, server-side logic restricted this within `CRM_Contact_BAO_Contact::processImageParams`.

After
----------------------------------------
Only allowed file types are allowed.

Comments
----------------------------------------
`CRM_Contact_BAO_Contact::processImageParams` actually accepts `image/bmp`, as well as aliases like `image/x-png`. All modern browsers will understand the accept value I have defined, and I really can't see anyone wanting to upload a bmp image in 2022! Therefore I went for a simplified list of mime types.