### PR TITLE
Fix calculation and assignment of taxAmount on contribution page confirmation

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1363,10 +1363,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         CRM_Price_BAO_PriceSet::processAmount($this->_values['fee'], $params, $lineItem[$priceSetId], $priceSetId);
       }
 
-      if ($params['tax_amount']) {
-        $this->set('tax_amount', $params['tax_amount']);
-      }
-
       if ($proceFieldAmount) {
         $lineItem[$params['priceSetId']][$fieldOption]['unit_price'] = $proceFieldAmount;
         $lineItem[$params['priceSetId']][$fieldOption]['line_total'] = $proceFieldAmount;


### PR DESCRIPTION
Overview
----------------------------------------
When using a contribution page with "Separate Membership Payment" we get an error if both membership and contribution amount have a tax component. It was trying to use `$params['tax_amount']` for each contribution which was incorrect and came from the form submission and was the sum of both.

Before
----------------------------------------
Incorrect usage of tax_amount

After
----------------------------------------
Calculated tax_amount

Technical Details
----------------------------------------


Comments
----------------------------------------
Tested using a contribution page with `Separate Membership Payment` enabled, recurring set to every 1 day and installments=10. Using "quick config" so amounts configured directly on contribution page configuration and not via pricesets.

