### PR TITLE
dev/core#3184 - Definitively load mainfiles during bootstrap - Option 3

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -617,6 +617,7 @@ class Container {
       \CRM_Extension_System::singleton(TRUE);
       \CRM_Extension_System::singleton()->getClassLoader()->register();
       \CRM_Extension_System::singleton()->getMixinLoader()->run();
+      \CRM_Utils_Hook::singleton()->commonBuildModuleList('civicrm_boot');
       $bootServices['dispatcher.boot']->setDispatchPolicy($mainDispatchPolicy);
 
       $runtime->includeCustomPath();


### PR DESCRIPTION
Overview
----------------------------------------

Each extension defines some main/top-level PHP file (eg `myext.php` or `mymodule.php`; hereafter, "mainfiles"). However, the moment of loading that file is somewhat indefinite. This makes it definitive.

Before
----------------------------------------

Responsibility for loading the mainfiles lies in `CRM_Utils_Hook`. As soon you as dispatch a hook, it will get a list of all active extensions and load the files.

But which hook fires first? That's the indefinite part. For example, consider that (during bootstrap) the system initializes the container (`Civi\Core\Container->loadContainer()`); this has two major paths:

* If there is no valid container-cache, it will make one. During this process, it fires `hook_civicrm_container`. (*It does load mainfiles.*)
* If there is a valid container-cache, it will load that file and return. It does _not_ fire any hooks. (*It does not load mainfiles.*)

Thus, sometimes, `loadContainer()` may have the effect of also loading the extension files. But other times it does not.

After
----------------------------------------

The code for loading the mainfiles is still physically in the same place (`CRM_Utils_Hook`). But the activation changes - it _always_ runs during the bootstrap. Note the placement:

* It runs just after the class-loader and mixin-loader. 
    * This means the mainfile can reference classes and any other outputs from the mixins.
* It runs just before the container starts.
    * This means that the container can reference functions in the mainfile.
* This placement is fairly close to where it happened before (in the case of an uncached container).

Technical Details
----------------------------------------

Aside: How can we be sure that hooks don't fire somewhere else? In `Civi\Core\Container::boot()`, note the boundaries of the `dispatchPolicy`. Hooks are generally blocked from firing until the `dispatchPolicy` is relaxed. `loadContainer()` comes right after the policy is relaxed. This means that `loadContainer`/`hook_container` is the earliest opportunity to load mainfiles (notwithstanding some obscure hypotheticals around `includeCustomPath`).
