### PR TITLE
[REF] [Import] Move datasource interaction to datasource class

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -811,7 +811,13 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       return CRM_Import_Parser::ERROR;
 
     }
-    // sleep(3);
+
+    if (empty($this->_unparsedStreetAddressContacts)) {
+      $this->setImportStatus((int) ($values[count($values) - 1]), 'IMPORTED', '', $contactID);
+      return CRM_Import_Parser::VALID;
+    }
+
+    // @todo - record unparsed address as 'imported' but the presence of a message is meaningful?
     return $this->processMessage($values, $statusFieldName, CRM_Import_Parser::VALID);
   }
 
@@ -2265,7 +2271,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param array $mapper
    * @param int $mode
    * @param int $statusID
-   * @param int $totalRowCount
    *
    * @return mixed
    * @throws \API_Exception|\CRM_Core_Exception
@@ -2273,8 +2278,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   public function run(
     $mapper = [],
     $mode = self::MODE_PREVIEW,
-    $statusID = NULL,
-    $totalRowCount = NULL
+    $statusID = NULL
   ) {
 
     // TODO: Make the timeout actually work
@@ -2295,7 +2299,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->_warnings = [];
     $this->_unparsedAddresses = [];
 
-    $this->_tableName = $tableName = $this->getUserJob()['metadata']['DataSource']['table_name'];
     $this->_primaryKeyName = '_id';
     $this->_statusFieldName = '_status';
 
@@ -2310,10 +2313,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $this->progressImport($statusID);
       $startTimestamp = $currTimestamp = $prevTimestamp = time();
     }
-    // get the contents of the temp. import table
-    $query = "SELECT * FROM $tableName";
+    $dataSource = $this->getDataSourceObject();
+    $totalRowCount = $dataSource->getRowCount(['new']);
     if ($mode == self::MODE_IMPORT) {
-      $query .= " WHERE _status = 'NEW'";
+      $dataSource->setStatuses(['new']);
     }
     if ($this->_maxLinesToProcess > 0) {
       // Note this would only be the case in MapForm mode, where it is set to 100
@@ -2325,19 +2328,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       // which is the number of columns a row might have.
       // However, the mapField class may no longer use activeFieldsCount for contact
       // to be continued....
-      $query .= ' LIMIT ' . $this->_maxLinesToProcess;
+      $dataSource->setLimit($this->_maxLinesToProcess);
     }
 
-    $result = CRM_Core_DAO::executeQuery($query);
-
-    while ($result->fetch()) {
-      $values = array_values($result->toArray());
+    while ($row = $dataSource->getRow()) {
+      $values = array_values($row);
       $this->_rowCount++;
-
-      /* trim whitespace around the values */
-      foreach ($values as $k => $v) {
-        $values[$k] = trim($v, " \t\r\n");
-      }
 
       $this->_totalCount++;
 
@@ -2629,29 +2625,21 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * Set the import status for the given record.
-   *
-   * If this is a sql import then the sql table will be used and the update
-   * will not happen as the relevant fields don't exist in the table - hence
-   * the checks that statusField & primary key are set.
+   * Update the status of the import row to reflect the processing outcome.
    *
    * @param int $id
    * @param string $status
    * @param string $message
+   * @param int|null $entityID
+   *   Optional created entity ID
+   * @param array $relatedEntityIDs
+   *   Optional array e.g ['related_contact' => 4]
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  public function setImportStatus(int $id, string $status, string $message): void {
-    if ($this->_statusFieldName && $this->_primaryKeyName) {
-      CRM_Core_DAO::executeQuery("
-        UPDATE $this->_tableName
-        SET $this->_statusFieldName = %1,
-          {$this->_statusFieldName}Msg = %2
-        WHERE  $this->_primaryKeyName = %3
-      ", [
-        1 => [$status, 'String'],
-        2 => [$message, 'String'],
-        3 => [$id, 'Integer'],
-      ]);
-    }
+  public function setImportStatus(int $id, string $status, string $message, ?int $entityID = NULL, array $relatedEntityIDs = []): void {
+    $this->getDataSourceObject()->updateStatus($id, $status, $message, $entityID, $relatedEntityIDs);
   }
 
   /**
@@ -3131,19 +3119,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $params = $this->getParams($values);
     $params['contact_type'] = $this->getContactType();
     return $params;
-  }
-
-  /**
-   * Is the job complete.
-   *
-   * This function transitionally accesses the table from the userJob
-   * directly - but the function should be moved to the dataSource class.
-   *
-   * @throws \API_Exception
-   */
-  public function isComplete() {
-    $tableName = $this->getUserJob()['metadata']['DataSource']['table_name'];
-    return (bool) CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM $tableName WHERE _status = 'NEW' LIMIT 1");
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -518,6 +518,10 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $message = array_pop($record);
     // Also pop off the status - but we are not going to use this at this stage.
     array_pop($record);
+    // Related entities
+    array_pop($record);
+    // Entity_id
+    array_pop($record);
     array_unshift($record, $message);
     array_unshift($record, $rowNumber);
     return $record;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -86,6 +86,22 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Get the relevant datasource object.
+   *
+   * @return \CRM_Import_DataSource|null
+   *
+   * @throws \API_Exception
+   */
+  protected function getDataSourceObject(): ?CRM_Import_DataSource {
+    $className = $this->getSubmittedValue('dataSource');
+    if ($className) {
+      /* @var CRM_Import_DataSource $dataSource */
+      return new $className($this->getUserJobID());
+    }
+    return NULL;
+  }
+
+  /**
    * Get the submitted value, as stored on the user job.
    *
    * @param string $fieldName
@@ -96,6 +112,18 @@ abstract class CRM_Import_Parser {
    */
   protected function getSubmittedValue(string $fieldName) {
     return $this->getUserJob()['metadata']['submitted_values'][$fieldName];
+  }
+
+  /**
+   * Has the import completed.
+   *
+   * @return bool
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function isComplete() :bool {
+    return $this->getDataSourceObject()->isCompleted();
   }
 
   /**

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -130,6 +130,9 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    * edge case. Note if it has more than one column then the blank line gets
    * skipped because of some checking for column-count matches in the import,
    * and so you don't hit the current fail.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   public function testBlankLineAtEnd(): void {
     $form = $this->submitDatasourceForm('blankLineAtEnd.csv');
@@ -146,6 +149,9 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    * @param string $csvFileName
    *
    * @return \CRM_Contact_Import_Form_DataSource
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function submitDatasourceForm(string $csvFileName): CRM_Contact_Import_Form_DataSource {
     $_GET['dataSource'] = 'CRM_Import_DataSource_CSV';
@@ -156,6 +162,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
       ],
       'skipColumnHeader' => TRUE,
       'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'dataSource' => 'CRM_Import_DataSource_CSV',
     ]);
     $form->buildForm();
     $form->postProcess();


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Move datasource interaction to datasource class

Before
----------------------------------------
The Parser class interacts direction with the datasource (which is a table holding the rows to import in all current implementations)

After
----------------------------------------
All actions interacting with the DataSource are on the datasource class

I also added some unexposed functionality - the imported ids are also recorded in the table that tracks the import - the plan is to expose 'at some point' since being able to view imported contacts is really handy!

Technical Details
----------------------------------------

Comments
----------------------------------------
This file is handy for testing as it has more than 100 rows, including 15 that will fail validation
https://lab.civicrm.org/dev/core/uploads/2627012d2b7d5278ba5d7abe94c59ab2/contact-more-than-100-rows.csv