### PR TITLE
CRM-18217 On the website front-end, CiviCRM page heading should start from h2 and not h1

### DIFF
--- a/templates/CRM/common/CMSPrint.tpl
+++ b/templates/CRM/common/CMSPrint.tpl
@@ -24,10 +24,19 @@
   </div>
 {/if}
 
-{if $pageTitle}
-  <div class="crm-title">
-    <h1 class="title">{if $isDeleted}<del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>
-  </div>
+{if $urlIsPublic}
+    {if $pageTitle}
+      <div class="crm-title">
+        <h2 class="title">{$pageTitle}</h2>
+      </div>
+    {/if}
+{else}
+    {if $pageTitle}
+      <div class="crm-title">
+        <h1 class="title">{if $isDeleted}
+          <del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>
+      </div>
+    {/if}
 {/if}
 
 {crmRegion name='page-header'}


### PR DESCRIPTION
Overview
----------------------------------------
On the website front-end, CiviCRM page heading should start from h2 and not h1 because the web page itself will most likely have output the page title as a h1 tag already.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/58866555/165875582-d6636ece-9296-47ea-8e51-00b73605937f.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/58866555/165875364-fcc80ecb-3ddc-4f95-ab07-716318a95983.png)


Technical Details
----------------------------------------
Uses the **urlIsPublic** variable and follows the existing pattern for outputting the public footer.

Comments
----------------------------------------
https://issues.civicrm.org/jira/browse/CRM-18217

Agileware Ref: CIVIUX-153
