### PR TITLE
[Import] Fix 5.50 error url

### DIFF
--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -80,9 +80,6 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
     $this->assign('dupeActionString', $dupeActionString);
 
     $properties = [
-      'downloadErrorRecordsUrl',
-      'duplicateRowCount',
-      'downloadDuplicateRecordsUrl',
       'downloadMismatchRecordsUrl',
       'groupAdditions',
       'tagAdditions',
@@ -95,8 +92,9 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
     $this->assign('totalRowCount', $this->getRowCount());
     $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
     $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
+    $this->assign('duplicateRowCount', $this->getRowCount(CRM_Import_Parser::DUPLICATE));
     $this->assign('downloadDuplicateRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::DUPLICATE));
-
+    $this->assign('downloadErrorRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::ERROR));
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext(CRM_Utils_System::url('civicrm/import/contact', 'reset=1'));
   }


### PR DESCRIPTION
@monishdeb I was just looking at https://github.com/civicrm/civicrm-core/commit/99e3c5f721637dc5c43a880ae4e0f5d0f764cc53 & I think the new url for the error output got lost from the PR in one of the rebases -the error url looks like it's still the old one - which would not be written to now I believe