### PR TITLE
[REF] [Import] Remove warning count - never returned

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -500,7 +500,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
       return FALSE;
     }
 
-    $this->_lineCount = $this->_warningCount = 0;
+    $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
     $this->_totalCount = $this->_conflictCount = 0;
 
@@ -575,13 +575,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         if ($mode == self::MODE_MAPFIELD) {
           $this->_rows[] = $values;
           $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
-        }
-      }
-
-      if ($returnCode & self::WARNING) {
-        $this->_warningCount++;
-        if ($this->_warningCount < $this->_maxWarningCount) {
-          $this->_warningCount[] = $line;
         }
       }
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -282,6 +282,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *
    * @return bool
    *   the result of this processing
+   *   CRM_Import_Parser::ERROR or CRM_Import_Parser::VALID
    */
   public function preview(&$values) {
     return $this->summary($values);
@@ -295,6 +296,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *
    * @return bool
    *   the result of this processing
+   *   CRM_Import_Parser::ERROR or CRM_Import_Parser::VALID
    */
   public function summary(&$values): int {
     $erroneousField = NULL;
@@ -2605,7 +2607,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
     $this->init();
 
-    $this->_rowCount = $this->_warningCount = 0;
+    $this->_rowCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
     $this->_totalCount = $this->_conflictCount = 0;
 
@@ -2687,13 +2689,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         if ($mode == self::MODE_MAPFIELD) {
           $this->_rows[] = $values;
           $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
-        }
-      }
-
-      if ($returnCode & self::WARNING) {
-        $this->_warningCount++;
-        if ($this->_warningCount < $this->_maxWarningCount) {
-          $this->_warningCount[] = $line;
         }
       }
 

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -189,7 +189,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       return FALSE;
     }
 
-    $this->_lineCount = $this->_warningCount = $this->_validSoftCreditRowCount = $this->_validPledgePaymentRowCount = 0;
+    $this->_lineCount = $this->_validSoftCreditRowCount = $this->_validPledgePaymentRowCount = 0;
     $this->_invalidRowCount = $this->_validCount = $this->_invalidSoftCreditRowCount = $this->_invalidPledgePaymentRowCount = 0;
     $this->_totalCount = $this->_conflictCount = 0;
 
@@ -284,13 +284,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         if ($mode == self::MODE_MAPFIELD) {
           $this->_rows[] = $values;
           $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
-        }
-      }
-
-      if ($returnCode == self::WARNING) {
-        $this->_warningCount++;
-        if ($this->_warningCount < $this->_maxWarningCount) {
-          $this->_warningCount[] = $line;
         }
       }
 

--- a/CRM/Custom/Import/Parser.php
+++ b/CRM/Custom/Import/Parser.php
@@ -93,7 +93,7 @@ abstract class CRM_Custom_Import_Parser extends CRM_Import_Parser {
       return FALSE;
     }
 
-    $this->_lineCount = $this->_warningCount = 0;
+    $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
     $this->_totalCount = $this->_conflictCount = 0;
 
@@ -161,13 +161,6 @@ abstract class CRM_Custom_Import_Parser extends CRM_Import_Parser {
         if ($mode == self::MODE_MAPFIELD) {
           $this->_rows[] = $values;
           $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
-        }
-      }
-
-      if ($returnCode & self::WARNING) {
-        $this->_warningCount++;
-        if ($this->_warningCount < $this->_maxWarningCount) {
-          $this->_warnings[] = $this->_lineCount;
         }
       }
 

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -780,7 +780,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       return FALSE;
     }
 
-    $this->_lineCount = $this->_warningCount = 0;
+    $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
     $this->_totalCount = $this->_conflictCount = 0;
 
@@ -848,13 +848,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         if ($mode == self::MODE_MAPFIELD) {
           $this->_rows[] = $values;
           $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
-        }
-      }
-
-      if ($returnCode & self::WARNING) {
-        $this->_warningCount++;
-        if ($this->_warningCount < $this->_maxWarningCount) {
-          $this->_warningCount[] = $line;
         }
       }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -97,12 +97,6 @@ abstract class CRM_Import_Parser {
   protected $_duplicates;
 
   /**
-   * Running total number of warnings
-   * @var int
-   */
-  protected $_warningCount;
-
-  /**
    * Maximum number of warnings to store
    * @var int
    */

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -131,7 +131,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
       return FALSE;
     }
 
-    $this->_lineCount = $this->_warningCount = 0;
+    $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
     $this->_totalCount = $this->_conflictCount = 0;
 
@@ -204,13 +204,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         if ($mode == self::MODE_MAPFIELD) {
           $this->_rows[] = $values;
           $this->_activeFieldCount = max($this->_activeFieldCount, count($values));
-        }
-      }
-
-      if ($returnCode & self::WARNING) {
-        $this->_warningCount++;
-        if ($this->_warningCount < $this->_maxWarningCount) {
-          $this->_warningCount[] = $line;
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Remove warning count - never returned

Before
----------------------------------------
lots of handling for possibility that SELF::WARNING could be returned - but it never is...

After
----------------------------------------
poof

Technical Details
----------------------------------------
The writer of this code seems to have imagined a vision that never happened

Comments
----------------------------------------
I did a universe output - a couple of places in @mlutfy's extension & the civihr import - but they are self-contained. In core all the places remaining after this relate to psr logging

![image](https://user-images.githubusercontent.com/336308/163885305-2816062c-d623-4084-895e-0b53446a21fb.png)

![image](https://user-images.githubusercontent.com/336308/163885362-e57487dd-82d8-4714-b95f-1a468cd3b65b.png)

