### PR TITLE
Update expired root certs for when retrieving messages from civicrm.org on civi dashboard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "psr/log": "~1.0",
     "symfony/finder": "~3.0 || ~4.4",
     "tecnickcom/tcpdf" : "6.4.*",
-    "totten/ca-config": "~17.05",
+    "totten/ca-config": "~22.05",
     "zetacomponents/base": "1.9.*",
     "zetacomponents/mail": "1.9.*",
     "marcj/topsort": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b33687888fc16f55cf7323e0fd8755c",
+    "content-hash": "4cb8d7de594faef8145b91723bc83f47",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -4440,16 +4440,16 @@
         },
         {
             "name": "totten/ca-config",
-            "version": "v17.05.0",
+            "version": "v22.05.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/totten/ca_config.git",
-                "reference": "461cf05f932897c37ca87e9a85283d4963b49f09"
+                "reference": "5d71e1587ea6b18532f0b72b06fab103c1dcf8db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/totten/ca_config/zipball/461cf05f932897c37ca87e9a85283d4963b49f09",
-                "reference": "461cf05f932897c37ca87e9a85283d4963b49f09",
+                "url": "https://api.github.com/repos/totten/ca_config/zipball/5d71e1587ea6b18532f0b72b06fab103c1dcf8db",
+                "reference": "5d71e1587ea6b18532f0b72b06fab103c1dcf8db",
                 "shasum": ""
             },
             "require": {
@@ -4475,9 +4475,9 @@
             "homepage": "https://github.com/totten/ca_config",
             "support": {
                 "issues": "https://github.com/totten/ca_config/issues",
-                "source": "https://github.com/totten/ca_config/tree/master"
+                "source": "https://github.com/totten/ca_config/tree/v22.05.0"
             },
-            "time": "2017-05-10T20:08:17+00:00"
+            "time": "2022-05-05T05:35:59+00:00"
         },
         {
             "name": "totten/lurkerlite",
@@ -4909,5 +4909,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------

Some PHP builds do not get a list of root certificates from the operating-system. For these systems, Civi may use a fallback list (*provided by curl+Mozilla*). This updates the fallback data.

See also: https://github.com/totten/ca_config/issues/2

Before
----------------------------------------

```
Exception: "Certificate Authority file is too old. Please contact the system administrator. See also: \sites\all\modules\civicrm\vendor\totten\ca-config\src\CA\Config/cacert.pem"

0 \sites\all\modules\civicrm\CRM\Utils\HttpClient.php(180): CA_Config_Curl::probe((Array:3))
1 \sites\all\modules\civicrm\CRM\Utils\HttpClient.php(118): CRM_Utils_HttpClient->createCurl("https://alert.civicrm.org/alert?prot=1&ver=5.50.alpha1&uf=Drupal...")
2 \sites\all\modules\civicrm\CRM\Core\CommunityMessages.php(126): CRM_Utils_HttpClient->get("https://alert.civicrm.org/alert?prot=1&ver=5.50.alpha1&uf=Drupal...")
3 \sites\all\modules\civicrm\CRM\Core\CommunityMessages.php(100): CRM_Core_CommunityMessages->fetchDocument()
4 \sites\all\modules\civicrm\CRM\Core\CommunityMessages.php(159): CRM_Core_CommunityMessages->getDocument()
5 \sites\all\modules\civicrm\CRM\Contact\Page\DashBoard.php(100): CRM_Core_CommunityMessages->pick()
6 \sites\all\modules\civicrm\CRM\Contact\Page\DashBoard.php(39): CRM_Contact_Page_DashBoard->getCommunityMessageOutput()
7 \sites\all\modules\civicrm\CRM\Core\Invoke.php(319): CRM_Contact_Page_DashBoard->run((Array:2), NULL)
8 \sites\all\modules\civicrm\CRM\Core\Invoke.php(69): CRM_Core_Invoke::runItem((Array:17))
9 \sites\all\modules\civicrm\CRM\Core\Invoke.php(36): CRM_Core_Invoke::_invoke((Array:2))
10 \sites\all\modules\civicrm\drupal\civicrm.module(471): CRM_Core_Invoke::invoke((Array:2))
11 \includes\menu.inc(527): civicrm_invoke("dashboard")
```

After
---------

Same request works.
