### PR TITLE
Fix malformed query when user with no access to any financial acls accesses civimember search

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -224,12 +224,9 @@ function _financialacls_civicrm_get_accessible_financial_types(): array {
  * @throws \API_Exception
  */
 function _financialacls_civicrm_get_membership_type_clause(): string {
-  if (!CRM_Core_Component::isEnabled('CiviMember')) {
-    return 1;
-  }
   $financialTypes = _financialacls_civicrm_get_accessible_financial_types();
-  if ($financialTypes === [0]) {
-    return 0;
+  if ($financialTypes === [0] || !CRM_Core_Component::isEnabled('CiviMember')) {
+    return '= 0';
   }
   $membershipTypes = (array) MembershipType::get(FALSE)
     ->addWhere('financial_type_id', 'IN', $financialTypes)->execute()->indexBy('id');


### PR DESCRIPTION
Overview
----------------------------------------
1) enable financial acls
2) give civimember access to webuser
3) log in as advisor/advisor & access membership search

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/163649368-65230bd9-46c1-4c8a-9f5b-858794c1f003.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/163649430-3ff0d5f8-9251-4330-94a5-8379aa75691a.png)


Technical Details
----------------------------------------
The contact cannot view any memberships but returning 0 winds up dropped - '= 0' works...

Comments
----------------------------------------
