### PR TITLE
Fix empty money handling

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -120,6 +120,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     }
     if ($this->isMoneyField($field)) {
       $currency = $this->getCurrency($row);
+      if (empty($fieldValue) && !is_numeric($fieldValue)) {
+        $fieldValue = 0;
+      }
       if (!$currency) {
         // too hard basket for now - just do what we always did.
         return $row->format('text/plain')->tokens($entity, $field,

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -94,7 +94,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
       '{participant.register_date}' => 'February 19th, 2007',
       '{participant.source}' => 'Wimbeldon',
       '{participant.fee_level}' => 'low',
-      '{participant.fee_amount}' => NULL,
+      '{participant.fee_amount}' => '$ 0.00',
       '{participant.registered_by_id}' => NULL,
       '{participant.transferred_to_contact_id}' => NULL,
       '{participant.role_id:label}' => 'Attendee',


### PR DESCRIPTION
Overview
----------------------------------------
In testing another PR I got a fatal error when the template had `{contribution.tax_amount}` and that value was set to ''

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/169607964-96345e9c-5a2b-41af-83f9-b0e3583c9c19.png)

After
----------------------------------------
works by treating any empty-ish value as 0

Technical Details
----------------------------------------
I'm assuming this is a recent regression either due to template changes or the new-ish token changes so targetting 5.50

Comments
----------------------------------------
