### PR TITLE
5.50.alpha1.mysql.tpl - Escape `grouping` (reserved word in MySQL 8.0)

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.50.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.50.alpha1.mysql.tpl
@@ -36,20 +36,20 @@ INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name
 SELECT @option_group_id_cgeo := max(id) FROM civicrm_option_group WHERE name = 'cg_extend_objects';
 
 UPDATE civicrm_option_value
-  SET grouping = 'case_type_id', {localize field='description'}description = NULL{/localize}
+  SET `grouping` = 'case_type_id', {localize field='description'}description = NULL{/localize}
   WHERE option_group_id = @option_group_id_cgeo AND value = 'Case';
 
 SELECT @option_group_id_cdt := max(id) FROM civicrm_option_group WHERE name = 'custom_data_type';
 
 UPDATE civicrm_option_value
-  SET {localize field='label'}label = '{ts escape="sql"}Participants (Role){/ts}'{/localize}, grouping = 'role_id'
+  SET {localize field='label'}label = '{ts escape="sql"}Participants (Role){/ts}'{/localize}, `grouping` = 'role_id'
   WHERE option_group_id = @option_group_id_cdt AND name = 'ParticipantRole';
 
 UPDATE civicrm_option_value
-  SET {localize field='label'}label = '{ts escape="sql"}Participants (Event Name){/ts}'{/localize}, grouping = 'event_id'
+  SET {localize field='label'}label = '{ts escape="sql"}Participants (Event Name){/ts}'{/localize}, `grouping` = 'event_id'
   WHERE option_group_id = @option_group_id_cdt AND name = 'ParticipantEventName';
 
 UPDATE civicrm_option_value
-  SET {localize field='label'}label = '{ts escape="sql"}Participants (Event Type){/ts}'{/localize}, grouping = 'event_id.event_type_id'
+  SET {localize field='label'}label = '{ts escape="sql"}Participants (Event Type){/ts}'{/localize}, `grouping` = 'event_id.event_type_id'
   WHERE option_group_id = @option_group_id_cdt AND name = 'ParticipantEventType';
 


### PR DESCRIPTION
Overview
----------------------------------------

Upgrade from 5.49-stable to 5.50-rc fails on MySQL 8.0.

See also: https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-G

Before
----------------------------------------

```
$ cv upgrade:db -vv

...

Cleanup old files (CRM_Upgrade_Form::doFileCleanup(/Users/totten/.cv/upgrade/9b45b6ba86431b98dba8b6ebb3b9c813.dat))
Checking extensions (CRM_Upgrade_Form::disableOldExtensions(/Users/totten/.cv/upgrade/9b45b6ba86431b98dba8b6ebb3b9c813.dat))
Begin Upgrade to 5.50.alpha1 (CRM_Upgrade_Form::doIncrementalUpgradeStart(5.50.alpha1))
Upgrade DB to 5.50.alpha1 (CRM_Upgrade_Form::doIncrementalUpgradeStep(5.50.alpha1,5.49.1,5.50.beta1,/Users/totten/.cv/upgrade/9b45b6ba86431b98dba8b6ebb3b9c813.dat))
Upgrade DB to 5.50.alpha1: SQL (CRM_Upgrade_Incremental_php_FiveFifty::runSql(5.50.alpha1))
Cannot execute UPDATE civicrm_option_value
  SET grouping = 'case_type_id', description = NULL  WHERE option_group_id = @option_group_id_cgeo AND value = 'Case': DB Error: syntax error[bknix-max:~/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm]
```

After
----------------------------------------

Works