### PR TITLE
Paypal pro, a.net ipn - do not update start date, status

### DIFF
--- a/CRM/Core/Payment/AuthorizeNetIPN.php
+++ b/CRM/Core/Payment/AuthorizeNetIPN.php
@@ -121,7 +121,6 @@ class CRM_Core_Payment_AuthorizeNetIPN extends CRM_Core_Payment_BaseIPN {
     if ($input['response_code'] == 1) {
       // Approved
       if ($first) {
-        $recur->start_date = $now;
         $recur->trxn_id = $recur->processor_id;
         $isFirstOrLastRecurringPayment = CRM_Core_Payment::RECURRING_PAYMENT_START;
       }

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -288,10 +288,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
         break;
 
       case 'recurring_payment':
-        if ($first) {
-          $recur->start_date = $now;
-        }
-        else {
+        if (!$first) {
           if ($input['paymentStatus'] !== 'Completed') {
             throw new CRM_Core_Exception("Ignore all IPN payments that are not completed");
           }
@@ -319,11 +316,6 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
           $subscriptionPaymentStatus = CRM_Core_Payment::RECURRING_PAYMENT_END;
         }
 
-        // make sure the contribution status is not done
-        // since order of ipn's is unknown
-        if ($recur->contribution_status_id != $contributionStatuses['Completed']) {
-          $recur->contribution_status_id = $contributionStatuses['In Progress'];
-        }
         break;
     }
 


### PR DESCRIPTION

Overview
----------------------------------------
Paypal pro, a.net ipn - do not update start date, status

Before
----------------------------------------
- start_date updated on first paypal or ipn payment
- redundant update to contribution_recur.contribution_status_id

After
----------------------------------------
poof

Technical Details
----------------------------------------
On Follows on from https://github.com/civicrm/civicrm-core/pull/23081 we discussed whether start_date should be updated - I was of the opinion it should be standard behaviour & @mattwire made the case that paypal & a.net were outliers in updating the date.

The update to contribution_status_id traces back to here
 
https://github.com/civicrm/civicrm-svn/commit/404e8bf31970c2170268dd35d124c29d3b47b3fe

I STILL don't really understand the comment - however the BAO class ensures the status is updated to 'In Progress' when the first payment is converted to Completed

Comments
----------------------------------------
