### PR TITLE
Profiles, if the optional field, Frontend Title for the Profile is blank there's a reason it's blank - so do not display the internal Profile Title

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3550,7 +3550,7 @@ SELECT  group_id
   }
 
   /**
-   * Get the frontend_title for the profile, falling back on 'title' if none.
+   * Get the frontend_title for the profile, otherwise blank if none set.
    *
    * @param int $profileID
    *
@@ -3560,7 +3560,7 @@ SELECT  group_id
    */
   public static function getFrontEndTitle(int $profileID) {
     $profile = civicrm_api3('UFGroup', 'getsingle', ['id' => $profileID, 'return' => ['title', 'frontend_title']]);
-    return $profile['frontend_title'] ?? $profile['title'];
+    return trim($profile['frontend_title']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When used on the frontend, a CiviCRM Profile does not _always_ need to have a Profile Title shown on the web page, for example when the CiviCRM Profile has been embedded on a web page which already has a heading and some introductory text.

Consider this example on WordPress when embedding the CiviCRM Profile on the page.

The user would expect the CiviCRM Profile form to be shown immediately below the heading.

![image](https://user-images.githubusercontent.com/58866555/165893359-dd77f09e-1ce8-49c9-b724-4486b032dd63.png)


Before
----------------------------------------
CiviCRM Profile, displays the internal Profile Title if the Frontend Title for the Profile is blank.

![image](https://user-images.githubusercontent.com/58866555/165893382-310f7955-c61c-4641-9c1d-447da7b9a4e4.png)


After
----------------------------------------
CiviCRM Profile, does NOT display the internal Profile Title if the Frontend Title for the Profile is blank.

![image](https://user-images.githubusercontent.com/58866555/165893370-10f2f8e7-fa12-4e9f-883b-eb0317c931b5.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
Agileware Ref: CIVIUX-152
