### PR TITLE
dev/core#3439 change batch geocode query to include events

### DIFF
--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -116,7 +116,7 @@ class CRM_Utils_Address_BatchUpdate {
    */
   public function processContacts($processGeocode, $parseStreetAddress) {
     // build where clause.
-    $clause = ['( c.id = a.contact_id )'];
+    $clause = [];
     $params = [];
     if ($this->start) {
       $clause[] = "( c.id >= %1 )";
@@ -137,19 +137,22 @@ class CRM_Utils_Address_BatchUpdate {
     $whereClause = implode(' AND ', $clause);
 
     $query = "
-    SELECT     c.id,
-               a.id as address_id,
-               a.street_address,
-               a.city,
-               a.postal_code,
-               a.country_id,
-               s.name as state,
-               o.name as country
-    FROM       civicrm_contact  c
-    INNER JOIN civicrm_address        a ON a.contact_id = c.id
-    LEFT  JOIN civicrm_country        o ON a.country_id = o.id
-    LEFT  JOIN civicrm_state_province s ON a.state_province_id = s.id
-    WHERE      {$whereClause}
+      SELECT c.id,
+        a.id as address_id,
+        a.street_address,
+        a.city,
+        a.postal_code,
+        a.country_id,
+        s.name as state,
+        o.name as country
+      FROM civicrm_address a
+      LEFT JOIN civicrm_contact c
+        ON a.contact_id = c.id
+      LEFT JOIN civicrm_country o
+        ON a.country_id = o.id
+      LEFT JOIN civicrm_state_province s
+        ON a.state_province_id = s.id
+      WHERE {$whereClause}
       ORDER BY a.id
     ";
 


### PR DESCRIPTION
Overview
----------------------------------------
The batch geocode API does not process event addresses because they are not tied to a contact record and the query is currently contact table dependent.

Before
----------------------------------------
Job.geocode is run but event addresses are not geocoded.

After
----------------------------------------
Event addresses are geocoded.

This PR also reformats the SQL to current standards.