### PR TITLE
Afform - Add "clear" button to non-required radios 

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/inputType/Radio.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Radio.html
@@ -3,4 +3,7 @@
     <input class="crm-form-radio" type="radio" ng-checked="defaultValueContains(opt.id)" ng-click="toggleDefaultValueItem(opt.id)" >
     {{ opt.label }}
   </label>
+  <a href ng-if="!getProp('required')" class="crm-hover-button" title="{{:: ts('Clear Default') }}" ng-click="toggleDefaultValueItem(getSet('afform_default'))">
+    <i class="crm-i fa-times" aria-hidden="true"></i>
+  </a>
 </div>

--- a/ext/afform/core/ang/af/fields/Radio.html
+++ b/ext/afform/core/ang/af/fields/Radio.html
@@ -2,3 +2,6 @@
   <input class="crm-form-radio" type="radio" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]" ng-value="opt.id" />
   {{:: opt.label }}
 </label>
+<a ng-if="!$ctrl.defn.required" class="crm-hover-button" title="{{:: ts('Clear') }}" ng-show="!!dataProvider.getFieldData()[$ctrl.fieldName] || dataProvider.getFieldData()[$ctrl.fieldName] === false || dataProvider.getFieldData()[$ctrl.fieldName] === 0" ng-click="dataProvider.getFieldData()[$ctrl.fieldName] = null">
+  <i class="crm-i fa-times" aria-hidden="true"></i>
+</a>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3450](https://lab.civicrm.org/dev/core/-/issues/3450)
Allows the value of radio buttons to be unset if the field is not required, consistent with the rest of the CiviCRM UI.

Before
----------------------------------------
No way to clear radio buttons.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/167453895-6012f8ef-1b6d-47b7-9b43-4df73e007984.png)

