### PR TITLE
Ensure deleteURL variable for ContactImage.tpl

### DIFF
--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -207,6 +207,9 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
     // Add links for actions menu
     self::addUrls($this, $this->_contactId);
     $this->assign('groupOrganizationUrl', $this->getGroupOrganizationUrl($contactType));
+
+    // Assign deleteURL variable, used as part of ContactImage.tpl
+    self::$_template->ensureVariablesAreAssigned(['deleteURL']);
   }
 
   /**

--- a/templates/CRM/Contact/Page/ContactImage.tpl
+++ b/templates/CRM/Contact/Page/ContactImage.tpl
@@ -11,7 +11,7 @@
   <div class="crm-contact_image crm-contact_image-block">
     {$imageURL}
   </div>
-  {if $action eq 0 or $action neq 1}
+  {if $action eq 0 or $action neq 1 and $deleteURL}
     <div class='crm-contact_image-block crm-contact_image crm-contact_image-delete'>{$deleteURL}</div>
   {/if}
 {/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Ensure deleteURL variable is defined for `ContactImage.tpl`

Before
----------------------------------------
An E_Notice was thrown when viewing a contact who had an image uploaded.

After
----------------------------------------
The notice is no longer thrown on the contact view screen.

Comments
----------------------------------------
`ContactImage.tpl` is also used for profiles, but I've had a quick check and they still seem to work as expected following this change, with no new notices thrown.
