### PR TITLE
ManagedEntities - Update version number for mgd-php

### DIFF
--- a/mixin/mgd-php@1/mixin.php
+++ b/mixin/mgd-php@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "**.mgd.php" files.
  *
  * @mixinName mgd-php
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.1.0
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up/correction for #22959 (circa 5.50.alpha1; specifically fdc67a75b2f20aea9f0961683bd8a59c78755d5f). The prior revision had updated the behavior of `mgd-php`, so it should have also updated the version-number.

(In a deployment with multiple copies of `mgd-php`, the version attribute determines the active one.)
