### PR TITLE
[Ref] [Import] Cleanup function return

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1982,10 +1982,11 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param bool $dupeCheck
    * @param null|int $dedupeRuleGroupID
    *
+   * @return ?array
    * @throws \CRM_Core_Exception
    */
   public function deprecated_contact_check_params(
-    &$params,
+    $params,
     $dupeCheck = TRUE,
     $dedupeRuleGroupID = NULL) {
 
@@ -2004,12 +2005,17 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       // $dupes = civicrm_api3('Contact', 'duplicatecheck', (array('match' => $params, 'dedupe_rule_id' => $dedupeRuleGroupID)));
       // $ids = $dupes['count'] ? implode(',', array_keys($dupes['values'])) : NULL;
       $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, $params['contact_type'], 'Unsupervised', [], CRM_Utils_Array::value('check_permissions', $params), $dedupeRuleGroupID);
+
       if ($ids != NULL) {
-        $error = CRM_Core_Error::createError("Found matching contacts: " . implode(',', $ids),
-          CRM_Core_Error::DUPLICATE_CONTACT,
-          'Fatal', $ids
-        );
-        return civicrm_api3_create_error($error->pop());
+        return [
+          'is_error' => 1,
+          'error_message' => [
+            'code' => CRM_Core_Error::DUPLICATE_CONTACT,
+            'params' => $ids,
+            'level' => 'Fatal',
+            'message' => 'Found matching contacts: ' . implode(',', $ids),
+          ],
+        ];
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] [Import] Cleanup function return

Before
----------------------------------------
Hard to see what is actually being returned

![image](https://user-images.githubusercontent.com/336308/169400240-bfda9f04-ea5d-4ffd-b784-0d8c0d3bcd9b.png)


After
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/23474 - we've figured it out!

![image](https://user-images.githubusercontent.com/336308/169400408-9f8fd27d-2146-4e3b-9960-c3f50504376e.png)


Technical Details
----------------------------------------
The other 2 chunks of this function have open PRs to be removed - here https://github.com/civicrm/civicrm-core/pull/23509 and here https://github.com/civicrm/civicrm-core/pull/23491/files#diff-6381f637d7d41cb4ea44e8337383a8be3fb2f0c4ce894e8513981113fc2ea672L2042 - so clarifying what is going on for the last bit will allow us to fully unpack this deprecated function (that originated in v2 api)

Comments
----------------------------------------
