### PR TITLE
[Import] Add tests for contact type & contact subtype handling

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1105,6 +1105,10 @@ abstract class CRM_Import_Parser {
    * @return array
    */
   protected function getIdsOfMatchingContacts(array $formatted):array {
+    if ($formatted['id'] ?? NULL) {
+      return [$formatted['id']];
+    }
+
     // the call to the deprecated function seems to add no value other that to do an additional
     // check for the contact_id & type.
     $error = _civicrm_api3_deprecated_duplicate_formatted_contact($formatted);

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -153,6 +153,42 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test updating an existing contact with external_identifier match but subtype mismatch.
+   *
+   * @throws \Exception
+   */
+  public function testImportParserWithUpdateWithExternalIdentifierSubtypeMismatch(): void {
+    $contactID = $this->individualCreate(['external_identifier' => 'billy', 'first_name' => 'William', 'contact_sub_type' => 'Parent']);
+    $this->runImport([
+      'external_identifier' => 'billy',
+      'nick_name' => 'Old Bill',
+      'contact_sub_type' => 'Staff',
+    ], CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['id' => $contactID]);
+    $this->assertEquals('Old Bill', $contact['nick_name']);
+    $this->assertEquals('William', $contact['first_name']);
+    $this->assertEquals('billy', $contact['external_identifier']);
+    $this->assertEquals(['Staff'], $contact['contact_sub_type']);
+  }
+
+  /**
+   * Test updating an existing contact with external_identifier match but subtype mismatch.
+   *
+   * @throws \Exception
+   */
+  public function testImportParserWithUpdateWithExternalIdentifierTypeMismatch(): void {
+    $contactID = $this->organizationCreate(['external_identifier' => 'billy']);
+    $this->runImport([
+      'external_identifier' => 'billy',
+      'nick_name' => 'Old Bill',
+    ], CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::NO_MATCH);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['id' => $contactID]);
+    $this->assertEquals('', $contact['nick_name']);
+    $this->assertEquals('billy', $contact['external_identifier']);
+    $this->assertEquals('Organization', $contact['contact_type']);
+  }
+
+  /**
    * Test import parser will fallback to external identifier.
    *
    * In this case no primary match exists (e.g the details are not supplied) so it falls back on external identifier.


### PR DESCRIPTION

Overview
----------------------------------------
[Import] Add tests for contact type & contact subtype handling

Before
----------------------------------------
No tests to cover what happens when you update a contact with an external identifier match and 
a) a different contact type or
b) a different contact subtype

After
----------------------------------------
Tests lock in what happens which turns out to be 
a) no update if the contact type doesn't match
b) subtype is replaced on update


Technical Details
----------------------------------------
There is no real change to the non-test code. I had to add an early return due to an enotice but the code would otherwise return the same value here

Comments
----------------------------------------
