### PR TITLE
Start to fix misnamed FinancialTrxn bao

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -14,59 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_FinancialTrxn extends CRM_Financial_DAO_FinancialTrxn {
-
-  /**
-   * Takes an associative array and creates a financial transaction object.
-   *
-   * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
-   * @return CRM_Financial_DAO_FinancialTrxn
-   */
-  public static function create(array $params): CRM_Financial_DAO_FinancialTrxn {
-    if (empty($params['id'])) {
-      $params = array_merge([
-        'currency' => CRM_Core_Config::singleton()->defaultCurrency,
-        'status_id' => CRM_Core_Pseudoconstant::getKey(__CLASS__, 'status_id', 'Paid'),
-      ], $params);
-      if (!CRM_Utils_Rule::currencyCode($params['currency'])) {
-        CRM_Core_Error::deprecatedWarning('invalid currency data for financial transactions is deprecated');
-        $params['currency'] = CRM_Core_Config::singleton()->defaultCurrency;
-      }
-    }
-
-    $trxn = new CRM_Financial_DAO_FinancialTrxn();
-    $trxn->copyValues($params);
-
-    if (isset($params['fee_amount']) && is_numeric($params['fee_amount'])) {
-      if (!isset($params['total_amount'])) {
-        $trxn->fetch();
-        $params['total_amount'] = $trxn->total_amount;
-      }
-      $trxn->net_amount = $params['total_amount'] - $params['fee_amount'];
-    }
-
-    $trxn->save();
-
-    if (!empty($params['id'])) {
-      // For an update entity financial transaction record will already exist. Return early.
-      return $trxn;
-    }
-
-    // Save to entity_financial_trxn table.
-    $entityFinancialTrxnParams = [
-      'entity_table' => CRM_Utils_Array::value('entity_table', $params, 'civicrm_contribution'),
-      'entity_id' => CRM_Utils_Array::value('entity_id', $params, CRM_Utils_Array::value('contribution_id', $params)),
-      'financial_trxn_id' => $trxn->id,
-      'amount' => $params['total_amount'],
-    ];
-
-    $entityTrxn = new CRM_Financial_DAO_EntityFinancialTrxn();
-    $entityTrxn->copyValues($entityFinancialTrxnParams);
-    $entityTrxn->save();
-    return $trxn;
-  }
+class CRM_Core_BAO_FinancialTrxn extends CRM_Financial_BAO_FinancialTrxn {
 
   /**
    * @param int $contributionId
@@ -722,25 +670,6 @@ WHERE ceft.entity_id = %1";
     self::createDeferredTrxn(CRM_Utils_Array::value('line_item', $inputParams), $currentContribution, TRUE, 'changePaymentInstrument');
 
     return TRUE;
-  }
-
-  /**
-   * Generate and assign an arbitrary value to a field of a test object.
-   *
-   * Always set is_payment to 1 as this is used for Payment api as  well as FinancialTrxn.
-   *
-   * @param string $fieldName
-   * @param array $fieldDef
-   * @param int $counter
-   *   The globally-unique ID of the test object.
-   */
-  protected function assignTestValue($fieldName, &$fieldDef, $counter) {
-    if ($fieldName === 'is_payment') {
-      $this->is_payment = 1;
-    }
-    else {
-      parent::assignTestValue($fieldName, $fieldDef, $counter);
-    }
   }
 
 }

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2280,12 +2280,6 @@ SELECT contact_id
     // Prefer to instantiate BAO's instead of DAO's (when possible)
     // so that assignTestValue()/assignTestFK() can be overloaded.
     $baoName = str_replace('_DAO_', '_BAO_', $daoName);
-    if ($baoName === 'CRM_Financial_BAO_FinancialTrxn') {
-      // OMG OMG OMG this is so incredibly bad. The BAO is insanely named.
-      // @todo create a new class called what the BAO SHOULD be
-      // that extends BAO-crazy-name.... migrate.
-      $baoName = 'CRM_Core_BAO_FinancialTrxn';
-    }
     if (class_exists($baoName)) {
       $daoName = $baoName;
     }

--- a/CRM/Financial/BAO/FinancialTrxn.php
+++ b/CRM/Financial/BAO/FinancialTrxn.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Financial_BAO_FinancialTrxn extends CRM_Financial_DAO_FinancialTrxn {
+
+  /**
+   * Takes an associative array and creates a financial transaction object.
+   *
+   * @param array $params
+   *
+   * @return CRM_Financial_DAO_FinancialTrxn
+   */
+  public static function create(array $params): CRM_Financial_DAO_FinancialTrxn {
+    $trxn = new CRM_Financial_DAO_FinancialTrxn();
+    $trxn->copyValues($params);
+
+    if (isset($params['fee_amount']) && is_numeric($params['fee_amount'])) {
+      if (!isset($params['total_amount'])) {
+        $trxn->fetch();
+        $params['total_amount'] = $trxn->total_amount;
+      }
+      $trxn->net_amount = $params['total_amount'] - $params['fee_amount'];
+    }
+
+    if (empty($params['id']) && !CRM_Utils_Rule::currencyCode($trxn->currency)) {
+      $trxn->currency = CRM_Core_Config::singleton()->defaultCurrency;
+    }
+
+    $trxn->save();
+
+    if (!empty($params['id'])) {
+      // For an update entity financial transaction record will already exist. Return early.
+      return $trxn;
+    }
+
+    // Save to entity_financial_trxn table.
+    $entityFinancialTrxnParams = [
+      'entity_table' => CRM_Utils_Array::value('entity_table', $params, 'civicrm_contribution'),
+      'entity_id' => CRM_Utils_Array::value('entity_id', $params, CRM_Utils_Array::value('contribution_id', $params)),
+      'financial_trxn_id' => $trxn->id,
+      'amount' => $params['total_amount'],
+    ];
+
+    $entityTrxn = new CRM_Financial_DAO_EntityFinancialTrxn();
+    $entityTrxn->copyValues($entityFinancialTrxnParams);
+    $entityTrxn->save();
+    return $trxn;
+  }
+
+  /**
+   * Generate and assign an arbitrary value to a field of a test object.
+   *
+   * Always set is_payment to 1 as this is used for Payment api as  well as
+   * FinancialTrxn.
+   *
+   * @param string $fieldName
+   * @param array $fieldDef
+   * @param int $counter
+   *   The globally-unique ID of the test object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function assignTestValue($fieldName, &$fieldDef, $counter): void {
+    if ($fieldName === 'is_payment') {
+      $this->is_payment = 1;
+    }
+    else {
+      parent::assignTestValue($fieldName, $fieldDef, $counter);
+    }
+  }
+
+}


### PR DESCRIPTION

Overview
----------------------------------------
Baby-step carve-out from https://github.com/civicrm/civicrm-core/pull/22400

Before
----------------------------------------
FinancialTrxn BAO is misnamed, not matching the DAO name

`CRM_Core_BAO_FinancialTrxn `
vs
`CRM_Financial_DAO_FinancialTrxn `

After
----------------------------------------
`CRM_Financial_BAO_FinancialTrxn ` created, the old class extends it - only create function is moved so far

Technical Details
----------------------------------------

@pradpnayak  started to try to address this in #222400 but it stalled on some test
issue & went stale

This is a baby-step on that which puts the right file there & moves
the create function, while not touching the rest.

The function doesn't refer to 'self' so should be all good.

I obsevered some of the functions are NOT used.... and should not be transferred but rather removed

Comments
----------------------------------------

