### PR TITLE
[Import] Use table rather than csvs for no-match & unparsed

### DIFF
--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -34,7 +34,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $mismatchCount = $this->get('unMatchCount');
     $columnNames = $this->get('columnNames');
     $this->_disableUSPS = $this->get('disableUSPS');
 
@@ -64,14 +63,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
     $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
     $this->assign('totalRowCount', $this->getRowCount([]));
-
-    if ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-
     $this->assign('mapper', $this->getMappedFieldLabels());
-
     $this->assign('dataValues', $this->getDataRows([], 2));
 
     $this->setStatusUrl();
@@ -191,7 +183,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       'allTags' => $this->get('tag'),
       'mapper' => $this->controller->exportValue('MapField', 'mapper'),
       'mapFields' => $this->getAvailableFields(),
-      'contactType' => $this->get('contactType'),
+      'contactType' => $this->getContactType(),
       'contactSubType' => $this->getSubmittedValue('contactSubType'),
       'primaryKeyName' => '_id',
       'statusFieldName' => '_status',
@@ -242,9 +234,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       fclose($fd);
 
       $this->set('errorFile', $errorFile);
-
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
     }
 
     //hack to clean db

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -22,79 +22,43 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
 
   /**
    * Set variables up before form is built.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
     // set the error message path to display
     $this->assign('errorFile', $this->get('errorFile'));
-
-    $totalRowCount = $this->getRowCount();
-    $relatedCount = $this->get('relatedCount');
-    $totalRowCount += $relatedCount;
-
-    $invalidRowCount = $this->get('invalidRowCount');
-    $duplicateRowCount = $this->get('duplicateRowCount');
     $onDuplicate = $this->get('onDuplicate');
-    $mismatchCount = $this->get('unMatchCount');
-    $unparsedAddressCount = $this->get('unparsedAddressCount');
-    if ($duplicateRowCount > 0) {
-      $urlParams = 'type=' . CRM_Import_Parser::DUPLICATE . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->set('downloadDuplicateRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    elseif ($mismatchCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::NO_MATCH . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->set('downloadMismatchRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-    }
-    else {
-      $duplicateRowCount = 0;
-      $this->set('duplicateRowCount', $duplicateRowCount);
-    }
-    if ($unparsedAddressCount) {
-      $urlParams = 'type=' . CRM_Import_Parser::UNPARSED_ADDRESS_WARNING . '&parser=CRM_Contact_Import_Parser_Contact';
-      $this->assign('downloadAddressRecordsUrl', CRM_Utils_System::url('civicrm/export', $urlParams));
-      $unparsedStreetAddressString = ts('Records imported successfully but unable to parse some of the street addresses');
-      $this->assign('unparsedStreetAddressString', $unparsedStreetAddressString);
-    }
     $this->assign('dupeError', FALSE);
 
     if ($onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
-      $dupeActionString = ts('These records have been updated with the imported data.');
+      $this->assign('dupeActionString', ts('These records have been updated with the imported data.'));
     }
     elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_REPLACE) {
-      $dupeActionString = ts('These records have been replaced with the imported data.');
+      $this->assign('dupeActionString', ts('These records have been replaced with the imported data.'));
     }
     elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_FILL) {
-      $dupeActionString = ts('These records have been filled in with the imported data.');
+      $this->assign('dupeActionString', ts('These records have been filled in with the imported data.'));
     }
     else {
       /* Skip by default */
-
-      $dupeActionString = ts('These records have not been imported.');
-
+      $this->assign('dupeActionString', ts('These records have not been imported.'));
       $this->assign('dupeError', TRUE);
     }
-    //now we also create relative contact in update and fill mode
-    $this->set('validRowCount', $totalRowCount - $invalidRowCount -
-       $duplicateRowCount - $mismatchCount
-    );
 
-    $this->assign('dupeActionString', $dupeActionString);
-
-    $properties = [
-      'downloadMismatchRecordsUrl',
-      'groupAdditions',
-      'tagAdditions',
-      'unMatchCount',
-      'unparsedAddressCount',
-    ];
-    foreach ($properties as $property) {
-      $this->assign($property, $this->get($property));
-    }
+    $this->assign('groupAdditions', $this->get('groupAdditions'));
+    $this->assign('tagAdditions', $this->get('tagAdditions'));
     $this->assign('totalRowCount', $this->getRowCount());
