### PR TITLE
CiviContribute - Fix SQL error when interpreting ACL

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4393,7 +4393,7 @@ LIMIT 1;";
 
     $clauses = [];
     foreach ($whereClauses as $key => $clause) {
-      $clauses[] = 'b.' . $key . ' ' . implode(' AND b.' . $key, (array) $clause);
+      $clauses[] = 'b.' . $key . ' ' . implode(' AND b.' . $key . ' ', (array) $clause);
     }
     $clauses[] = 'b.contact_id IN (' . $contactIDs . ')';
     $clauses[] = 'b.is_test = 0';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression sql error in the annual query (e.g on contribution tab) for an acld user without permission to view deleted contacts in 5.48+

Before
----------------------------------------
Fatal ...
SELECT COUNT(*) AS count, SUM(total_amount) AS amount, AVG(total_amount) AS average, currency
FROM civicrm_contribution b
WHERE b.contact_id IN (SELECT contact_id FROM civicrm_acl_contact_cache WHERE user_id = 202)
  AND **b.contact_idIN(SELECT `id`** FROM `civicrm_contact` WHERE is_deleted != 1)
  AND b.financial_type_id IN (1)
  AND b.contact_id IN (71)
  AND b.is_test = 0
  AND b.receive_date >= 20220101
  AND b.receive_date < 20230101
GROUP BY currency, contribution_status_id
HAVING contribution_status_id = 1

After
----------------------------------------
works

Technical Details
----------------------------------------
This patch
https://github.com/civicrm/civicrm-core/commit/56f5e9dbbebb987e6502e2f1dfa9a3789acf5315#diff-4c9d0b1abe07057a4eea2b47bc627eecb95face8ed8d86c1c005312a52cca811R4377 

added the acl for deleted contacts - but it is being joined with no space

Comments
----------------------------------------

We should backport but the fact it is tied to the view deleted permission is probably why no-one noticed as yet...