### PR TITLE
AfformGui - Optional reset button for search and submit forms

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -196,6 +196,7 @@ class AfformAdminMeta {
         ],
         'submit' => [
           'title' => E::ts('Submit Button'),
+          'afform_type' => ['form'],
           'element' => [
             '#tag' => 'button',
             'class' => 'af-button btn btn-primary',
@@ -206,8 +207,22 @@ class AfformAdminMeta {
             ],
           ],
         ],
+        'reset' => [
+          'title' => E::ts('Reset Button'),
+          'afform_type' => ['form', 'search'],
+          'element' => [
+            '#tag' => 'button',
+            'class' => 'af-button btn btn-warning',
+            'type' => 'reset',
+            'crm-icon' => 'fa-undo',
+            '#children' => [
+              ['#text' => E::ts('Reset')],
+            ],
+          ],
+        ],
         'fieldset' => [
           'title' => E::ts('Fieldset'),
+          'afform_type' => ['form'],
           'element' => [
             '#tag' => 'fieldset',
             'af-fieldset' => NULL,

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -122,7 +122,9 @@
         $scope.elementList.length = 0;
         $scope.elementTitles.length = 0;
         _.each(afGui.meta.elements, function(element, name) {
-          if (!search || _.contains(name, search) || _.contains(element.title.toLowerCase(), search)) {
+          if (
+            (!element.afform_type || _.contains(element.afform_type, 'form')) &&
+            (!search || _.contains(name, search) || _.contains(element.title.toLowerCase(), search))) {
             var node = _.cloneDeep(element.element);
             if (name === 'fieldset') {
               if (!ctrl.editor.allowEntityConfig) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -157,11 +157,11 @@
         $scope.elementList.length = 0;
         $scope.elementTitles.length = 0;
         _.each(afGui.meta.elements, function(element, name) {
-          if (!search || _.contains(name, search) || _.contains(element.title.toLowerCase(), search)) {
+          if (
+            (!element.afform_type || _.contains(element.afform_type, 'search')) &&
+            (!search || _.contains(name, search) || _.contains(element.title.toLowerCase(), search))
+          ) {
             var node = _.cloneDeep(element.element);
-            if (name === 'fieldset') {
-              return;
-            }
             $scope.elementList.push(node);
             $scope.elementTitles.push(element.title);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3430

Allows search and submit forms to have a "Reset" button, and only allows a "Submit" button to be added to submission forms.

Technical Details
----------------------------------------
Adds some metadata about what elements belong on what form types, which will now hide the "submit" button as an option for non-submission forms.