### PR TITLE
[REF] Move list of fields that have been upgraded

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -82,6 +82,20 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   protected $fieldMetadata = [];
 
   /**
+   * Fields which are being handled by metadata formatting & validation functions.
+   *
+   * This is intended as a temporary parameter as we phase in metadata handling.
+   *
+   * The end result is that all fields will be & this will go but for now it is
+   * opt in.
+   *
+   * @var array
+   */
+  protected $metadataHandledFields = [
+    'gender_id',
+  ];
+
+  /**
    * Relationship labels.
    *
    * Temporary cache of labels to reduce queries in getRelationshipLabels.

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -54,6 +54,18 @@ abstract class CRM_Import_Parser {
   protected $userJobID;
 
   /**
+   * Fields which are being handled by metadata formatting & validation functions.
+   *
+   * This is intended as a temporary parameter as we phase in metadata handling.
+   *
+   * The end result is that all fields will be & this will go but for now it is
+   * opt in.
+   *
+   * @var array
+   */
+  protected $metadataHandledFields = [];
+
+  /**
    * @return int|null
    */
   public function getUserJobID(): ?int {
@@ -1186,8 +1198,8 @@ abstract class CRM_Import_Parser {
    * @throws \API_Exception
    */
   protected function getTransformedFieldValue(string $fieldName, $importedValue) {
-    // For now only do gender_id as we need to work through removing duplicate handling
-    if ($fieldName !== 'gender_id' || empty($importedValue)) {
+    // For now only do gender_id etc as we need to work through removing duplicate handling
+    if (empty($importedValue) || !in_array($fieldName, $this->metadataHandledFields, TRUE)) {
       return $importedValue;
     }
     return $this->getFieldOptions($fieldName)[$importedValue] ?? 'invalid_import_value';


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Move list of fields that have been upgraded

Before
----------------------------------------
list of fields which have been 'upgraded' to support metadata-based formatting and validation are in-line

After
----------------------------------------
list of fields which have been 'upgraded' to support metadata-based formatting and validation are in an array

Technical Details
----------------------------------------
The list only contains 'gender_id' so far - but there are several PRs that attempt to add to it as other fields are tested & verifed & they all conflict...

Comments
----------------------------------------
At least with an array there is 'before' and 'after' so not every PR will conflict