### PR TITLE
dev/core#3177 Switch sms to use flexmailer token rendering

### DIFF
--- a/CRM/Mailing/BAO/SMSJob.php
+++ b/CRM/Mailing/BAO/SMSJob.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Job for SMS deliery functions.
+ */
+class CRM_Mailing_BAO_SMSJob extends CRM_Mailing_BAO_MailingJob {
+
+  /**
+   * This is used by CiviMail but will be made redundant by FlexMailer.
+   * @param array $fields
+   *   List of intended recipients.
+   *   Each recipient is an array with keys 'hash', 'contact_id', 'email', etc.
+   * @param $mailing
+   * @param $mailer
+   * @param $job_date
+   * @param $attachments
+   *
+   * @return bool|null
+   * @throws Exception
+   */
+  public function deliverGroup(&$fields, &$mailing, &$mailer, &$job_date, &$attachments) {
+    $count = 0;
+    // dev/core#1768 Get the mail sync interval.
+    $mail_sync_interval = Civi::settings()->get('civimail_sync_interval');
+    $retryGroup = FALSE;
+
+    foreach ($fields as $field) {
+      $contact = civicrm_api3('Contact', 'getsingle', ['id' => $field['contact_id']]);
+
+      $preview = civicrm_api3('Mailing', 'preview', [
+        'id' => $mailing->id,
+        'contact_id' => $field['contact_id'],
+      ])['values'];
+      $mailParams = [
+        'text' => $preview['body_text'],
+        'toName' => $contact['display_name'],
+        'job_id' => $this->id,
+      ];
+      CRM_Utils_Hook::alterMailParams($mailParams, 'civimail');
+      $body = $mailParams['text'];
+      $headers = ['To' => $field['phone']];
+
+      try {
+        $result = $mailer->send($headers['To'], $headers, $body, $this->id);
+
+        // Register the delivery event.
+        $deliveredParams[] = $field['id'];
+        $targetParams[] = $field['contact_id'];
+
+        $count++;
+        // dev/core#1768 Mail sync interval is now configurable.
+        if ($count % $mail_sync_interval == 0) {
+          $this->writeToDB(
+            $deliveredParams,
+            $targetParams,
+            $mailing,
+            $job_date
+          );
+          $count = 0;
+
+          // hack to stop mailing job at run time, CRM-4246.
+          // to avoid making too many DB calls for this rare case
+          // lets do it when we snapshot
+          $status = CRM_Core_DAO::getFieldValue(
+            'CRM_Mailing_DAO_MailingJob',
+            $this->id,
+            'status',
+            'id',
+            TRUE
+          );
+
+          if ($status !== 'Running') {
+            return FALSE;
+          }
+        }
+      }
+      catch (CRM_Core_Exception $e) {
+        // Handle SMS errors: CRM-15426
+        $job_id = (int) $this->id;
+        $mailing_id = (int) $mailing->id;
+        CRM_Core_Error::debug_log_message("Failed to send SMS message. Vars: mailing_id: ${mailing_id}, job_id: ${job_id}. Error message follows.");
+        CRM_Core_Error::debug_log_message($e->getMessage());
+      }
+
+      unset($result);
+
+      // If we have enabled the Throttle option, this is the time to enforce it.
+      $mailThrottleTime = Civi::settings()->get('mailThrottleTime');
+      if (!empty($mailThrottleTime)) {
+        usleep((int ) $mailThrottleTime);
+      }
+    }
+
+    $result = $this->writeToDB(
+      $deliveredParams,
+      $targetParams,
+      $mailing,
+      $job_date
+    );
+
+    if ($retryGroup) {
+      return FALSE;
+    }
+
+    return $result;
+  }
+
+}

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -150,7 +150,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     $mailing = $result['values'] ?? NULL;
 
     $title = NULL;
