### PR TITLE
[REF] [Import] Stop passing unused parameters

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -217,17 +217,9 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     $parser = new CRM_Contact_Import_Parser_Contact($mapper);
     $parser->setMaxLinesToProcess(100);
     $parser->setUserJobID($this->getUserJobID());
-    $parser->run(NULL,
+    $parser->run(
       [],
-      CRM_Import_Parser::MODE_MAPFIELD,
-      $this->getSubmittedValue('contactType'),
-      '_id',
-      '_status',
-      CRM_Import_Parser::DUPLICATE_SKIP,
-      NULL, NULL, FALSE,
-      CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
-      $this->getSubmittedValue('contactSubType'),
-      $this->getSubmittedValue('dedupe_rule_id')
+      CRM_Import_Parser::MODE_MAPFIELD
     );
 
     // add all the necessary variables to the form

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -554,15 +554,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $parser->run(NULL,
       $mapper,
-      CRM_Import_Parser::MODE_PREVIEW,
-      NULL,
-      '_id',
-      '_status',
-      (int) $this->getSubmittedValue('onDuplicate'),
-      NULL, NULL, FALSE,
-      CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
-      $this->getSubmittedValue('contactSubType'),
-      $this->getSubmittedValue('dedupe_rule_id')
+      CRM_Import_Parser::MODE_PREVIEW
     );
     return $parser;
   }

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -178,18 +178,11 @@ class CRM_Contact_Import_ImportJob {
       $parserParameters['relatedContactWebsiteType']
     );
     $this->_parser->setUserJobID($this->_userJobID);
-    $this->_parser->run(NULL, $mapperFields,
+    $this->_parser->run(
+      $mapperFields,
       CRM_Import_Parser::MODE_IMPORT,
-      $this->_contactType,
-      $this->_primaryKeyName,
-      $this->_statusFieldName,
-      $this->_onDuplicate,
       $this->_statusID,
-      $this->_totalRowCount,
-      $this->_doGeocodeAddress,
-      CRM_Contact_Import_Parser_Contact::DEFAULT_TIMEOUT,
-      $this->_contactSubType,
-      $this->_dedupe
+      $this->_totalRowCount
     );
 
     $contactIds = $this->_parser->getImportedContacts();

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2435,27 +2435,17 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   /**
    * Run import.
    *
-   * @param string $tableName
    * @param array $mapper
    * @param int $mode
-   * @param int $contactType
-   * @param string $primaryKeyName
-   * @param string $statusFieldName
-   * @param int $onDuplicate
    * @param int $statusID
    * @param int $totalRowCount
    *
    * @return mixed
-   * @throws \API_Exception
+   * @throws \API_Exception|\CRM_Core_Exception
    */
   public function run(
-    $tableName,
     $mapper = [],
     $mode = self::MODE_PREVIEW,
-    $contactType = self::CONTACT_INDIVIDUAL,
-    $primaryKeyName = '_id',
-    $statusFieldName = '_status',
-    $onDuplicate = self::DUPLICATE_SKIP,
     $statusID = NULL,
     $totalRowCount = NULL
   ) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Stop passing unused parameter

Before
----------------------------------------
The functions that call Import_Parser_Contact::run() are still passing parameters that it discards or does not accept

![image](https://user-images.githubusercontent.com/336308/167067763-4ba73a4c-42a5-449f-b92e-57ddfce6e70a.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/167067928-d7e8f526-9273-4455-8813-3d87086fa8ba.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
