### PR TITLE
[Ref] Remove call to function that always returns the same thing

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -340,7 +340,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $createNewContact = FALSE;
       // @todo - it feels like all the rows from here to the end of the IF
       // could be removed in favour of a simple check for whether the contact_type & id match
-      $matchedIDs = $this->getIdsOfMatchingContacts($formatted);
+      $matchedIDs = [$params['id']];
       if (!empty($matchedIDs)) {
         if (count($matchedIDs) >= 1) {
           $updateflag = TRUE;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1098,32 +1098,6 @@ abstract class CRM_Import_Parser {
   }
 
   /**
-   * Get the ids of any contacts that match according to the rule.
-   *
-   * @param array $formatted
-   *
-   * @return array
-   */
-  protected function getIdsOfMatchingContacts(array $formatted):array {
-    if ($formatted['id'] ?? NULL) {
-      return [$formatted['id']];
-    }
-
-    // the call to the deprecated function seems to add no value other that to do an additional
-    // check for the contact_id & type.
-    $error = _civicrm_api3_deprecated_duplicate_formatted_contact($formatted);
-    if (!CRM_Core_Error::isAPIError($error, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
-      return [];
-    }
-    if (is_array($error['error_message']['params'][0])) {
-      return $error['error_message']['params'][0];
-    }
-    else {
-      return explode(',', $error['error_message']['params'][0]);
-    }
-  }
-
-  /**
    * Validate that the field requirements are met in the params.
    *
    * @param array $requiredFields


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Remove call to function that always returns the same thing

Before
----------------------------------------
We started doing a dedupe lookup earlier in the function which means that if there is a duplicate to be found by the time we get to

![image](https://user-images.githubusercontent.com/336308/169260769-4010d17f-44be-4457-a5c9-c694cc38a2d9.png)


it is already loaded at this point - so because of that & because of https://github.com/civicrm/civicrm-core/pull/23505 we can be sure that the value returned from `$this->getIdsOfMatchingContacts` would always be an array holding just the value of `$params['id']` - so we can bypass calling it...



![image](https://user-images.githubusercontent.com/336308/169259858-0dd62c10-24b8-4cf1-8182-78c3ebf121e9.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
The goal is to look up contacts to update ONLY IN ONE PLACE! ie `getPossibleContactMatch`

Comments
----------------------------------------
