### PR TITLE
Standardise activity datasource text

### DIFF
--- a/templates/CRM/Activity/Import/Form/DataSource.tpl
+++ b/templates/CRM/Activity/Import/Form/DataSource.tpl
@@ -10,26 +10,24 @@
 {* Import Wizard - Step 1 (choose data source) *}
 <div class="crm-block crm-form-block crm-import-datasource-form-block">
 
- {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
- {include file="CRM/common/WizardHeader.tpl"}
+  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
+  {include file="CRM/common/WizardHeader.tpl"}
+  <div class="help">
+    {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
+    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}
+  </div>
 
- <div class="help">
-    <p>
-    {ts}The Activity Import Wizard allows you to easily upload activity from other applications into CiviCRM. Contacts must already exist in your CiviCRM database prior to importing activity.{/ts}
-    {help id="id-upload"}
-    </p>
- </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
  <div id="upload-file">
  <h3>{ts}Upload Data File{/ts}</h3>
       <table class="form-layout-compressed">
-        <tr class="crm-activity-import-uploadfile-form-block-uploadFile">
+        <tr class="crm-import-uploadfile-from-block-uploadFile">
            <td class="label">{$form.uploadFile.label}</td>
            <td>{$form.uploadFile.html}<br />
                 <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span><br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
            </td>
         </tr>
-        <tr class="crm-activity-import-uploadfile-form-block-skipColumnHeader">
+        <tr class="crm-import-uploadfile-form-block-skipColumnHeader">
            <td class="label"></td>
            <td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
                <span class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Activity Type', 'Activity Date').{/ts}</span>
@@ -41,7 +39,7 @@
         </tr>
         <tr>{include file="CRM/Core/Date.tpl"}</tr>
         {if $savedMapping}
-        <tr class="crm-activity-import-uploadfile-form-block-savedMapping">
+        <tr class="crm-import-uploadfile-form-block-savedMapping">
         <td>{$form.savedMapping.label}</td>
            <td>{$form.savedMapping.html}<br />
               <span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span>


### PR DESCRIPTION
Overview
----------------------------------------
Standardise activity datasource text - this applies the same text standardisations figured out on Membership & Contribution to Activity

Before
----------------------------------------

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/163512753-533f5bd3-aa00-4a9e-b833-9bc1c61e182d.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
In trying to work through the activity form I discovered an html difference in terms of a 'heading' for upload data file

![image](https://user-images.githubusercontent.com/336308/163512871-061e2f44-5e48-47c1-80f6-6dc59cca774a.png)


vs

![image](https://user-images.githubusercontent.com/336308/163512895-966b8664-4f6b-4fd4-8768-a0718329eee7.png)

So am looking for input as to which to standardise on. Here is contact:  - shich suggests 'go with the headings but add in 'Import Options' too - it's likely the Select datasource will be extended to the other imports (I kinda hate it but if one has it they might as well all have it & it is permission-restricted)

![image](https://user-images.githubusercontent.com/336308/163512944-aff94afd-c8ba-415d-9955-db5bdcfa4aa2.png)



![image](https://user-images.githubusercontent.com/336308/163513126-89cd6f63-f35d-4afb-ba4f-883789c80be8.png)


![image](https://user-images.githubusercontent.com/336308/163513157-5a3ae52e-c3c4-430d-8f48-b3ad793fccec.png)

![image](https://user-images.githubusercontent.com/336308/163513183-704f0ba5-51f7-4222-8043-6a2930ba6e44.png)
