### PR TITLE
[REF] [Import] Minor simplification

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2345,8 +2345,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $relatedContactType = $this->getRelatedContactType($mappedField['relationship_type_id'], $mappedField['relationship_direction']);
       $relatedContactLocationTypeID = $relatedContactKey ? $mappedField['location_type_id'] : NULL;
       $relatedContactWebsiteTypeID = $relatedContactKey ? $mappedField['website_type_id'] : NULL;
-      $relatedContactIMProviderID = $relatedContactKey ? $mappedField['provider_id'] : NULL;
-      $relatedContactPhoneTypeID = $relatedContactKey ? $mappedField['phone_type_id'] : NULL;
 
       $locationFields = ['location_type_id', 'phone_type_id', 'provider_id', 'website_type_id'];
       $value = array_filter(array_intersect_key($mappedField, array_fill_keys($locationFields, 1)));
@@ -2381,27 +2379,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           ) {
             $params[$relatedContactKey][$relatedContactFieldName] = [];
           }
-          $value = [
-            $relatedContactFieldName => $importedValue,
-            'location_type_id' => $relatedContactLocationTypeID,
-          ];
-
-          if (isset($relatedContactPhoneTypeID)) {
-            $value['phone_type_id'] = $relatedContactPhoneTypeID;
-          }
-
-          // get IM service Provider type id for related contact
-          if (isset($relatedContactIMProviderID)) {
-            $value['provider_id'] = $relatedContactIMProviderID;
-          }
-
+          $value[$relatedContactFieldName] = $importedValue;
           $params[$relatedContactKey][$relatedContactFieldName][] = $value;
         }
         elseif (isset($relatedContactWebsiteTypeID)) {
-          $params[$relatedContactKey][$relatedContactFieldName][] = [
-            'url' => $importedValue,
-            'website_type_id' => $relatedContactWebsiteTypeID,
-          ];
+          $value[$relatedContactFieldName] = $importedValue;
+          $params[$relatedContactKey][$relatedContactFieldName][] = $value;
         }
         elseif (empty($importedValue) && isset($relatedContactLocationTypeID)) {
           if (empty($params[$relatedContactKey][$relatedContactFieldName])) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Minor simplification

Before
----------------------------------------
More code

After
----------------------------------------
Less code

Technical Details
----------------------------------------
At this stage value already holds the phone_type_id, location_type_id, im_provider_id, website_type_id
if any, so we don't need to throw it away & start again.

The main thing this clarifies is that if website_type_id is set at this point the field will be 'url' and we don't need to check for that - obviously there may have been some past ambiguity but we now load the code from the civicrm_mapping_field table & on checking the 2 go together

Comments
----------------------------------------
There is still more simplification here to do - some of it still confuses me even thought it seems like a simple function.

However, my feeling is that in the end the function would ALSO map option values to ids & reformat dates, leaving less work for the validation function