### PR TITLE
dev/core#3414 [REF] [Import] [Contact] - Move All table handling to be datasource object

### DIFF
--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -178,6 +178,7 @@ class CRM_Contact_Import_ImportJob {
       $parserParameters['mapperWebsiteType'],
       $parserParameters['relatedContactWebsiteType']
     );
+
     $this->_parser->setUserJobID($this->_userJobID);
     $this->_parser->run(NULL, $mapperFields,
       CRM_Import_Parser::MODE_IMPORT,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3414 [REF] [Import] [Contact] - Move All table handling to be datasource object #23273


Before
----------------------------------------
The datasources (CSV & SQL) set up temp tables to store the data to be imported - but then `DataSource` form class does an ALTER to add extra fields (`_status` and a primary key `_id` and `_statusMessage`) and the `DataSource` form class takes responsibility for dropping the tables on re-submit and tracking the table name

After
----------------------------------------
All handling of the temp tables is moved to the DataSource class . As discussed in https://lab.civicrm.org/dev/core/-/issues/3414 we no longer need to call the `Parser` class from the `DataSource` form as it is now just noise

Also note that the temp table is no longer dropped from the `Summary` form - this is because an intent is to allow the csv outcomes to be generated at will from the temp table (until it is cleaned up) rather than output them as the import runs

Technical Details
----------------------------------------

Comments
----------------------------------------

Note that some required PRs are included in this - they can be rebased out if merged first

https://github.com/civicrm/civicrm-core/pull/23276
https://github.com/civicrm/civicrm-core/pull/23284
https://github.com/civicrm/civicrm-core/pull/23279

Also - if those are merged I can split out the remainin commits - which do each stand alone and are fairly readable in isolation