### PR TITLE
Always use cancelSubscription form for cancelling recurring contributions

### DIFF
--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -100,8 +100,16 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
     $this->setTitle($this->_mid ? ts('Cancel Auto-renewal') : ts('Cancel Recurring Contribution'));
     $this->assign('mode', $this->_mode);
 
+    if ($this->isSelfService() || !$this->_paymentProcessorObj->supports('cancelRecurring')) {
+      // If we are self service (contact is cancelling for themselves via a cancel link)
+      // or the processor does not support cancellation then remove the fields
+      // specifying whether to notify the processor.
+      unset($this->entityFields['send_cancel_request']);
+    }
     if ($this->isSelfService()) {
-      unset($this->entityFields['send_cancel_request'], $this->entityFields['is_notify']);
+      // Arguably the is_notify field should be removed in self-service mode.
+      // Historically this has been the case...
+      unset($this->entityFields['is_notify']);
     }
 
     if ($this->getSubscriptionDetails()->contact_id) {

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -82,14 +82,9 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     $links[CRM_Core_Action::DISABLE] = [
       'name' => ts('Cancel'),
       'title' => ts('Cancel'),
-      'ref' => 'crm-enable-disable',
+      'url' => 'civicrm/contribute/unsubscribe',
+      'qs' => 'reset=1&crid=%%crid%%&cid=%%cid%%&context=' . $context,
     ];
-
-    if ($paymentProcessorObj->supports('cancelRecurring')) {
-      unset($links[CRM_Core_Action::DISABLE]['extra'], $links[CRM_Core_Action::DISABLE]['ref']);
-      $links[CRM_Core_Action::DISABLE]['url'] = "civicrm/contribute/unsubscribe";
-      $links[CRM_Core_Action::DISABLE]['qs'] = "reset=1&crid=%%crid%%&cid=%%cid%%&context={$context}";
-    }
 
     if ($paymentProcessorObj->supports('UpdateSubscriptionBillingInfo')) {
       $links[CRM_Core_Action::RENEW] = [

--- a/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
@@ -56,9 +56,12 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test if the full fledged form is displayed on cancelling the Recurring Contribution with a payment processor which does not support cancelling a Recurring Contribution
+   * Test if the full fledged form is displayed on cancelling the Recurring
+   * Contribution with a payment processor which does not support cancelling a
+   * Recurring Contribution
    *
-   * @throws \CRM_Core_Exception|\API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testCancelSubscriptionForm(): void {
     $this->addContribution();
@@ -74,10 +77,8 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CiviUnitTestCase {
     ]);
 
     $actions = CRM_Contribute_Page_Tab::recurLinks($this->getContributionRecurID());
-    // Using "crm-enable-disable"
-    $this->assertEquals($actions[CRM_Core_Action::DISABLE]['ref'], 'crm-enable-disable');
     // Using "Cancel Recurring" form
-    // $this->assertEquals($actions[CRM_Core_Action::DISABLE]['url'], 'civicrm/contribute/unsubscribe');
+    $this->assertEquals('civicrm/contribute/unsubscribe', $actions[CRM_Core_Action::DISABLE]['url']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Always use cancelSubscription form for cancelling recurring contributions

This is https://github.com/civicrm/civicrm-core/pull/18196 without the bit I was uncomfortable with

Before
----------------------------------------
To replicate this you need to imitate a payment processor that does not support cancel - the easiest is to edit the dummy processor class to return FALSE not TRUE for cancel recurring - in this case the action to cancel the recurring pops up a form with no space to add the cancel reason

After
----------------------------------------
The cancel form pops up

Technical Details
----------------------------------------
This is the part of https://github.com/civicrm/civicrm-core/pull/18196 I was comfortable with -  I slightly re-wrote so that I could put the comments next to the relevant fields

Comments
----------------------------------------
@mattwire 
