### PR TITLE
[Import] Enotice fix on contact import field mapping screen

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -390,7 +390,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param array $fields
    *   Posted values of the form.
    *
-   * @return array
+   * @return array|true
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields) {
@@ -411,16 +411,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     if (!empty($fields['saveMapping'])) {
       $template->assign('isCheked', TRUE);
     }
-
-    if (!empty($errors)) {
-      $_flag = 1;
-      $assignError = new CRM_Core_Page();
-      $assignError->assign('mappingDetailsError', $_flag);
-      return $errors;
-    }
-    else {
-      return TRUE;
-    }
+    return empty($errors) ? TRUE : $errors;
   }
 
   /**

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -86,14 +86,14 @@
           </tr>
         </table>
       </div>
-      <script type="text/javascript">
-        {if $mappingDetailsError }
-          cj('#saveDetails').show();
-        {else}
-          cj('#saveDetails').hide();
-        {/if}
-
         {literal}
+        <script type="text/javascript">
+          if (cj('#saveMapping').prop('checked')) {
+            cj('#saveDetails').show();
+          } else {
+            cj('#saveDetails').hide();
+          }
+
           function showSaveDetails(chkbox) {
             if (chkbox.checked) {
               document.getElementById("saveDetails").style.display = "block";


### PR DESCRIPTION
Overview
----------------------------------------
 This fixes 1 of 2 notices on the Contact import field mapping screen.
    - instead of assigning a variable for show-hide it uses jquery

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/165386902-be23a8a7-39ae-4611-aa08-923a452fd654.png)


After
----------------------------------------
Yeah - only 1 down...

![image](https://user-images.githubusercontent.com/336308/165391547-184167d5-7034-4286-8d62-6d9162c1a915.png)

The show-hide for the mapping name field depends on whether the 'saveMapping' is checked as determined by jquery

`if (cj('#saveMapping').prop('checked')) `

Technical Details
----------------------------------------
I'm still getting my head around the other notice - I've figured out what the code does ....

If you have already saved the mapping the 'updateMapping' box appears & then that should be checked, not saveMapping when you re-submit

Comments
----------------------------------------