### PR TITLE
[Import] Simplify checking contact type is valid

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1925,6 +1925,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
     $checkParams = ['check_permissions' => FALSE, 'match' => $params];
     $checkParams['match']['contact_type'] = $this->_contactType;
+    $checkParams['dedupe_rule_id'] = $this->_dedupeRuleGroupID ?? NULL;
 
     $possibleMatches = civicrm_api3('Contact', 'duplicatecheck', $checkParams);
     if (!$extIDMatch) {

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1241,8 +1241,8 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     foreach ($fields as $index => $field) {
       $mapper[] = [$field, $mapperLocType[$index] ?? NULL, $field === 'phone' ? 1 : NULL];
     }
-    $userJobID = $this->getUserJobID(['mapper' => $mapper, 'onDuplicate' => $onDuplicateAction]);
-    $parser = new CRM_Contact_Import_Parser_Contact($fields, $mapperLocType);
+    $userJobID = $this->getUserJobID(['mapper' => $mapper, 'onDuplicate' => $onDuplicateAction, 'dedupe_rule_id' => $ruleGroupId]);
+    $parser = new CRM_Contact_Import_Parser_Contact($fields);
     $parser->setUserJobID($userJobID);
     $parser->_dedupeRuleGroupID = $ruleGroupId;
     $parser->init();
@@ -1412,6 +1412,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT first_name FROM civicrm_contact',
           'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
+          'dedupe_rule_id' => NULL,
         ], $submittedValues),
       ],
       'status_id:name' => 'draft',

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -271,16 +271,26 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    *
    * @throws \Exception
    */
-  public function testImportParserWithUpdateWithExternalIdentifierTypeMismatch(): void {
+  public function testImportParserWithUpdateWithTypeMismatch(): void {
     $contactID = $this->organizationCreate(['external_identifier' => 'billy']);
     $this->runImport([
       'external_identifier' => 'billy',
       'nick_name' => 'Old Bill',
-    ], CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::NO_MATCH);
+    ], CRM_Import_Parser::DUPLICATE_UPDATE, FALSE);
     $contact = $this->callAPISuccessGetSingle('Contact', ['id' => $contactID]);
     $this->assertEquals('', $contact['nick_name']);
     $this->assertEquals('billy', $contact['external_identifier']);
     $this->assertEquals('Organization', $contact['contact_type']);
+
+    $this->runImport([
+      'id' => $contactID,
+      'nick_name' => 'Old Bill',
+    ], CRM_Import_Parser::DUPLICATE_UPDATE, FALSE);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['id' => $contactID]);
+    $this->assertEquals('', $contact['nick_name']);
+    $this->assertEquals('billy', $contact['external_identifier']);
+    $this->assertEquals('Organization', $contact['contact_type']);
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Simplify checking contact type is valid

This builds on other open PRs & ensures we are checking in a sensible way that we are not changing the contact type

Before
----------------------------------------
Where to start -  this is being handled in multiple places

After
----------------------------------------
The `lookupContactID` function 
1) loads the id from external identifier, if applicable
2) checks the contact type is the same as the saved one & rejects the row if now
3) loads from the dedupe rule if the other failed - note the ContactType is implicit in the dedupe rule load

Technical Details
----------------------------------------
There is still a lotta code around contact_subtype handling which I'll move over next

Comments
----------------------------------------
