### PR TITLE
(dev/core#3171) "Manage Extensions" - Tweak messaging for "Install" screen

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -49,7 +49,10 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
     if (!CRM_Utils_Type::validate($this->_key, 'ExtensionKey') && !empty($this->_key)) {
       throw new CRM_Core_Exception('Extension Key does not match expected standard');
     }
-    $this->label = $remoteExtensionRows[$this->_key]['label'] ?? $this->_key;
+
+    $name = $remoteExtensionRows[$this->_key]['label'] ?? $localExtensionRows[$this->_key]['label'] ?? NULL;
+    $this->label = $name ? sprintf('%s (<em>%s</em>)', htmlentities($name), htmlentities($this->_key))
+        : sprintf('<em>%s</em>', htmlentities($this->_key));
     $session = CRM_Core_Session::singleton();
     $url = CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1&action=browse');
     $session->pushUserContext($url);

--- a/templates/CRM/Admin/Form/Extensions.tpl
+++ b/templates/CRM/Admin/Form/Extensions.tpl
@@ -19,7 +19,7 @@
    {if $action eq 1}
      <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
-        {ts}Installing this extension will provide you with new functionality. Please make sure that the extension you're installing comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
+        {ts}Installing this extension will provide you with new functionality.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 2}

--- a/templates/CRM/Admin/Form/Extensions.tpl
+++ b/templates/CRM/Admin/Form/Extensions.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* this template is used for install /uninstall extensions  *}
-<h3>{$title}</h3>
+<h3>{$title|smarty:nodefaults}</h3>
 <div class="crm-block crm-form-block crm-admin-optionvalue-form-block">
    {if $action eq 8}
       <div class="messages status no-popup">


### PR DESCRIPTION
Overview
----------------------------------------

This tweaks the presentation on the "Install" screen:

* Tweak extension title
* Tweak alert prose

See https://lab.civicrm.org/dev/core/-/issues/3171

Before
----------------------------------------
<img width="1009" alt="Screen Shot 2022-04-14 at 1 01 12 PM" src="https://user-images.githubusercontent.com/1336047/163466983-42db9c48-99b1-448d-8e53-d7d2d51fc447.png">


After
----------------------------------------

<img width="1011" alt="Screen Shot 2022-04-14 at 1 01 33 PM" src="https://user-images.githubusercontent.com/1336047/163466989-1d271fca-f5d9-4b08-8dd6-39248926f4cd.png">

