### PR TITLE
SearchKit - Pick better default for aggregate functions

### DIFF
--- a/Civi/Api4/Query/SqlFunctionABS.php
+++ b/Civi/Api4/Query/SqlFunctionABS.php
@@ -18,6 +18,8 @@ class SqlFunctionABS extends SqlFunction {
 
   protected static $category = self::CATEGORY_MATH;
 
+  protected static $dataType = 'Integer';
+
   protected static function params(): array {
     return [
       [

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -18,6 +18,8 @@ class SqlFunctionAVG extends SqlFunction {
 
   protected static $category = self::CATEGORY_AGGREGATE;
 
+  protected static $dataType = 'Float';
+
   protected static function params(): array {
     return [
       [

--- a/Civi/Api4/Query/SqlFunctionBINARY.php
+++ b/Civi/Api4/Query/SqlFunctionBINARY.php
@@ -18,6 +18,8 @@ class SqlFunctionBINARY extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
+  protected static $dataType = 'String';
+
   protected static function params(): array {
     return [
       [

--- a/Civi/Api4/Query/SqlFunctionRAND.php
+++ b/Civi/Api4/Query/SqlFunctionRAND.php
@@ -18,6 +18,8 @@ class SqlFunctionRAND extends SqlFunction {
 
   protected static $category = self::CATEGORY_MATH;
 
+  protected static $dataType = 'Float';
+
   protected static function params(): array {
     return [
       [

--- a/Civi/Api4/Query/SqlFunctionREPLACE.php
+++ b/Civi/Api4/Query/SqlFunctionREPLACE.php
@@ -18,6 +18,8 @@ class SqlFunctionREPLACE extends SqlFunction {
 
   protected static $category = self::CATEGORY_STRING;
 
+  protected static $dataType = 'String';
+
   protected static function params(): array {
     return [
       [

--- a/Civi/Api4/Query/SqlFunctionROUND.php
+++ b/Civi/Api4/Query/SqlFunctionROUND.php
@@ -18,6 +18,8 @@ class SqlFunctionROUND extends SqlFunction {
 
   protected static $category = self::CATEGORY_MATH;
 
+  protected static $dataType = 'Float';
+
   protected static function params(): array {
     return [
       [

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -12,7 +12,6 @@
         afformLoad,
         fieldsForJoinGetters = {};
 
-      this.DEFAULT_AGGREGATE_FN = 'GROUP_CONCAT';
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
       this.afformAdminEnabled = 'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
       this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'id');
@@ -331,7 +330,8 @@
           if (ctrl.canAggregate(col)) {
             // Ensure all non-grouped columns are aggregated if using GROUP BY
             if (!info.fn || info.fn.category !== 'aggregate') {
-              ctrl.savedSearch.api_params.select[pos] = ctrl.DEFAULT_AGGREGATE_FN + '(DISTINCT ' + fieldExpr + ') AS ' + ctrl.DEFAULT_AGGREGATE_FN + '_' + fieldExpr.replace(/[.:]/g, '_');
+              var dfl = searchMeta.getDefaultAggregateFn(info);
+              ctrl.savedSearch.api_params.select[pos] = dfl.fnName + '(' + dfl.flag_before + fieldExpr + ') AS ' + dfl.fnName + '_' + fieldExpr.replace(/[.:]/g, '_');
             }
           } else {
             // Remove aggregate functions when no grouping


### PR DESCRIPTION
Overview
----------------------------------------
Picks a more sensible default in SearchKit for how grouped fields should be aggregated.

Before
----------------------------------------
When adding a GroupBy to the search, columns are automatically aggregated using **List** (aka `GROUP_CONCAT`).

After
----------------------------------------
When adding a GroupBy to the search, columns are automatically aggregated using **Count** for the ID, **Sum** for numeric fields and **List** for others.

Technical Details
----------------------------------------
Improves the metadata for SQL functions as well.