### PR TITLE
Dashboard - Show full title when hovering an inactive dashlet

### DIFF
--- a/ang/crmDashboard/InactiveDashlet.html
+++ b/ang/crmDashboard/InactiveDashlet.html
@@ -1,4 +1,4 @@
-<div class="crm-dashlet-header">
+<div class="crm-dashlet-header" title="{{:: $ctrl.dashlet.label }}">
   <a href class="crm-i fa-trash" title="{{:: ts('Permanently Delete %1', {1: $ctrl.dashlet.label}) }}" aria-hidden="true" crm-confirm="$ctrl.confirmParams" on-yes="$ctrl.delete()" ng-if="$ctrl.isAdmin && !$ctrl.dashlet.is_reserved"></a>
-  <h3>{{ $ctrl.dashlet.label }}</h3>
+  <h3>{{:: $ctrl.dashlet.label }}</h3>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Makes it easier to see the full title of a dashlet when adding to dashboard, for dashlets with long titles.

Before
----------------------------------------
Impossible to see full title of dashlet when adding to dashboard.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/167843951-ce073a7e-6157-413c-b5e2-aac924500ddb.png)

