### PR TITLE
(dev/core#3166) "Metadata" cache - Strictly separate by version

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -168,9 +168,11 @@ class Container {
       'contactTypes' => 'contactTypes',
       'metadata' => 'metadata',
     ];
+    $verSuffixCaches = ['metadata'];
+    $verSuffix = '_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version());
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
-        'name' => $cacheGrp,
+        'name' => $cacheGrp . (in_array($cacheGrp, $verSuffixCaches) ? $verSuffix : ''),
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       ];
       // For Caches that we don't really care about the ttl for and/or maybe accessed


### PR DESCRIPTION
Overview
-------------

This addresses some symptoms identified in the discussion of [dev/core#3166](https://lab.civicrm.org/dev/core/-/issues/3166) where a recently-updated codebase generates errors due to stale cache data. 

With this patch, the `metadata` cache will be de-facto reset whenever you load new code.

Before
------

The `metadata` cache is always stored with the name `metadata`.

If you load a newer codebase, it still reads `metadata` from the older code base (until something explicitly clears the cache).

After
-----

The `metadata` cache is always stored with the name `metadata_{version}`, eg `metadata_5_48_0`.

If you load a newer codebase (eg `5.49.0`), it will ignore the older `metadata_5_48_0` and create a new `metadata_5_49_0`.

Comments
--------

The upgrade system also clears cache, but many users rely on navigating through the site to get to the upgrader.

The change could make sense with other caches, but I only applied the change to the `metadata` cache because there is _some_ risk; eg if some caller bypasses the cache objects. (I was also slightly concerned about the possibility the some caller relies on `$cache->getName()` or `$cache->getPrefix()` or similar... but I haven't been able to find any methods like that...). It seems safer to put that sort of change into a monthly update rather than minor patch.

The discussion in 3166 touched on a few different error scenarios in a few different environments. I don't know that it helps all of them, but it helps the ones that I experienced/reproduced.