### PR TITLE
correct logic for handling empty-array values for checkboxes;

### DIFF
--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1100,7 +1100,7 @@ function _civicrm_api3_custom_format_params($params, &$values, $extends, $entity
   foreach ($params as $key => $value) {
     [$customFieldID, $customValueID] = CRM_Core_BAO_CustomField::getKeyID($key, TRUE);
     if ($customFieldID && (!is_null($value))) {
-      if ($checkCheckBoxField && !empty($fields['custom_' . $customFieldID]) && $fields['custom_' . $customFieldID]['html_type'] == 'CheckBox') {
+      if ($checkCheckBoxField && isset($fields['custom_' . $customFieldID]) && $fields['custom_' . $customFieldID]['html_type'] == 'CheckBox') {
         formatCheckBoxField($value, 'custom_' . $customFieldID, $entity);
       }
 
@@ -1170,6 +1170,10 @@ function formatCheckBoxField(&$checkboxFieldValue, $customFieldLabel, $entity) {
     return;
   }
 
+  if (is_array($checkboxFieldValue) && empty($checkboxFieldValue)) {
+    $checkboxFieldValue = '';
+    return;
+  }
   $options = $options['values'];
   $validValue = TRUE;
   if (is_array($checkboxFieldValue)) {


### PR DESCRIPTION
Overview
----------------------------------------
API Contact.create has an edge-case for Checkbox custom-fields that does not handle empty arrays properly. There is a comment to this effect on the function, `formatCheckBoxField()`;
> We can't rely on downstream to add separators to checkboxes so we'll check here.

Before
----------------------------------------
> PHP Fatal error:  Uncaught TypeError: mysqli_real_escape_string(): Argument #2 ($string) must be of type string, array given in /var/www/html/wp-content/plugins/civicrm/civicrm/vendor/pear/db/DB/mysqli.php:873
Stack trace:
#0 /var/www/html/wp-content/plugins/civicrm/civicrm/vendor/pear/db/DB/mysqli.php(873): mysqli_real_escape_string()
#1 /var/www/html/wp-content/plugins/civicrm/civicrm/packages/DB/DataObject.php(1851): DB_mysqli->escapeSimple()
#2 /var/www/html/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php(2198): DB_DataObject->escape()
#3 /var/www/html/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php(1735): CRM_Core_DAO::escapeString()
#4 /var/www/html/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php(1615): CRM_Core_DAO::composeQuery()
#5 /var/www/html/wp-content/plugins/civicrm/civicrm/CRM/Core/BAO/CustomValueTable.php(271): CRM_Core_DAO::executeQuery()
#6 /var/www/html/wp-content/plugins/civicrm/civicrm/CRM/Core/BAO/CustomValueTable.php(398): CRM_Core_BAO_CustomValueTable::create()
#7 /var/www/html/wp-content/plugins/civicrm/civicrm/CRM/Contact/BAO/Contact.php(378): CRM_Core_BAO_CustomValueTable::store()
#8 /var/www/html/wp-content/plugins/civicrm/civicrm/api/v3/Contact.php(574): CRM_Contact_BAO_Contact::create()
#9 /var/www/html/wp-content/plugins/civicrm/civicrm/api/v3/Contact.php(99): _civicrm_api3_contact_update()
#10 /var/www/html/wp-content/plugins/civicrm/civicrm/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_contact_create()
#11 /var/www/html/wp-content/plugins/civicrm/civicrm/Civi/API/Kernel.php(149): Civi\API\Provider\MagicFunctionProvider->invoke()
#12 /var/www/html/wp-content/plugins/civicrm/civicrm/Civi/API/Kernel.php(81): Civi\API\Kernel->runRequest()
#13 /var/www/html/wp-content/plugins/civicrm/civicrm/api/api.php(22): Civi\API\Kernel->runSafe()
#14 phar:///usr/local/bin/cv/src/Command/ApiCommand.php(74): civicrm_api()
#15 phar:///usr/local/bin/cv/vendor/symfony/console/Command/Command.php(255): Civi\Cv\Command\ApiCommand->execute()
#16 phar:///usr/local/bin/cv/vendor/symfony/console/Application.php(1009): Symfony\Component\Console\Command\Command->run()
#17 phar:///usr/local/bin/cv/vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
#18 phar:///usr/local/bin/cv/src/Application.php(59): Symfony\Component\Console\Application->doRun()
#19 phar:///usr/local/bin/cv/vendor/symfony/console/Application.php(149): Civi\Cv\Application->doRun()
#20 phar:///usr/local/bin/cv/src/Application.php(26): Symfony\Component\Console\Application->run()
#21 phar:///usr/local/bin/cv/bin/cv(27): Civi\Cv\Application::main()
#22 /usr/local/bin/cv(14): require('...')
#23 {main}
  thrown in /var/www/html/wp-content/plugins/civicrm/civicrm/vendor/pear/db/DB/mysqli.php on line 873


After
----------------------------------------
Changed `!empty()` to `isset()`, and added a check for `!empty()` before looping through the array.


To Reproduce
----------------------------------------
Create a custom field for a contact that is Alphanumeric and type Checkbox(es).

Attempt to save an empty value:
``` bash
echo '{"id":"200447","custom_212":[]}' | cv api3 --in=json Contact.create
```

For those unfamiliar with using the API on the command-line, some assumptions:
* you must have cv installed
* the current directory of your command line must be in htdocs so cv can find the installation
* After creating the custom field, note the ID, and replace it in the example json.
* Since we are executing api Contact.create, the `id` in the input-json must be a valid Contact ID.

In the above example, the custom field ID was `212`, and the contact ID was `200447`.
If we have a fresh-install with demo data, a likely existing contact ID, might be `99`, and a custom field ID might be something lower, such as `42`.

Which then would mean the command would be:
``` bash
echo '{"id":"99","custom_42":[]}' | cv api3 --in=json Contact.create
```