### PR TITLE
(NFC) Skip CliRunnerTest on php80+drush+Backdrop

### DIFF
--- a/tests/phpunit/E2E/Extern/CliRunnerTest.php
+++ b/tests/phpunit/E2E/Extern/CliRunnerTest.php
@@ -96,7 +96,11 @@ class E2E_Extern_CliRunnerTest extends CiviEndToEndTestCase {
     if (CIVICRM_UF === 'WordPress') {
       $cliRunners['wp'] = ['wp', 'wp eval \'civicrm_initialize();\'@PHP'];
     }
-    if (CIVICRM_UF === 'Drupal' || CIVICRM_UF === 'Backdrop') {
+    if (CIVICRM_UF === 'Drupal') {
+      $cliRunners['drush'] = ['drush', 'drush ev \'civicrm_initialize();\'@PHP'];
+    }
+    if (CIVICRM_UF === 'Backdrop' && version_compare(PHP_VERSION, '8', '<')) {
+      // At time of writing, "drush ev" doesn't work on our php80+backdrop environments
       $cliRunners['drush'] = ['drush', 'drush ev \'civicrm_initialize();\'@PHP'];
     }
     // TODO: Drupal8 w/drush (doesn't use civicrm_initialize?)


### PR DESCRIPTION
Overview
----------------------------------------

The `CliRunnerTest` goes through various permutations of CLI commands (`cv`, `drush`, `wp-cli`) in different environments (`php7`/min, `php8`/max, D7, D9, BD, WP, etc). The permutation for `php8`+`backdrop`+`drush` has been failing persistently (https://test.civicrm.org/job/CiviCRM-E2E-Matrix/).

Skip this test permutation. It is blocked by upstream issues in drush-backdrop, and (AFAIK) this permutation has never worked.

CC @seamuslee001 @herbdool 

Before
----------------------------------------

These tests fail in php8+backdrop+drush:

```
E2E_Extern_CliRunnerTest.testBasicPathUrl with data set "drush"
E2E_Extern_CliRunnerTest.testPathUrlMatch with data set #0
E2E_Extern_CliRunnerTest.testPathUrlMatch with data set #1
```

After
----------------------------------------

The tests are skipped in php8+backdrop+drush.

Technical Details
----------------------------------------

The problem does not seem to be specific to the functionality `civicrm-core.git` -- it appears to affect anything going through `drush-backdrop` on php8, and it's been blocked on upstream fixes.  You can see this by running just `drush ev`:

```
$ drush ev 'echo 123;'
PDOException: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens: SELECT name FROM {system} WHERE type=&#039;module&#039; AND status=1; Array
(
    [:type] => module
    [:status] => 1
)
 in drush_db_select() (line 131 of phar:///Users/totten/bknix/extern/drush8.phar/includes/dbtng.inc).
Drush command terminated abnormally due to an unrecoverable error.
```

I'm not too worried about losing coverage here - `CliRunnerTest` still provides coverage for several adjacent configurations, ie

* PHP8 + D7 + Drush (differ only by CMS)
* PHP8 + Backdrop + Cv (differ only by CLI-runner)
* PHP7 + Backdrop + Drush (differ only by PHP-version)

Comments
-----------

It's hard to see this when skimming the matrix (https://test.civicrm.org/job/CiviCRM-E2E-Matrix/), but there is an additional error for `backdrop,max` regarding `SoapTest`. I haven't been able to reproduce this yet. I mention it only to show why these extra red-flags matter -- when we get multiple+persistent red-flags for something outside our control, we're less likely to see other red-flags.

When/if there's an upstream fix, we can re-enable the test...