### PR TITLE
Fixes dev/core#3475 - Allow 'yesno' as a valid value of `html_type`

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -312,6 +312,7 @@ trait CRM_Admin_Form_SettingTrait {
       'entity_reference' => 'EntityRef',
       'advmultiselect' => 'Element',
       'chainselect' => 'ChainSelect',
+      'yesno' => 'YesNo',
     ];
     $mapping += array_fill_keys(CRM_Core_Form::$html5Types, '');
     return $mapping[$htmlType] ?? '';


### PR DESCRIPTION

See dev/core#3475

Allow YesNo radio buttons to be specified in settings metadata using `yesno` in the `html_type` property instead of requiring use of the deprecated `quick_form_type` property.