### PR TITLE
Wording changes in the Unsubscribe form

### DIFF
--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -27,22 +27,22 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
   /**
    * @var int
    */
-  private $_job_id;
+  protected $_job_id;
 
   /**
    * @var int
    */
-  private $_queue_id;
+  protected $_queue_id;
 
   /**
    * @var string
    */
-  private $_hash;
+  protected $_hash;
 
   /**
    * @var string
    */
-  private $_email;
+  protected $_email;
 
   public function preProcess() {
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);
@@ -55,12 +55,12 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     }
 
     // verify that the three numbers above match
-    $q = CRM_Mailing_Event_BAO_Queue::verify($job_id, $queue_id, $hash);
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
     if (!$q) {
       throw new CRM_Core_Exception(ts("There was an error in your request"));
     }
 
-    list($displayName, $email) = CRM_Mailing_Event_BAO_Queue::getContactInfo($queue_id);
+    list($displayName, $email) = CRM_Mailing_Event_BAO_MailingEventQueue::getContactInfo($queue_id);
     $this->assign('display_name', $displayName);
     $names = explode(" ", $displayName);
     foreach ($names as $name) {
@@ -76,7 +76,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $optOutURL = CRM_Utils_System::url("civicrm/mailing/optout", "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}");
     $this->assign('optout_URL', $optOutURL);
 
-    $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups);
     $groupExist = NULL;
     foreach ($groups as $value) {
@@ -116,10 +116,10 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     CRM_Core_Session::singleton()->pushUserContext($confirmURL);
 
     // Email address verified
-    $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($this->_job_id, $this->_queue_id, $this->_hash);
+    $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($this->_job_id, $this->_queue_id, $this->_hash);
 
     if (count($groups)) {
-      CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);
+      CRM_Mailing_Event_BAO_MailingEventUnsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);
     }
 
     $statusMsg = ts('%1 has been unsubscribed successfully.', [1 => $displayName]);

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -73,9 +73,6 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $this->assign('email', $email);
     $this->_email = $email;
 
-    $optOutURL = CRM_Utils_System::url("civicrm/mailing/optout", "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}");
-    $this->assign('optout_URL', $optOutURL);
-
     $groups = CRM_Mailing_Event_BAO_MailingEventUnsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups);
     $groupExist = NULL;

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -62,6 +62,12 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
 
     list($displayName, $email) = CRM_Mailing_Event_BAO_Queue::getContactInfo($queue_id);
     $this->assign('display_name', $displayName);
+    $names = explode(" ", $displayName);
+    foreach ($names as $name) {
+      $nameMasked .= substr($name, 0, 2) . "***** ";
+    }
+    $this->assign('name_masked', $nameMasked);
+
     $emailMasked = CRM_Utils_String::maskEmail($email);
     $this->assign('email_masked', $emailMasked);
     $this->assign('email', $email);
@@ -121,3 +127,4 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
   }
 
 }
+

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -67,6 +67,9 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $this->assign('email', $email);
     $this->_email = $email;
 
+    $optOutURL = CRM_Utils_System::url("civicrm/mailing/optout", "reset=1&jid={$job_id}&qid={$queue_id}&h={$hash}");
+    $this->assign('optout_URL', $optOutURL);
+
     $groups = CRM_Mailing_Event_BAO_Unsubscribe::unsub_from_mailing($job_id, $queue_id, $hash, TRUE);
     $this->assign('groups', $groups);
     $groupExist = NULL;
@@ -76,7 +79,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       }
     }
     if (!$groupExist && !$isConfirm) {
-      $statusMsg = ts('%1 has already been unsubscribed.', [1 => $email]);
+      $statusMsg = ts('%1 has already been unsubscribed.', [1 => $displayName]);
       CRM_Core_Session::setStatus($statusMsg, '', 'error');
     }
     $this->assign('groupExist', $groupExist);
@@ -113,7 +116,7 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
       CRM_Mailing_Event_BAO_Unsubscribe::send_unsub_response($this->_queue_id, $groups, FALSE, $this->_job_id);
     }
 
-    $statusMsg = ts('%1 has been unsubscribed successfully.', [1 => $this->_email]);
+    $statusMsg = ts('%1 has been unsubscribed successfully.', [1 => $displayName]);
     CRM_Core_Session::setStatus($statusMsg, '', 'success');
   }
 

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -127,4 +127,3 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
   }
 
 }
-

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -10,7 +10,7 @@
 <div>
   {if $groupExist}
     <div class="messages status no-popup">
-      {ts}Are you sure you want to remove {$name_masked} from the mailing list(s) shown below:{/ts}<br/>
+      {ts 1=$name_masked}Are you sure you want to remove %1 from the mailing list(s) shown below:{/ts}<br/>
     </div>
     <table class="selector" style="width: auto; margin-top: 20px;">
       {counter start=0 skip=1 print=false}
