### PR TITLE
[Import] Duplicate finding cleanup, including using supplied dedupe rule 

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1925,6 +1925,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
     $checkParams = ['check_permissions' => FALSE, 'match' => $params];
     $checkParams['match']['contact_type'] = $this->_contactType;
+    $checkParams['dedupe_rule_id'] = $this->_dedupeRuleGroupID ?? NULL;
 
     $possibleMatches = civicrm_api3('Contact', 'duplicatecheck', $checkParams);
     if (!$extIDMatch) {

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1241,8 +1241,8 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     foreach ($fields as $index => $field) {
       $mapper[] = [$field, $mapperLocType[$index] ?? NULL, $field === 'phone' ? 1 : NULL];
     }
-    $userJobID = $this->getUserJobID(['mapper' => $mapper, 'onDuplicate' => $onDuplicateAction]);
-    $parser = new CRM_Contact_Import_Parser_Contact($fields, $mapperLocType);
+    $userJobID = $this->getUserJobID(['mapper' => $mapper, 'onDuplicate' => $onDuplicateAction, 'dedupe_rule_id' => $ruleGroupId]);
+    $parser = new CRM_Contact_Import_Parser_Contact($fields);
     $parser->setUserJobID($userJobID);
     $parser->_dedupeRuleGroupID = $ruleGroupId;
     $parser->init();
@@ -1412,6 +1412,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT first_name FROM civicrm_contact',
           'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
+          'dedupe_rule_id' => NULL,
         ], $submittedValues),
       ],
       'status_id:name' => 'draft',


### PR DESCRIPTION
Overview
----------------------------------------
Fix from @darrick https://github.com/darrick/civicrm-core/commit/9b1470a89baee225e6f03206d02170afa8c27b23 combined with cleanup of how duplicate contacts are handled in the import script

Before
----------------------------------------
Dedupe handling is 'lightly sprinkled' throughout the script

After
----------------------------------------
Baby steps on consolidation

Technical Details
----------------------------------------
@darrick if you get a chance to test this please do - I'm gonna try to do a bit more cleanup on top of this

Comments
----------------------------------------
A more ambitious version of this PR is https://github.com/civicrm/civicrm-core/pull/23476 - if that is merged then this will automatically closed or if this is merged first then I will rebase this out of that (it depends which a reviewer prefers)