### PR TITLE
Afform - Dispatch event to alter admin metadata; provide mixin

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -135,7 +135,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
     if ($info['definition']['type'] === 'form') {
       if ($newForm) {
         $entities[] = $this->entity;
-        $defaultEntity = AfformAdminMeta::getAfformEntity($this->entity);
+        $defaultEntity = AfformAdminMeta::getMetadata()['entities'][$this->entity] ?? [];
         if (!empty($defaultEntity['boilerplate'])) {
           $scanBlocks($defaultEntity['boilerplate']);
         }

--- a/ext/afform/admin/ang/afGuiEditor.ang.php
+++ b/ext/afform/admin/ang/afGuiEditor.ang.php
@@ -9,7 +9,7 @@ return [
   'css' => ['ang/afGuiEditor.css'],
   'partials' => ['ang/afGuiEditor'],
   'requires' => ['crmUi', 'crmUtil', 'dialogService', 'api4', 'crmMonaco', 'ui.sortable'],
-  'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getGuiSettings'],
+  'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getMetadata'],
   'basePages' => [],
   'exports' => [
     'af-gui-editor' => 'E',

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -33,5 +33,6 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
+    <mixin>afform-entity-php@1.0.0</mixin>
   </mixins>
 </extension>

--- a/mixin/afform-entity-php@1/mixin.php
+++ b/mixin/afform-entity-php@1/mixin.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Auto-register "afformEntities/*.php" files.
+ *
+ * @mixinName afform-entity-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  Civi::dispatcher()->addListener('civi.afform_admin.metadata', function ($e) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive() || !is_dir($mixInfo->getPath('afformEntities'))) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('afformEntities/*.php'));
+    foreach ($files as $file) {
+      $entityInfo = include $file;
+      $entityName = basename($file, '.php');
+      $apiInfo = \Civi\AfformAdmin\AfformAdminMeta::getApiEntity($entityInfo['entity'] ?? $entityName);
+      // Skip disabled contact types & entities from disabled components/extensions
+      if (!$apiInfo) {
+        continue;
+      }
+      $entityInfo += $apiInfo;
+      $e->entities[$entityName] = $entityInfo;
+    }
+  });
+
+};


### PR DESCRIPTION
Overview
----------------------------------------
Makes Form-Builder more extensible by allowing extensions to add to the list of available entities, elements, input types, styles, etc.

Before
----------------------------------------
Entities were gathered only by file-scanning. Other metadata like elements & styles not alterable.

After
----------------------------------------
Instead of scanning files for Afform entities, this dispatches an event to allow metadata be altered.
It provides a mixin which extensions can use to automatically do the file scanning for entities, similar to the scanning for Ang modules and managed entities.

Technical Details
----------------------------------------
Extensions which rely on file scanning should subscribe to the mixin and also add a small shim for backward-compatibility.
[Like this](https://github.com/eileenmcnaughton/deduper/pull/26).