### PR TITLE
(REF) CRM_Upgrade_Form - Remove silly method `runQuery`

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -263,15 +263,6 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   }
 
   /**
-   * @param $query
-   *
-   * @return Object
-   */
-  public function runQuery($query) {
-    return CRM_Core_DAO::executeQuery($query);
-  }
-
-  /**
    * @param $version
    *
    * @return Object
@@ -283,7 +274,7 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
 UPDATE civicrm_domain
 SET    version = '$version'
 ";
-    return $this->runQuery($query);
+    return CRM_Core_DAO::executeQuery($query);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

This method just wraps `CRM_Core_DAO::executeQuery`, and it's only used once. It's silly.

Before
----------------------------------------

Rowan Atkinson

After
----------------------------------------

Daniel Day Lewis
