### PR TITLE
Fix button breakage on viewContribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4289,50 +4289,50 @@ LIMIT 1;";
     }
     $actionLinks = [];
     $actionLinks[] = [
-      'url' => CRM_Utils_System::url('civicrm/payment', [
-        'action' => 'add',
-        'reset' => 1,
-        'id' => $id,
-        'is_refund' => 0,
-      ]),
+      'url' => 'civicrm/payment',
       'title' => ts('Record Payment'),
       'accessKey' => '',
       'ref' => '',
       'name' => '',
-      'qs' => '',
+      'qs' => [
+        'action' => 'add',
+        'reset' => 1,
+        'id' => $id,
+        'is_refund' => 0,
+      ],
       'extra' => '',
     ];
 
     if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
       $actionLinks[] = [
-        'url' => CRM_Utils_System::url('civicrm/payment', [
+        'url' => 'civicrm/payment',
+        'title' => ts('Submit Credit Card payment'),
+        'accessKey' => '',
+        'ref' => '',
+        'name' => '',
+        'qs' => [
           'action' => 'add',
           'reset' => 1,
           'is_refund' => 0,
           'id' => $id,
           'mode' => 'live',
-        ]),
-        'title' => ts('Submit Credit Card payment'),
-        'accessKey' => '',
-        'ref' => '',
-        'name' => '',
-        'qs' => '',
+        ],
         'extra' => '',
       ];
     }
     if ($contributionStatus !== 'Pending') {
       $actionLinks[] = [
-        'url' => CRM_Utils_System::url('civicrm/payment', [
-          'action' => 'add',
-          'reset' => 1,
-          'id' => $id,
-          'is_refund' => 1,
-        ]),
+        'url' => 'civicrm/payment',
         'title' => ts('Record Refund'),
         'accessKey' => '',
         'ref' => '',
         'name' => '',
-        'qs' => '',
+        'qs' => [
+          'action' => 'add',
+          'reset' => 1,
+          'id' => $id,
+          'is_refund' => 1,
+        ],
         'extra' => '',
       ];
     }

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -355,6 +355,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($id, 'contribution', TRUE);
     $title = ts('View Payment');
     $this->assign('transaction', TRUE);
+    // Used in paymentInfoBlock.tpl
     $this->assign('payments', $paymentInfo['transaction']);
     $this->assign('paymentLinks', $paymentInfo['payment_links']);
     return $title;

--- a/templates/CRM/Contribute/Form/PaymentInfoBlock.tpl
+++ b/templates/CRM/Contribute/Form/PaymentInfoBlock.tpl
@@ -41,7 +41,7 @@
 {/if}
 
   {foreach from=$paymentLinks item=paymentLink}
-    <a class="open-inline action-item crm-hover-button" href="{$paymentLink.url}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}{$paymentLink.title}{/ts}</a>
+    <a class="open-inline action-item crm-hover-button" href="{crmURL p=$paymentLink.url q=$paymentLink.qs}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}{$paymentLink.title}{/ts}</a>
   {/foreach}
 
 {/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Several buttons on the View Contribution form are not working due to a malformed url

![image](https://user-images.githubusercontent.com/336308/163326917-a49ad544-94c6-4937-abc7-e15bccd08ed4.png)


Before
----------------------------------------
e.g Record Payment is broken

After
----------------------------------------
Fixed - also these work
![image](https://user-images.githubusercontent.com/336308/163326984-15a7ebc3-24a6-436f-8cde-06b133576d72.png)

Technical Details
----------------------------------------
The url was being run through CRM:url in the php layer which was not 'desired' for the bottom buttons in the tpl layer  - this removes that & sets the other place that calls them to expect to call crm.url

Comments
----------------------------------------
We will backport to 5.48