### PR TITLE
(REF) CryptoRegistry - Fix type declaration

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -232,7 +232,7 @@ class Container {
     $container->setDefinition('pear_mail', new Definition('Mail'))
       ->setFactory('CRM_Utils_Mail::createMailer')->setPublic(TRUE);
 
-    $container->setDefinition('crypto.registry', new Definition('Civi\Crypto\CryptoService'))
+    $container->setDefinition('crypto.registry', new Definition('Civi\Crypto\CryptoRegistry'))
       ->setFactory('Civi\Crypto\CryptoRegistry::createDefaultRegistry')->setPublic(TRUE);
 
     $container->setDefinition('crypto.token', new Definition('Civi\Crypto\CryptoToken', []))

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -61,7 +61,7 @@ class CryptoRegistry {
    * @throws \CRM_Core_Exception
    * @throws \Civi\Crypto\Exception\CryptoException
    */
-  public static function createDefaultRegistry() {
+  public static function createDefaultRegistry(): CryptoRegistry {
     $registry = new static();
     $registry->addCipherSuite(new \Civi\Crypto\PhpseclibCipherSuite());
 


### PR DESCRIPTION
Overview
----------------------------------------

Tighten/fix type-signature.

Before
----------------------------------------

The Container has inaccurate metadata about the type of `crypto.registry`. It claims type `CryptoService`, but that type doesn't exist. (That was an older/interim name used during drafting.) The true type is `CryptoRegistry`.

```
$ cv ev 'echo get_class(Civi::service("crypto.registry"));'
Civi\Crypto\CryptoRegistry
```

After
----------------------------------------

Correct type.

Comments
----------------------------------------

AFAIK, this is entirely asymptomatic. The use of factory-method means that the declared-type is basically not used at runtime.

So this is just a small tidy-up.