### PR TITLE
dev/core#3184 - Financialacls - avoid type error in symfony 6 - Option 2

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -14,15 +14,7 @@ use CRM_Financialacls_ExtensionUtil as E;
  */
 function financialacls_civicrm_config(&$config) {
   _financialacls_civix_civicrm_config($config);
-}
-
-/**
- * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
- */
-function financialacls_civicrm_container($container) {
-  $dispatcherDefn = $container->getDefinition('dispatcher');
-  $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
-  $dispatcherDefn->addMethodCall('addListener', ['civi.api4.authorizeRecord::Contribution', '_financialacls_civi_api4_authorizeContribution']);
+  \Civi::dispatcher()->addListener('civi.api4.authorizeRecord::Contribution', '_financialacls_civi_api4_authorizeContribution');
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3184

Before
----------------------------------------
Type error in symfony 6

After
----------------------------------------


Technical Details
----------------------------------------
See lab ticket.

Comments
----------------------------------------
This moves it to hook_civicrm_config, which is simpler code-wise than option 1, but executes at a later time.

I don't know how to _fully_ test the acl code since I don't really know how it's supposed to work or how to turn it on, but I can see the hook is being called when I view a contribution when logged in as a non-admin.