### PR TITLE
[REF] [Import] Remove unused field get action (death to copy & paste)

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -502,7 +502,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -585,7 +585,6 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -133,7 +133,6 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     $hasHeaders = !empty($this->_columnHeaders);
     $headerPatterns = $this->get('headerPatterns');
     $dataPatterns = $this->get('dataPatterns');
-    $hasLocationTypes = $this->get('fieldTypes');
     /* Initialize all field usages to false */
 
     foreach ($mapperKeys as $key) {

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -949,7 +949,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -148,7 +148,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $hasHeaders = !empty($this->_columnHeaders);
     $headerPatterns = $this->get('headerPatterns');
     $dataPatterns = $this->get('dataPatterns');
-    $hasLocationTypes = $this->get('fieldTypes');
 
     /* Initialize all field usages to false */
 

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -342,7 +342,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
     $store->set('lineCount', $this->_lineCount);
     $store->set('separator', $this->_separator);
     $store->set('fields', $this->getSelectValues());
-    $store->set('fieldTypes', $this->getSelectTypes());
 
     $store->set('headerPatterns', $this->getHeaderPatterns());
     $store->set('dataPatterns', $this->getDataPatterns());


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Remove unused field get action

The 'fieldTypes' form variable is ONLY used in the Contact Import class but the joys of copy & paste mean it is on th others too....

Before
----------------------------------------
Field is set a lot, it is got a little & in exactly one of those cases is it used....

![image](https://user-images.githubusercontent.com/336308/167748859-97d76d30-d2cf-4270-896d-a72421fec4fd.png)


![image](https://user-images.githubusercontent.com/336308/167748781-43f91d25-44ec-434f-a595-7451d59f9627.png)

![image](https://user-images.githubusercontent.com/336308/167749064-fbaf8e05-2990-4f4d-b11e-b3d0ea1fa182.png)

After
----------------------------------------
poof - only the import class instance remains

![image](https://user-images.githubusercontent.com/336308/167749150-919c4fa6-ed70-4737-8998-011be5535a9d.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
