### PR TITLE
(E2E) testErrorChrome - Skip Backdrop and D8+ (much like D7)

### DIFF
--- a/tests/phpunit/E2E/Core/ErrorTest.php
+++ b/tests/phpunit/E2E/Core/ErrorTest.php
@@ -31,6 +31,8 @@ class ErrorTest extends \CiviEndToEndTestCase {
     // Format: "{$uf}_{$testFunc}_{$errorType}"
     '/WordPress_testErrorStatus_(fatal|exception)/',
     '/Drupal_testErrorChrome_(fatal|exception)/',
+    '/Drupal8_testErrorChrome_(fatal|exception)/',
+    '/Backdrop_testErrorChrome_(fatal|exception)/',
   ];
 
   public function getErrorTypes() {


### PR DESCRIPTION
Overview
----------------------------------------

This test was added during 5.50.alpha (#23257, #22805).  It's purpose is to
assert that the page-chrome/site-wide-template is present on certain
error-messages; however, the underlying behavior was only implemented on
WordPress. It has not yet been implemented on other CMS.

Before
------

* __WordPress__: Runs testErrorChrome. Expected to pass.
* __Drupal 7__: Skip testErrorChrome (mostly) because it is expected to fail.
* __Drupal 8+, Backdrop__: Runs testErrorChrome. Fails.

After
-----

* __WordPress__: Runs testErrorChrome. Expected to pass.
* __Drupal 7, Drupal 8+, Backdrop__: Skip testErrorChrome (mostly) because it is expected to fail.


Comment
-------

It still runs `testErrorChrome` for `permission` errors; per MM discussion, it appears that this does actually work, but we need another patch to tune assertion for BD+D8.