### PR TITLE
(E2E) `testErrorChrome` - Update assertions for page-chrome

### DIFF
--- a/tests/phpunit/E2E/Core/ErrorTest.php
+++ b/tests/phpunit/E2E/Core/ErrorTest.php
@@ -97,7 +97,7 @@ class ErrorTest extends \CiviEndToEndTestCase {
       'Backdrop' => '/body class=\".*not-logged-in/',
       'Drupal' => '/body class=\".*not-logged-in/',
       'Drupal8' => '/body class=\".*not-logged-in/',
-      'WordPress' => '/ role=.navigation./',
+      'WordPress' => '/( role=.navigation.| class=.site-header.)/',
     ];
     if (!isset($patterns[CIVICRM_UF])) {
       $this->markTestIncomplete('testErrorChrome() cannot check for chrome on ' . CIVICRM_UF);

--- a/tests/phpunit/E2E/Core/ErrorTest.php
+++ b/tests/phpunit/E2E/Core/ErrorTest.php
@@ -94,9 +94,9 @@ class ErrorTest extends \CiviEndToEndTestCase {
   public function testErrorChrome(string $url, string $errorType) {
     $this->skipIfNonCompliant(__FUNCTION__, $errorType);
     $patterns = [
-      'Backdrop' => '/body class=\".*not-logged-in/',
-      'Drupal' => '/body class=\".*not-logged-in/',
-      'Drupal8' => '/body class=\".*not-logged-in/',
+      'Backdrop' => '/href=.*user\/(login|register)/',
+      'Drupal' => '/href=.*user\/register/',
+      'Drupal8' => '/href=.*user\/(login|register)/',
       'WordPress' => '/( role=.navigation.| class=.site-header.)/',
     ];
     if (!isset($patterns[CIVICRM_UF])) {


### PR DESCRIPTION
Overview
----------------------------------------

This test was added during 5.50.alpha (#23257, #22805).  It's purpose is to
assert that the page-chrome/site-wide-template is present.  It appears that
the markup from WordPress has changed slightly.  (It may be that I
originally tested against an older version of WP.) In any event, this
relaxes the test so that it also passes on a newer WP build.

Before
----------------------------------------

`E2E_Core_ErrorTest::testErrorChrome` fails with newer WordPress (eg 6.0-rc), Backdrop, and Drupal 8+.

After
----------------------------------------

`E2E_Core_ErrorTest::testErrorChrome` passes with newer WordPress (eg 6.0-rc) and Backdrop.

I haven't tested Drupal 8+. But I did re-run on D7, and that still worked.

Comment
----------------------------------------

For WordPress, the page-chrome appears on all error-pages (exception/fatal/permission).

For Drupal-style systems, the page-chrome appears on permission error-pages (but not on exception/fatal error-pages). There is a separate #23398 to dial-back the testing for currently-unsupported-aspects.