### PR TITLE
SearchKit - Fix in-place editing custom relationship fields

### DIFF
--- a/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/CustomGroupJoinable.php
@@ -13,6 +13,7 @@
 namespace Civi\Api4\Service\Schema\Joinable;
 
 use Civi\Api4\CustomField;
+use Civi\Api4\Utils\CoreUtil;
 
 class CustomGroupJoinable extends Joinable {
 
@@ -52,12 +53,13 @@ class CustomGroupJoinable extends Joinable {
     $cacheKey = 'APIv4_CustomGroupJoinable-' . $this->getTargetTable();
     $entityFields = (array) \Civi::cache('metadata')->get($cacheKey);
     if (!$entityFields) {
+      $baseEntity = CoreUtil::getApiNameFromTableName($this->getBaseTable());
       $fields = CustomField::get(FALSE)
         ->setSelect(['custom_group_id.name', 'custom_group_id.extends', 'custom_group_id.table_name', 'custom_group_id.title', '*'])
         ->addWhere('custom_group_id.table_name', '=', $this->getTargetTable())
         ->execute();
       foreach ($fields as $field) {
-        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, self::getEntityFromExtends($field['custom_group_id.extends']));
+        $entityFields[] = \Civi\Api4\Service\Spec\SpecFormatter::arrayToField($field, $baseEntity);
       }
       \Civi::cache('metadata')->set($cacheKey, $entityFields);
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -1,16 +1,18 @@
 <?php
 namespace api\v4\SearchDisplay;
 
-use Civi\Api4\Contact;
+// This is apparently necessary due to autoloader issues with test classes
+require_once 'tests/phpunit/api/v4/Api4TestBase.php';
+require_once 'tests/phpunit/api/v4/Custom/CustomTestBase.php';
+
+use api\v4\Custom\CustomTestBase;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
-use Civi\Api4\File;
-use Civi\Test\HeadlessInterface;
 
 /**
  * @group headless
  */
-class SearchRunWithCustomFieldTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+class SearchRunWithCustomFieldTest extends CustomTestBase {
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
@@ -24,7 +26,15 @@ class SearchRunWithCustomFieldTest extends \PHPUnit\Framework\TestCase implement
    * @throws \API_Exception
    */
   public function tearDown(): void {
-    CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
+    // Core bug: `civicrm_entity_file` doesn't get cleaned up when a contact is deleted,
+    // so trying to delete `civicrm_file` causes a constraint violation :(
+    // For now, truncate the table manually.
+    $this->cleanup([
+      'tablesToTruncate' => [
+        'civicrm_entity_file',
+      ],
+    ]);
+    // Now the file record can be auto-deleted
     parent::tearDown();
   }
 
@@ -35,8 +45,7 @@ class SearchRunWithCustomFieldTest extends \PHPUnit\Framework\TestCase implement
     CustomGroup::create(FALSE)
       ->addValue('title', 'TestSearchFields')
       ->addValue('extends', 'Individual')
-      ->execute()
-      ->first();
+      ->execute();
 
     CustomField::create(FALSE)
       ->addValue('label', 'MyFile')
@@ -47,16 +56,16 @@ class SearchRunWithCustomFieldTest extends \PHPUnit\Framework\TestCase implement
 
     $lastName = uniqid(__FUNCTION__);
 
-    $file = File::create()
-      ->addValue('mime_type', 'image/png')
-      ->addValue('uri', "tmp/$lastName.png")
-      ->execute()->first();
+    $file = $this->createTestRecord('File', [
+      'mime_type' => 'image/png',
+      'uri' => "tmp/$lastName.png",
+    ]);
 
     $sampleData = [
       ['first_name' => 'Zero', 'last_name' => $lastName, 'TestSearchFields.MyFile' => $file['id']],
       ['first_name' => 'One', 'middle_name' => 'None', 'last_name' => $lastName],
     ];
-    Contact::save(FALSE)->setRecords($sampleData)->execute();
+    $this->saveTestRecords('Contact', ['records' => $sampleData]);
 
     $params = [
       'checkPermissions' => FALSE,
@@ -101,6 +110,163 @@ class SearchRunWithCustomFieldTest extends \PHPUnit\Framework\TestCase implement
     $this->assertEmpty($result[1]['data']['TestSearchFields.MyFile']);
     // Placeholder image
     $this->assertStringContainsString('example.com', $result[1]['columns'][1]['img']['src']);
+  }
+
+  public function testEditableRelationshipCustomFields() {
+
+    CustomGroup::create(FALSE)
+      ->addValue('title', 'TestChildFields')
+      ->addValue('extends', 'Relationship')
+      ->addValue('extends_entity_column_value:name', ['Child of'])
+      ->addChain('fields', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('label', 'Child')
+        ->addValue('html_type', 'Text')
+      )
+      ->execute();
+
+    CustomGroup::create(FALSE)
+      ->addValue('title', 'TestSpouseFields')
+      ->addValue('extends', 'Relationship')
+      ->addValue('extends_entity_column_value:name', ['Spouse of'])
+      ->addChain('fields', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('label', 'Spouse')
+        ->addValue('html_type', 'Text')
+      )
+      ->execute();
+
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => array_fill(0, 3, []),
+    ]);
+    // Reverse the contacts array so we don't get an accidental match of
+    // sequential contact ids and relationship ids. This test needs to ensure
+    // that the correct id is always being used.
+    $contacts = array_column(array_reverse((array) $contacts), 'id');
+
+    $spouse = $this->createTestRecord('Contact', ['first_name' => 's'])['id'];
+    $child = $this->createTestRecord('Contact', ['first_name' => 'c'])['id'];
+
+    $childRel = $this->createTestRecord('Relationship', [
+      'contact_id_b' => $contacts[0],
+      'contact_id_a' => $child,
+      'relationship_type_id:name' => 'Child of',
+      'TestChildFields.Child' => 'abc',
+    ])['id'];
+    $spouseRel = $this->createTestRecord('Relationship', [
+      'contact_id_a' => $contacts[1],
+      'contact_id_b' => $spouse,
+      'relationship_type_id:name' => 'Spouse of',
+      'description' => 'Married',
+    ])['id'];
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'first_name',
+            'Relative.first_name',
+            'Relative.description',
+            'Relative.TestChildFields.Child',
+            'Relative.TestSpouseFields.Spouse',
+          ],
+          'where' => [['id', 'IN', $contacts]],
+          'join' => [
+            [
+              'Contact AS Relative',
+              'LEFT',
+              'RelationshipCache',
+              ['id', '=', 'Relative.far_contact_id'],
+            ],
+          ],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'limit' => 20,
+          'pager' => FALSE,
+          'columns' => [
+            [
+              'key' => 'first_name',
+              'label' => 'Name',
+              'type' => 'field',
+              'editable' => TRUE,
+            ],
+            [
+              'key' => 'Relative.first_name',
+              'label' => 'Child Name',
+              'type' => 'field',
+              'editable' => TRUE,
+            ],
+            [
+              'key' => 'Relative.description',
+              'label' => 'Relationship Description',
+              'type' => 'field',
+              'editable' => TRUE,
+            ],
+            [
+              'key' => 'Relative.TestChildFields.Child',
+              'label' => 'Child Custom',
+              'type' => 'field',
+              'editable' => TRUE,
+            ],
+            [
+              'key' => 'Relative.TestSpouseFields.Spouse',
+              'label' => 'Spouse Custom',
+              'type' => 'field',
+              'editable' => TRUE,
+            ],
+          ],
+          'sort' => [
+            // To match the reversed array of contacts
+            ['id', 'DESC'],
+          ],
+        ],
+      ],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(3, $result);
+    // Editing first name - edit id should always match primary contact id
+    $this->assertEquals($contacts[0], $result[0]['columns'][0]['edit']['record']['id']);
+    $this->assertEquals($contacts[1], $result[1]['columns'][0]['edit']['record']['id']);
+    $this->assertEquals($contacts[2], $result[2]['columns'][0]['edit']['record']['id']);
+
+    // First contact has a child relation but not a spouse
+    $this->assertEquals('c', $result[0]['columns'][1]['val']);
+    $this->assertEquals($child, $result[0]['columns'][1]['edit']['record']['id']);
+    $this->assertEquals('', $result[0]['columns'][2]['val']);
+    $this->assertEquals($childRel, $result[0]['columns'][2]['edit']['record']['id']);
+    $this->assertEquals('abc', $result[0]['columns'][3]['val']);
+    $this->assertEquals($childRel, $result[0]['columns'][3]['edit']['record']['id']);
+    $this->assertNull($result[0]['columns'][4]['val']);
+    // $this->assertArrayNotHasKey('edit', $result[0]['columns'][4]);
+
+    // Second contact has a spouse relation but not a child
+    $this->assertEquals('s', $result[1]['columns'][1]['val']);
+    $this->assertEquals($spouse, $result[1]['columns'][1]['edit']['record']['id']);
+    $this->assertEquals('Married', $result[1]['columns'][2]['val']);
+    $this->assertEquals($spouseRel, $result[1]['columns'][2]['edit']['record']['id']);
+    $this->assertNull($result[1]['columns'][3]['val']);
+    // $this->assertArrayNotHasKey('edit', $result[1]['columns'][3]);
+    $this->assertNull($result[1]['columns'][4]['val']);
+    $this->assertEquals($spouseRel, $result[1]['columns'][4]['edit']['record']['id']);
+
+    // Third contact is all alone in this world...
+    $this->assertNull($result[2]['columns'][1]['val']);
+    $this->assertArrayNotHasKey('edit', $result[2]['columns'][1]);
+    $this->assertNull($result[2]['columns'][2]['val']);
+    $this->assertArrayNotHasKey('edit', $result[2]['columns'][2]);
+    $this->assertNull($result[2]['columns'][3]['val']);
+    $this->assertArrayNotHasKey('edit', $result[2]['columns'][3]);
+    $this->assertNull($result[2]['columns'][4]['val']);
+    $this->assertArrayNotHasKey('edit', $result[2]['columns'][4]);
   }
 
 }

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -61,7 +61,16 @@ class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
     if (!in_array('Civi\Test\TransactionalInterface', $impliments, TRUE)) {
       // Delete all test records in reverse order to prevent fk constraints
       foreach (array_reverse($this->testRecords) as $record) {
-        civicrm_api4($record[0], 'delete', ['checkPermissions' => FALSE, 'where' => $record[1]]);
+        $params = ['checkPermissions' => FALSE, 'where' => $record[1]];
+
+        // Set useTrash param if it exists
+        $entityClass = CoreUtil::getApiClass($record[0]);
+        $deleteAction = $entityClass::delete();
+        if (property_exists($deleteAction, 'useTrash')) {
+          $params['useTrash'] = FALSE;
+        }
+
+        civicrm_api4($record[0], 'delete', $params);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug in SearchKit in-place editing.

Before
----------------------------------------
In-place edit updates the wrong record for custom relationship fields in a related contact search.

After
----------------------------------------
Fixed. Test added.
Also added unit test coverage for #23496.