### PR TITLE
[Import] Remove svn whimsy - DUPLICATE_REPLACE

### DIFF
--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -35,9 +35,6 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
     if ($onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
       $this->assign('dupeActionString', ts('These records have been updated with the imported data.'));
     }
-    elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_REPLACE) {
-      $this->assign('dupeActionString', ts('These records have been replaced with the imported data.'));
-    }
     elseif ($onDuplicate == CRM_Import_Parser::DUPLICATE_FILL) {
       $this->assign('dupeActionString', ts('These records have been filled in with the imported data.'));
     }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1944,11 +1944,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $cid = NULL;
 
     $vals = ['contact_id' => $contactId];
-
-    if ($onDuplicate == CRM_Import_Parser::DUPLICATE_REPLACE) {
-      civicrm_api('contact', 'delete', $vals);
-      $cid = CRM_Contact_BAO_Contact::createProfileContact($formatted, $contactFields, $contactId, NULL, NULL, $formatted['contact_type']);
-    }
     if (in_array((int) $onDuplicate, [CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::DUPLICATE_FILL], TRUE)) {
       $newContact = $this->createContact($formatted, $contactFields, $onDuplicate, $contactId);
     }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -35,7 +35,7 @@ abstract class CRM_Import_Parser {
   /**
    * Codes for duplicate record handling
    */
-  const DUPLICATE_SKIP = 1, DUPLICATE_REPLACE = 2, DUPLICATE_UPDATE = 4, DUPLICATE_FILL = 8, DUPLICATE_NOCHECK = 16;
+  const DUPLICATE_SKIP = 1, DUPLICATE_UPDATE = 4, DUPLICATE_FILL = 8, DUPLICATE_NOCHECK = 16;
 
   /**
    * Contact types


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Remove svn whimsy - DUPLICATE_REPLACE

Before
----------------------------------------
Although we have handling for the import mode `DUPLICATE_REPLACE` deep in the code - it turns out it is not a selectable option on this import screen  - and this appears to have been the case even back when we were on svn

https://github.com/civicrm/civicrm-svn/search?q=DUPLICATE_REPLACE

![image](https://user-images.githubusercontent.com/336308/169252537-0185730b-6034-4039-b9a3-bb3ac1d0435c.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
I did a universe search & found one additional place (which I removed) in a unit test https://github.com/eileenmcnaughton/Email-Amender/commit/c391ed1136785cc97ee69d9204d6d6916eeef8b0

Comments
----------------------------------------
