### PR TITLE
Remove sets for no-longer gotten vars

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -204,10 +204,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     foreach ($storeParams as $storeName => $value) {
       $this->set($storeName, $value);
     }
-    $this->set('disableUSPS', $this->getSubmittedValue('disableUSPS'));
-    $this->set('dataSource', $this->getSubmittedValue('dataSource'));
-    $this->set('skipColumnHeader', CRM_Utils_Array::value('skipColumnHeader', $this->_params));
-
     CRM_Core_Session::singleton()->set('dateTypes', $storeParams['dateFormats']);
 
     $this->instantiateDataSource();


### PR DESCRIPTION
Overview
----------------------------------------
Remove sets for no-longer gotten vars - these used to be accessed with `$this->get('')` but no more

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/168195694-582e3795-2a9a-43a9-95b1-83879dd49518.png)

![image](https://user-images.githubusercontent.com/336308/168195739-35c87fa2-09ab-4917-a21e-19bef28eee7f.png)

![image](https://user-images.githubusercontent.com/336308/168195804-eefc7c98-a974-4db0-9af5-c7a3ace9669f.png)



After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
