### PR TITLE
Add custom data when creating smart group

### DIFF
--- a/CRM/Contact/Form/Task/SaveSearch.php
+++ b/CRM/Contact/Form/Task/SaveSearch.php
@@ -54,6 +54,9 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     $modeValue = CRM_Contact_Form_Search::getModeValue(CRM_Utils_Array::value('component_mode', $values, CRM_Contact_BAO_Query::MODE_CONTACTS));
     $className = $modeValue['taskClassName'];
     $this->_task = $values['task'] ?? NULL;
+
+    // Add group custom data
+    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Group');
   }
 
   /**
@@ -104,6 +107,9 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     //CRM-14190
     CRM_Group_Form_Edit::buildParentGroups($this);
     CRM_Group_Form_Edit::buildGroupOrganizations($this);
+
+    // Build custom data
+    CRM_Custom_Form_CustomData::buildQuickForm($this);
 
     // get the group id for the saved search
     $groupID = NULL;
@@ -210,6 +216,8 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
       $params['id'] = CRM_Contact_BAO_SavedSearch::getName($this->_id, 'id');
     }
 
+    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($formValues, $this->_id, 'Group');
+
     $group = CRM_Contact_BAO_Group::create($params);
 
     // Update mapping with the name and description of the group.
@@ -242,6 +250,7 @@ class CRM_Contact_Form_Task_SaveSearch extends CRM_Contact_Form_Task {
     if (empty($defaults['parents'])) {
       $defaults['parents'] = CRM_Core_BAO_Domain::getGroupId();
     }
+    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
     return $defaults;
   }
 

--- a/templates/CRM/Contact/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Contact/Form/Task/SaveSearch.tpl
@@ -39,6 +39,9 @@
         <td class="label">{$form.group_type.label}</td>
         <td>{$form.group_type.html}</td>
       </tr>
+      <tr>
+        <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>
+      </tr>
     {/if}
   </table>
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds group custom fields when creating a new smart group from search action Group -> Create Smart Group

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/28389118/165522137-6ee214cc-c0a2-4caa-a909-999c930a2a53.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/28389118/165522234-7e5bfb07-b7a2-402b-9cc1-edd33d090f1d.png)

Technical Details
----------------------------------------
Mostly just copies https://github.com/civicrm/civicrm-core/pull/21716.
