### PR TITLE
Deprecate stuff getting super deep into the BAO unformatted

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -275,9 +275,19 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
       ])) {
         $date = $date . '-01-01';
       }
-      $contact->birth_date = CRM_Utils_Date::processDate($date);
+      $processedDate = CRM_Utils_Date::processDate($date);
+      $existing = substr(str_replace('-', '', $contact->birth_date), 0, 8) . '000000';
+      // By adding this check here we can rip out this whole routine in a few
+      // months after confirming it actually does nothing, ever.
+      if ($existing !== $processedDate) {
+        CRM_Core_Error::deprecatedWarning('birth_date formatting should happen before BAO is hit');
+        $contact->birth_date = $processedDate;
+      }
     }
     elseif ($contact->birth_date) {
+      if ($contact->birth_date !== CRM_Utils_Date::isoToMysql($contact->birth_date)) {
+        CRM_Core_Error::deprecatedWarning('birth date formatting should happen before BAO is hit');
+      }
       $contact->birth_date = CRM_Utils_Date::isoToMysql($contact->birth_date);
     }
 
@@ -307,14 +317,26 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
       ])) {
         $date = $date . '-01-01';
       }
-
+      $processedDate = CRM_Utils_Date::processDate($date);
+      $existing = substr(str_replace('-', '', $contact->deceased_date), 0, 8) . '000000';
+      // By adding this check here we can rip out this whole routine in a few
+      // months after confirming it actually does nothing, ever.
+      if ($existing !== $processedDate) {
+        CRM_Core_Error::deprecatedWarning('deceased formatting should happen before BAO is hit');
+      }
       $contact->deceased_date = CRM_Utils_Date::processDate($date);
     }
     elseif ($contact->deceased_date) {
+      if ($contact->deceased_date !== CRM_Utils_Date::isoToMysql($contact->deceased_date)) {
+        CRM_Core_Error::deprecatedWarning('deceased date formatting should happen before BAO is hit');
+      }
       $contact->deceased_date = CRM_Utils_Date::isoToMysql($contact->deceased_date);
     }
 
     if ($middle_name = CRM_Utils_Array::value('middle_name', $params)) {
+      if ($middle_name !== $contact->middle_name) {
+        CRM_Core_Error::deprecatedWarning('random magic is deprecated - how could this be true');
+      }
       $contact->middle_name = $middle_name;
     }
 

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -76,7 +76,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contactId = $contact->id;
 
     $this->assertInstanceOf('CRM_Contact_DAO_Contact', $contact, 'Check for created object');
-
+    $createdContact = $this->callAPISuccessGetSingle('Contact', ['id' => $contact->id]);
     $this->assertEquals($params['first_name'], $contact->first_name, 'Check for first name creation.');
     $this->assertEquals($params['last_name'], $contact->last_name, 'Check for last name creation.');
     $this->assertEquals($params['middle_name'], $contact->middle_name, 'Check for middle name creation.');
@@ -94,14 +94,10 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $this->assertEquals($params['suffix_id'], $contact->suffix_id, 'Check for suffix_id creation.');
     $this->assertEquals($params['job_title'], $contact->job_title, 'Check for job_title creation.');
     $this->assertEquals($params['gender_id'], $contact->gender_id, 'Check for gender_id creation.');
-    $this->assertEquals('1', $contact->is_deceased, 'Check for is_deceased creation.');
-    $this->assertEquals(CRM_Utils_Date::processDate($params['birth_date']),
-      $contact->birth_date, 'Check for birth_date creation.'
-    );
-    $this->assertEquals(CRM_Utils_Date::processDate($params['deceased_date']),
-      $contact->deceased_date, 'Check for deceased_date creation.'
-    );
     $this->assertEquals('135', $contact->preferred_communication_method);
+    $this->assertEquals(1, $createdContact['is_deceased'], 'Check is_deceased');
+    $this->assertEquals('1961-06-06', $createdContact['birth_date'], 'Check birth_date');
+    $this->assertEquals('1991-07-07', $createdContact['deceased_date'], 'Check deceased_date');
 
     $updateParams = [
       'contact_type' => 'Individual',


### PR DESCRIPTION
Overview
----------------------------------------
Could these lines really be still doing stuff? Thie function is ONLY called from `BAO_Contact::create`