### PR TITLE
Standardize DataSource file for Contribution & Membership

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -32,6 +32,31 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
 
     // check for post max size
     CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
+    $this->assign('importEntity', $this->getTranslatedEntity());
+    $this->assign('importEntities', $this->getTranslatedEntities());
+  }
+
+  /**
+   * Get the import entity (translated).
+   *
+   * Used for template layer text.
+   *
+   * @return string
+   */
+  protected function getTranslatedEntity(): string {
+    return Civi\Api4\Utils\CoreUtil::getInfoItem($this::IMPORT_ENTITY, 'title');
+  }
+
+  /**
+   * Get the import entity plural (translated).
+   *
+   * Used for template layer text.
+   *
+   * @return string
+   */
+  protected function getTranslatedEntities(): string {
+    return Civi\Api4\Utils\CoreUtil::getInfoItem($this::IMPORT_ENTITY, 'title_plural');
+
   }
 
   /**

--- a/templates/CRM/Activity/Import/Form/DataSource.tpl
+++ b/templates/CRM/Activity/Import/Form/DataSource.tpl
@@ -7,9 +7,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Activity Import Wizard - Step 1 (upload data file) *}
-{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-<div class="crm-block crm-form-block crm-activity-import-uploadfile-form-block">
+{* Import Wizard - Step 1 (choose data source) *}
+<div class="crm-block crm-form-block crm-import-datasource-form-block">
 
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -13,8 +13,6 @@
   {include file=$dataSourceFormTemplateFile}
 {else}
   {* Import Wizard - Step 1 (choose data source) *}
-  {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-
   {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
   {include file="CRM/common/WizardHeader.tpl"}
    <div class="help">

--- a/templates/CRM/Contribute/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contribute/Import/Form/DataSource.tpl
@@ -7,36 +7,61 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Contribution Import Wizard - Step 1 (upload data file) *}
-{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
- <div class="crm-block crm-form-block  crm-contribution-import-uploadfile-form-block" id="upload-file">
- {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
-{include file="CRM/common/WizardHeader.tpl"}
-<div class="help">
-    {ts}The Contribution Import Wizard allows you to easily upload contributions from other applications into CiviCRM.{/ts}
-    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match the contribution to an existing contact in your CiviCRM database.{/ts} {help id='upload'}
- </div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+
+{* Import Wizard - Step 1 (choose data source) *}
+<div class="crm-block crm-form-block crm-import-datasource-form-block">
+
+  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+  {include file="CRM/common/WizardHeader.tpl"}
+  <div class="help">
+    {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
+    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}
+  </div>
+
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   <table class="form-layout-compressed">
-    <tr><td class="label">{$form.uploadFile.label}</td><td class="html-adjust"> {$form.uploadFile.html}<br />
-            <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span></td></tr>
-        <tr><td class="label"></td><td>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</td></tr>
-        <tr><td class="label"></td><td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
-                <span class="description">
-                    {ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Amount').{/ts} </span></td></tr>
-        <tr><td class="{$form.contactType.name} label">{$form.contactType.label}</td><td class="{$form.contactType.name}">{$form.contactType.html}<br />
-            <span class="description">
-                {ts}Select 'Individual' if you are importing contributions made by individual persons.{/ts}
-                {ts}Select 'Organization' or 'Household' if you are importing contributions made by contacts of that type. (NOTE: Some built-in contact types may not be enabled for your site.){/ts}</span></td></tr>
-        <tr><td class="label">{$form.onDuplicate.label}</td><td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td></tr>
-        <tr class="crm-import-datasource-form-block-fieldSeparator">
-          <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
-          <td>{$form.fieldSeparator.html}</td>
+    <tr class="crm-import-uploadfile-from-block-uploadFile">
+      <td class="label">{$form.uploadFile.label}</td>
+      <td class="html-adjust"> {$form.uploadFile.html}<br />
+        <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span>
+        <br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
+      </td>
+    </tr>
+    <tr class="crm-import-uploadfile-from-block-skipColumnHeader">
+      <td class="label"></td><td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
+        <span class="description">
+          {ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Amount').{/ts}
+        </span>
+      </td>
+    </tr>
+    <tr class="crm-import-uploadfile-from-block-contactType">
+      <td class="label">{$form.contactType.label}</td>
+      <td>{$form.contactType.html}<br />
+        <span class="description">
+          {ts 1=$importEntities}Select 'Individual' if you are importing %1 made by individual persons.{/ts}
+          {ts 1=$importEntities}Select 'Organization' or 'Household' if you are importing %1 made by contacts of that type. (NOTE: Some built-in contact types may not be enabled for your site.){/ts}
+        </span>
+      </td>
+    </tr>
+    <tr class="crm-import-uploadfile-from-block-onDuplicate">
+      <td class="label">{$form.onDuplicate.label}</td>
+      <td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td>
+    </tr>
+    <tr class="crm-import-datasource-form-block-fieldSeparator">
+      <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
+      <td>{$form.fieldSeparator.html}</td>
+    </tr>
+    <tr class="crm-import-uploadfile-from-block-date">{include file="CRM/Core/Date.tpl"}</tr>
+      {if $savedMapping}
+        <tr class="crm-import-uploadfile-from-block-savedMapping">
+          <td>{$form.savedMapping.label}</td>
+          <td>{$form.savedMapping.html}<br />
+            <span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>
+          </td>
         </tr>
-        <tr>{include file="CRM/Core/Date.tpl"}</tr>
-  {if $savedMapping}
-        <tr> <td class="label">{$form.savedMapping.label}</td><td>{$form.savedMapping.html}<br /> <span class="description">{ts}Select a saved field mapping if this file format matches a previous import.{/ts}</span></tr>
-  {/if}
-    </table>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
- </div>
+      {/if}
+  </table>
+  <div class="spacer"></div>
+
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/templates/CRM/Custom/Import/Form/DataSource.tpl
+++ b/templates/CRM/Custom/Import/Form/DataSource.tpl
@@ -8,12 +8,11 @@
  +--------------------------------------------------------------------+
 *}
 
-{* Multi-value Custom Data Import Wizard - Step 1 (upload data file) *}
-{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
+{* Import Wizard - Step 1 (choose data source) *}
+<div class="crm-block crm-form-block crm-import-datasource-form-block">
 
-<div class="crm-block crm-form-block crm-custom-import-uploadfile-form-block">
- {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
- {include file="CRM/common/WizardHeader.tpl"}
+  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+  {include file="CRM/common/WizardHeader.tpl"}
  {if !$fieldGroups}
   <div class="messages warning no-popup">
     {ts}This import screen cannot be used because there are no Multi-value custom data groups.{/ts}

--- a/templates/CRM/Event/Import/Form/DataSource.tpl
+++ b/templates/CRM/Event/Import/Form/DataSource.tpl
@@ -7,10 +7,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Event Import Wizard - Step 1 (upload data file) *}
-{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-
-<div class="crm-block crm-form-block crm-event-import-uploadfile-form-block">
+{* Import Wizard - Step 1 (choose data source) *}
+<div class="crm-block crm-form-block crm-import-datasource-form-block">
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
 

--- a/templates/CRM/Member/Import/Form/DataSource.tpl
+++ b/templates/CRM/Member/Import/Form/DataSource.tpl
@@ -7,61 +7,62 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
- <div class="crm-block crm-form-block crm-member-import-uploadfile-form-block">
-{* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
- {include file="CRM/common/WizardHeader.tpl"}
-<div class="help">
-    {ts}The Membership Import Wizard allows you to easily upload memberships from other applications into CiviCRM.{/ts}
-    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match the membership data to an existing contact in your CiviCRM database.{/ts} {help id='upload'}
- </div>
-{* Membership Import Wizard - Step 1 (upload data file) *}
-{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
 
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-   <table class="form-layout">
-      <div id="upload-file" class="form-item">
-       <tr class="crm-member-import-uploadfile-from-block-uploadFile">
-           <td class="label">{$form.uploadFile.label}</td>
-           <td>{$form.uploadFile.html}<br />
-                <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span>
-                 <br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
-           </td>
+{* Import Wizard - Step 1 (choose data source) *}
+<div class="crm-block crm-form-block crm-import-datasource-form-block">
+
+  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+  {include file="CRM/common/WizardHeader.tpl"}
+  <div class="help">
+    {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
+    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}
+  </div>
+
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+    <table class="form-layout-compressed">
+      <tr class="crm-import-uploadfile-from-block-uploadFile">
+        <td class="label">{$form.uploadFile.label}</td>
+        <td class="html-adjust"> {$form.uploadFile.html}<br />
+          <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span>
+          <br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
+        </td>
+      </tr>
+       <tr class="crm-import-uploadfile-from-block-skipColumnHeader">
+         <td class="label"></td><td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
+           <span class="description">
+             {ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Amount').{/ts}
+           </span>
+         </td>
        </tr>
-       <tr class="crm-member-import-uploadfile-from-block-skipColumnHeader">
-           <td class="label">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{$form.skipColumnHeader.html} </td>
-     <td>{$form.skipColumnHeader.label}<br />
-               <span class="description">
-                {ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Amount').{/ts}</span>
-           </td>
-       <tr class="crm-member-import-uploadfile-from-block-contactType">
-           <td class="label">{$form.contactType.label}</tdt>
-     <td>{$form.contactType.html}<br />
-                <span class="description">
-                {ts}Select 'Individual' if you are importing memberships for individual persons.{/ts}
-                {ts}Select 'Organization' or 'Household' if you are importing memberships made by contacts of that type. (NOTE: Some built-in contact types may not be enabled for your site.){/ts}
-                </span>
-           </td>
+       <tr class="crm-import-uploadfile-from-block-contactType">
+         <td class="label">{$form.contactType.label}</td>
+         <td>{$form.contactType.html}<br />
+           <span class="description">
+             {ts 1=$importEntities}Select 'Individual' if you are importing %1 made by individual persons.{/ts}
+             {ts 1=$importEntities}Select 'Organization' or 'Household' if you are importing %1 made by contacts of that type. (NOTE: Some built-in contact types may not be enabled for your site.){/ts}
+           </span>
+         </td>
        </tr>
-       <tr class="crm-member-import-uploadfile-from-block-onDuplicate">
-           <td class="label" >{$form.onDuplicate.label}</td>
-           <td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td>
+       <tr class="crm-import-uploadfile-from-block-onDuplicate">
+         <td class="label">{$form.onDuplicate.label}</td>
+         <td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td>
        </tr>
         <tr class="crm-import-datasource-form-block-fieldSeparator">
           <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
           <td>{$form.fieldSeparator.html}</td>
         </tr>
-       <tr class="crm-member-import-uploadfile-from-block-date">{include file="CRM/Core/Date.tpl"}</tr>
-{if $savedMapping}
-       <tr  class="crm-member-import-uploadfile-from-block-savedMapping">
-         <td>{$form.savedMapping.label}</td>
-         <td>{$form.savedMapping.html}<br />
-           <span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>
-         </td>
-       </tr>
-{/if}
-</div>
-</table>
-<div class="spacer"></div>
+       <tr class="crm-import-uploadfile-from-block-date">{include file="CRM/Core/Date.tpl"}</tr>
+       {if $savedMapping}
+         <tr class="crm-import-uploadfile-from-block-savedMapping">
+           <td>{$form.savedMapping.label}</td>
+           <td>{$form.savedMapping.html}<br />
+             <span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>
+           </td>
+         </tr>
+       {/if}
+    </table>
+    <div class="spacer"></div>
 
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
+


### PR DESCRIPTION
Overview
----------------------------------------
Standardize DataSource file for Contribution & Membership
I've gone through the Datasource.tpl files for Contribution & Membership imports and made them the same - the next step is actually to remove them and use  a shared file (& then fix a couple of bugs) but I set out to reconcile them first

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/163096382-509af514-b4c1-4073-8d46-4e425da6ad9a.png)

![image](https://user-images.githubusercontent.com/336308/163096410-033255a3-f33f-4477-86b5-68f131bc4c2d.png)

![image](https://user-images.githubusercontent.com/336308/163095915-34e7e780-2bee-4029-8975-d58e1dff94bb.png)

![image](https://user-images.githubusercontent.com/336308/163096224-7f557ffd-b9d7-4fac-9817-d174b5b09d73.png)


After
----------------------------------------
Note - I tested the membership html & contribution html in an online validator

![image](https://user-images.githubusercontent.com/336308/163095242-234e919e-d0ea-4bd0-b3e4-960ff4ea7aae.png)


![image](https://user-images.githubusercontent.com/336308/163095176-cf3020e1-5790-4929-92af-dc08f63a7d30.png)

![image](https://user-images.githubusercontent.com/336308/163095647-faf20aed-df6b-4bec-9633-730254579299.png)

![image](https://user-images.githubusercontent.com/336308/163096080-e39e4996-ab35-4645-9ff6-b3a445d826d3.png)


Technical Details
----------------------------------------
Most of the noise is formatting - however notable changes

1) Class standardisation across fields - e.g 
`<div class="crm-block crm-form-block crm-activity-import-uploadfile-form-block">`
becomes

`<div class="crm-block crm-form-block crm-import-datasource-form-block">`

2) Re-use of strings -  e.g 
```
    {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}
```

3) standisation of html around membership import turned out to fix a shoreditch formatting bug :-)

@colemanw - can you confirm the strings approach is OK - if we want to make any further text of class changes now would be the time - I'm gonna check the other tpls for anything that doesn't fit this pattern & consolidate to 1 file 
 

Comments
----------------------------------------

