### PR TITLE
[Import] Unpack the weird wild error return

### DIFF
--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -42,27 +42,33 @@ function _civicrm_api3_deprecated_duplicate_formatted_contact($params) {
 
     if ($contact->find(TRUE)) {
       if ($params['contact_type'] != $contact->contact_type) {
-        return civicrm_api3_create_error("Mismatched contact IDs OR Mismatched contact Types");
+        return ['is_error' => 1, 'error_message' => 'Mismatched contact IDs OR Mismatched contact Types'];
       }
-
-      $error = CRM_Core_Error::createError("Found matching contacts: $contact->id",
-        CRM_Core_Error::DUPLICATE_CONTACT,
-        'Fatal', $contact->id
-      );
-      return civicrm_api3_create_error($error->pop());
+      return [
+        'is_error' => 1,
+        'error_message' => [
+          'code' => CRM_Core_Error::DUPLICATE_CONTACT,
+          'params' => $contact->id,
+          'level' => 'Fatal',
+          'message' => "Found matching contacts: $contact->id",
+        ],
+      ];
     }
   }
   else {
     $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, $params['contact_type'], 'Unsupervised');
 
     if (!empty($ids)) {
-      $ids = implode(',', $ids);
-      $error = CRM_Core_Error::createError("Found matching contacts: $ids",
-        CRM_Core_Error::DUPLICATE_CONTACT,
-        'Fatal', $ids
-      );
-      return civicrm_api3_create_error($error->pop());
+      return [
+        'is_error' => 1,
+        'error_message' => [
+          'code' => CRM_Core_Error::DUPLICATE_CONTACT,
+          'params' => $ids,
+          'level' => 'Fatal',
+          'message' => 'Found matching contacts: ' . implode(',', $ids),
+        ],
+      ];
     }
   }
-  return civicrm_api3_create_success(TRUE);
+  return ['is_error' => 0];
 }

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -113,11 +113,8 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   /**
    *  Test Import.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
-  public function testImport() {
+  public function testImport(): void {
     $this->individualCreate();
     $contact2Params = [
       'first_name' => 'Anthonita',


### PR DESCRIPTION
Overview
----------------------------------------
This unravels what is happening in a bit of deprecated code - I captured the array that is created as a result of the weird push & pop routine 

![image](https://user-images.githubusercontent.com/336308/168728953-7c353d01-bccd-499f-ad82-6501e44af008.png)

Before
----------------------------------------
It has always been a mystery to me what all that array pushing & popping resulted in

After
----------------------------------------
Return array specifically coded to have the same effect & be explicit

Technical Details
----------------------------------------


Comments
----------------------------------------

Turns out test cover in `CRM_Member_Import_Parser_MembershipTest.testImport`