### PR TITLE
dev/core#2300 Can not use Custom Fields defined on a contact_sub_type in dedupe…

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -220,7 +220,11 @@ class CRM_Dedupe_Finder {
     }
 
     // handle custom data
-    $tree = CRM_Core_BAO_CustomGroup::getTree($ctype, NULL, NULL, -1);
+
+    $subTypes = $fields['contact_sub_type'] ?? [];
+    // Only return custom for subType + unrestricted or return all custom
+    // fields.
+    $tree = CRM_Core_BAO_CustomGroup::getTree($ctype, NULL, NULL, -1, $subTypes, NULL, TRUE, NULL, TRUE);
     CRM_Core_BAO_CustomGroup::postProcess($tree, $fields, TRUE);
     foreach ($tree as $key => $cg) {
       if (!is_int($key)) {


### PR DESCRIPTION
Overview
----------------------------------------
Year old issue is here: https://lab.civicrm.org/dev/core/-/issues/2300

I added Finder tests for the Custom Field types because I wasn't sure if every field type was supported.  I.e. date, int, float, etc.  Doing that found another bug in that if a user created a rule programmatically with sub Type fields.   dedupeWithParams would not find a match because the passed in params were getting filtered incorrectly.  

