### PR TITLE
Remove always true if conditions (whitespace in next commit)

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -468,16 +468,11 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $this->formatCommonData($params, $formatted, $contactFields);
 
     $relationship = FALSE;
-    $createNewContact = TRUE;
-    // Support Match and Update Via Contact ID
-    if ($this->_updateWithId && isset($params['id'])) {
-      $createNewContact = FALSE;
-    }
 
     //fixed CRM-4148
     //now we create new contact in update/fill mode also.
     $contactID = NULL;
-    if ($createNewContact || ($this->_updateWithId)) {
+    if (1) {
       // @todo - there are multiple places where formatting is done that need consolidation.
       // This handles where the label has been passed in and it has gotten this far.
       // probably a bunch of hard-coded stuff could be removed to rely on this.


### PR DESCRIPTION
Overview
----------------------------------------
Remove always true if conditions (whitespace in next commit)

Before
----------------------------------------
`if ($createNewContact || ($this->_updateWithId)) {`

But we can see the first would only be FALSE if the second is TRUE

![image](https://user-images.githubusercontent.com/336308/169628016-2b2fa468-780f-4565-97f5-2e6968648050.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