-    $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
+    $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID) + $this->getRowCount(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
     $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
     $this->assign('duplicateRowCount', $this->getRowCount(CRM_Import_Parser::DUPLICATE));
+    $this->assign('unMatchCount', $this->getRowCount(CRM_Import_Parser::NO_MATCH));
+    $this->assign('unparsedAddressCount', $this->getRowCount(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
     $this->assign('downloadDuplicateRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::DUPLICATE));
     $this->assign('downloadErrorRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::ERROR));
+    $this->assign('downloadMismatchRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::NO_MATCH));
+    $this->assign('downloadAddressRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext(CRM_Utils_System::url('civicrm/import/contact', 'reset=1'));
   }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2216,27 +2216,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @throw CRM_Core_Error
    */
   public function deprecated_validate_formatted_contact(&$params): void {
-    // Look for offending email addresses
-
-    if (array_key_exists('email', $params)) {
-      foreach ($params['email'] as $count => $values) {
-        if (!is_array($values)) {
-          continue;
-        }
-        if ($email = CRM_Utils_Array::value('email', $values)) {
-          // validate each email
-          if (!CRM_Utils_Rule::email($email)) {
-            throw new CRM_Core_Exception('No valid email address');
-          }
-
-          // check for loc type id.
-          if (empty($values['location_type_id'])) {
-            throw new CRM_Core_Exception('Location Type Id missing.');
-          }
-        }
-      }
-    }
-
     // Validate custom data fields
     if (array_key_exists('custom', $params) && is_array($params['custom'])) {
       foreach ($params['custom'] as $key => $custom) {
@@ -3338,13 +3317,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           else {
             $errorMessage = ts('Missing required field:') . ' ' . ts('Email Address');
           }
-          throw new CRM_Core_Exception($errorMessage);
-        }
-      }
-
-      $email = $values[$this->_emailIndex] ?? NULL;
-      if ($email) {
-        if (!CRM_Utils_Rule::email($email)) {
           throw new CRM_Core_Exception($errorMessage);
         }
       }

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -471,6 +471,8 @@ abstract class CRM_Import_DataSource {
       CRM_Import_Parser::VALID => ['imported', 'new'],
       CRM_Import_Parser::ERROR => ['error', 'invalid'],
       CRM_Import_Parser::DUPLICATE => ['duplicate'],
+      CRM_Import_Parser::NO_MATCH => ['invalid_no_match'],
+      CRM_Import_Parser::UNPARSED_ADDRESS_WARNING => ['warning_unparsed_address'],
     ];
   }
 

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -47,7 +47,7 @@
     {/if}
 
     {if $unparsedAddressCount}
-        <p class="error">{$unparsedStreetAddressString}</p>
+        <p class="error">{ts}Records imported successfully but unable to parse some of the street addresses{/ts}</p>
         <p class="error">
         {ts 1=$downloadAddressRecordsUrl}You can <a href='%1'>Download Street Address Records </a>. You may then edit those contact records and update the street address accordingly.{/ts}
         </p>

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_contact_sub_type.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_contact_sub_type.csv
@@ -1,0 +1,2 @@
+first_name,Last Name,Contact Subtype
+Joe,Green,Team

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_email.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_email.csv
@@ -1,0 +1,2 @@
+Dads email,First Name,Last Name
+joseph-email.com,Joseph,Savage

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_missing_name.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_missing_name.csv
@@ -1,0 +1,2 @@
+First Name
+Joseph

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_related_email.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_related_email.csv
@@ -1,0 +1,2 @@
+email,First Name,Last Name
+joseph-email.com,Joseph,Savage

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -743,6 +743,16 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         'mapper' => [['last_name']],
         'expected_error' => 'Missing required fields: First Name OR Email Address',
       ],
+      'individual_bad_email' => [
+        'csv' => 'individual_invalid_email.csv',
+        'mapper' => [['email', 1], ['first_name'], ['last_name']],
+        'expected_error' => 'Invalid value for field(s) : email',
+      ],
+      'individual_related_bad_email' => [
+        'csv' => 'individual_invalid_related_email.csv',
+        'mapper' => [['1_a_b', 'email', 1], ['first_name'], ['last_name']],
+        'expected_error' => 'Invalid value for field(s) : email',
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -767,8 +767,9 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @dataProvider importDataProvider
    *
    * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  public function testImport($csv, $mapper, $expectedError): void {
+  public function testImport($csv, $mapper, $expectedError, $expectedOutcomes = []): void {
     try {
       $this->importCSV($csv, $mapper);
     }
@@ -778,6 +779,10 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     }
     if ($expectedError) {
       $this->fail('expected error :' . $expectedError);
+    }
+    $dataSource = new CRM_Import_DataSource_CSV(UserJob::get(FALSE)->setSelect(['id'])->execute()->first()['id']);
+    foreach ($expectedOutcomes as $outcome => $count) {
+      $this->assertEquals($dataSource->getRowCount([$outcome]), $count);
     }
   }
 
@@ -791,7 +796,8 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'individual_invalid_sub_type' => [
         'csv' => 'individual_invalid_contact_sub_type.csv',
         'mapper' => [['first_name'], ['last_name'], ['contact_sub_type']],
-        'expected_error' => 'Invalid value for field(s) : type',
+        'expected_error' => '',
+        'expected_outcomes' => [CRM_Import_Parser::NO_MATCH => 1],
       ],
     ];
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3221,12 +3221,14 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
       case 'CRM_Contact_Import_Form_DataSource':
       case 'CRM_Contact_Import_Form_MapField':
+      case 'CRM_Contact_Import_Form_Preview':
         $form->controller = new CRM_Contact_Import_Controller();
         $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
         // The submitted values should be set on one or the other of the forms in the flow.
         // For test simplicity we set on all rather than figuring out which ones go where....
         $_SESSION['_' . $form->controller->_name . '_container']['values']['DataSource'] = $formValues;
         $_SESSION['_' . $form->controller->_name . '_container']['values']['MapField'] = $formValues;
+        $_SESSION['_' . $form->controller->_name . '_container']['values']['Preview'] = $formValues;
         return $form;
 
       case strpos($class, '_Form_') !== FALSE:


### PR DESCRIPTION
Overview
----------------------------------------
Use table rather than csvs for no-match & unparsed

The user experience should be unchanged - ie importing the following file with a mapping of first_name, last_name, contact sub type should result in

[contact_sub_type.csv](https://github.com/civicrm/civicrm-core/files/8660045/contact_sub_type.csv)


![image](https://user-images.githubusercontent.com/336308/167591606-62167d37-1825-44b4-ae3e-cf2fd29a3d8f.png)


Before
----------------------------------------
CSVs for No match and 'unparsed' are compiled during import

After
----------------------------------------
The temp table is updated, as is done with errors, duplicates, and it downloadable on the summary form

Technical Details
----------------------------------------
This rips out a fair bit of code (yay) and also has tests for the full flow. It builds on other open PRs which can be rebased out if merged first

Comments
----------------------------------------
