### PR TITLE
Avoid PHP notices on FinancialAccount table

### DIFF
--- a/CRM/Financial/Page/FinancialAccount.php
+++ b/CRM/Financial/Page/FinancialAccount.php
@@ -105,6 +105,14 @@ class CRM_Financial_Page_FinancialAccount extends CRM_Core_Page_Basic {
         }
       }
 
+      // Ensure keys are always set to avoid Smarty notices
+      if (!isset($contributionType[$dao->id]['accounting_code'])) {
+        $contributionType[$dao->id]['accounting_code'] = FALSE;
+      }
+      if (!isset($contributionType[$dao->id]['account_type_code'])) {
+        $contributionType[$dao->id]['account_type_code'] = FALSE;
+      }
+
       $contributionType[$dao->id]['action'] = CRM_Core_Action::formLink(self::links(), $action,
         ['id' => $dao->id],
         ts('more'),


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP notices on FinancialAccount table.

Before
----------------------------------------
When new financial accounts were created with optional fields left blank, this caused PHP notices to occur on the `civicrm/admin/financial/financialAccount` page.

After
----------------------------------------
No such PHP notices occur.
