### PR TITLE
Add hook to add/remove/re-order elements on User Dashboard

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -173,6 +173,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
         $dashboardElements[$index]['class'] = NULL;
       }
     }
+    CRM_Utils_Hook::userDashboard($this->_contactId, $dashboardElements, $this);
     $this->assign('dashboardElements', $dashboardElements);
 
     if (!empty($dashboardOptions['Groups'])) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2877,4 +2877,22 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * This hook is called when rendering the dashboard (q=civicrm/user/dashboard)
+   *
+   * @param int $contactID
+   *   The contactID for whom the user dashboard is being rendered.
+   * @param array $dashboardElements
+   *   The array of user dashboard elements (widgets)
+   * @param CRM_Core_Page $page
+   *
+   * @return mixed
+   */
+  public static function userDashboard($contactID, &$dashboardElements, $page) {
+    return self::singleton()->invoke(['contactID', 'dashboardElements', 'page'], $contactID, $dashboardElements,
+      $page, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_userDashboard'
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Currently there is no way to add / remove / re-order elements on the User Dashboard (civicrm/user/dashboard) without patching code.
This PR adds a hook to do that. With this hook you could do the following:
* Add a new dashboard element.
* Remove a dashboard element.
* Change the order of the dashboard elements (eg. you'd like to see memberships listed before events).

This does not allow you to change the individual elements, but you could copy them and replace them with your own.

Before
----------------------------------------
Cannot modify User Dashboard without patching code.

After
----------------------------------------
Can modify User Dashboard without patching code.

Technical Details
----------------------------------------
Just exposes elements via a hook at the point in the code where it is generated.

Comments
----------------------------------------
@mlutfy I remember you showed me something in Barcelona where you modified the User Dashboard. Would this hook help you?
@colemanw I think supporting afform on the User Dashboard is on your roadmap but not funded yet? Be good if you could comment here if this would make that goal easier/harder/indifferent (I don't think it would actually be too hard to rewrite all the user dashboard elements to use afform at the same time when the time comes - they are mostly pretty simple searches).
