### PR TITLE
dev/user-interface#47 Disable scrolling on time inputs

### DIFF
--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -44,6 +44,7 @@
           .change(updateDataField)
           .timeEntry({
             spinnerImage: '',
+            useMouseWheel: false,
             show24Hours: settings.time === true || settings.time === undefined ? CRM.config.timeIs24Hr : settings.time == '24'
           });
         if (!placeholder) {


### PR DESCRIPTION
Overview
----------------------------------------

The time widgets used by CiviCRM are a bit sensitive. Combined to the fact that we often have rather long forms (ex: Event Management), an admin can easily accidentally change the time of an event.

To reproduce:

* Go to Event > New Event
* Scroll on the page
* scroll over a time widget (ex: time of the event)

notice how the time was changed.

I feel like this is not useful at all, because the scrolling is super sensitive, and I find it pretty hard to really set the right time using scrolling.

https://lab.civicrm.org/dev/user-interface/-/issues/47

Before
----------------------------------------

![ui47scrolling-fixed](https://user-images.githubusercontent.com/254741/164291779-4c657eea-7798-45f3-b52f-be83f89eed44.gif)


After
----------------------------------------

Scrolling over the time input will scroll the page, but not the time.

Technical Details
----------------------------------------

Widget docs: http://keith-wood.name/timeEntry.html

Comments
----------------------------------------

A few users complained about this. The scrolling time makes them very uncomfortable about accidentally breaking things.

Drupal9 devs testing this need to run composer so that the `/libraries` folder is updated as well.