### PR TITLE
Event self-service cancel: allow cancelling Waitlist registration

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1866,8 +1866,8 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
       $details['ineligible_message'] = ts('This event registration can not be transferred or cancelled. Contact the event organizer if you have questions.');
       return $details;
     }
-    //verify participant status is still Registered
-    if ($details['status'] != 'Registered') {
+    // Verify participant status is one that can be self-cancelled
+    if (!in_array($details['status'], ['Registered', 'Pending from pay later', 'On waitlist'])) {
       $details['eligible'] = FALSE;
       $details['ineligible_message'] = "You cannot transfer or cancel your registration for " . $eventTitle . ' as you are not currently registered for this event.';
       return $details;

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -454,6 +454,15 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'isBackOffice' => FALSE,
       'successExpected' => TRUE,
     ];
+    // Allow to cancel if on waitlist
+    $scenarios[] = [
+      'selfSvcEnabled' => 1,
+      'selfSvcHours' => 12,
+      'hoursToEvent' => 16,
+      'participantStatusId' => 7,
+      'isBackOffice' => FALSE,
+      'successExpected' => TRUE,
+    ];
     // Too late to self-service
     $scenarios[] = [
       'selfSvcEnabled' => 1,
@@ -463,7 +472,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'isBackOffice' => FALSE,
       'successExpected' => FALSE,
     ];
-    // Participant status is other than "Registered".
+    // Participant status cannot cancel (ex: Attended)
     $scenarios[] = [
       'selfSvcEnabled' => 1,
       'selfSvcHours' => 12,


### PR DESCRIPTION
Overview
----------------------------------------

In CiviEvent, when "allow service cancel or transfer", we only allow 'Registered' participants to cancel. A participant on the waitlist, for example (or Pending Payment), cannot cancel.

Before
----------------------------------------

When the participant tries to cancel, they get an error "You cannot transfer or cancel your registration for Event Title as you are not currently registered for this event".

After
----------------------------------------

Participant can cancel.

Technical Details
----------------------------------------

One-line patch.

Comments
----------------------------------------

I did not add all cancellable statuses, only those that made most sense in my opinion.

Not sure about:

- Pending from waitlist (not sure what the difference is from 'On waitlist?')
- Pending from approval: I figured it's a more niche-workflow, and probably better not mess with it now.

Some prior discussion:

- https://civicrm.stackexchange.com/questions/33726/you-cannot-transfer-or-cancel-as-you-are-not-currently-registered-for-this-even
- https://lab.civicrm.org/dev/event/-/issues/26

cc @MegaphoneJon you had worked on this in the past, and closed dev/event#26. Any thoughts?