### PR TITLE
Make static function static - processCaseTags

### DIFF
--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -23,7 +23,7 @@ class CRM_Case_Page_AJAX {
   /**
    * @throws \CRM_Core_Exception
    */
-  public function processCaseTags() {
+  public static function processCaseTags() {
 
     $caseId = CRM_Utils_Type::escape($_POST['case_id'], 'Positive');
     $tags = CRM_Utils_Type::escape($_POST['tag'], 'String');


### PR DESCRIPTION
Overview
----------------------------------------
Function is called via ajax so is [called statically](https://github.com/civicrm/civicrm-core/blob/5bab835a1cbe46e3c310cd28fd3f43b24f60a9ed/CRM/Case/xml/Menu/Case.xml#L122). Since it's an ajax popup the error goes unnoticed but it shows in drupal watchdog, or you can install the loudnotices extension.

Before
----------------------------------------
1. Create some case tags.
2. Go to manage case for a case.
3. Add some tags on the case or edit some tags if it has tags.
4. `Non-static method CRM_Case_Page_AJAX::processCaseTags() should not be called statically`

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
Function isn't called from anywhere else that I can see.
