### PR TITLE
Add crmRegions to contact headers and associated inline forms

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Household.tpl
+++ b/templates/CRM/Contact/Form/Edit/Household.tpl
@@ -9,18 +9,20 @@
 *}
 {* tpl for building Household related fields *}
 <table class="form-layout-compressed">
-  <tr>
-    <td>
-      {$form.household_name.label}<br/>
-      {$form.household_name.html}
-    </td>
-    <td>
-      {$form.nick_name.label}<br/>
-      {$form.nick_name.html}
-    </td>
-    <td>
-      {$form.contact_sub_type.label}<br />
-      {$form.contact_sub_type.html}
-    </td>
-  </tr>
+  {crmRegion name="contact-form-edit-household"}
+    <tr>
+      <td>
+        {$form.household_name.label}<br/>
+        {$form.household_name.html}
+      </td>
+      <td>
+        {$form.nick_name.label}<br/>
+        {$form.nick_name.html}
+      </td>
+      <td>
+        {$form.contact_sub_type.label}<br />
+        {$form.contact_sub_type.html}
+      </td>
+    </tr>
+  {/crmRegion}
 </table>

--- a/templates/CRM/Contact/Form/Edit/Individual.tpl
+++ b/templates/CRM/Contact/Form/Edit/Individual.tpl
@@ -9,63 +9,65 @@
 *}
 {* tpl for building Individual related fields *}
 <table class="form-layout-compressed">
-  <tr>
-    {if !empty($form.prefix_id)}
-    <td>
-      {$form.prefix_id.label}<br/>
-      {$form.prefix_id.html}
-    </td>
-    {/if}
-    {if $form.formal_title}
-    <td>
-      {$form.formal_title.label}<br/>
-      {$form.formal_title.html}
-    </td>
-    {/if}
-    {if !empty($form.first_name)}
-    <td>
-      {$form.first_name.label}<br />
-      {$form.first_name.html}
-    </td>
-    {/if}
-    {if !empty($form.middle_name)}
-    <td>
-      {$form.middle_name.label}<br />
-      {$form.middle_name.html}
-    </td>
-    {/if}
-    {if !empty($form.last_name)}
-    <td>
-      {$form.last_name.label}<br />
-      {$form.last_name.html}
-    </td>
-    {/if}
-    {if !empty($form.suffix_id)}
-    <td>
-      {$form.suffix_id.label}<br/>
-      {$form.suffix_id.html}
-    </td>
-    {/if}
-  </tr>
+  {crmRegion name="contact-form-edit-individual"}
+    <tr>
+      {if !empty($form.prefix_id)}
+      <td>
+        {$form.prefix_id.label}<br/>
+        {$form.prefix_id.html}
+      </td>
+      {/if}
+      {if $form.formal_title}
+      <td>
+        {$form.formal_title.label}<br/>
+        {$form.formal_title.html}
+      </td>
+      {/if}
+      {if !empty($form.first_name)}
+      <td>
+        {$form.first_name.label}<br />
+        {$form.first_name.html}
+      </td>
+      {/if}
+      {if !empty($form.middle_name)}
+      <td>
+        {$form.middle_name.label}<br />
+        {$form.middle_name.html}
+      </td>
+      {/if}
+      {if !empty($form.last_name)}
+      <td>
+        {$form.last_name.label}<br />
+        {$form.last_name.html}
+      </td>
+      {/if}
+      {if !empty($form.suffix_id)}
+      <td>
+        {$form.suffix_id.label}<br/>
+        {$form.suffix_id.html}
+      </td>
+      {/if}
+    </tr>
 
