### PR TITLE
[Import] Consolidate DataSource.tpl - template for first file on activity import

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -34,13 +34,6 @@ class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-
-    // FIXME: This 'onDuplicate' form element is never used -- copy/paste error?
-    $this->addRadio('onDuplicate', ts('On duplicate entries'), [
-      CRM_Import_Parser::DUPLICATE_SKIP => ts('Skip'),
-      CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
-      CRM_Import_Parser::DUPLICATE_FILL => ts('Fill'),
-    ]);
   }
 
   /**
@@ -48,7 +41,6 @@ class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    */
   public function postProcess() {
     $this->storeFormValues([
-      'onDuplicate',
       'dateFormats',
       'savedMapping',
     ]);

--- a/templates/CRM/Activity/Import/Form/DataSource.tpl
+++ b/templates/CRM/Activity/Import/Form/DataSource.tpl
@@ -7,47 +7,4 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Import Wizard - Step 1 (choose data source) *}
-<div class="crm-block crm-form-block crm-import-datasource-form-block">
-
-  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
-  {include file="CRM/common/WizardHeader.tpl"}
-  <div class="help">
-    {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
-    {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}
-  </div>
-
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
- <div id="upload-file">
- <h3>{ts}Upload Data File{/ts}</h3>
-      <table class="form-layout-compressed">
-        <tr class="crm-import-uploadfile-from-block-uploadFile">
-           <td class="label">{$form.uploadFile.label}</td>
-           <td>{$form.uploadFile.html}<br />
-                <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span><br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
-           </td>
-        </tr>
-        <tr class="crm-import-uploadfile-form-block-skipColumnHeader">
-           <td class="label"></td>
-           <td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
-               <span class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Activity Type', 'Activity Date').{/ts}</span>
-           </td>
-        </tr>
-        <tr class="crm-import-datasource-form-block-fieldSeparator">
-          <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
-          <td>{$form.fieldSeparator.html}</td>
-        </tr>
-        <tr>{include file="CRM/Core/Date.tpl"}</tr>
-        {if $savedMapping}
-        <tr class="crm-import-uploadfile-form-block-savedMapping">
-        <td>{$form.savedMapping.label}</td>
-           <td>{$form.savedMapping.html}<br />
-              <span class="description">{ts}Select Saved Mapping or Leave blank to create a new One.{/ts}</span>
-{/if}
-           </td>
-        </tr>
- </table>
- <div class="spacer"></div>
- </div>
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-</div>
+{include file="CRM/Import/Form/DataSource.tpl"}

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -34,26 +34,30 @@
            </span>
          </td>
        </tr>
-       <tr class="crm-import-uploadfile-from-block-contactType">
-         <td class="label">{$form.contactType.label}</td>
-         <td>{$form.contactType.html}<br />
-           <span class="description">
-             {ts 1=$importEntities}Select 'Individual' if you are importing %1 made by individual persons.{/ts}
-             {ts 1=$importEntities}Select 'Organization' or 'Household' if you are importing %1 made by contacts of that type. (NOTE: Some built-in contact types may not be enabled for your site.){/ts}
-           </span>
-         </td>
-       </tr>
-       <tr class="crm-import-uploadfile-from-block-onDuplicate">
-         <td class="label">{$form.onDuplicate.label}</td>
-         <td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td>
-       </tr>
+      {if array_key_exists('contactType', $form)}
+        <tr class="crm-import-uploadfile-from-block-contactType">
+          <td class="label">{$form.contactType.label}</td>
+          <td>{$form.contactType.html}<br />
+            <span class="description">
+              {ts 1=$importEntities}Select 'Individual' if you are importing %1 made by individual persons.{/ts}
+              {ts 1=$importEntities}Select 'Organization' or 'Household' if you are importing %1 made by contacts of that type. (NOTE: Some built-in contact types may not be enabled for your site.){/ts}
+            </span>
+          </td>
+        </tr>
+      {/if}
+      {if array_key_exists('onDuplicate', $form)}
+        <tr class="crm-import-uploadfile-from-block-onDuplicate">
+          <td class="label">{$form.onDuplicate.label}</td>
+          <td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td>
+        </tr>
+      {/if}
         <tr class="crm-import-datasource-form-block-fieldSeparator">
           <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
           <td>{$form.fieldSeparator.html}</td>
         </tr>
-       <tr class="crm-import-uploadfile-from-block-date">{include file="CRM/Core/Date.tpl"}</tr>
+       <tr class="crm-import-uploadfile-form-block-date">{include file="CRM/Core/Date.tpl"}</tr>
        {if $savedMapping}
-         <tr class="crm-import-uploadfile-from-block-savedMapping">
+         <tr class="crm-import-uploadfile-form-block-savedMapping">
            <td>{$form.savedMapping.label}</td>
            <td>{$form.savedMapping.html}<br />
              <span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate DataSource.tpl - template for first file on activity import

There are no substantive differences between the tpl used for Activity import compared with the one currenly shared by Contribution & Membership import


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/168385161-f1823437-4edc-4c3d-8b03-66c3892546d9.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/168392539-0c75c315-4d8c-478e-b010-1f784f8c1e92.png)


Technical Details
----------------------------------------
I took a look at the activity DataSource.tpl and aside from minor
markup the only difference between it and the shared markup is
the absense of 'contactType' on the Activity form - so
I added an 'if'

Also - as suggested in the readme - onDuplicate is not used in the Activity import - it's just copy & paste so I removed from php & made it conditional in the tpl

Comments
----------------------------------------
