### PR TITLE
[REF] Do not treat site having a default location type as optional

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -138,12 +138,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $this->_location_types = ['Primary' => ts('Primary')] + CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
-
-    // Pass default location to js
-    if ($defaultLocationType) {
-      $this->assign('defaultLocationType', $defaultLocationType->id);
-      $this->assign('defaultLocationTypeLabel', $this->_location_types[$defaultLocationType->id]);
-    }
+    $this->assign('defaultLocationType', $defaultLocationType->id);
+    $this->assign('defaultLocationTypeLabel', $this->_location_types[$defaultLocationType->id]);
 
     /* Initialize all field usages to false */
     foreach ($mapperKeys as $key) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Do not treat site having a default location type as optional

I found plenty of places where the code expects a response from
this function - just a couple of places in really old code
(like this) where it is optional....

For example - on the email edit form there is no allowance for there to be no default location type...


![image](https://user-images.githubusercontent.com/336308/164568142-5d119c05-9415-4752-bb8f-b171b44d486f.png)


Before
----------------------------------------
Extraneous IF

After
----------------------------------------
One less point of confusion

Technical Details
----------------------------------------

Comments
----------------------------------------
