### PR TITLE
[REF] [Import] Remove unused variable / form pass-thru

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -134,7 +134,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $defaults = [];
     $mapperKeys = array_keys($this->_mapperFields);
     $hasColumnNames = !empty($this->_columnNames);
-    $hasLocationTypes = $this->get('fieldTypes');
 
     $this->_location_types = ['Primary' => ts('Primary')] + CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
@@ -207,7 +206,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         $values = [];
         foreach ($relatedFields as $name => $field) {
           $values[$name] = $field['title'];
-          if (isset($hasLocationTypes[$name])) {
+          if ($this->isLocationTypeRequired($name)) {
             $sel3[$key][$name] = $this->_location_types;
           }
           elseif ($name === 'url') {
@@ -271,7 +270,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
       else {
         $options = NULL;
-        if (!empty($hasLocationTypes[$key])) {
+        if ($this->isLocationTypeRequired($key)) {
           $options = $this->_location_types;
         }
         elseif ($key === 'url') {
@@ -649,6 +648,21 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
     }
     return $highlightedFields;
+  }
+
+  /**
+   * Get an array of fields with TRUE or FALSE to reflect need for location type.
+   *
+   * e.g ['first_name' => FALSE, 'email' => TRUE, 'street_address' => TRUE']
+   *
+   * @return bool
+   */
+  private function isLocationTypeRequired($name): bool {
+    static $fields = NULL;
+    if (!$fields) {
+      $fields = (new CRM_Contact_Import_Parser_Contact())->setUserJobID($this->getUserJobID())->getSelectTypes();
+    }
+    return (bool) ($fields[$name] ?? FALSE);
   }
 
 }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2578,8 +2578,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param int $mode
    */
   public function set($store, $mode = self::MODE_SUMMARY) {
-    // To be removed in https://github.com/civicrm/civicrm-core/pull/23281
-    $store->set('fieldTypes', $this->getSelectTypes());
   }
 
   /**

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -502,7 +502,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -585,7 +585,6 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -133,7 +133,6 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     $hasHeaders = !empty($this->_columnHeaders);
     $headerPatterns = $this->get('headerPatterns');
     $dataPatterns = $this->get('dataPatterns');
-    $hasLocationTypes = $this->get('fieldTypes');
     /* Initialize all field usages to false */
 
     foreach ($mapperKeys as $key) {

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -949,7 +949,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -64,9 +64,12 @@ abstract class CRM_Import_Parser {
    * Set user job ID.
    *
    * @param int $userJobID
+   *
+   * @return self
    */
-  public function setUserJobID(int $userJobID): void {
+  public function setUserJobID(int $userJobID): self {
     $this->userJobID = $userJobID;
+    return $this;
   }
 
   /**
@@ -403,6 +406,9 @@ abstract class CRM_Import_Parser {
    */
   public function getSelectTypes() {
     $values = [];
+    // This is only called from the MapField form in isolation now,
+    // so we need to set the metadata.
+    $this->init();
     foreach ($this->_fields as $name => $field) {
       if (isset($field->_hasLocationType)) {
         $values[$name] = $field->_hasLocationType;

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -148,7 +148,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $hasHeaders = !empty($this->_columnHeaders);
     $headerPatterns = $this->get('headerPatterns');
     $dataPatterns = $this->get('dataPatterns');
-    $hasLocationTypes = $this->get('fieldTypes');
 
     /* Initialize all field usages to false */
 

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -342,7 +342,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Remove unused variable / form pass-thru

Passing selectTypes is a pattern copy & pasted from the contact import....

It returns

![image](https://user-images.githubusercontent.com/336308/164560301-a0bdddcb-7117-492d-bc28-768a426bd86e.png)


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/164560107-9c4ec88d-53e6-4247-9033-bb36634f1149.png)

![image](https://user-images.githubusercontent.com/336308/164560366-bb903c52-b7a2-45ee-9c4b-fecef3d56ad8.png)


![image](https://user-images.githubusercontent.com/336308/164560182-87e0bfed-ac59-430f-824a-aac981bf265d.png)

After
----------------------------------------
Location type field still being added on the only place that leverages this

![image](https://user-images.githubusercontent.com/336308/164561570-ef20b0c0-8aca-4c2c-85b1-6f16ade3f382.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
