### PR TITLE
Don't overescape links in pledge tab

### DIFF
--- a/templates/CRM/Pledge/Page/Tab.tpl
+++ b/templates/CRM/Pledge/Page/Tab.tpl
@@ -17,14 +17,13 @@
     {ts 1=$displayName}Pledges received from %1 since inception.{/ts}
     {if $permission EQ 'edit'}
      {capture assign=newContribURL}{crmURL p="civicrm/contact/view/pledge" q="reset=1&action=add&cid=`$contactId`&context=pledge"}{/capture}
-     {capture assign=link}class="action-item" href="{$newContribURL}"{/capture}
-     {ts 1=$link}Click <a %1>Add Pledge</a> to record a new pledge received from this contact.{/ts}
+     {ts 1=$link}Click <a class="action-item" href="{$newContribURL|smarty:nodefaults}">Add Pledge</a> to record a new pledge received from this contact.{/ts}
     {/if}
 </div>
 
 {if $action eq 16 and $permission EQ 'edit'}
     <div class="action-link">
-       <a accesskey="N" href="{$newContribURL}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Pledge{/ts}</a></span>
+       <a accesskey="N" href="{$newContribURL|smarty:nodefaults}" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add Pledge{/ts}</a></span>
        <br/><br/>
     </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Don't overescape links in pledge tab.

Before
----------------------------------------
The "Add pledge" button on the pledge tab of a single contact did not work - ampersands were overescaped as `&amp;` breaking the URL. Drupal is not affected due to the differing URL structure.

After
----------------------------------------
The links work.

Comments
----------------------------------------
I couldn't seem to work out how to make `|smarty:nodefaults` work inside a capture - whatever I did the output was still over escaped. In the end I had to give up and refactor to not use a capture - I'm not sure if this is something anyone has spotted before now?

A number of other contact changes will need the same change applied, but I wanted to start small given the question over the capture.
