### PR TITLE
[REF] [Import] Remove another good intention from the import class

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -594,12 +594,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         }
       }
 
-      // we give the derived class a way of aborting the process
-      // note that the return code could be multiple code or'ed together
-      if ($returnCode & self::STOP) {
-        break;
-      }
-
       // if we are done processing the maxNumber of lines, break
       if ($this->_maxLinesToProcess > 0 && $this->_validCount >= $this->_maxLinesToProcess) {
         break;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2714,11 +2714,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         array_unshift($values, $this->_rowCount);
         $this->_unparsedAddresses[] = $values;
       }
-      // we give the derived class a way of aborting the process
-      // note that the return code could be multiple code or'ed together
-      if ($returnCode & self::STOP) {
-        break;
-      }
 
       // see if we've hit our timeout yet
       /* if ( $the_thing_with_the_stuff ) {

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -340,12 +340,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         }
       }
 
-      // we give the derived class a way of aborting the process
-      // note that the return code could be multiple code or'ed together
-      if ($returnCode == self::STOP) {
-        break;
-      }
-
       // if we are done processing the maxNumber of lines, break
       if ($this->_maxLinesToProcess > 0 && $this->_validCount >= $this->_maxLinesToProcess) {
         break;

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -504,12 +504,6 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
         }
       }
 
-      // we give the derived class a way of aborting the process
-      // note that the return code could be multiple code or'ed together
-      if ($returnCode & self::STOP) {
-        break;
-      }
-
       // if we are done processing the maxNumber of lines, break
       if ($this->_maxLinesToProcess > 0 && $this->_validCount >= $this->_maxLinesToProcess) {
         break;

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -861,12 +861,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         }
       }
 
-      // we give the derived class a way of aborting the process
-      // note that the return code could be multiple code or'ed together
-      if ($returnCode & self::STOP) {
-        break;
-      }
-
       // if we are done processing the maxNumber of lines, break
       if ($this->_maxLinesToProcess > 0 && $this->_validCount >= $this->_maxLinesToProcess) {
         break;

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -231,12 +231,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         }
       }
 
-      // we give the derived class a way of aborting the process
-      // note that the return code could be multiple code or'ed together
-      if ($returnCode & self::STOP) {
-        break;
-      }
-
       // if we are done processing the maxNumber of lines, break
       if ($this->_maxLinesToProcess > 0 && $this->_validCount >= $this->_maxLinesToProcess) {
         break;


### PR DESCRIPTION
Once upon a time - the import classes were written....

Back then it seemed like a good idea to give the derived classes
a way to abort processing.

Like unicorns and mermaids derived classes turned out to
be mythical creatures - not even found by searching the
git universe....
