### PR TITLE
[REF] [TEST ONLY] APIv4 - Reorganize test classes, don't use transactions for custom field tests

### DIFF
--- a/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
@@ -18,12 +18,13 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class AbstractActionFunctionTest extends UnitTestCase {
+class AbstractActionFunctionTest extends Api4TestBase implements TransactionalInterface {
 
   public function testUndefinedParamException(): void {
     $this->expectException('API_Exception');

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -19,16 +19,17 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\MockBasicEntity;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class BasicActionsTest extends UnitTestCase implements HookInterface {
+class BasicActionsTest extends Api4TestBase implements HookInterface, TransactionalInterface {
 
   /**
    * Listens for civi.api4.entityTypes event to manually add this nonstandard entity

--- a/tests/phpunit/api/v4/Action/ChainTest.php
+++ b/tests/phpunit/api/v4/Action/ChainTest.php
@@ -19,16 +19,17 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ChainTest extends UnitTestCase {
+class ChainTest extends Api4TestBase implements TransactionalInterface {
 
   public function tearDown(): void {
     CustomField::delete()

--- a/tests/phpunit/api/v4/Action/ComplexQueryTest.php
+++ b/tests/phpunit/api/v4/Action/ComplexQueryTest.php
@@ -19,10 +19,11 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Test\CiviEnvBuilder;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
@@ -30,7 +31,7 @@ use Civi\Test\CiviEnvBuilder;
  * This class tests a series of complex query situations described in the
  * initial APIv4 specification
  */
-class ComplexQueryTest extends UnitTestCase {
+class ComplexQueryTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless(): CiviEnvBuilder {
     $this->loadDataSet('DefaultDataSet');

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -19,13 +19,15 @@
 
 namespace api\v4\Action;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Email;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ContactApiKeyTest extends \api\v4\UnitTestCase {
+class ContactApiKeyTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetApiKey() {
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'add contacts', 'edit api keys', 'view all contacts', 'edit all contacts'];

--- a/tests/phpunit/api/v4/Action/ContactChecksumTest.php
+++ b/tests/phpunit/api/v4/Action/ContactChecksumTest.php
@@ -19,12 +19,14 @@
 
 namespace api\v4\Action;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ContactChecksumTest extends \api\v4\UnitTestCase {
+class ContactChecksumTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetChecksum() {
     $contact = Contact::create(FALSE)

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -19,13 +19,15 @@
 
 namespace api\v4\Action;
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Relationship;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ContactGetTest extends \api\v4\UnitTestCase {
+class ContactGetTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetDeletedContacts() {
     $last_name = uniqid('deleteContactTest');

--- a/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
+++ b/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
@@ -19,12 +19,13 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ContactIsDeletedTest extends UnitTestCase {
+class ContactIsDeletedTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $relatedTables = [

--- a/tests/phpunit/api/v4/Action/CurrentFilterTest.php
+++ b/tests/phpunit/api/v4/Action/CurrentFilterTest.php
@@ -20,13 +20,14 @@
 namespace api\v4\Action;
 
 use Civi\Api4\Relationship;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class CurrentFilterTest extends UnitTestCase {
+class CurrentFilterTest extends Api4TestBase implements TransactionalInterface {
 
   public function testCurrentRelationship() {
     $cid1 = Contact::create()->addValue('first_name', 'Bob1')->execute()->first()['id'];

--- a/tests/phpunit/api/v4/Action/DateTest.php
+++ b/tests/phpunit/api/v4/Action/DateTest.php
@@ -23,12 +23,13 @@ use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
 use Civi\Api4\Relationship;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class DateTest extends UnitTestCase {
+class DateTest extends Api4TestBase implements TransactionalInterface {
 
   public function testRelationshipDate() {
     $c1 = Contact::create()

--- a/tests/phpunit/api/v4/Action/EvaluateConditionTest.php
+++ b/tests/phpunit/api/v4/Action/EvaluateConditionTest.php
@@ -20,12 +20,13 @@
 namespace api\v4\Action;
 
 use Civi\Api4\MockBasicEntity;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class EvaluateConditionTest extends UnitTestCase {
+class EvaluateConditionTest extends Api4TestBase implements TransactionalInterface {
 
   public function testEvaluateCondition() {
     $action = MockBasicEntity::get();

--- a/tests/phpunit/api/v4/Action/EventTest.php
+++ b/tests/phpunit/api/v4/Action/EventTest.php
@@ -16,12 +16,14 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use api\v4\Api4TestBase;
 use Civi\Api4\Event;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class EventTest extends \api\v4\UnitTestCase {
+class EventTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * Test that the event api filters out templates by default.

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -19,7 +19,7 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\CiviCase;
 use Civi\Api4\Contact;
@@ -28,11 +28,12 @@ use Civi\Api4\EntityTag;
 use Civi\Api4\Phone;
 use Civi\Api4\Relationship;
 use Civi\Api4\Tag;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class FkJoinTest extends UnitTestCase {
+class FkJoinTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $this->loadDataSet('DefaultDataSet');

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -19,16 +19,17 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\Tag;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GetExtraFieldsTest extends UnitTestCase {
+class GetExtraFieldsTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetFieldsByContactType() {
     $getFields = Contact::getFields(FALSE)->addSelect('name')->addWhere('type', '=', 'Field');

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -19,16 +19,17 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Campaign;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GetFieldsTest extends UnitTestCase {
+class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
 
   public function testOptionsAreReturned() {
     $fields = Contact::getFields(FALSE)

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -19,13 +19,14 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\MockArrayEntity;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GetFromArrayTest extends UnitTestCase {
+class GetFromArrayTest extends Api4TestBase implements TransactionalInterface {
 
   public function testArrayGetWithLimit() {
     $result = MockArrayEntity::get()

--- a/tests/phpunit/api/v4/Action/IndexTest.php
+++ b/tests/phpunit/api/v4/Action/IndexTest.php
@@ -19,12 +19,13 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class IndexTest extends UnitTestCase {
+class IndexTest extends Api4TestBase implements TransactionalInterface {
 
   public function testIndex() {
     // Results indexed by name

--- a/tests/phpunit/api/v4/Action/IsPrimaryTest.php
+++ b/tests/phpunit/api/v4/Action/IsPrimaryTest.php
@@ -24,12 +24,13 @@ use Civi\Api4\IM;
 use Civi\Api4\Phone;
 use Civi\Api4\Address;
 use Civi\Api4\OpenID;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class IsPrimaryTest extends UnitTestCase {
+class IsPrimaryTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * Test that creating a location entity or deleting one re-assigns is_primary correctly.

--- a/tests/phpunit/api/v4/Action/NullValueTest.php
+++ b/tests/phpunit/api/v4/Action/NullValueTest.php
@@ -21,12 +21,13 @@ namespace api\v4\Action;
 
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class NullValueTest extends UnitTestCase {
+class NullValueTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $format = '{contact.first_name}{ }{contact.last_name}';

--- a/tests/phpunit/api/v4/Action/RecentItemsTest.php
+++ b/tests/phpunit/api/v4/Action/RecentItemsTest.php
@@ -19,14 +19,15 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\RecentItem;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class RecentItemsTest extends UnitTestCase {
+class RecentItemsTest extends Api4TestBase implements TransactionalInterface {
 
   public function testAddDeleteActivity(): void {
     $cid = $this->createLoggedInUser();

--- a/tests/phpunit/api/v4/Action/ReplaceTest.php
+++ b/tests/phpunit/api/v4/Action/ReplaceTest.php
@@ -24,13 +24,14 @@ use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomValue;
 use Civi\Api4\Email;
 use api\v4\Traits\TableDropperTrait;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ReplaceTest extends UnitTestCase {
+class ReplaceTest extends Api4TestBase implements TransactionalInterface {
   use TableDropperTrait;
 
   /**

--- a/tests/phpunit/api/v4/Action/RequiredFieldTest.php
+++ b/tests/phpunit/api/v4/Action/RequiredFieldTest.php
@@ -20,12 +20,13 @@
 namespace api\v4\Action;
 
 use Civi\Api4\Event;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class RequiredFieldTest extends UnitTestCase {
+class RequiredFieldTest extends Api4TestBase implements TransactionalInterface {
 
   public function testRequired() {
     $msg = '';

--- a/tests/phpunit/api/v4/Action/ResultTest.php
+++ b/tests/phpunit/api/v4/Action/ResultTest.php
@@ -20,12 +20,13 @@
 namespace api\v4\Action;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ResultTest extends UnitTestCase {
+class ResultTest extends Api4TestBase implements TransactionalInterface {
 
   public function testJsonSerialize() {
     $result = Contact::getFields(FALSE)->addWhere('type', '=', 'Field')->execute();

--- a/tests/phpunit/api/v4/Action/SaveTest.php
+++ b/tests/phpunit/api/v4/Action/SaveTest.php
@@ -19,13 +19,14 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SaveTest extends UnitTestCase {
+class SaveTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * @dataProvider getMatchingCriteriaDataProvider

--- a/tests/phpunit/api/v4/Action/SqlExpressionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlExpressionTest.php
@@ -19,14 +19,15 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Email;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SqlExpressionTest extends UnitTestCase {
+class SqlExpressionTest extends Api4TestBase implements TransactionalInterface {
 
   public function testSelectNull() {
     Contact::create()->addValue('first_name', 'bob')->setCheckPermissions(FALSE)->execute();

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -19,15 +19,16 @@
 
 namespace api\v4\Action;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SqlFunctionTest extends UnitTestCase {
+class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetFunctions() {
     $functions = array_column(\CRM_Api4_Page_Api4Explorer::getSqlFunctions(), NULL, 'name');

--- a/tests/phpunit/api/v4/Action/UpdateContactTest.php
+++ b/tests/phpunit/api/v4/Action/UpdateContactTest.php
@@ -20,14 +20,15 @@
 namespace api\v4\Action;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Class UpdateContactTest
  * @package api\v4\Action
  * @group headless
  */
-class UpdateContactTest extends UnitTestCase {
+class UpdateContactTest extends Api4TestBase implements TransactionalInterface {
 
   public function testUpdateWithIdInWhere() {
     $contactId = Contact::create(FALSE)

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -22,14 +22,13 @@ namespace api\v4;
 use api\v4\Traits\TestDataLoaderTrait;
 use Civi\Api4\UFMatch;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\TransactionalInterface;
 
 require_once 'api/Exception.php';
 
 /**
  * @group headless
  */
-class UnitTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
 
   use TestDataLoaderTrait;
 

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
@@ -31,7 +31,7 @@ use Civi\Api4\RelationshipCache;
 /**
  * @group headless
  */
-class BasicCustomFieldTest extends BaseCustomValueTest {
+class BasicCustomFieldTest extends CustomTestBase {
 
   public function tearDown(): void {
     FinancialType::delete(FALSE)

--- a/tests/phpunit/api/v4/Custom/ContactCustomJoinTest.php
+++ b/tests/phpunit/api/v4/Custom/ContactCustomJoinTest.php
@@ -17,17 +17,16 @@
  */
 
 
-namespace api\v4\Entity;
+namespace api\v4\Custom;
 
 use Civi\Api4\Contact;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomField;
-use api\v4\Action\BaseCustomValueTest;
 
 /**
  * @group headless
  */
-class ContactCustomJoinTest extends BaseCustomValueTest {
+class ContactCustomJoinTest extends CustomTestBase {
 
   /**
    * Add test to ensure that in the very unusual and not really supported situation where there is a space in the

--- a/tests/phpunit/api/v4/Custom/CoreUtilTest.php
+++ b/tests/phpunit/api/v4/Custom/CoreUtilTest.php
@@ -17,9 +17,8 @@
  */
 
 
-namespace api\v4\Utils;
+namespace api\v4\Custom;
 
-use api\v4\UnitTestCase;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\Utils\CoreUtil;
@@ -27,7 +26,7 @@ use Civi\Api4\Utils\CoreUtil;
 /**
  * @group headless
  */
-class CoreUtilTest extends UnitTestCase {
+class CoreUtilTest extends CustomTestBase {
 
   /**
    */

--- a/tests/phpunit/api/v4/Custom/CreateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CreateCustomValueTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
@@ -28,7 +28,7 @@ use Civi\Api4\OptionValue;
 /**
  * @group headless
  */
-class CreateCustomValueTest extends BaseCustomValueTest {
+class CreateCustomValueTest extends CustomTestBase {
 
   public function testGetWithCustomData() {
     $optionValues = ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'];

--- a/tests/phpunit/api/v4/Custom/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CreateWithOptionGroupTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
@@ -26,7 +26,7 @@ use Civi\Api4\Contact;
 /**
  * @group headless
  */
-class CreateWithOptionGroupTest extends BaseCustomValueTest {
+class CreateWithOptionGroupTest extends CustomTestBase {
 
   public function testGetWithCustomData() {
     $group = uniqid('fava');

--- a/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
@@ -26,7 +26,7 @@ use Civi\Api4\CustomGroup;
 /**
  * @group headless
  */
-class CustomContactRefTest extends BaseCustomValueTest {
+class CustomContactRefTest extends CustomTestBase {
 
   public function testGetWithJoin() {
     $firstName = uniqid('fav');

--- a/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Activity;
 use Civi\Api4\CustomField;
@@ -26,7 +26,7 @@ use Civi\Api4\CustomGroup;
 /**
  * @group headless
  */
-class CustomFieldAlterTest extends BaseCustomValueTest {
+class CustomFieldAlterTest extends CustomTestBase {
 
   public function testChangeSerialize() {
     $contact = $this->createEntity(['type' => 'Individual']);

--- a/tests/phpunit/api/v4/Custom/CustomGroupACLTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomGroupACLTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\ACL;
 use Civi\Api4\Contact;
@@ -28,7 +28,7 @@ use Civi\Api4\CustomValue;
 /**
  * @group headless
  */
-class CustomGroupACLTest extends BaseCustomValueTest {
+class CustomGroupACLTest extends CustomTestBase {
 
   public function tearDown(): void {
     parent::tearDown();

--- a/tests/phpunit/api/v4/Custom/CustomTestBase.php
+++ b/tests/phpunit/api/v4/Custom/CustomTestBase.php
@@ -17,13 +17,21 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomField;
 
-abstract class BaseCustomValueTest extends UnitTestCase {
+/**
+ * Use this base class for any APIv4 tests which create custom groups/fields,
+ * to ensure they get cleaned up properly.
+ *
+ * Note: The TransactionalInterface won't work with custom fields because of adding/dropping tables.
+ * So these tests have to do their own cleanup of any contacts or other entities created.
+ * The recommended way is to override the `tearDown` function and calling `parent::tearDown()`.
+ */
+abstract class CustomTestBase extends Api4TestBase {
 
   /**
    * Delete all created options groups.

--- a/tests/phpunit/api/v4/Custom/CustomValuePerformanceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValuePerformanceTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
@@ -27,7 +27,7 @@ use api\v4\Traits\QueryCounterTrait;
 /**
  * @group headless
  */
-class CustomValuePerformanceTest extends BaseCustomValueTest {
+class CustomValuePerformanceTest extends CustomTestBase {
 
   use QueryCounterTrait;
 

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
@@ -28,7 +28,7 @@ use Civi\Api4\Entity;
 /**
  * @group headless
  */
-class CustomValueTest extends BaseCustomValueTest {
+class CustomValueTest extends CustomTestBase {
 
   protected $contactID;
 

--- a/tests/phpunit/api/v4/Custom/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Custom/ExtendFromIndividualTest.php
@@ -17,23 +17,23 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
-use CRM_Core_BAO_CustomValueTable as CustomValueTable;
 
 /**
  * @group headless
  */
-class UpdateCustomValueTest extends BaseCustomValueTest {
+class ExtendFromIndividualTest extends CustomTestBase {
 
-  public function testGetWithCustomData() {
+  public function testGetWithNonStandardExtends() {
 
     $customGroup = CustomGroup::create(FALSE)
       ->addValue('title', 'MyContactFields')
-      ->addValue('extends', 'Contact')
+      // not Contact
+      ->addValue('extends', 'Individual')
       ->execute()
       ->first();
 
@@ -45,25 +45,21 @@ class UpdateCustomValueTest extends BaseCustomValueTest {
       ->execute();
 
     $contactId = Contact::create(FALSE)
-      ->addValue('first_name', 'Red')
+      ->addValue('first_name', 'Johann')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
       ->addValue('MyContactFields.FavColor', 'Red')
       ->execute()
       ->first()['id'];
 
-    Contact::update(FALSE)
+    $contact = Contact::get(FALSE)
+      ->addSelect('display_name')
+      ->addSelect('MyContactFields.FavColor')
       ->addWhere('id', '=', $contactId)
-      ->addValue('first_name', 'Red')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactFields.FavColor', 'Blue')
-      ->execute();
+      ->execute()
+      ->first();
 
-    $result = CustomValueTable::getEntityValues($contactId, 'Contact');
-
-    $this->assertEquals(1, count($result));
-    $this->assertContains('Blue', $result);
+    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
   }
 
 }

--- a/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
@@ -17,7 +17,7 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Address;
 use Civi\Api4\Campaign;
@@ -35,7 +35,7 @@ use Civi\Api4\Tag;
 /**
  * @group headless
  */
-class PseudoconstantTest extends BaseCustomValueTest {
+class PseudoconstantTest extends CustomTestBase {
 
   public function testOptionValue() {
     $cid = Contact::create(FALSE)->addValue('first_name', 'bill')->execute()->first()['id'];

--- a/tests/phpunit/api/v4/Custom/UpdateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/UpdateCustomValueTest.php
@@ -17,23 +17,23 @@
  */
 
 
-namespace api\v4\Action;
+namespace api\v4\Custom;
 
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
+use CRM_Core_BAO_CustomValueTable as CustomValueTable;
 
 /**
  * @group headless
  */
-class ExtendFromIndividualTest extends BaseCustomValueTest {
+class UpdateCustomValueTest extends CustomTestBase {
 
-  public function testGetWithNonStandardExtends() {
+  public function testGetWithCustomData() {
 
     $customGroup = CustomGroup::create(FALSE)
       ->addValue('title', 'MyContactFields')
-      // not Contact
-      ->addValue('extends', 'Individual')
+      ->addValue('extends', 'Contact')
       ->execute()
       ->first();
 
@@ -45,21 +45,25 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
       ->execute();
 
     $contactId = Contact::create(FALSE)
-      ->addValue('first_name', 'Johann')
+      ->addValue('first_name', 'Red')
       ->addValue('last_name', 'Tester')
       ->addValue('contact_type', 'Individual')
       ->addValue('MyContactFields.FavColor', 'Red')
       ->execute()
       ->first()['id'];
 
-    $contact = Contact::get(FALSE)
-      ->addSelect('display_name')
-      ->addSelect('MyContactFields.FavColor')
+    Contact::update(FALSE)
       ->addWhere('id', '=', $contactId)
-      ->execute()
-      ->first();
+      ->addValue('first_name', 'Red')
+      ->addValue('last_name', 'Tester')
+      ->addValue('contact_type', 'Individual')
+      ->addValue('MyContactFields.FavColor', 'Blue')
+      ->execute();
 
-    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
+    $result = CustomValueTable::getEntityValues($contactId, 'Contact');
+
+    $this->assertEquals(1, count($result));
+    $this->assertContains('Blue', $result);
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/ActivityTest.php
+++ b/tests/phpunit/api/v4/Entity/ActivityTest.php
@@ -19,7 +19,7 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\ActivityContact;
 use Civi\Test\TransactionalInterface;
@@ -32,7 +32,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class ActivityTest extends UnitTestCase implements TransactionalInterface {
+class ActivityTest extends Api4TestBase implements TransactionalInterface {
 
   public function testActivityUpdate() {
 

--- a/tests/phpunit/api/v4/Entity/AddressTest.php
+++ b/tests/phpunit/api/v4/Entity/AddressTest.php
@@ -18,7 +18,7 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Test\TransactionalInterface;
@@ -28,7 +28,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class AddressTest extends UnitTestCase implements TransactionalInterface {
+class AddressTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * Check that 2 addresses for the same contact can't both be primary

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -20,13 +20,14 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\CiviCase;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Relationship;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class CaseTest extends UnitTestCase {
+class CaseTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -26,7 +26,7 @@ use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\Entity;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Event\ValidateValuesEvent;
 use Civi\Api4\Service\Spec\CustomFieldSpec;
 use Civi\Api4\Service\Spec\FieldSpec;
@@ -35,11 +35,12 @@ use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\PostEvent;
 use Civi\Core\Event\PreEvent;
 use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ConformanceTest extends UnitTestCase implements HookInterface {
+class ConformanceTest extends Api4TestBase implements HookInterface, TransactionalInterface {
 
   use CheckAccessTrait;
   use TableDropperTrait;

--- a/tests/phpunit/api/v4/Entity/ContactInterchangeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactInterchangeTest.php
@@ -20,7 +20,7 @@ namespace api\v4\Entity;
 
 use Civi\Api4\ActivityContact;
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -29,7 +29,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class ContactInterchangeTest extends UnitTestCase implements TransactionalInterface {
+class ContactInterchangeTest extends Api4TestBase implements TransactionalInterface {
 
   public function getExamples() {
     $apiWriters = [

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -21,12 +21,13 @@ namespace api\v4\Entity;
 
 use Civi\Api4\Contact;
 use Civi\Api4\OptionValue;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ContactJoinTest extends UnitTestCase {
+class ContactJoinTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $relatedTables = [

--- a/tests/phpunit/api/v4/Entity/ContactTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactTypeTest.php
@@ -20,7 +20,7 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\ContactType;
 use Civi\Api4\Email;
 use Civi\Api4\Navigation;
@@ -29,7 +29,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  */
-class ContactTypeTest extends UnitTestCase implements TransactionalInterface {
+class ContactTypeTest extends Api4TestBase implements TransactionalInterface {
 
   public function testMenuItemWillBeCreatedAndDeleted() {
     ContactType::create(FALSE)

--- a/tests/phpunit/api/v4/Entity/DomainTest.php
+++ b/tests/phpunit/api/v4/Entity/DomainTest.php
@@ -18,14 +18,14 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Domain;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class DomainTest extends UnitTestCase implements TransactionalInterface {
+class DomainTest extends Api4TestBase implements TransactionalInterface {
 
   public function testActiveDomain() {
     Domain::create(FALSE)

--- a/tests/phpunit/api/v4/Entity/EntityTest.php
+++ b/tests/phpunit/api/v4/Entity/EntityTest.php
@@ -21,12 +21,13 @@ namespace api\v4\Entity;
 
 use Civi\API\Exception\NotImplementedException;
 use Civi\Api4\Entity;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class EntityTest extends UnitTestCase {
+class EntityTest extends Api4TestBase implements TransactionalInterface {
 
   public function testEntityGet() {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');

--- a/tests/phpunit/api/v4/Entity/ExampleDataTest.php
+++ b/tests/phpunit/api/v4/Entity/ExampleDataTest.php
@@ -19,12 +19,13 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ExampleDataTest extends UnitTestCase {
+class ExampleDataTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * Basic canary test fetching a specific example.

--- a/tests/phpunit/api/v4/Entity/ExtensionTest.php
+++ b/tests/phpunit/api/v4/Entity/ExtensionTest.php
@@ -19,13 +19,14 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Extension;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ExtensionTest extends UnitTestCase {
+class ExtensionTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGet() {
     $moduleTest = Extension::get(FALSE)

--- a/tests/phpunit/api/v4/Entity/GroupContactTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupContactTest.php
@@ -19,13 +19,14 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\GroupContact;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GroupContactTest extends UnitTestCase {
+class GroupContactTest extends Api4TestBase implements TransactionalInterface {
 
   public function testCreate() {
     $contact = $this->createEntity(['type' => 'Individual']);

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -18,7 +18,7 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Domain;
 use Civi\Api4\Group;
 use Civi\Api4\Managed;
@@ -32,7 +32,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  */
-class ManagedEntityTest extends UnitTestCase implements TransactionalInterface, HookInterface {
+class ManagedEntityTest extends Api4TestBase implements TransactionalInterface, HookInterface {
   /**
    * @var array[]
    */

--- a/tests/phpunit/api/v4/Entity/MembershipTest.php
+++ b/tests/phpunit/api/v4/Entity/MembershipTest.php
@@ -18,7 +18,7 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Domain;
 use Civi\Api4\MembershipType;
@@ -27,7 +27,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  */
-class MembershipTest extends UnitTestCase implements TransactionalInterface {
+class MembershipTest extends Api4TestBase implements TransactionalInterface {
 
   public function testUpdateWeights() {
     $getValues = function($domain) {

--- a/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
+++ b/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
@@ -18,7 +18,7 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Test\DbTestTrait;
 use Civi\Test\GenericAssertionsTrait;
 use Civi\Test\TransactionalInterface;
@@ -26,7 +26,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  */
-class MessageTemplateTest extends UnitTestCase implements TransactionalInterface {
+class MessageTemplateTest extends Api4TestBase implements TransactionalInterface {
 
   use GenericAssertionsTrait;
   use DbTestTrait;

--- a/tests/phpunit/api/v4/Entity/NavigationTest.php
+++ b/tests/phpunit/api/v4/Entity/NavigationTest.php
@@ -18,14 +18,14 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Navigation;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class NavigationTest extends UnitTestCase implements TransactionalInterface {
+class NavigationTest extends Api4TestBase implements TransactionalInterface {
 
   public function testCreate() {
     $created = Navigation::create(FALSE)

--- a/tests/phpunit/api/v4/Entity/NoteTest.php
+++ b/tests/phpunit/api/v4/Entity/NoteTest.php
@@ -18,14 +18,14 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Note;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class NoteTest extends UnitTestCase implements TransactionalInterface {
+class NoteTest extends Api4TestBase implements TransactionalInterface {
 
   public function testDeleteWithChildren() {
     $c1 = $this->createEntity(['type' => 'Individual']);

--- a/tests/phpunit/api/v4/Entity/OptionValueTest.php
+++ b/tests/phpunit/api/v4/Entity/OptionValueTest.php
@@ -18,7 +18,7 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\OptionGroup;
 use Civi\Api4\OptionValue;
 use Civi\Test\TransactionalInterface;
@@ -26,7 +26,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  */
-class OptionValueTest extends UnitTestCase implements TransactionalInterface {
+class OptionValueTest extends Api4TestBase implements TransactionalInterface {
 
   public function testNullDefault() {
     OptionGroup::create(FALSE)

--- a/tests/phpunit/api/v4/Entity/ParticipantTest.php
+++ b/tests/phpunit/api/v4/Entity/ParticipantTest.php
@@ -20,12 +20,13 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Participant;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ParticipantTest extends UnitTestCase {
+class ParticipantTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v4/Entity/RecentItemTest.php
+++ b/tests/phpunit/api/v4/Entity/RecentItemTest.php
@@ -18,7 +18,7 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\RecentItem;
 use Civi\Api4\Contact;
 use Civi\Test\TransactionalInterface;
@@ -28,7 +28,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class RecentItemTest extends UnitTestCase implements TransactionalInterface {
+class RecentItemTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    *

--- a/tests/phpunit/api/v4/Entity/RelationshipTest.php
+++ b/tests/phpunit/api/v4/Entity/RelationshipTest.php
@@ -19,7 +19,7 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Relationship;
 use Civi\Api4\RelationshipCache;
 use Civi\Test\TransactionalInterface;
@@ -30,7 +30,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class RelationshipTest extends UnitTestCase implements TransactionalInterface {
+class RelationshipTest extends Api4TestBase implements TransactionalInterface {
 
   public function testRelCacheCount() {
     $c1 = Contact::create(FALSE)->addValue('first_name', '1')->execute()->first()['id'];

--- a/tests/phpunit/api/v4/Entity/RouteTest.php
+++ b/tests/phpunit/api/v4/Entity/RouteTest.php
@@ -20,12 +20,12 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Route;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 
 /**
  * @group headless
  */
-class RouteTest extends UnitTestCase {
+class RouteTest extends Api4TestBase {
 
   public function testGet() {
     $result = Route::get()->addWhere('path', '=', 'civicrm/admin')->execute();

--- a/tests/phpunit/api/v4/Entity/SavedSearchTest.php
+++ b/tests/phpunit/api/v4/Entity/SavedSearchTest.php
@@ -19,14 +19,15 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\Email;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SavedSearchTest extends UnitTestCase {
+class SavedSearchTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * @throws \API_Exception

--- a/tests/phpunit/api/v4/Entity/SettingTest.php
+++ b/tests/phpunit/api/v4/Entity/SettingTest.php
@@ -20,12 +20,13 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Setting;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SettingTest extends UnitTestCase {
+class SettingTest extends Api4TestBase implements TransactionalInterface {
 
   public function testSettingASetting() {
     $setting = Setting::set()->addValue('menubar_position', 'above-crm-container')->setCheckPermissions(FALSE)->execute()->first();

--- a/tests/phpunit/api/v4/Entity/SystemRotateKeyTest.php
+++ b/tests/phpunit/api/v4/Entity/SystemRotateKeyTest.php
@@ -19,14 +19,15 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Crypto\CryptoTestTrait;
+use Civi\Test\TransactionalInterface;
 use Psr\Log\LoggerInterface;
 
 /**
  * @group headless
  */
-class RotateKeyTest extends UnitTestCase {
+class RotateKeyTest extends Api4TestBase implements TransactionalInterface {
 
   use CryptoTestTrait;
 

--- a/tests/phpunit/api/v4/Entity/SystemTest.php
+++ b/tests/phpunit/api/v4/Entity/SystemTest.php
@@ -22,12 +22,13 @@ namespace api\v4\Entity;
 use Civi\Api4\Setting;
 use Civi\Api4\StatusPreference;
 use Civi\Api4\System;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SystemTest extends UnitTestCase {
+class SystemTest extends Api4TestBase implements TransactionalInterface {
 
   public function testSystemCheck() {
     $origEnv = \CRM_Core_Config::environment();

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -19,7 +19,7 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\EntityTag;
 use Civi\Api4\Tag;
 use Civi\Test\TransactionalInterface;
@@ -27,7 +27,7 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  */
-class TagTest extends UnitTestCase implements TransactionalInterface {
+class TagTest extends Api4TestBase implements TransactionalInterface {
 
   public function testTagFilter() {
     $conTag = Tag::create(FALSE)

--- a/tests/phpunit/api/v4/Entity/TranslationTest.php
+++ b/tests/phpunit/api/v4/Entity/TranslationTest.php
@@ -19,12 +19,13 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class TranslationTest extends UnitTestCase {
+class TranslationTest extends Api4TestBase implements TransactionalInterface {
 
   protected $ids = [];
 

--- a/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
+++ b/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
@@ -19,7 +19,7 @@
 namespace api\v4\Entity;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Event\ValidateValuesEvent;
 use Civi\Test\TransactionalInterface;
 
@@ -28,7 +28,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class ValidateValuesTest extends UnitTestCase implements TransactionalInterface {
+class ValidateValuesTest extends Api4TestBase implements TransactionalInterface {
 
   private $lastValidator;
 

--- a/tests/phpunit/api/v4/Entity/WordReplacementTest.php
+++ b/tests/phpunit/api/v4/Entity/WordReplacementTest.php
@@ -19,12 +19,13 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class WordReplacementTest extends UnitTestCase {
+class WordReplacementTest extends Api4TestBase implements TransactionalInterface {
 
   public function testDefaults() {
     $create = \Civi\Api4\WordReplacement::create(FALSE)

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -19,13 +19,14 @@
 
 namespace api\v4\Entity;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\WorkflowMessage;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class WorkflowMessageTest extends UnitTestCase {
+class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGet() {
     $result = \Civi\Api4\WorkflowMessage::get(0)

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -21,12 +21,13 @@ namespace api\v4\Query;
 
 use Civi\API\Request;
 use Civi\Api4\Query\Api4SelectQuery;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class Api4SelectQueryTest extends UnitTestCase {
+class Api4SelectQueryTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $relatedTables = [

--- a/tests/phpunit/api/v4/Query/OneToOneJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OneToOneJoinTest.php
@@ -20,14 +20,15 @@
 namespace api\v4\Query;
 
 use Civi\Api4\Contact;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Class OneToOneJoinTest
  * @package api\v4\Query
  * @group headless
  */
-class OneToOneJoinTest extends UnitTestCase {
+class OneToOneJoinTest extends Api4TestBase implements TransactionalInterface {
 
   public function testOneToOneJoin() {
     $armenianContact = Contact::create()

--- a/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OptionValueJoinTest.php
@@ -20,12 +20,13 @@
 namespace api\v4\Query;
 
 use Civi\Api4\Query\Api4SelectQuery;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class OptionValueJoinTest extends UnitTestCase {
+class OptionValueJoinTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $relatedTables = [

--- a/tests/phpunit/api/v4/Query/PermissionCheckTest.php
+++ b/tests/phpunit/api/v4/Query/PermissionCheckTest.php
@@ -19,16 +19,17 @@
 
 namespace api\v4\Query;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Contact;
 use Civi\Api4\Event;
 use Civi\Api4\Participant;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class PermissionCheckTest extends UnitTestCase {
+class PermissionCheckTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * Clean up after test.

--- a/tests/phpunit/api/v4/Query/SelectQueryMultiJoinTest.php
+++ b/tests/phpunit/api/v4/Query/SelectQueryMultiJoinTest.php
@@ -20,14 +20,15 @@
 namespace api\v4\Query;
 
 use Civi\Api4\Email;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Class SelectQueryMultiJoinTest
  * @package api\v4\Query
  * @group headless
  */
-class SelectQueryMultiJoinTest extends UnitTestCase {
+class SelectQueryMultiJoinTest extends Api4TestBase implements TransactionalInterface {
 
   public function setUpHeadless() {
     $this->cleanup(['tablesToTruncate' => ['civicrm_contact', 'civicrm_email']]);

--- a/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
+++ b/tests/phpunit/api/v4/Query/SqlExpressionParserTest.php
@@ -19,13 +19,14 @@
 
 namespace api\v4\Query;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Query\SqlExpression;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SqlExpressionParserTest extends UnitTestCase {
+class SqlExpressionParserTest extends Api4TestBase implements TransactionalInterface {
 
   public function aggregateFunctions() {
     return [

--- a/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
+++ b/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
@@ -22,12 +22,13 @@ namespace api\v4\Service\Schema;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Civi\Api4\Service\Schema\SchemaMap;
 use Civi\Api4\Service\Schema\Table;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
+use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SchemaMapperTest extends UnitTestCase {
+class SchemaMapperTest extends Api4TestBase implements TransactionalInterface {
 
   public function testWillHaveNoPathWithNoTables() {
     $map = new SchemaMap();

--- a/tests/phpunit/api/v4/Spec/RequestSpecTest.php
+++ b/tests/phpunit/api/v4/Spec/RequestSpecTest.php
@@ -21,12 +21,12 @@ namespace api\v4\Spec;
 
 use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 
 /**
  * @group headless
  */
-class RequestSpecTest extends UnitTestCase {
+class RequestSpecTest extends Api4TestBase {
 
   public function testRequiredFieldFetching() {
     $spec = new RequestSpec('Contact', 'get');

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -21,12 +21,12 @@ namespace api\v4\Spec;
 
 use Civi\Api4\Service\Spec\CustomFieldSpec;
 use Civi\Api4\Service\Spec\SpecFormatter;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 
 /**
  * @group headless
  */
-class SpecFormatterTest extends UnitTestCase {
+class SpecFormatterTest extends Api4TestBase {
 
   /**
    * @dataProvider arrayFieldSpecProvider

--- a/tests/phpunit/api/v4/Spec/SpecGathererTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecGathererTest.php
@@ -23,7 +23,7 @@ use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\Provider\Generic\SpecProviderInterface;
 use Civi\Api4\Service\Spec\SpecGatherer;
 use api\v4\Traits\OptionCleanupTrait;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use api\v4\Traits\TableDropperTrait;
@@ -32,7 +32,7 @@ use Prophecy\Argument;
 /**
  * @group headless
  */
-class SpecGathererTest extends UnitTestCase {
+class SpecGathererTest extends Api4TestBase {
 
   use TableDropperTrait;
   use OptionCleanupTrait;

--- a/tests/phpunit/api/v4/Utils/ArrayInsertionServiceTest.php
+++ b/tests/phpunit/api/v4/Utils/ArrayInsertionServiceTest.php
@@ -20,12 +20,12 @@
 namespace api\v4\Utils;
 
 use Civi\Api4\Utils\ArrayInsertionUtil;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 
 /**
  * @group headless
  */
-class ArrayInsertionServiceTest extends UnitTestCase {
+class ArrayInsertionServiceTest extends Api4TestBase {
 
   public function testInsertWillWork() {
     $arr = [];

--- a/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
+++ b/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
@@ -21,12 +21,12 @@ namespace api\v4\Utils;
 
 use Civi\Api4\Utils\ReflectionUtils;
 use api\v4\Mock\MockV4ReflectionGrandchild;
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 
 /**
  * @group headless
  */
-class ReflectionUtilsTest extends UnitTestCase {
+class ReflectionUtilsTest extends Api4TestBase {
 
   /**
    * Test that class annotations are returned across @inheritDoc

--- a/tests/phpunit/api/v4/Utils/SelectUtilTest.php
+++ b/tests/phpunit/api/v4/Utils/SelectUtilTest.php
@@ -19,13 +19,13 @@
 
 namespace api\v4\Utils;
 
-use api\v4\UnitTestCase;
+use api\v4\Api4TestBase;
 use Civi\Api4\Utils\SelectUtil;
 
 /**
  * @group headless
  */
-class SelectUtilTest extends UnitTestCase {
+class SelectUtilTest extends Api4TestBase {
 
   private $emailFieldNames = [
     'id',


### PR DESCRIPTION
Overview
----------------------------------------
Reorganizes APIv4 test classes and fixes some issues with transactions in the custom field tests.

Technical Details
-----------
Transactions don't work for custom field tests because schema alterations can't be inside transactions.
This moves the "implements TransactionalInterface" declaration from the base class to the test classes so each one can opt-in individually.
