### PR TITLE
(dev/core#3166) "Metadata" cache - Strictly separate by version (5.48)

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -168,9 +168,11 @@ class Container {
       'contactTypes' => 'contactTypes',
       'metadata' => 'metadata',
     ];
+    $verSuffixCaches = ['metadata'];
+    $verSuffix = '_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version());
     foreach ($basicCaches as $cacheSvc => $cacheGrp) {
       $definitionParams = [
-        'name' => $cacheGrp,
+        'name' => $cacheGrp . (in_array($cacheGrp, $verSuffixCaches) ? $verSuffix : ''),
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
       ];
       // For Caches that we don't really care about the ttl for and/or maybe accessed


### PR DESCRIPTION
Overview
----------

This addresses some symptoms identified in the discussion of [dev/core#3166](https://lab.civicrm.org/dev/core/-/issues/3166) where a recently-updated codebase generates errors due to stale cache data. 

With this patch, the `metadata` cache will be de-facto reset whenever you load new code.

Backport of #23148 from 5.49-rc to 5.48-stable.
