### PR TITLE
APIv4 - Fix fatal error on getFields when passing in contact id

### DIFF
--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -52,7 +52,7 @@ class RequestSpec implements \Iterator {
     $this->entityTableName = CoreUtil::getTableName($entity);
     // Set contact_type from id if possible
     if ($entity === 'Contact' && empty($values['contact_type']) && !empty($values['id'])) {
-      $values['contact_type'] = \CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $values['id'], 'contact_id');
+      $values['contact_type'] = \CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $values['id'], 'contact_type');
     }
     $this->values = $values;
   }

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -45,11 +45,20 @@ class GetExtraFieldsTest extends UnitTestCase {
     $this->assertNotContains('contact_type', $individualFields);
     $this->assertContains('first_name', $individualFields);
 
-    $organizationFields = $getFields->setValues(['contact_type' => 'Organization'])->execute()->column('name');
+    $orgId = Contact::create(FALSE)->addValue('contact_type', 'Organization')->execute()->first()['id'];
+    $organizationFields = $getFields->setValues(['id' => $orgId])->execute()->column('name');
+    $this->assertContains('organization_name', $organizationFields);
     $this->assertContains('sic_code', $organizationFields);
     $this->assertNotContains('contact_type', $organizationFields);
     $this->assertNotContains('first_name', $organizationFields);
     $this->assertNotContains('household_name', $organizationFields);
+
+    $hhId = Contact::create(FALSE)->addValue('contact_type', 'Household')->execute()->first()['id'];
+    $householdFields = $getFields->setValues(['id' => $hhId])->execute()->column('name');
+    $this->assertNotContains('sic_code', $householdFields);
+    $this->assertNotContains('contact_type', $householdFields);
+    $this->assertNotContains('first_name', $householdFields);
+    $this->assertContains('household_name', $householdFields);
   }
 
   public function testGetOptionsAddress() {


### PR DESCRIPTION
Overview
----------------------------------------
Prevents a fatal error caused by a typo in APIv4 getfields. Test added.
