### PR TITLE
Import - fix count on preview

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -459,7 +459,7 @@ abstract class CRM_Import_DataSource {
   protected function getStatusMapping(): array {
     return [
       CRM_Import_Parser::VALID => ['imported', 'new'],
-      CRM_Import_Parser::ERROR => ['error'],
+      CRM_Import_Parser::ERROR => ['error', 'invalid'],
       CRM_Import_Parser::DUPLICATE => ['duplicate'],
     ];
   }


### PR DESCRIPTION
I found that rows that fail validation are marked 'invalid'
rather than error & won't show on the preview screen.

I guess I could check for invalid vs error separately
- gets kinda weird though - if you leave them
in the file you are importing surely they are still errors
to see on the summary screen even though
you knew they were invalid on the Preview?

