### PR TITLE
dev/drupal#176 - Symfony cmf removed from drupal 10

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -419,8 +419,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $kernel->preHandle($request);
     $container = $kernel->rebuildContainer();
     // Add our request to the stack and route context.
-    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
-    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME, '<none>');
+    $routeInterface = class_exists('\Drupal\Core\Routing\RouteObjectInterface')
+      ? '\Drupal\Core\Routing\RouteObjectInterface'
+      : '\Symfony\Cmf\Component\Routing\RouteObjectInterface';
+    $request->attributes->set($routeInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
+    $request->attributes->set($routeInterface::ROUTE_NAME, '<none>');
     $container->get('request_stack')->push($request);
     $container->get('router.request_context')->fromRequest($request);
 

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -419,8 +419,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $kernel->preHandle($request);
     $container = $kernel->rebuildContainer();
     // Add our request to the stack and route context.
-    $request->attributes->set(\Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
-    $request->attributes->set(\Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_NAME, '<none>');
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME, '<none>');
     $container->get('request_stack')->push($request);
     $container->get('router.request_context')->fromRequest($request);
 


### PR DESCRIPTION
Overview
----------------------------------------
See https://www.drupal.org/node/3151009. This is the same as https://github.com/civicrm/cv/pull/120.

https://lab.civicrm.org/dev/drupal/-/issues/176

Before
----------------------------------------
Error: Class "Symfony\Cmf\Component\Routing\RouteObjectInterface" not found when using `cv` in drupal 10.

After
----------------------------------------


Technical Details
----------------------------------------

Comments
----------------------------------------
This works in drupal 9 and 10 but not drupal 8, but drupal 8 been eol for 6 months and doesn't get security fixes and civi can be run equally as well on drupal 9.