### PR TITLE
 (NFC) karma - Enable all Civi components (not just CiviCase) 

### DIFF
--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -1,6 +1,6 @@
 <?php
 // This file declares an Angular module which can be autoloaded
-$isDebug = Civi::settings()->get('debug_enabled');
+$isPretty = \Civi::settings()->get('debug_enabled') && !defined('CIVICRM_KARMA');
 
 return [
   'ext' => 'civicrm',
@@ -13,6 +13,6 @@ return [
       'ui.utils',
     ],
     // Only require the +10kb if we're likely to need it.
-    $isDebug ? ['jsonFormatter'] : []
+    $isPretty ? ['jsonFormatter'] : []
   ),
 ];

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@ var cv = require('civicrm-cv')({mode: 'sync'});
 var _CV = cv('vars:show');
 var cmd =
   'define("CIVICRM_KARMA", 1);' +
-  'CRM_Core_BAO_ConfigSetting::enableComponent("CiviCase");' +
+  'CRM_Core_BAO_ConfigSetting::enableAllComponents();' +
   'global $civicrm_root;' +
   '$f = CRM_Utils_File::addTrailingSlash($civicrm_root)."tmp/karma.cv.js";' +
   'mkdir(dirname($f), 0777, TRUE);' +

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,7 @@
 var cv = require('civicrm-cv')({mode: 'sync'});
 var _CV = cv('vars:show');
 var cmd =
+  'define("CIVICRM_KARMA", 1);' +
   'CRM_Core_BAO_ConfigSetting::enableComponent("CiviCase");' +
   'global $civicrm_root;' +
   '$f = CRM_Utils_File::addTrailingSlash($civicrm_root)."tmp/karma.cv.js";' +


### PR DESCRIPTION
Overview
----------

This is a small cleanup (suggested by @colemanw) that makes the `karma.conf.js` appear more general.

It modifies the startup process for a test-runner; as long as the test-runner still gives the same output, it should be safe.

(*Note: The patch extends/depends upon #23449 because they modify adjacent lines. But functionally, they're separate.*)

Before
------

`karma` loads baseline Angular modules and CiviCase Angular modules.

After
-----

`karma` loads baseline Angular modules and any/all component-based Angular modules

Comment
-------

Why was it only CiviCase?  Not certain...  but I *think* it's because (historically) `crmMailing.ang.php` did extra work to build `settings`, and this extra work was a bit too heavy.  That work has moved (`settings` became `settingsFactory`) and maybe makes this safer.