### PR TITLE
Remove extra question mark from url

### DIFF
--- a/CRM/Utils/Check/Component/Schema.php
+++ b/CRM/Utils/Check/Component/Schema.php
@@ -154,7 +154,7 @@ class CRM_Utils_Check_Component_Schema extends CRM_Utils_Check_Component {
           }
         }
         $groupEdit = '<a href="' . CRM_Utils_System::url('civicrm/contact/search/advanced', "reset=1&ssID={$field['ssid']}", TRUE) . '" title="' . ts('Edit search criteria', ['escape' => 'js']) . '"> <i class="crm-i fa-pencil" aria-hidden="true"></i> </a>';
-        $groupConfig = '<a href="' . CRM_Utils_System::url('civicrm/group', "?reset=1&action=update&id={$id}", TRUE) . '" title="' . ts('Group settings', ['escape' => 'js']) . '"> <i class="crm-i fa-gear" aria-hidden="true"></i> </a>';
+        $groupConfig = '<a href="' . CRM_Utils_System::url('civicrm/group', "reset=1&action=update&id={$id}", TRUE) . '" title="' . ts('Group settings', ['escape' => 'js']) . '"> <i class="crm-i fa-gear" aria-hidden="true"></i> </a>';
         $html .= "<tr><td>{$id} - {$field['title']} </td><td>{$groupEdit} {$groupConfig}</td><td class='disabled'>{$fieldName}</td>";
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Too many question marks

Before
----------------------------------------
On system status page:

<img width="490" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/168844617-0ee2d72e-6e3b-4566-bdd8-509eeb297cdb.png">


After
----------------------------------------
Only one question mark

Technical Details
----------------------------------------
The function automatically does the right thing depending on CMS and clean urls so the question mark shouldn't be in the params.

Comments
----------------------------------------

