### PR TITLE
Translation: remove support for CiviCRM pre-4.5 l10n file locations

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -126,7 +126,6 @@ class CRM_Core_I18n {
    * @param string $locale
    */
   protected function setNativeGettextLocale($locale) {
-
     $locale .= '.utf8';
     putenv("LANG=$locale");
 
@@ -141,33 +140,29 @@ class CRM_Core_I18n {
 
     $this->_phpgettext = new CRM_Core_I18n_NativeGettext();
     $this->_extensioncache['civicrm'] = 'civicrm';
-
   }
 
   /**
    * Set getText locale.
    *
+   * Since CiviCRM 4.5, expected dir structure is civicrm/l10n/xx_XX/LC_MESSAGES/civicrm.mo
+   * because that is what native gettext expects. Fallback support for the pre-4.5 structure
+   * was removed in CiviCRM 5.51.
+   *
+   * CiviCRM 5.23 added support for the CIVICRM_L10N_BASEDIR constant (and [civicrm.l10n])
+   * so that mo files can be stored elsewhere (such as in a web-writable directory, to
+   * support extensions sur as l10nupdate.
+   *
    * @param string $locale
    */
   protected function setPhpGettextLocale($locale) {
-
-    // we support both the old file hierarchy format and the new:
-    // pre-4.5:  civicrm/l10n/xx_XX/civicrm.mo
-    // post-4.5: civicrm/l10n/xx_XX/LC_MESSAGES/civicrm.mo
     require_once 'PHPgettext/streams.php';
     require_once 'PHPgettext/gettext.php';
 
     $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . 'civicrm.mo';
-
-    if (!file_exists($mo_file)) {
-      // fallback to pre-4.5 mode
-      $mo_file = CRM_Core_I18n::getResourceDir() . $locale . DIRECTORY_SEPARATOR . 'civicrm.mo';
-    }
-
     $streamer = new FileReader($mo_file);
     $this->_phpgettext = new gettext_reader($streamer);
     $this->_extensioncache['civicrm'] = $this->_phpgettext;
-
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

When we added support for "native gettext" in CiviCRM 4.5, the file structure for the "mo" translation files (in the `l10n` directory) changed. Since few people used native gettext at the time, and since tooling had to be adjusted, we included a fallback mode so that the older file hierarchy still worked.

8 years later, I think we can assume people have fixed their tooling, and use the expected file hierarchy ;)

Before
----------------------------------------

Fallback mode for `mo` files in the old location.

After
----------------------------------------

Fallback removed.

Comments
----------------------------------------

I plan on adding an option to load extension `mo` files from the `[civicrm.l10n]` directory. It's not directly related, but I saw this old code and wanted to tidy up first.