### PR TITLE
[Ref] [Import] Cleanup cleanup on old tables for form re-submission

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -176,6 +176,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
       $this->createUserJob();
     }
     else {
+      $this->flushDataSource();
       $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     }
     // Setup the params array
@@ -209,11 +210,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
 
     CRM_Core_Session::singleton()->set('dateTypes', $storeParams['dateFormats']);
 
-    //hack to prevent multiple tables.
-    $this->_params['import_table_name'] = $this->get('importTableName');
-    if (!$this->_params['import_table_name']) {
-      $this->_params['import_table_name'] = 'civicrm_import_job_' . md5(uniqid(rand(), TRUE));
-    }
     $this->instantiateDataSource();
 
     // We should have the data in the DB now, parse it

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -83,7 +83,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     $result = self::_CsvToTable(
       $file,
       $firstRowIsColumnHeader,
-      CRM_Utils_Array::value('import_table_name', $params),
+      NULL,
       CRM_Utils_Array::value('fieldSeparator', $params, ',')
     );
 

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -86,7 +86,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
    */
   public function postProcess(&$params, &$db, &$form) {
     $importJob = new CRM_Contact_Import_ImportJob(
-      CRM_Utils_Array::value('import_table_name', $params),
+      NULL,
       $params['sqlQuery'], TRUE
     );
 

--- a/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
@@ -52,7 +52,6 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
    *
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testDataSources(): void {
     $this->createLoggedInUser();


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup cleanup on old tables for form re-submission

Before
----------------------------------------
The form needs to know about the table name

After
----------------------------------------
Responsibility is with the dataSource - the data source flushes the table, and the table is explicity flushed when it's clear the form is being re-submitted rather than in a hidden magic place

Technical Details
----------------------------------------

Comments
----------------------------------------
