### PR TITLE
[Import] Check subtype validity in validate rather than wait for 'imort'

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1220,12 +1220,17 @@ abstract class CRM_Import_Parser {
    *
    * @param string $fieldName
    * @param bool $loadOptions
+   * @param bool $limitToContactType
+   *   Only show fields for the type to import (not appropriate when looking up
+   *   related contact fields).
+   *
    *
    * @return array
    * @throws \API_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
    */
-  protected function getFieldMetadata(string $fieldName, bool $loadOptions = FALSE): array {
-    $fieldMetadata = $this->getImportableFieldsMetadata()[$fieldName];
+  protected function getFieldMetadata(string $fieldName, bool $loadOptions = FALSE, $limitToContactType = FALSE): array {
+    $fieldMetadata = $this->getImportableFieldsMetadata()[$fieldName] ?? ($limitToContactType ? NULL : CRM_Contact_BAO_Contact::importableFields('All')[$fieldName]);
     if ($loadOptions && !isset($fieldMetadata['options'])) {
       if (empty($fieldMetadata['pseudoconstant'])) {
         $this->importableFieldsMetadata[$fieldName]['options'] = FALSE;

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_contact_sub_types.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_contact_sub_types.csv
@@ -1,0 +1,8 @@
+first_name,Last Name,Organization,Contact Subtype,Organization SubType,expected
+Joe,Green,Greenfingers,baby,,Valid
+Joe,Green,Greenfingers,Infant,,Valid
+Joe,Green,Greenfingers,infant,,Valid
+Joe,Green,Greenfingers,rando,,Invalid
+Joe,Green,Greenfingers,,baby,Invalid
+Joe,Green,Greenfingers,,Infant,Invalid
+Joe,Green,Greenfingers,,infant,Invalid

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/.~lock.contributions.csv#
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/.~lock.contributions.csv#
@@ -1,0 +1,1 @@
+,eileen,eileen-laptop,20.05.2022 17:00,file:///home/eileen/.config/libreoffice/4;

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.CSV
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.CSV
@@ -1,0 +1,2 @@
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to
+bob,65,2008-09-20,Donation,mum@example.com

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
@@ -1,0 +1,2 @@
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to
+bob,65,2008-09-20,Donation,mum@example.com

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.txt
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.txt
@@ -1,0 +1,2 @@
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to
+bob,65,2008-09-20,Donation,mum@example.com


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Check subtype validity in validate rather than wait for 'import', test

Before
----------------------------------------
Validate routine does not check for contact subtype validity - but it will (often) fail on import

After
----------------------------------------
`getParams` does the mapping to ensure we have a name & then this can be checked during validation

Technical Details
----------------------------------------
Test cover added

Comments
----------------------------------------