### PR TITLE
Add smarty:nodefaults to default.tpl form.

### DIFF
--- a/templates/CRM/Form/default.tpl
+++ b/templates/CRM/Form/default.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {if !$suppressForm}
-<form {$form.attributes} >
+<form {$form.attributes|smarty:nodefaults}>
   {crmRegion name='form-top'}{/crmRegion}
 {/if}
 


### PR DESCRIPTION
This allows core forms (e.g. search forms) to submit correctly,
even with CIVICRM_SMARTY_DEFAULT_ESCAPE mode.

Without this change, quote marks were turned into HTML attributes,
meaning the form essentially had no method or action.

Before
----------------------------------------

<img width="1387" alt="Screenshot 2022-04-10 at 16 19 48" src="https://user-images.githubusercontent.com/1931323/162626623-6c040cb7-cbfe-4532-bf58-999cc92b205e.png">

After
----------------------------------------
<img width="1333" alt="Screenshot 2022-04-10 at 16 20 36" src="https://user-images.githubusercontent.com/1931323/162626652-018e2200-935e-4bb3-82a5-54c4355ec43f.png">


Technical Details
----------------------------------------
This seemed to be affecting all search forms, and probably other forms as well. This fix was developed in a WordPress context, but I assume the same flaw existed on Drupal/Joomla too.