### PR TITLE
dev/core#3414 Stop dropping temp table on finish of contact import job

### DIFF
--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -290,7 +290,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     //hack to clean db
     //if job complete drop table.
-    $importJob->isComplete(TRUE);
+    $importJob->isComplete();
   }
 
 }

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -107,15 +107,6 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
    * Clean up the import table we used.
    */
   public function postProcess() {
-    $dao = new CRM_Core_DAO();
-    $db = $dao->getDatabaseConnection();
-
-    $importTableName = $this->get('importTableName');
-    // do a basic sanity check here
-    if (strpos($importTableName, 'civicrm_import_job_') === 0) {
-      $query = "DROP TABLE IF EXISTS $importTableName";
-      $db->query($query);
-    }
   }
 
 }

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -84,12 +84,12 @@ class CRM_Contact_Import_ImportJob {
   }
 
   /**
-   * @param bool $dropIfComplete
+   * Has the job completed.
    *
    * @return bool
    * @throws Exception
    */
-  public function isComplete($dropIfComplete = TRUE) {
+  public function isComplete() {
     if (!$this->_statusFieldName) {
       throw new CRM_Core_Exception("Could not get name of the import status field");
     }
@@ -98,10 +98,6 @@ class CRM_Contact_Import_ImportJob {
     $result = CRM_Core_DAO::executeQuery($query);
     if ($result->fetch()) {
       return FALSE;
-    }
-    if ($dropIfComplete) {
-      $query = "DROP TABLE $this->_tableName";
-      CRM_Core_DAO::executeQuery($query);
     }
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------

dev/core#3414 Stop dropping temp table on finish of contact import job

Per https://lab.civicrm.org/dev/core/-/issues/3414 the intent is to leave the temp table in place after the job so that the output can be downloaded directly from the temp table. In addition it might be possible to allow viewing without downloading & leaves the potential for updating  retrying.

Tracking the temp table through the user job, rather than the forms, also helps towards offline batch processing

Before
----------------------------------------
The import form process manages the deletion of the import temp tables

After
-----------------------------------------
It is left to the `clearTempTables` - this clears them after 2 days from the scheduled job or immediately when a more active system flush is done

https://github.com/civicrm/civicrm-core/blob/c18711195b2e2c7e86b2d131e01ce2429d28716f/CRM/Core/Config.php#L360-L376

Technical details
-----------------------------------------
If the scheduled job or occassional system flushes are happening (or not much importing is happening) the temp tables won't build up in the database, I might need to look at adding some sort of status check for if they do 

The bigger picture is that ideally temp tables will be removed when the row is deleted from civicrm_user_job or when it's expires data passes - this would give more control - eg. to sysadmins who want to check in on imports 

