### PR TITLE
[Ref] [Import] Remove another good intention....mapField

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -125,18 +125,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
   }
 
   /**
-   * Handle the values in mapField mode.
-   *
-   * @param array $values
-   *   The array of values belonging to this line.
-   *
-   * @return bool
-   */
-  public function mapField(&$values) {
-    return CRM_Import_Parser::VALID;
-  }
-
-  /**
    * Handle the values in preview mode.
    *
    * @param array $values
@@ -551,7 +539,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
       $this->_totalCount++;
 
       if ($mode == self::MODE_MAPFIELD) {
-        $returnCode = $this->mapField($values);
+        $returnCode = CRM_Import_Parser::VALID;
       }
       elseif ($mode == self::MODE_PREVIEW) {
         $returnCode = $this->preview($values);

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -263,18 +263,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * Handle the values in mapField mode.
-   *
-   * @param array $values
-   *   The array of values belonging to this line.
-   *
-   * @return bool
-   */
-  public function mapField(&$values) {
-    return CRM_Import_Parser::VALID;
-  }
-
-  /**
    * Handle the values in preview mode.
    *
    * @param array $values
@@ -2662,7 +2650,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $this->_totalCount++;
 
       if ($mode == self::MODE_MAPFIELD) {
-        $returnCode = $this->mapField($values);
+        $returnCode = CRM_Import_Parser::VALID;
       }
       elseif ($mode == self::MODE_PREVIEW) {
         $returnCode = $this->preview($values);

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -242,7 +242,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       $this->_totalCount++;
 
       if ($mode == self::MODE_MAPFIELD) {
-        $returnCode = $this->mapField($values);
+        $returnCode = CRM_Import_Parser::VALID;
       }
       elseif ($mode == self::MODE_PREVIEW) {
         $returnCode = $this->preview($values);
@@ -750,18 +750,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       }
       $index++;
     }
-  }
-
-  /**
-   * Handle the values in mapField mode.
-   *
-   * @param array $values
-   *   The array of values belonging to this line.
-   *
-   * @return bool
-   */
-  public function mapField(&$values) {
-    return CRM_Import_Parser::VALID;
   }
 
   /**

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -133,18 +133,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
   }
 
   /**
-   * Handle the values in mapField mode.
-   *
-   * @param array $values
-   *   The array of values belonging to this line.
-   *
-   * @return bool
-   */
-  public function mapField(&$values) {
-    return CRM_Import_Parser::VALID;
-  }
-
-  /**
    * Handle the values in preview mode.
    *
    * @param array $values
@@ -827,7 +815,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       $this->_totalCount++;
 
       if ($mode == self::MODE_MAPFIELD) {
-        $returnCode = $this->mapField($values);
+        $returnCode = CRM_Import_Parser::VALID;
       }
       elseif ($mode == self::MODE_PREVIEW) {
         $returnCode = $this->preview($values);

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -223,15 +223,6 @@ abstract class CRM_Import_Parser {
   abstract protected function fini();
 
   /**
-   * Map field.
-   *
-   * @param array $values
-   *
-   * @return mixed
-   */
-  abstract protected function mapField(&$values);
-
-  /**
    * Preview.
    *
    * @param array $values

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -180,7 +180,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
       $this->_totalCount++;
 
       if ($mode == self::MODE_MAPFIELD) {
-        $returnCode = $this->mapField($values);
+        $returnCode = CRM_Import_Parser::VALID;
       }
       elseif ($mode == self::MODE_PREVIEW) {
         $returnCode = $this->preview($values);
@@ -491,18 +491,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
       }
       $index++;
     }
-  }
-
-  /**
-   * Handle the values in mapField mode.
-   *
-   * @param array $values
-   *   The array of values belonging to this line.
-   *
-   * @return bool
-   */
-  public function mapField(&$values) {
-    return CRM_Import_Parser::VALID;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
The mapField() function in the import parser classes looks like a good intention - in every instance it does nothing except
1) makes the code hard to read
2) returns the same constant.

It currently has to be implemented due to the abstract function - but does nothing helpful.

Before
----------------------------------------
blah blah blah

After
----------------------------------------
poof

Technical Details
----------------------------------------
I have removed the pattern from csvimporter just now - but not the civiHR classes that extend this abstract class as it doesn't matter if they DO continue to implement the function - it's just fugly

Comments
----------------------------------------
