### PR TITLE
[Import] Fix Contribution Import mapping fields to use labels

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -15,8 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Api4\MappingField;
-
 /**
  * This class gets the name of the file to upload.
  */
@@ -458,7 +456,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     //Updating Mapping Records
     if (!empty($params['updateMapping'])) {
-      for ($i = 0; $i < $this->_columnCount; $i++) {
+      foreach (array_keys($this->getColumnHeaders()) as $i) {
         $this->saveMappingField($params['mappingId'], $i, TRUE);
       }
     }
@@ -487,46 +485,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       CRM_Import_Parser::MODE_PREVIEW
     );
     return $parser;
-  }
-
-  /**
-   * Save the mapping field.
-   *
-   * @param int $mappingID
-   * @param int $columnNumber
-   * @param bool $isUpdate
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   */
-  protected function saveMappingField(int $mappingID, int $columnNumber, bool $isUpdate = FALSE): void {
-    $fieldMapping = (array) $this->getSubmittedValue('mapper')[$columnNumber];
-    $mappedField = $this->getMappedField($fieldMapping, $mappingID, $columnNumber);
-    if ($isUpdate) {
-      MappingField::update(FALSE)
-        ->setValues($mappedField)
-        ->addWhere('column_number', '=', $columnNumber)
-        ->addWhere('mapping_id', '=', $mappingID)
-        ->execute();
-    }
-    else {
-      MappingField::create(FALSE)
-        ->setValues($mappedField)->execute();
-    }
-  }
-
-  /**
-   * Get the field mapped to the savable format.
-   *
-   * @param array $fieldMapping
-   * @param int $mappingID
-   * @param int $columnNumber
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  protected function getMappedField(array $fieldMapping, int $mappingID, int $columnNumber): array {
-    return (new CRM_Contact_Import_Parser_Contact())->setContactType($this->getContactType())->getMappingFieldFromMapperInput($fieldMapping, $mappingID, $columnNumber);
   }
 
   /**
@@ -593,6 +551,15 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       Civi::$statics[__CLASS__]['location_fields'] = (new CRM_Contact_Import_Parser_Contact())->setUserJobID($this->getUserJobID())->getSelectTypes();
     }
     return (bool) (Civi::$statics[__CLASS__]['location_fields'][$name] ?? FALSE);
+  }
+
+  /**
+   * @return \CRM_Contact_Import_Parser_Contact
+   */
+  protected function getParser(): CRM_Contact_Import_Parser_Contact {
+    $parser = new CRM_Contact_Import_Parser_Contact();
+    $parser->setUserJobID($this->getUserJobID());
+    return $parser;
   }
 
 }

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -261,4 +261,13 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     return $mapper;
   }
 
+  /**
+   * @return \CRM_Contact_Import_Parser_Contact
+   */
+  protected function getParser(): CRM_Contact_Import_Parser_Contact {
+    $parser = new CRM_Contact_Import_Parser_Contact();
+    $parser->setUserJobID($this->getUserJobID());
+    return $parser;
+  }
+
 }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -182,45 +182,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * Gets the fields available for importing in a key-name, title format.
