### PR TITLE
(Re-)Set version to 5.50.alpha1

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -16,7 +16,7 @@
   <version>5.50.alpha1</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.23</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>Form Builder provides a UI to administer and edit forms. It is an optional admin tool and not required for the forms to function.</comments>
   <requires>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -16,7 +16,7 @@
   <version>5.50.alpha1</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>5.23</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>The Form Core extension is required to use any dynamic form. To administer and edit forms, also install the Form Builder extension.</comments>
   <civix>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -16,7 +16,7 @@
   <version>5.50.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.23</ver>
+    <ver>5.50</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -18,7 +18,7 @@
   </tags>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.23</ver>
+    <ver>5.50</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.47</ver>
+    <ver>5.50</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.search_kit</ext>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -16,7 +16,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.47</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>CiviGrant was originally a core component before migrating to an extension</comments>
   <requires>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.39</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This is the version of CKEditor that originally shipped with CiviCRM core</comments>
   <classloader>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.32</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This code has been moved from core to a separate extension in 5.32. Note that if you disable it failed or cancelled contributions will not cause related memberships and participant records to be updated</comments>
   <classloader>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -19,7 +19,7 @@
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.29</ver>
+    <ver>5.50</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -21,7 +21,7 @@
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.31</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This is an extension to contain the eWAY Single Currency Payment Processor</comments>
   <classloader>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.30</ver>
+    <ver>5.50</ver>
   </compatibility>
   <tags>
     <tag>mgmt:hidden</tag>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -23,7 +23,7 @@
     to provide richer email features.
   </comments>
   <compatibility>
-    <ver>5.29</ver>
+    <ver>5.50</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\FlexMailer\" path="src"/>

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -21,7 +21,7 @@
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.31</ver>
+    <ver>5.50</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -21,7 +21,7 @@
     <tag>mgmt:hidden</tag>
   </tags>
   <compatibility>
-    <ver>5.40</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This is hidden on install to give extensions that require it time to add it to their requires and to allow us to get it out of GroupContact load</comments>
   <classloader>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -21,7 +21,7 @@
   </tags>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.43</ver>
+    <ver>5.50</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.50</ver>
   </compatibility>
   <requires>
     <ext version="~4.5">org.civicrm.afform</ext>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This extension is extraction of the original Core Payflow Pro Payment Processor</comments>
   <classloader>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -19,7 +19,7 @@
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.37</ver>
+    <ver>5.50</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -18,7 +18,7 @@
   <version>5.50.alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.50</ver>
   </compatibility>
   <comments>This extension is still in beta. Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -21,7 +21,7 @@
   </tags>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.24</ver>
+    <ver>5.50</ver>
   </compatibility>
   <mixins>
     <mixin>setting-php@1.0.0</mixin>


### PR DESCRIPTION
Overview
----------------------------------------

Re-run the `set-version.php` script after #23143.

cc @colemanw 

Before
----------------------------------------

The various core extensions (`ext/*/info.xml`) set inconsistent+often innacurate expectations about which versions of `civicrm-core` are compatible.

After
----------------------------------------

All the versions match the target release (ie in `civicrm-cor@5.50.alpha1`, the core extensions each require `5.50.alpha1`).
