### PR TITLE
[REF] [Import] Clean up on map fields & preview templates in Contact import

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -209,7 +209,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
 
     // We should have the data in the DB now, parse it
     $importTableName = $this->get('importTableName');
-    $fieldNames = $this->_prepareImportTable($importTableName);
+    $this->_prepareImportTable($importTableName);
     $mapper = [];
 
     $parser = new CRM_Contact_Import_Parser_Contact($mapper);
@@ -219,8 +219,8 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
       $mapper,
       CRM_Import_Parser::MODE_MAPFIELD,
       $storeParams['contactType'],
-      $fieldNames['pk'],
-      $fieldNames['status'],
+      '_id',
+      '_status',
       CRM_Import_Parser::DUPLICATE_SKIP,
       NULL, NULL, FALSE,
       CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -246,7 +246,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     $dao = new CRM_Core_DAO();
     $db = $dao->getDatabaseConnection();
     $dataSource->postProcess($this->_params, $db, $this);
-    $this->updateUserJobMetadata('DataSource', $dataSource->getDataSourceMetadata());
   }
 
   /**

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -31,8 +31,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    //get the data from the session
-    $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
@@ -82,7 +80,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'locations',
       'phones',
       'ims',
-      'dataValues',
       'columnCount',
       'totalRowCount',
       'validRowCount',
@@ -103,6 +100,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
     }
+    $this->assign('dataValues', $this->getDataRows(2));
 
     $this->setStatusUrl();
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -184,17 +184,16 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->_mapperRelatedContactWebsiteType = $mapperRelatedContactWebsiteType;
     // get IM service provider type id for related contact
     $this->_mapperRelatedContactImProvider = &$mapperRelatedContactImProvider;
+    $this->setFieldMetadata();
+    foreach ($this->getImportableFieldsMetadata() as $name => $field) {
+      $this->addField($name, $field['title'], CRM_Utils_Array::value('type', $field), CRM_Utils_Array::value('headerPattern', $field), CRM_Utils_Array::value('dataPattern', $field), CRM_Utils_Array::value('hasLocationType', $field));
+    }
   }
 
   /**
    * The initializer code, called before processing.
    */
   public function init() {
-    $this->setFieldMetadata();
-    foreach ($this->getImportableFieldsMetadata() as $name => $field) {
-      $this->addField($name, $field['title'], CRM_Utils_Array::value('type', $field), CRM_Utils_Array::value('headerPattern', $field), CRM_Utils_Array::value('dataPattern', $field), CRM_Utils_Array::value('hasLocationType', $field));
-    }
-
     $this->_newContacts = [];
 
     $this->setActiveFields($this->_mapperKeys);
@@ -2598,9 +2597,17 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->_conflicts = [];
     $this->_unparsedAddresses = [];
 
+    // Transitional support for deprecating table_name (and other fields)
+    // form input - the goal is to load them from userJob - but eventually
+    // we will just load the datasource object and this code will not know the
+    // table name.
+    if (!$tableName && $this->userJobID) {
+      $tableName = $this->getUserJob()['metadata']['DataSource']['table_name'];
+    }
+
     $this->_tableName = $tableName;
-    $this->_primaryKeyName = $primaryKeyName;
-    $this->_statusFieldName = $statusFieldName;
+    $this->_primaryKeyName = '_id';
+    $this->_statusFieldName = '_status';
 
     if ($mode == self::MODE_MAPFIELD) {
       $this->_rows = [];

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -333,4 +333,52 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $this->userJob['metadata'] = $metaData;
   }
 
+  /**
+   * Get column headers for the datasource or empty array if none apply.
+   *
+   * This would be the first row of a csv or the fields in an sql query.
+   *
+   * If the csv does not have a header row it will be empty.
+   *
+   * @return array
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getColumnHeaders(): array {
+    return $this->getDataSourceObject()->getColumnHeaders();
+  }
+
+  /**
+   * Get the number of importable columns in the data source.
+   *
+   * @return int
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getNumberOfColumns(): int {
+    return $this->getDataSourceObject()->getNumberOfColumns();
+  }
+
+  /**
+   * Get x data rows from the datasource.
+   *
+   * At this stage we are fetching from what has been stored in the form
+   * during `postProcess` on the DataSource form.
+   *
+   * In the future we will use the dataSource object, likely
+   * supporting offset as well.
+   *
+   * @param int $limit
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
+   */
+  protected function getDataRows(int $limit): array {
+    return $this->getDataSourceObject()->getRows($limit);
+  }
+
 }

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -19,7 +19,7 @@
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   {* Table for mapping data to CRM fields *}
- {include file="CRM/Contact/Import/Form/MapTable.tpl}
+ {include file="CRM/Contact/Import/Form/MapTable.tpl" mapper=$form.mapper}
 
 <script type="text/javascript" >
 {literal}

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -16,42 +16,34 @@
     {if $savedMappingName}
         <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
     {/if}
-        <tr class="columnheader">
-      {if $showColNames}
-          {assign var="totalRowsDisplay" value=$rowDisplayCount+1}
-      {else}
-          {assign var="totalRowsDisplay" value=$rowDisplayCount}
-      {/if}
-            {section name=rows loop=$totalRowsDisplay}
-                {if $smarty.section.rows.iteration == 1 and $showColNames}
-                  <td>{ts}Column Names{/ts}</td>
-                {elseif $showColNames}
-                  <td>{ts 1=$smarty.section.rows.iteration-1}Import Data (row %1){/ts}</td>
-    {else}
-      <td>{ts 1=$smarty.section.rows.iteration}Import Data (row %1){/ts}</td>
-                {/if}
-            {/section}
 
-            <td>{ts}Matching CiviCRM Field{/ts}</td>
-        </tr>
+    {* Header row - has column for column names if they have been supplied *}
+    <tr class="columnheader">
+      {if $columnNames}
+        <td>{ts}Column Names{/ts}</td>
+      {/if}
+      {foreach from=$dataValues item=row key=index}
+        {math equation="x + y" x=$index y=1 assign="rowNumber"}
+        <td>{ts 1=$rowNumber}Import Data (row %1){/ts}</td>
+      {/foreach}
+      <td>{ts}Matching CiviCRM Field{/ts}</td>
+    </tr>
 
         {*Loop on columns parsed from the import data rows*}
-        {section name=cols loop=$columnCount}
-            {assign var="i" value=$smarty.section.cols.index}
+        {foreach from=$mapper key=i item=mapperField}
+
             <tr style="border: 1px solid #DDDDDD;">
 
-                {if $showColNames}
-                    <td class="even-row labels">{$columnNames[$i]}</td>
+                {if array_key_exists($i, $columnNames)}
+                  <td class="even-row labels">{$columnNames[$i]}</td>
                 {/if}
-
-                {section name=rows loop=$rowDisplayCount}
-                    {assign var="j" value=$smarty.section.rows.index}
-                    <td class="odd-row">{$dataValues[$j][$i]|escape}</td>
-                {/section}
+                {foreach from=$dataValues item=row key=index}
+                  <td class="odd-row">{$row[$i]|escape}</td>
+                {/foreach}
 
                 {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
                 <td class="form-item even-row{if $wizard.currentStepName == 'Preview'} labels{/if}">
-                    {if $wizard.currentStepName == 'Preview'}
+                  {if $wizard.currentStepName == 'Preview'}
                     {if $relatedContactDetails && $relatedContactDetails[$i] != ''}
                             {$mapper[$i]} - {$relatedContactDetails[$i]}
 
@@ -97,13 +89,13 @@
                                 {$mapper[$i]}
                             {*/if*}
                         {/if}
-                    {else}
-                        {$form.mapper[$i].html|smarty:nodefaults}
-                    {/if}
+                  {else}
+                    {$mapperField.html|smarty:nodefaults}
+                  {/if}
                 </td>
 
             </tr>
-        {/section}
+        {/foreach}
 
     </table>
   {/strip}


### PR DESCRIPTION
Overview
----------------------------------------
Builds on  https://github.com/civicrm/civicrm-core/pull/23245 

This provides a bit of sanity to the MapTable.tpl which is included from
    MapField and Preview - the focus being around getting
    rid of all the section tags which rely on Count being assigned
    and getting back to for-eaching the relevant arrays

Before
----------------------------------------
Lots of crazy values being calculated to use [smarty section syntax](https://www.smarty.net/docs/en/language.function.section.tpl) - despite the docs saying

![image](https://user-images.githubusercontent.com/336308/164163847-14b36aca-0346-44c9-be58-3b98139137c8.png)


After
----------------------------------------
Use of foreach - affects MapField and Preview screens in the contact import flow

eg. from the map field screen (in this case with an SQL data source using SELECT first_name, last_name from civicrm_contact)

![image](https://user-images.githubusercontent.com/336308/164164153-4695a97b-1667-49ff-8c3b-3b6d084ed596.png)

![image](https://user-images.githubusercontent.com/336308/164164016-a14a682a-8dc4-4221-8e88-0daadb73b1a0.png)



Technical Details
----------------------------------------


Comments
----------------------------------------
