### PR TITLE
Cleanup gender handling in contact import + add test

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -781,7 +781,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
 
     CRM_Utils_Array::lookupValue($defaults, 'prefix', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'prefix_id'), $reverse);
     CRM_Utils_Array::lookupValue($defaults, 'suffix', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'suffix_id'), $reverse);
-    CRM_Utils_Array::lookupValue($defaults, 'gender', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'), $reverse);
     CRM_Utils_Array::lookupValue($defaults, 'communication_style', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'communication_style_id'), $reverse);
 
     //lookup value of email/postal greeting, addressee, CRM-4575

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -495,13 +495,14 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
   /**
    * Test case for resolveDefaults( ).
    *
+   * @todo the resolveDefaults function is on it's way out - so is this test...
+   *
    * Test all pseudoConstant, stateProvince, country.
    */
   public function testResolveDefaults() {
     $params = [
       'prefix_id' => 3,
       'suffix_id' => 2,
-      'gender_id' => 2,
       'birth_date' => '1983-12-13',
     ];
 
@@ -515,8 +516,6 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     CRM_Contact_BAO_Contact::resolveDefaults($params);
 
     //check the resolve values.
-    $genders = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
-    $this->assertEquals($genders[$params['gender_id']], $params['gender'], 'Check for gender.');
     $prefix = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'prefix_id');
     $this->assertEquals($prefix[$params['prefix_id']], $params['prefix'], 'Check for prefix.');
     $suffix = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'suffix_id');

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_genders.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_genders.csv
@@ -1,0 +1,17 @@
+first_name,Last Name,Gender,mum_first_name,mum_last_name,mum_gender,Expected
+Madame,1,Female,Mum,1,,Valid
+Madame,2,FEMALE,Mum,2,,Valid
+Madame,3,female,Mum,3,,Valid
+Madame,4,Female.,Mum,4,,Invalid
+Madame,5,F,Mum,5,,Invalid
+Madame,6,f,Mum,6,,Invalid
+Madame,7,Cat,Mum,7,,Invalid
+Madame,8,1,Mum,8,,Valid
+Daughter,9,,Madame,9,Female,Valid
+Daughter,10,,Madame,10,FEMALE,Valid
+Daughter,11,,Madame,11,female,Valid
+Daughter,12,,Madame,12,Female.,Invalid
+Daughter,13,,Madame,13,F,Invalid
+Daughter,14,,Madame,14,f,Invalid
+Daughter,15,,Madame,15,Cat,Invalid
+Daughter,16,,Madame,16,1,Valid

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -14,6 +14,7 @@
  * File for the CRM_Contact_Imports_Parser_ContactTest class.
  */
 
+use Civi\Api4\Contact;
 use Civi\Api4\UserJob;
 
 /**
@@ -883,6 +884,52 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the handling of validation when importing genders.
+   *
+   * If it's not gonna import it should fail at the validation stage...
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportGenders(): void {
+    $mapper = [
+      ['first_name'],
+      ['last_name'],
+      ['gender_id'],
+      ['1_a_b', 'first_name'],
+      ['1_a_b', 'last_name'],
+      ['1_a_b', 'gender_id'],
+      ['do_not_import'],
+    ];
+    $csv = 'individual_genders.csv';
+    /* @var CRM_Import_DataSource_CSV $dataSource */
+    /* @var \CRM_Contact_Import_Parser_Contact $parser */
+    [$dataSource, $parser] = $this->getDataSourceAndParser($csv, $mapper, []);
+    while ($values = $dataSource->getRow()) {
+      try {
+        $parser->validateValues(array_values($values));
+        if ($values['expected'] !== 'Valid') {
+          $this->fail($values['gender'] . ' should not have been valid');
+        }
+      }
+      catch (CRM_Core_Exception $e) {
+        if ($values['expected'] !== 'Invalid') {
+          $this->fail($values['gender'] . ' should have been valid');
+        }
+      }
+    }
+
+    $this->importCSV($csv, $mapper);
+    $contacts = Contact::get()
+      ->addWhere('first_name', '=', 'Madame')
+      ->addSelect('gender_id:name')->execute();
+    foreach ($contacts as $contact) {
+      $this->assertEquals('Female', $contact['gender_id:name']);
+    }
+    $this->assertCount(8, $contacts);
+  }
+
+  /**
    * Test that setting duplicate action to fill doesn't blow away data
    * that exists, but does fill in where it's empty.
    *
@@ -1109,6 +1156,33 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * @param string $csv
+   * @param array $mapper
+   * @param array $submittedValues
+   *
+   * @return array
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected function getDataSourceAndParser(string $csv, array $mapper, array $submittedValues): array {
+    $userJobID = $this->getUserJobID(array_merge([
+      'uploadFile' => ['name' => __DIR__ . '/../Form/data/' . $csv],
+      'skipColumnHeader' => TRUE,
+      'fieldSeparator' => ',',
+      'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
+      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'mapper' => $mapper,
+      'dataSource' => 'CRM_Import_DataSource_CSV',
+    ], $submittedValues));
+
+    $dataSource = new CRM_Import_DataSource_CSV($userJobID);
+    $parser = new CRM_Contact_Import_Parser_Contact();
+    $parser->setUserJobID($userJobID);
+    $parser->init();
+    return [$dataSource, $parser];
+  }
+
+  /**
    * @param array $fields Array of fields to be imported
    * @param array $allfields Array of all fields which can be part of import
    */
@@ -1272,20 +1346,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   protected function validateCSV(string $csv, array $mapper, $submittedValues): void {
-    $userJobID = $this->getUserJobID(array_merge([
-      'uploadFile' => ['name' => __DIR__ . '/../Form/data/' . $csv],
-      'skipColumnHeader' => TRUE,
-      'fieldSeparator' => ',',
-      'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
-      'mapper' => $mapper,
-      'dataSource' => 'CRM_Import_DataSource_CSV',
-    ], $submittedValues));
-
-    $dataSource = new CRM_Import_DataSource_CSV($userJobID);
-    $parser = new CRM_Contact_Import_Parser_Contact();
-    $parser->setUserJobID($userJobID);
-    $parser->init();
+    [$dataSource, $parser] = $this->getDataSourceAndParser($csv, $mapper, $submittedValues);
     $parser->validateValues(array_values($dataSource->getRow()));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup gender handling in contact import + add test

This lays the foundation for option values to be transformed based on metadata in `getParams`, simplifying validation & later transformations

Before
----------------------------------------
No testing on gender_id handling and unclear expectations.

On adding the test I discovered that there were 2 types invalid values for gender
- those that fail validation
- those that pass validation but are silently discarded later on

Despite generous consideration in the validation routine only values that were an exact match for the label actually got saved to the database.

I concluded that if a value was not to be saved to the database it should fail validation - and hence the test checks both the validation and the actual import

After
----------------------------------------
The initial `getParams` transformation now converts the imported value to an integer, based on metadata. 

In line with import handling for other fields in various import places I made it accept any of id, name, label

I ALSO made it accept name & label in all upper or all lower case. This is something that was coded into `checkGender` but ultimately didn't work. The way I did it is not truly case-insensitive - I might think more on that but there is some risk with non-latin alphabets - at least the way I did it won't mess with a matching font sitll matching.



Technical Details
----------------------------------------

Comments
----------------------------------------
Note that the test includes a csv file suitale for r-run testing