### PR TITLE
 [Import] Rename dedupe rule id field from dedupe to dedupe_rule_id field

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -209,7 +209,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
 
     // We should have the data in the DB now, parse it
     $importTableName = $this->get('importTableName');
-    $fieldNames = $this->_prepareImportTable($importTableName);
+    $this->_prepareImportTable($importTableName);
     $mapper = [];
 
     $parser = new CRM_Contact_Import_Parser_Contact($mapper);
@@ -219,8 +219,8 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
       $mapper,
       CRM_Import_Parser::MODE_MAPFIELD,
       $storeParams['contactType'],
-      $fieldNames['pk'],
-      $fieldNames['status'],
+      '_id',
+      '_status',
       CRM_Import_Parser::DUPLICATE_SKIP,
       NULL, NULL, FALSE,
       CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -111,7 +111,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions, [], NULL, FALSE, $contactTypeAttributes);
 
     $this->addElement('select', 'subType', ts('Subtype'));
-    $this->addElement('select', 'dedupe', ts('Dedupe Rule'));
+    $this->addElement('select', 'dedupe_rule_id', ts('Dedupe Rule'));
 
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
 
@@ -182,19 +182,18 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     $this->_params = $this->controller->exportValues($this->_name);
 
     $storeParams = [
-      'onDuplicate' => $this->exportValue('onDuplicate'),
-      'dedupe' => $this->exportValue('dedupe'),
-      'contactType' => $this->exportValue('contactType'),
-      'contactSubType' => $this->exportValue('subType'),
-      'dateFormats' => $this->exportValue('dateFormats'),
-      'savedMapping' => $this->exportValue('savedMapping'),
+      'onDuplicate' => $this->getSubmittedValue('onDuplicate'),
+      'dedupe' => $this->getSubmittedValue('dedupe_rule_id'),
+      'contactType' => $this->getSubmittedValue('contactType'),
+      'contactSubType' => $this->getSubmittedValue('subType'),
+      'dateFormats' => $this->getSubmittedValue('dateFormats'),
+      'savedMapping' => $this->getSubmittedValue('savedMapping'),
     ];
 
     foreach ($storeParams as $storeName => $value) {
       $this->set($storeName, $value);
     }
-    $this->set('disableUSPS', !empty($this->_params['disableUSPS']));
-
+    $this->set('disableUSPS', $this->getSubmittedValue('disableUSPS'));
     $this->set('dataSource', $this->getSubmittedValue('dataSource'));
     $this->set('skipColumnHeader', CRM_Utils_Array::value('skipColumnHeader', $this->_params));
 
@@ -216,16 +215,16 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     $parser->setMaxLinesToProcess(100);
     $parser->setUserJobID($this->getUserJobID());
     $parser->run($importTableName,
-      $mapper,
+      [],
       CRM_Import_Parser::MODE_MAPFIELD,
-      $storeParams['contactType'],
+      $this->getSubmittedValue('contactType'),
       '_id',
       '_status',
       CRM_Import_Parser::DUPLICATE_SKIP,
       NULL, NULL, FALSE,
       CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
-      $storeParams['contactSubType'],
-      $storeParams['dedupe']
+      $this->getSubmittedValue('contactSubType'),
+      $this->getSubmittedValue('dedupe_rule_id')
     );
 
     // add all the necessary variables to the form

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -246,7 +246,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     $dao = new CRM_Core_DAO();
     $db = $dao->getDatabaseConnection();
     $dataSource->postProcess($this->_params, $db, $this);
