### PR TITLE
[REF] [Import] [Trivial] Make 'mapper' field available as a submittable value throughout the flow

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -111,6 +111,11 @@ class CRM_Import_Forms extends CRM_Core_Form {
     'dedupe_rule_id' => 'DataSource',
     'onDuplicate' => 'DataSource',
     'disableUSPS' => 'DataSource',
+    'doGeocodeAddress' => 'DataSource',
+    // Note we don't add the save mapping instructions for MapField here
+    // (eg 'updateMapping') - as they really are an action for that form
+    // rather than part of the mapping config.
+    'mapper' => 'MapField',
   ];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] [Trivial] Make 'mapper' field available as a submittable value throughout the flow

Before
----------------------------------------
The submitted value for `mapper` (and `doGeocodeAddress`) needs to be passed from form to form within the flow

After
----------------------------------------
It can be accessed from any form in the flow using `$this->getSubmittedValue('mapper')`

Technical Details
----------------------------------------

The fields defined here can be accessed from any field in
the flow, removing the need to pass the values from form to form - this array tells it which form in the flow the values would have been submitted on

Comments
----------------------------------------
Getting this merged will mean that this change can be re-based out of other PRs & will reduce conflicts