### PR TITLE
[REF] [Import] [Trivial] Make mapperKeys parameter optional in construct

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -64,7 +64,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
    *
    * @param array $mapperKeys
    */
-  public function __construct($mapperKeys) {
+  public function __construct($mapperKeys = []) {
     parent::__construct();
     $this->_mapperKeys = $mapperKeys;
   }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -166,7 +166,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param array $mapperRelatedContactWebsiteType
    */
   public function __construct(
-    $mapperKeys, $mapperLocType = [], $mapperPhoneType = [], $mapperImProvider = [], $mapperRelated = [], $mapperRelatedContactType = [], $mapperRelatedContactDetails = [], $mapperRelatedContactLocType = [], $mapperRelatedContactPhoneType = [], $mapperRelatedContactImProvider = [],
+    $mapperKeys = [], $mapperLocType = [], $mapperPhoneType = [], $mapperImProvider = [], $mapperRelated = [], $mapperRelatedContactType = [], $mapperRelatedContactDetails = [], $mapperRelatedContactLocType = [], $mapperRelatedContactPhoneType = [], $mapperRelatedContactImProvider = [],
     $mapperWebsiteType = [], $mapperRelatedContactWebsiteType = []
   ) {
     parent::__construct();

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -42,7 +42,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    * @param null $mapperPhoneType
    * @param array $mapperSoftCreditType
    */
-  public function __construct(&$mapperKeys, $mapperSoftCredit = [], $mapperPhoneType = NULL, $mapperSoftCreditType = []) {
+  public function __construct(&$mapperKeys = [], $mapperSoftCredit = [], $mapperPhoneType = NULL, $mapperSoftCreditType = []) {
     parent::__construct();
     $this->_mapperKeys = &$mapperKeys;
     $this->_mapperSoftCredit = &$mapperSoftCredit;

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -52,7 +52,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
    * @param null $mapperLocType
    * @param null $mapperPhoneType
    */
-  public function __construct(&$mapperKeys, $mapperLocType = NULL, $mapperPhoneType = NULL) {
+  public function __construct(&$mapperKeys = [], $mapperLocType = NULL, $mapperPhoneType = NULL) {
     parent::__construct();
     $this->_mapperKeys = &$mapperKeys;
   }

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -72,7 +72,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    *
    * @param array $mapperKeys
    */
-  public function __construct(&$mapperKeys) {
+  public function __construct(&$mapperKeys = []) {
     parent::__construct();
     $this->_mapperKeys = &$mapperKeys;
   }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -72,7 +72,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    *
    * @param $mapperKeys
    */
-  public function __construct($mapperKeys) {
+  public function __construct($mapperKeys = []) {
     parent::__construct();
     $this->_mapperKeys = $mapperKeys;
   }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] [Trivial] Make mapperKeys parameter optional in construct

Before
----------------------------------------
`$mapperKeys` is a required reference parameter & hence it is necessary to instantiate an empty array when called with an empty array (as happens in the DataSource usage ++)

After
----------------------------------------
optional parameter

Technical Details
----------------------------------------
@colemanw @demeritcowboy @seamuslee001 @totten - I'm trying to pull out some of the trivial changes that pretty much all PRs require into tiny PRs like this to try to get them merged & reduce the conflicts  - would be good to get this merged & then I can rebase all the others that include some form of it

Comments
----------------------------------------
