### PR TITLE
[Ref][Import] Start adding testing to validation, simplify

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_missing_name.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_missing_name.csv
@@ -1,0 +1,2 @@
+First Name
+Joseph


### PR DESCRIPTION
Overview
----------------------------------------
[Ref][Import] Start adding testing to validation, simplify 

This PR should result in the Preview process continuing to identify if name fields are missing with no change in behaviour

Before
----------------------------------------
- no testing on the validation process
- validation process follows a very confusing process whereby first it iterates through the fields & determines the 'index' for key fields and then checks that index in the `$values` array - which represents a row in the csv
- second round of validation for required fields in the `deprecated` function - which originated from shared code

After
----------------------------------------
- test
- validation process acts on the `$params` once the `$values` row has been mapped to a `$params` - this means it can just check the params keys
- second round of validation removed

Technical Details
----------------------------------------
This will be simplified once other open PRs - ~~#23401~~ #23408 are merged

The second round of validation would have been required in the past for the related contacts (not currently checked in the first round) because it used to then call the `Contact:create` BAO directly - which didn't do validation. However, it now calls the v3 api - so the same exception would be thrown from the api as would be thrown from the second-round-validation

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