-  <tr>
-    <td colspan="2">
-      {$form.employer_id.label}&nbsp;{help id="id-current-employer" file="CRM/Contact/Form/Contact.hlp"}<br />
-      {$form.employer_id.html}
-    </td>
-    <td>
-      {$form.job_title.label}<br />
-      {$form.job_title.html}
-    </td>
-    <td>
-      {$form.nick_name.label}<br />
-      {$form.nick_name.html}
-    </td>
-    {if !empty($form.contact_sub_type)}
-    <td>
-      {$form.contact_sub_type.label}<br />
-      {$form.contact_sub_type.html}
-    </td>
-    {/if}
-  </tr>
+    <tr>
+      <td colspan="2">
+        {$form.employer_id.label}&nbsp;{help id="id-current-employer" file="CRM/Contact/Form/Contact.hlp"}<br />
+        {$form.employer_id.html}
+      </td>
+      <td>
+        {$form.job_title.label}<br />
+        {$form.job_title.html}
+      </td>
+      <td>
+        {$form.nick_name.label}<br />
+        {$form.nick_name.html}
+      </td>
+      {if !empty($form.contact_sub_type)}
+      <td>
+        {$form.contact_sub_type.label}<br />
+        {$form.contact_sub_type.html}
+      </td>
+      {/if}
+    </tr>
+  {/crmRegion}
 </table>

--- a/templates/CRM/Contact/Form/Edit/Organization.tpl
+++ b/templates/CRM/Contact/Form/Edit/Organization.tpl
@@ -9,26 +9,28 @@
 *}
 {* tpl for building Organization related fields *}
 <table class="form-layout-compressed">
-  <tr>
-    <td>{
-      $form.organization_name.label}<br/>
-      {$form.organization_name.html}
-    </td>
-    <td>
-      {$form.legal_name.label}<br/>
-      {$form.legal_name.html}
-    </td>
-    <td>
-      {$form.nick_name.label}<br/>
-      {$form.nick_name.html}
-    </td>
-    <td>
-      {$form.sic_code.label}<br/>
-      {$form.sic_code.html}
-    </td>
-    <td>
-      {$form.contact_sub_type.label}<br />
-      {$form.contact_sub_type.html}
-    </td>
-  </tr>
+  {crmRegion name="contact-form-edit-organization"}
+    <tr>
+      <td>{
+        $form.organization_name.label}<br/>
+        {$form.organization_name.html}
+      </td>
+      <td>
+        {$form.legal_name.label}<br/>
+        {$form.legal_name.html}
+      </td>
+      <td>
+        {$form.nick_name.label}<br/>
+        {$form.nick_name.html}
+      </td>
+      <td>
+        {$form.sic_code.label}<br/>
+        {$form.sic_code.html}
+      </td>
+      <td>
+        {$form.contact_sub_type.label}<br />
+        {$form.contact_sub_type.html}
+      </td>
+    </tr>
+  {/crmRegion}
 </table>

--- a/templates/CRM/Contact/Form/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactName.tpl
@@ -13,49 +13,51 @@
   <div class="crm-inline-button">
     {include file="CRM/common/formButtons.tpl"}
   </div>
-  {if $contactType eq 'Individual'}
-    {if !empty($form.prefix_id)}
-      <div class="crm-inline-edit-field">
-        {$form.prefix_id.label}<br/>
-        {$form.prefix_id.html}
-      </div>
+  {crmRegion name="contact-form-inline-contactname"}
+    {if $contactType eq 'Individual'}
+      {if !empty($form.prefix_id)}
+        <div class="crm-inline-edit-field">
+          {$form.prefix_id.label}<br/>
+          {$form.prefix_id.html}
+        </div>
+      {/if}
+      {if !empty($form.formal_title)}
+        <div class="crm-inline-edit-field">
+          {$form.formal_title.label}<br/>
+          {$form.formal_title.html}
+        </div>
+      {/if}
+      {if !empty($form.first_name)}
+        <div class="crm-inline-edit-field">
+          {$form.first_name.label}<br />
+          {$form.first_name.html}
+        </div>
+      {/if}
+      {if !empty($form.middle_name)}
+        <div class="crm-inline-edit-field">
+          {$form.middle_name.label}<br />
+          {$form.middle_name.html}
+        </div>
+      {/if}
+      {if !empty($form.last_name)}
+        <div class="crm-inline-edit-field">
+          {$form.last_name.label}<br />
+          {$form.last_name.html}
+        </div>
+      {/if}
+      {if !empty($form.suffix_id)}
+        <div class="crm-inline-edit-field">
+          {$form.suffix_id.label}<br/>
+          {$form.suffix_id.html}
+        </div>
+      {/if}
+    {elseif $contactType eq 'Organization'}
+      <div class="crm-inline-edit-field">{$form.organization_name.label}&nbsp;
+      {$form.organization_name.html}</div>
+    {elseif $contactType eq 'Household'}
+      <div class="crm-inline-edit-field">{$form.household_name.label}&nbsp;
+      {$form.household_name.html}</div>
     {/if}
