### PR TITLE
[Import] Remove silly param

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -29,7 +29,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   use CRM_Contact_Import_MetadataTrait;
 
   protected $_mapperKeys = [];
-  protected $_relationships;
 
   /**
    * Is update only permitted on an id match.
@@ -1059,9 +1058,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *   A string containing all the error-fields.
    *
    * @param null $csType
-   * @param null $relationships
    */
-  public static function isErrorInCustomData($params, &$errorMessage, $csType = NULL, $relationships = NULL) {
+  public static function isErrorInCustomData($params, &$errorMessage, $csType = NULL) {
     $dateType = CRM_Core_Session::singleton()->get("dateTypes");
     $errors = [];
 
@@ -1220,18 +1218,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           }
         }
       }
-      elseif (is_array($params[$key]) && isset($params[$key]["contact_type"])) {
+      elseif (is_array($params[$key]) && isset($params[$key]["contact_type"]) && in_array(substr($key, -3), ['a_b', 'b_a'], TRUE)) {
         //CRM-5125
         //supporting custom data of related contact subtypes
-        $relation = NULL;
-        if ($relationships) {
-          if (array_key_exists($key, $relationships)) {
-            $relation = $key;
-          }
-          elseif (CRM_Utils_Array::key($key, $relationships)) {
-            $relation = CRM_Utils_Array::key($key, $relationships);
-          }
-        }
+        $relation = $key;
         if (!empty($relation)) {
           [$id, $first, $second] = CRM_Utils_System::explode('_', $relation, 3);
           $direction = "contact_sub_type_$second";
@@ -1244,7 +1234,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           }
         }
 
-        self::isErrorInCustomData($params[$key], $errorMessage, $csType, $relationships);
+        self::isErrorInCustomData($params[$key], $errorMessage, $csType);
       }
     }
     if ($errors) {
@@ -1900,8 +1890,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    */
   protected function setFieldMetadata() {
     $this->setImportableFieldsMetadata($this->getContactImportMetadata());
-    // Probably no longer needed but here for now.
-    $this->_relationships = $this->getRelationships();
   }
 
   /**
@@ -2831,7 +2819,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
 
     //checking error in custom data
-    $this->isErrorInCustomData($params, $errorMessage, $csType, $this->_relationships);
+    $this->isErrorInCustomData($params, $errorMessage, $csType);
 
     //checking error in core data
     $this->isErrorInCoreData($params, $errorMessage);


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Remove silly param

I've finally solved the mystery of this parameter - the crux of this change is this

![image](https://user-images.githubusercontent.com/336308/169187587-2b8aabbe-8f3b-4316-b3c2-3c81dce7d670.png)


Before
----------------------------------------
`$relationships` is an array of available relationships - in format like 
`['5_a_b' => 'Employer Of']`

It is metadata passed into the custom data function and the reason turns out to be to confirm that the sub-array within `$params` 'really really' is a relationship type sub-array. In actual fact I'm pretty sure the check to see if it is an array with a `'contact_type'` key is enough to confirm it

It also handles the impossible situation where the key is the relationship label instead - maybe once that was possible

![image](https://user-images.githubusercontent.com/336308/169186546-1e317e39-8295-4898-b12b-b43d161ac53c.png)


After
----------------------------------------
The additional check is now to see if the string ends in a_b or b_a instead

Technical Details
----------------------------------------
This is the custom data validation routine so not a place to check the validity of the relationship 

Comments
----------------------------------------
