### PR TITLE
Set limit to 0 when processing send sms task

### DIFF
--- a/CRM/Contact/Form/Task/SMSCommon.php
+++ b/CRM/Contact/Form/Task/SMSCommon.php
@@ -159,6 +159,7 @@ class CRM_Contact_Form_Task_SMSCommon {
       $form->_contactDetails = civicrm_api3('Contact', 'get', [
         'id' => ['IN' => $form->_contactIds],
         'return' => ['sort_name', 'phone', 'do_not_sms', 'is_deceased', 'display_name'],
+        'options' => ['limit' => 0],
       ])['values'];
 
       // make a copy of all contact details


### PR DESCRIPTION
Overview
----------------------------------------
Select contact more than 25 with a valid  phone type and try to send SMS using 'SMS - schedule/send'

Before
----------------------------------------
only 25 contacts are shown selected  in 'To' field and 25 contacts SMS is sent

After
----------------------------------------
All contacts selected from the search page are shown in 'To' field