### PR TITLE
SearchKit - Keep label when switching entity

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -78,14 +78,14 @@
     // Controller for creating a new search
     .controller('searchCreate', function($scope, $routeParams, $location) {
       searchEntity = $routeParams.entity;
-      $scope.$ctrl = this;
+      var ctrl = $scope.$ctrl = this;
       this.savedSearch = {
         api_entity: searchEntity
       };
       // Changing entity will refresh the angular page
       $scope.$watch('$ctrl.savedSearch.api_entity', function(newEntity, oldEntity) {
         if (newEntity && oldEntity && newEntity !== oldEntity) {
-          $location.url('/create/' + newEntity);
+          $location.url('/create/' + newEntity + (ctrl.savedSearch.label ? '?label=' + ctrl.savedSearch.label : ''));
         }
       });
     })

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -58,6 +58,13 @@
             deep: true,
             default: defaults
           });
+
+          $scope.$bindToRoute({
+            param: 'label',
+            expr: '$ctrl.savedSearch.label',
+            format: 'raw',
+            default: ''
+          });
         }
 
         $scope.mainEntitySelect = searchMeta.getPrimaryAndSecondaryEntitySelect();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a minor annoyance in SearchKit where switching entities will delete the label.

Before
----------------------------------------
In this example, "Test Label" would be deleted when switching to a different main entity.
![image](https://user-images.githubusercontent.com/2874912/165707142-21eb0bc3-02da-479a-990c-829667c1540b.png)


After
----------------------------------------
It persists.