### PR TITLE
dev/drupal#176 - Allow wider range of psr-log versions to be installed

### DIFF
--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -52,7 +52,7 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
    * @param string $message
    * @param array $context
    */
-  public function log($level, $message, array $context = []) {
+  public function log($level, $message, array $context = []): void {
     // FIXME: This flattens a $context a bit prematurely. When integrating
     // with external/CMS logs, we should pass through $context.
     if (!empty($context)) {

--- a/CRM/Utils/EchoLogger.php
+++ b/CRM/Utils/EchoLogger.php
@@ -23,7 +23,7 @@ class CRM_Utils_EchoLogger extends Psr\Log\AbstractLogger implements \Psr\Log\Lo
    * @param string $message
    * @param array $context
    */
-  public function log($level, $message, array $context = []) {
+  public function log($level, $message, array $context = []): void {
     echo $message . "\n";
   }
 

--- a/CRM/Utils/SystemLogger.php
+++ b/CRM/Utils/SystemLogger.php
@@ -23,7 +23,7 @@ class CRM_Utils_SystemLogger extends Psr\Log\AbstractLogger implements \Psr\Log\
    * @param string $message
    * @param array $context
    */
-  public function log($level, $message, array $context = []) {
+  public function log($level, $message, array $context = []): void {
     if (!isset($context['hostname'])) {
       $context['hostname'] = CRM_Utils_System::ipAddress();
     }

--- a/Civi/Api4/Action/System/RotateKey.php
+++ b/Civi/Api4/Action/System/RotateKey.php
@@ -60,7 +60,7 @@ class RotateKey extends AbstractAction {
        * @param string $message
        * @param array $context
        */
-      public function log($level, $message, array $context = []) {
+      public function log($level, $message, array $context = []): void {
         $evalVar = function($m) use ($context) {
           return $context[$m[1]] ?? '';
         };

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "symfony/filesystem": "~3.0 || ~4.4",
     "symfony/process": "~3.0 || ~4.4",
     "symfony/var-dumper": "~3.0 || ~4.4 || ~5.1",
-    "psr/log": "~1.0",
+    "psr/log": "~1.0 || ~2.0 || ~3.0",
     "symfony/finder": "~3.0 || ~4.4",
     "tecnickcom/tcpdf" : "6.4.*",
     "totten/ca-config": "~22.05",


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/176

This is an alternate version of (ubuntu 22.04-related) https://github.com/civicrm/civicrm-core/pull/23297

Before
----------------------------------------
Only psr-log 1.x allowed

After
----------------------------------------
More

Technical Details
----------------------------------------
Note that composer.lock is not updated, so this only changes the actual installed version for Drupal 10 and customized builds. Drupal 9 uses 1.1.4 (or at most ~1.0 if not using core-recommended). Drupal 10 requires 2.0, and it sounds like Ubuntu 22.04 requires 3.0 for the bundled civicrm package.

Comments
----------------------------------------

