### PR TITLE
Make links to sign a petition easily accessible on the form.

### DIFF
--- a/templates/CRM/Campaign/Form/Petition.tpl
+++ b/templates/CRM/Campaign/Form/Petition.tpl
@@ -100,6 +100,18 @@
           <div class="description">{ts}Is this the default petition?{/ts}</div>
         </td>
       </tr>
+      <tr class="crm-campaign-survey-form-block-links">
+        <td class="label"><label>{ts}Links to sign this petition{/ts}</label></td>
+        <td>
+          {if $surveyId}
+            {ts}Public{/ts}: <pre>{$config->userFrameworkBaseURL}civicrm/petition/sign?sid={$surveyId}&amp;reset=1</pre><br/>
+            {ts}CiviMail{/ts}: <pre>{$config->userFrameworkBaseURL}civicrm/petition/sign?sid={$surveyId}&amp;reset=1&amp;&#123;contact.checksum&#125;&amp;cid=&#123;contact.contact_id&#125;</pre></br/>
+            <div class="description">{ts}Copy and paste the public link anywhere on the Internet, including social media. The CiviMail link should only be copied into a CiviMail message. It will pre-populate the profile with existing information for the person who receives the email.{/ts}</div>
+          {else}
+            <div class="description">{ts}The links will be visible after you save the petition.{/ts}</div>
+          {/if}
+        </td>
+      </tr>
     </table>
     {include file="CRM/common/customDataBlock.tpl"}
   {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Add links to the bottom of the petition edit form so users can more easily publicize their petition.

Before
----------------------------------------
Before, users can find the signature link by clicking on the "..." menu on the list of petitions and clicking the "Sign" option and then copying the URL from the browser location bar. Very easy for experienced Internet folks, but impossibly complicated for people who don't know what an URL is.

Here's what the bottom of the edit petition form looks like prior to the change:
![link-before](https://user-images.githubusercontent.com/4511942/165617297-e347e62f-60e4-4844-b906-c40ce337ad94.png)


After
----------------------------------------

When editing an existing petition, the links now appear in a way that is easy to copy and paste. Additionally, we provide the link you can insert into a CiviMail message to have the profile pre-populated.

![link-after](https://user-images.githubusercontent.com/4511942/165617713-98baa8bd-a28a-4f26-89ef-45a9d84511c6.png)


Technical Details
----------------------------------------
The code is very simple and completely lives in the template.

