### PR TITLE
Contribution dashboard links work in escape-on-output mode

### DIFF
--- a/templates/CRM/Contribute/Page/DashBoard.tpl
+++ b/templates/CRM/Contribute/Page/DashBoard.tpl
@@ -52,10 +52,10 @@
 <table class="form-layout-compressed">
   <tr>
     <td>
-      <a href="{$configPagesURL}" class="button no-popup"><span>{ts}Manage Contribution Pages{/ts}</span></a>
+      <a href="{$configPagesURL|smarty:nodefaults}" class="button no-popup"><span>{ts}Manage Contribution Pages{/ts}</span></a>
     </td>
     <td>
-      <a href="{$newPageURL}" class="button no-popup"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Contribution Page{/ts}</span></a>
+      <a href="{$newPageURL|smarty:nodefaults}" class="button no-popup"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Contribution Page{/ts}</span></a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
Overview
----------------------------------------
Contribution dashboard links work in escape-on-output mode

Before
----------------------------------------
The manage and add contribution page links at the top of the civicrm/contribute page were broken.

After
----------------------------------------
The links work.

Comments
----------------------------------------
For the reasons described https://github.com/civicrm/civicrm-core/pull/23153#issuecomment-1094298929, this wouldn't be a problem in a Drupal environment, due to differing URL structures between CMSs.