### PR TITLE
Don't overescape weights in default-escape mode

### DIFF
--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -51,7 +51,7 @@
             <tr id="row_{$row.id}" class="crm-labelFormat {cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}">
               <td class="crm-labelFormat-name">{$row.label}</td>
               <td class="crm-labelFormat-name">{$row.groupName}</td>
-              <td class="crm-labelFormat-order nowrap">{$row.weight}</td>
+              <td class="crm-labelFormat-order nowrap">{$row.weight|smarty:nodefaults}</td>
               <td class="crm-labelFormat-description">{$row.grouping}</td>
               <td class="crm-labelFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
               <td class="crm-labelFormat-is_reserved">{if $row.is_reserved eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}

--- a/templates/CRM/Admin/Page/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Page/ParticipantStatusType.tpl
@@ -36,7 +36,7 @@
           <td class="center crmf-is_reserved">{icon condition=$row.is_reserved}{ts}Reserved{/ts}{/icon}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="center crmf-is_counted">{icon condition=$row.is_counted}{ts}Counted{/ts}{/icon}</td>
-          <td class="crmf-weight">{$row.weight}</td>
+          <td class="crmf-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crmf-visibility">{$row.visibility}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Admin/Page/PdfFormats.tpl
+++ b/templates/CRM/Admin/Page/PdfFormats.tpl
@@ -51,7 +51,7 @@
             <td class="crm-pdfFormat-name">{$row.name}</td>
             <td class="crm-pdfFormat-description">{$row.description}</td>
             <td class="crm-pdfFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
-          <td class="crm-pdfFormat-order nowrap">{$row.weight}</td>
+          <td class="crm-pdfFormat-order nowrap">{$row.weight|smarty:nodefaults}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}

--- a/templates/CRM/Campaign/Page/SurveyType.tpl
+++ b/templates/CRM/Campaign/Page/SurveyType.tpl
@@ -32,7 +32,7 @@
           <td class="crm-admin-options-label crm-editable" data-field="label">{$row.label}</td>
           <td class="crm-admin-options-value">{$row.value}</td>
           <td class="crm-admin-options-description">{if !empty($row.description)}{$row.description}{/if}</td>
-          <td class="nowrap crm-admin-options-order">{$row.weight}</td>
+          <td class="nowrap crm-admin-options-order">{$row.weight|smarty:nodefaults}</td>
           <td class="crm-admin-options-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crm-admin-options-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>

--- a/templates/CRM/Contribute/Page/Premium.tpl
+++ b/templates/CRM/Contribute/Page/Premium.tpl
@@ -34,7 +34,7 @@
           <td class="crm-contribution-form-block-min_contribution">{$row.min_contribution|crmMoney}</td>
           <td class="crm-contribution-form-block-cost">{$row.cost|crmMoney}</td>
           <td class="crm-contribution-form-block-financial_type">{$row.financial_type}</td>
-          <td class="nowrap crm-contribution-form-block-weight">{$row.weight}</td>
+          <td class="nowrap crm-contribution-form-block-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crm-contribution-form-block-action">{$row.action}</td>
         </tr>
         {/foreach}

--- a/templates/CRM/Member/Page/MembershipStatus.tpl
+++ b/templates/CRM/Member/Page/MembershipStatus.tpl
@@ -46,7 +46,7 @@
           <td class="nowrap crmf-end_event_adjust_interval">{if !empty($row.end_event_adjust_interval)}{$row.end_event_adjust_interval}{/if}</td>
           <td class="crmf-is_current_member crm-editable" data-type="boolean">{if $row.is_current_member eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crmf-is_admin crm-editable" data-type="boolean">{if $row.is_admin eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td class="nowrap crmf-weight">{$row.weight}</td>
+          <td class="nowrap crmf-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crmf-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if !empty($row.action)}{$row.action|replace:'xx':$row.id}{/if}</td>
         </tr>

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -47,7 +47,7 @@
           <td class="crmf-relationship_type">{$row.relationshipTypeName}</td>
           <td class="crmf-max_related" align="right">{$row.max_related}</td>
           <td class="crmf-visibility crm-editable" data-type="select">{$row.visibility}</td>
-          <td class="nowrap crmf-weight">{$row.weight}</td>
+          <td class="nowrap crmf-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{$row.action|replace:'xx':$row.id}</td>
         </tr>

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -61,7 +61,7 @@
       <tr id="price_field-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}{if NOT $row.is_active} disabled{/if}">
         <td class="crm-editable" data-field="label">{$row.label}</td>
         <td>{$row.html_type_display}</td>
-        <td class="nowrap">{$row.weight}</td>
+        <td class="nowrap">{$row.weight|smarty:nodefaults}</td>
         <td class="crm-editable" data-field="is_required" data-type="boolean">{if $row.is_required eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
         <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
         <td>{if $row.active_on}{$row.active_on|crmDate}{/if}</td>

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -70,7 +70,7 @@
               {/if}
               <td class="crm-price-option-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}</td>
               <td class="nowrap crm-price-option-financial-type-id">{$row.financial_type_id}</td>
-              <td class="nowrap crm-price-option-order">{$row.weight}</td>
+              <td class="nowrap crm-price-option-order">{$row.weight|smarty:nodefaults}</td>
               {if $getTaxDetails}
                 <td>{if $row.tax_rate != '' }
                       {$taxTerm} ({$row.tax_rate}%)

--- a/templates/CRM/Report/Page/Options.tpl
+++ b/templates/CRM/Report/Page/Options.tpl
@@ -43,7 +43,7 @@
             <td class="crm-report-optionList-label crm-editable" data-field="label">{$row.label}</td>
             <td class="crm-report-optionList-value">{$row.value}</td>
             <td class="crm-report-optionList-description">{$row.description}</td>
-            <td class="nowrap crm-report-optionList-order">{$row.weight}</td>
+            <td class="nowrap crm-report-optionList-order">{$row.weight|smarty:nodefaults}</td>
             {if !empty($showIsDefault)}
               <td class="crm-report-optionList-default_value">{$row.default_value}</td>
             {/if}

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -49,7 +49,7 @@
                 <td class="crm-editable crmf-is_searchable" data-type="boolean">{if $row.is_searchable eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-in_selector" data-type="boolean">{if $row.in_selector eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 {/if}
-                <td class="nowrap">{$row.weight}</td>
+                <td class="nowrap">{$row.weight|smarty:nodefaults}</td>
                 <td class="crm-editable crmf-is_required" data-type="boolean">{if $row.is_required eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-is_view" data-type="boolean">{if $row.is_view eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>{if $row.is_reserved     eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Extends https://github.com/civicrm/civicrm-core/pull/22256 to the full set of weights (orders).

Before
----------------------------------------
Order links overescaped - something like this: 

![image](https://user-images.githubusercontent.com/1931323/162613523-a8f495e4-1319-43ab-a9d8-98b385c4e78f.png)


After
----------------------------------------
No more overescaping.