-    if (isset($mailing['body_html']) && empty($_GET['text'])) {
+    if (!empty($mailing['body_html']) && empty($_GET['text'])) {
       $header = 'text/html; charset=utf-8';
       $content = $mailing['body_html'];
       if (strpos($content, '<head>') === FALSE && strpos($content, '<title>') === FALSE) {

--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -84,38 +84,6 @@ abstract class CRM_SMS_Provider {
   abstract public function send($recipients, $header, $message, $dncID = NULL);
 
   /**
-   * Return message text.
-   *
-   * Child class could override this function to have better control over the message being sent.
-   *
-   * @param Mail_mime $message
-   * @param int $contactID
-   * @param array $contactDetails
-   *
-   * @return string
-   */
-  public function getMessage($message, $contactID, $contactDetails) {
-    $html = $message->getHTMLBody();
-    $text = $message->getTXTBody();
-
-    return $html ? $html : $text;
-  }
-
-  /**
-   * Get recipient details.
-   *
-   * @param array $fields
-   * @param array $additionalDetails
-   *
-   * @return mixed
-   */
-  public function getRecipientDetails($fields, $additionalDetails) {
-    // we could do more altering here
-    $fields['To'] = $fields['phone'];
-    return $fields;
-  }
-
-  /**
    * @param int $apiMsgID
    * @param $message
    * @param array $headers

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -554,11 +554,11 @@ function civicrm_api3_mailing_preview($params) {
   $mailingParams = ['contact_id' => $contactID];
 
   if (!$contactID) {
-    $details = CRM_Utils_Token::getAnonymousTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+    $details = CRM_Utils_Token::getAnonymousTokenDetails($mailingParams, $returnProperties, empty($mailing->sms_provider_id), TRUE, NULL, $mailing->getFlattenedTokens());
     $details = $details[0][0] ?? NULL;
   }
   else {
-    [$details] = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, TRUE, TRUE, NULL, $mailing->getFlattenedTokens());
+    [$details] = CRM_Utils_Token::getTokenDetails($mailingParams, $returnProperties, empty($mailing->sms_provider_id), TRUE, NULL, $mailing->getFlattenedTokens());
     $details = $details[$contactID];
   }
 

--- a/ext/flexmailer/src/API/MailingPreview.php
+++ b/ext/flexmailer/src/API/MailingPreview.php
@@ -33,7 +33,7 @@ class MailingPreview {
       $mailing->copyValues($params);
     }
 
-    if (!Abdicator::isFlexmailPreferred($mailing)) {
+    if (!Abdicator::isFlexmailPreferred($mailing) && empty($mailing->sms_provider_id)) {
       require_once 'api/v3/Mailing.php';
       return civicrm_api3_mailing_preview($params);
     }

--- a/ext/flexmailer/src/Listener/DefaultComposer.php
+++ b/ext/flexmailer/src/Listener/DefaultComposer.php
@@ -57,7 +57,7 @@ class DefaultComposer extends BaseListener {
       $this->createTokenProcessorContext($e));
 
     $tpls = $this->createMessageTemplates($e);
-    $tp->addMessage('subject', $tpls['subject'], 'text/plain');
+    $tp->addMessage('subject', $tpls['subject'] ?? '', 'text/plain');
     $tp->addMessage('body_text', isset($tpls['text']) ? $tpls['text'] : '',
       'text/plain');
     $tp->addMessage('body_html', isset($tpls['html']) ? $tpls['html'] : '',

--- a/tests/phpunit/CRM/SMS/PreviewTest.php
+++ b/tests/phpunit/CRM/SMS/PreviewTest.php
@@ -27,7 +27,7 @@ class CRM_SMS_PreviewTest extends CiviUnitTestCase {
   /**
    * Test SMS preview.
    */
-  public function testSMSPreview() {
+  public function testSMSPreview(): void {
     $result = $this->callAPISuccess('SmsProvider', 'create', [
       'title' => 'test SMS provider',
       'username' => 'test',
@@ -41,10 +41,10 @@ class CRM_SMS_PreviewTest extends CiviUnitTestCase {
     $provider_id = $result['id'];
     $result = $this->callAPISuccess('Mailing', 'create', [
       'name' => "Test1",
-      'from_name' => "+12223334444",
-      'from_email' => "test@test.com",
+      'from_name' => '+12223334444',
+      'from_email' => 'test@test.com',
       'replyto_email' => "test@test.com",
-      'body_text' => "Testing body",
+      'body_text' => 'Testing body',
       'sms_provider_id' => $provider_id,
       'header_id' => NULL,
       'footer_id' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3177 Switch sms to use flexmailer token rendering

Note that I have only been able to do limited testing on this so it needs much more robust testing

I found that what I COULD do was
1) install twillio https://civicrm.org/extensions/twilio-sms-provider
2) add a new SMS provider - with made up credentials
3) Make sure users have the 'Create SMS' permission
4) At this point I could create mass mailings and 'send' them - I have no idea what happened to them when sent - I was just inspecting the values up until the send was hit 

UPDATE - look what I found - https://github.com/3sd/io.3sd.dummysms - haven't tried it though

Before
----------------------------------------
Regardless of whether flexmailer is installed tokens for SMS are rendered through smarty

After
----------------------------------------
I think the answer is to split out SMS processing from Mailing Job processing. To this end I have Created a new class `SMSJob` that extends `MailingJob` and overrides the `deliverGroup` function with one that does only the much lesser amount of work that is required for SMS - which really just needs body-text & a phone number it seems

Technical Details
----------------------------------------
I suspect that when flexmailer is NOT installed this will result in a loop - options are to use tokenProcessor directly, not `mailing_preview` api or to simply call `parent::deliverGroup` absent flexmailer. Note that I didn't see any evidence of the `SMS` screen offering any non-contact tokens so the latter might be fine

Comments
----------------------------------------
@totten @seamuslee001 
