### PR TITLE
SearchKit - Ensure all date and timestamp fields are presented with datepicker

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -102,7 +102,7 @@
           return '~/crmSearchTasks/crmSearchInput/text.html';
         }
 
-        if (field.input_type === 'Date') {
+        if (field.data_type === 'Date' || field.data_type === 'Timestamp') {
           return '~/crmSearchTasks/crmSearchInput/date.html';
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3424

Before
----------------------------------------
Not all date fields get a datepicker in SearchKit.

After
----------------------------------------
Now they all do.