### PR TITLE
Add a hidden total_amount element to priceset lineitems so total amount can be extracted using javascript

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -87,6 +87,8 @@
         </div>
         {assign var="totalAmount" value=$pendingAmount}
         {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+        {* This is required to allow the total_amount to be extracted from the form using javascript (eg. for Stripe) *}
+        <input type="hidden" id="total_amount" name="total_amount" value="{$totalAmount}">
       {else}
         <div class="display-block">
           <td class="label">{$form.total_amount.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes https://lab.civicrm.org/extensions/stripe/-/issues/348 and makes it easier for total amount to be extracted from a contribution page with a priceset.
It appears that this only becomes a problem when you are using the contribution page in "invoice" mode (ie. you specify ccid=X where X is a pending contribution) and the pending contribution has a lineitem with qty > 1.

Before
----------------------------------------
Total amount cannot be extracted from the contribution page in a sensible way.

After
----------------------------------------
Total amount can be extracted from the contribution page using the hidden total_amount input element.

Technical Details
----------------------------------------
See https://lab.civicrm.org/extensions/stripe/-/issues/348

Comments
----------------------------------------
As mentioned by @mlutfy this "fix" is probably a bit hacky. But without rewriting the entire contribution page template it is probably the safest and simplest fix. It will only "load" on the main contribution page and only if we are loading the LineItem.tpl.