### PR TITLE
restore using non-organizations as employers

### DIFF
--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -126,6 +126,8 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
 
   /**
    * Get the id of the employee relationship, checking it is valid.
+   * We check that contact_type_a is Individual, but not contact_type_b because there's
+   * nowhere in the code that requires it to be Organization.
    *
    * @return int|string
    *
@@ -137,7 +139,6 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
         $relationship = RelationshipType::get(FALSE)
           ->addWhere('name_a_b', '=', 'Employee of')
           ->addWhere('contact_type_a', '=', 'Individual')
-          ->addWhere('contact_type_b', '=', 'Organization')
           ->addSelect('id')->execute()->first();
         if (empty($relationship)) {
           throw new API_Exception('no valid relationship');


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3182

Overview
----------------------------------------
Prior to Civi 5.47, it was possible to change the employee/employer relationship to have non-organization employers (since folks are often employed by other individuals).  Civi 5.47 has a "Contact B is always an Organization" relationship, but I've run my modification in production for several years and see no reason why this should be the case.

Before
----------------------------------------
Contact B must be an organization.

After
----------------------------------------
Contact B can be any contact type.