### PR TITLE
(dev/core#3436) MultipleRecordFieldsListing.tpl - JS strings should us JS escaping

### DIFF
--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -33,7 +33,7 @@
               {literal}
               <script type="text/javascript">
                 (function($) {
-                  var ZeroRecordText = {/literal}'{ts 1=$customGroupTitle|escape}No records of type \'%1\' found.{/ts}'{literal};
+                  var ZeroRecordText = {/literal}"{ts escape='js' 1=$customGroupTitle|smarty:nodefaults}No records of type '%1' found.{/ts}"{literal};
                   var $table = $('#records-' + {/literal}'{$customGroupId}'{literal});
                   $('table.crm-multifield-selector').data({
                     "ajax": {


### PR DESCRIPTION
Overview
----------------------------------------

Backport #23499 from 5.50-rc to 5.49-stable.

This doesn't require a new release. But if there is one, it would be fair to include.