-    $this->updateUserJobMetadata('DataSource', $dataSource->getDataSourceMetadata());
   }
 
   /**

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -707,7 +707,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       NULL, NULL, FALSE,
       CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
       $this->get('contactSubType'),
-      $this->get('dedupe')
+      $this->getSubmittedValue('dedupe_rule_id')
     );
     return $parser;
   }

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -214,7 +214,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'invalidRowCount' => $this->get('invalidRowCount'),
       'conflictRowCount' => $this->get('conflictRowCount'),
       'onDuplicate' => $this->get('onDuplicate'),
-      'dedupe' => $this->get('dedupe'),
+      'dedupe' => $this->getSubmittedValue('dedupe_rule_id'),
       'newGroupName' => $this->controller->exportValue($this->_name, 'newGroupName'),
       'newGroupDesc' => $this->controller->exportValue($this->_name, 'newGroupDesc'),
       'newGroupType' => $this->controller->exportValue($this->_name, 'newGroupType'),

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -31,8 +31,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    //get the data from the session
-    $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
     $conflictRowCount = $this->get('conflictRowCount');
@@ -82,7 +80,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'locations',
       'phones',
       'ims',
-      'dataValues',
       'columnCount',
       'totalRowCount',
       'validRowCount',
@@ -103,6 +100,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
     }
+    $this->assign('dataValues', $this->getDataRows(2));
 
     $this->setStatusUrl();
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -184,17 +184,16 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->_mapperRelatedContactWebsiteType = $mapperRelatedContactWebsiteType;
     // get IM service provider type id for related contact
     $this->_mapperRelatedContactImProvider = &$mapperRelatedContactImProvider;
+    $this->setFieldMetadata();
+    foreach ($this->getImportableFieldsMetadata() as $name => $field) {
+      $this->addField($name, $field['title'], CRM_Utils_Array::value('type', $field), CRM_Utils_Array::value('headerPattern', $field), CRM_Utils_Array::value('dataPattern', $field), CRM_Utils_Array::value('hasLocationType', $field));
+    }
   }
 
   /**
    * The initializer code, called before processing.
    */
   public function init() {
-    $this->setFieldMetadata();
-    foreach ($this->getImportableFieldsMetadata() as $name => $field) {
-      $this->addField($name, $field['title'], CRM_Utils_Array::value('type', $field), CRM_Utils_Array::value('headerPattern', $field), CRM_Utils_Array::value('dataPattern', $field), CRM_Utils_Array::value('hasLocationType', $field));
-    }
-
     $this->_newContacts = [];
 
     $this->setActiveFields($this->_mapperKeys);
@@ -2598,9 +2597,17 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->_conflicts = [];
     $this->_unparsedAddresses = [];
 
+    // Transitional support for deprecating table_name (and other fields)
+    // form input - the goal is to load them from userJob - but eventually
+    // we will just load the datasource object and this code will not know the
+    // table name.
+    if (!$tableName && $this->userJobID) {
+      $tableName = $this->getUserJob()['metadata']['DataSource']['table_name'];
+    }
+
     $this->_tableName = $tableName;
-    $this->_primaryKeyName = $primaryKeyName;
-    $this->_statusFieldName = $statusFieldName;
+    $this->_primaryKeyName = '_id';
+    $this->_statusFieldName = '_status';
 
     if ($mode == self::MODE_MAPFIELD) {
       $this->_rows = [];

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -104,9 +104,13 @@ class CRM_Import_Forms extends CRM_Core_Form {
     'fieldSeparator' => 'DataSource',
     'uploadFile' => 'DataSource',
     'contactType' => 'DataSource',
+    'contactSubType' => 'DataSource',
     'dateFormats' => 'DataSource',
     'savedMapping' => 'DataSource',
     'dataSource' => 'DataSource',
+    'dedupe_rule_id' => 'DataSource',
+    'onDuplicate' => 'DataSource',
+    'disableUSPS' => 'DataSource',
   ];
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -333,4 +333,52 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $this->userJob['metadata'] = $metaData;
   }
 
+  /**
+   * Get column headers for the datasource or empty array if none apply.
+   *
+   * This would be the first row of a csv or the fields in an sql query.
+   *
+   * If the csv does not have a header row it will be empty.
+   *
+   * @return array
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getColumnHeaders(): array {
+    return $this->getDataSourceObject()->getColumnHeaders();
+  }
+
+  /**
+   * Get the number of importable columns in the data source.
+   *
+   * @return int
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getNumberOfColumns(): int {
+    return $this->getDataSourceObject()->getNumberOfColumns();
+  }
+
+  /**
+   * Get x data rows from the datasource.
+   *
+   * At this stage we are fetching from what has been stored in the form
+   * during `postProcess` on the DataSource form.
+   *
+   * In the future we will use the dataSource object, likely
+   * supporting offset as well.
+   *
+   * @param int $limit
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \API_Exception
+   */
+  protected function getDataRows(int $limit): array {
+    return $this->getDataSourceObject()->getRows($limit);
+  }
+
 }

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -43,8 +43,8 @@
              <td>{$form.onDuplicate.html} {help id='dupes'}</td>
          </tr>
          <tr class="crm-import-datasource-form-block-dedupe">
-             <td class="label">{$form.dedupe.label}</td>
-             <td><span id="contact-dedupe">{$form.dedupe.html}</span> {help id='id-dedupe_rule'}</td>
+             <td class="label">{$form.dedupe_rule_id.label}</td>
+             <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule'}</td>
          </tr>
          <tr class="crm-import-datasource-form-block-fieldSeparator">
              <td class="label">{$form.fieldSeparator.label}</td>