@@ -22,7 +22,7 @@
       {/foreach}
     </table>
     <div class="crm-block crm-form-block crm-miscellaneous-form-block">
-      <p>{ts}You are requesting to unsubscribe <strong>all email addresses for {$name_masked}</strong> from the above mailing list.{/ts}</p>
+      <p>{ts 1=$name_masked}You are requesting to unsubscribe <strong>all email addresses for %1</strong> from the above mailing list.{/ts}</p>
       <p>
         {ts}If this is not your name, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
         {ts}If you <strong>wish to unsubscribe this person</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -10,7 +10,7 @@
 <div>
   {if $groupExist}
     <div class="messages status no-popup">
-      {ts}Are you sure you want to be removed from the mailing list(s) shown below:{/ts}<br/>
+      {ts}Are you sure you want to remove {$display_name} from the mailing list(s) shown below:{/ts}<br/>
     </div>
     <table class="selector" style="width: auto; margin-top: 20px;">
       {counter start=0 skip=1 print=false}
@@ -22,11 +22,11 @@
       {/foreach}
     </table>
     <div class="crm-block crm-form-block crm-miscellaneous-form-block">
-      <p>{ts}You are requesting to unsubscribe this email address:{/ts}</p>
-      <h3>{$email_masked}</h3>
+      <p>{ts}You are requesting to unsubscribe <strong>all email addresses for {$display_name}</strong> from the above mailing list.{/ts}</p>
       <p>
-        {ts}If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
-        {ts}If this is your email address and you <strong>wish to unsubscribe</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
+        {ts}If this is not your name, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
+        {ts}If you want to remove only the address {$email_masked} from all mailing lists, please use <a href='{$optout_URL}'>this Opt Out form</a>.{/ts}
+        {ts}If you <strong>wish to unsubscribe {$display_name}</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
       </p>
       <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -10,7 +10,7 @@
 <div>
   {if $groupExist}
     <div class="messages status no-popup">
-      {ts}Are you sure you want to remove {$display_name} from the mailing list(s) shown below:{/ts}<br/>
+      {ts}Are you sure you want to remove {$name_masked} from the mailing list(s) shown below:{/ts}<br/>
     </div>
     <table class="selector" style="width: auto; margin-top: 20px;">
       {counter start=0 skip=1 print=false}
@@ -22,10 +22,10 @@
       {/foreach}
     </table>
     <div class="crm-block crm-form-block crm-miscellaneous-form-block">
-      <p>{ts}You are requesting to unsubscribe <strong>all email addresses for {$display_name}</strong> from the above mailing list.{/ts}</p>
+      <p>{ts}You are requesting to unsubscribe <strong>all email addresses for {$name_masked}</strong> from the above mailing list.{/ts}</p>
       <p>
         {ts}If this is not your name, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
-        {ts}If you <strong>wish to unsubscribe {$display_name}</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
+        {ts}If you <strong>wish to unsubscribe this person</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
       </p>
       <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -25,7 +25,6 @@
       <p>{ts}You are requesting to unsubscribe <strong>all email addresses for {$display_name}</strong> from the above mailing list.{/ts}</p>
       <p>
         {ts}If this is not your name, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
-        {ts}If you want to remove only the address {$email_masked} from all mailing lists, please use <a href='{$optout_URL}'>this Opt Out form</a>.{/ts}
         {ts}If you <strong>wish to unsubscribe {$display_name}</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
       </p>
       <div class="crm-submit-buttons">


### PR DESCRIPTION
Change unsubscribe form wording and feedback to reflect that the **Contact** is being unsubscribed, not just a single email address.

See https://lab.civicrm.org/dev/core/-/issues/3174

Overview
----------------------------------------
The Unsubscribe form refers to removing an email address from a Mailing List, when in reality the Contact is removed from the mailing list for all email addresses they may have. For example, if a Contact is subscribed to bulk mail at both Home and Work email addresses and then changes jobs, the inheritor of the Work email account is likely to click the Unsubscribe link, causing the Contact to be unsubscribed at both email addresses. The ideal action is Opt Out, but this is not clear in the language used on the Unsubscribe form, and the general public cannot be expected to parse the distinction between Unsubscribe and Opt Out.

Before
----------------------------------------
An inheritor of a Work email account clicks on an unsubscribe link and the Unsubscribe form says "You are requesting to unsubscribe this email address: **\[email address\]**" suggesting that only that one address -- not the Contact -- is going to be unsubscribed.

After
----------------------------------------
Barring changes to how Mailing Lists/Groups function in the back-end, wording changes to the Unsubscribe form could help clarify for front-end, public users what result their action will take, preventing inadvertent unsubscribes. Such as "You are requesting to unsubscribe **all email addresses for {$display_name}** from the above mailing list", add a link to the Opt Out form, and other language changes.