### PR TITLE
dev/core#3164 : Report Filter Statistics don't show filters with vaue of "0"

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3510,7 +3510,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                 $value = CRM_Utils_Array::value($op, $pair) . " " .
                   CRM_Utils_Array::value($val, $field['options'], $val);
               }
-              elseif ($val) {
+              elseif ($val || $val == '0') {
                 $value = CRM_Utils_Array::value($op, $pair) . " " . $val;
               }
             }


### PR DESCRIPTION
As described at https://lab.civicrm.org/dev/core/-/issues/3164

Overview
----------------------------------------
When running a report, the "criteria" statistics section does not display filter criteria for which the value is "0".

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/759449/163286128-5870d837-0874-426a-9cdd-087e2102ee73.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/759449/163286320-8b1a79e2-845a-4f10-80f3-02349a69b69a.png)


Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.
