### PR TITLE
[REF] Fix PHP8.1 issue with passing NULL to trim()

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -706,7 +706,7 @@ class CRM_Core_CodeGen_Specification {
     $foreignKey = [
       'idColumn' => trim($foreignXML->idColumn),
       'typeColumn' => trim($foreignXML->typeColumn),
-      'key' => trim($this->value('key', $foreignXML)),
+      'key' => trim($this->value('key', $foreignXML) ?? ''),
     ];
     $dynamicForeignKeys[] = $foreignKey;
   }


### PR DESCRIPTION
Overview
----------------------------------------

Fix a console warning when running `setup.sh` on php81.

To reproduce, you can use these commands:

```
rm -f  CRM/ACL/DAO/ACL.php  CRM/Financial/DAO/FinancialItem.php  CRM/Mailing/DAO/MailingGroup.php 
./bin/setup.sh -g
```

Before
----------------------------------------

```
~/bknix/build/dmaster/web/sites/all/modules/civicrm/xml ~/bknix/build/dmaster/web/sites/all/modules/civicrm

civicrm_domain.version := 5.50.alpha1

Parsing schema description schema/Schema.xml
Extracting database information
Extracting table information

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Specification.php on line 709

Call Stack:
    0.0025     422184   1. {main}() /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/xml/GenCode.php:0
    0.0059    1091200   2. CRM_Core_CodeGen_Main->main() /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/xml/GenCode.php:58
    0.0060    1091232   3. CRM_Core_CodeGen_Main->getTasks() /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:113
    0.0060    1091232   4. CRM_Core_CodeGen_Main->init() /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:126
    0.0064    1247624   5. CRM_Core_CodeGen_Specification->parse($schemaPath = 'schema/Schema.xml', $buildVersion = '5.50', $verbose = ???) /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:145
    0.0271    1249048   6. CRM_Core_CodeGen_Specification->getTables($dbXML = class SimpleXMLElement { public $name = 'civicrm'; public $character_set = 'utf8mb4'; public $collate = 'utf8mb4_unicode_ci'; public $table_type = 'InnoDB'; public $comment = 'Schema for CiviCRM'; public $tables = [0 => class SimpleXMLElement { ... }, 1 => class SimpleXMLElement { ... }, 2 => class SimpleXMLElement { ... }, 3 => class SimpleXMLElement { ... }, 4 => class SimpleXMLElement { ... }, 5 => class SimpleXMLElement { ... }, 6 => class SimpleXMLElement { ... }, 7 => class SimpleXMLElement { ... }, 8 => class SimpleXMLElement { ... }, 9 => class SimpleXMLElement { ... }, 10 => class SimpleXMLElement { ... }, 11 => class SimpleXMLElement { ... }, 12 => class SimpleXMLElement { ... }, 13 => class SimpleXMLElement { ... }, 14 => class SimpleXMLElement { ... }, 15 => class SimpleXMLElement { ... }, 16 => class SimpleXMLElement { ... }, 17 => class SimpleXMLElement { ... }, 18 => class SimpleXMLElement { ... }, 19 => class SimpleXMLElement { ... }, 20 => class SimpleXMLElement { ... }, 21 => class SimpleXMLElement { ... }, 22 => class SimpleXMLElement { ... }] }, $database = ['name' => 'civicrm', 'attributes' => 'DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'tableAttributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'tableAttributes_simple' => 'TYPE=InnoDB', 'comment' => 'Schema for CiviCRM']) /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Specification.php:39
    0.0301    1766360   7. CRM_Core_CodeGen_Specification->getTable($tableXML = class SimpleXMLElement { public $base = 'CRM/Core'; public $class = 'Discount'; public $name = 'civicrm_discount'; public $comment = 'Stores discounts for events on the basis of date'; public $add = '2.1'; public $log = 'true'; public $field = [0 => class SimpleXMLElement { ... }, 1 => class SimpleXMLElement { ... }, 2 => class SimpleXMLElement { ... }, 3 => class SimpleXMLElement { ... }, 4 => class SimpleXMLElement { ... }, 5 => class SimpleXMLElement { ... }]; public $primaryKey = class SimpleXMLElement { public $name = 'id'; public $autoincrement = 'true' }; public $dynamicForeignKey = class SimpleXMLElement { public $idColumn = 'entity_id'; public $typeColumn = 'entity_table'; public $add = '2.1' }; public $index = [0 => class SimpleXMLElement { ... }, 1 => class SimpleXMLElement { ... }]; public $foreignKey = class SimpleXMLElement { public $name = 'price_set_id'; public $table = 'civicrm_price_set'; public $key = 'id'; public $add = '4.3'; public $onDelete = 'CASCADE' } }, $database = ['name' => 'civicrm', 'attributes' => 'DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'tableAttributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'tableAttributes_simple' => 'TYPE=InnoDB', 'comment' => 'Schema for CiviCRM'], $tables = ['civicrm_address' => ['name' => 'civicrm_address', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/Address.xml', 'fileName' => 'Address.php', 'objectName' => 'Address', 'title' => 'Address', 'titlePlural' => 'Addresses', 'icon' => class SimpleXMLElement { ... }, 'labelField' => NULL, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'address', 'className' => 'CRM_Core_DAO_Address', 'bao' => 'CRM_Core_BAO_Address', 'entity' => 'Address', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => 'Stores the physical street / mailing address. This format should be capable of storing ALL international addresses.', 'description' => NULL, 'localizable' => FALSE, 'log' => 'true', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'index' => [...], 'foreignKey' => [...]], 'civicrm_address_format' => ['name' => 'civicrm_address_format', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/AddressFormat.xml', 'fileName' => 'AddressFormat.php', 'objectName' => 'AddressFormat', 'title' => 'Address Format', 'titlePlural' => 'Address Formats', 'icon' => NULL, 'labelField' => NULL, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'address_format', 'className' => 'CRM_Core_DAO_AddressFormat', 'bao' => 'CRM_Core_DAO_AddressFormat', 'entity' => 'AddressFormat', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => NULL, 'description' => NULL, 'localizable' => FALSE, 'log' => 'false', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...]], 'civicrm_cache' => ['name' => 'civicrm_cache', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/Cache.xml', 'fileName' => 'Cache.php', 'objectName' => 'Cache', 'title' => 'Cache', 'titlePlural' => 'Caches', 'icon' => NULL, 'labelField' => NULL, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'cache', 'className' => 'CRM_Core_DAO_Cache', 'bao' => 'CRM_Core_BAO_Cache', 'entity' => 'Cache', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => 'Table to cache items for civicrm components.', 'description' => NULL, 'localizable' => FALSE, 'log' => 'false', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'index' => [...], 'foreignKey' => [...]], 'civicrm_country' => ['name' => 'civicrm_country', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/Country.xml', 'fileName' => 'Country.php', 'objectName' => 'Country', 'title' => 'Country', 'titlePlural' => 'Countries', 'icon' => NULL, 'labelField' => class SimpleXMLElement { ... }, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'country', 'className' => 'CRM_Core_DAO_Country', 'bao' => 'CRM_Core_BAO_Country', 'entity' => 'Country', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => NULL, 'description' => NULL, 'localizable' => FALSE, 'log' => 'false', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'index' => [...], 'foreignKey' => [...]], 'civicrm_county' => ['name' => 'civicrm_county', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/County.xml', 'fileName' => 'County.php', 'objectName' => 'County', 'title' => 'County', 'titlePlural' => 'Counties', 'icon' => NULL, 'labelField' => class SimpleXMLElement { ... }, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'county', 'className' => 'CRM_Core_DAO_County', 'bao' => 'CRM_Core_DAO_County', 'entity' => 'County', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => NULL, 'description' => NULL, 'localizable' => FALSE, 'log' => 'false', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'index' => [...], 'foreignKey' => [...]], 'civicrm_custom_group' => ['name' => 'civicrm_custom_group', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/CustomGroup.xml', 'fileName' => 'CustomGroup.php', 'objectName' => 'CustomGroup', 'title' => class SimpleXMLElement { ... }, 'titlePlural' => 'Custom Field Groups', 'icon' => NULL, 'labelField' => class SimpleXMLElement { ... }, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'custom_group', 'className' => 'CRM_Core_DAO_CustomGroup', 'bao' => 'CRM_Core_BAO_CustomGroup', 'entity' => 'CustomGroup', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => 'All extended (custom) properties are associated with a group. These are logical sets of related data.\n  ', 'description' => NULL, 'localizable' => TRUE, 'log' => 'true', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'index' => [...], 'foreignKey' => [...]], 'civicrm_custom_field' => ['name' => 'civicrm_custom_field', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/CustomField.xml', 'fileName' => 'CustomField.php', 'objectName' => 'CustomField', 'title' => 'Custom Field', 'titlePlural' => 'Custom Fields', 'icon' => NULL, 'labelField' => class SimpleXMLElement { ... }, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'custom_field', 'className' => 'CRM_Core_DAO_CustomField', 'bao' => 'CRM_Core_BAO_CustomField', 'entity' => 'CustomField', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => 'Stores info about an extended (custom) property (data and form field info).', 'description' => NULL, 'localizable' => TRUE, 'log' => 'true', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'index' => [...], 'foreignKey' => [...]], 'civicrm_dashboard' => ['name' => 'civicrm_dashboard', 'base' => 'CRM/Core/DAO/', 'sourceFile' => 'xml/schema/CRM/Core/Dashboard.xml', 'fileName' => 'Dashboard.php', 'objectName' => 'Dashboard', 'title' => 'Dashboard', 'titlePlural' => 'Dashboards', 'icon' => NULL, 'labelField' => NULL, 'add' => class SimpleXMLElement { ... }, 'component' => NULL, 'paths' => [...], 'labelName' => 'dashboard', 'className' => 'CRM_Core_DAO_Dashboard', 'bao' => 'CRM_Core_BAO_Dashboard', 'entity' => 'Dashboard', 'attributes_simple' => 'TYPE=InnoDB', 'attributes_modern' => 'ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', 'comment' => 'Table to store dashboard.', 'description' => NULL, 'localizable' => TRUE, 'log' => 'false', 'archive' => 'false', 'fields' => [...], 'primaryKey' => [...], 'foreignKey' => [...]]]) /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Specification.php:104
    0.0302    1786080   8. CRM_Core_CodeGen_Specification->getDynamicForeignKey($foreignXML = class SimpleXMLElement { public $idColumn = 'entity_id'; public $typeColumn = 'entity_table'; public $add = '2.1' }, $dynamicForeignKeys = [], 'civicrm_discount') /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Specification.php:288
    0.0302    1786536   9. trim($string = NULL) /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Specification.php:709
```

After
----------------------------------------

This warning is resolved.

Comments
----------------------------------------

There are still other issues remaining for php81 compatibility (e.g. `strftime` in Smarty). However, this gets us closer.