### PR TITLE
[REF] [Import] Stop overloading dataSource form

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -236,7 +236,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
       }
       $this->set('disableUSPS', !empty($this->_params['disableUSPS']));
 
-      $this->set('dataSource', $this->_params['dataSource']);
+      $this->set('dataSource', $this->getSubmittedValue('dataSource'));
       $this->set('skipColumnHeader', CRM_Utils_Array::value('skipColumnHeader', $this->_params));
 
       CRM_Core_Session::singleton()->set('dateTypes', $storeParams['dateFormats']);

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -57,7 +57,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     }
 
     while ($file = readdir($handler)) {
-      if ($file != '.' && $file != '..' &&
+      if ($file !== '.' && $file !== '..' &&
         in_array($file, $errorFiles) && !is_writable($config->uploadDir . $file)
       ) {
         $results[] = $file;
@@ -164,7 +164,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
 
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
 
-    $config = CRM_Core_Config::singleton();
     $geoCode = FALSE;
     if (CRM_Utils_GeocodeProvider::getUsableClassName()) {
       $geoCode = TRUE;
@@ -195,18 +194,15 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
   /**
    * Set the default values of various form elements.
    *
-   * access        public
-   *
    * @return array
    *   reference to the array of default values
    */
   public function setDefaultValues() {
-    $config = CRM_Core_Config::singleton();
     $defaults = [
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
       'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
-      'fieldSeparator' => $config->fieldSeparator,
+      'fieldSeparator' => CRM_Core_Config::singleton()->fieldSeparator,
     ];
 
     if ($this->get('loadedMapping')) {

--- a/CRM/Core/xml/Menu/Import.xml
+++ b/CRM/Core/xml/Menu/Import.xml
@@ -39,4 +39,12 @@
     <page_callback>CRM_Contact_Import_Page_AJAX::status</page_callback>
     <access_arguments>import contacts,access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/import/datasource</path>
+    <title>Import</title>
+    <access_arguments>access CiviCRM</access_arguments>
+    <page_type>1</page_type>
+    <page_callback>CRM_Import_Form_DataSourceConfig</page_callback>
+    <weight>450</weight>
+  </item>
 </menu>

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -89,10 +89,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     );
 
     $form->set('originalColHeader', CRM_Utils_Array::value('original_col_header', $result));
-
-    $table = $result['import_table_name'];
-    $importJob = new CRM_Contact_Import_ImportJob($table);
-    $form->set('importTableName', $importJob->getTableName());
+    $form->set('importTableName', $result['import_table_name']);
   }
 
   /**

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -24,7 +24,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    * @return array
    *   collection of info about this data source
    */
-  public function getInfo() {
+  public function getInfo(): array {
     return ['title' => ts('Comma-Separated Values (CSV)')];
   }
 

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -22,7 +22,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
    * @return array
    *   collection of info about this data source
    */
-  public function getInfo() {
+  public function getInfo(): array {
     return [
       'title' => ts('SQL Query'),
       'permissions' => ['import SQL datasource'],

--- a/CRM/Import/Form/DataSourceConfig.php
+++ b/CRM/Import/Form/DataSourceConfig.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class allows datasource specific fields to be added to the datasource form.
+ */
+class CRM_Import_Form_DataSourceConfig extends CRM_Import_Forms {
+
+  /**
+   * Set variables up before form is built.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function preProcess(): void {
+    $dataSourcePath = explode('_', $this->getDataSourceClassName());
+    $templateFile = 'CRM/Contact/Import/Form/' . $dataSourcePath[3] . '.tpl';
+    $this->assign('dataSourceFormTemplateFile', $templateFile ?? NULL);
+  }
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm(): void {
+    $this->buildDataSourceFields();
+  }
+
+}

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -34,6 +34,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
       'contactType' => 'DataSource',
       'dateFormats' => 'DataSource',
       'savedMapping' => 'DataSource',
+      'dataSource' => 'DataSource',
     ];
     if (array_key_exists($fieldName, $mappedValues)) {
       return $this->controller->exportValue($mappedValues[$fieldName], $fieldName);
@@ -64,6 +65,78 @@ class CRM_Import_Forms extends CRM_Core_Form {
       }
     }
     return $dataSources;
+  }
+
+  /**
+   * Get the name of the datasource class.
+   *
+   * This function prioritises retrieving from GET and POST over 'submitted'.
+   * The reason for this is the submitted array will hold the previous submissions
+   * data until after buildForm is called.
+   *
+   * This is problematic in the forward->back flow & option changing flow. As in....
+   *
+   * 1) Load DataSource form - initial default datasource is set to CSV and the
+   * form is via ajax (this calls DataSourceConfig to get the data).
+   * 2) User changes the source to SQL - the ajax updates the html but the
+   * form was built with the expectation that the csv-specific fields would be
+   * required.
+   * 3) When the user submits Quickform calls preProcess and buildForm and THEN
+   * retrieves the submitted values based on what has been added in buildForm.
+   * Only the submitted values for fields added in buildForm are available - but
+   * these have to be added BEFORE the submitted values are determined. Hence
+   * we look in the POST or GET to get the updated value.
+   *
+   * Note that an imminent refactor will involve storing the values in the
+   * civicrm_user_job table - this will hopefully help with a known (not new)
+   * issue whereby the previously submitted values (eg. skipColumnHeader has
+   * been checked or sql has been filled in) are not loaded via the ajax request.
+   *
+   * @return string|null
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getDataSourceClassName(): ?string {
+    $className = CRM_Utils_Request::retrieveValue(
+      'dataSource',
+      'String'
+    );
+    if (!$className) {
+      $className = $this->getSubmittedValue('dataSource');
+    }
+    if (!$className) {
+      $className = $this->getDefaultDataSource();
+    }
+    if ($this->getDataSources()[$className]) {
+      return $className;
+    }
+    throw new CRM_Core_Exception('Invalid data source');
+  }
+
+  /**
+   * Allow the datasource class to add fields.
+   *
+   * This is called as a snippet in DataSourceConfig and
+   * also from DataSource::buildForm to add the fields such
+   * that quick form picks them up.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function buildDataSourceFields(): void {
+    $className = $this->getDataSourceClassName();
+    if ($className) {
+      $dataSourceClass = new $className();
+      $dataSourceClass->buildQuickForm($this);
+    }
+  }
+
+  /**
+   * Get the default datasource.
+   *
+   * @return string
+   */
+  protected function getDefaultDataSource(): string {
+    return 'CRM_Import_DataSource_CSV';
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -42,4 +42,28 @@ class CRM_Import_Forms extends CRM_Core_Form {
 
   }
 
+  /**
+   * Get the available datasource.
+   *
+   * Permission dependent, this will look like
+   * [
+   *   'CRM_Import_DataSource_CSV' => 'Comma-Separated Values (CSV)',
+   *   'CRM_Import_DataSource_SQL' => 'SQL Query',
+   * ]
+   *
+   * The label is translated.
+   *
+   * @return array
+   */
+  protected function getDataSources(): array {
+    $dataSources = [];
+    foreach (['CRM_Import_DataSource_SQL', 'CRM_Import_DataSource_CSV'] as $dataSourceClass) {
+      $object = new $dataSourceClass();
+      if ($object->checkPermission()) {
+        $dataSources[$dataSourceClass] = $object->getInfo()['title'];
+      }
+    }
+    return $dataSources;
+  }
+
 }

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -9,9 +9,6 @@
 *}
 
 <div class="crm-block crm-form-block crm-import-datasource-form-block">
-{if $showOnlyDataSourceFormPane}
-  {include file=$dataSourceFormTemplateFile}
-{else}
   {* Import Wizard - Step 1 (choose data source) *}
   {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
   {include file="CRM/common/WizardHeader.tpl"}
@@ -31,9 +28,6 @@
 
   {* Data source form pane is injected here when the data source is selected. *}
   <div id="data-source-form-block">
-    {if $dataSourceFormTemplateFile}
-      {include file=$dataSourceFormTemplateFile}
-    {/if}
   </div>
 
   <div id="common-form-controls" class="form-item">
@@ -178,5 +172,5 @@
 
     </script>
   {/literal}
-{/if}
+
 </div>

--- a/templates/CRM/Import/Form/DataSourceConfig.tpl
+++ b/templates/CRM/Import/Form/DataSourceConfig.tpl
@@ -1,0 +1,10 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{include file=$dataSourceFormTemplateFile}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3218,6 +3218,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       case 'CRM_Event_Form_Registration_Confirm':
         $form->controller = new CRM_Event_Controller_Registration();
         break;
+      case 'CRM_Contact_Import_Form_DataSource':
+        $form->controller = new CRM_Contact_Import_Controller();
+        break;
 
       case strpos($class, '_Form_') !== FALSE:
         $form->controller = new CRM_Core_Controller_Simple($class, $pageName);

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3218,6 +3218,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       case 'CRM_Event_Form_Registration_Confirm':
         $form->controller = new CRM_Event_Controller_Registration();
         break;
+
       case 'CRM_Contact_Import_Form_DataSource':
         $form->controller = new CRM_Contact_Import_Controller();
         break;


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Stop overloading dataSource form

Before
----------------------------------------

The form options that load on the import datasource form are loaded by ajax - but by overloading the same form (ie calling the same civicrm/import/contact?reset=1 url with the form doing different things because of the snippet and datasource url parameters

![image](https://user-images.githubusercontent.com/336308/163772678-f7203b69-8e83-45a3-aa3b-6e495906f41c.png)

**IMPORTANT - if you r-run locally & don't rebuild you will need to at least rebuild menus**


After
----------------------------------------
The form and template to load the datasource are moved to their own class

Technical Details
----------------------------------------
It tooks me quite a bit to figure out what this code was doing & having done that tackled separating it to be more readable

This incorporates a couple of patches that are currently subject to their own PRs (which I will rebase out if merged). I also left a very-silly-if in place in order to remove it as a follow up - for white-space-reasons.

It took me quite a bit to figure out the whole business of getting quickform to handle adding fields by snippet - I commented at some length on that in the docblock on `getDataSourceClassName` so won't repeat it here but the trick is to get it work in r-run such that you can switch between data sources and it validates the right fields and so that you can go back and it loads the right datasource fields. I found that it is NOT loading the submitted values for those fields - but it turned out it wasn't before either. I dug into that a bit but in the end realised that in addition to this being non-regressive I can see a way to fix it by loading from the user_job table in my next follow up

Comments
----------------------------------------

I've given this pretty extensive r-run & will be working on some follow up that will also require r-run 