@@ -151,16 +151,16 @@
 
                         success: function(dedupe){
                                                    if ( dedupe.length == 0 ) {
-                                                      cj("#dedupe").empty();
+                                                      cj("#dedupe_rule_id").empty();
                                                       cj("#contact-dedupe").hide();
                                                    } else {
                                                        cj("#contact-dedupe").show();
-                                                       cj("#dedupe").empty();
+                                                       cj("#dedupe_rule_id").empty();
 
-                                                       cj("#dedupe").append("<option value=''>- {/literal}{ts escape='js'}select{/ts}{literal} -</option>");
+                                                       cj("#dedupe_rule_id").append("<option value=''>- {/literal}{ts escape='js'}select{/ts}{literal} -</option>");
                                                        for ( var key in  dedupe ) {
                                                            // stick these new options in the dedupe select
-                                                           cj("#dedupe").append("<option value="+key+">"+dedupe[key]+" </option>");
+                                                           cj("#dedupe_rule_id").append("<option value="+key+">"+dedupe[key]+" </option>");
                                                        }
                                                    }
 

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -19,7 +19,7 @@
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
   {* Table for mapping data to CRM fields *}
- {include file="CRM/Contact/Import/Form/MapTable.tpl}
+ {include file="CRM/Contact/Import/Form/MapTable.tpl" mapper=$form.mapper}
 
 <script type="text/javascript" >
 {literal}

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -16,42 +16,34 @@
     {if $savedMappingName}
         <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
     {/if}
-        <tr class="columnheader">
-      {if $showColNames}
-          {assign var="totalRowsDisplay" value=$rowDisplayCount+1}
-      {else}
-          {assign var="totalRowsDisplay" value=$rowDisplayCount}
-      {/if}
-            {section name=rows loop=$totalRowsDisplay}
-                {if $smarty.section.rows.iteration == 1 and $showColNames}
-                  <td>{ts}Column Names{/ts}</td>
-                {elseif $showColNames}
-                  <td>{ts 1=$smarty.section.rows.iteration-1}Import Data (row %1){/ts}</td>
-    {else}
-      <td>{ts 1=$smarty.section.rows.iteration}Import Data (row %1){/ts}</td>
-                {/if}
-            {/section}
 
-            <td>{ts}Matching CiviCRM Field{/ts}</td>
-        </tr>
+    {* Header row - has column for column names if they have been supplied *}
+    <tr class="columnheader">
+      {if $columnNames}
+        <td>{ts}Column Names{/ts}</td>
+      {/if}
+      {foreach from=$dataValues item=row key=index}
+        {math equation="x + y" x=$index y=1 assign="rowNumber"}
+        <td>{ts 1=$rowNumber}Import Data (row %1){/ts}</td>
+      {/foreach}
+      <td>{ts}Matching CiviCRM Field{/ts}</td>
+    </tr>
 
         {*Loop on columns parsed from the import data rows*}
-        {section name=cols loop=$columnCount}
-            {assign var="i" value=$smarty.section.cols.index}
+        {foreach from=$mapper key=i item=mapperField}
+
             <tr style="border: 1px solid #DDDDDD;">
 
-                {if $showColNames}
-                    <td class="even-row labels">{$columnNames[$i]}</td>
+                {if array_key_exists($i, $columnNames)}
+                  <td class="even-row labels">{$columnNames[$i]}</td>
                 {/if}
-
-                {section name=rows loop=$rowDisplayCount}
-                    {assign var="j" value=$smarty.section.rows.index}
-                    <td class="odd-row">{$dataValues[$j][$i]|escape}</td>
-                {/section}
+                {foreach from=$dataValues item=row key=index}
+                  <td class="odd-row">{$row[$i]|escape}</td>
+                {/foreach}
 
                 {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
                 <td class="form-item even-row{if $wizard.currentStepName == 'Preview'} labels{/if}">
-                    {if $wizard.currentStepName == 'Preview'}
+                  {if $wizard.currentStepName == 'Preview'}
                     {if $relatedContactDetails && $relatedContactDetails[$i] != ''}
                             {$mapper[$i]} - {$relatedContactDetails[$i]}
 
@@ -97,13 +89,13 @@
                                 {$mapper[$i]}
                             {*/if*}
                         {/if}
-                    {else}
-                        {$form.mapper[$i].html|smarty:nodefaults}
-                    {/if}
+                  {else}
+                    {$mapperField.html|smarty:nodefaults}
+                  {/if}
                 </td>
 
             </tr>
-        {/section}
+        {/foreach}
 
     </table>
   {/strip}


### PR DESCRIPTION
Overview
----------------------------------------
 [Import] Rename dedupe rule id field from dedupe to dedupe_rule_id field

Builds on other open prs - if they are merged this can be rebased down....
    


Before
----------------------------------------
The field name for 'dedupe_rule_id' is 'dedupe;

After
----------------------------------------
Renamed to 'dedupe_rule_id' in the Contact flow -     It is still dedupe internally as those places will 'age out'

Technical Details
----------------------------------------
A universe search showed that @mlutfy's advanced import extension refers to the form value (which is unchanged in this PR) - however, I think it's probably best that once this piece of work is all merged I work with @mlutfy to update advanced import as there are a bunch of things it does where core code could be leveraged  - e.g the 'dedupe' value is saved to ` civicrm_advimport` - but that will be redundant as submitted_values are  being saved to the new `civicrm_user_job` once the open PRs are merged.so advimport can access from there.

Comments
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/23245 and #23260 - can be rebased when that is merged (or that will close when this is is merged)