### PR TITLE
SearchKit - Make inline edit only available when applicable

### DIFF
--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -111,7 +111,7 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
           throw new \API_Exception('Illegal expression');
         }
         $baoName = CoreUtil::getBAOFromApiName($this->getEntityName());
-        $options = $baoName::buildOptions($fieldName, $context);
+        $options = $baoName::buildOptions($fieldName, $context) ?: [];
         $this->values[$fieldName] = FormattingUtil::replacePseudoconstant($options, $this->values[$key], TRUE);
         unset($this->values[$key]);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3423 Make inline edit for custom fields only available when applicable](https://lab.civicrm.org/dev/core/-/issues/3423)

Before
----------------------------------------
Custom fields presented as editable for entity sub-types that they were not applicable to, e.g. if a set of custom fields only belongs to Activities of type Meeting, it would be editable for all activities in the SearchKit results table.

After
----------------------------------------
Correctly shown as editable only when applicable.
