### PR TITLE
[REF] [Import] Remove another good intention - import 'conflicts'

### DIFF
--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -29,7 +29,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
 
     // Get the mapping name displayed if the mappingId is set.
@@ -46,11 +45,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($conflictRowCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Activity_Import_Parser_Activity';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     if ($mismatchCount) {
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Activity_Import_Parser_Activity';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
@@ -63,9 +57,7 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
       'downloadErrorRecordsUrl',
-      'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     ];
     $this->setStatusUrl();
@@ -83,7 +75,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
@@ -139,8 +130,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Activity_Import_Parser_Activity';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Activity_Import_Parser_Activity';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Activity_Import_Parser_Activity';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }

--- a/CRM/Activity/Import/Form/Summary.php
+++ b/CRM/Activity/Import/Form/Summary.php
@@ -33,7 +33,6 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
     $this->set('totalRowCount', $totalRowCount);
 
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mismatchCount = $this->get('unMatchCount');
@@ -68,7 +67,7 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
       // Only subtract dupes from successful import if we're skipping.
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $conflictRowCount - $duplicateRowCount - $mismatchCount
+         $duplicateRowCount - $mismatchCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -77,8 +76,6 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
-      'downloadConflictRecordsUrl',
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -485,11 +485,10 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
 
     $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
-    $this->_totalCount = $this->_conflictCount = 0;
+    $this->_totalCount = 0;
 
     $this->_errors = [];
     $this->_warnings = [];
-    $this->_conflicts = [];
 
     $this->_fileSize = number_format(filesize($fileName) / 1024.0, 2);
 
@@ -571,16 +570,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         $this->_errors[] = $values;
       }
 
-      if ($returnCode & self::CONFLICT) {
-        $this->_conflictCount++;
-        $recordNumber = $this->_lineCount;
-        if ($this->_haveColumnHeader) {
-          $recordNumber--;
-        }
-        array_unshift($values, $recordNumber);
-        $this->_conflicts[] = $values;
-      }
-
       if ($returnCode & self::DUPLICATE) {
         $this->_duplicateCount++;
         $recordNumber = $this->_lineCount;
@@ -620,14 +609,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         $this->_errorFileName = self::errorFileName(self::ERROR);
         self::exportCSV($this->_errorFileName, $headers, $this->_errors);
       }
