### PR TITLE
[REF] [Import] remove pointless fini functions.

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -70,11 +70,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
   }
 
   /**
-   * Function of undocumented functionality required by the interface.
-   */
-  protected function fini() {}
-
-  /**
    * The initializer code, called before the processing.
    */
   public function init() {
@@ -656,7 +651,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         self::exportCSV($this->_duplicateFileName, $headers, $this->_duplicates);
       }
     }
-    return $this->fini();
   }
 
   /**

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1307,12 +1307,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * The initializer code, called before the processing.
-   */
-  public function fini() {
-  }
-
-  /**
    * Check if an error in custom data.
    *
    * @param array $params
@@ -2788,8 +2782,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         self::exportCSV($this->_errorFileName, $headers, $this->_unparsedAddresses);
       }
     }
-    //echo "$this->_totalCount,$this->_invalidRowCount,$this->_conflictCount,$this->_duplicateCount";
-    return $this->fini();
   }
 
   /**

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -418,7 +418,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         self::exportCSV($this->_duplicateFileName, $headers, $this->_duplicates);
       }
     }
-    return $this->fini();
   }
 
   /**
@@ -1109,12 +1108,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   public function &getImportedContributions() {
     return $this->_newContributions;
-  }
-
-  /**
-   * The initializer code, called before the processing.
-   */
-  public function fini() {
   }
 
   /**

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -492,14 +492,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
   }
 
   /**
-   * The initializer code, called before the processing
-   *
-   * @return void
-   */
-  public function fini() {
-  }
-
-  /**
    * Format values
    *
    * @todo lots of tidy up needed here - very old function relocated.
@@ -930,7 +922,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         self::exportCSV($this->_duplicateFileName, $headers, $this->_duplicates);
       }
     }
-    return $this->fini();
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -213,40 +213,6 @@ abstract class CRM_Import_Parser {
   }
 
   /**
-   * Abstract function definitions.
-   */
-  abstract protected function init();
-
-  /**
-   * @return mixed
-   */
-  abstract protected function fini();
-
-  /**
-   * Preview.
-   *
-   * @param array $values
-   *
-   * @return mixed
-   */
-  abstract protected function preview(&$values);
-
-  /**
-   * @param $values
-   *
-   * @return mixed
-   */
-  abstract protected function summary(&$values);
-
-  /**
-   * @param $onDuplicate
-   * @param $values
-   *
-   * @return mixed
-   */
-  abstract protected function import($onDuplicate, &$values);
-
-  /**
    * Set and validate field values.
    *
    * @param array $elements

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -289,7 +289,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         self::exportCSV($this->_duplicateFileName, $headers, $this->_duplicates);
       }
     }
-    return $this->fini();
   }
 
   /**
@@ -936,14 +935,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    */
   public function &getImportedMemberships() {
     return $this->_newMemberships;
-  }
-
-  /**
-   * The initializer code, called before the processing
-   *
-   * @return void
-   */
-  public function fini() {
   }
 
   /**


### PR DESCRIPTION
These never do anything - there are there only through copy & paste + a the abstract class requiring them.

In fact all the abstract functions are dumb - the are only called internally
within the classes so I have gotten rid of the abstractness so they
can be removed at will. import makes sense - but the signature doesn't...

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
