### PR TITLE
Allow for custom base page in AJAX requests

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -28,11 +28,13 @@
       path = path.split('#')[0];
     }
     frag = path.split('?');
+    // Remove basepage as it can be changed on some CMS eg. WordPress frontend.
+    frag[0] = frag[0].replace('civicrm/', '/');
     // Encode url path only if slashes in placeholder were also encoded
-    if (tplURL[mode].indexOf('civicrm/placeholder-url-path') >= 0) {
-      url = tplURL[mode].replace('civicrm/placeholder-url-path', frag[0]);
+    if (tplURL[mode].indexOf('/placeholder-url-path') >= 0) {
+      url = tplURL[mode].replace('/placeholder-url-path', frag[0]);
     } else {
-      url = tplURL[mode].replace('civicrm%2Fplaceholder-url-path', encodeURIComponent(frag[0]));
+      url = tplURL[mode].replace('%2Fplaceholder-url-path', encodeURIComponent(frag[0]));
     }
 
     if (_.isEmpty(query)) {

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -31,10 +31,10 @@
     // Remove basepage as it can be changed on some CMS eg. WordPress frontend.
     frag[0] = frag[0].replace('civicrm/', '/');
     // Encode url path only if slashes in placeholder were also encoded
-    if (tplURL[mode].indexOf('/placeholder-url-path') >= 0) {
-      url = tplURL[mode].replace('/placeholder-url-path', frag[0]);
+    if (tplURL[mode].indexOf('/crmajax-placeholder-url-path') >= 0) {
+      url = tplURL[mode].replace('/crmajax-placeholder-url-path', frag[0]);
     } else {
-      url = tplURL[mode].replace('%2Fplaceholder-url-path', encodeURIComponent(frag[0]));
+      url = tplURL[mode].replace('%2Fcrmajax-placeholder-url-path', encodeURIComponent(frag[0]));
     }
 
     if (_.isEmpty(query)) {

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -29,7 +29,7 @@
   CRM.config.entityRef = $.extend({ldelim}{rdelim}, {$entityRef|@json_encode}, CRM.config.entityRef || {ldelim}{rdelim});
 
   // Initialize CRM.url and CRM.formatMoney
-  CRM.url({ldelim}back: '{crmURL p="civicrm/placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm/placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
+  CRM.url({ldelim}back: '{crmURL p="civicrm/crmajax-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fb=1}', front: '{crmURL p="civicrm/crmajax-placeholder-url-path" q="civicrm-placeholder-url-query=1" h=0 fe=1}'{rdelim});
   CRM.formatMoney('init', false, {$moneyFormat|@json_encode});
 
   // Localize select2

--- a/tests/karma/unit/crmMailingSpec.js
+++ b/tests/karma/unit/crmMailingSpec.js
@@ -17,7 +17,7 @@ describe('crmMailing', function() {
         $provide.value('crmNavigator', navigator);
       });
       inject(['crmLegacy', function(crmLegacy) {
-        crmLegacy.url({back: '/civicrm/placeholder-url-path?civicrm-placeholder-url-query=1', front: '/civicrm/placeholder-url-path?civicrm-placeholder-url-query=1'});
+        crmLegacy.url({back: '/civicrm/crmajax-placeholder-url-path?civicrm-placeholder-url-query=1', front: '/civicrm/crmajax-placeholder-url-path?civicrm-placeholder-url-query=1'});
       }]);
       inject(['$controller', function($controller) {
         ctrl = $controller('ListMailingsCtrl', {});


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/20702. This is a simpler, safer fix for the same issue.

Variants of this issue come up a lot with anything CiviCRM that uses AJAX/API requests on the frontend with a custom base page on WordPress. Eg. Stripe - https://lab.civicrm.org/extensions/stripe/-/issues/370

Before
----------------------------------------
Custom base page does not work for AJAX requests from "frontend".

After
----------------------------------------
AJAX requests can be used with any "base page".

Technical Details
----------------------------------------
On WordPress it is possible to define a custom "base page" for frontend CiviCRM URLs. Eg. if you specify custom base page as `crm` then the URL `civicrm/ajax/rest` would need to be rewritten as `crm/ajax/rest`.

CiviCRM uses a placeholder URL `civicrm/placeholder-url-path` in crm.ajax.js and l10n.js scripts which is replaced with the actual URL using a match/replace. But this fails if you have the custom basepage because the placeholder URL gets set to eg. `crm/placeholder-url-path` in l10n.js and then does not match the find/replace in crm.ajax.js.

We fix that by matching on the part *after* `civicrm` so we are not dependent on the part that can change.  The second commit in this PR changes `civicrm/placeholder-url-path` to `civicrm/civicrm-placeholder-url-path` so that the second part is more unique (in case we had another plugin/software on the frontend that also decided to use `placeholder-url-path`).

Comments
----------------------------------------
You can test this by eg:
1. Open a contribution page on WordPress frontend.
2. Run `CRM.url('civicrm/ajax/rest')` on the browser console and seeing what it returns.
3. Now do the same again but configure CiviCRM/WordPress to use a custom base page.

Be careful that you clear CiviCRM caches between tests (l10n.js is processed using assetbuilder and is only updated when caches are cleared).

