### PR TITLE
CRM_Utils_Check - Catch Guzzle exception, same as core exception

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -587,7 +587,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     try {
       $remotes = $extensionSystem->getBrowser()->getExtensions();
     }
-    catch (CRM_Extension_Exception $e) {
+    catch (CRM_Extension_Exception | \GuzzleHttp\Exception\GuzzleException $e) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
         $e->getMessage(),


### PR DESCRIPTION
Overview
--------

`checkExtensions()` is supposed to show status-messages which report on any out-of-date extensions.  This requires a list of available updates.

Alas, the Internet is a big and scary place, and sometimes the list is unavailable.  DNS servers, HTTP servers, timeouts, yadda yadda.  If it can't get the list of extensions, it should show a status-message about this problem.

ping @eileenmcnaughton 

Before
------

Throws an exception, causing a full failure in the page-view that does the status-check.

After
-----

Catches the exception. Reports a status-message about the failure.

Comments
--------

It appears that this was probably the behavior before (ie `checkExtension()` already has a try/catch for this kind of problem). However, the underlying HTTP request was changed a versions back (ie from `HttpClient` to `Guzzle`) which means that errors can get reported in other ways.

To simulate errors, I did this:

1. Run buggy/placeholder TCP service (`nc -l 8199`)
2. Hack `CRM_Extension_Browser::__construct()` to set `$this->repoUrl` to `http://localhost:8199`
3. Run `cv api System.check`
