### PR TITLE
Master only import regression - fix contactSubType handling

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -110,7 +110,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     }
     $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions, [], NULL, FALSE, $contactTypeAttributes);
 
-    $this->addElement('select', 'subType', ts('Subtype'));
+    $this->addElement('select', 'contactSubType', ts('Subtype'));
     $this->addElement('select', 'dedupe_rule_id', ts('Dedupe Rule'));
 
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
@@ -181,11 +181,21 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     // Setup the params array
     $this->_params = $this->controller->exportValues($this->_name);
 
+    // @todo - this params are being set here because they were / possibly still
+    // are in some places being accessed by forms later in the flow
+    // ie CRM_Contact_Import_Form_MapField, CRM_Contact_Import_Form_Preview
+    // or CRM_Contact_Import_Form_Summary using `$this->get()
+    // which was the old way of saving values submitted on this form such that
+    // the other forms could access them. Now they should use
+    // `getSubmittedValue` or simply not get them if the only
+    // reason is to pass to the Parser which can itself
+    // call 'getSubmittedValue'
+    // Once the mentioned forms no longer call $this->get() all this 'setting'
+    // is obsolete.
     $storeParams = [
       'onDuplicate' => $this->getSubmittedValue('onDuplicate'),
       'dedupe' => $this->getSubmittedValue('dedupe_rule_id'),
       'contactType' => $this->getSubmittedValue('contactType'),
-      'contactSubType' => $this->getSubmittedValue('subType'),
       'dateFormats' => $this->getSubmittedValue('dateFormats'),
       'savedMapping' => $this->getSubmittedValue('savedMapping'),
     ];

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -74,7 +74,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   public function preProcess() {
     $this->_mapperFields = $this->getAvailableFields();
     $this->_importTableName = $this->get('importTableName');
-    $this->_contactSubType = $this->get('contactSubType');
+    $this->_contactSubType = $this->getSubmittedValue('contactSubType');
     //format custom field names, CRM-2676
     $contactType = $this->getContactType();
 
@@ -294,7 +294,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $processor->setFormName($formName);
     $processor->setMetadata($this->getContactImportMetadata());
     $processor->setContactTypeByConstant($this->getSubmittedValue('contactType'));
-    $processor->setContactSubType($this->get('contactSubType'));
+    $processor->setContactSubType($this->getSubmittedValue('contactSubType'));
 
     for ($i = 0; $i < $this->_columnCount; $i++) {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -229,7 +229,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'mapper' => $this->controller->exportValue('MapField', 'mapper'),
       'mapFields' => $this->getAvailableFields(),
       'contactType' => $this->get('contactType'),
-      'contactSubType' => $this->get('contactSubType'),
+      'contactSubType' => $this->getSubmittedValue('contactSubType'),
       'primaryKeyName' => $this->get('primaryKeyName'),
       'statusFieldName' => $this->get('statusFieldName'),
       'statusID' => $this->get('statusID'),

--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -103,13 +103,4 @@ trait CRM_Contact_Import_MetadataTrait {
     return CRM_Utils_Array::collect('title', $this->getContactImportMetadata());
   }
 
-  /**
-   * Get configured contact sub type.
-   *
-   * @return string
-   */
-  protected function getContactSubType() {
-    return $this->_contactSubType ?? NULL;
-  }
-
 }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2577,8 +2577,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     // Since $this->_contactType is still being called directly do a get call
     // here to make sure it is instantiated.
     $this->getContactType();
-
-    $this->_contactSubType = $contactSubType;
+    $this->getContactSubType();
 
     $this->init();
 
@@ -3043,6 +3042,17 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param int $mode
    */
   public function set($store, $mode = self::MODE_SUMMARY) {
+    // @todo - this params are being set here because they were / possibly still
+    // are in some places being accessed by forms later in the flow
+    // ie CRM_Contact_Import_Form_MapField, CRM_Contact_Import_Form_Preview
+    // or CRM_Contact_Import_Form_Summary using `$this->get()
+    // which was the old way of saving values submitted on this form such that
+    // the other forms could access them. Now they should use
+    // `getSubmittedValue` or simply not get them if the only
+    // reason is to pass to the Parser which can itself
+    // call 'getSubmittedValue'
+    // Once the mentioned forms no longer call $this->get() all this 'setting'
+    // is obsolete.
     $store->set('rowCount', $this->_rowCount);
     $store->set('fieldTypes', $this->getSelectTypes());
 

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -316,6 +316,18 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
+   * Get the contact sub type selected for the import (on the datasource form).
+   *
+   * @return string|null
+   *   e.g Staff.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContactSubType(): ?string {
+    return $this->getSubmittedValue('contactSubType');
+  }
+
+  /**
    * Create a user job to track the import.
    *
    * @return int

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -116,6 +116,20 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Get configured contact type.
+   *
+   * @return string|null
+   *
+   * @throws \API_Exception
+   */
+  public function getContactSubType() {
+    if (!$this->_contactSubType) {
+      $this->_contactSubType = $this->getSubmittedValue('contactSubType');
+    }
+    return $this->_contactSubType;
+  }
+
+  /**
    * Total number of non empty lines
    * @var int
    */
@@ -266,12 +280,23 @@ abstract class CRM_Import_Parser {
    * @var string
    */
   public $_contactType;
+
   /**
    * Contact sub-type
    *
-   * @var int
+   * @var int|null
    */
   public $_contactSubType;
+
+  /**
+   * @param int|null $contactSubType
+   *
+   * @return self
+   */
+  public function setContactSubType(?int $contactSubType): self {
+    $this->_contactSubType = $contactSubType;
+    return $this;
+  }
 
   /**
    * Class constructor.

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -36,7 +36,7 @@
          <tr class="crm-import-datasource-form-block-contactType">
        <td class="label">{$form.contactType.label}</td>
              <td>{$form.contactType.html} {help id='contact-type'}&nbsp;&nbsp;&nbsp;
-               <span id="contact-subtype">{$form.subType.label}&nbsp;&nbsp;&nbsp;{$form.subType.html} {help id='contact-sub-type'}</span></td>
+               <span id="contact-subtype">{$form.contactSubType.label}&nbsp;&nbsp;&nbsp;{$form.contactSubType.html} {help id='contact-sub-type'}</span></td>
          </tr>
          <tr class="crm-import-datasource-form-block-onDuplicate">
              <td class="label">{$form.onDuplicate.label}</td>
@@ -123,16 +123,16 @@
 
                         success: function(subtype){
                                                    if ( subtype.length == 0 ) {
-                                                      cj("#subType").empty();
+                                                      cj("#contactSubType").empty();
                                                       cj("#contact-subtype").hide();
                                                    } else {
                                                        cj("#contact-subtype").show();
-                                                       cj("#subType").empty();
+                                                       cj("#contactSubType").empty();
 
-                                                       cj("#subType").append("<option value=''>- {/literal}{ts escape='js'}select{/ts}{literal} -</option>");
+                                                       cj("#contactSubType").append("<option value=''>- {/literal}{ts escape='js'}select{/ts}{literal} -</option>");
                                                        for ( var key in  subtype ) {
                                                            // stick these new options in the subtype select
-                                                           cj("#subType").append("<option value="+key+">"+subtype[key]+" </option>");
+                                                           cj("#contactSubType").append("<option value="+key+">"+subtype[key]+" </option>");
                                                        }
                                                    }
 

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -145,6 +145,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     CRM_Core_DAO::executeQuery('CREATE TABLE IF NOT EXISTS civicrm_tmp_d_import_job_xxx (`nada` text, `first_name` text, `last_name` text, `address` text) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci');
     $submittedValues = array_merge([
       'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactSubType' => '',
       'dataSource' => 'CRM_Import_DataSource_SQL',
       'sqlQuery' => 'SELECT * FROM civicrm_tmp_d_import_job_xxx',
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
@@ -388,6 +389,16 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
    */
   protected function getContactType(): string {
     return $this->_contactType ?? 'Individual';
+  }
+
+  /**
+   * This is accessed by virtue of the MetaDataTrait being included.
+   *
+   * The use of the metadataTrait came from a transitional refactor
+   * but it probably should be phased out again.
+   */
+  protected function getContactSubType(): string {
+    return $this->_contactSubType ?? '';
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Master only import regression - fix contactSubType handling

Before
----------------------------------------
Master branch only - contact subtype specific fields not loading on mapfield

After
----------------------------------------
Loading & I tested that they are imported to with r-run

Technical Details
----------------------------------------
I found that the fieldname for contactSubType was actually subType
so renamed to contactSubType & ensured the type was set before
metadata loading


Comments
----------------------------------------