-    {if !empty($form.formal_title)}
-      <div class="crm-inline-edit-field">
-        {$form.formal_title.label}<br/>
-        {$form.formal_title.html}
-      </div>
-    {/if}
-    {if !empty($form.first_name)}
-      <div class="crm-inline-edit-field">
-        {$form.first_name.label}<br />
-        {$form.first_name.html}
-      </div>
-    {/if}
-    {if !empty($form.middle_name)}
-      <div class="crm-inline-edit-field">
-        {$form.middle_name.label}<br />
-        {$form.middle_name.html}
-      </div>
-    {/if}
-    {if !empty($form.last_name)}
-      <div class="crm-inline-edit-field">
-        {$form.last_name.label}<br />
-        {$form.last_name.html}
-      </div>
-    {/if}
-    {if !empty($form.suffix_id)}
-      <div class="crm-inline-edit-field">
-        {$form.suffix_id.label}<br/>
-        {$form.suffix_id.html}
-      </div>
-    {/if}
-  {elseif $contactType eq 'Organization'}
-    <div class="crm-inline-edit-field">{$form.organization_name.label}&nbsp;
-    {$form.organization_name.html}</div>
-  {elseif $contactType eq 'Household'}
-    <div class="crm-inline-edit-field">{$form.household_name.label}&nbsp;
-    {$form.household_name.html}</div>
-  {/if}
+  {/crmRegion}
 </div>
 <div class="clear"></div>

--- a/templates/CRM/Contact/Page/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Page/Inline/ContactName.tpl
@@ -8,15 +8,17 @@
  +--------------------------------------------------------------------+
 *}
 <div id="crm-contactname-content" {if $permission EQ 'edit'}class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "class_name": "CRM_Contact_Form_Inline_ContactName"{rdelim}' data-dependent-fields='["#crm-communication-pref-content"]'{/if}>
-  <div class="crm-inline-block-content"{if $permission EQ 'edit'} title="{ts}Edit Contact Name{/ts}"{/if}>
-    {if $permission EQ 'edit'}
-      <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit name{/ts}
-      </div>
-    {/if}
+  {crmRegion name="contact-page-contactname"}
+    <div class="crm-inline-block-content"{if $permission EQ 'edit'} title="{ts}Edit Contact Name{/ts}"{/if}>
+      {if $permission EQ 'edit'}
+        <div class="crm-edit-help">
+          <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit name{/ts}
+        </div>
+      {/if}
 
-    <div class="crm-summary-display_name">
-      {$title}{if $domainContact} ({ts}default organization{/ts}){/if}
+      <div class="crm-summary-display_name">
+        {$title}{if $domainContact} ({ts}default organization{/ts}){/if}
+      </div>
     </div>
-  </div>
+  {/crmRegion}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Add crmRegions to contact headers and associated inline forms

Before
----------------------------------------
There are no crmRegions available for customization in contact headers and inline forms.

After
----------------------------------------
There are new crmRegions available for use in extensions and customizations.
* contact-form-page-contactname in CRM/Contact/Page/Inline/ContactName.tpl
* contact-form-inline-contactname in CRM/Contact/Form/Inline/ContactName.tpl
* contact-form-edit-individual in CRM/Contact/Form/Edit/Indivdual.tpl
* contact-form-edit-organization in CRM/Contact/Form/Edit/Organization.tpl
* contact-form-edit-household in CRM/Contact/Form/Edit/Household.tpl


Technical Details
----------------------------------------
I don't believe there are any additional details that aren't apparent in the code & notes above.

Comments
----------------------------------------
We've had requests to add prominent information & fields in these areas. This PR provides a way to accomplish those.
