### PR TITLE
Upgrader - Add support for automatic snapshots

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -539,7 +539,7 @@ SET    version = '$version'
     if (empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
       $task = new CRM_Queue_Task(
         ['CRM_Upgrade_Snapshot', 'cleanupTask'],
-        [],
+        ['core'],
         "Cleanup old upgrade snapshots"
       );
       $queue->createItem($task, ['weight' => 0]);

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -539,7 +539,7 @@ SET    version = '$version'
     if (empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
       $task = new CRM_Queue_Task(
         ['CRM_Upgrade_Snapshot', 'cleanupTask'],
-        ['core'],
+        ['civicrm'],
         "Cleanup old upgrade snapshots"
       );
       $queue->createItem($task, ['weight' => 0]);

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -536,6 +536,15 @@ SET    version = '$version'
     );
     $queue->createItem($task, ['weight' => 0]);
 
+    if (empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
+      $task = new CRM_Queue_Task(
+        ['CRM_Upgrade_Snapshot', 'cleanupTask'],
+        [],
+        "Cleanup old upgrade snapshots"
+      );
+      $queue->createItem($task, ['weight' => 0]);
+    }
+
     $task = new CRM_Queue_Task(
       ['CRM_Upgrade_Form', 'disableOldExtensions'],
       [$postUpgradeMessageFile],

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -159,6 +159,36 @@ class CRM_Upgrade_Incremental_Base {
   }
 
   /**
+   * Add a task to store a snapshot of some data (if upgrade-snapshots are supported).
+   *
+   * If there is a large amount of data, this may actually add multiple tasks.
+   *
+   * Ex :$this->addSnapshotTask('event_dates', CRM_Utils_SQL_Select::from('civicrm_event')
+   *      ->select('id, start_date, end_date'));
+   *
+   * @param string $name
+   *   Logical name for the snapshot. This will become part of the table.
+   * @param \CRM_Utils_SQL_Select $select
+   * @throws \CRM_Core_Exception
+   */
+  protected function addSnapshotTask(string $name, CRM_Utils_SQL_Select $select): void {
+    if (!preg_match(';^[a-z0-9_]+$;', $name)) {
+      throw new \CRM_Core_Exception("Malformed snapshot name: $name");
+    }
+    if (!empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
+      return;
+    }
+
+    $queue = CRM_Queue_Service::singleton()->load([
+      'type' => 'Sql',
+      'name' => CRM_Upgrade_Form::QUEUE_NAME,
+    ]);
+    foreach (CRM_Upgrade_Snapshot::createTasks($this->getMajorMinor(), $name, $select) as $task) {
+      $queue->createItem($task, ['weight' => -1]);
+    }
+  }
+
+  /**
    * Add a task to activate an extension. This task will run post-upgrade (after all
    * changes to core DB are settled).
    *

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -172,7 +172,7 @@ class CRM_Upgrade_Incremental_Base {
    * @throws \CRM_Core_Exception
    */
   protected function addSnapshotTask(string $name, CRM_Utils_SQL_Select $select): void {
-    CRM_Upgrade_Snapshot::createTableName('core', $this->getMajorMinor(), $name);
+    CRM_Upgrade_Snapshot::createTableName('civicrm', $this->getMajorMinor(), $name);
     // ^^ To simplify QA -- we should always throw an exception for bad snapshot names, even if the local policy doesn't use snapshots.
 
     if (!empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
@@ -183,7 +183,7 @@ class CRM_Upgrade_Incremental_Base {
       'type' => 'Sql',
       'name' => CRM_Upgrade_Form::QUEUE_NAME,
     ]);
-    foreach (CRM_Upgrade_Snapshot::createTasks('core', $this->getMajorMinor(), $name, $select) as $task) {
+    foreach (CRM_Upgrade_Snapshot::createTasks('civicrm', $this->getMajorMinor(), $name, $select) as $task) {
       $queue->createItem($task, ['weight' => -1]);
     }
   }

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -172,9 +172,9 @@ class CRM_Upgrade_Incremental_Base {
    * @throws \CRM_Core_Exception
    */
   protected function addSnapshotTask(string $name, CRM_Utils_SQL_Select $select): void {
-    if (!preg_match(';^[a-z0-9_]+$;', $name)) {
-      throw new \CRM_Core_Exception("Malformed snapshot name: $name");
-    }
+    CRM_Upgrade_Snapshot::createTableName('core', $this->getMajorMinor(), $name);
+    // ^^ To simplify QA -- we should always throw an exception for bad snapshot names, even if the local policy doesn't use snapshots.
+
     if (!empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
       return;
     }
@@ -183,7 +183,7 @@ class CRM_Upgrade_Incremental_Base {
       'type' => 'Sql',
       'name' => CRM_Upgrade_Form::QUEUE_NAME,
     ]);
-    foreach (CRM_Upgrade_Snapshot::createTasks($this->getMajorMinor(), $name, $select) as $task) {
+    foreach (CRM_Upgrade_Snapshot::createTasks('core', $this->getMajorMinor(), $name, $select) as $task) {
       $queue->createItem($task, ['weight' => -1]);
     }
   }

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -140,6 +140,10 @@ class CRM_Upgrade_Incremental_General {
           function($issue) {
             return sprintf('<li>%s</li>', $issue);
           }, $snapshotIssues)) . '</ul>';
+      $preUpgradeMessage .= '<p>' . ts('You may enable snapshots in "<code>%1</code>" by setting the experimental option "<code>%2</code>".', [
+        1 => 'civicrm.settings.php',
+        2 => htmlentities('define(\'CIVICRM_UPGRADE_SNAPSHOT\', TRUE)'),
+      ]) . '</p>';
       $preUpgradeMessage .= '</details>';
     }
   }

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -129,6 +129,19 @@ class CRM_Upgrade_Incremental_General {
         2 => 'https://github.com/JMAConsulting/biz.jmaconsulting.financialaclreport',
       ]);
     }
