### PR TITLE
Remove another good intention - unused variables

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -287,8 +287,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *   CRM_Import_Parser::ERROR or CRM_Import_Parser::VALID
    */
   public function summary(&$values): int {
-    $erroneousField = NULL;
-    $this->setActiveFieldValues($values, $erroneousField);
+    $this->setActiveFieldValues($values);
     $rowNumber = (int) ($values[count($values) - 1]);
     $errorMessage = NULL;
     $errorRequired = FALSE;

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -110,13 +110,11 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
    * @see CRM_Custom_Import_Parser_BaseClass::summary()
    */
   public function summary(&$values) {
-    $erroneousField = NULL;
-    $response = $this->setActiveFieldValues($values, $erroneousField);
+    $this->setActiveFieldValues($values);
     $errorRequired = FALSE;
     $missingField = '';
     $this->_params = &$this->getActiveFieldParams();
 
-    $formatted = $this->_params;
     $this->_updateWithId = FALSE;
     $this->_parseStreetAddress = CRM_Utils_Array::value('street_address_parsing', CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'address_options'), FALSE);
 

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -155,10 +155,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    *   the result of this processing
    */
   public function summary(&$values) {
-    $erroneousField = NULL;
-
-    $response = $this->setActiveFieldValues($values, $erroneousField);
-    $errorRequired = FALSE;
+    $this->setActiveFieldValues($values);
     $index = -1;
 
     if ($this->_eventIndex > -1 && $this->_eventTitleIndex > -1) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -255,12 +255,8 @@ abstract class CRM_Import_Parser {
    *
    * @param array $elements
    *   array.
-   * @param $erroneousField
-   *   reference.
-   *
-   * @return int
    */
-  public function setActiveFieldValues($elements, &$erroneousField = NULL) {
+  public function setActiveFieldValues($elements): void {
     $maxCount = count($elements) < $this->_activeFieldCount ? count($elements) : $this->_activeFieldCount;
     for ($i = 0; $i < $maxCount; $i++) {
       $this->_activeFields[$i]->setValue($elements[$i]);
@@ -270,18 +266,6 @@ abstract class CRM_Import_Parser {
     for (; $i < $this->_activeFieldCount; $i++) {
       $this->_activeFields[$i]->resetValue();
     }
-
-    // now validate the fields and return false if error
-    $valid = self::VALID;
-    for ($i = 0; $i < $this->_activeFieldCount; $i++) {
-      if (!$this->_activeFields[$i]->validate()) {
-        // no need to do any more validation
-        $erroneousField = $i;
-        $valid = self::ERROR;
-        break;
-      }
-    }
-    return $valid;
   }
 
   /**

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -508,8 +508,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    *   the result of this processing
    */
   public function summary(&$values) {
-    $erroneousField = NULL;
-    $this->setActiveFieldValues($values, $erroneousField);
+
+    $this->setActiveFieldValues($values);
 
     $errorRequired = FALSE;
 


### PR DESCRIPTION
100% of the responses from setActiveFields are discarded and 100% of the time
the erroneousField value is not used. Hence it makes sense to remove them....

