### PR TITLE
[REF] Move assignPaymentProcessors to FrontEndPaymentFormTrait

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -356,7 +356,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         CRM_Utils_Array::value('payment_processor', $this->_values)
       ));
 
-      $this->assignPaymentProcessor($isPayLater);
+      $this->assignPaymentProcessor((bool) $isPayLater);
 
       // get price info
       // CRM-5095

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -874,36 +874,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * This if a front end form function for setting the payment processor.
-   *
-   * It would be good to sync it with the back-end function on abstractEditPayment & use one everywhere.
-   *
-   * @param bool $isPayLaterEnabled
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function assignPaymentProcessor($isPayLaterEnabled) {
-    $this->_paymentProcessors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors([ucfirst($this->_mode) . 'Mode'], $this->_paymentProcessorIDs);
-    if ($isPayLaterEnabled) {
-      $this->_paymentProcessors[0] = CRM_Financial_BAO_PaymentProcessor::getPayment(0);
-    }
-
-    if (!empty($this->_paymentProcessors)) {
-      foreach ($this->_paymentProcessors as $paymentProcessorID => $paymentProcessorDetail) {
-        if (empty($this->_paymentProcessor) && $paymentProcessorDetail['is_default'] == 1 || (count($this->_paymentProcessors) == 1)
-        ) {
-          $this->_paymentProcessor = $paymentProcessorDetail;
-          $this->assign('paymentProcessor', $this->_paymentProcessor);
-          // Setting this is a bit of a legacy overhang.
-          $this->_paymentObject = $paymentProcessorDetail['object'];
-        }
-      }
-      // It's not clear why we set this on the form.
-      $this->set('paymentProcessors', $this->_paymentProcessors);
-    }
-  }
-
-  /**
    * Assign an array of variables to the form/tpl
    *
    * @param array $values Array of [key => value] to assign to the form

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -293,7 +293,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $this->_paymentProcessorIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR, CRM_Utils_Array::value('payment_processor',
           $this->_values['event']
         ));
-        $this->assignPaymentProcessor($isPayLater);
+        $this->assignPaymentProcessor((bool) $isPayLater);
       }
       //init event fee.
       self::initEventFee($this, $this->_eventId);

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -16,7 +16,9 @@
  */
 
 /**
- * This class holds functionality shared between various front end forms.
+ * This class holds functionality shared between contribution and event forms.
+ *
+ * It should not be used by other forms.
  */
 trait CRM_Financial_Form_FrontEndPaymentFormTrait {
 
@@ -200,6 +202,34 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
       $ppKeys = array_keys($paymentProcessors);
       $currentPP = array_pop($ppKeys);
       $this->addElement('hidden', 'payment_processor_id', $currentPP);
+    }
+  }
+
+  /**
+   * Set paymentProcessors on the form and in the template for front end form usage..
+   *
+   * @param bool $isPayLaterEnabled
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function assignPaymentProcessor(bool $isPayLaterEnabled): void {
+    $this->_paymentProcessors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors([ucfirst($this->_mode) . 'Mode'], $this->_paymentProcessorIDs);
+    if ($isPayLaterEnabled) {
+      $this->_paymentProcessors[0] = CRM_Financial_BAO_PaymentProcessor::getPayment(0);
+    }
+
+    if (!empty($this->_paymentProcessors)) {
+      foreach ($this->_paymentProcessors as $paymentProcessorDetail) {
+        if (empty($this->_paymentProcessor) && $paymentProcessorDetail['is_default'] == 1 || (count($this->_paymentProcessors) == 1)
+        ) {
+          $this->_paymentProcessor = $paymentProcessorDetail;
+          $this->assign('paymentProcessor', $this->_paymentProcessor);
+          // Setting this is a bit of a legacy overhang.
+          $this->_paymentObject = $paymentProcessorDetail['object'];
+        }
+      }
+      // It's not clear why we set this on the form.
+      $this->set('paymentProcessors', $this->_paymentProcessors);
     }
   }
 

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -154,10 +154,33 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     }
     else {
       $this->_paymentProcessorIDs = [$payment_processor_id];
-      $this->assignPaymentProcessor(FALSE);
+      $this->assignPaymentProcessor();
       CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, FALSE);
     }
     $this->assign('currency', $this->getCurrency());
+  }
+
+  /**
+   * Assign the payment processor to the places is is traditionally assigned to..
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function assignPaymentProcessor() {
+    $this->_paymentProcessors = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessors([ucfirst($this->_mode) . 'Mode'], $this->_paymentProcessorIDs);
+
+    if (!empty($this->_paymentProcessors)) {
+      foreach ($this->_paymentProcessors as $paymentProcessorDetail) {
+        if (empty($this->_paymentProcessor) && $paymentProcessorDetail['is_default'] == 1 || (count($this->_paymentProcessors) == 1)
+        ) {
+          $this->_paymentProcessor = $paymentProcessorDetail;
+          $this->assign('paymentProcessor', $this->_paymentProcessor);
+          // Setting this is a bit of a legacy overhang.
+          $this->_paymentObject = $paymentProcessorDetail['object'];
+        }
+      }
+      // It's not clear why we set this on the form.
+      $this->set('paymentProcessors', $this->_paymentProcessors);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Move assignPaymentProcessors to FrontEndPaymentFormTrait

Before
----------------------------------------
`assignPaymentProcessors` was moved to `CRM_Core_Form` when traits were just a tilt in php's kilt. Based on a universe search It is only shared by the contribution forms, the event forms and the core-event-cart extension so it makes more sense to be moved to the appropriate place

After
----------------------------------------
The function is moved to the shared FrontEndTrait function.

Event cart gets it's own copy as the goal in moving the code to an extension is to (over a long time) make that code stand alone and not share functions with really-core forms

Technical Details
----------------------------------------

Comments
----------------------------------------