-      if ($this->_conflictCount) {
-        $headers = array_merge(
-          [ts('Line Number'), ts('Reason')],
-          $customHeaders
-        );
-        $this->_conflictFileName = self::errorFileName(self::CONFLICT);
-        self::exportCSV($this->_conflictFileName, $headers, $this->_conflicts);
-      }
+
       if ($this->_duplicateCount) {
         $headers = array_merge(
           [ts('Line Number'), ts('View Activity History URL')],
@@ -700,14 +682,11 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
     $store->set('totalRowCount', $this->_totalCount);
     $store->set('validRowCount', $this->_validCount);
     $store->set('invalidRowCount', $this->_invalidRowCount);
-    $store->set('conflictRowCount', $this->_conflictCount);
 
     if ($this->_invalidRowCount) {
       $store->set('errorsFileName', $this->_errorFileName);
     }
-    if ($this->_conflictCount) {
-      $store->set('conflictsFileName', $this->_conflictFileName);
-    }
+
     if (isset($this->_rows) && !empty($this->_rows)) {
       $store->set('dataValues', $this->_rows);
     }

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -34,7 +34,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
     $columnNames = $this->get('columnNames');
     $this->_disableUSPS = $this->get('disableUSPS');
@@ -65,12 +64,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
     $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
     $this->assign('totalRowCount', $this->getRowCount([]));
-
-    // @todo conflict rows are still being output in the parser & not updating the temp table - fix
-    if ($conflictRowCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
 
     if ($mismatchCount) {
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contact_Import_Parser_Contact';
@@ -185,7 +178,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     $importJobParams = array(
       'doGeocodeAddress' => $this->controller->exportValue('DataSource', 'doGeocodeAddress'),
       'invalidRowCount' => $this->get('invalidRowCount'),
-      'conflictRowCount' => $this->get('conflictRowCount'),
       'onDuplicate' => $this->get('onDuplicate'),
       'dedupe' => $this->getSubmittedValue('dedupe_rule_id'),
       'newGroupName' => $this->controller->exportValue($this->_name, 'newGroupName'),
@@ -250,10 +242,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       fclose($fd);
 
       $this->set('errorFile', $errorFile);
-
-      // @todo - these should use the new url but are not reliably updating the table yet.
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
 
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contact_Import_Parser_Contact';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -32,7 +32,6 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
     $totalRowCount += $relatedCount;
 
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mismatchCount = $this->get('unMatchCount');
@@ -75,14 +74,12 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
     }
     //now we also create relative contact in update and fill mode
     $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-      $conflictRowCount - $duplicateRowCount - $mismatchCount
+       $duplicateRowCount - $mismatchCount
     );
 
     $this->assign('dupeActionString', $dupeActionString);
 
     $properties = [
-      'conflictRowCount',
-      'downloadConflictRecordsUrl',
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -26,7 +26,6 @@ class CRM_Contact_Import_ImportJob {
 
   protected $_doGeocodeAddress;
   protected $_invalidRowCount;
-  protected $_conflictRowCount;
   protected $_onDuplicate;
   protected $_dedupe;
   protected $_newGroupName;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2576,11 +2576,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
     $this->_rowCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
-    $this->_totalCount = $this->_conflictCount = 0;
+    $this->_totalCount = 0;
 
     $this->_errors = [];
     $this->_warnings = [];
-    $this->_conflicts = [];
     $this->_unparsedAddresses = [];
 
     $this->_tableName = $tableName = $this->getUserJob()['metadata']['DataSource']['table_name'];
@@ -2672,12 +2671,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         $this->_errors[] = $values;
       }
 
-      if ($returnCode & self::CONFLICT) {
-        $this->_conflictCount++;
-        array_unshift($values, $this->_rowCount);
-        $this->_conflicts[] = $values;
-      }
-
       if ($returnCode & self::NO_MATCH) {
         $this->_unMatchCount++;
         array_unshift($values, $this->_rowCount);
@@ -2715,14 +2708,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         }
       }
 
-      if ($this->_conflictCount) {
-        $headers = array_merge([
-          ts('Line Number'),
-          ts('Reason'),
-        ], $customHeaders);
-        $this->_conflictFileName = self::errorFileName(self::CONFLICT);
-        self::exportCSV($this->_conflictFileName, $headers, $this->_conflicts);
-      }
       if ($this->_unMatchCount) {
         $headers = array_merge([
           ts('Line Number'),
@@ -3039,7 +3024,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $store->set('totalRowCount', $this->_totalCount);
     $store->set('validRowCount', $this->_validCount);
     $store->set('invalidRowCount', $this->_invalidRowCount);
-    $store->set('conflictRowCount', $this->_conflictCount);
     $store->set('unMatchCount', $this->_unMatchCount);
 
     switch ($this->_contactType) {
@@ -3055,9 +3039,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         $store->set('contactType', CRM_Import_Parser::CONTACT_ORGANIZATION);
     }
 
-    if ($this->_conflictCount) {
-      $store->set('conflictsFileName', $this->_conflictFileName);
-    }
     if (isset($this->_rows) && !empty($this->_rows)) {
       $store->set('dataValues', $this->_rows);
     }

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -31,7 +31,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     $softCreditFields = $this->get('softCreditFields');
     $mapperSoftCreditType = $this->get('mapperSoftCreditType');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
 
     //get the mapping name displayed if the mappingId is set
@@ -48,11 +47,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($conflictRowCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Contribute_Import_Parser_Contribution';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     if ($mismatchCount) {
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contribute_Import_Parser_Contribution';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
@@ -67,9 +61,7 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
       'downloadErrorRecordsUrl',
-      'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     ];
     $this->setStatusUrl();
@@ -85,7 +77,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mapperSoftCreditType = $this->get('mapperSoftCreditType');
 
@@ -152,8 +143,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Contribute_Import_Parser_Contribution';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Contribute_Import_Parser_Contribution';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contribute_Import_Parser_Contribution';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }

--- a/CRM/Contribute/Import/Form/Summary.php
+++ b/CRM/Contribute/Import/Form/Summary.php
@@ -45,7 +45,6 @@ class CRM_Contribute_Import_Form_Summary extends CRM_Import_Form_Summary {
       $this->set('downloadPledgePaymentErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
     $validPledgePaymentRowCount = $this->get('validPledgePaymentRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mismatchCount = $this->get('unMatchCount');
@@ -80,7 +79,7 @@ class CRM_Contribute_Import_Form_Summary extends CRM_Import_Form_Summary {
       /* only subtract dupes from successful import if we're skipping */
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $conflictRowCount - $duplicateRowCount - $mismatchCount - $invalidSoftCreditRowCount - $invalidPledgePaymentRowCount
+        $duplicateRowCount - $mismatchCount - $invalidSoftCreditRowCount - $invalidPledgePaymentRowCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -91,8 +90,6 @@ class CRM_Contribute_Import_Form_Summary extends CRM_Import_Form_Summary {
       'invalidRowCount',
       'validSoftCreditRowCount',
       'invalidSoftCreditRowCount',
-      'conflictRowCount',
-      'downloadConflictRecordsUrl',
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -191,11 +191,10 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
 
     $this->_lineCount = $this->_validSoftCreditRowCount = $this->_validPledgePaymentRowCount = 0;
     $this->_invalidRowCount = $this->_validCount = $this->_invalidSoftCreditRowCount = $this->_invalidPledgePaymentRowCount = 0;
-    $this->_totalCount = $this->_conflictCount = 0;
+    $this->_totalCount = 0;
 
     $this->_errors = [];
     $this->_warnings = [];
-    $this->_conflicts = [];
     $this->_pledgePaymentErrors = [];
     $this->_softCreditErrors = [];
     if ($statusID) {
@@ -317,16 +316,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         $this->_softCreditErrors[] = $values;
       }
 
-      if ($returnCode == self::CONFLICT) {
-        $this->_conflictCount++;
-        $recordNumber = $this->_lineCount;
-        if ($this->_haveColumnHeader) {
-          $recordNumber--;
-        }
-        array_unshift($values, $recordNumber);
-        $this->_conflicts[] = $values;
-      }
-
       if ($returnCode == self::DUPLICATE) {
         $this->_duplicateCount++;
         $recordNumber = $this->_lineCount;
@@ -387,14 +376,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         self::exportCSV($this->_softCreditErrorsFileName, $headers, $this->_softCreditErrors);
       }
 
-      if ($this->_conflictCount) {
-        $headers = array_merge([
-          ts('Line Number'),
-          ts('Reason'),
-        ], $customHeaders);
-        $this->_conflictFileName = self::errorFileName(self::CONFLICT);
-        self::exportCSV($this->_conflictFileName, $headers, $this->_conflicts);
-      }
       if ($this->_duplicateCount) {
         $headers = array_merge([
           ts('Line Number'),
@@ -536,7 +517,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     $store->set('validSoftCreditRowCount', $this->_validSoftCreditRowCount);
     $store->set('invalidPledgePaymentRowCount', $this->_invalidPledgePaymentRowCount);
     $store->set('validPledgePaymentRowCount', $this->_validPledgePaymentRowCount);
-    $store->set('conflictRowCount', $this->_conflictCount);
 
     switch ($this->_contactType) {
       case 'Individual':
@@ -553,9 +533,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
 
     if ($this->_invalidRowCount) {
       $store->set('errorsFileName', $this->_errorFileName);
-    }
-    if ($this->_conflictCount) {
-      $store->set('conflictsFileName', $this->_conflictFileName);
     }
     if (isset($this->_rows) && !empty($this->_rows)) {
       $store->set('dataValues', $this->_rows);

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -18,7 +18,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
     $entity = $this->get('_entity');
 
@@ -36,11 +35,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($conflictRowCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . $this->_importParserUrl;
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     if ($mismatchCount) {
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . $this->_importParserUrl;
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
@@ -53,9 +47,7 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
       'downloadErrorRecordsUrl',
-      'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     ];
 
@@ -73,7 +65,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->getSubmittedValue('uploadFile');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $entity = $this->get('_entity');
 
@@ -128,8 +119,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . $this->_importParserUrl;
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . $this->_importParserUrl;
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . $this->_importParserUrl;
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -33,7 +33,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
 
     //get the mapping name displayed if the mappingId is set
@@ -50,11 +49,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($conflictRowCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Event_Import_Parser_Participant';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     if ($mismatchCount) {
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Event_Import_Parser_Participant';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
@@ -67,9 +61,7 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
       'downloadErrorRecordsUrl',
-      'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     ];
 
@@ -88,7 +80,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
     $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
@@ -141,8 +132,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Event_Import_Parser_Participant';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Event_Import_Parser_Participant';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Event_Import_Parser_Participant';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }

--- a/CRM/Event/Import/Form/Summary.php
+++ b/CRM/Event/Import/Form/Summary.php
@@ -35,7 +35,6 @@ class CRM_Event_Import_Form_Summary extends CRM_Import_Form_Summary {
     $this->set('totalRowCount', $totalRowCount);
 
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mismatchCount = $this->get('unMatchCount');
@@ -70,7 +69,7 @@ class CRM_Event_Import_Form_Summary extends CRM_Import_Form_Summary {
       /* only subtract dupes from successful import if we're skipping */
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $conflictRowCount - $duplicateRowCount - $mismatchCount
+        $duplicateRowCount - $mismatchCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -79,8 +78,6 @@ class CRM_Event_Import_Form_Summary extends CRM_Import_Form_Summary {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
-      'downloadConflictRecordsUrl',
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -759,11 +759,10 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
 
     $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
-    $this->_totalCount = $this->_conflictCount = 0;
+    $this->_totalCount = 0;
 
     $this->_errors = [];
     $this->_warnings = [];
-    $this->_conflicts = [];
 
     $this->_fileSize = number_format(filesize($fileName) / 1024.0, 2);
 
@@ -838,16 +837,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         $this->_errors[] = $values;
       }
 
-      if ($returnCode & self::CONFLICT) {
-        $this->_conflictCount++;
-        $recordNumber = $this->_lineCount;
-        if ($this->_haveColumnHeader) {
-          $recordNumber--;
-        }
-        array_unshift($values, $recordNumber);
-        $this->_conflicts[] = $values;
-      }
-
       if ($returnCode & self::DUPLICATE) {
         $this->_duplicateCount++;
         $recordNumber = $this->_lineCount;
@@ -887,14 +876,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         ], $customHeaders);
         $this->_errorFileName = self::errorFileName(self::ERROR);
         self::exportCSV($this->_errorFileName, $headers, $this->_errors);
-      }
-      if ($this->_conflictCount) {
-        $headers = array_merge([
-          ts('Line Number'),
-          ts('Reason'),
-        ], $customHeaders);
-        $this->_conflictFileName = self::errorFileName(self::CONFLICT);
-        self::exportCSV($this->_conflictFileName, $headers, $this->_conflicts);
       }
       if ($this->_duplicateCount) {
         $headers = array_merge([
@@ -977,7 +958,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
     $store->set('totalRowCount', $this->_totalCount);
     $store->set('validRowCount', $this->_validCount);
     $store->set('invalidRowCount', $this->_invalidRowCount);
-    $store->set('conflictRowCount', $this->_conflictCount);
 
     switch ($this->_contactType) {
       case 'Individual':
@@ -994,9 +974,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
 
     if ($this->_invalidRowCount) {
       $store->set('errorsFileName', $this->_errorFileName);
-    }
-    if ($this->_conflictCount) {
-      $store->set('conflictsFileName', $this->_conflictFileName);
     }
     if (isset($this->_rows) && !empty($this->_rows)) {
       $store->set('dataValues', $this->_rows);

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -441,7 +441,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @return array|int
    *   One or more of the statues available - e.g
    *   CRM_Import_Parser::VALID
-   *   or [CRM_Import_Parser::ERROR, CRM_Import_Parser::CONFLICT]
+   *   or [CRM_Import_Parser::ERROR, CRM_Import_Parser::VALID]
    *
    * @throws \CRM_Core_Exception
    * @throws \API_Exception

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -161,18 +161,6 @@ abstract class CRM_Import_Parser {
   protected $_errors;
 
   /**
-   * Total number of conflict lines
-   * @var int
-   */
-  protected $_conflictCount;
-
-  /**
-   * Array of conflict lines
-   * @var array
-   */
-  protected $_conflicts;
-
-  /**
    * Total number of duplicate (from database) lines
    * @var int
    */
@@ -259,13 +247,6 @@ abstract class CRM_Import_Parser {
    * @var string
    */
   protected $_errorFileName;
-
-  /**
-   * Filename of conflict data
-   *
-   * @var string
-   */
-  protected $_conflictFileName;
 
   /**
    * Filename of duplicate data
@@ -502,10 +483,6 @@ abstract class CRM_Import_Parser {
         $fileName .= '.errors';
         break;
 
-      case self::CONFLICT:
-        $fileName .= '.conflicts';
-        break;
-
       case self::DUPLICATE:
         $fileName .= '.duplicates';
         break;
@@ -536,10 +513,6 @@ abstract class CRM_Import_Parser {
     switch ($type) {
       case self::ERROR:
         $fileName = 'Import_Errors.csv';
-        break;
-
-      case self::CONFLICT:
-        $fileName = 'Import_Conflicts.csv';
         break;
 
       case self::DUPLICATE:

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -32,7 +32,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $mismatchCount = $this->get('unMatchCount');
 
     //get the mapping name displayed if the mappingId is set
@@ -49,11 +48,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($conflictRowCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Member_Import_Parser_Membership';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     if ($mismatchCount) {
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Member_Import_Parser_Membership';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
@@ -66,9 +60,7 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
       'downloadErrorRecordsUrl',
-      'downloadConflictRecordsUrl',
       'downloadMismatchRecordsUrl',
     ];
     $this->setStatusUrl();
@@ -87,7 +79,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function postProcess() {
     $fileName = $this->getSubmittedValue('uploadFile');
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $onDuplicate = $this->get('onDuplicate');
 
     $mapper = $this->controller->exportValue('MapField', 'mapper');
@@ -160,8 +151,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Member_Import_Parser_Membership';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::CONFLICT . '&parser=CRM_Member_Import_Parser_Membership';
-      $this->set('downloadConflictRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
       $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Member_Import_Parser_Membership';
       $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }

--- a/CRM/Member/Import/Form/Summary.php
+++ b/CRM/Member/Import/Form/Summary.php
@@ -35,7 +35,6 @@ class CRM_Member_Import_Form_Summary extends CRM_Import_Form_Summary {
     $this->set('totalRowCount', $totalRowCount);
 
     $invalidRowCount = $this->get('invalidRowCount');
-    $conflictRowCount = $this->get('conflictRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
     $mismatchCount = $this->get('unMatchCount');
@@ -70,7 +69,7 @@ class CRM_Member_Import_Form_Summary extends CRM_Import_Form_Summary {
       /* only subtract dupes from successful import if we're skipping */
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $conflictRowCount - $duplicateRowCount - $mismatchCount
+        $duplicateRowCount - $mismatchCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -79,8 +78,6 @@ class CRM_Member_Import_Form_Summary extends CRM_Import_Form_Summary {
       'totalRowCount',
       'validRowCount',
       'invalidRowCount',
-      'conflictRowCount',
-      'downloadConflictRecordsUrl',
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -133,11 +133,10 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
 
     $this->_lineCount = 0;
     $this->_invalidRowCount = $this->_validCount = 0;
-    $this->_totalCount = $this->_conflictCount = 0;
+    $this->_totalCount = 0;
 
     $this->_errors = [];
     $this->_warnings = [];
-    $this->_conflicts = [];
 
     $this->_fileSize = number_format(filesize($fileName) / 1024.0, 2);
 
@@ -214,13 +213,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         $this->_errors[] = $values;
       }
 
-      if ($returnCode & self::CONFLICT) {
-        $this->_conflictCount++;
-        $recordNumber = $this->_lineCount;
-        array_unshift($values, $recordNumber);
-        $this->_conflicts[] = $values;
-      }
-
       if ($returnCode & self::DUPLICATE) {
         $this->_duplicateCount++;
         $recordNumber = $this->_lineCount;
@@ -257,14 +249,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         $this->_errorFileName = self::errorFileName(self::ERROR);
 
         self::exportCSV($this->_errorFileName, $headers, $this->_errors);
-      }
-      if ($this->_conflictCount) {
-        $headers = array_merge([
-          ts('Line Number'),
-          ts('Reason'),
-        ], $customHeaders);
-        $this->_conflictFileName = self::errorFileName(self::CONFLICT);
-        self::exportCSV($this->_conflictFileName, $headers, $this->_conflicts);
       }
       if ($this->_duplicateCount) {
         $headers = array_merge([
@@ -367,7 +351,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
     $store->set('totalRowCount', $this->_totalCount);
     $store->set('validRowCount', $this->_validCount);
     $store->set('invalidRowCount', $this->_invalidRowCount);
-    $store->set('conflictRowCount', $this->_conflictCount);
 
     switch ($this->_contactType) {
       case 'Individual':
@@ -384,9 +367,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
 
     if ($this->_invalidRowCount) {
       $store->set('errorsFileName', $this->_errorFileName);
-    }
-    if ($this->_conflictCount) {
-      $store->set('conflictsFileName', $this->_conflictFileName);
     }
     if (isset($this->_rows) && !empty($this->_rows)) {
       $store->set('dataValues', $this->_rows);

--- a/templates/CRM/Activity/Import/Form/Preview.tpl
+++ b/templates/CRM/Activity/Import/Form/Preview.tpl
@@ -25,13 +25,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
-        </p>
-    {/if}
-
-
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -49,17 +42,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <div class="action-link"><a href="{$downloadErrorRecordsUrl}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-   {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows{/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting transaction ids within this file. These rows will be skipped (not imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Activity/Import/Form/Summary.tpl
+++ b/templates/CRM/Activity/Import/Form/Summary.tpl
@@ -37,15 +37,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting transaction IDs within this data file or relative to existing activity records. These records have not been imported.'}CiviCRM has detected one record with conflicting transaction ID within this data file or relative to existing activity records. This record have not been imported.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadConflictRecordsUrl}You can <a href='%1'>Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the transaction IDs for those that are not.{/ts}
-        </p>
-    {/if}
-
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
         {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM activity records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM activity record.{/ts} {$dupeActionString}
@@ -80,17 +71,6 @@
         <td class="explanation">{ts}Rows with mismatched activity IDs (NOT updated).{/ts}
             {if $unMatchCount}
                 <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Activity records{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows (skipped){/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting transaction IDs (NOT imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -24,12 +24,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting email addresses within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
-        </p>
-    {/if}
-
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -37,15 +37,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting email addresses within this data file or relative to existing contact records. These records have not been imported.'}CiviCRM has detected one record with conflicting email addresses within this data file or relative to existing contact records. This record has not been imported.{/ts} {ts}CiviCRM does not allow multiple contact records to have the same primary email address.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadConflictRecordsUrl}You can <a href='%1'>Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the email addresses for those that are not.{/ts}
-        </p>
-    {/if}
-
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
         {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM contact records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM contact record.{/ts} {$dupeActionString}
@@ -87,17 +78,6 @@
         <td class="explanation">{ts}Rows with mismatched contact IDs... (NOT updated).{/ts}
             {if $unMatchCount}
                 <<div class="action-link"><a href="{$downloadMismatchRecordsUrl}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Mismatched Contacts{/ts}</a></div>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows (skipped){/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting email addresses (NOT imported).{/ts}
-            {if $conflictRowCount}
-                <div class="action-link"><a href="{$downloadConflictRecordsUrl}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Conflicts{/ts}</a></div>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Contribute/Import/Form/Preview.tpl
+++ b/templates/CRM/Contribute/Import/Form/Preview.tpl
@@ -24,13 +24,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped.  You can download a file with just these problem records: <a href='%2'>Download Conflicts</a>.  If you wish, you can then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
-        </p>
-    {/if}
-
-
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -48,17 +41,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <p><a href="{$downloadErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows{/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting transaction ids within this file. These rows will be skipped (not imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Contribute/Import/Form/Summary.tpl
+++ b/templates/CRM/Contribute/Import/Form/Summary.tpl
@@ -36,15 +36,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting transaction IDs within this data file or relative to existing contribution records. These records have not been imported.'}CiviCRM has detected one record with conflicting transaction ID within this data file or relative to existing contribution records. This record has not been imported.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadConflictRecordsUrl}You can <a href="%1">Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the transaction IDs for those that are not.{/ts}
-        </p>
-    {/if}
-
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
         {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM contribution records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM contribution record.{/ts} {$dupeActionString}
@@ -114,17 +105,6 @@
         <td class="explanation">{ts}Rows with mismatched contribution IDs... (NOT updated).{/ts}
             {if $unMatchCount}
                 <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Contributions{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows (skipped){/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting transaction IDs (NOT imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Event/Import/Form/Preview.tpl
+++ b/templates/CRM/Event/Import/Form/Preview.tpl
@@ -25,13 +25,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting participant IDs within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
-        </p>
-    {/if}
-
-
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
 
@@ -51,17 +44,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <p><a href="{$downloadErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows{/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting participant IDs within this file. These rows will be skipped (not imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Event/Import/Form/Summary.tpl
+++ b/templates/CRM/Event/Import/Form/Summary.tpl
@@ -38,15 +38,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting participant IDs within this data file or relative to existing participant records. These records have not been imported.'}CiviCRM has detected one record with conflicting participant ID within this data file or relative to existing participant records. This record has not been imported.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadConflictRecordsUrl}You can <a href="%1">Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the participant IDs for those that are not.{/ts}
-        </p>
-    {/if}
-
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
         {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM participant records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM participant record.{/ts} {$dupeActionString}
@@ -84,17 +75,6 @@
         <td class="explanation">{ts}Rows with mismatched participant IDs... (NOT updated).{/ts}
             {if $unMatchCount}
                 <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched participants{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows (skipped){/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting participant IDs (NOT imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Member/Import/Form/Preview.tpl
+++ b/templates/CRM/Member/Import/Form/Preview.tpl
@@ -25,13 +25,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts 1=$conflictRowCount 2=$downloadConflictRecordsUrl}CiviCRM has detected %1 records with conflicting transaction ids within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.{/ts}
-        </p>
-    {/if}
-
-
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
@@ -49,17 +42,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <div class="action-link"><a href="{$downloadErrorRecordsUrl}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows{/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting transaction ids within this file. These rows will be skipped (not imported).{/ts}
-            {if $conflictRowCount}
-                <div class="action-link"><a href="{$downloadConflictRecordsUrl}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Conflicts{/ts}</a></div>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Member/Import/Form/Summary.tpl
+++ b/templates/CRM/Member/Import/Form/Summary.tpl
@@ -37,15 +37,6 @@
         </p>
     {/if}
 
-    {if $conflictRowCount}
-        <p class="error">
-        {ts count=$conflictRowCount plural='CiviCRM has detected %count records with conflicting transaction IDs within this data file or relative to existing membership records. These records have not been imported.'}CiviCRM has detected one record with conflicting transaction ID within this data file or relative to existing membership records. This record has not been imported.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadConflictRecordsUrl}You can <a href="%1">Download Conflicts</a>. You may then review these records to determine if they are actually conflicts, and correct the transaction IDs for those that are not.{/ts}
-        </p>
-    {/if}
-
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
         {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM membership records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM membership record.{/ts} {$dupeActionString}
@@ -80,17 +71,6 @@
         <td class="explanation">{ts}Rows with mismatched membership IDs... (NOT updated).{/ts}
             {if $unMatchCount}
                 <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Memberships{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $conflictRowCount}
-    <tr class="error"><td class="label crm-grid-cell">{ts}Conflicting Rows (skipped){/ts}</td>
-        <td class="data">{$conflictRowCount}</td>
-        <td class="explanation">{ts}Rows with conflicting transaction IDs (NOT imported).{/ts}
-            {if $conflictRowCount}
-                <p><a href="{$downloadConflictRecordsUrl}">{ts}Download Conflicts{/ts}</a></p>
             {/if}
         </td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Remove another good intention - conflict

There is a lot of handling for the concept of 'conflict' in the import classes - but when I searched I was unable to find a way in which it would be invoked.

I actually couldn't figure out from the text when it *should* be invoked - what is an email with 'conflicting email addresses'?

> CiviCRM has detected %1 records with conflicting email addresses within this data file. If you continue, these records will be skipped. OR, you can download a file with just these problem records - <a href='%2'>Download Conflicts</a>. Then correct them in the original import file, cancel this import and begin again at step 1.

I've been all over this code and can not find a single place where it is set (but lots of places where it is handled) so am concluding it was a good intention. Also, on balance, I wonder how useful it really is to have different types of errors? Ie we have
- invalid
- no_match for mismatched contact subtypes (is that more useful that invalid)
- conflict (until this is merged)
- valid
- parsed address error - this seems like a warning so OK
- duplicate matches - 

Of the above I think no_match is just another type of 'invalid'. Duplicate matches does feel special but I think 'no_match' could be folded into 'invalid'

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/167015831-af904c15-c079-46a7-939e-c40100d91bfb.png)

![image](https://user-images.githubusercontent.com/336308/167015973-802bfbd4-2cff-43a3-a5f5-54690e9f4456.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
Note that despite the huge amount of code what it is doing is quite simple - if an attempt to import a row resulted in a return code of `CRM_Import_Parser::CONFLICT` then the `Parser` class would output it to a csv file. Knowledge of the existence of the csv file would be passed around and assigned to the template - resulting in access to the csv

If this were to still happen in ANY class it would be the Contact class - but in addition to grepping I've been all over that code - it just doesn't happen

Comments
----------------------------------------
Oddly these functions propagated out from `CRM_Contact_Import_Parser` which was the in-between contact parser class folded into `CRM_Contact_Import_Parser_Contact` in 5.49 - that class says it was imported from svn - but the class doesn't seem to exist in svn over here - https://github.com/civicrm/civicrm-svn 