### PR TITLE
Ensure comma not formatted into amount

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1155,20 +1155,20 @@ abstract class CRM_Core_Payment {
   }
 
   /**
-   * Legacy. Better for a method to work on its own PropertyBag,
-   * but also, this function does not do very much.
+   * Get the submitted amount, padded to 2 decimal places, if needed.
    *
    * @param array $params
    *
    * @return string
-   * @throws \CRM_Core_Exception
    */
   protected function getAmount($params = []) {
     if (!CRM_Utils_Rule::numeric($params['amount'])) {
       CRM_Core_Error::deprecatedWarning('Passing Amount value that is not numeric is deprecated please report this in gitlab');
       return CRM_Utils_Money::formatUSLocaleNumericRounded(filter_var($params['amount'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION), 2);
     }
-    return CRM_Utils_Money::formatUSLocaleNumericRounded($params['amount'], 2);
+    // Amount is already formatted to a machine-friendly format but may NOT have
+    // decimal places - eg. it could be 1000.1 so this would return 1000.10.
+    return Civi::format()->machineMoney($params['amount']);
   }
 
   /**

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -93,8 +93,34 @@ class Format {
       return '';
     }
     $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL);
-    $money = Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
-    return $money->formatWith($formatter);
+    return Money::of($amount, $currency, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+  }
+
+  /**
+   * Get a number formatted to a machine format with padded decimal places.
+   *
+   * This is intended to be a machine-friendly format that is also suitable
+   * for sending out to other systems that might expect 2 digits after the
+   * decimal point.
+   *
+   * Most currencies format to 2 decimal places so the default of 'USD' will
+   * achieve that.
+   *
+   * For example an input of 1000.1 will return 1000.10.
+   *
+   * This will ensure that
+   *
+   * @param string|float|int $amount
+   * @param string $currency
+   *
+   * @return string
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function machineMoney($amount, string $currency = 'USD'): string {
+    $formatter = $this->getMoneyFormatter($currency, 'en_US', NumberFormatter::DECIMAL, [NumberFormatter::GROUPING_USED => FALSE]);
+    return Money::of($amount, $currency, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**

--- a/ext/payflowpro/tests/phpunit/CRM/Core/Payment/PayflowProTest.php
+++ b/ext/payflowpro/tests/phpunit/CRM/Core/Payment/PayflowProTest.php
@@ -48,7 +48,7 @@ class CRM_Core_Payment_PayflowProTest extends \PHPUnit\Framework\TestCase implem
   public function testSinglePayment(): void {
     $this->setupMockHandler();
     $params = $this->getBillingParams();
-    $params['amount'] = 20.00;
+    $params['amount'] = 1020.00;
     $params['currency'] = 'AUD';
     $params['description'] = 'Test Contribution';
     $params['invoiceID'] = 'xyz';
@@ -244,7 +244,7 @@ class CRM_Core_Payment_PayflowProTest extends \PHPUnit\Framework\TestCase implem
    */
   public function getExpectedSinglePaymentRequests(): array {
     return [
-      'USER[4]=test&VENDOR[4]=test&PARTNER[6]=PayPal&PWD[8]=test1234&TENDER[1]=C&TRXTYPE[1]=S&ACCT[16]=4111111111111111&CVV2[3]=123&EXPDATE[4]=1022&ACCTTYPE[4]=Visa&AMT[5]=20.00&CURRENCY[3]=AUD&FIRSTNAME[4]=John&LASTNAME[8]=O\'Connor&STREET[16]=8 Hobbitton Road&CITY[9]=The+Shire&STATE[3]=NSW&ZIP[4]=5010&COUNTRY[3]=AUS&EMAIL[24]=unittesteway@civicrm.org&CUSTIP[9]=127.0.0.1&COMMENT1[4]=4200&COMMENT2[4]=live&INVNUM[3]=xyz&ORDERDESC[17]=Test+Contribution&VERBOSITY[6]=MEDIUM&BILLTOCOUNTRY[3]=AUS',
+      'USER[4]=test&VENDOR[4]=test&PARTNER[6]=PayPal&PWD[8]=test1234&TENDER[1]=C&TRXTYPE[1]=S&ACCT[16]=4111111111111111&CVV2[3]=123&EXPDATE[4]=1022&ACCTTYPE[4]=Visa&AMT[7]=1020.00&CURRENCY[3]=AUD&FIRSTNAME[4]=John&LASTNAME[8]=O\'Connor&STREET[16]=8 Hobbitton Road&CITY[9]=The+Shire&STATE[3]=NSW&ZIP[4]=5010&COUNTRY[3]=AUS&EMAIL[24]=unittesteway@civicrm.org&CUSTIP[9]=127.0.0.1&COMMENT1[4]=4200&COMMENT2[4]=live&INVNUM[3]=xyz&ORDERDESC[17]=Test+Contribution&VERBOSITY[6]=MEDIUM&BILLTOCOUNTRY[3]=AUS',
     ];
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Ensure comma not formatted into amount

Before
----------------------------------------
Calling `getAmount`  on `CRM_Core_Payment` adds a thousand separator

After
----------------------------------------
It doesn't

Technical Details
----------------------------------------
Probably the function doesn't add anything as params['amount']
should be correctly formatted - however,
it shouldn't add a comma - per
https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/227


Comments
----------------------------------------
I think this must have regressed recently-ish when we messed with money formatting  - but I'm not 100% sure when