### PR TITLE
Fix master-only regression on showing fields for contact type

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -72,16 +72,13 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function preProcess() {
-    $this->_mapperFields = $this->get('fields');
+    $this->_mapperFields = $this->getAvailableFields();
     $this->_importTableName = $this->get('importTableName');
     $this->_contactSubType = $this->get('contactSubType');
     //format custom field names, CRM-2676
     $contactType = $this->getContactType();
 
     $this->_contactType = $contactType;
-    if ($this->isSkipDuplicates()) {
-      unset($this->_mapperFields['id']);
-    }
 
     if ($this->isIgnoreDuplicates()) {
       //Mark Dedupe Rule Fields as required, since it's used in matching contact
@@ -636,13 +633,13 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $parser->run($this->_importTableName,
       $mapper,
       CRM_Import_Parser::MODE_PREVIEW,
-      $this->get('contactType'),
+      NULL,
       '_id',
       '_status',
       (int) $this->getSubmittedValue('onDuplicate'),
       NULL, NULL, FALSE,
       CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
-      $this->get('contactSubType'),
+      $this->getSubmittedValue('contactSubType'),
       $this->getSubmittedValue('dedupe_rule_id')
     );
     return $parser;

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -206,6 +206,8 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
   /**
    * Process the mapped fields and map it into the uploaded file.
+   *
+   * @throws \API_Exception
    */
   public function postProcess() {
 
@@ -225,7 +227,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'tag' => $this->controller->exportValue($this->_name, 'tag'),
       'allTags' => $this->get('tag'),
       'mapper' => $this->controller->exportValue('MapField', 'mapper'),
-      'mapFields' => $this->get('fields'),
+      'mapFields' => $this->getAvailableFields(),
       'contactType' => $this->get('contactType'),
       'contactSubType' => $this->get('contactSubType'),
       'primaryKeyName' => $this->get('primaryKeyName'),

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -407,4 +407,18 @@ class CRM_Import_Forms extends CRM_Core_Form {
     return $this->getDataSourceObject()->getRows($limit);
   }
 
+  /**
+   * Get the fields available for import selection.
+   *
+   * @return array
+   *   e.g ['first_name' => 'First Name', 'last_name' => 'Last Name'....
+   *
+   * @throws \API_Exception
+   */
+  protected function getAvailableFields(): array {
+    $parser = new CRM_Contact_Import_Parser_Contact();
+    $parser->setUserJobID($this->getUserJobID());
+    return $parser->getAvailableFields();
+  }
+
 }

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -25,6 +25,27 @@ class CRM_Import_ImportProcessor {
   protected $metadata = [];
 
   /**
+   * Id of the created user job.
+   *
+   * @var int
+   */
+  protected $userJobID;
+
+  /**
+   * @return int
+   */
+  public function getUserJobID(): int {
+    return $this->userJobID;
+  }
+
+  /**
+   * @param int $userJobID
+   */
+  public function setUserJobID(int $userJobID): void {
+    $this->userJobID = $userJobID;
+  }
+
+  /**
    * Metadata keyed by field title.
    *
    * @var array
@@ -415,8 +436,8 @@ class CRM_Import_ImportProcessor {
       $this->getFieldWebsiteTypes()
       // $mapperRelatedContactWebsiteType = []
     );
+    $importer->setUserJobID($this->getUserJobID());
     $importer->init();
-    $importer->_contactType = $this->getContactType();
     return $importer;
   }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -86,6 +86,36 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Get the submitted value, as stored on the user job.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   *
+   * @throws \API_Exception
+   */
+  protected function getSubmittedValue(string $fieldName) {
+    return $this->getUserJob()['metadata']['submitted_values'][$fieldName];
+  }
+
+  /**
+   * Get configured contact type.
+   *
+   * @throws \API_Exception
+   */
+  protected function getContactType() {
+    if (!$this->_contactType) {
+      $contactTypeMapping = [
+        CRM_Import_Parser::CONTACT_INDIVIDUAL => 'Individual',
+        CRM_Import_Parser::CONTACT_HOUSEHOLD => 'Household',
+        CRM_Import_Parser::CONTACT_ORGANIZATION => 'Organization',
+      ];
+      $this->_contactType = $contactTypeMapping[$this->getSubmittedValue('contactType')];
+    }
+    return $this->_contactType;
+  }
+
+  /**
    * Total number of non empty lines
    * @var int
    */
@@ -233,7 +263,7 @@ abstract class CRM_Import_Parser {
   /**
    * Contact type
    *
-   * @var int
+   * @var string
    */
   public $_contactType;
   /**

--- a/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
@@ -61,6 +61,7 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
     $sqlFormValues = [
       'dataSource' => 'CRM_Import_DataSource_SQL',
       'sqlQuery' => 'SELECT "bob" as first_name FROM civicrm_option_value LIMIT 5',
+      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
     ];
     $form = $this->submitDataSourceForm($sqlFormValues);
     $userJobID = $form->getUserJobID();
@@ -87,6 +88,7 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
     $csvFormValues = [
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'skipColumnHeader' => 1,
+      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
       'uploadFile' => [
         'name' => __DIR__ . '/data/yogi.csv',
         'type' => 'text/csv',

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -147,6 +147,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
       'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
       'dataSource' => 'CRM_Import_DataSource_SQL',
       'sqlQuery' => 'SELECT * FROM civicrm_tmp_d_import_job_xxx',
+      'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ], $submittedValues);
     $userJobID = UserJob::create()->setValues([
       'metadata' => [

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -150,6 +150,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
         'name' => __DIR__ . '/' . $csvFileName,
       ],
       'skipColumnHeader' => TRUE,
+      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
     ]);
     $form->buildForm();
     $form->postProcess();


### PR DESCRIPTION
Overview
----------------------------------------
Fix master-only regression on showing fields for contact type

Before
----------------------------------------
Master-only regression whereby contact-type-specific fields were not being offered up for mapping for Organization and Household

After
----------------------------------------
Back to the future

Technical Details
----------------------------------------
The issue was the available fields were being calculated before the contact type was available. There is definitely an intent to be able to get this data withough going through the `run` function which is is a jack-of-all-trades-and-a-master-of-none so I added a funciton to do that - using the userJobID as the source of information for `contactType`

I also hit an uncaught exception - I added a catch for it but it is not quite being handled consistently with other errors as their handling will change in https://github.com/civicrm/civicrm-core/pull/23292

Comments
----------------------------------------
@demeritcowboy tthis is a fix for the issue you found