### PR TITLE
ensure checkbox custom fields on contributions import properly

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -886,13 +886,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       return CRM_Import_Parser::ERROR;
     }
 
-    if ($onDuplicate != CRM_Import_Parser::DUPLICATE_UPDATE) {
-      $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-        NULL,
-        'Contribution'
-      );
-    }
-    else {
+    if ($onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
       //fix for CRM-2219 - Update Contribution
       // onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE
       if (!empty($paramValues['invoice_id']) || !empty($paramValues['trxn_id']) || !empty($paramValues['contribution_id'])) {
@@ -901,15 +895,10 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
           'trxn_id' => $paramValues['trxn_id'] ?? NULL,
           'invoice_id' => $paramValues['invoice_id'] ?? NULL,
         ];
-
         $ids['contribution'] = CRM_Contribute_BAO_Contribution::checkDuplicateIds($dupeIds);
 
         if ($ids['contribution']) {
           $formatted['id'] = $ids['contribution'];
-          $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-            $formatted['id'],
-            'Contribution'
-          );
           //process note
           if (!empty($paramValues['note'])) {
             $noteID = [];
@@ -953,8 +942,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
           }
 
           $formatted['id'] = $ids['contribution'];
-          $newContribution = CRM_Contribute_BAO_Contribution::create($formatted);
-          $this->_newContributions[] = $newContribution->id;
+
+          $newContribution = civicrm_api3('contribution', 'create', $formatted);
+          $this->_newContributions[] = $newContribution['id'];
 
           //return soft valid since we need to show how soft credits were added
           if (!empty($formatted['soft_credit'])) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -993,12 +993,7 @@ abstract class CRM_Import_Parser {
         if ((strtolower(trim($customLabel['label'])) == strtolower(trim($v1))) ||
           (strtolower(trim($customValue)) == strtolower(trim($v1)))
         ) {
-          if ($fieldType == 'CheckBox') {
-            $values[$customValue] = 1;
-          }
-          else {
-            $values[] = $customValue;
-          }
+          $values[] = $customValue;
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
We've been treating checkboxes differently when importing for a while, but perhaps the need for the different behavior is over? I've included a test and am hoping we have enough test coverage to see a failure if the checkbox exception is still needed somewhere.

Before
----------------------------------------
When importing a Contribution, that includes a custom field of the the type checkbox in which there is no value of "1", an error is returned.

When testing it's important that you use a custom option set that does not use numeric values - you must use string values.
 
After
----------------------------------------

The contribution and custom field is properly imported.

Technical Details
----------------------------------------

The old code unserialized a comma separated list into an array with the array key set to the option value and the value to the number 1. It expected the proper values to be extracted from the keys.

However, when imported, the values are taken from the array values, not the keys, so it's always "1". 

Some tests might not detect a failure here. Suppose you have an option list with the name "Blue" assigned the value 1. You can test this option list and it passes simply because you wanted the value "1" and it just so happens that all values get set to 1.

Comments
----------------------------------------
I expect some test failures which might suggest this is a bad idea or might suggest that we should fix the code that is failing. I'm really not sure.
