### PR TITLE
[REF] [Import] Extract getContactType

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -89,20 +89,18 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $highlightedFields[] = 'email';
     $highlightedFields[] = 'external_identifier';
     //format custom field names, CRM-2676
+    $contactType = $this->getContactType();
     switch ($this->get('contactType')) {
       case CRM_Import_Parser::CONTACT_INDIVIDUAL:
-        $contactType = 'Individual';
         $highlightedFields[] = 'first_name';
         $highlightedFields[] = 'last_name';
         break;
 
       case CRM_Import_Parser::CONTACT_HOUSEHOLD:
-        $contactType = 'Household';
         $highlightedFields[] = 'household_name';
         break;
 
       case CRM_Import_Parser::CONTACT_ORGANIZATION:
-        $contactType = 'Organization';
         $highlightedFields[] = 'organization_name';
         break;
     }
@@ -668,23 +666,9 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       $saveMapping = civicrm_api3('Mapping', 'create', $mappingParams);
 
-      $contactType = $this->get('contactType');
-      switch ($contactType) {
-        case CRM_Import_Parser::CONTACT_INDIVIDUAL:
-          $cType = 'Individual';
-          break;
-
-        case CRM_Import_Parser::CONTACT_HOUSEHOLD:
-          $cType = 'Household';
-          break;
-
-        case CRM_Import_Parser::CONTACT_ORGANIZATION:
-          $cType = 'Organization';
-      }
-
       $mappingID = NULL;
       foreach (array_keys($this->getColumnHeaders()) as $i) {
-        $mappingID = $this->saveMappingField($mapperKeys, $saveMapping, $cType, $i, $mapper, $parserParameters);
+        $mappingID = $this->saveMappingField($mapperKeys, $saveMapping, $this->getContactType(), $i, $mapper, $parserParameters);
       }
       $this->set('savedMapping', $mappingID);
     }

--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -104,13 +104,6 @@ trait CRM_Contact_Import_MetadataTrait {
   }
 
   /**
-   * Get configured contact type.
-   */
-  protected function getContactType() {
-    return $this->_contactType ?? 'Individual';
-  }
-
-  /**
    * Get configured contact sub type.
    *
    * @return string

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -262,6 +262,13 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
+   * Get configured contact type.
+   */
+  protected function getContactType() {
+    return $this->_contactType ?? 'Individual';
+  }
+
+  /**
    * Handle the values in preview mode.
    *
    * @param array $values

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -294,6 +294,23 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
+   * Get the contact type selected for the import (on the datasource form).
+   *
+   * @return string
+   *   e.g Individual, Organization, Household.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContactType(): string {
+    $contactTypeMapping = [
+      CRM_Import_Parser::CONTACT_INDIVIDUAL => 'Individual',
+      CRM_Import_Parser::CONTACT_HOUSEHOLD => 'Household',
+      CRM_Import_Parser::CONTACT_ORGANIZATION => 'Organization',
+    ];
+    return $contactTypeMapping[$this->getSubmittedValue('contactType')];
+  }
+
+  /**
    * Create a user job to track the import.
    *
    * @return int

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3220,8 +3220,14 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
         break;
 
       case 'CRM_Contact_Import_Form_DataSource':
+      case 'CRM_Contact_Import_Form_MapField':
         $form->controller = new CRM_Contact_Import_Controller();
-        break;
+        $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
+        // The submitted values should be set on one or the other of the forms in the flow.
+        // For test simplicity we set on all rather than figuring out which ones go where....
+        $_SESSION['_' . $form->controller->_name . '_container']['values']['DataSource'] = $formValues;
+        $_SESSION['_' . $form->controller->_name . '_container']['values']['MapField'] = $formValues;
+        return $form;
 
       case strpos($class, '_Form_') !== FALSE:
         $form->controller = new CRM_Core_Controller_Simple($class, $pageName);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Extract getContactType

Before
----------------------------------------
Repetitive Switch statement

After
----------------------------------------
Who woulda thunk it - re-usable function

Technical Details
----------------------------------------
The `getSubmittedValue` function is clever enough to retrieve this field as it was submitted on the `DataSource` form

Note that the function on the MetaDataTrait is moved to the
Parser_Class - 3 forms use the trait - a unittest class,
the Parser_Class and MapField.
    
MapField was not calling the old function but the newly added one
clashes - and highlights that the contents of the function
should differ for the 2 scenarios - hence moving
off the Trait


Comments
----------------------------------------
