### PR TITLE
dev/core#3172 Update phpleague/csv from 9.2 to 9.6 (supports php 8)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
-      "php": "7.2"
+      "php": "7.2.5"
     },
     "allow-plugins": {
       "civicrm/composer-compile-plugin": true,
@@ -47,7 +47,7 @@
     }
   },
   "require": {
-    "php": "~7.2 || ~8",
+    "php": "~7.2.5 || ~7.3 || ~8",
     "cache/integration-tests": "~0.17.0",
     "dompdf/dompdf" : "~1.2.1",
     "firebase/php-jwt": ">=3 <6",
@@ -79,7 +79,7 @@
     "pear/log": "1.13.3",
     "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^3.0",
-    "league/csv": "^9.2",
+    "league/csv": "^9.6",
     "league/oauth2-client": "^2.4",
     "league/oauth2-google": "^3.0",
     "tplaner/when": "~3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b33687888fc16f55cf7323e0fd8755c",
+    "content-hash": "3d5a355a6c98016285351c9d51076c50",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1179,31 +1179,34 @@
         },
         {
             "name": "league/csv",
-            "version": "9.2.1",
+            "version": "9.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "b574a7d8b28f1528e011d8652fb7d2e83410d4c9"
+                "reference": "f28da6e483bf979bac10e2add384c90ae9983e4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/b574a7d8b28f1528e011d8652fb7d2e83410d4c9",
-                "reference": "b574a7d8b28f1528e011d8652fb7d2e83410d4c9",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/f28da6e483bf979bac10e2add384c90ae9983e4e",
+                "reference": "f28da6e483bf979bac10e2add384c90ae9983e4e",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": ">=7.0.10"
+                "php": ">=7.2.5"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "friendsofphp/php-cs-fixer": "^2.12",
-                "phpstan/phpstan": "^0.9.2",
-                "phpstan/phpstan-phpunit": "^0.9.4",
-                "phpstan/phpstan-strict-rules": "^0.9.0",
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12.0",
+                "phpstan/phpstan-phpunit": "^0.12.0",
+                "phpstan/phpstan-strict-rules": "^0.12.0",
+                "phpunit/phpunit": "^8.5"
             },
             "suggest": {
+                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
                 "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
             },
             "type": "library",
@@ -1232,24 +1235,31 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Csv data manipulation made easy in PHP",
+            "description": "CSV data manipulation made easy in PHP",
             "homepage": "http://csv.thephpleague.com",
             "keywords": [
+                "convert",
                 "csv",
                 "export",
                 "filter",
                 "import",
                 "read",
+                "transform",
                 "write"
             ],
             "support": {
                 "docs": "https://csv.thephpleague.com",
-                "forum": "https://groups.google.com/forum/#!forum/thephpleague",
                 "issues": "https://github.com/thephpleague/csv/issues",
                 "rss": "https://github.com/thephpleague/csv/releases.atom",
                 "source": "https://github.com/thephpleague/csv"
             },
-            "time": "2019-06-07T06:24:33+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-10T19:40:30+00:00"
         },
         {
             "name": "league/oauth2-client",
@@ -4901,13 +4911,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.2 || ~8",
+        "php": "~7.2.5 || ~7.3 || ~8",
         "ext-intl": "*",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2"
+        "php": "7.2.5"
     },
     "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update phpleague/csv to php8-compatible version https://github.com/thephpleague/csv

https://lab.civicrm.org/dev/core/-/issues/3172

Before
----------------------------------------
phpleague/csv  = 9.2

After
----------------------------------------
phpleague/csv  = 9.6

Technical Details
----------------------------------------
Minimum php version is 7.2.5 - which is a VERY old variant of 7.2

Comments
----------------------------------------
