### PR TITLE
karma - Allow execution with debug_mode=1. Hide jsonFormatter.

### DIFF
--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -1,6 +1,6 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-$isDebug = Civi::settings()->get('debug_enabled');
+$isPretty = \Civi::settings()->get('debug_enabled') && !defined('CIVICRM_KARMA');
 
 return [
   'ext' => 'civicrm',
@@ -13,6 +13,6 @@ return [
       'ui.utils',
     ],
     // Only require the +10kb if we're likely to need it.
-    $isDebug ? ['jsonFormatter'] : []
+    $isPretty ? ['jsonFormatter'] : []
   ),
 ];

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,7 @@
 var cv = require('civicrm-cv')({mode: 'sync'});
 var _CV = cv('vars:show');
 var cmd =
+  'define("CIVICRM_KARMA", 1);' +
   'CRM_Core_BAO_ConfigSetting::enableComponent("CiviCase");' +
   'global $civicrm_root;' +
   '$f = CRM_Utils_File::addTrailingSlash($civicrm_root)."tmp/karma.cv.js";' +


### PR DESCRIPTION
Overview
---------

Fix a small bug with running `karma` tests locally. ping @colemanw 

Before
------

If you enable `debug_mode=1` and run `karma`, it produces a large number of failures:

```
PhantomJS 2.1.1 (Mac OS 0.0.0): Executed 81 of 81 (55 FAILED) (2.686 secs / 2.387 secs)
```

After
-----

If you enable `debug_mode=1` and run `karma`, it passes:

```
PhantomJS 2.1.1 (Mac OS 0.0.0): Executed 81 of 81 SUCCESS (7.232 secs / 6.95 secs)
```

Comments
--------

The `jsonFormatter` plugin is a DX nicety; when browsing a page with `?angularDebug=1` and with `debug_mode=1`, it will load extra files so that `<crm-ui-debug>` panels look pretty. But ordinarily, loading these files is extraneous.

