### PR TITLE
PR 22070 follow-up: reinstate respecting no_display on report column headers

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2507,10 +2507,12 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       if (!empty($value['no_display'])) {
         unset($this->_columnHeaders[$key]);
       }
-      foreach (['colspan', 'type'] as $expectedKey) {
-        if (!isset($this->_columnHeaders[$key][$expectedKey])) {
-          // Ensure it is set to prevent smarty notices.
-          $this->_columnHeaders[$key][$expectedKey] = FALSE;
+      else {
+        foreach (['colspan', 'type'] as $expectedKey) {
+          if (!isset($this->_columnHeaders[$key][$expectedKey])) {
+            // Ensure it is set to prevent smarty notices.
+            $this->_columnHeaders[$key][$expectedKey] = FALSE;
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
PR 22070 included a change that stopped the no_display property being respected on report column headers. This PR addresses that. Discussed at https://github.com/civicrm/civicrm-core/pull/22070#issuecomment-1106684241 .

Before
----------------------------------------
Before PR 22070, the no_display property was respected on report column headers.
After PR 22070, the no_display property was no longer respected.

After
----------------------------------------
After this PR, the no_display property is again respected.