### PR TITLE
[REF] Remove unreachable code

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -373,36 +373,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           }
         }
       }
-      else {
-        if (!empty($params['id'])) {
-          //validation of subtype for update mode
-          //CRM-5125
-          $contactSubType = NULL;
-          if (!empty($params['contact_sub_type'])) {
-            $contactSubType = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['id'], 'contact_sub_type');
-          }
-
-          if (!empty($contactSubType) && (!CRM_Contact_BAO_ContactType::isAllowEdit($params['id'], $contactSubType) && $contactSubType != CRM_Utils_Array::value('contact_sub_type', $formatted))) {
-
-            $message = "Mismatched contact SubTypes :";
-            array_unshift($values, $message);
-            $this->_retCode = CRM_Import_Parser::NO_MATCH;
-          }
-          else {
-            $newContact = $this->createContact($formatted, $contactFields, $onDuplicate, $params['id'], FALSE, $this->_dedupeRuleGroupID);
-            $this->_retCode = CRM_Import_Parser::VALID;
-          }
-        }
-        else {
-          //CRM-4148
-          //now we want to create new contact on update/fill also.
-          $createNewContact = TRUE;
-        }
-      }
-
-      if (isset($newContact) && is_a($newContact, 'CRM_Contact_BAO_Contact')) {
-        $relationship = TRUE;
-      }
     }
 
     //fixed CRM-4148


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Remove unreachable code

Before
----------------------------------------
The contents of this 'if' are unreachable - however important they pretend to be

![image](https://user-images.githubusercontent.com/336308/169261934-37784e7b-0744-4b1a-9db5-3c620b659283.png)

As we can see from https://github.com/civicrm/civicrm-core/pull/23505 - `$params['id']` is always an integer if we get this far  & hence per https://github.com/civicrm/civicrm-core/pull/23506 `$matchedIDs` is never empty if we get this far - so the `else` will never be accessed

After
----------------------------------------
poof

Technical Details
----------------------------------------
There is actually test cover here in the `Parser_ContactTest` class

The actual updates happen in the loop a little lower down....

![image](https://user-images.githubusercontent.com/336308/169262669-b1d0a27d-1eef-4cf4-b52b-876c921e882f.png)


Comments
----------------------------------------