-   *
-   * @return array
-   *   eg. ['first_name' => 'First Name'.....]
-   *
-   * @throws \API_Exception
-   *
-   * @todo - we are constructing the metadata before we
-   * have set the contact type so we re-do it here.
-   *
-   * Once we have cleaned up the way the mapper is handled
-   * we can ditch all the existing _construct parameters in favour
-   * of just the userJobID - there are current open PRs towards this end.
-   */
-  public function getAvailableFields(): array {
-    $this->setFieldMetadata();
-    $return = [];
-    foreach ($this->getImportableFieldsMetadata() as $name => $field) {
-      if ($name === 'id' && $this->isSkipDuplicates()) {
-        // Duplicates are being skipped so id matching is not availble.
-        continue;
-      }
-      $return[$name] = $field['title'];
-    }
-    return $return;
-  }
-
-  /**
-   * Did the user specify duplicates should be skipped and not imported.
-   *
-   * @return bool
-   *
-   * @throws \API_Exception
-   */
-  private function isSkipDuplicates(): bool {
-    return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_SKIP;
-  }
-
-  /**
    * Did the user specify duplicates checking should be skipped, resulting in possible duplicate contacts.
    *
    * Note we still need to check for external_identifier as it will hard-fail

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -193,4 +193,44 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return '';
   }
 
+  /**
+   * Get the field mapped to the savable format.
+   *
+   * @param array $fieldMapping
+   * @param int $mappingID
+   * @param int $columnNumber
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function getMappedField(array $fieldMapping, int $mappingID, int $columnNumber): array {
+    return $this->getParser()->getMappingFieldFromMapperInput($fieldMapping, $mappingID, $columnNumber);
+  }
+
+  /**
+   * Save the mapping field.
+   *
+   * @param int $mappingID
+   * @param int $columnNumber
+   * @param bool $isUpdate
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function saveMappingField(int $mappingID, int $columnNumber, bool $isUpdate = FALSE): void {
+    $fieldMapping = (array) $this->getSubmittedValue('mapper')[$columnNumber];
+    $mappedField = $this->getMappedField($fieldMapping, $mappingID, $columnNumber);
+    if ($isUpdate) {
+      Civi\Api4\MappingField::update(FALSE)
+        ->setValues($mappedField)
+        ->addWhere('column_number', '=', $columnNumber)
+        ->addWhere('mapping_id', '=', $mappingID)
+        ->execute();
+    }
+    else {
+      Civi\Api4\MappingField::create(FALSE)
+        ->setValues($mappedField)->execute();
+    }
+  }
+
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -550,9 +550,16 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \API_Exception
    */
   protected function getAvailableFields(): array {
-    $parser = new CRM_Contact_Import_Parser_Contact();
-    $parser->setUserJobID($this->getUserJobID());
-    return $parser->getAvailableFields();
+    return $this->getParser()->getAvailableFields();
+  }
+
+  /**
+   * Get an instance of the parser class.
+   *
+   * @return \CRM_Contact_Import_Parser_Contact|\CRM_Contribute_Import_Parser_Contribution
+   */
+  protected function getParser() {
+    return NULL;
   }
 
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -262,6 +262,45 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Gets the fields available for importing in a key-name, title format.
+   *
+   * @return array
+   *   eg. ['first_name' => 'First Name'.....]
+   *
+   * @throws \API_Exception
+   *
+   * @todo - we are constructing the metadata before we
+   * have set the contact type so we re-do it here.
+   *
+   * Once we have cleaned up the way the mapper is handled
+   * we can ditch all the existing _construct parameters in favour
+   * of just the userJobID - there are current open PRs towards this end.
+   */
+  public function getAvailableFields(): array {
+    $this->setFieldMetadata();
+    $return = [];
+    foreach ($this->getImportableFieldsMetadata() as $name => $field) {
+      if ($name === 'id' && $this->isSkipDuplicates()) {
+        // Duplicates are being skipped so id matching is not availble.
+        continue;
+      }
+      $return[$name] = $field['title'];
+    }
+    return $return;
+  }
+
+  /**
+   * Did the user specify duplicates should be skipped and not imported.
+   *
+   * @return bool
+   *
+   * @throws \API_Exception
+   */
+  protected function isSkipDuplicates(): bool {
+    return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_SKIP;
+  }
+
+  /**
    * Array of the fields that are actually part of the import process
    * the position in the array also dictates their position in the import
    * file


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Fix Contribution Import mapping fields to use labels 

This is already done for Contact imports in 5.50 but not for the others.

A ot of the code in this PR is to move the code for contact to where it can be re-used by another class

Before
----------------------------------------
Labels are saved as 'name' to civicrm_mapping_field

![image](https://user-images.githubusercontent.com/336308/169460436-d4f27de5-6d3c-40c2-9f7a-2d9b10bd60e0.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/169463838-7f53c9c4-d00a-4f6b-b2c9-f11c520e4e9c.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
