### PR TITLE
APIv4 - Add NOW() date function

### DIFF
--- a/Civi/Api4/Query/SqlFunctionNOW.php
+++ b/Civi/Api4/Query/SqlFunctionNOW.php
@@ -14,11 +14,11 @@ namespace Civi\Api4\Query;
 /**
  * Sql function
  */
-class SqlFunctionCURDATE extends SqlFunction {
+class SqlFunctionNOW extends SqlFunction {
 
   protected static $category = self::CATEGORY_DATE;
 
-  protected static $dataType = 'Date';
+  protected static $dataType = 'Timestamp';
 
   protected static function params(): array {
     return [];
@@ -28,14 +28,14 @@ class SqlFunctionCURDATE extends SqlFunction {
    * @return string
    */
   public static function getTitle(): string {
-    return ts('Today');
+    return ts('Now');
   }
 
   /**
    * @return string
    */
   public static function getDescription(): string {
-    return ts('The current date.');
+    return ts('The current date and time.');
   }
 
 }

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -245,6 +245,32 @@ class SqlFunctionTest extends UnitTestCase {
     }
   }
 
+  public function testCurrentDate() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'abc', 'last_name' => $lastName, 'birth_date' => 'now'],
+      ['first_name' => 'def', 'last_name' => $lastName, 'birth_date' => 'now - 1 year'],
+      ['first_name' => 'def', 'last_name' => $lastName, 'birth_date' => 'now - 10 year'],
+    ];
+    Contact::save(FALSE)
+      ->setRecords($sampleData)
+      ->execute();
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $lastName)
+      ->addWhere('birth_date', '=', 'CURDATE()', TRUE)
+      ->selectRowCount()
+      ->execute();
+    $this->assertCount(1, $result);
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $lastName)
+      ->addWhere('birth_date', '<', 'DATE(NOW())', TRUE)
+      ->selectRowCount()
+      ->execute();
+    $this->assertCount(2, $result);
+  }
+
   public function testRandFunction() {
     Contact::save(FALSE)
       ->setRecords(array_fill(0, 6, []))


### PR DESCRIPTION
Overview
----------------------------------------
Adds a function for `NOW` which returns the full date+time, and distinguishes
it from `CURDATE` which just returns the date part.

Before
----------------------------------------
Only `CURDATE` available.

After
----------------------------------------
Both available. Test added.