### PR TITLE
[REF][Import] Simplify access to submitted value disableUSPS

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -204,7 +204,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     foreach ($storeParams as $storeName => $value) {
       $this->set($storeName, $value);
     }
-    $this->set('disableUSPS', $this->getSubmittedValue('disableUSPS'));
     $this->set('dataSource', $this->getSubmittedValue('dataSource'));
     $this->set('skipColumnHeader', CRM_Utils_Array::value('skipColumnHeader', $this->_params));
 

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -21,13 +21,6 @@
 class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
   /**
-   * Whether USPS validation should be disabled during import.
-   *
-   * @var bool
-   */
-  protected $_disableUSPS;
-
-  /**
    * Set variables up before form is built.
    *
    * @throws \API_Exception
@@ -36,7 +29,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function preProcess() {
     $mismatchCount = $this->get('unMatchCount');
     $columnNames = $this->get('columnNames');
-    $this->_disableUSPS = $this->get('disableUSPS');
 
     //assign column names
     $this->assign('columnNames', $columnNames);
@@ -210,7 +202,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       CRM_ACL_BAO_Cache::deleteContactCacheEntry($userID);
     }
 
-    CRM_Utils_Address_USPS::disable($this->_disableUSPS);
+    CRM_Utils_Address_USPS::disable($this->getSubmittedValue('disableUSPS'));
 
     // run the import
     $importJob->runImport($this);


### PR DESCRIPTION
Overview
----------------------------------------
[REF][Import] Simplify access to submitted value disableUSPS

Before
----------------------------------------
submitted value set on DataSource form, accessed using 'get' on Preview, set to a property & then retrieved from there on the same form

After
----------------------------------------
We can access the submittedValue directly when it is used

Technical Details
----------------------------------------
By virtue of being defined in https://github.com/civicrm/civicrm-core/blob/da8d3d49ea50b3b00e613d359180e7a6e666c93f/CRM/Import/Forms.php#L114 the submittedValue can be accessed anywhere in the flow

Comments
----------------------------------------
