### PR TITLE
[Import] Stop passing unused parameter

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -553,7 +553,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $parser->setUserJobID($this->getUserJobID());
 
     $parser->run(
-      $mapper,
+      [],
       CRM_Import_Parser::MODE_PREVIEW
     );
     return $parser;

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -155,7 +155,6 @@ class CRM_Contact_Import_ImportJob {
           }
         }
       }
-      $mapperFields[] = implode(' - ', $header);
     }
 
     $this->_parser = new CRM_Contact_Import_Parser_Contact(
@@ -169,7 +168,7 @@ class CRM_Contact_Import_ImportJob {
     );
     $this->_parser->setUserJobID($this->_userJobID);
     $this->_parser->run(
-      $mapperFields,
+      [],
       CRM_Import_Parser::MODE_IMPORT,
       $this->_statusID,
       $this->_totalRowCount


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Stop passing unused parameter

Before
----------------------------------------
the `run` function no longer uses `$mapper` but it is still passed in...

![image](https://user-images.githubusercontent.com/336308/167707617-cd0fa195-8771-4d00-8de7-fa235ef96cdd.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
I left out the follow on cleanup because it's over 2 classes  & would be a lot to read in one PR

Comments
----------------------------------------
