### PR TITLE
(NFC) mixin/mgd-php@1 - Twiddle `@since`

### DIFF
--- a/mixin/mgd-php@1/mixin.php
+++ b/mixin/mgd-php@1/mixin.php
@@ -5,7 +5,7 @@
  *
  * @mixinName mgd-php
  * @mixinVersion 1.1.0
- * @since 5.50
+ * @since 5.45
  *
  * @param CRM_Extension_MixInfo $mixInfo
  *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.


### PR DESCRIPTION
Overview
--------

Revises #23423. Switch `@since` from "modified" version (`5.50`) to "introduced" version (`5.45`).

Comment
-------

The [spec for `@since`](https://docs.phpdoc.org/guide/references/phpdoc/tags/since.html) is kind of interesting to read (e.g. it's open-ended and even allows multiple `@since` clauses). But this is still conformant, and it matches _de facto_ usage in the same repo (which is also conformant).