### PR TITLE
[Ref] MembershipView page - Remove redundant financialacl check

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Membership;
+
 /**
  * This class generates form components for Payment-Instrument
  */
@@ -154,11 +156,14 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
     $this->assign('context', $context);
 
     if ($this->membershipID) {
-      $values = \Civi\Api4\Membership::get()
+      $memberships = Membership::get()
         ->addSelect('*', 'status_id:label', 'membership_type_id:label', 'membership_type_id.financial_type_id', 'status_id.is_current_member')
         ->addWhere('id', '=', $this->membershipID)
-        ->execute()
-        ->first();
+        ->execute();
+      if (!count($memberships)) {
+        CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+      }
+      $values = $memberships->first();
 
       // Ensure keys expected by MembershipView.tpl are set correctly
       // Some of these defaults are overwritten dependant on context below
@@ -170,16 +175,11 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
       $values['owner_display_name'] = FALSE;
       $values['campaign'] = FALSE;
 
-      if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()) {
-        $finTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $values['membership_type_id'], 'financial_type_id');
-        $finType = CRM_Contribute_PseudoConstant::financialType($finTypeId);
-        if (!CRM_Core_Permission::check('view contributions of type ' . $finType)) {
-          CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-        }
-      }
-      else {
-        $this->assign('noACL', TRUE);
-      }
+      // This tells the template not to check financial acls when determining
+      // whether to show edit & delete links. Link decisions
+      // should be moved to the php layer - with financialacls using hooks.
+      $this->assign('noACL', !CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus());
+
       $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypeDetails($values['membership_type_id']);
 
       // Do the action on related Membership if needed


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from https://github.com/civicrm/civicrm-core/pull/22664 - removes the financial acl check that @colemanw questioned removing in the PR

Before
----------------------------------------
The same should work before & after .....

1. Give webuser role 'access CiviMembership' - or merge this pr https://github.com/civicrm/civicrm-buildkit/pull/690 and rebuild the site...
2. In incognito login as advisor/advisor
3. Do a membership search & view a membership record
4. As admin user enable financial acls
5. try refreshing the view screen for advisor - should no longer load


After
----------------------------------------
No change in r-run, some code removed

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/23228 needs to be merged through to master before merge (then I'll rebase it out) - but if testing / adding MOP before then you will need it :-)

Comments
----------------------------------------
