### PR TITLE
dev/core#3431 - Case activity only has 25 contacts listed from Case Resources in the Send Copy section

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1574,7 +1574,7 @@ HERESQL;
     $relatedContacts = self::getRelatedContacts($caseId);
 
     $groupInfo = [];
-    $globalContacts = self::getGlobalContacts($groupInfo);
+    $globalContacts = self::getGlobalContacts($groupInfo, NULL, FALSE, FALSE, 0, 0);
 
     //unset values which are not required.
     foreach ($globalContacts as $k => & $v) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3431

Before
----------------------------------------
1. Add more than 25 contacts to the Case Resources group, e.g. 28 contacts.
2. Create a case activity from Manage Case.
3. In the Send Copy section only 25 contacts from the Case Resources group are listed.

After
----------------------------------------
All of them

Technical Details
----------------------------------------
It's not the usual api3 limit, it's that the parameter defaults to 25 and there's no way to change it.

Comments
----------------------------------------
A pager might make sense except how would you select across pages. Or a select2 box or something fancy, but this issue has existed forever and seems unlikely to come up in real life because it would be unusual to have so many people in the list, and over time it's usually pruned as people leave. So what I've done is just set to unlimited, because it's unlikely to contain thousands of contacts.

Has test, which fails before and passes after.

A check of universe shows this is only used on the case activity form.