### PR TITLE
[REF] [Import] Simplify dataSource contract - remove unused preProcess

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -139,13 +139,6 @@ abstract class CRM_Import_DataSource {
   abstract public function getInfo();
 
   /**
-   * Set variables up before form is built.
-   *
-   * @param CRM_Core_Form $form
-   */
-  abstract public function preProcess(&$form);
-
-  /**
    * This is function is called by the form object to get the DataSource's form snippet.
    *
    * It should add all fields necessary to get the data uploaded to the temporary table in the DB.
@@ -153,15 +146,6 @@ abstract class CRM_Import_DataSource {
    * @param CRM_Core_Form $form
    */
   abstract public function buildQuickForm(&$form);
-
-  /**
-   * Process the form submission.
-   *
-   * @param array $params
-   * @param string $db
-   * @param CRM_Core_Form $form
-   */
-  abstract public function postProcess(&$params, &$db, &$form);
 
   /**
    * Determine if the current user has access to this data source.

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -36,14 +36,6 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
   }
 
   /**
-   * Set variables up before form is built.
-   *
-   * @param CRM_Core_Form $form
-   */
-  public function preProcess(&$form) {
-  }
-
-  /**
    * This is function is called by the form object to get the DataSource's form snippet.
    *
    * It should add all fields necessary to get the data
@@ -56,9 +48,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
   public function buildQuickForm(&$form) {
     $form->add('hidden', 'hidden_dataSource', 'CRM_Import_DataSource_CSV');
 
-    $config = CRM_Core_Config::singleton();
-
-    $uploadFileSize = CRM_Utils_Number::formatUnitSize($config->maxFileSize . 'm', TRUE);
+    $uploadFileSize = CRM_Utils_Number::formatUnitSize(Civi::settings()->get('maxFileSize') . 'm', TRUE);
     //Fetch uploadFileSize from php_ini when $config->maxFileSize is set to "no limit".
     if (empty($uploadFileSize)) {
       $uploadFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), TRUE);

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -37,14 +37,6 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
   }
 
   /**
-   * Set variables up before form is built.
-   *
-   * @param CRM_Core_Form $form
-   */
-  public function preProcess(&$form) {
-  }
-
-  /**
    * This is function is called by the form object to get the DataSource's
    * form snippet. It should add all fields necesarry to get the data
    * uploaded to the temporary table in the DB.


### PR DESCRIPTION
The choice of required functions was not great - postProcess passes silly
params & preProcess is never used / always empty - this removes preProcess
and gets rid of the abstract class for postProcess (which
will be decommissioned in a follow up)

