### PR TITLE
[REF] [Import] Stop calling Parser in MapField mode (contact import)

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -179,8 +179,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
       $this->flushDataSource();
       $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     }
-    // Setup the params array
-    $this->_params = $this->controller->exportValues($this->_name);
 
     // @todo - this params are being set here because they were / possibly still
     // are in some places being accessed by forms later in the flow
@@ -194,9 +192,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     // Once the mentioned forms no longer call $this->get() all this 'setting'
     // is obsolete.
     $storeParams = [
-      'onDuplicate' => $this->getSubmittedValue('onDuplicate'),
-      'dedupe' => $this->getSubmittedValue('dedupe_rule_id'),
-      'contactType' => $this->getSubmittedValue('contactType'),
       'dateFormats' => $this->getSubmittedValue('dateFormats'),
       'savedMapping' => $this->getSubmittedValue('savedMapping'),
     ];
@@ -207,17 +202,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Forms {
     CRM_Core_Session::singleton()->set('dateTypes', $storeParams['dateFormats']);
 
     $this->instantiateDataSource();
-
-    $mapper = [];
-
-    $parser = new CRM_Contact_Import_Parser_Contact($mapper);
-    $parser->setMaxLinesToProcess(100);
-    $parser->setUserJobID($this->getUserJobID());
-    $parser->run(
-      [],
-      CRM_Import_Parser::MODE_MAPFIELD
-    );
-
   }
 
   /**

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2235,18 +2235,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     if ($mode == self::MODE_IMPORT) {
       $dataSource->setStatuses(['new']);
     }
-    if ($this->_maxLinesToProcess > 0) {
-      // Note this would only be the case in MapForm mode, where it is set to 100
-      // rows. In fact mapField really only needs 2 rows - the reason for
-      // 100 seems to be that the other import classes are processing a
-      // csv file, and there was a concern that some rows might have more
-      // columns than others - hence checking 100 rows perhaps seemed like
-      // a good precaution presumably when determining the activeFieldsCount
-      // which is the number of columns a row might have.
-      // However, the mapField class may no longer use activeFieldsCount for contact
-      // to be continued....
-      $dataSource->setLimit($this->_maxLinesToProcess);
-    }
 
     while ($row = $dataSource->getRow()) {
       $values = array_values($row);
@@ -2254,10 +2242,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
       $this->_totalCount++;
 
-      if ($mode == self::MODE_MAPFIELD) {
-        $returnCode = CRM_Import_Parser::VALID;
-      }
-      elseif ($mode == self::MODE_PREVIEW) {
+      if ($mode == self::MODE_PREVIEW) {
         $returnCode = $this->preview($values);
       }
       elseif ($mode == self::MODE_SUMMARY) {


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Import] Stop calling Parser in MapField mode

Before
----------------------------------------
The `DataSource` form calls `CRM_Contact_Import_Parser_Contact::run()` - however, this no longer does anything

After
----------------------------------------
poof

Technical Details
----------------------------------------
The point of calling `run` here was to load the csv and calculate information like the number of rows and the headers which was then passed to the next form using `$form->set()` and retrieved using `$form->get()` on the following form. Nothing is `set` anymore & only a couple of values are still potentially subject to 'get' calls

![image](https://user-images.githubusercontent.com/336308/168688715-5dd752aa-f48e-4d06-8144-a14619eb9aac.png)

![image](https://user-images.githubusercontent.com/336308/168688943-b354a69e-377e-4a60-a531-6f8ecab31f34.png)


Comments
----------------------------------------
@monishdeb this is a further clean up following the csv stuff you merged
