### PR TITLE
SearchKit - Fix aggregation issues & test regression

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SavedSearchInspectorTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SavedSearchInspectorTrait.php
@@ -157,8 +157,10 @@ trait SavedSearchInspectorTrait {
    * @return bool
    */
   private function canAggregate($fieldPath) {
-    $apiParams = $this->savedSearch['api_params'] ?? [];
+    // Disregard suffix
+    [$fieldPath] = explode(':', $fieldPath);
     $field = $this->getField($fieldPath);
+    $apiParams = $this->savedSearch['api_params'] ?? [];
 
     // If the query does not use grouping or the field doesn't exist, never
     if (empty($apiParams['groupBy']) || !$field) {
@@ -170,8 +172,7 @@ trait SavedSearchInspectorTrait {
     }
 
     // If the entity this column belongs to is being grouped by id, then also no
-    $suffix = strstr($fieldPath, ':') ?: '';
-    $idField = substr($fieldPath, 0, 0 - strlen($field['name'] . $suffix)) . CoreUtil::getIdFieldName($field['entity']);
+    $idField = substr($fieldPath, 0, 0 - strlen($field['name'])) . CoreUtil::getIdFieldName($field['entity']);
     return !in_array($idField, $apiParams['groupBy']);
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -430,7 +430,7 @@
         }
         var arg = _.findWhere(searchMeta.parseExpr(col).args, {type: 'field'}) || {};
         // If the column is not a database field, no
-        if (!arg.field || !arg.field.entity || !_.includes(['Field', 'Custom'], arg.field.type)) {
+        if (!arg.field || !arg.field.entity || !_.includes(['Field', 'Custom', 'Extra'], arg.field.type)) {
           return false;
         }
         // If the column is used for a groupBy, no


### PR DESCRIPTION
Overview
----------------
Fixes recent SearchKit test regression caused by #23247 and a UI bug when using calculated fields with Group By.

Technical Details
-----------------
In the UI, "Extra" fields like `Contact.age_years` were not being aggregated properly.

On the server, fixes mismatch when checking an aggregate field with a suffix.

Fixes recent test regression caused by #23247.