### PR TITLE
[REF] [Import] Stop passing submittedValues as parameters

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -465,8 +465,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param array $values
    *   The array of values belonging to this line.
    *
-   * @param bool $doGeocodeAddress
-   *
    * @return bool
    *   the result of this processing
    *
@@ -474,9 +472,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @throws \CRM_Core_Exception
    * @throws \API_Exception
    */
-  public function import($onDuplicate, &$values, $doGeocodeAddress = FALSE) {
+  public function import($onDuplicate, &$values) {
     $this->_unparsedStreetAddressContacts = [];
-    if (!$doGeocodeAddress) {
+    if (!$this->getSubmittedValue('doGeocodeAddress')) {
       // CRM-5854, reset the geocode method to null to prevent geocoding
       CRM_Utils_GeocodeProvider::disableForSession();
     }
@@ -2541,12 +2539,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param int $onDuplicate
    * @param int $statusID
    * @param int $totalRowCount
-   * @param bool $doGeocodeAddress
-   * @param int $timeout
-   * @param string $contactSubType
-   * @param int $dedupeRuleGroupID
    *
    * @return mixed
+   * @throws \API_Exception
    */
   public function run(
     $tableName,
@@ -2557,16 +2552,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $statusFieldName = '_status',
     $onDuplicate = self::DUPLICATE_SKIP,
     $statusID = NULL,
-    $totalRowCount = NULL,
-    $doGeocodeAddress = FALSE,
-    $timeout = CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
-    $contactSubType = NULL,
-    $dedupeRuleGroupID = NULL
+    $totalRowCount = NULL
   ) {
 
     // TODO: Make the timeout actually work
-    $this->_onDuplicate = $onDuplicate;
-    $this->_dedupeRuleGroupID = $dedupeRuleGroupID;
+    $this->_onDuplicate = $onDuplicate = $this->getSubmittedValue('onDuplicate');
+    $this->_dedupeRuleGroupID = $this->getSubmittedValue('dedupe_rule_id');
     // Since $this->_contactType is still being called directly do a get call
     // here to make sure it is instantiated.
     $this->getContactType();
@@ -2640,7 +2631,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       }
       elseif ($mode == self::MODE_IMPORT) {
         try {
-          $returnCode = $this->import($onDuplicate, $values, $doGeocodeAddress);
+          $returnCode = $this->import($onDuplicate, $values);
         }
         catch (CiviCRM_API3_Exception $e) {
           // When we catch errors here we are not adding to the errors array - mostly

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -149,6 +149,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
       'contactSubType' => '',
       'dataSource' => 'CRM_Import_DataSource_SQL',
       'sqlQuery' => 'SELECT * FROM civicrm_tmp_d_import_job_xxx',
+      'dedupe_rule_id' => '',
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ], $submittedValues);
     $userJobID = UserJob::create()->setValues([

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1059,6 +1059,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         'submitted_values' => array_merge([
           'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
           'contactSubType' => '',
+          'doGeocodeAddress' => 0,
         ], $submittedValues),
       ],
       'status_id:name' => 'draft',


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Stop passing submittedValues as parameters

Before
----------------------------------------
Parameters submitted on the import forms passed by code to the Parser object run function

After
----------------------------------------
Since these values are stored on the user job and the user job is always available (or else the contact fields would fail) when the `Parser` is loaded it can simply use `getSubmittedValue` to obtain them

Technical Details
----------------------------------------
While I haven't simplified the upstream functions at this stage then no longer need to pass around these variables to ensure they are available when calling run

This array specifies the fields that are available - in addition the datasource specific fields are - stored to the user job

https://github.com/civicrm/civicrm-core/blob/80cb71bb3c477dcd1047e8cfafd5b2b928df2de4/CRM/Import/Forms.php#L99-L118

Comments
----------------------------------------
