### PR TITLE
APIv4 - Add `Managed::reconcile` action.

### DIFF
--- a/Civi/Api4/Action/Managed/Reconcile.php
+++ b/Civi/Api4/Action/Managed/Reconcile.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Managed;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Refresh managed entities.
+ *
+ * @method $this setModules(array $modules) Set modules
+ * @method array getModules() Get modules param
+ */
+class Reconcile extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Limit scope of reconcile to specific module(s).
+   *
+   * @var array
+   */
+  protected $modules = NULL;
+
+  /**
+   * @param string $moduleName
+   * @return $this
+   */
+  public function addModule(string $moduleName) {
+    $this->modules[] = $moduleName;
+    return $this;
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    \CRM_Core_ManagedEntities::singleton()->reconcile($this->modules);
+  }
+
+}

--- a/Civi/Api4/Managed.php
+++ b/Civi/Api4/Managed.php
@@ -22,4 +22,13 @@ namespace Civi\Api4;
  */
 class Managed extends Generic\DAOEntity {
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Contact\GetChecksum
+   */
+  public static function reconcile($checkPermissions = TRUE) {
+    return (new Action\Managed\Reconcile(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Entity;
 use api\v4\UnitTestCase;
 use Civi\Api4\Domain;
 use Civi\Api4\Group;
+use Civi\Api4\Managed;
 use Civi\Api4\Navigation;
 use Civi\Api4\OptionGroup;
 use Civi\Api4\OptionValue;
@@ -82,7 +83,7 @@ class ManagedEntityTest extends UnitTestCase implements TransactionalInterface, 
       ],
     ];
 
-    \CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    Managed::reconcile(FALSE)->addModule('civicrm')->execute();
 
     $search = SavedSearch::get(FALSE)
       ->addWhere('name', '=', 'TestManagedSavedSearch')


### PR DESCRIPTION
Overview
----------------------------------------
Adds APIv4 wrapper around ManagedEntities->reconcile();

Before
----------------------------------------
Extensions had to call internal function to trigger this.

After
----------------------------------------
Now they have an API.

Comments
----------------------------------------
Note that per the defaults, the permission required to use this action is `"administer CiviCRM"`.