### PR TITLE
Add test to ensure emails are validated & remove duplicate validation 

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2216,27 +2216,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @throw CRM_Core_Error
    */
   public function deprecated_validate_formatted_contact(&$params): void {
-    // Look for offending email addresses
-
-    if (array_key_exists('email', $params)) {
-      foreach ($params['email'] as $count => $values) {
-        if (!is_array($values)) {
-          continue;
-        }
-        if ($email = CRM_Utils_Array::value('email', $values)) {
-          // validate each email
-          if (!CRM_Utils_Rule::email($email)) {
-            throw new CRM_Core_Exception('No valid email address');
-          }
-
-          // check for loc type id.
-          if (empty($values['location_type_id'])) {
-            throw new CRM_Core_Exception('Location Type Id missing.');
-          }
-        }
-      }
-    }
-
     // Validate custom data fields
     if (array_key_exists('custom', $params) && is_array($params['custom'])) {
       foreach ($params['custom'] as $key => $custom) {
@@ -3338,13 +3317,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           else {
             $errorMessage = ts('Missing required field:') . ' ' . ts('Email Address');
           }
-          throw new CRM_Core_Exception($errorMessage);
-        }
-      }
-
-      $email = $values[$this->_emailIndex] ?? NULL;
-      if ($email) {
-        if (!CRM_Utils_Rule::email($email)) {
           throw new CRM_Core_Exception($errorMessage);
         }
       }

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_email.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_email.csv
@@ -1,0 +1,2 @@
+Dads email,First Name,Last Name
+joseph-email.com,Joseph,Savage

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_missing_name.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_missing_name.csv
@@ -1,0 +1,2 @@
+First Name
+Joseph

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_related_email.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_related_email.csv
@@ -1,0 +1,2 @@
+email,First Name,Last Name
+joseph-email.com,Joseph,Savage

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -743,6 +743,16 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         'mapper' => [['last_name']],
         'expected_error' => 'Missing required fields: First Name OR Email Address',
       ],
+      'individual_bad_email' => [
+        'csv' => 'individual_invalid_email.csv',
+        'mapper' => [['email', 1], ['first_name'], ['last_name']],
+        'expected_error' => 'Invalid value for field(s) : email',
+      ],
+      'individual_related_bad_email' => [
+        'csv' => 'individual_invalid_related_email.csv',
+        'mapper' => [['1_a_b', 'email', 1], ['first_name'], ['last_name']],
+        'expected_error' => 'Invalid value for field(s) : email',
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Extends https://github.com/civicrm/civicrm-core/pull/23415 to also test that emails are validated - tests demonstrate that they are caught in the `isErrorInCoreData` function & the other places (in old code) are redundant

Before
----------------------------------------
Validation of emails occurs in multiple places & we are too scared to change that because of the lack of tests

After
----------------------------------------
Tests added, redundant code removed

Technical Details
----------------------------------------
If https://github.com/civicrm/civicrm-core/pull/23415 is merged first it can be rebased out

Comments
----------------------------------------

