### PR TITLE
Compare currencies as well as amounts on template Contribution change

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -995,11 +995,12 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
       ->execute()
       ->first();
 
-    if ($contribution->total_amount === NULL) {
+    if ($contribution->total_amount === NULL || $contribution->currency === NULL) {
+      // The contribution has not been fully loaded, so fetch a full copy now.
       $contribution->find(TRUE);
     }
 
-    if (!CRM_Utils_Money::equals($contributionRecur['amount'], $contribution->total_amount, $contribution->currency)) {
+    if ($contribution->currency !== $contributionRecur['currency'] || !CRM_Utils_Money::equals($contributionRecur['amount'], $contribution->total_amount, $contribution->currency)) {
       ContributionRecur::update(FALSE)
         ->addValue('amount', $contribution->total_amount)
         ->addValue('currency', $contribution->currency)


### PR DESCRIPTION
Overview
----------------------------------------

Follow up from https://github.com/civicrm/civicrm-core/pull/21473 

if the currency is the only thing that has changed, e.g. it's in as 10USD but should be 10GBP, then the comparison will not pick it up since we pass only one currency in the comparator function, so 10 === 10, i.e. unchanged. 


Before
----------------------------------------

Change currency on template contribution; Contribution Recur unchanged.


After
----------------------------------------

Change currency on template contribution; Contribution Recur changed.

