### PR TITLE
[Import] [Ref] Iterate through the mapping of fields

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -393,9 +393,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       $this->controller->resetPage($this->_name);
       return;
     }
-    $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');
-
-    $parser = $this->submit($params, $mapperKeys);
+    $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
+    $parser = $this->submit($params);
 
     // add all the necessary variables to the form
     $parser->set($this);
@@ -446,7 +445,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CiviCRM_API3_Exception
    * @throws \CRM_Core_Exception
    */
-  public function submit($params, $mapperKeys) {
+  public function submit($params) {
+    $mapperKeys = $this->getSubmittedValue('mapper');
     $mapper = $mapperKeysMain = $locations = [];
     $parserParameters = CRM_Contact_Import_Parser_Contact::getParameterForParser($this->_columnCount);
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2768,28 +2768,30 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *
    * @return array
    *   (reference ) associative array of name/value pairs
+   * @throws \API_Exception
    */
   public function &getActiveFieldParams() {
     $params = [];
-
-    for ($i = 0; $i < $this->_activeFieldCount; $i++) {
-      $fieldName = $this->_activeFields[$i]->_name;
+    $mapper = $this->getSubmittedValue('mapper');
+    foreach ($this->getFieldMappings() as $i => $mappedField) {
+      // The key is in the format 5_a_b where 5 is the relationship_type_id and a_b is the direction.
+      $relatedContactKey = $mappedField['relationship_type_id'] ? ($mappedField['relationship_type_id'] . '_' . $mappedField['relationship_direction']) : NULL;
+      $fieldName = $relatedContactKey ? NULL : $mappedField['name'];
       if ($fieldName === 'do_not_import') {
         continue;
       }
-      $relatedContactFieldName = $this->_activeFields[$i]->_relatedContactDetails;
+      $relatedContactFieldName = $relatedContactKey ? $mappedField['name'] : NULL;
+      // RelatedContactType is not part of the mapping but rather calculated from the relationship.
       $relatedContactType = $this->_activeFields[$i]->_relatedContactType;
-      $relatedContactLocationTypeID = $this->_activeFields[$i]->_relatedContactLocType;
-      $relatedContactWebsiteTypeID = $this->_activeFields[$i]->_relatedContactWebsiteType ?? NULL;
-      $relatedContactIMProviderID = $this->_activeFields[$i]->_relatedContactImProvider ?? NULL;
-      $relatedContactPhoneTypeID = $this->_activeFields[$i]->_relatedContactPhoneType ?? NULL;
-      // The key is in the format 5_a_b where 5 is the relationship_type_id and a_b is the direction.
-      $relatedContactKey = $this->_activeFields[$i]->_related;
+      $relatedContactLocationTypeID = $relatedContactKey ? $mappedField['location_type_id'] : NULL;
+      $relatedContactWebsiteTypeID = $relatedContactKey ? $mappedField['website_type_id'] : NULL;
+      $relatedContactIMProviderID = $relatedContactKey ? $mappedField['im_provider_id'] : NULL;
+      $relatedContactPhoneTypeID = $relatedContactKey ? $mappedField['phone_type_id'] : NULL;
 
-      $locationTypeID = $this->_activeFields[$i]->_hasLocationType;
-      $phoneTypeID = $this->_activeFields[$i]->_phoneType;
-      $imProviderID = $this->_activeFields[$i]->_imProvider ?? NULL;
-      $websiteTypeID = $this->_activeFields[$i]->_websiteType ?? NULL;
+      $locationTypeID = $relatedContactKey ? NULL : $mappedField['location_type_id'];
+      $phoneTypeID = $relatedContactKey ? NULL : $mappedField['phone_type_id'];
+      $imProviderID = $relatedContactKey ? NULL : $mappedField['im_provider_id'];
+      $websiteTypeID = $relatedContactKey ? NULL : $mappedField['website_type_id'];
 
       $importedValue = $this->_activeFields[$i]->_value;
 
@@ -3634,6 +3636,29 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $tempMsg = "Invalid value for field(s) : $errorMessage";
       throw new CRM_Core_Exception($tempMsg);
     }
+  }
+
+  /**
+   * Get the field mappings for the import.
+   *
+   * This is the same format as saved in civicrm_mapping_field except
+   * that location_type_id = 'Primary' rather than empty where relevant.
+   *
+   * @return array
+   * @throws \API_Exception
+   */
+  protected function getFieldMappings(): array {
+    $mappedFields = [];
+    foreach ($this->getSubmittedValue('mapper') as $i => $mapperRow) {
+      $mappedField = $this->getMappingFieldFromMapperInput($mapperRow, 0, $i);
+      if (!$mappedField['location_type_id'] && !empty($this->importableFieldsMetadata[$mappedField['name']]['hasLocationType'])) {
+        $mappedField['location_type_id'] = 'Primary';
+      }
+      // Just for clarity since 0 is a pseudovalue
+      unset($mappedField['mapping_id']);
+      $mappedFields[] = $mappedField;
+    }
+    return $mappedFields;
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -60,9 +60,8 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
    */
   public function testSubmit(array $params, array $mapper, array $expecteds = []): void {
     $form = $this->getMapFieldFormObject(['mapper' => $mapper]);
-    $form->set('contactType', CRM_Import_Parser::CONTACT_INDIVIDUAL);
     $form->preProcess();
-    $form->submit($params, $mapper);
+    $form->submit($params);
 
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_tmp_d_import_job_xxx');
     if (!empty($expecteds)) {
@@ -78,7 +77,6 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
         }
       }
     }
-    $this->quickCleanup(['civicrm_mapping', 'civicrm_mapping_field']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[Import] [Ref] Iterate through the mapping of fields

Before
----------------------------------------
The process for mapping fields is crazy complex.....

The form layer has to take the submitted value for 'mapper' and split it into 8 arrays ie
```
$fields = ['first_name', 'last_name', 'email', NULL];
$location_types = [NULL, NULL, 1, NULL];
$relatedContactFieldName = [NULL, NULL, NULL, 'email'];
$relatedContactLocationType = [NULL, NULL, NULL, 1];
```

These arrays are passed to the field constructer and tinkered with a bit in `init` before being accessed in `getActiveFieldMapping` to determine how the row of values maps to a `$params` array

After
----------------------------------------
We already have  a function that interprets what the `mapper` means into the format we use in `civicrm_field_mapping` so use that function to interpret rather than array-o-rama. The only thing we need to change is to interpret 'email with no location type' to 'email with location_type of "Primary" - everything else is already done in this function

Technical Details
----------------------------------------
The change involves updating tests to pass in the `mapper` - rather than doing weird contortions to imitate the forms.

We have good test cover - including a test specifically merged in preparation for this (`testMapFields`)

Comments
----------------------------------------
With this change most of the `construct` function & `init` is obsolete as well as a lot of code on the form layer - I've left that cleanup as a follow up for legibility