### PR TITLE
[REF] [Import] Remove unused variable

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -774,7 +774,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
     if ($this->_updateWithId) {
       //return warning if street address is unparsed, CRM-5886
-      return $this->processMessage($values, $statusFieldName, $this->_retCode);
+      return $this->processMessage($values, $this->_retCode);
     }
     //dupe checking
     if (is_array($newContact) && civicrm_error($newContact)) {
@@ -797,7 +797,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
 
     // @todo - record unparsed address as 'imported' but the presence of a message is meaningful?
-    return $this->processMessage($values, $statusFieldName, CRM_Import_Parser::VALID);
+    return $this->processMessage($values, CRM_Import_Parser::VALID);
   }
 
   /**
@@ -1886,13 +1886,11 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *
    * @param array $values
    *   The array of values belonging to each row.
-   * @param array $statusFieldName
-   *   Store formatted date in this array.
    * @param $returnCode
    *
    * @return int
    */
-  public function processMessage(&$values, $statusFieldName, $returnCode) {
+  private function processMessage(&$values, $returnCode) {
     if (empty($this->_unparsedStreetAddressContacts)) {
       $this->setImportStatus((int) ($values[count($values) - 1]), 'IMPORTED', '');
     }
@@ -2111,7 +2109,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
     $this->setImportStatus((int) $values[count($values) - 1], 'Imported', '');
     //return warning if street address is not parsed, CRM-5886
-    return $this->processMessage($values, $statusFieldName, CRM_Import_Parser::VALID);
+    return $this->processMessage($values, CRM_Import_Parser::VALID);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Remove unused variable

Before
----------------------------------------
Function is public but internal to the class & not used outside it (& logically would not be) and has an extraneous input

![image](https://user-images.githubusercontent.com/336308/168448433-e135b7e6-4732-46bb-9880-aaa872ae3c89.png)

![image](https://user-images.githubusercontent.com/336308/168448457-2d5cba97-7eaf-44f8-a0e4-a4cf9dd58d62.png)

After
----------------------------------------
Method is private for clarity, `$statusFieldName` removed

Technical Details
----------------------------------------

Comments
----------------------------------------