### PR TITLE
(REF) Importer - Remove unused parameters. Simplify signature.

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -232,14 +232,11 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
    *
    * This gives the datasource a chance to do any table creation etc.
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
   private function instantiateDataSource(): void {
-    $dataSource = $this->getDataSourceObject();
-    // Get the PEAR::DB object
-    $dao = new CRM_Core_DAO();
-    $db = $dao->getDatabaseConnection();
-    $dataSource->postProcess($this->_params, $db, $this);
+    $this->getDataSourceObject()->initialize();
   }
 
   /**

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -348,6 +348,16 @@ abstract class CRM_Import_DataSource {
   abstract public function buildQuickForm(&$form);
 
   /**
+   * Initialize the datasource, based on the submitted values stored in the user job.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function initialize(): void {
+
+  }
+
+  /**
    * Determine if the current user has access to this data source.
    *
    * @return bool

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -68,17 +68,12 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
   }
 
   /**
-   * Process the form submission.
-   *
-   * @param array $params
-   * @param string $db
-   * @param \CRM_Core_Form $form
+   * Initialize the datasource, based on the submitted values stored in the user job.
    *
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
-   * @throws \API_Exception
    */
-  public function postProcess(&$params, &$db, &$form) {
+  public function initialize(): void {
     $result = self::_CsvToTable(
       $this->getSubmittedValue('uploadFile')['name'],
       $this->getSubmittedValue('skipColumnHeader'),

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -74,17 +74,12 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
   }
 
   /**
-   * Process the form submission.
-   *
-   * @param array $params
-   * @param string $db
-   * @param \CRM_Core_Form $form
+   * Initialize the datasource, based on the submitted values stored in the user job.
    *
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function postProcess(&$params, &$db, &$form) {
+  public function initialize(): void {
     $table = CRM_Utils_SQL_TempTable::build()->setDurable();
     $tableName = $table->getName();
     $table->createWithQuery($this->getSubmittedValue('sqlQuery'));

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -163,7 +163,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     /* @var CRM_Contact_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_MapField', $submittedValues);
     $form->set('user_job_id', $userJobID);
-    $dataSource->postProcess($submittedValues, $null, $form);
+    $dataSource->initialize();
 
     $contactFields = CRM_Contact_BAO_Contact::importableFields();
     $fields = [];


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Fix database initialization to remove unused parameters

Before
----------------------------------------
The function that sets up the datasource is called `postProcess` (a very formy name) and receives 3 parameters, none of which are used anymore -

After
----------------------------------------
The function is renamed `initialize` and takes no parameters

Technical Details
----------------------------------------
We are pretty close to the point where we could usefully bikeshed how the datasource class might look - assuming we imaging csv & sql query might not be the only 2 ever - I don' tthink that should hold this up merging but if there is interest in discussing at this stage I'll open a gitlab. Here are how the current public functions look....

![image](https://user-images.githubusercontent.com/336308/167235731-205842a5-832a-48e1-8f64-d7a4cc6bbaf6.png)

& here is which ones are actually overridden 

![image](https://user-images.githubusercontent.com/336308/167235770-cf7a162f-9797-42df-90ad-000831d495d6.png)

Comments
----------------------------------------
