### PR TITLE
(dev/core#3436) MultipleRecordFieldsListing.tpl - JS strings should us JS escaping

### DIFF
--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -33,7 +33,7 @@
               {literal}
               <script type="text/javascript">
                 (function($) {
-                  var ZeroRecordText = {/literal}'{ts 1=$customGroupTitle|escape}No records of type \'%1\' found.{/ts}'{literal};
+                  var ZeroRecordText = {/literal}"{ts escape='js' 1=$customGroupTitle|smarty:nodefaults}No records of type '%1' found.{/ts}"{literal};
                   var $table = $('#records-' + {/literal}'{$customGroupId}'{literal});
                   $('table.crm-multifield-selector').data({
                     "ajax": {


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you make a multi-record custom-data group with a funny name

![Screenshot from 2022-05-18 21-53-38](https://user-images.githubusercontent.com/1336047/169211144-de64f5c5-a83a-4537-ad64-95076ae3d13f.png)

The good thing is that doesn't execute this. But it does do excessive escaping in one place.

Before
----------------------------------------

Most widgets+screens showing this name will display characters like `<` as `<`. Notice the tab-bar and the button-bar.

However, there's an outlier in the middle which displays `<` as `&lt;`:

![Screenshot from 2022-05-18 21-54-37](https://user-images.githubusercontent.com/1336047/169211146-bc52cc2a-188a-4a60-be5a-45f52e08e28d.png)

After
----------------------------------------

Like everywhere else, the center of the page displays `<` as `<`. (It looks the same as when it was typed.)

![Screenshot from 2022-05-18 21-55-37](https://user-images.githubusercontent.com/1336047/169211148-14b9237b-1f70-444c-955d-156a4465ac1a.png)

Comments
----------------------------------------

Noticed this well reading https://lab.civicrm.org/dev/core/-/issues/3436, though it's a bit tangential to that problem.