### PR TITLE
[REF] [Import] Activity - clean up copy & paste

### DIFF
--- a/CRM/Activity/Import/Form/Summary.php
+++ b/CRM/Activity/Import/Form/Summary.php
@@ -33,17 +33,7 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
     $this->set('totalRowCount', $totalRowCount);
 
     $invalidRowCount = $this->get('invalidRowCount');
-    $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
-
-    if ($duplicateRowCount > 0) {
-      $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Activity_Import_Parser_Activity';
-      $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    else {
-      $duplicateRowCount = 0;
-      $this->set('duplicateRowCount', $duplicateRowCount);
-    }
 
     $this->assign('dupeError', FALSE);
 
@@ -62,9 +52,7 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
 
       // Only subtract dupes from successful import if we're skipping.
 
-      $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-         $duplicateRowCount
-      );
+      $this->set('validRowCount', $totalRowCount - $invalidRowCount);
     }
     $this->assign('dupeActionString', $dupeActionString);
 
@@ -73,8 +61,6 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
       'validRowCount',
       'invalidRowCount',
       'downloadErrorRecordsUrl',
-      'duplicateRowCount',
-      'downloadDuplicateRecordsUrl',
       'groupAdditions',
     ];
     foreach ($properties as $property) {

--- a/templates/CRM/Activity/Import/Form/Summary.tpl
+++ b/templates/CRM/Activity/Import/Form/Summary.tpl
@@ -27,15 +27,6 @@
         {ts 1=$downloadErrorRecordsUrl}You can <a href='%1'>Download Errors</a>. You may then correct them, and import the new file with the corrected data.{/ts}
         </p>
     {/if}
-
-    {if $duplicateRowCount}
-        <p {if $dupeError}class="error"{/if}>
-        {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM activity records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM activity record.{/ts} {$dupeActionString}
-        </p>
-        <p {if $dupeError}class="error"{/if}>
-        {ts 1=$downloadDuplicateRecordsUrl}You can <a href='%1'>Download Duplicates</a>. You may then review these records to determine if they are actually duplicates, and correct the transaction IDs for those that are not.{/ts}
-        </p>
-    {/if}
  </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
  {* Summary of Import Results (record counts) *}
@@ -55,18 +46,6 @@
         </td>
     </tr>
     {/if}
-
-    {if $duplicateRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Duplicate Rows{/ts}</td>
-        <td class="data">{$duplicateRowCount}</td>
-        <td class="explanation">{ts}Rows which are duplicates of existing CiviCRM activity records.{/ts} {$dupeActionString}
-            {if $duplicateRowCount}
-                <p><a href="{$downloadDuplicateRecordsUrl}">{ts}Download Duplicates{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
     <tr><td class="label crm-grid-cell">{ts}Records Imported{/ts}</td>
         <td class="data">{$validRowCount}</td>
         <td class="explanation">{ts}Rows imported successfully.{/ts}</td>


### PR DESCRIPTION
This class has a lot of handling for error codes but the 2 functions called
- import() and summary() only error return valid or error - the rest of this handling is simply copy and paste
from the contact import - which does indeed handle conflicts and duplicates and record them


Although there is handling for a function called internally to return a conflict  this is converted to an error...

![image](https://user-images.githubusercontent.com/336308/164946654-4a92b4b6-e3c5-4a4b-97e3-d225df7dc4b7.png)

Note that the activity import does not off the option of duplicate handling  - which is the context in which these error types are used in the contact import

![image](https://user-images.githubusercontent.com/336308/164946804-99cf977b-c95b-48db-b2bf-2b75051a380d.png)

