### PR TITLE
Afform - Fix RC regression of missing input types

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -31,7 +31,7 @@
       this.$onInit = function() {
         ctrl.hasDefaultValue = !!getSet('afform_default');
         ctrl.fieldDefn = angular.extend({}, ctrl.getDefn(), ctrl.node.defn);
-        ctrl.inputTypes = _.transform(_.cloneDeep(afGui.meta.inputType), function(inputTypes, type) {
+        ctrl.inputTypes = _.transform(_.cloneDeep(afGui.meta.inputTypes), function(inputTypes, type) {
           if (inputTypeCanBe(type.name)) {
             // Change labels for EntityRef fields
             if (ctrl.getDefn().input_type === 'EntityRef') {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing input types in the Afform UI.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/167450409-75caf446-00a3-4fd3-994a-9bab14a4dc31.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/167450648-62d8d3b1-2235-45a5-ae80-c2113416367e.png)


Technical Details
----------------------------------------
This regressed because the client-side variable was renamed as part of 47332dba8ff22aa6f08d473a0437dc02ca53458d