### PR TITLE
Remove extraneous deprecated check

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1530,7 +1530,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if ($error) {
         return $error;
       }
-      $this->deprecated_validate_formatted_contact($formatted);
     }
     catch (CRM_Core_Exception $e) {
       return ['error_message' => $e->getMessage(), 'is_error' => 1, 'code' => $e->getCode()];
@@ -1928,37 +1927,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->setImportStatus((int) $values[count($values) - 1], 'Imported', '');
     //return warning if street address is not parsed, CRM-5886
     return $this->processMessage($values, CRM_Import_Parser::VALID);
-  }
-
-  /**
-   * Validate a formatted contact parameter list.
-   *
-   * @param array $params
-   *   Structured parameter list (as in crm_format_params).
-   *
-   * @throw CRM_Core_Error
-   */
-  public function deprecated_validate_formatted_contact(&$params): void {
-    // Validate custom data fields
-    if (array_key_exists('custom', $params) && is_array($params['custom'])) {
-      foreach ($params['custom'] as $key => $custom) {
-        if (is_array($custom)) {
-          foreach ($custom as $fieldId => $value) {
-            $valid = CRM_Core_BAO_CustomValue::typecheck(CRM_Utils_Array::value('type', $value),
-              CRM_Utils_Array::value('value', $value)
-            );
-            if (!$valid && $value['is_required']) {
-              throw new CRM_Core_Exception('Invalid value for custom field \'' .
-                $custom['name'] . '\''
-              );
-            }
-            if (CRM_Utils_Array::value('type', $custom) == 'Date') {
-              $params['custom'][$key][$fieldId]['value'] = str_replace('-', '', $params['custom'][$key][$fieldId]['value']);
-            }
-          }
-        }
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove extraneous deprecated check

Before
----------------------------------------
We have already validated the custom fields in the extension `isErrorInCustomData` AND in a smattering of other places + we then call the api - I really can't believe this validation adds anything

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
