### PR TITLE
[REF][Import] [Contact] Clean up preview screen

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -521,18 +521,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     $this->set('columnNames', $this->_columnNames);
-    $this->set('websites', $parserParameters['mapperWebsiteType']);
-    $this->set('locations', $locations);
-    $this->set('phones', $parserParameters['mapperPhoneType']);
-    $this->set('ims', $parserParameters['mapperImProvider']);
-    $this->set('related', $parserParameters['mapperRelated']);
-    $this->set('relatedContactType', $parserParameters['relatedContactType']);
-    $this->set('relatedContactDetails', $parserParameters['relatedContactDetails']);
-    $this->set('relatedContactLocType', $parserParameters['relatedContactLocType']);
-    $this->set('relatedContactPhoneType', $parserParameters['relatedContactPhoneType']);
-    $this->set('relatedContactImProvider', $parserParameters['relatedContactImProvider']);
-    $this->set('relatedContactWebsiteType', $parserParameters['relatedContactWebsiteType']);
-    $this->set('mapper', $mapper);
 
     // store mapping Id to display it in the preview page
     $this->set('loadMappingId', CRM_Utils_Array::value('mappingId', $params));

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -76,10 +76,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
 
     $properties = array(
-      'mapper',
-      'locations',
-      'phones',
-      'ims',
       'columnCount',
       'totalRowCount',
       'validRowCount',
@@ -88,14 +84,9 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'downloadErrorRecordsUrl',
       'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
-      'related',
-      'relatedContactDetails',
-      'relatedContactLocType',
-      'relatedContactPhoneType',
-      'relatedContactImProvider',
-      'websites',
-      'relatedContactWebsiteType',
     );
+
+    $this->assign('mapper', $this->getMappedFieldLabels());
 
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
@@ -294,6 +285,26 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     //hack to clean db
     //if job complete drop table.
     $importJob->isComplete();
+  }
+
+  /**
+   * Get the mapped fields as an array of labels.
+   *
+   * e.g
+   * ['First Name', 'Employee Of - First Name', 'Home - Street Address']
+   *
+   * @return array
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getMappedFieldLabels(): array {
+    $mapper = [];
+    $parser = new CRM_Contact_Import_Parser_Contact();
+    $parser->setUserJobID($this->getUserJobID());
+    foreach ($this->getSubmittedValue('mapper') as $columnNumber => $mappedField) {
+      $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput($mappedField, 0, $columnNumber));
+    }
+    return $mapper;
   }
 
 }

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -42,23 +42,7 @@
         {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
         <td class="form-item even-row{if $wizard.currentStepName == 'Preview'} labels{/if}">
           {if $wizard.currentStepName == 'Preview'}
-            {if $relatedContactDetails && $relatedContactDetails[$i] != ''}
-                {$mapper[$i]} - {$relatedContactDetails[$i]}
-              {if $relatedContactLocType && $relatedContactLocType[$i] != ''} - {$relatedContactLocType[$i]}{/if}
-              {if $relatedContactPhoneType && $relatedContactPhoneType[$i] != ''} - {$relatedContactPhoneType[$i]}{/if}
-              {* append IM Service Provider type for related contact *}
-              {if  $relatedContactImProvider && $relatedContactImProvider[$i] != ''} - {$relatedContactImProvider[$i]}{/if}
-              {* append website type *}
-              {if  $relatedContactWebsiteType && $relatedContactWebsiteType[$i] != ''} - {$relatedContactWebsiteType[$i]}{/if}
-            {else}
-              {if $locations[$i]}{$locations[$i]} - {/if}
-              {if $phones[$i]}{$phones[$i]} - {/if}
-              {* append IM Service provider type for contact *}
-              {if $ims[$i]}{$ims[$i]} - {/if}
-              {* append website type *}
-              {if $websites[$i]}{$websites[$i]} - {/if}
-              {$mapper[$i]}
-            {/if}
+            {$mapperField}
           {else}
             {$mapperField.html|smarty:nodefaults}
           {/if}


### PR DESCRIPTION
Overview
----------------------------------------
[REF][Import] [Contact] Clean up preview screen

Before
----------------------------------------
The field preview is built up in a very complicated way - involving compiling multiple arrays on the MapField screen which are passed to Preview using `$this->set()` and `$this->get()` and assigned to the tpl layer where the smarty code mixes & matches them to get the relevant titles.



After
----------------------------------------
The Preview form leverages a function on the Parser class to simply obtain a list of titles to iterate - output unchanged

![image](https://user-images.githubusercontent.com/336308/166343090-0b7cb7ef-b5c9-48ee-a508-5aaeb5b35b9c.png)


Technical Details
---------------------------------------
The new way is pretty straight forward - the hard part is understanding why it was ever done the old way!

Comments
---------------------------------------
There is some slight change in the order of the labels when there is a relationship - the relationship label is first & then it is the same as where there is no relationship - I couldn't see a reason to make it more complicated