### PR TITLE
SearchKit - Allow functions in the GROUP BY clause

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/compose.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose.html
@@ -26,7 +26,10 @@
     <fieldset ng-if=":: $ctrl.paramExists('groupBy')">
       <div class="form-inline" ng-repeat="groupBy in $ctrl.savedSearch.api_params.groupBy">
         <label for="crm-search-groupBy-{{ $index }}">{{:: ts('Group By') }}</label>
-        <input id="crm-search-groupBy-{{ $index }}" class="form-control huge" ng-model="$ctrl.savedSearch.api_params.groupBy[$index]" crm-ui-select="{placeholder: ' ', data: fieldsForGroupBy}" ng-change="changeGroupBy($index)" />
+        <crm-search-function class="form-group" expr="$ctrl.savedSearch.api_params.groupBy[$index]" mode="groupBy"></crm-search-function>
+        <span ng-if="!$ctrl.hasFunction($ctrl.savedSearch.api_params.groupBy[$index])">
+          <input id="crm-search-groupBy-{{ $index }}" class="form-control huge" ng-model="$ctrl.savedSearch.api_params.groupBy[$index]" crm-ui-select="{placeholder: ' ', data: fieldsForGroupBy}" ng-change="changeGroupBy($index)" />
+        </span>
         <hr>
       </div>
       <div class="form-inline">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -145,6 +145,10 @@
         return _.includes(searchMeta.getEntity(ctrl.savedSearch.api_entity).params, param);
       };
 
+      this.hasFunction = function(expr) {
+        return expr.indexOf('(') > -1;
+      };
+
       this.addDisplay = function(type) {
         var count = _.filter(ctrl.savedSearch.displays, {type: type}).length,
           searchLabel = ctrl.savedSearch.label || searchMeta.getEntity(ctrl.savedSearch.api_entity).title_plural;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -91,7 +91,7 @@
       this.getFunctions = function() {
         var allowedTypes = [], functions = [];
         if (ctrl.expr && ctrl.fieldArg) {
-          if (ctrl.crmSearchAdmin.canAggregate(ctrl.expr)) {
+          if (ctrl.mode !== 'groupBy' && ctrl.crmSearchAdmin.canAggregate(ctrl.expr)) {
             allowedTypes.push('aggregate');
           } else {
             allowedTypes.push('comparison', 'string');


### PR DESCRIPTION
Overview
----------------------------------------
See dev/core#2485

Before
----------------------------------------
Cannot use functions in the GROUP BY clause.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/167875761-5f8c6faf-c9e8-4c62-894a-28449c7ebe0b.png)

Comments
----------------------------------------
There's still more to do to make this really useful, like allowing that expression to be shown as a column, but this is a good step and has a test.