### PR TITLE
SearchKit - Allow duplicates in select clause

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -389,7 +389,7 @@
       }
 
       this.addParam = function(name, value) {
-        if (value && !_.contains(ctrl.savedSearch.api_params[name], value)) {
+        if (value) {
           ctrl.savedSearch.api_params[name].push(value);
           // This needs to be called when adding a field as well as changing groupBy
           reconcileAggregateColumns();

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -60,10 +60,7 @@
       };
 
       $scope.fieldsForSelect = function() {
-        return {results: ctrl.crmSearchAdmin.getAllFields(':label', ['Field', 'Custom', 'Extra', 'Pseudo'], function(key) {
-            return _.contains(ctrl.search.api_params.select, key);
-          })
-        };
+        return {results: ctrl.crmSearchAdmin.getAllFields(':label', ['Field', 'Custom', 'Extra', 'Pseudo'])};
       };
 
       $scope.addColumn = function(col) {

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -9,7 +9,7 @@
       <tr ng-model="$ctrl.search.api_params.select" ui-sortable="sortableColumnOptions">
         <th class="crm-search-result-select" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.settings.actions">
         </th>
-        <th ng-repeat="item in $ctrl.search.api_params.select" ng-click="$ctrl.setSort($ctrl.settings.columns[$index], $event)" title="{{$index || !$ctrl.crmSearchAdmin.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
+        <th ng-repeat="item in $ctrl.search.api_params.select track by $index" ng-click="$ctrl.setSort($ctrl.settings.columns[$index], $event)" title="{{$index || !$ctrl.crmSearchAdmin.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
           <i ng-if=":: $ctrl.isSortable($ctrl.settings.columns[$index])" class="crm-i {{ $ctrl.getSort($ctrl.settings.columns[$index]) }}"></i>
           <span ng-class="{'crm-draggable': $index || !$ctrl.crmSearchAdmin.groupExists}">{{ $ctrl.settings.columns[$index].label }}</span>
           <span ng-switch="$index || !$ctrl.crmSearchAdmin.groupExists ? 'sortable' : 'locked'">


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes there's a legitimate use for adding the same field twice as a searchKit column. This lifts that restriction from the UI.

Before
----------------------------------------
Could not add the same field as a column multiple times.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/165584958-a3d32503-ea9d-4958-9bce-d6ccfcc82cf9.png)

Comments
----------------------------------------
The typical use-case is to want to apply a field transformation a field, and also include it without the transformation, or with a different transofmation.
That's already possible, but you have to do the transformation first before it will allow you to select the field again. This change hopefully removes that confusing limitation.
