### PR TITLE
Add smarty:nodefaults to ManageEvent page.

### DIFF
--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -119,10 +119,10 @@
               </span>
             </div>
             <div class="crm-event-links">
-              {$row.eventlinks|replace:'xx':$row.id}
+              {$row.eventlinks|smarty:nodefaults|replace:'xx':$row.id}
             </div>
             <div class="crm-event-more">
-              {$row.action|replace:'xx':$row.id}
+              {$row.action|smarty:nodefaults|replace:'xx':$row.id}
             </div>
           </td>
           <td class="crm-event-start_date hiddenElement">{$row.start_date|crmDate}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Add smarty:nodefaults to ManageEvent page.
This ensures that the links render correctly in escape-on-output mode.

Before
----------------------------------------
<img width="1386" alt="Screenshot 2022-04-12 at 07 42 16" src="https://user-images.githubusercontent.com/1931323/162897225-3280725c-483b-4411-bad1-890bdddbf7df.png">

After
----------------------------------------
<img width="1382" alt="Screenshot 2022-04-12 at 07 41 56" src="https://user-images.githubusercontent.com/1931323/162897265-1a923312-e410-43e4-b482-2f031bb5448e.png">
