### PR TITLE
SearchKit - Don't transform case for fieldsets on admin screen (more translation-friendly)

### DIFF
--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -70,7 +70,7 @@
   width: auto;
   border: 0 none;
   padding: 2px 5px;
-  text-transform: capitalize;
+  text-transform: none;
 }
 #bootstrap-theme.crm-search crm-search-clause > .btn-group {
   position: absolute;


### PR DESCRIPTION
Overview
----------------------------------------
Don't mess with the capitalization of translated strings "Field Transformations" and "Query Info"

Before
----------------------------------------
Words are forced to Title Case, even if that's not appropriate for a given language.

![image](https://user-images.githubusercontent.com/2874912/167899319-84b88964-baa2-49ca-8971-6f3ed88f414d.png)


After
----------------------------------------
Translations not messed-with.