### PR TITLE
SearchKit - Consistently check for date field

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -21,7 +21,7 @@
 
         this.ngModel.$render = function() {
           ctrl.value = ctrl.ngModel.$viewValue;
-          if (!rendered && field.input_type === 'Date') {
+          if (!rendered && isDateField(field)) {
             setDateType();
           }
           rendered = true;
@@ -102,7 +102,7 @@
           return '~/crmSearchTasks/crmSearchInput/text.html';
         }
 
-        if (field.data_type === 'Date' || field.data_type === 'Timestamp') {
+        if (isDateField(field)) {
           return '~/crmSearchTasks/crmSearchInput/date.html';
         }
 
@@ -133,6 +133,10 @@
         var field = ctrl.field || {};
         return {results: formatForSelect2(field.options || [], ctrl.optionKey || 'id', 'label', ['description', 'color', 'icon'])};
       };
+
+      function isDateField(field) {
+        return field.data_type === 'Date' || field.data_type === 'Timestamp';
+      }
 
     }
   });


### PR DESCRIPTION
Overview
----------------------------------------
Followup from #23335, makes the logic more consistent between rendering and initializing a date widget.

Before
----------------------------------------
Fields like `Contact.created_date` are rendered with a datePicker as of #23335 but when loading a saved search they might not get initialized correctly in the UI.

After
----------------------------------------
Works better.