### PR TITLE
Remove mealy-mouthed `isset` check from `params['id']`

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -336,7 +336,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $relationship = FALSE;
     $createNewContact = TRUE;
     // Support Match and Update Via Contact ID
-    if ($this->_updateWithId && isset($params['id'])) {
+    if ($this->_updateWithId && $params['id']) {
       $createNewContact = FALSE;
       // @todo - it feels like all the rows from here to the end of the IF
       // could be removed in favour of a simple check for whether the contact_type & id match


### PR DESCRIPTION
Overview
----------------------------------------
Remove isset to clarify that `$params['id']` is either a value or NULL


Before
----------------------------------------
To get to this point 

![image](https://user-images.githubusercontent.com/336308/169257762-66d89643-33d1-4bd6-a1e7-f02625343936.png)

the code must pass through this try -catch

![image](https://user-images.githubusercontent.com/336308/169257037-0c5d106c-9c4a-477a-b060-15dc8650d6ed.png)

so we 
a) know the array key exists
b) know that it is either NULL or an integer per the return values of `$this->lookupContactID`

After
----------------------------------------
Checking for truthy-ness makes it clear that if there is a value it is meaningful (not an empty string for example)

![image](https://user-images.githubusercontent.com/336308/169257680-16668e48-bda3-4761-91a6-4862cae1218f.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
