### PR TITLE
SearchKit - Default to search for individuals

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -46,6 +46,7 @@ class Admin {
       'defaultPagerSize' => \Civi::settings()->get('default_pager_size'),
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),
       'modules' => $extensions,
+      'defaultContactType' => \CRM_Contact_BAO_ContactType::basicTypeInfo()['Individual']['name'] ?? NULL,
       'tags' => Tag::get()
         ->addSelect('id', 'name', 'color', 'is_selectable', 'description')
         ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -51,6 +51,10 @@
               defaults[param] = [];
             }
           });
+          // Default to Individuals
+          if (this.savedSearch.api_entity === 'Contact' && CRM.crmSearchAdmin.defaultContactType) {
+            defaults.where.push(['contact_type:name', '=', CRM.crmSearchAdmin.defaultContactType]);
+          }
 
           $scope.$bindToRoute({
             param: 'params',


### PR DESCRIPTION
Overview
----------------------------------------
When clicking "+ New Search" in Search Kit, default to search for Individuals instead of all contacts.

Comments
----------------------------------------
I think this is a more user-friendly start to a new search because:
a) searching for individuals is more common than all contacts
b) it demonstrates how to use the where clause

Technical Details
----------------------------------------
Probably overkill but I added a guard to prevent errors in case the "Individual" contact type is disabled.
