### PR TITLE
Don't overescape tab links

### DIFF
--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -111,7 +111,7 @@
       <ul class="crm-contact-tabs-list">
         {foreach from=$allTabs item=tabValue}
           <li id="tab_{$tabValue.id}" class="crm-tab-button ui-corner-all{if is_numeric($tabValue.count)} crm-count-{$tabValue.count}{/if}{if $tabValue.class} {$tabValue.class}{/if}">
-            <a href="{if $tabValue.template}#contact-{$tabValue.id}{else}{$tabValue.url}{/if}" title="{$tabValue.title|escape}">
+            <a href="{if $tabValue.template}#contact-{$tabValue.id}{else}{$tabValue.url|smarty:nodefaults}{/if}" title="{$tabValue.title|escape}">
               <i class="{if !empty($tabValue.icon)}{$tabValue.icon}{else}crm-i fa-puzzle-piece{/if}" aria-hidden="true"></i>
               <span>{$tabValue.title}</span>
               {if empty($tabValue.hideCount)}<em>{if is_numeric($tabValue.count)}{$tabValue.count}{/if}</em>{/if}

--- a/templates/CRM/common/TabHeader.tpl
+++ b/templates/CRM/common/TabHeader.tpl
@@ -15,7 +15,7 @@
        {foreach from=$tabHeader key=tabName item=tabValue}
           <li id="tab_{$tabName}" class="crm-tab-button ui-corner-all{if !$tabValue.valid} disabled{/if} {$tabValue.class}" {$tabValue.extra}>
           {if $tabValue.active}
-             <a href="{if $tabValue.template}#panel_{$tabName}{else}{$tabValue.link}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
+             <a href="{if $tabValue.template}#panel_{$tabName}{else}{$tabValue.link|smarty:nodefaults}{/if}" title="{$tabValue.title|escape}{if !$tabValue.valid} ({ts}disabled{/ts}){/if}">
                {if $tabValue.icon}<i class="{$tabValue.icon}"></i>{/if}
                <span>{$tabValue.title}</span>
                {if is_numeric($tabValue.count)}<em>{$tabValue.count}</em>{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Don't overescape tab links, ensure tabs work when escape-on-output is enabled.

Before
----------------------------------------
Tabs failed to load. E.g.:

 - Contact page
 - Manage event page

After
----------------------------------------
Tabs load

Technical Details
----------------------------------------
This does not affect Drupal due to the difference in URL structure between environments, and the short-circuits already in place to make escape-on-output work.

Comments
----------------------------------------
Possibly there should be an escape method for URLs - something like `esc_url` in WordPress. The risk of leaving these unescaped seems low though, and is no worse than the status quo (i.e. without escape-on-output).
