### PR TITLE
[TEST ONLY] APIv4 - ensure test records are cleaned up in non-transaction tests

### DIFF
--- a/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
@@ -19,12 +19,11 @@
 namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class AbstractActionFunctionTest extends Api4TestBase implements TransactionalInterface {
+class AbstractActionFunctionTest extends Api4TestBase {
 
   public function testUndefinedParamException(): void {
     $this->expectException('API_Exception');

--- a/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetExtraFieldsTest.php
@@ -24,12 +24,11 @@ use Civi\Api4\Activity;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\Tag;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GetExtraFieldsTest extends Api4TestBase implements TransactionalInterface {
+class GetExtraFieldsTest extends Api4TestBase {
 
   public function testGetFieldsByContactType() {
     $getFields = Contact::getFields(FALSE)->addSelect('name')->addWhere('type', '=', 'Field');

--- a/tests/phpunit/api/v4/Action/GetFromArrayTest.php
+++ b/tests/phpunit/api/v4/Action/GetFromArrayTest.php
@@ -21,12 +21,11 @@ namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\MockArrayEntity;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class GetFromArrayTest extends Api4TestBase implements TransactionalInterface {
+class GetFromArrayTest extends Api4TestBase {
 
   public function testArrayGetWithLimit() {
     $result = MockArrayEntity::get()

--- a/tests/phpunit/api/v4/Action/IndexTest.php
+++ b/tests/phpunit/api/v4/Action/IndexTest.php
@@ -20,12 +20,11 @@
 namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class IndexTest extends Api4TestBase implements TransactionalInterface {
+class IndexTest extends Api4TestBase {
 
   public function testIndex() {
     // Results indexed by name

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -56,9 +56,13 @@ class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
   /**
    */
   public function tearDown(): void {
-    // Delete all test records in reverse order to prevent fk constraints
-    foreach (array_reverse($this->testRecords) as $record) {
-      civicrm_api4($record[0], 'delete', ['checkPermissions' => FALSE, 'where' => $record[1]]);
+    $impliments = class_implements($this);
+    // If not created in a transaction, test records must be deleted
+    if (!in_array('Civi\Test\TransactionalInterface', $impliments, TRUE)) {
+      // Delete all test records in reverse order to prevent fk constraints
+      foreach (array_reverse($this->testRecords) as $record) {
+        civicrm_api4($record[0], 'delete', ['checkPermissions' => FALSE, 'where' => $record[1]]);
+      }
     }
   }
 
@@ -114,7 +118,7 @@ class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
    * @throws \Civi\API\Exception\NotImplementedException
    */
   public function createTestRecord(string $entityName, array $values = []) {
-    return $this->saveTestRecords($entityName, ['records' => [$values]])->first();
+    return $this->saveTestRecords($entityName, ['records' => [$values]])->single();
   }
 
   /**

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -22,26 +22,13 @@ namespace api\v4\Custom;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
-use Civi\Api4\Event;
-use Civi\Api4\FinancialType;
 use Civi\Api4\OptionGroup;
-use Civi\Api4\Relationship;
 use Civi\Api4\RelationshipCache;
 
 /**
  * @group headless
  */
 class BasicCustomFieldTest extends CustomTestBase {
-
-  public function tearDown(): void {
-    FinancialType::delete(FALSE)
-      ->addWhere('name', '=', 'Test_Type')
-      ->execute();
-    Event::delete(FALSE)
-      ->addWhere('id', '>', 0)
-      ->execute();
-    parent::tearDown();
-  }
 
   /**
    * @throws \API_Exception
@@ -66,13 +53,12 @@ class BasicCustomFieldTest extends CustomTestBase {
     $this->assertContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type' => 'Individual'])->execute()->column('name'));
     $this->assertNotContains('MyIndividualFields.FavColor', $getFields->setValues(['contact_type:name' => 'Household'])->execute()->column('name'));
 
-    $contactId = Contact::create(FALSE)
-      ->addValue('first_name', 'Johann')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyIndividualFields.FavColor', 'Red')
-      ->execute()
-      ->first()['id'];
+    $contactId = $this->createTestRecord('Contact', [
+      'first_name' => 'Johann',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyIndividualFields.FavColor' => 'Red',
+    ])['id'];
 
     $contact = Contact::get(FALSE)
       ->addSelect('first_name')
@@ -158,21 +144,19 @@ class BasicCustomFieldTest extends CustomTestBase {
     // But the api will report is_required as not nullable
     $this->assertFalse($fields['MyContactFields2.FavFood']['nullable']);
 
-    $contactId1 = Contact::create(FALSE)
-      ->addValue('first_name', 'Johann')
-      ->addValue('last_name', 'Tester')
-      ->addValue('MyContactFields.FavColor', 'Red')
-      ->addValue('MyContactFields.FavFood', 'Cherry')
-      ->execute()
-      ->first()['id'];
+    $contactId1 = $this->createTestRecord('Contact', [
+      'first_name' => 'Johann',
+      'last_name' => 'Tester',
+      'MyContactFields.FavColor' => 'Red',
+      'MyContactFields.FavFood' => 'Cherry',
+    ])['id'];
 
-    $contactId2 = Contact::create(FALSE)
-      ->addValue('first_name', 'MaryLou')
-      ->addValue('last_name', 'Tester')
-      ->addValue('MyContactFields.FavColor', 'Purple')
-      ->addValue('MyContactFields.FavFood', 'Grapes')
-      ->execute()
-      ->first()['id'];
+    $contactId2 = $this->createTestRecord('Contact', [
+      'first_name' => 'MaryLou',
+      'last_name' => 'Tester',
+      'MyContactFields.FavColor' => 'Purple',
+      'MyContactFields.FavFood' => 'Grapes',
+    ])['id'];
 
     $contact = Contact::get(FALSE)
       ->addSelect('first_name')
@@ -287,26 +271,24 @@ class BasicCustomFieldTest extends CustomTestBase {
       ->execute()
     );
 
-    $parent = Contact::create(FALSE)
-      ->addValue('first_name', 'Parent')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $parent = $this->createTestRecord('Contact', [
+      'first_name' => 'Parent',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+    ])['id'];
 
-    $child = Contact::create(FALSE)
-      ->addValue('first_name', 'Child')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $child = $this->createTestRecord('Contact', [
+      'first_name' => 'Child',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+    ])['id'];
 
-    Relationship::create(FALSE)
-      ->addValue('contact_id_a', $parent)
-      ->addValue('contact_id_b', $child)
-      ->addValue('relationship_type_id', 1)
-      ->addValue("$cgName.PetName", 'Buddy')
-      ->execute();
+    $this->createTestRecord('Relationship', [
+      'contact_id_a' => $parent,
+      'contact_id_b' => $child,
+      'relationship_type_id' => 1,
+      "$cgName.PetName" => 'Buddy',
+    ]);
 
     // Test get directly from relationshipCache entity
     $results = RelationshipCache::get(FALSE)
@@ -351,25 +333,23 @@ class BasicCustomFieldTest extends CustomTestBase {
         ->addValue('data_type', 'String'))
       ->execute();
 
-    $parent = Contact::create(FALSE)
-      ->addValue('first_name', 'Parent')
-      ->addValue('last_name', 'Tester')
-      ->addValue("$cgName.FavColor", 'Purple')
-      ->execute()
-      ->first()['id'];
+    $parent = $this->createTestRecord('Contact', [
+      'first_name' => 'Parent',
+      'last_name' => 'Tester',
+      "$cgName.FavColor" => 'Purple',
+    ])['id'];
 
-    $child = Contact::create(FALSE)
-      ->addValue('first_name', 'Child')
-      ->addValue('last_name', 'Tester')
-      ->addValue("$cgName.FavColor", 'Cyan')
-      ->execute()
-      ->first()['id'];
+    $child = $this->createTestRecord('Contact', [
+      'first_name' => 'Child',
+      'last_name' => 'Tester',
+      "$cgName.FavColor" => 'Cyan',
+    ])['id'];
 
-    Relationship::create(FALSE)
-      ->addValue('contact_id_a', $parent)
-      ->addValue('contact_id_b', $child)
-      ->addValue('relationship_type_id', 1)
-      ->execute();
+    $this->createTestRecord('Relationship', [
+      'contact_id_a' => $parent,
+      'contact_id_b' => $child,
+      'relationship_type_id' => 1,
+    ]);
 
     $results = Contact::get(FALSE)
       ->addSelect('first_name', 'child.first_name', "$cgName.FavColor", "child.$cgName.FavColor")
@@ -514,13 +494,12 @@ class BasicCustomFieldTest extends CustomTestBase {
         ->addValue('time_format', '1'))
       ->execute();
 
-    $cid = Contact::create(FALSE)
-      ->addValue('first_name', 'Parent')
-      ->addValue('last_name', 'Tester')
-      ->addValue("$cgName.DateOnly", '2025-05-10')
-      ->addValue("$cgName.DateTime", '2025-06-11 12:15:30')
-      ->execute()
-      ->first()['id'];
+    $cid = $this->createTestRecord('Contact', [
+      'first_name' => 'Parent',
+      'last_name' => 'Tester',
+      "$cgName.DateOnly" => '2025-05-10',
+      "$cgName.DateTime" => '2025-06-11 12:15:30',
+    ])['id'];
     $contact = Contact::get(FALSE)
       ->addSelect('custom.*')
       ->addWhere('id', '=', $cid)
@@ -570,11 +549,11 @@ class BasicCustomFieldTest extends CustomTestBase {
     $this->assertEquals('case_type_id', $options['Case']);
 
     // Test contribution type
-    $financialType = FinancialType::create(FALSE)
-      ->addValue('name', 'Test_Type')
-      ->addValue('is_deductible', TRUE)
-      ->addValue('is_reserved', FALSE)
-      ->execute()->single();
+    $financialType = $this->createTestRecord('FinancialType', [
+      'name' => 'Test_Type',
+      'is_deductible' => TRUE,
+      'is_reserved' => FALSE,
+    ]);
     $contributionGroup = CustomGroup::create(FALSE)
       ->addValue('extends', 'Contribution')
       ->addValue('title', 'Contribution Fields')
@@ -584,21 +563,21 @@ class BasicCustomFieldTest extends CustomTestBase {
   }
 
   public function testExtendsParticipantMetadata() {
-    $event1 = Event::create(FALSE)
-      ->addValue('event_type_id:name', 'Fundraiser')
-      ->addValue('title', 'Test Fun Event')
-      ->addValue('start_date', '2022-05-02 18:24:00')
-      ->execute()->first();
-    $event2 = Event::create(FALSE)
-      ->addValue('event_type_id:name', 'Fundraiser')
-      ->addValue('title', 'Test Fun Event2')
-      ->addValue('start_date', '2022-05-02 18:24:00')
-      ->execute()->first();
-    $event3 = Event::create(FALSE)
-      ->addValue('event_type_id:name', 'Meeting')
-      ->addValue('title', 'Test Me Event')
-      ->addValue('start_date', '2022-05-02 18:24:00')
-      ->execute()->first();
+    $event1 = $this->createTestRecord('Event', [
+      'event_type_id:name' => 'Fundraiser',
+      'title' => 'Test Fun Event',
+      'start_date' => '2022-05-02 18:24:00',
+    ]);
+    $event2 = $this->createTestRecord('Event', [
+      'event_type_id:name' => 'Fundraiser',
+      'title' => 'Test Fun Event2',
+      'start_date' => '2022-05-02 18:24:00',
+    ]);
+    $event3 = $this->createTestRecord('Event', [
+      'event_type_id:name' => 'Meeting',
+      'title' => 'Test Me Event',
+      'start_date' => '2022-05-02 18:24:00',
+    ]);
 
     $field = \Civi\Api4\CustomGroup::getFields(FALSE)
       ->setLoadOptions(['id', 'name', 'label'])

--- a/tests/phpunit/api/v4/Custom/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CreateWithOptionGroupTest.php
@@ -70,14 +70,14 @@ class CreateWithOptionGroupTest extends CustomTestBase {
       ->addValue('data_type', 'Money')
       ->execute();
 
-    Contact::create(FALSE)
-      ->addValue('first_name', 'Jerome')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue("$group.$colorField", 'r')
-      ->addValue("$group.$foodField", '1')
-      ->addValue('FinancialStuff.Salary', 50000)
-      ->execute();
+    $this->createTestRecord('Contact', [
+      'first_name' => 'Jerome',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      "$group.$colorField" => 'r',
+      "$group.$foodField" => '1',
+      'FinancialStuff.Salary' => 50000,
+    ]);
 
     $result = Contact::get(FALSE)
       ->addSelect('first_name')
@@ -136,23 +136,23 @@ class CreateWithOptionGroupTest extends CustomTestBase {
       ->addValue('data_type', 'Money')
       ->execute();
 
-    Contact::create(FALSE)
-      ->addValue('first_name', 'Red')
-      ->addValue('last_name', 'Corn')
-      ->addValue('contact_type', 'Individual')
-      ->addValue("$group.$colorField", 'r')
-      ->addValue("$group.$foodField", '1')
-      ->addValue('FinancialStuff.Salary', 10000)
-      ->execute();
+    $this->createTestRecord('Contact', [
+      'first_name' => 'Red',
+      'last_name' => 'Corn',
+      'contact_type' => 'Individual',
+      "$group.$colorField" => 'r',
+      "$group.$foodField" => '1',
+      'FinancialStuff.Salary' => 10000,
+    ]);
 
-    Contact::create(FALSE)
-      ->addValue('first_name', 'Blue')
-      ->addValue('last_name', 'Cheese')
-      ->addValue('contact_type', 'Individual')
-      ->addValue("$group.$colorField", 'b')
-      ->addValue("$group.$foodField", '3')
-      ->addValue('FinancialStuff.Salary', 500000)
-      ->execute();
+    $this->createTestRecord('Contact', [
+      'first_name' => 'Blue',
+      'last_name' => 'Cheese',
+      'contact_type' => 'Individual',
+      "$group.$colorField" => 'b',
+      "$group.$foodField" => '3',
+      'FinancialStuff.Salary' => 500000,
+    ]);
 
     $result = Contact::get(FALSE)
       ->addSelect('first_name')

--- a/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
@@ -52,43 +52,38 @@ class CustomContactRefTest extends CustomTestBase {
       ->addValue('serialize', 1)
       ->execute();
 
-    $favPersonId = Contact::create(FALSE)
-      ->addValue('first_name', $firstName)
-      ->addValue('last_name', 'Person')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $favPersonId = $this->createTestRecord('Contact', [
+      'first_name' => $firstName,
+      'last_name' => 'Person',
+      'contact_type' => 'Individual',
+    ])['id'];
 
-    $favPeopleId1 = Contact::create(FALSE)
-      ->addValue('first_name', 'FirstFav')
-      ->addValue('last_name', 'People1')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $favPeopleId1 = $this->createTestRecord('Contact', [
+      'first_name' => 'FirstFav',
+      'last_name' => 'People1',
+      'contact_type' => 'Individual',
+    ])['id'];
 
-    $favPeopleId2 = Contact::create(FALSE)
-      ->addValue('first_name', 'SecondFav')
-      ->addValue('last_name', 'People2')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $favPeopleId2 = $this->createTestRecord('Contact', [
+      'first_name' => 'SecondFav',
+      'last_name' => 'People2',
+      'contact_type' => 'Individual',
+    ])['id'];
 
-    $contactId1 = Contact::create(FALSE)
-      ->addValue('first_name', 'Mya')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactRef.FavPerson', $favPersonId)
-      ->addValue('MyContactRef.FavPeople', [$favPeopleId2, $favPeopleId1])
-      ->execute()
-      ->first()['id'];
+    $contactId1 = $this->createTestRecord('Contact', [
+      'first_name' => 'Mya',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactRef.FavPerson' => $favPersonId,
+      'MyContactRef.FavPeople' => [$favPeopleId2, $favPeopleId1],
+    ])['id'];
 
-    $contactId2 = Contact::create(FALSE)
-      ->addValue('first_name', 'Bea')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactRef.FavPeople', [$favPeopleId2])
-      ->execute()
-      ->first()['id'];
+    $contactId2 = $this->createTestRecord('Contact', [
+      'first_name' => 'Bea',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactRef.FavPeople' => [$favPeopleId2],
+    ])['id'];
 
     $result = Contact::get(FALSE)
       ->addSelect('display_name')
@@ -139,13 +134,12 @@ class CustomContactRefTest extends CustomTestBase {
       ->addValue('data_type', 'ContactReference')
       ->execute();
 
-    $contactId = Contact::create(FALSE)
-      ->addValue('first_name', 'Mya')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactRef.FavPerson', 'user_contact_id')
-      ->execute()
-      ->first()['id'];
+    $contactId = $this->createTestRecord('Contact', [
+      'first_name' => 'Mya',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactRef.FavPerson' => 'user_contact_id',
+    ])['id'];
 
     $contact = Contact::get(FALSE)
       ->addSelect('display_name')

--- a/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
@@ -68,13 +68,16 @@ class CustomFieldAlterTest extends CustomTestBase {
       ->execute()
       ->first();
 
-    Activity::save(FALSE)
-      ->setDefaults(['activity_type_id' => 1, 'source_contact_id' => $contact['id']])
-      ->addRecord(['subject' => 'A1', 'MyFieldsToAlter.TestText' => 'A1', 'MyFieldsToAlter.TestOptions' => '1'])
-      ->addRecord(['subject' => 'A2', 'MyFieldsToAlter.TestText' => 'A2', 'MyFieldsToAlter.TestOptions' => '2'])
-      ->addRecord(['subject' => 'A3', 'MyFieldsToAlter.TestText' => 'A3', 'MyFieldsToAlter.TestOptions' => ''])
-      ->addRecord(['subject' => 'A4', 'MyFieldsToAlter.TestText' => 'A4', 'MyFieldsToAlter.TestCountry' => [1228, 1039]])
-      ->execute();
+    $sampeData = [
+      ['subject' => 'A1', 'MyFieldsToAlter.TestText' => 'A1', 'MyFieldsToAlter.TestOptions' => '1'],
+      ['subject' => 'A2', 'MyFieldsToAlter.TestText' => 'A2', 'MyFieldsToAlter.TestOptions' => '2'],
+      ['subject' => 'A3', 'MyFieldsToAlter.TestText' => 'A3', 'MyFieldsToAlter.TestOptions' => ''],
+      ['subject' => 'A4', 'MyFieldsToAlter.TestText' => 'A4', 'MyFieldsToAlter.TestCountry' => [1228, 1039]],
+    ];
+    $this->saveTestRecords('Activity', [
+      'defaults' => ['activity_type_id' => 1, 'source_contact_id' => $contact['id']],
+      'records' => $sampeData,
+    ]);
 
     $result = Activity::get(FALSE)
       ->addWhere('MyFieldsToAlter.TestText', 'IS NOT NULL')

--- a/tests/phpunit/api/v4/Custom/CustomValuePerformanceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValuePerformanceTest.php
@@ -73,15 +73,15 @@ class CustomValuePerformanceTest extends CustomTestBase {
 
     $this->beginQueryCount();
 
-    Contact::create(FALSE)
-      ->addValue('first_name', 'Red')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactFields.FavColor', 'r')
-      ->addValue('MyContactFields.FavAnimal', 'Sheep')
-      ->addValue('MyContactFields.FavLetter', 'z')
-      ->addValue('MyContactFields.FavFood', 'Coconuts')
-      ->execute();
+    $this->createTestRecord('Contact', [
+      'first_name' => 'Red',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactFields.FavColor' => 'r',
+      'MyContactFields.FavAnimal' => 'Sheep',
+      'MyContactFields.FavLetter' => 'z',
+      'MyContactFields.FavFood' => 'Coconuts',
+    ]);
 
     Contact::get(FALSE)
       ->addSelect('display_name')
@@ -100,6 +100,8 @@ class CustomValuePerformanceTest extends CustomTestBase {
     // FIXME: This count is artificially high due to the line
     // $this->entity = Tables::getBriefName(Tables::getClassForTable($targetTable));
     // In class Joinable. TODO: Investigate why.
+    // $this->assertLessThan(10, $this->getQueryCount());
+
   }
 
 }

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -22,7 +22,6 @@ namespace api\v4\Custom;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomValue;
-use Civi\Api4\Contact;
 use Civi\Api4\Entity;
 
 /**
@@ -73,12 +72,11 @@ class CustomValueTest extends CustomTestBase {
       ->addValue('data_type', 'String')
       ->execute()->first();
 
-    $this->contactID = Contact::create(FALSE)
-      ->addValue('first_name', 'Johann')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $this->contactID = $this->createTestRecord('Contact', [
+      'first_name' => 'Johann',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+    ])['id'];
 
     // Ensure virtual api entity has been created
     $entity = Entity::get(FALSE)
@@ -220,12 +218,11 @@ class CustomValueTest extends CustomTestBase {
 
     // CASE 3: Test CustomValue::replace
     // create a second contact which will be used to replace the custom values, created earlier
-    $secondContactID = Contact::create(FALSE)
-      ->addValue('first_name', 'Adam')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->execute()
-      ->first()['id'];
+    $secondContactID = $this->createTestRecord('Contact', [
+      'first_name' => 'Adam',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+    ])['id'];
     // Replace all the records which was created earlier with entity_id = first contact
     //  with custom record [$colorField => 'g', 'entity_id' => $secondContactID]
     CustomValue::replace($group)

--- a/tests/phpunit/api/v4/Custom/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Custom/ExtendFromIndividualTest.php
@@ -44,13 +44,12 @@ class ExtendFromIndividualTest extends CustomTestBase {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $contactId = Contact::create(FALSE)
-      ->addValue('first_name', 'Johann')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactFields.FavColor', 'Red')
-      ->execute()
-      ->first()['id'];
+    $contactId = $this->createTestRecord('Contact', [
+      'first_name' => 'Johann',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactFields.FavColor' => 'Red',
+    ])['id'];
 
     $contact = Contact::get(FALSE)
       ->addSelect('display_name')

--- a/tests/phpunit/api/v4/Custom/UpdateCustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/UpdateCustomValueTest.php
@@ -44,13 +44,12 @@ class UpdateCustomValueTest extends CustomTestBase {
       ->addValue('data_type', 'String')
       ->execute();
 
-    $contactId = Contact::create(FALSE)
-      ->addValue('first_name', 'Red')
-      ->addValue('last_name', 'Tester')
-      ->addValue('contact_type', 'Individual')
-      ->addValue('MyContactFields.FavColor', 'Red')
-      ->execute()
-      ->first()['id'];
+    $contactId = $this->createTestRecord('Contact', [
+      'first_name' => 'Red',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactFields.FavColor' => 'Red',
+    ])['id'];
 
     Contact::update(FALSE)
       ->addWhere('id', '=', $contactId)

--- a/tests/phpunit/api/v4/Entity/EntityTest.php
+++ b/tests/phpunit/api/v4/Entity/EntityTest.php
@@ -22,12 +22,11 @@ namespace api\v4\Entity;
 use Civi\API\Exception\NotImplementedException;
 use Civi\Api4\Entity;
 use api\v4\Api4TestBase;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class EntityTest extends Api4TestBase implements TransactionalInterface {
+class EntityTest extends Api4TestBase {
 
   public function testEntityGet() {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');

--- a/tests/phpunit/api/v4/Entity/ExampleDataTest.php
+++ b/tests/phpunit/api/v4/Entity/ExampleDataTest.php
@@ -20,12 +20,11 @@
 namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class ExampleDataTest extends Api4TestBase implements TransactionalInterface {
+class ExampleDataTest extends Api4TestBase {
 
   /**
    * Basic canary test fetching a specific example.

--- a/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
+++ b/tests/phpunit/api/v4/Service/Schema/SchemaMapperTest.php
@@ -23,12 +23,11 @@ use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Civi\Api4\Service\Schema\SchemaMap;
 use Civi\Api4\Service\Schema\Table;
 use api\v4\Api4TestBase;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SchemaMapperTest extends Api4TestBase implements TransactionalInterface {
+class SchemaMapperTest extends Api4TestBase {
 
   public function testWillHaveNoPathWithNoTables() {
     $map = new SchemaMap();

--- a/tests/phpunit/api/v4/Spec/SpecGathererTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecGathererTest.php
@@ -22,10 +22,9 @@ namespace api\v4\Spec;
 use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\Provider\Generic\SpecProviderInterface;
 use Civi\Api4\Service\Spec\SpecGatherer;
+use Civi\Api4\Utils\CoreUtil;
 use api\v4\Traits\OptionCleanupTrait;
 use api\v4\Api4TestBase;
-use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 use api\v4\Traits\TableDropperTrait;
 use Prophecy\Argument;
 
@@ -37,21 +36,10 @@ class SpecGathererTest extends Api4TestBase {
   use TableDropperTrait;
   use OptionCleanupTrait;
 
-  public function setUpHeadless() {
-    $this->dropByPrefix('civicrm_value_favorite');
-    $this->cleanup([
-      'tablesToTruncate' => [
-        'civicrm_custom_group',
-        'civicrm_custom_field',
-      ],
-    ]);
-    return parent::setUpHeadless();
-  }
-
   public function testBasicFieldsGathering() {
     $gatherer = new SpecGatherer();
     $specs = $gatherer->getSpec('Contact', 'get', FALSE);
-    $contactDAO = _civicrm_api3_get_DAO('Contact');
+    $contactDAO = CoreUtil::getBAOFromApiName('Contact');
     $contactFields = $contactDAO::fields();
     $specFieldNames = $specs->getFieldNames();
     $contactFieldNames = array_column($contactFields, 'name');
@@ -75,38 +63,6 @@ class SpecGathererTest extends Api4TestBase {
     $fieldNames = $spec->getFieldNames();
 
     $this->assertContains('foo', $fieldNames);
-  }
-
-  public function testPseudoConstantOptionsWillBeAdded() {
-    $customGroupId = CustomGroup::create(FALSE)
-      ->addValue('title', 'FavoriteThings')
-      ->addValue('extends', 'Contact')
-      ->execute()
-      ->first()['id'];
-
-    $options = ['r' => 'Red', 'g' => 'Green', 'p' => 'Pink'];
-
-    CustomField::save(FALSE)
-      ->addRecord([
-        'label' => 'FavColor',
-        'custom_group_id' => $customGroupId,
-        'option_values' => $options,
-        'html_type' => 'Select',
-        'data_type' => 'String',
-      ])
-      ->execute();
-
-    $gatherer = new SpecGatherer();
-    $spec = $gatherer->getSpec('Contact', 'get', TRUE);
-
-    $regularField = $spec->getFieldByName('contact_type');
-    $this->assertNotEmpty($regularField->getOptions());
-    $this->assertContains('Individual', array_column($regularField->getOptions([], ['id', 'label']), 'label', 'id'));
-
-    $customField = $spec->getFieldByName('FavoriteThings.FavColor');
-    $options = array_column($customField->getOptions([], ['id', 'name', 'label']), NULL, 'id');
-    $this->assertEquals('Green', $options['g']['name']);
-    $this->assertEquals('Pink', $options['p']['label']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up APIv4 unit tests to make sure created records are cleaned up after the test finishes.

Technical Details
----------------------------------------
- Use the new `createTestRecord` and `saveTestRecords` in non-transaction test classes so the created records are automatically cleaned-up.
- Removes `use TransactionalInterface` from classes that don't need it (because they don't create any records).