### PR TITLE
APIv4 - Avoid php error

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -219,7 +219,7 @@ class Api4SelectQuery {
     }
     else {
       if ($this->forceSelectId) {
-        $keys = CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
+        $keys = (array) CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
         $select = array_merge($keys, $select);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevents a potential php error during upgrade mode.

Before
----------------------------------------
In some scenarios this can cause a php error when calling `array_merge()` on `null`, particularly when extension upgrades are pending.

After
----------------------------------------
No error.