### PR TITLE
(NFC) mixin/**.php - Add @since tags 

### DIFF
--- a/mixin/afform-entity-php@1/mixin.php
+++ b/mixin/afform-entity-php@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName afform-entity-php
  * @mixinVersion 1.0.0
+ * @since 5.50
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/ang-php@1/mixin.php
+++ b/mixin/ang-php@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName ang-php
  * @mixinVersion 1.0.0
+ * @since 5.45
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/case-xml@1/mixin.php
+++ b/mixin/case-xml@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName case-xml
  * @mixinVersion 1.0.0
+ * @since 5.45
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/menu-xml@1/mixin.php
+++ b/mixin/menu-xml@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName menu-xml
  * @mixinVersion 1.0.0
+ * @since 5.45
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/mgd-php@1/mixin.php
+++ b/mixin/mgd-php@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName mgd-php
  * @mixinVersion 1.1.0
+ * @since 5.50
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/mgd-php@1/mixin.php
+++ b/mixin/mgd-php@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "**.mgd.php" files.
  *
  * @mixinName mgd-php
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.1.0
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/setting-php@1/mixin.php
+++ b/mixin/setting-php@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName setting-php
  * @mixinVersion 1.0.0
+ * @since 5.45
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/mixin/theme-php@1/mixin.php
+++ b/mixin/theme-php@1/mixin.php
@@ -5,6 +5,7 @@
  *
  * @mixinName theme-php
  * @mixinVersion 1.0.0
+ * @since 5.45
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.

--- a/tools/mixin/bin/mixer
+++ b/tools/mixin/bin/mixer
@@ -129,9 +129,15 @@ function task_test(array $options, string $targetDir, ...$args) {
 
 function task_list(array $options, ...$mixinNames) {
   $mixinNames = resolve_mixin_names($mixinNames);
+  fprintf(STDOUT, "%-20s %-8s %-8s %s\n", "NAME", "VERSION", "SINCE", "DESCRIPTION");
+  fprintf(STDOUT, "%-20s %-8s %-8s %s\n", "----", "-------", "-----", "-----------");
   foreach ($mixinNames as $mixinName) {
     $mixin = mixlib()->get($mixinName);
-    fprintf(STDOUT, "%-20s %-10s %s\n", $mixin['mixinName'], $mixin['mixinVersion'] ?? '', $mixin['description'] ?? '');
+    fprintf(STDOUT, "%-20s %-8s %-8s %s\n",
+      $mixin['mixinName'],
+      $mixin['mixinVersion'] ?? '',
+      $mixin['since'] ?? '',
+      $mixin['description'] ?? '');
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------

Adds extra metadata to the mixin files. 

This will enable better code-generation -- ie  `civix` would be able to skip unnecessary backports. It is an off-shoot from discussion in https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/520

NOTE: This PR builds on #23422, so you'll see 1-2 extra lines in the diff. It does not _fundamentally_ depend on 23422, but they touch on adjacent annotations, and they would conflict if merged in parallel. One has to go before the other. This one can go second.

Before
----------------------------------------

Hard to tell when a mixin was introduced (unless you go poking through git history).

After
----------------------------------------

Each mixin reports when it was introduced (`@since`). 

Technical Details
----------------------------------------

You can inspect the parsed metadata and see the 'since' value:

```
$ ./tools/mixin/bin/mixer list

NAME                 VERSION  SINCE    DESCRIPTION
----                 -------  -----    -----------
afform-entity-php    1.0.0    5.50     Auto-register "afformEntities/*.php" files.
ang-php              1.0.0    5.45     Auto-register "ang/*.ang.php" files.
case-xml             1.0.0    5.45     Auto-register "xml/case/*.xml" files.
menu-xml             1.0.0    5.45     Auto-register "xml/Menu/*.xml" files.
mgd-php              1.1.0    5.50     Auto-register "**.mgd.php" files.
setting-php          1.0.0    5.45     Auto-register "settings/*.setting.php" files.
theme-php            1.0.0    5.45     Auto-register "*.theme.php" files.
```