+
+    $snapshotIssues = CRM_Upgrade_Snapshot::getActivationIssues();
+    if ($snapshotIssues) {
+      $preUpgradeMessage .= '<details>';
+      $preUpgradeMessage .= '<summary>' . ts('This upgrade will NOT use automatic snapshots.') . '</summary>';
+      $preUpgradeMessage .= '<p>' . ts('If an upgrade problem is discovered in the future, automatic snapshots may help recover. However, they also require additional storage and may not be available or appropriate in all configurations.') . '</p>';
+      $preUpgradeMessage .= ts('Here are the reasons why automatic snapshots are disabled:');
+      $preUpgradeMessage .= '<ul>' . implode("", array_map(
+          function($issue) {
+            return sprintf('<li>%s</li>', $issue);
+          }, $snapshotIssues)) . '</ul>';
+      $preUpgradeMessage .= '</details>';
+    }
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FiveFifty.php
+++ b/CRM/Upgrade/Incremental/php/FiveFifty.php
@@ -21,6 +21,17 @@
  */
 class CRM_Upgrade_Incremental_php_FiveFifty extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    parent::setPreUpgradeMessage($preUpgradeMessage, $rev, $currentVer);
+    if ($rev === '5.50.alpha1') {
+      $preUpgradeMessage = '<p>' . ts('To improve data-protection, CiviCRM (5.50+) may create snapshots of upgraded data ("snap_*" tables). The upgrader will automatically prune old snapshots. The "snap_*" tables should generally follow the same backup/replication rules as other MySQL tables, but advanced administrators may fine-tune per preference.') . '</p>'
+        . $preUpgradeMessage;
+      // The issue here is that most backup/replication rules are per-database (eg `mysqldump DB_NAME`), but some
+      // systems have special filters in their backup configuration (eg `civicrm_*` vs `civicrm_tmp_*` vs `log_civicrm_*`).
+      // We want to let these users know there's a change -- without scaring the regular users who don't have that.
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *

--- a/CRM/Upgrade/Incremental/php/FiveFifty.php
+++ b/CRM/Upgrade/Incremental/php/FiveFifty.php
@@ -28,6 +28,8 @@ class CRM_Upgrade_Incremental_php_FiveFifty extends CRM_Upgrade_Incremental_Base
    *   The version number matching this function name
    */
   public function upgrade_5_50_alpha1($rev): void {
+    $this->addSnapshotTask('mappings', CRM_Utils_SQL_Select::from('civicrm_mapping'));
+    $this->addSnapshotTask('fields', CRM_Utils_SQL_Select::from('civicrm_mapping_field'));
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask(ts('Convert import mappings to use names'), 'convertMappingFieldLabelsToNames', $rev);
 

--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -119,7 +119,8 @@ class CRM_Upgrade_Snapshot {
         'MIN' => $offset,
         'MAX' => $offset + $pageSize,
       ]);
-      $sqlAction = ($offset === 0) ? "CREATE TABLE {$destTable} AS " : "INSERT INTO {$destTable} ";
+      $sqlAction = ($offset === 0) ? "CREATE TABLE {$destTable} ROW_FORMAT=COMPRESSED AS " : "INSERT INTO {$destTable} ";
+      // Note: 'CREATE TABLE AS' implicitly preserves the character-set of the source-material, so we don't set that explicitly.
       yield new CRM_Queue_Task(
         [static::class, 'insertSnapshotTask'],
         [$sqlAction . $pageSelect->toSQL()],

--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -40,7 +40,10 @@ class CRM_Upgrade_Snapshot {
    */
   public static function getActivationIssues(): array {
     if (static::$activationIssues === NULL) {
-      // TODO This policy should probably be more configurable, eg via `setting` or `define()`.
+      $policy = CRM_Utils_Constant::value('CIVICRM_UPGRADE_SNAPSHOT', 'auto');
+      if ($policy === TRUE) {
+        return [];
+      }
 
       $limits = [
         'civicrm_contact' => 200 * 1000,
@@ -70,6 +73,10 @@ class CRM_Upgrade_Snapshot {
 
       if (CRM_Core_I18n::isMultilingual()) {
         static::$activationIssues['multilingual'] = ts('Multilingual snapshots have not been implemented.');
+      }
+
+      if ($policy === FALSE) {
+        static::$activationIssues['override'] = ts('Snapshots disabled by override (CIVICRM_UPGRADE_SNAPSHOT).');
       }
     }
 

--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -81,13 +81,13 @@ class CRM_Upgrade_Snapshot {
    *
    * @param string $owner
    *   Name of the component/module/extension that owns the snapshot.
-   *   Ex: 'core', 'sequentialcreditnotes', 'oauth_client'
+   *   Ex: 'civicrm', 'sequentialcreditnotes', 'oauth_client'
    * @param string $version
    *   Ex: '5.50'
    * @param string $name
    *   Ex: 'dates'
    * @return string
-   *   Ex: 'civicrm_snap_v5_50_dates'
+   *   Ex: 'snap_civicrm_v5_50_dates'
    * @throws \CRM_Core_Exception
    *   If the resulting table name would be invalid, then this throws an exception.
    */
@@ -101,7 +101,7 @@ class CRM_Upgrade_Snapshot {
     }
     $versionExpr = ($versionParts[0] . '_' . $versionParts[1]);
 
-    $table = sprintf('civicrm_snap_%s_v%s_%s', $owner, $versionExpr, $name);
+    $table = sprintf('snap_%s_v%s_%s', $owner, $versionExpr, $name);
     if (!preg_match(';^[a-z0-9_]+$;', $table)) {
       throw new CRM_Core_Exception("Malformed snapshot name ($table)");
     }
@@ -117,7 +117,7 @@ class CRM_Upgrade_Snapshot {
    *
    * @param string $owner
    *   Name of the component/module/extension that owns the snapshot.
-   *   Ex: 'core', 'sequentialcreditnotes', 'oauth_client'
+   *   Ex: 'civicrm', 'sequentialcreditnotes', 'oauth_client'
    * @param string $version
    *   Ex: '5.50'
    * @param string $name
@@ -170,7 +170,7 @@ class CRM_Upgrade_Snapshot {
    *
    * @param CRM_Queue_TaskContext|null $ctx
    * @param string $owner
-   *   Ex: 'core', 'sequentialcreditnotes', 'oauth_client'
+   *   Ex: 'civicrm', 'sequentialcreditnotes', 'oauth_client'
    * @param string|null $version
    *   The current version of CiviCRM.
    * @param int|null $cleanupAfter
@@ -178,7 +178,7 @@ class CRM_Upgrade_Snapshot {
    *   Time is measured in terms of MINOR versions - eg "4" means "retain for 4 MINOR versions".
    *   Thus, on v5.60, you could delete any snapshots predating 5.56.
    */
-  public static function cleanupTask(?CRM_Queue_TaskContext $ctx = NULL, string $owner = 'core', ?string $version = NULL, ?int $cleanupAfter = NULL): void {
+  public static function cleanupTask(?CRM_Queue_TaskContext $ctx = NULL, string $owner = 'civicrm', ?string $version = NULL, ?int $cleanupAfter = NULL): void {
     $version = $version ?: CRM_Core_BAO_Domain::version();
     $cleanupAfter = $cleanupAfter ?: static::$cleanupAfter;
 
@@ -194,11 +194,11 @@ class CRM_Upgrade_Snapshot {
     ";
     $tables = CRM_Core_DAO::executeQuery($query, [
       1 => [$dao->database(), 'String'],
-      2 => ["civicrm_snap_{$owner}_v%", 'String'],
+      2 => ["snap_{$owner}_v%", 'String'],
     ])->fetchMap('tableName', 'tableName');
 
     $oldTables = array_filter($tables, function($table) use ($owner, $cutoff) {
-      if (preg_match(";^civicrm_snap_{$owner}_v(\d+)_(\d+)_;", $table, $m)) {
+      if (preg_match(";^snap_{$owner}_v(\d+)_(\d+)_;", $table, $m)) {
         $generatedVer = $m[1] . '.' . $m[2];
         return (bool) version_compare($generatedVer, $cutoff, '<');
       }

--- a/tests/phpunit/CRM/Upgrade/SnapshotTest.php
+++ b/tests/phpunit/CRM/Upgrade/SnapshotTest.php
@@ -12,6 +12,30 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
     CRM_Upgrade_Snapshot::$cleanupAfter = 4;
   }
 
+  public function testTableNames_good() {
+    $this->assertEquals('civicrm_snap_core_v5_45_stuff', CRM_Upgrade_Snapshot::createTableName('core', '5.45', 'stuff'));
+    $this->assertEquals('civicrm_snap_core_v5_50_stuffy_things', CRM_Upgrade_Snapshot::createTableName('core', '5.50', 'stuffy_things'));
+    $this->assertEquals('civicrm_snap_oauth_client_v12_34_ext_things', CRM_Upgrade_Snapshot::createTableName('oauth_client', '12.34', 'ext_things'));
+    $this->assertEquals('civicrm_snap_oauth_client_v0_1234_ext_things', CRM_Upgrade_Snapshot::createTableName('oauth_client', '0.1234', 'ext_things'));
+  }
+
+  public function testTableNames_bad() {
+    try {
+      CRM_Upgrade_Snapshot::createTableName('core', '5.45', 'ab&cd');
+      $this->fail('Accepted invalid name');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertRegExp('/Malformed snapshot name/', $e->getMessage());
+    }
+    try {
+      CRM_Upgrade_Snapshot::createTableName('core', '5.45', 'loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmod');
+      $this->fail('Accepted excessive name');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertRegExp('/Snapshot name is too long/', $e->getMessage());
+    }
+  }
+
   /**
    * This example creates a snapshot based on particular sliver of data (ie
    * the "display_name" and "sort_name" for "Individual" records). It ensures that:
@@ -26,25 +50,25 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
       $this->organizationCreate([], $i);
     }
 
-    $this->runAll(CRM_Upgrade_Snapshot::createTasks('5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('core', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
       ->select('id, display_name, sort_name, modified_date')
       ->where('contact_type = "Individual"')
     ));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
-    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_v5_45_names.display_name');
-    $this->assertSameSchema('civicrm_contact.sort_name', 'civicrm_snap_v5_45_names.sort_name');
-    $this->assertSameSchema('civicrm_contact.modified_date', 'civicrm_snap_v5_45_names.modified_date');
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
+    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_core_v5_45_names.display_name');
+    $this->assertSameSchema('civicrm_contact.sort_name', 'civicrm_snap_core_v5_45_names.sort_name');
+    $this->assertSameSchema('civicrm_contact.modified_date', 'civicrm_snap_core_v5_45_names.modified_date');
     $this->assertTrue(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_contact', 'legal_name'));
-    $this->assertFalse(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_snap_v5_45_names', 'legal_name'));
+    $this->assertFalse(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_snap_core_v5_45_names', 'legal_name'));
 
     $liveContacts = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact');
     $liveIndividuals = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact WHERE contact_type = "Individual"');
-    $snapCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_v5_45_names');
+    $snapCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_core_v5_45_names');
     $this->assertEquals($liveIndividuals, $snapCount, 'The snapshot should have as many records as live table.');
     $this->assertTrue($liveContacts > $liveIndividuals);
     $this->assertGreaterThan(CRM_Upgrade_Snapshot::$pageSize, $snapCount, "There should be more than 1 page of data in the snapshot. Found $snapCount records.");
 
-    CRM_Core_DAO::executeQuery('DROP TABLE civicrm_snap_v5_45_names');
+    CRM_Core_DAO::executeQuery('DROP TABLE civicrm_snap_core_v5_45_names');
   }
 
   /**
@@ -59,28 +83,28 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
     $this->eventCreate([]);
     $this->eventCreate([]);
 
-    $this->runAll(CRM_Upgrade_Snapshot::createTasks('5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('core', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
       ->select('id, display_name, sort_name')
       ->where('contact_type = "Individual"')
     ));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
-    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_v5_45_names.display_name');
-    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_v5_45_names'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
+    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_core_v5_45_names.display_name');
+    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_core_v5_45_names'));
 
-    $this->runAll(CRM_Upgrade_Snapshot::createTasks('5.50', 'dates', CRM_Utils_SQL_Select::from('civicrm_event')
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('core', '5.50', 'dates', CRM_Utils_SQL_Select::from('civicrm_event')
       ->select('id, start_date, end_date, registration_start_date, registration_end_date')
     ));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_50_dates'));
-    $this->assertSameSchema('civicrm_event.start_date', 'civicrm_snap_v5_50_dates.start_date');
-    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_v5_50_dates'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_50_dates'));
+    $this->assertSameSchema('civicrm_event.start_date', 'civicrm_snap_core_v5_50_dates.start_date');
+    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_core_v5_50_dates'));
 
-    CRM_Upgrade_Snapshot::cleanupTask(NULL, '5.52', 6);
-    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_50_dates'));
+    CRM_Upgrade_Snapshot::cleanupTask(NULL, 'core', '5.52', 6);
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_50_dates'));
 
-    CRM_Upgrade_Snapshot::cleanupTask(NULL, '5.58', 6);
-    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
-    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_50_dates'));
+    CRM_Upgrade_Snapshot::cleanupTask(NULL, 'core', '5.58', 6);
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_50_dates'));
   }
 
   /**

--- a/tests/phpunit/CRM/Upgrade/SnapshotTest.php
+++ b/tests/phpunit/CRM/Upgrade/SnapshotTest.php
@@ -13,22 +13,22 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
   }
 
   public function testTableNames_good() {
-    $this->assertEquals('civicrm_snap_core_v5_45_stuff', CRM_Upgrade_Snapshot::createTableName('core', '5.45', 'stuff'));
-    $this->assertEquals('civicrm_snap_core_v5_50_stuffy_things', CRM_Upgrade_Snapshot::createTableName('core', '5.50', 'stuffy_things'));
-    $this->assertEquals('civicrm_snap_oauth_client_v12_34_ext_things', CRM_Upgrade_Snapshot::createTableName('oauth_client', '12.34', 'ext_things'));
-    $this->assertEquals('civicrm_snap_oauth_client_v0_1234_ext_things', CRM_Upgrade_Snapshot::createTableName('oauth_client', '0.1234', 'ext_things'));
+    $this->assertEquals('snap_civicrm_v5_45_stuff', CRM_Upgrade_Snapshot::createTableName('civicrm', '5.45', 'stuff'));
+    $this->assertEquals('snap_civicrm_v5_50_stuffy_things', CRM_Upgrade_Snapshot::createTableName('civicrm', '5.50', 'stuffy_things'));
+    $this->assertEquals('snap_oauth_client_v12_34_ext_things', CRM_Upgrade_Snapshot::createTableName('oauth_client', '12.34', 'ext_things'));
+    $this->assertEquals('snap_oauth_client_v0_1234_ext_things', CRM_Upgrade_Snapshot::createTableName('oauth_client', '0.1234', 'ext_things'));
   }
 
   public function testTableNames_bad() {
     try {
-      CRM_Upgrade_Snapshot::createTableName('core', '5.45', 'ab&cd');
+      CRM_Upgrade_Snapshot::createTableName('civicrm', '5.45', 'ab&cd');
       $this->fail('Accepted invalid name');
     }
     catch (CRM_Core_Exception $e) {
       $this->assertRegExp('/Malformed snapshot name/', $e->getMessage());
     }
     try {
-      CRM_Upgrade_Snapshot::createTableName('core', '5.45', 'loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmod');
+      CRM_Upgrade_Snapshot::createTableName('civicrm', '5.45', 'loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmod');
       $this->fail('Accepted excessive name');
     }
     catch (CRM_Core_Exception $e) {
@@ -50,25 +50,25 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
       $this->organizationCreate([], $i);
     }
 
-    $this->runAll(CRM_Upgrade_Snapshot::createTasks('core', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('civicrm', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
       ->select('id, display_name, sort_name, modified_date')
       ->where('contact_type = "Individual"')
     ));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
-    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_core_v5_45_names.display_name');
-    $this->assertSameSchema('civicrm_contact.sort_name', 'civicrm_snap_core_v5_45_names.sort_name');
-    $this->assertSameSchema('civicrm_contact.modified_date', 'civicrm_snap_core_v5_45_names.modified_date');
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_45_names'));
+    $this->assertSameSchema('civicrm_contact.display_name', 'snap_civicrm_v5_45_names.display_name');
+    $this->assertSameSchema('civicrm_contact.sort_name', 'snap_civicrm_v5_45_names.sort_name');
+    $this->assertSameSchema('civicrm_contact.modified_date', 'snap_civicrm_v5_45_names.modified_date');
     $this->assertTrue(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_contact', 'legal_name'));
-    $this->assertFalse(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_snap_core_v5_45_names', 'legal_name'));
+    $this->assertFalse(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('snap_civicrm_v5_45_names', 'legal_name'));
 
     $liveContacts = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact');
     $liveIndividuals = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact WHERE contact_type = "Individual"');
-    $snapCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_core_v5_45_names');
+    $snapCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM snap_civicrm_v5_45_names');
     $this->assertEquals($liveIndividuals, $snapCount, 'The snapshot should have as many records as live table.');
     $this->assertTrue($liveContacts > $liveIndividuals);
     $this->assertGreaterThan(CRM_Upgrade_Snapshot::$pageSize, $snapCount, "There should be more than 1 page of data in the snapshot. Found $snapCount records.");
 
-    CRM_Core_DAO::executeQuery('DROP TABLE civicrm_snap_core_v5_45_names');
+    CRM_Core_DAO::executeQuery('DROP TABLE snap_civicrm_v5_45_names');
   }
 
   /**
@@ -83,28 +83,28 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
     $this->eventCreate([]);
     $this->eventCreate([]);
 
-    $this->runAll(CRM_Upgrade_Snapshot::createTasks('core', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('civicrm', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
       ->select('id, display_name, sort_name')
       ->where('contact_type = "Individual"')
     ));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
-    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_core_v5_45_names.display_name');
-    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_core_v5_45_names'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_45_names'));
+    $this->assertSameSchema('civicrm_contact.display_name', 'snap_civicrm_v5_45_names.display_name');
+    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM snap_civicrm_v5_45_names'));
 
-    $this->runAll(CRM_Upgrade_Snapshot::createTasks('core', '5.50', 'dates', CRM_Utils_SQL_Select::from('civicrm_event')
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('civicrm', '5.50', 'dates', CRM_Utils_SQL_Select::from('civicrm_event')
       ->select('id, start_date, end_date, registration_start_date, registration_end_date')
     ));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_50_dates'));
-    $this->assertSameSchema('civicrm_event.start_date', 'civicrm_snap_core_v5_50_dates.start_date');
-    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_core_v5_50_dates'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_50_dates'));
+    $this->assertSameSchema('civicrm_event.start_date', 'snap_civicrm_v5_50_dates.start_date');
+    $this->assertGreaterThan(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM snap_civicrm_v5_50_dates'));
 
-    CRM_Upgrade_Snapshot::cleanupTask(NULL, 'core', '5.52', 6);
-    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
-    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_50_dates'));
+    CRM_Upgrade_Snapshot::cleanupTask(NULL, 'civicrm', '5.52', 6);
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_45_names'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_50_dates'));
 
-    CRM_Upgrade_Snapshot::cleanupTask(NULL, 'core', '5.58', 6);
-    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_45_names'));
-    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_core_v5_50_dates'));
+    CRM_Upgrade_Snapshot::cleanupTask(NULL, 'civicrm', '5.58', 6);
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_45_names'));
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('snap_civicrm_v5_50_dates'));
   }
 
   /**

--- a/tests/phpunit/CRM/Upgrade/SnapshotTest.php
+++ b/tests/phpunit/CRM/Upgrade/SnapshotTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Class CRM_Upgrade_SnapshotTest
+ * @group headless
+ */
+class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    CRM_Upgrade_Snapshot::$pageSize = 10;
+    CRM_Upgrade_Snapshot::$cleanupAfter = 4;
+  }
+
+  // protected function tearDown(): void {
+  //   // We just throw a lot of random stuff in the DB. Don't care about slow cleanup, since this test is a schema-heavy oddball with low# iterations.
+  //   // \Civi\Test::headless()->apply(TRUE);
+  //   parent::tearDown();
+  // }
+
+  /**
+   * "php" requirement (composer.json) should match
+   * CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER.
+   */
+  public function testBasicLifecycle(): void {
+    for ($i = 0; $i < 15; $i++) {
+      $this->individualCreate([], $i);
+      $this->organizationCreate([], $i);
+    }
+
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
+      ->select('id, display_name, sort_name')
+      ->where('contact_type = "Individual"')
+    ));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
+    $this->assertSameSchema('civicrm_contact.display_name', 'civicrm_snap_v5_45_names.display_name');
+    $this->assertSameSchema('civicrm_contact.sort_name', 'civicrm_snap_v5_45_names.sort_name');
+    $this->assertTrue(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_contact', 'legal_name'));
+    $this->assertFalse(CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_snap_v5_45_names', 'legal_name'));
+
+    $liveContacts = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact');
+    $liveIndividuals = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_contact WHERE contact_type = "Individual"');
+    $snapCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_snap_v5_45_names');
+    $this->assertEquals($liveIndividuals, $snapCount, 'The snapshot should have as many records as live table.');
+    $this->assertTrue($liveContacts > $liveIndividuals);
+    $this->assertGreaterThan(CRM_Upgrade_Snapshot::$pageSize, $snapCount, "There should be more than 1 page of data in the snapshot. Found $snapCount records.");
+
+    $this->runAll(CRM_Upgrade_Snapshot::createTasks('5.50', 'dates', CRM_Utils_SQL_Select::from('civicrm_event')
+      ->select('id, start_date, end_date, registration_start_date, registration_end_date')
+    ));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_50_dates'));
+    $this->assertSameSchema('civicrm_event.start_date', 'civicrm_snap_v5_50_dates.start_date');
+    $this->assertSameSchema('civicrm_event.registration_end_date', 'civicrm_snap_v5_50_dates.registration_end_date');
+
+    CRM_Upgrade_Snapshot::cleanupTask(NULL, '5.52', 6);
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
+    $this->assertTrue(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_50_dates'));
+
+    CRM_Upgrade_Snapshot::cleanupTask(NULL, '5.58', 6);
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_45_names'));
+    $this->assertFalse(CRM_Core_DAO::checkTableExists('civicrm_snap_v5_50_dates'));
+  }
+
+  /**
+   * Assert that two columns have the same schema.
+   *
+   * @param string $expectField
+   *   ex: "table_1.column_1"
+   * @param string $actualField
+   *   ex: "table_2.column_2"
+   */
+  protected function assertSameSchema(string $expectField, string $actualField): void {
+    [$expectTable, $expectColumn] = explode('.', $expectField);
+    [$actualTable, $actualColumn] = explode('.', $actualField);
+
+    $expectDao = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM {$expectTable} LIKE %1", [
+      1 => [$expectColumn, 'String'],
+    ]);
+    $expectDao->fetch();
+
+    $actualDao = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM {$actualTable} LIKE %1", [
+      1 => [$actualColumn, 'String'],
+    ]);
+    $actualDao->fetch();
+
+    foreach (['Type', 'Null'] as $fieldProp) {
+      $this->assertEquals($expectDao->{$fieldProp}, $actualDao->{$fieldProp}, "The fields $expectField and $actualField should have the same schema.");
+    }
+  }
+
+  protected function runAll(iterable $tasks): void {
+    $queue = Civi::queue('snaptest', ['type' => 'Memory']);
+    foreach ($tasks as $task) {
+      $queue->createItem($task);
+    }
+    $r = new CRM_Queue_Runner([
+      'queue' => $queue,
+      'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
+    ]);
+    $r->runAll();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM upgrades sometimes manipulate MySQL data. However, any time you change the data, there is a risk of changing it incorrectly. This PR adds a general snapshot/backup mechanism for use in upgrade scripts, eg

```php
public function upgrade_N_N_N($rev) {
  $this->addSnapshotTask('my_snapshot', CRM_Utils_SQL_Select::from('civicrm_foobar')
    ->select('id, whiz, bang')
  );
}
```

which creates a snapshot-table similar to this:

```
mysql> SELECT * FROM snap_civicrm_v5_50_my_snapshot;
+----+------+-------------+
| id | whiz | bang        |
+----+------+-------------+
| 1  | aaa  | eh eh eh    |
| 2  | bbb  | bee bee bee |
| 3  | ccc  | see see see |
+----+------+-------------+
```

(*Note: During discussion of the PR, the naming formula switched; it was `civicrm_snap_v5_50_my_snapshot`
and became `snap_civicrm_v5_50_my_snapshot`.*)

Motivation
----------------------------------------

In recent months, we had two releases where the upgrade script caused lossy changes that were initially difficult to discover - and subsequently difficult to cleanup (eg [event timezones/timestamps](https://lab.civicrm.org/dev/core/-/wikis/CiviEvent-v5.47-Timezone-Notice) and [reminders/`limit_to`](https://lab.civicrm.org/dev/core/-/wikis/CiviCRM-v5.49-Schedule-Reminder-Notice)).

In both cases, we were able to develop mitigations that *probably-mostly* restored the data, but they required a bunch of effort (*eg working backwards from flawed event-times and guessing about the user's DST*), and they still couldn't fix everything, so they required publishing advisories to describe the problematic-cases (*where manual cleanup is necessary*).

Adding snapshot support directly to the upgrade is a fairly simple change. It would significantly reduce the guess-work involved with restoring munged data, and (for a large number of Civi sites) the cost of storing some extra snapshots should be quite acceptable.

Technical Details
----------------------------------------

As a first+simple example, the PR incorporates a snapshot at the start of the `5.50.alpha1` upgrade:

```php
public function upgrade_5_50_alpha1($rev): void {
    $this->addSnapshotTask('mappings', CRM_Utils_SQL_Select::from('civicrm_mapping'));
    $this->addSnapshotTask('fields', CRM_Utils_SQL_Select::from('civicrm_mapping_field'));
```

This runs two queries and stores two snapshot-tables:

*  `SELECT * FROM civicrm_mapping` ==> `snap_civicrm_v5_50_mappings`
*  `SELECT * FROM civicrm_mapping_field` ==> `snap_civicrm_v5_50_fields`

Here's a more interesting example -- a hypothetical revision to `display_name`:

```php
function upgrade_5_60_alpha1$($rev): void {
  $this->addSnapshotTask('names', CRM_Utils_SQL_Select::from('civicrm_contact')
    ->select('id,display_name'));
  $this->addTask(ts('Drop old version of "display_name"', 'dropColumn', 'civicrm_contact', 'display_name'));
  $this->addTask(ts('Re-create display_name as generated column', 'addColumn', 'display_name'
    'VARCHAR GENERATED ALWAYS AS (CONCAT(first_name, ' ', last_name)) STORED');
}
```

This also creates a snapshot-table:

* `SELECT id, display_name FROM civicrm_contact` ==> `snap_civicrm_v5_60_names`

This example is interesting for a couple reasons:

* The `civicrm_contact` table has many columns that don't change. We only need to backup the one that changes.
* The `civicrm_contact` table can be large --  large enough to merit pagination. The `addSnapshotTask()` will paginate the work. (It currently runs with pages of 50k rows.)

Both examples create MySQL tables with predictable names (`snap_civicrm_{$VERSION}_{$NAME}`). The tables can be cleaned up in a few ways:

* Future upgrades will automatically remove old snapshots after +4 versions. (Thus, when upgrading to 5.64, it will drop `snap_civicrm_v5_60_names`.)
* If the sysadmin is more eager to save space, they can browse the tables (`SHOW TABLES LIKE 'snap_civicrm_%'`) and drop any they don't care to keep.

Comments
----------------------------------------

* _MySQL schema_: You don't have to define all the fiddly schema details for each snapshot table - because it builds on `CREATE TABLE ... SELECT ...`, and MySQL is fairly clever about inferring schema for this automatically.
* _Not all deployments_: The PR does not enable snapshots for all deployments.
    * It skips multlingual deployments. I'm sure it's possible -- it's patch/project welcome. I simply haven't looked at it seriously.
    * On very large deployments, MySQL storage can be an issue, and snapshots may aggravate storage challenges. The current PR sets an arbitrary threshold (*200k contacts or 200k contributions or 200k activities...*); if a site exceeds the threshold, then it will NOT create snapshots. It shows a warning instead.
        * I don't think we should expect to reach 100% of sites. I think it's an improvement if we can get snapshots on 80%+ of sites. And the really large systems are likely to have extra constraints that we won't anticipate.
        * I'm not hardset on this particular rule. Maybe some other heuristic or policy-mechanism is better? Is that something we can tune over time?
* _Not a replacement for backups_: One should still take backups for any number of reasons. 
* _Improvements over 5.47_: I think 5.47 is a robust example scenario, but I think this improves on some of the techniques we used/discussed there:
    * _Compared to synthesizing older database dumps from `*.mysql` files_:
        * With automatic `snap_civicrm_*` tables, it's easier to write portable cleanup scripts.
    * _Compared to `civicrm_event.*_bak`  backup columns_:
        * It's easier to define snapshots for additional tables+columns.
        * The phase-out/purging is more clearly defined.
        * At runtime, the snapshot data is "cold". The size/performance/limits of the regular table are demonstrably unaffected.
