### PR TITLE
[Import] Simplify and limit dataSource retrieval in contact import

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -24,7 +24,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    * @return array
    *   collection of info about this data source
    */
-  public function getInfo() {
+  public function getInfo(): array {
     return ['title' => ts('Comma-Separated Values (CSV)')];
   }
 

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -22,7 +22,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
    * @return array
    *   collection of info about this data source
    */
-  public function getInfo() {
+  public function getInfo(): array {
     return [
       'title' => ts('SQL Query'),
       'permissions' => ['import SQL datasource'],

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -42,4 +42,28 @@ class CRM_Import_Forms extends CRM_Core_Form {
 
   }
 
+  /**
+   * Get the available datasource.
+   *
+   * Permission dependent, this will look like
+   * [
+   *   'CRM_Import_DataSource_CSV' => 'Comma-Separated Values (CSV)',
+   *   'CRM_Import_DataSource_SQL' => 'SQL Query',
+   * ]
+   *
+   * The label is translated.
+   *
+   * @return array
+   */
+  protected function getDataSources(): array {
+    $dataSources = [];
+    foreach (['CRM_Import_DataSource_SQL', 'CRM_Import_DataSource_CSV'] as $dataSourceClass) {
+      $object = new $dataSourceClass();
+      if ($object->checkPermission()) {
+        $dataSources[$dataSourceClass] = $object->getInfo()['title'];
+      }
+    }
+    return $dataSources;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Simplify and limit dataSource retrieval in contact import

This restricts the available data sources to the 2 that ship with core and simplifies the code around them.

I concluded that this could be done because

1) I did a universe search & found no attempts to define alternate `CRM_Import_DataSource_` files
2) it was never documented as a way to customise CiviCRM
3) the contract is so nasty & hard to make sense of it it clear why no-one seems to have customised in this way.

- I will point this out in dev-digest but I think it doesn't have to go out before merge. In the extremely unlikely scenario someone pipes up I'll work with them on it.

Before
----------------------------------------
Undocumented option to create custom datasource classes, lots of code to load & handle

After
----------------------------------------
Only the 2 core ones (csv & sql table are loaded)

Technical Details
----------------------------------------

Comments
----------------------------------------

