### PR TITLE
[Import] Fix & test check on contact subtype change

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -321,6 +321,16 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         throw new CRM_Core_Exception('Mismatched or Invalid Contact Subtype.', CRM_Import_Parser::NO_MATCH);
       }
       $params['id'] = $formatted['id'] = $this->lookupContactID($params, ($this->isSkipDuplicates() || $this->isIgnoreDuplicates()));
+      if ($params['id'] && $params['contact_sub_type']) {
+        $contactSubType = Contact::get(FALSE)
+          ->addWhere('id', '=', $params['id'])
+          ->addSelect('contact_sub_type')
+          ->execute()
+          ->first()['contact_sub_type'];
+        if (!empty($contactSubType) && $contactSubType[0] !== $params['contact_sub_type'] && !CRM_Contact_BAO_ContactType::isAllowEdit($params['id'], $contactSubType[0])) {
+          throw new CRM_Core_Exception('Mismatched contact SubTypes :', CRM_Import_Parser::NO_MATCH);
+        }
+      }
     }
     catch (CRM_Core_Exception $e) {
       $statuses = [CRM_Import_Parser::DUPLICATE => 'DUPLICATE', CRM_Import_Parser::ERROR => 'ERROR', CRM_Import_Parser::NO_MATCH => 'invalid_no_match'];
@@ -342,36 +352,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       // could be removed in favour of a simple check for whether the contact_type & id match
       $matchedIDs = $this->getIdsOfMatchingContacts($formatted);
       if (!empty($matchedIDs)) {
-        if (count($matchedIDs) >= 1) {
-          $updateflag = TRUE;
-          foreach ($matchedIDs as $contactId) {
-            if ($params['id'] == $contactId) {
-              //validation of subtype for update mode
-              //CRM-5125
-              $contactSubType = NULL;
-              if (!empty($params['contact_sub_type'])) {
-                $contactSubType = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $params['id'], 'contact_sub_type');
-              }
 
-              if (!empty($contactSubType) && (!CRM_Contact_BAO_ContactType::isAllowEdit($params['id'], $contactSubType) && $contactSubType != CRM_Utils_Array::value('contact_sub_type', $formatted))) {
-
-                $message = "Mismatched contact SubTypes :";
-                array_unshift($values, $message);
-                $updateflag = FALSE;
-                $this->_retCode = CRM_Import_Parser::NO_MATCH;
-              }
-              else {
-                $updateflag = FALSE;
-                $this->_retCode = CRM_Import_Parser::VALID;
-              }
-            }
-          }
-          if ($updateflag) {
-            $message = "Mismatched contact IDs OR Mismatched contact Types :";
-            array_unshift($values, $message);
-            $this->_retCode = CRM_Import_Parser::NO_MATCH;
-          }
-        }
       }
       else {
         if (!empty($params['id'])) {

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -273,6 +273,27 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   /**
    * Test updating an existing contact with external_identifier match but subtype mismatch.
    *
+   * The subtype is not updated, as there is conflicting contact data.
+   *
+   * @throws \Exception
+   */
+  public function testImportParserUpdateWithExternalIdentifierSubtypeChangeFail(): void {
+    $contactID = $this->individualCreate(['external_identifier' => 'billy', 'first_name' => 'William', 'contact_sub_type' => 'Parent']);
+    $this->addChild($contactID);
+
+    $this->runImport([
+      'external_identifier' => 'billy',
+      'nick_name' => 'Old Bill',
+      'contact_sub_type' => 'Staff',
+    ], CRM_Import_Parser::DUPLICATE_UPDATE, NULL);
+    $contact = $this->callAPISuccessGetSingle('Contact', ['id' => $contactID]);
+    $this->assertEquals('', $contact['nick_name']);
+    $this->assertEquals(['Parent'], $contact['contact_sub_type']);
+  }
+
+  /**
+   * Test updating an existing contact with external_identifier match but subtype mismatch.
+   *
    * @throws \Exception
    */
   public function testImportParserWithUpdateWithTypeMismatch(): void {


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Fix & test check on contact subtype change

- To replicate - create a Contact of Subtype 'Parent'. 
- Ensure that you have a relationship 'Parent of' where the contact sub type must be parent
- Give the parent a child
- Do an import with the parent's ID and a contact_subtype_field that is NOT parent. It *should* fail because you can't change the parent's subtype if doing so makes the relationship invalid

Before
----------------------------------------
Code existed to ensure that if you try to import a contact and the import would cause a contact subtype change then it would fail if the contact already had a relationship or custom data specific to their current type.

However, the code turned out to do .... nothing ... because it was doing an SQL query comparing the subtype name with the subtype name wrapped it our magic separators


After
----------------------------------------
Test added - functionality fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
