### PR TITLE
dev/core#3458 Fix table and alias for Event ActionMapping check

### DIFF
--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -136,7 +136,7 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
     $query = \CRM_Utils_SQL_Select::from("{$this->entity} e")->param($defaultParams);
-    $query['casAddlCheckFrom'] = 'civicrm_event r';
+    $query['casAddlCheckFrom'] = 'civicrm_participant e';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';
     $query['casContactTableAlias'] = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue where scheduled reminders fail for **Event** reminders with:
- Repetition turned on, and
- "Limit or Add Recipients" is set to "Also Include"

Due to a DB Error: `Not unique table/alias: 'r'`

Before
----------------------------------------
CRM_Event_ActionMapping has the `casAddlCheckFrom` query parameter set to `civicrm_event r`, and also specifies a join to the `civicrm_event` table with the same alias.
Not only is the alias duplicate (and incorrect according to the later query), but the entity appears wrong.

The query generated to check if there are any recipients in the relevant phase to look like:

```sql
SELECT *
FROM civicrm_event r
INNER JOIN civicrm_event r ON e.event_id = r.id
INNER JOIN civicrm_contact c ON c.id = e.contact_id AND c.is_deleted = 0 AND c.is_deceased = 0
WHERE (r.id IN ("111")) AND (r.is_active = 1) AND (r.is_template = 0) AND ("20220512113156" <= DATE_SUB(
start_date, INTERVAL 3 hour))
LIMIT 1
OFFSET 0
```

Exception is thrown due to DB Error, further scheduled reminders are not sent (cron job does not appear to stop, though)

After
----------------------------------------
Replaces the incorrect table / alias with `civicrm_participant e`

Resulting query:

```sql
SELECT *
FROM civicrm_participant e
INNER JOIN civicrm_event r ON e.event_id = r.id
INNER JOIN civicrm_contact c ON c.id = e.contact_id AND c.is_deleted = 0 AND c.is_deceased = 0
WHERE (r.id IN ("111")) AND (r.is_active = 1) AND (r.is_template = 0) AND ("20220512113156" <= DATE_SUB(
start_date, INTERVAL 3 hour))
LIMIT 1
OFFSET 0
```

Exception is not thrown due to DB Error, Scheduled Reminders are sent

Technical Details
----------------------------------------

The `e` alias is in line with other ActionMapping classes, and lines up with the reset of the generated query.
`civicrm_participant` is the correct table to associate a Contact with with an event, which appears to be what we're checking for – i.e. only send reminders to additional recipients for events that have participants.

Other
----------------------------------------
Agileware ref CIVICRM-1981 