### PR TITLE
[REF] Remove handling for non-existent 'savedMapping' field

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -382,13 +382,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function postProcess() {
     $params = $this->controller->exportValues('MapField');
-
-    //reload the mapfield if load mapping is pressed
-    if (!empty($params['savedMapping'])) {
-      $this->set('savedMapping', $params['savedMapping']);
-      $this->controller->resetPage($this->_name);
-      return;
-    }
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $parser = $this->submit($params);
 


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Remove handling for non-existent 'savedMapping' field

Before
----------------------------------------
The `mapField` class has handling for the field `savedMapping` - however this field is NOT present on the `mapField` form - it IS present on the `DataSource` form - but that isn't accessed by the mapField class - so I can't see any way the inside of the removed IF is reachable.

`MapField` does have the field `saveMapping` - the difference is not a typo - the field on `DataSource` would ideally be `saved_mapping_id` whereas `saveMapping` is an instruction to save the mapping

After
----------------------------------------
poof

Technical Details
----------------------------------------
This pattern is repeated across all the `MapField` classes so my analysis here is right then I can remove in the others too

Comments
----------------------------------------
I did an r-run in the Membership import