### PR TITLE
Translation - distinguish between 'On' for date and 'On'/'Off'

### DIFF
--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -199,11 +199,11 @@
 <tr><td class="label">{ts}From{/ts}</td><td>{$report.mailing.from_name} &lt;{$report.mailing.from_email}&gt;</td></tr>
 <tr><td class="label">{ts}Reply-to email{/ts}</td><td>{$report.mailing.replyto_email|htmlentities}</td></tr>
 
-<tr><td class="label">{ts}Forward replies{/ts}</td><td>{if $report.mailing.forward_replies}{ts}On{/ts}{else}{ts}Off{/ts}{/if}</td></tr>
-<tr><td class="label">{ts}Auto-respond to replies{/ts}</td><td>{if $report.mailing.auto_responder}{ts}On{/ts}{else}{ts}Off{/ts}{/if}</td></tr>
+<tr><td class="label">{ts}Forward replies{/ts}</td><td>{if $report.mailing.forward_replies}{ts}Enabled{/ts}{else}{ts}Disabled{/ts}{/if}</td></tr>
+<tr><td class="label">{ts}Auto-respond to replies{/ts}</td><td>{if $report.mailing.auto_responder}{ts}Enabled{/ts}{else}{ts}Disabled{/ts}{/if}</td></tr>
 
-<tr><td class="label">{ts}Open tracking{/ts}</td><td>{if $report.mailing.open_tracking}{ts}On{/ts}{else}{ts}Off{/ts}{/if}</td></tr>
-<tr><td class="label">{ts}URL Click-through tracking{/ts}</td><td>{if $report.mailing.url_tracking}{ts}On{/ts}{else}{ts}Off{/ts}{/if}</td></tr>
+<tr><td class="label">{ts}Open tracking{/ts}</td><td>{if $report.mailing.open_tracking}{ts}Enabled{/ts}{else}{ts}Disabled{/ts}{/if}</td></tr>
+<tr><td class="label">{ts}URL Click-through tracking{/ts}</td><td>{if $report.mailing.url_tracking}{ts}Enabled{/ts}{else}{ts}Disabled{/ts}{/if}</td></tr>
 {if $public_url}<td class="label">{ts}Public url{/ts}</td><td><a href="{$public_url}"> {$public_url}</a></td></tr>{/if}
 {if $report.mailing.campaign}
 <tr><td class="label">{ts}Campaign{/ts}</td><td>{$report.mailing.campaign}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
The string 'On' is used in the context of a date and in a context of a boolean state On/Off.

In transifex it's impossible to translate both giving odd translation in CiviMail Report.

Before
----------------------------------------
Impossible to translate "On" for CiviMail Report

![ksnip_20220505-131454](https://user-images.githubusercontent.com/372004/166977217-6663710f-0791-4ada-bd09-7cf014ad148b.png)


After
----------------------------------------
The string "On"/"Off" are replaced with "Enabled"/"Disabled" to distinguish the context.

![Screenshot 2022-05-05 at 13-17-59 CiviMail Report Sparkpost Transactional Emails Foundation for Future Generations](https://user-images.githubusercontent.com/372004/166977682-4e6836d4-9dc7-4d02-83f2-d044d1a10ec0.png)


Technical Details
----------------------------------------
Minor change that only impacts the display in admin mailing report.


