### PR TITLE
dev/core#3184 - Financialacls - avoid type error in symfony 6 - Option 1

### DIFF
--- a/ext/financialacls/Civi/Financialacls/Hooks.php
+++ b/ext/financialacls/Civi/Financialacls/Hooks.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Civi\Financialacls;
+
+class Hooks {
+
+  /**
+   * Listener for 'civi.api4.authorizeRecord::Contribution'
+   *
+   * @param \Civi\Api4\Event\AuthorizeRecordEvent $e
+   * @throws \CRM_Core_Exception
+   */
+  public static function api4_authorizeContribution(\Civi\Api4\Event\AuthorizeRecordEvent $e) {
+    if (!financialacls_is_acl_limiting_enabled()) {
+      return;
+    }
+    if ($e->getEntityName() === 'Contribution') {
+      $contributionID = $e->getRecord()['id'] ?? NULL;
+      $financialTypeID = $e->getRecord()['financial_type_id'] ?? \CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionID, 'financial_type_id');
+      if (!\CRM_Core_Permission::check(_financialacls_getRequiredPermission($financialTypeID, $e->getActionName()), $e->getUserID())) {
+        $e->setAuthorized(FALSE);
+      }
+      if ($e->getActionName() === 'delete') {
+        // First check contribution financial type
+        // Now check permissioned line items & permissioned contribution
+        if (!\CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributionID, 'delete', FALSE, $e->getUserID())
+        ) {
+          $e->setAuthorized(FALSE);
+        }
+      }
+    }
+  }
+
+}

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -22,7 +22,7 @@ function financialacls_civicrm_config(&$config) {
 function financialacls_civicrm_container($container) {
   $dispatcherDefn = $container->getDefinition('dispatcher');
   $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
-  $dispatcherDefn->addMethodCall('addListener', ['civi.api4.authorizeRecord::Contribution', '_financialacls_civi_api4_authorizeContribution']);
+  $dispatcherDefn->addMethodCall('addListener', ['civi.api4.authorizeRecord::Contribution', ['\Civi\Financialacls\Hooks', 'api4_authorizeContribution']]);
 }
 
 /**
@@ -313,33 +313,6 @@ function financialacls_civicrm_permission(&$permissions) {
     ts('CiviCRM: administer CiviCRM Financial Types'),
     ts('Administer access to Financial Types'),
   ];
-}
-
-/**
- * Listener for 'civi.api4.authorizeRecord::Contribution'
- *
- * @param \Civi\Api4\Event\AuthorizeRecordEvent $e
- * @throws \CRM_Core_Exception
- */
-function _financialacls_civi_api4_authorizeContribution(\Civi\Api4\Event\AuthorizeRecordEvent $e) {
-  if (!financialacls_is_acl_limiting_enabled()) {
-    return;
-  }
-  if ($e->getEntityName() === 'Contribution') {
-    $contributionID = $e->getRecord()['id'] ?? NULL;
-    $financialTypeID = $e->getRecord()['financial_type_id'] ?? CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionID, 'financial_type_id');
-    if (!CRM_Core_Permission::check(_financialacls_getRequiredPermission($financialTypeID, $e->getActionName()), $e->getUserID())) {
-      $e->setAuthorized(FALSE);
-    }
-    if ($e->getActionName() === 'delete') {
-      // First check contribution financial type
-      // Now check permissioned line items & permissioned contribution
-      if (!CRM_Financial_BAO_FinancialType::checkPermissionedLineItems($contributionID, 'delete', FALSE, $e->getUserID())
-      ) {
-        $e->setAuthorized(FALSE);
-      }
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3184


Before
----------------------------------------
Type error in symfony 6

After
----------------------------------------


Technical Details
----------------------------------------
See lab ticket.

Comments
----------------------------------------
This moves more stuff around than option 2, but keeps it in hook_civicrm_container.

I don't know how to _fully_ test the acl function since I don't really know how it's supposed to work or how to turn it on, but I can see the hook is being called when I view a contribution when logged in as a non-admin.