### PR TITLE
Ensure setting deceased date sets is_deceased in the BAO

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -138,6 +138,9 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
     }
     $params = array_merge($defaults, $params);
 
+    if (!empty($params['deceased_date']) && $params['deceased_date'] !== 'null') {
+      $params['is_deceased'] = TRUE;
+    }
     $allNull = $contact->copyValues($params);
 
     $contact->id = $contactID;

--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -67,8 +67,6 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
       $params['individual_suffix'] = $suffix = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'suffix_id', $suffix_id);
     }
 
-    $params['is_deceased'] = CRM_Utils_Array::value('is_deceased', $params, FALSE);
-
     $individual = NULL;
     if ($contact->id) {
       $individual = new CRM_Contact_BAO_Contact();


### PR DESCRIPTION
Overview
----------------------------------------
Ensure setting deceased date sets is_deceased in the BAO

Before
----------------------------------------
Setting deceased date in the api does not set is_deceased to TRUE

`drush @dmaster cvapi Contact.create deceased_date=2020-01-01 id=2`

After
----------------------------------------
No more life after death

Technical Details
----------------------------------------

Comments
----------------------------------------
