### PR TITLE
Remove preferred email format from inline edit

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -68,8 +68,6 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
     //using for display purpose.
     $form->assign('commPreference', $commPreference);
 
-    $form->addField('preferred_mail_format', ['entity' => 'contact', 'label' => ts('Email Format')]);
-
     $form->addField('is_opt_out', ['entity' => 'contact', 'label' => ts('NO BULK EMAILS (User Opt Out)')]);
 
     $form->addField('communication_style_id', ['entity' => 'contact', 'type' => 'RadioGroup']);

--- a/templates/CRM/Contact/Form/Contact.hlp
+++ b/templates/CRM/Contact/Form/Contact.hlp
@@ -7,19 +7,13 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{htxt id="id-emailFormat-title"}
-  {ts}Email Format{/ts}
-{/htxt}
-{htxt id="id-emailFormat"}
-{ts}Select the email format preferred by this contact. Select 'Both' to send HTML and Text formats.{/ts}
-{/htxt}
 
 {htxt id="id-bulkmail-title"}
   {ts}Bulk Mailings{/ts}
 {/htxt}
 {htxt id="id-bulkmail"}
 {ts}If you are using the CiviMail component to send mailings to contacts, this field provides additional control over which email address is used. By default, CiviMail sends mail to each contact's preferred email address. If the contact has multiple locations, then the preferred email of the primary location is used. However, if the contact prefers to have CiviMail ('bulk') mailings set to an alternate email address - check the 'Use for Bulk Mailings' box next to that email address.{/ts}
-{/htxt} 
+{/htxt}
 
 {htxt id="id-optOut-title"}
   {ts}Opt Out{/ts}


### PR DESCRIPTION
We removed other places in the UI where this shows up....
