### PR TITLE
APIv4 - Respect max length for name with export action

### DIFF
--- a/Civi/Api4/Generic/ExportAction.php
+++ b/Civi/Api4/Generic/ExportAction.php
@@ -129,6 +129,8 @@ class ExportAction extends AbstractAction {
       }
     }
     $name = ($parentName ?? '') . $entityType . '_' . ($record['name'] ?? count($this->exportedEntities[$entityType]));
+    // Ensure safe characters, max length
+    $name = \CRM_Utils_String::munge($name, '_', 127);
     $result[] = [
       'name' => $name,
       'entity' => $entityType,


### PR DESCRIPTION
Overview
----------------------------------------
When using the APIv4 Export action, make sure the name of each exported item is not longer than allowed by the `civicrm_managed` table.

Before
----------------------------------------
Issue noted in https://github.com/civicrm/civicrm-core/pull/23452#issuecomment-1127848084

After
----------------------------------------
Length constrained.

Technical Details
----------------------------------------
IMO the maxlength of 127 is unnecessarily short, but the fix isn't a simple matter of increasing it because extensions typically support multiple versions of CiviCRM.

Comments
----------------------------------------
Note that the export action is simply a code generator, so this isn't directly causing a runtime error, but it's still nice to generate working code.
