### PR TITLE
Fix missing contactID when registering for paid event from waitlist

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -524,6 +524,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             $value['email'] = CRM_Utils_Array::valueByRegexKey('/^email-/', $value);
           }
 
+          // If registering from waitlist participant_id is set but contact_id is not.
+          // We need a contact ID to process the payment so set the "primary" contact ID.
+          if (empty($value['contact_id'])) {
+            $value['contact_id'] = $contactID;
+          }
+
           if (is_object($payment)) {
             // Not quite sure why we don't just user $value since it contains the data
             // from result

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -192,6 +192,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           continue;
         }
         $individualTaxAmount = 0;
+        $append = '';
         //display tax amount on confirmation page
         $taxAmount += $v['tax_amount'];
         if (is_array($v)) {
@@ -1255,6 +1256,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $form->_paymentProcessor = $params['paymentProcessorObj'];
     }
     $form->postProcess();
+    return $form;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/extensions/stripe/-/issues/347 but note this is not a Stripe issue and variants of this will happen with any payment processor because no contact ID is passed in when registering from the waitlist.

For a processor using payment propertyBag accessing contactID will cause CiviCRM to crash. For a payment processor using the passed in array there will at least be a PHP notice if contact_id is accessed and anything that needs the contact ID will not be setup correctly.

Before
----------------------------------------
Attempt to make a paid registration from the waitlist has no contact ID and can cause payment processors to fail.

After
----------------------------------------
Attempt to make a paid registration from the waitlist succeeds.

Technical Details
----------------------------------------
The registration code is rather complex but basically:
- When registering via waitlist (civicrm/register/confirm?participantId=X) the parameters that get passed to the `processPayment()` function (https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/Confirm.php#L1262) does not include a contact ID in the `$value` array.
- When registering through the "normal" register form a contact ID *is* included in the `$value` array as `$value['contact_id'].
- We already calculated the primary contact ID and it's a simple step to pass it in if not already set.

Comments
----------------------------------------
There's not much testing on register from waitlist. I found `CRM_Event_Form_Registration_RegisterTest::testDoubleWaitlistRegistration()` which could probably be extended.
