### PR TITLE
[REF] [Import] Remove unused tpl assign showColNames

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -108,7 +108,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->_formattedFieldNames[$contactType] = $this->_mapperFields = array_merge($this->_mapperFields, $formattedFieldNames);
 
     $columnNames = $this->getColumnHeaders();
-    $this->assign('showColNames', !empty($columnNames));
 
     $this->_columnCount = $this->getNumberOfColumns();
     $this->_columnNames = $columnNames;

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -94,14 +94,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     $this->assign('dataValues', $this->getDataRows(2));
 
     $this->setStatusUrl();
-
-    $showColNames = TRUE;
-    if ('CRM_Import_DataSource_CSV' == $this->get('dataSource') &&
-      !$this->getSubmittedValue('skipColumnHeader')
-    ) {
-      $showColNames = FALSE;
-    }
-    $this->assign('showColNames', $showColNames);
   }
 
   /**

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -35,8 +35,6 @@ class CRM_Custom_Import_Form_MapField extends CRM_Contact_Import_Form_MapField {
     $skipColumnHeader = $this->controller->exportValue('DataSource', 'skipColumnHeader');
     $this->_onDuplicate = $this->get('onDuplicate');
     if ($skipColumnHeader) {
-      //showColNames needs to be true to show "Column Names" column
-      $this->assign('showColNames', $skipColumnHeader);
       $this->assign('columnNames', $columnNames);
       /* if we had a column header to skip, stash it for later */
       $this->_columnHeaders = $this->_dataValues[0];


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Remove unused tpl assign showColNames

Before
----------------------------------------
`showColNames` assigned to the template - but no longer used

![image](https://user-images.githubusercontent.com/336308/166841954-b6f417dd-31ca-4bfc-b392-d7acbf1804a8.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
Prior to cleanup in `MapTable.tpl` the variable was used....

![image](https://user-images.githubusercontent.com/336308/166842008-131ed950-63cd-4df4-a7de-bfc64cd64179.png)


Comments
----------------------------------------
