### PR TITLE
SearchKit - Move grid css to its own file

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3900,30 +3900,6 @@ span.crm-status-icon {
   border: 1px solid grey;
 }
 
-/* search kit grid layout styling */
-.crm-search-display-grid-container {
-  display: grid;
-  grid-gap: 1em;
-  align-items: center;
-  justify-items: center;
-}
-
-.crm-search-display-grid-layout-2 {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.crm-search-display-grid-layout-3 {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.crm-search-display-grid-layout-4 {
-  grid-template-columns: repeat(4, 1fr);
-}
-
-.crm-search-display-grid-layout-5 {
-  grid-template-columns: repeat(5, 1fr);
-}
-
 /* Dedupe rules */
 .crm-dedupe-rules-form-block-used div {
   max-width: 800px;

--- a/ext/search_kit/ang/crmSearchDisplayGrid.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayGrid.ang.php
@@ -1,5 +1,5 @@
 <?php
-// Module for rendering List Search Displays.
+// Module for rendering Grid Search Displays.
 return [
   'js' => [
     'ang/crmSearchDisplayGrid.module.js',
@@ -7,6 +7,9 @@ return [
   ],
   'partials' => [
     'ang/crmSearchDisplayGrid',
+  ],
+  'css' => [
+    'css/crmSearchDisplayGrid.css',
   ],
   'basePages' => ['civicrm/search', 'civicrm/admin/search'],
   'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap'],

--- a/ext/search_kit/css/crmSearchDisplayGrid.css
+++ b/ext/search_kit/css/crmSearchDisplayGrid.css
@@ -1,0 +1,23 @@
+/* search kit grid layout styling */
+.crm-search-display-grid-container {
+  display: grid;
+  grid-gap: 1em;
+  align-items: center;
+  justify-items: center;
+}
+
+.crm-search-display-grid-layout-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.crm-search-display-grid-layout-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.crm-search-display-grid-layout-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.crm-search-display-grid-layout-5 {
+  grid-template-columns: repeat(5, 1fr);
+}


### PR DESCRIPTION
Overview
----------------------------------------
Moves css code for Grid search displays to a more appropriate location.

Before
----------------------------------------
Located in civicrm.css, which is not loaded by all themes.

After
----------------------------------------
Located in a css file specific to the searchDisplayGrid module.
