### PR TITLE
[Import] Reduce unused copy & paste

### DIFF
--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -29,7 +29,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $mismatchCount = $this->get('unMatchCount');
 
     // Get the mapping name displayed if the mappingId is set.
     $mappingId = $this->get('loadMappingId');
@@ -45,11 +44,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Activity_Import_Parser_Activity';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     $properties = [
       'mapper',
       'dataValues',
@@ -58,7 +52,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       'validRowCount',
       'invalidRowCount',
       'downloadErrorRecordsUrl',
-      'downloadMismatchRecordsUrl',
     ];
     $this->setStatusUrl();
 
@@ -130,8 +123,6 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Activity_Import_Parser_Activity';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Activity_Import_Parser_Activity';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
   }
 

--- a/CRM/Activity/Import/Form/Summary.php
+++ b/CRM/Activity/Import/Form/Summary.php
@@ -35,14 +35,10 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
     $invalidRowCount = $this->get('invalidRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
-    $mismatchCount = $this->get('unMatchCount');
+
     if ($duplicateRowCount > 0) {
       $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Activity_Import_Parser_Activity';
       $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    elseif ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Activity_Import_Parser_Activity';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
     else {
       $duplicateRowCount = 0;
@@ -67,7 +63,7 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
       // Only subtract dupes from successful import if we're skipping.
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-         $duplicateRowCount - $mismatchCount
+         $duplicateRowCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -79,9 +75,7 @@ class CRM_Activity_Import_Form_Summary extends CRM_Import_Form_Summary {
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',
-      'downloadMismatchRecordsUrl',
       'groupAdditions',
-      'unMatchCount',
     ];
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -31,7 +31,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     $softCreditFields = $this->get('softCreditFields');
     $mapperSoftCreditType = $this->get('mapperSoftCreditType');
     $invalidRowCount = $this->get('invalidRowCount');
-    $mismatchCount = $this->get('unMatchCount');
 
     //get the mapping name displayed if the mappingId is set
     $mappingId = $this->get('loadMappingId');
@@ -47,11 +46,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contribute_Import_Parser_Contribution';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     $properties = [
       'mapper',
       'softCreditFields',
@@ -62,7 +56,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       'validRowCount',
       'invalidRowCount',
       'downloadErrorRecordsUrl',
-      'downloadMismatchRecordsUrl',
     ];
     $this->setStatusUrl();
 
@@ -143,8 +136,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Contribute_Import_Parser_Contribution';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contribute_Import_Parser_Contribution';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
   }
 

--- a/CRM/Contribute/Import/Form/Summary.php
+++ b/CRM/Contribute/Import/Form/Summary.php
@@ -47,14 +47,9 @@ class CRM_Contribute_Import_Form_Summary extends CRM_Import_Form_Summary {
     $validPledgePaymentRowCount = $this->get('validPledgePaymentRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
-    $mismatchCount = $this->get('unMatchCount');
     if ($duplicateRowCount > 0) {
       $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Contribute_Import_Parser_Contribution';
       $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    elseif ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contribute_Import_Parser_Contribution';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
     else {
       $duplicateRowCount = 0;
@@ -79,7 +74,7 @@ class CRM_Contribute_Import_Form_Summary extends CRM_Import_Form_Summary {
       /* only subtract dupes from successful import if we're skipping */
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $duplicateRowCount - $mismatchCount - $invalidSoftCreditRowCount - $invalidPledgePaymentRowCount
+        $duplicateRowCount - $invalidSoftCreditRowCount - $invalidPledgePaymentRowCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -93,9 +88,7 @@ class CRM_Contribute_Import_Form_Summary extends CRM_Import_Form_Summary {
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',
-      'downloadMismatchRecordsUrl',
       'groupAdditions',
-      'unMatchCount',
       'validPledgePaymentRowCount',
       'invalidPledgePaymentRowCount',
       'downloadPledgePaymentErrorRecordsUrl',

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -18,7 +18,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $mismatchCount = $this->get('unMatchCount');
     $entity = $this->get('_entity');
 
     //get the mapping name displayed if the mappingId is set
@@ -35,11 +34,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . $this->_importParserUrl;
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     $properties = [
       'mapper',
       'dataValues',
@@ -48,7 +42,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       'validRowCount',
       'invalidRowCount',
       'downloadErrorRecordsUrl',
-      'downloadMismatchRecordsUrl',
     ];
 
     foreach ($properties as $property) {
@@ -119,8 +112,6 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . $this->_importParserUrl;
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . $this->_importParserUrl;
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
   }
 

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -33,7 +33,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $mismatchCount = $this->get('unMatchCount');
 
     //get the mapping name displayed if the mappingId is set
     $mappingId = $this->get('loadMappingId');
@@ -49,11 +48,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Event_Import_Parser_Participant';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     $properties = [
       'mapper',
       'dataValues',
@@ -62,7 +56,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       'validRowCount',
       'invalidRowCount',
       'downloadErrorRecordsUrl',
-      'downloadMismatchRecordsUrl',
     ];
 
     foreach ($properties as $property) {
@@ -132,8 +125,6 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Event_Import_Parser_Participant';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Event_Import_Parser_Participant';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
   }
 

--- a/CRM/Event/Import/Form/Summary.php
+++ b/CRM/Event/Import/Form/Summary.php
@@ -37,14 +37,9 @@ class CRM_Event_Import_Form_Summary extends CRM_Import_Form_Summary {
     $invalidRowCount = $this->get('invalidRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
-    $mismatchCount = $this->get('unMatchCount');
     if ($duplicateRowCount > 0) {
       $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Event_Import_Parser_Participant';
       $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    elseif ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Event_Import_Parser_Participant';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
     else {
       $duplicateRowCount = 0;
@@ -69,7 +64,7 @@ class CRM_Event_Import_Form_Summary extends CRM_Import_Form_Summary {
       /* only subtract dupes from successful import if we're skipping */
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $duplicateRowCount - $mismatchCount
+        $duplicateRowCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -81,9 +76,7 @@ class CRM_Event_Import_Form_Summary extends CRM_Import_Form_Summary {
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',
-      'downloadMismatchRecordsUrl',
       'groupAdditions',
-      'unMatchCount',
     ];
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -32,7 +32,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
     $dataValues = $this->get('dataValues');
     $mapper = $this->get('mapper');
     $invalidRowCount = $this->get('invalidRowCount');
-    $mismatchCount = $this->get('unMatchCount');
 
     //get the mapping name displayed if the mappingId is set
     $mappingId = $this->get('loadMappingId');
@@ -48,11 +47,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
-    if ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Member_Import_Parser_Membership';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     $properties = [
       'mapper',
       'dataValues',
@@ -61,7 +55,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       'validRowCount',
       'invalidRowCount',
       'downloadErrorRecordsUrl',
-      'downloadMismatchRecordsUrl',
     ];
     $this->setStatusUrl();
 
@@ -151,8 +144,6 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->set('errorFile', $errorFile);
       $urlParams = 'type=' . CRM_Import_Parser::ERROR . '&parser=CRM_Member_Import_Parser_Membership';
       $this->set('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Member_Import_Parser_Membership';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
   }
 

--- a/CRM/Member/Import/Form/Summary.php
+++ b/CRM/Member/Import/Form/Summary.php
@@ -37,14 +37,10 @@ class CRM_Member_Import_Form_Summary extends CRM_Import_Form_Summary {
     $invalidRowCount = $this->get('invalidRowCount');
     $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
-    $mismatchCount = $this->get('unMatchCount');
+
     if ($duplicateRowCount > 0) {
       $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Member_Import_Parser_Membership';
       $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    elseif ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Member_Import_Parser_Membership';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
     else {
       $duplicateRowCount = 0;
@@ -69,7 +65,7 @@ class CRM_Member_Import_Form_Summary extends CRM_Import_Form_Summary {
       /* only subtract dupes from successful import if we're skipping */
 
       $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-        $duplicateRowCount - $mismatchCount
+        $duplicateRowCount
       );
     }
     $this->assign('dupeActionString', $dupeActionString);
@@ -81,9 +77,7 @@ class CRM_Member_Import_Form_Summary extends CRM_Import_Form_Summary {
       'downloadErrorRecordsUrl',
       'duplicateRowCount',
       'downloadDuplicateRecordsUrl',
-      'downloadMismatchRecordsUrl',
       'groupAdditions',
-      'unMatchCount',
     ];
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));

--- a/templates/CRM/Activity/Import/Form/Summary.tpl
+++ b/templates/CRM/Activity/Import/Form/Summary.tpl
@@ -19,15 +19,6 @@
     {ts}<strong>Import has completed successfully.</strong> The information below summarizes the results.{/ts}
     </p>
 
-   {if $unMatchCount }
-        <p class="error">
-        {ts count=$unMatchCount plural='CiviCRM has detected mismatched activity IDs. These records have not been Updated.'}CiviCRM has detected mismatched activity ID. This record have not been updated.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadMismatchRecordsUrl}You can <a href='%1'>Download Mismatched Activity records</a>. You may then correct them, and import the new file with the corrected data.{/ts}
-        </p>
-    {/if}
-
     {if $invalidRowCount }
         <p class="error">
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record have not been imported.{/ts}
@@ -60,17 +51,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <p><a href="{$downloadErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $unMatchCount }
-    <tr class="error"><td class="label crm-grid-cell">{ts}Mismatched Rows (skipped){/ts}</td>
-        <td class="data">{$unMatchCount}</td>
-        <td class="explanation">{ts}Rows with mismatched activity IDs (NOT updated).{/ts}
-            {if $unMatchCount}
-                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Activity records{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Contribute/Import/Form/Summary.tpl
+++ b/templates/CRM/Contribute/Import/Form/Summary.tpl
@@ -18,15 +18,6 @@
     <strong>{ts}Import has completed successfully.{/ts}</strong> {ts}The information below summarizes the results.{/ts}
     </p>
 
-   {if $unMatchCount }
-        <p class="error">
-        {ts count=$unMatchCount plural='CiviCRM has detected mismatched contribution IDs. These records have not been Updated.'}CiviCRM has detected mismatched contribution ID. This record has not been updated.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadMismatchRecordsUrl}You can <a href='%1'>Download Mismatched Contributions</a>. You may then correct them, and import the new file with the corrected data.{/ts}
-        </p>
-    {/if}
-
     {if $invalidRowCount }
         <p class="error">
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record has not been imported.{/ts}
@@ -95,16 +86,6 @@
         <td class="explanation">{ts}Rows marked as pledge payments where the contributor and / or contribution amount could not be matched to a pending pledge payment. These contribution rows have been skipped (not imported).{/ts}
             {if $invalidPledgePaymentRowCount}
                 <p><a href="{$downloadPledgePaymentErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-    {if $unMatchCount }
-    <tr class="error"><td class="label crm-grid-cell">{ts}Mismatched Rows (skipped){/ts}</td>
-        <td class="data">{$unMatchCount}</td>
-        <td class="explanation">{ts}Rows with mismatched contribution IDs... (NOT updated).{/ts}
-            {if $unMatchCount}
-                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Contributions{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Event/Import/Form/Summary.tpl
+++ b/templates/CRM/Event/Import/Form/Summary.tpl
@@ -20,15 +20,6 @@
     <strong>{ts}Import has completed successfully.{/ts}</strong> {ts}The information below summarizes the results.{/ts}
     </p>
 
-   {if $unMatchCount }
-        <p class="error">
-        {ts count=$unMatchCount plural='CiviCRM has detected mismatched participant IDs. These records have not been updated.'}CiviCRM has detected a mismatched participant ID. This record has not been updated.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadMismatchRecordsUrl}You can <a href="%1">Download Mismatched Participants</a>. You may then correct them, and import the new file with the corrected data.{/ts}
-        </p>
-    {/if}
-
     {if $invalidRowCount }
         <p class="error">
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record has not been imported.{/ts}
@@ -64,17 +55,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <p><a href="{$downloadErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $unMatchCount }
-    <tr class="error"><td class="label crm-grid-cell">{ts}Mismatched Rows (skipped){/ts}</td>
-        <td class="data">{$unMatchCount}</td>
-        <td class="explanation">{ts}Rows with mismatched participant IDs... (NOT updated).{/ts}
-            {if $unMatchCount}
-                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched participants{/ts}</a></p>
             {/if}
         </td>
     </tr>

--- a/templates/CRM/Member/Import/Form/Summary.tpl
+++ b/templates/CRM/Member/Import/Form/Summary.tpl
@@ -19,15 +19,6 @@
     <strong>{ts}Import has completed successfully.{/ts}</strong> {ts}The information below summarizes the results.{/ts}
     </p>
 
-   {if $unMatchCount }
-        <p class="error">
-        {ts count=$unMatchCount plural='CiviCRM has detected mismatched membership IDs. These records have not been Updated.'}CiviCRM has detected mismatched membership ID. This record has not been updated.{/ts}
-        </p>
-        <p class="error">
-        {ts 1=$downloadMismatchRecordsUrl}You can <a href='%1'>Download Mismatched Memberships</a>. You may then correct them, and import the new file with the corrected data.{/ts}
-        </p>
-    {/if}
-
     {if $invalidRowCount }
         <p class="error">
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record has not been imported.{/ts}
@@ -60,17 +51,6 @@
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
                 <div class="action-link"><a href="{$downloadErrorRecordsUrl}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
-            {/if}
-        </td>
-    </tr>
-    {/if}
-
-    {if $unMatchCount }
-    <tr class="error"><td class="label crm-grid-cell">{ts}Mismatched Rows (skipped){/ts}</td>
-        <td class="data">{$unMatchCount}</td>
-        <td class="explanation">{ts}Rows with mismatched membership IDs... (NOT updated).{/ts}
-            {if $unMatchCount}
-                <p><a href="{$downloadMismatchRecordsUrl}">{ts}Download Mismatched Memberships{/ts}</a></p>
             {/if}
         </td>
     </tr>


### PR DESCRIPTION


Overview
----------------------------------------
[Import] Reduce unused copy & paste

Before
----------------------------------------
All the import classes have handling for the NO_MATCH return code - but it is only used in the Contact import class

(This is similiar to the CONFLICT one we removed but in this case it is at least used in ONE class...)

All actual invocations of the return code are in CRM_Import_Parser_Contact - the rest are all handling (which is pointless outside the contact import)

![image](https://user-images.githubusercontent.com/336308/167234712-1afecd1f-3d41-41dc-afd3-5ed19f3a8cd3.png)

![image](https://user-images.githubusercontent.com/336308/167234726-535a068f-55aa-4a49-bc0e-5c60d32c6080.png)


After
----------------------------------------
poof


Technical Details
----------------------------------------
Unlike the CONFLICT return code the NO_MATCH code IS returned
- but ONLY in the contact import - in all the other imports
it is there by the virtue of copy & paste

Comments
----------------------------------------
