### PR TITLE
[REF] Fix handling of NULL values in count_characters smarty modifier…

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php
@@ -5,7 +5,6 @@
  * @subpackage plugins
  */
 
-
 /**
  * Smarty count_characters modifier plugin
  *
@@ -15,21 +14,19 @@
  * @link http://smarty.php.net/manual/en/language.modifier.count.characters.php
  *          count_characters (Smarty online manual)
  * @author   Monte Ohrt <monte at ohrt dot com>
- * @param string
- * @param boolean include whitespace in the character count
+ * @param string $string
+ * @param boolean $include_spaces include whitespace in the character count
  * @return integer
  */
-function smarty_modifier_crmCountCharacters($string, $include_spaces = false)
-{
-    if ($include_spaces)
-       return(strlen($string));
+function smarty_modifier_crmCountCharacters($string, $include_spaces = FALSE) {
+  if ($include_spaces) {
+    return(strlen($string));
+  }
 
-    if (is_null($string)) {
-      return 0;
-    }
-    return preg_match_all("/[^\s]/",$string, $match);
+  if (is_null($string)) {
+    return 0;
+  }
+  return preg_match_all("/[^\s]/", $string, $match);
 }
 
 /* vim: set expandtab: */
-
-?>

--- a/CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Smarty plugin
+ * @package Smarty
+ * @subpackage plugins
+ */
+
+
+/**
+ * Smarty count_characters modifier plugin
+ *
+ * Type:     modifier<br>
+ * Name:     crmCountCharacteres<br>
+ * Purpose:  count the number of characters in a text with handling for NULL values
+ * @link http://smarty.php.net/manual/en/language.modifier.count.characters.php
+ *          count_characters (Smarty online manual)
+ * @author   Monte Ohrt <monte at ohrt dot com>
+ * @param string
+ * @param boolean include whitespace in the character count
+ * @return integer
+ */
+function smarty_modifier_crmCountCharacters($string, $include_spaces = false)
+{
+    if ($include_spaces)
+       return(strlen($string));
+
+    if (is_null($string)) {
+      return 0;
+    }
+    return preg_match_all("/[^\s]/",$string, $match);
+}
+
+/* vim: set expandtab: */
+
+?>

--- a/templates/CRM/Block/Event.tpl
+++ b/templates/CRM/Block/Event.tpl
@@ -17,7 +17,7 @@
            <a href="{$ev.url}">{$ev.title}</a><br />
            {$ev.start_date|truncate:10:""|crmDate}<br />
            {assign var=evSummary value=$ev.summary|truncate:80:""}
-           <em>{$evSummary}{if $ev.summary|count_characters:true GT 80}  (<a href="{$ev.url}">{ts}more{/ts}...</a>){/if}</em>
+           <em>{$evSummary}{if $ev.summary|crmCountCharacters:true GT 80}  (<a href="{$ev.url}">{ts}more{/ts}...</a>){/if}</em>
            </p>
          {/foreach}
      {else}

--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -224,7 +224,7 @@
             <td class="crm-note-note">
                 {$note.note|mb_truncate:80:"...":false|nl2br}
                 {* Include '(more)' link to view entire note if it has been truncated *}
-                {assign var="noteSize" value=$note.note|count_characters:true}
+                {assign var="noteSize" value=$note.note|crmCountCharacters:true}
                 {if $noteSize GT 80}
                   <a class="crm-popup" href="{crmURL p='civicrm/contact/view/note' q="action=view&selectedChild=note&reset=1&cid=`$contactId`&id=`$note.id`"}">{ts}(more){/ts}</a>
                 {/if}

--- a/xml/templates/schema.tpl
+++ b/xml/templates/schema.tpl
@@ -32,7 +32,7 @@ CREATE TABLE `{$table.name}` ({assign var='first' value=true}
 {foreach from=$table.fields item=field}
 {if ! $first},{/if}{assign var='first' value=false}
 
-  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if isset($field.autoincrement)} AUTO_INCREMENT{/if}{if $field.default|count_characters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
+  `{$field.name}` {$field.sqlType}{if $field.collate} COLLATE {$field.collate}{/if}{if $field.required} {if $field.required == "false"}NULL{else}NOT NULL{/if}{/if}{if isset($field.autoincrement)} AUTO_INCREMENT{/if}{if $field.default|crmCountCharacters} DEFAULT {$field.default}{/if}{if $field.comment} COMMENT '{ts escape=sql}{$field.comment}{/ts}'{/if}
 {/foreach}{* table.fields *}{strip}
 
 {/strip}{if $table.primaryKey}{if !$first},


### PR DESCRIPTION
… by creating a CiviCRM specific one that handles them

Overview
----------------------------------------
This fixes a PHP8.1 issue whetre passing NULL to the 2nd parameter to preg_match_all is deprecated

Before
----------------------------------------
Deprecation error on php8.1

```
Deprecated: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/packages/Smarty/plugins/modifier.count_characters.php on line 27

Call Stack:
    0.0004     427320   1. {main}() /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/xml/GenCode.php:0
    0.0048    1094120   2. CRM_Core_CodeGen_Main->main() /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/xml/GenCode.php:58
    0.2600    9389072   3. CRM_Core_CodeGen_Schema->run() /home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:115
```

After
----------------------------------------
no deprecation error

ping @eileenmcnaughton @demeritcowboy 