### PR TITLE
SearchKit - Default to simple pager when creating new table display

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -44,7 +44,7 @@
 
       this.$onInit = function () {
         if (!ctrl.display.settings) {
-          ctrl.display.settings = _.extend({}, _.cloneDeep(CRM.crmSearchAdmin.defaultDisplay.settings), {columns: null});
+          ctrl.display.settings = _.extend({}, _.cloneDeep(CRM.crmSearchAdmin.defaultDisplay.settings), {columns: null, pager: {}});
           if (searchMeta.getEntity(ctrl.apiEntity).order_by) {
             ctrl.display.settings.sort.push([searchMeta.getEntity(ctrl.apiEntity).order_by, 'ASC']);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Defaults to a simpler pager when creating a new SearchKit display.

Before
----------------------------------------
Pager default included "row count" and "adjustible page size".

After
----------------------------------------
Defaults to simple pager without the extras.

Comments
----------------------------------------
The extra stuff isn't always useful and can break the layout on small screens or dashlets, so I think a better default is to exclude rather than include them.