### PR TITLE
SearchKit - Fix selection of fields when creating a Data Segment

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.component.js
@@ -6,7 +6,7 @@
       segmentId: '<',
     },
     templateUrl: '~/crmSearchAdmin/searchSegment/crmSearchAdminSegment.html',
-    controller: function ($scope, searchMeta, dialogService, crmApi4, crmStatus, formatForSelect2) {
+    controller: function ($scope, searchMeta, dialogService, crmApi4, crmStatus) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         originalEntity,
@@ -86,8 +86,18 @@
         return searchMeta.getField(fieldName, ctrl.segment.entity_name);
       };
 
+      // Select2-formatted fields that can be used in "when" clause, including :name suffix if applicable
       this.selectFields = function() {
-        return {results: formatForSelect2(searchMeta.getEntity(ctrl.segment.entity_name).fields, 'name', 'label', ['description'])};
+        var fields = {results: []};
+        _.each(searchMeta.getEntity(ctrl.segment.entity_name).fields, function(field) {
+          var item = {
+            id: field.name + (field.suffixes && _.includes(field.suffixes, 'name') ? ':name' : ''),
+            text: field.label,
+            description: field.description
+          };
+          fields.results.push(item);
+        });
+        return fields;
       };
 
       this.save = function() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug documented in https://github.com/civicrm/civicrm-core/pull/23059#issuecomment-1104136948

Before
----------------------------------------
Creating a SearchSegment in the UI doesn't work right for fields with options.

After
----------------------------------------
Works.

Note
----------------
Any broken segments created while testing the last PR should be deleted and recreated with the fixed UI.