### PR TITLE
[REF] Import - make condition clearer

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2637,44 +2637,45 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $importedValue = $this->_activeFields[$i]->_value;
 
       if (isset($importedValue)) {
-        if (isset($locationTypeID)) {
+        if (!$relatedContactKey) {
+          if (isset($locationTypeID)) {
+            if (!isset($params[$fieldName])) {
+              $params[$fieldName] = [];
+            }
+
+            $value = [
+              $fieldName => $importedValue,
+              'location_type_id' => $locationTypeID,
+            ];
+
+            if (isset($phoneTypeID)) {
+              $value['phone_type_id'] = $phoneTypeID;
+            }
+
+            // get IM service Provider type id
+            if (isset($imProviderID)) {
+              $value['provider_id'] = $imProviderID;
+            }
+
+            $params[$fieldName][] = $value;
+          }
+          elseif (isset($websiteTypeID)) {
+            $value = [
+              $fieldName => $importedValue,
+              'website_type_id' => $websiteTypeID,
+            ];
+
+            $params[$fieldName][] = $value;
+          }
+
           if (!isset($params[$fieldName])) {
-            $params[$fieldName] = [];
+            if (!isset($relatedContactKey)) {
+              $params[$fieldName] = $importedValue;
+            }
           }
 
-          $value = [
-            $fieldName => $importedValue,
-            'location_type_id' => $locationTypeID,
-          ];
-
-          if (isset($phoneTypeID)) {
-            $value['phone_type_id'] = $phoneTypeID;
-          }
-
-          // get IM service Provider type id
-          if (isset($imProviderID)) {
-            $value['provider_id'] = $imProviderID;
-          }
-
-          $params[$fieldName][] = $value;
         }
-        elseif (isset($websiteTypeID)) {
-          $value = [
-            $fieldName => $importedValue,
-            'website_type_id' => $websiteTypeID,
-          ];
-
-          $params[$fieldName][] = $value;
-        }
-
-        if (!isset($params[$fieldName])) {
-          if (!isset($relatedContactKey)) {
-            $params[$fieldName] = $importedValue;
-          }
-        }
-
-        //minor fix for CRM-4062
-        if (isset($relatedContactKey)) {
+        else {
           if (!isset($params[$relatedContactKey])) {
             $params[$relatedContactKey] = [];
           }


### PR DESCRIPTION

Overview
----------------------------------------
[REF] Import - make condition clearer

Before
----------------------------------------
The check for whether we are dealing with a relationship mapping relies on the implication that `$fieldName` is only set if not a relationship (which relies on the initiating function doing some work)

After
----------------------------------------
We explicitly if-else `$relatedContactKey`

Technical Details
----------------------------------------
This has some whitespace so use w=1

When the class is instantiated the class that constructs is specifies the mapped field names - it leaves it blank when the mapped field is a relationship - making `$fieldName` an implicity proxy for 'is a relationship' - but it's a lot easier to read when we can see 'here is what the code does if it is a relationship & here is what it does otherwise

Comments
----------------------------------------

The variable is NULL or something like '5_a_b' - so isset not required