### PR TITLE
fix to get around link issues in ckeditor when opening scheduled remi…

### DIFF
--- a/CRM/Admin/Page/ScheduleReminders.php
+++ b/CRM/Admin/Page/ScheduleReminders.php
@@ -51,6 +51,7 @@ class CRM_Admin_Page_ScheduleReminders extends CRM_Core_Page_Basic {
       self::$_links = [
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
+          'class' => 'no-popup',
           'url' => 'civicrm/admin/scheduleReminders',
           'qs' => 'action=update&id=%%id%%&reset=1',
           'title' => ts('Edit Schedule Reminders'),


### PR DESCRIPTION
…nder in popup

Overview
----------------------------------------
We have ckeditor issues as mentioned https://lab.civicrm.org/extensions/ckeditor5/-/issues/5
We can get around this by not having the pop available as we cannot add hyperlinks in Scheduled Reminders when in a popup. The error is caused by jquery-validate as mentioned in the ticket.

Before
----------------------------------------
link doesn't work in popup

After
----------------------------------------
pop up gone, works fine.