### PR TITLE
[REF] Simplify contact.create

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -241,34 +241,31 @@ AND    domain_id = %2
           if ($config->userSystem->is_drupal) {
             $primary_email = $uniqId;
           }
-          elseif ($uf == 'WordPress') {
+          elseif ($uf === 'WordPress') {
             $primary_email = $user->user_email;
           }
           else {
             $primary_email = $user->email;
           }
-          $params = ['email-Primary' => $primary_email];
+          $params = ['email' => $primary_email];
         }
 
-        if ($ctype == 'Organization') {
+        if ($ctype === 'Organization') {
           $params['organization_name'] = $uniqId;
         }
-        elseif ($ctype == 'Household') {
+        elseif ($ctype === 'Household') {
           $params['household_name'] = $uniqId;
         }
 
-        if (!$ctype) {
-          $ctype = "Individual";
-        }
-        $params['contact_type'] = $ctype;
+        $params['contact_type'] = $ctype ?? 'Individual';
 
         // extract first / middle / last name
         // for joomla
-        if ($uf == 'Joomla' && $user->name) {
+        if ($uf === 'Joomla' && $user->name) {
           CRM_Utils_String::extractName($user->name, $params);
         }
 
-        if ($uf == 'WordPress') {
+        if ($uf === 'WordPress') {
           if ($user->first_name) {
             $params['first_name'] = $user->first_name;
           }
@@ -278,7 +275,7 @@ AND    domain_id = %2
           }
         }
 
-        $contactId = CRM_Contact_BAO_Contact::createProfileContact($params);
+        $contactId = civicrm_api3('Contact', 'create', $params)['id'];
         $ufmatch->contact_id = $contactId;
         $ufmatch->uf_name = $uniqId;
       }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Simplify contact.create

Before
----------------------------------------
The very complicated & unpredictable `profileCreate` function is used

After
----------------------------------------
api v3 `contact.create` is used 

Technical Details
----------------------------------------
Browsing the function we can see the params are very straight forward so this is a solid drop in replacement here

I didn't use v4 because it's a PITA when you have `email` as a param 

Comments
----------------------------------------
