### PR TITLE
Apply nodefaults to row actions

### DIFF
--- a/templates/CRM/ACL/Page/EntityRole.tpl
+++ b/templates/CRM/ACL/Page/EntityRole.tpl
@@ -35,7 +35,7 @@
             <td class="crm-acl_entity_role-acl_role">{$row.acl_role}</td>
             <td class="crm-acl_entity_role-entity">{$row.entity}</td>
             <td class="crm-acl_entity_role-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
         </tbody>

--- a/templates/CRM/Activity/Form/Selector.tpl
+++ b/templates/CRM/Activity/Form/Selector.tpl
@@ -104,7 +104,7 @@
 
     <td>
       {if (!empty($row.id))}
-        {$row.action|replace:'xx':$row.id}
+        {$row.action|smarty:nodefaults|replace:'xx':$row.id}
       {else}
         {$row.action}
       {/if}

--- a/templates/CRM/Activity/Selector/Activity.tpl
+++ b/templates/CRM/Activity/Selector/Activity.tpl
@@ -83,7 +83,7 @@
 
         <td class="crm-activity-date_time">{$row.activity_date_time|crmDate}</td>
         <td class="crm-activity-status crm-activity-status_{$row.status_id}">{$row.status}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>
       {/foreach}
 

--- a/templates/CRM/Admin/Page/ContactType.tpl
+++ b/templates/CRM/Admin/Page/ContactType.tpl
@@ -36,7 +36,7 @@
         <td class="crm-contactType-label crm-editable" data-field="label">{ts}{$row.label}{/ts}</td>
         <td class="crm-contactType-parent">{if $row.parent}{ts}{$row.parent_label}{/ts}{else}{ts}(built-in){/ts}{/if}</td>
         <td class="crm-contactType-description crm-editable" data-field="description" data-type="textarea">{$row.description}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
     </tr>
     {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/EventTemplate.tpl
+++ b/templates/CRM/Admin/Page/EventTemplate.tpl
@@ -46,7 +46,7 @@
               <td class="crm-event-is_monetary">{if $row.is_monetary eq 1}{ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-event-is_online_registration">{if $row.is_online_registration eq 1}{ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-event-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-              <td class="crm-event-action">{$row.action|replace:'xx':$row.id}</td>
+              <td class="crm-event-action">{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -26,7 +26,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           </td>
           <td class="crm-extensions-version">{$row.version|escape}</td>
           <td class="crm-extensions-description">{$row.type|capitalize}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         <tr class="hiddenElement" id="crm-extensions-details-addnew-{$row.file}">
             <td>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -35,7 +35,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
             {/if}
           </td>
           <td class="crm-extensions-description">{$row.type|escape|capitalize}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         <tr class="hiddenElement" id="crm-extensions-details-{$row.file|escape}">
             <td>

--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -49,7 +49,7 @@
             <td class="crm-job-name">{if $row.parameters eq null}<em>{ts}no parameters{/ts}</em>{else}<pre>{$row.parameters}</pre>{/if}</td>
             <td class="crm-job-name">{if $row.last_run eq null}never{else}{$row.last_run|crmDate:$config->dateformatDatetime}{/if}</td>
             <td id="row_{$row.id}_status" class="crm-job-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -56,7 +56,7 @@
               <td class="crm-labelFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
               <td class="crm-labelFormat-is_reserved">{if $row.is_reserved eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}
                 &nbsp;</td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
           {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/LocationType.tpl
+++ b/templates/CRM/Admin/Page/LocationType.tpl
@@ -41,7 +41,7 @@
         <td class="crmf-description crm-editable">{$row.description}</td>
         <td id="row_{$row.id}_status" class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
         <td class="crmf-is_default">{if $row.is_default}{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;{/if}</td>
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
     </tr>
     {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/MailSettings.tpl
+++ b/templates/CRM/Admin/Page/MailSettings.tpl
@@ -44,7 +44,7 @@
               <!--<td>{$row.port}</td>-->
               <td class="crm-mailSettings-is_ssl">{if $row.is_ssl eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
               <td class="crm-mailSettings-is_default">{if $row.is_default eq 1}{ts}Bounce Processing <strong>(Default)</strong>{/ts}{else}{ts}Email-to-Activity{/ts}{/if}&nbsp;</td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Admin/Page/Mapping.tpl
+++ b/templates/CRM/Admin/Page/Mapping.tpl
@@ -31,7 +31,7 @@
                 <td class="crm-mapping-name">{$row.name}</td>
                 <td class="crm-mapping-description">{$row.description}</td>
                 <td class="crm-mapping-mapping_type">{$row.mapping_type}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
             {/foreach}
             </table>

--- a/templates/CRM/Admin/Page/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Page/MessageTemplates.tpl
@@ -131,7 +131,7 @@
                         <td>{$row.msg_subject}</td>
                         <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                       {/if}
-                      <td>{$row.action|replace:'xx':$row.id}</td>
+                      <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
                     </tr>
                 {/foreach}
                 </tbody>

--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -139,7 +139,7 @@
             {/if}
             <td class="crm-admin-options-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crm-admin-options-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}
         </tbody>

--- a/templates/CRM/Admin/Page/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Page/ParticipantStatusType.tpl
@@ -38,7 +38,7 @@
           <td class="center crmf-is_counted">{icon condition=$row.is_counted}{ts}Counted{/ts}{/icon}</td>
           <td class="crmf-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crmf-visibility">{$row.visibility}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
       {/foreach}
     </table>

--- a/templates/CRM/Admin/Page/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Page/PaymentProcessor.tpl
@@ -44,7 +44,7 @@
             <td class="crmf-is_active center">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
             <td class="crmf-is_default center">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;
             </td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/PdfFormats.tpl
+++ b/templates/CRM/Admin/Page/PdfFormats.tpl
@@ -52,7 +52,7 @@
             <td class="crm-pdfFormat-description">{$row.description}</td>
             <td class="crm-pdfFormat-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
           <td class="crm-pdfFormat-order nowrap">{$row.weight|smarty:nodefaults}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/PreferencesDate.tpl
+++ b/templates/CRM/Admin/Page/PreferencesDate.tpl
@@ -31,7 +31,7 @@
                 <td class="nowrap">{if !$row.date_format}{ts}Default{/ts}{else}{$row.date_format}{/if}</td>
                 <td align="right">{$row.start}</td>
                 <td align="right">{$row.end}</td>
-                <td><span>{$row.action|replace:'xx':$row.id}</span></td>
+                <td><span>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</span></td>
             </tr>
             {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/RelationshipType.tpl
+++ b/templates/CRM/Admin/Page/RelationshipType.tpl
@@ -54,7 +54,7 @@
                 {if $row.contact_type_b_display} {$row.contact_type_b_display}
                 {if !empty($row.contact_sub_type_b)} - {$row.contact_sub_type_b}{/if} {else} {ts}All Contacts{/ts} {/if} </td>
             <td class="crm-relationship-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-            <td>{$row.action|replace:'xx':$row.id}</td>
+            <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Admin/Page/Reminders.tpl
+++ b/templates/CRM/Admin/Page/Reminders.tpl
@@ -35,7 +35,7 @@
           <td class="crm-scheduleReminders-title">{$row.status}</td>
           <td class="crm-scheduleReminders-is_repeat">{if $row.is_repeat eq 1}{ts}Yes{/ts}{else}{ts}No{/ts}{/if}&nbsp;</td>
           <td id="row_{$row.id}_status" class="crm-scheduleReminders-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
           <td class="hiddenElement"></td>
         </tr>
       {/foreach}

--- a/templates/CRM/Badge/Page/Layout.tpl
+++ b/templates/CRM/Badge/Page/Layout.tpl
@@ -40,7 +40,7 @@
               </td>
               <td class="crm-badge-layout-is_default">{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;
               </td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
           {/foreach}
         </table>

--- a/templates/CRM/Campaign/Page/SurveyType.tpl
+++ b/templates/CRM/Campaign/Page/SurveyType.tpl
@@ -35,7 +35,7 @@
           <td class="nowrap crm-admin-options-order">{$row.weight|smarty:nodefaults}</td>
           <td class="crm-admin-options-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crm-admin-options-is_active" id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Contact/Page/DedupeRules.tpl
+++ b/templates/CRM/Contact/Page/DedupeRules.tpl
@@ -38,7 +38,7 @@
               <tr class="{cycle values="odd-row,even-row"}">
                 <td>{$row.title}</td>
                 <td>{$row.used_display}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
               </tr>
             {/foreach}
           </table>

--- a/templates/CRM/Contribute/Page/ContributionType.tpl
+++ b/templates/CRM/Contribute/Page/ContributionType.tpl
@@ -39,7 +39,7 @@
           <td>{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
          </table>

--- a/templates/CRM/Contribute/Page/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Page/ManagePremiums.tpl
@@ -51,7 +51,7 @@
           <td class="crm-contribution-form-block-cost">{$row.cost|crmMoney}</td>
           <td class="crm-contribution-form-block-financial_type">{$row.financial_type}</td>
           <td id="row_{$row.id}_status" >{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td id={$row.id}>{$row.action|replace:'xx':$row.id}</td>
+          <td id={$row.id}>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Financial/Page/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialAccount.tpl
@@ -54,7 +54,7 @@
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{icon condition=$row.is_default}{ts}Default{/ts}{/icon}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Financial/Page/FinancialType.tpl
+++ b/templates/CRM/Financial/Page/FinancialType.tpl
@@ -44,7 +44,7 @@
           <td class="crm-editable" data-field="is_deductible" data-type="boolean">{if $row.is_deductible eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
          </table>

--- a/templates/CRM/Financial/Page/FinancialTypeAccount.tpl
+++ b/templates/CRM/Financial/Page/FinancialTypeAccount.tpl
@@ -40,7 +40,7 @@
           <td>{$row.financial_account_type}{if $row.account_type_code} ({$row.account_type_code}){/if}</td>
           <td>{$row.owned_by}</td>
           <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
       </table>

--- a/templates/CRM/Group/Page/GroupRows.tpl
+++ b/templates/CRM/Group/Page/GroupRows.tpl
@@ -16,6 +16,6 @@
     {$row.description|mb_truncate:80:"...":true}
     </td>
     <td>{$row.visibility}</td>
-    <td>{$row.action|replace:'xx':$row.id}</td>
+    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
     </tr>
 {/foreach}

--- a/templates/CRM/Mailing/Page/Browse.tpl
+++ b/templates/CRM/Mailing/Page/Browse.tpl
@@ -70,7 +70,7 @@
        {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
           <td class="crm-mailing-campaign">{$row.campaign}</td>
       {/if}
-        <td>{$row.action|replace:'xx':$row.id}</td>
+        <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>
       {/foreach}
     </table>

--- a/templates/CRM/Mailing/Page/Component.tpl
+++ b/templates/CRM/Mailing/Page/Component.tpl
@@ -37,7 +37,7 @@
            <td>{$row.body_text|escape}</td>
            <td>{icon condition=$row.is_default}{ts}Default{/ts}{/icon}&nbsp;</td>
      <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-           <td>{$row.action|replace:'xx':$row.id}</td>
+           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
        {/foreach}
        </table>

--- a/templates/CRM/Member/Page/MembershipStatus.tpl
+++ b/templates/CRM/Member/Page/MembershipStatus.tpl
@@ -48,7 +48,7 @@
           <td class="crmf-is_admin crm-editable" data-type="boolean">{if $row.is_admin eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="nowrap crmf-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crmf-is_reserved">{if $row.is_reserved eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{if !empty($row.action)}{$row.action|replace:'xx':$row.id}{/if}</td>
+          <td>{if !empty($row.action)}{$row.action|smarty:nodefaults|replace:'xx':$row.id}{/if}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/Member/Page/MembershipType.tpl
+++ b/templates/CRM/Member/Page/MembershipType.tpl
@@ -49,7 +49,7 @@
           <td class="crmf-visibility crm-editable" data-type="select">{$row.visibility}</td>
           <td class="nowrap crmf-weight">{$row.weight|smarty:nodefaults}</td>
           <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
       {/foreach}
     </table>

--- a/templates/CRM/PCP/Page/PCP.tpl
+++ b/templates/CRM/PCP/Page/PCP.tpl
@@ -44,7 +44,7 @@
     <td>{$row.start_date|crmDate}</td>
     <td>{if $row.end_date}{$row.end_date|crmDate}{else}({ts}ongoing{/ts}){/if}</td>
     <td>{$row.status_id}</td>
-    <td id={$row.id}>{$row.action|replace:'xx':$row.id}</td>
+    <td id={$row.id}>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
   </tr>
   {/foreach}
   </tbody>

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -74,7 +74,7 @@
       </td>
             <td>{if $row.html_type eq "Text / Numeric Quantity" }{$row.tax_amount|crmMoney}{/if}</td>
         {/if}
-        <td class="field-action">{$row.action|replace:'xx':$row.id}</td>
+        <td class="field-action">{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>
       {/foreach}
     </table>

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -79,7 +79,7 @@
                 <td>{$row.tax_amount|crmMoney}</td>
               {/if}
               <td id="row_{$row.id}_status" class="crm-price-option-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-              <td>{$row.action|replace:'xx':$row.id}</td>
+              <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
           {/foreach}
           </tbody>

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -52,7 +52,7 @@
           <td class="crmf-title crm-editable">{$row.title}</td>
           <td class="crmf-extends">{$row.extends}</td>
           <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/SMS/Page/Provider.tpl
+++ b/templates/CRM/SMS/Page/Provider.tpl
@@ -38,7 +38,7 @@
         </td>
             <td class="crm-api-params">{if $row.api_params eq null}<em>{ts}no parameters{/ts}</em>{else}<pre>{$row.api_params}</pre>{/if}</td>
 
-          <td>{$row.action|replace:'xx':$row.id}</td>
+          <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
         </tr>
         {/foreach}
         </table>

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -53,7 +53,7 @@
                 <td class="crm-editable crmf-is_required" data-type="boolean">{if $row.is_required eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td class="crm-editable crmf-is_view" data-type="boolean">{if $row.is_view eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>{if $row.is_reserved     eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-                <td>{$row.action|replace:'xx':$row.id}</td>
+                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>
             {/foreach}
         </table>

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -81,7 +81,7 @@
                     <td>{$row.group_type}</td>
                     <td>{$row.id}</td>
                     <td>{$row.module}</td>
-                    <td>{$row.action|replace:'xx':$row.id}</td>
+                    <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
                   </tr>
                 {/if}
                 {/foreach}
@@ -126,7 +126,7 @@
                       <td>{$row.group_type}</td>
                       <td>{$row.id}</td>
                       <td>{$row.module}</td>
-                      <td>{$row.action|replace:'xx':$row.id}</td>
+                      <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
                     </tr>
                   {/if}
                 {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
More generic follow up to https://github.com/civicrm/civicrm-core/pull/23173 and https://github.com/civicrm/civicrm-core/pull/22290

Comments
----------------------------------------
This isn't actually needed most of the time as the `CRM_Core_Smarty::escape` method short-circuits if it sees `<span><a href`, which usually matches the output from `CRM_Core_Action::formLink`. However, that's not the case when the `$enclosedAllInSingleUL` parameter is set to true.

However, I think the consistency is good here. Possibly the `<span><a href` short-circuit could also be dropped following this change, but I've not tested that.
