### PR TITLE
Payment forms test fixes

### DIFF
--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -268,6 +268,7 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
       'contribution_status_id' => 1,
       'price_set_id' => 0,
     ]);
+    $form->buildForm();
     $form->postProcess();
     $contribution = $this->callAPISuccessGetSingle('Contribution',
       [

--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -54,6 +54,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
       'check_number' => '123XA',
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
     ]);
+    $form->buildForm();
     $form->postProcess();
     // fetch the financial trxn record later used in setting default values of payment edit form
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->_individualID]);

--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -124,6 +124,7 @@ class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
       'check_number' => $checkNumber1,
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
     ]);
+    $form->buildForm();
     $form->postProcess();
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->_individualID]);
     $payments = CRM_Contribute_BAO_Contribution::getPaymentInfo($contribution['id'], 'contribute', TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Call `buildForm()` to make sure that all expected variables/parameters are set in the same way they would be outside the test environment.  This should not cause any test passes/fails in itself but was found via #21471.

Before
----------------------------------------
Incomplete form object used in tests.

After
----------------------------------------
More complete form object used in tests.

Technical Details
----------------------------------------


Comments
----------------------------------------

