### PR TITLE
Fix Field mapping bug - forgets related fields

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -302,7 +302,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           // do array search first to see if has mapped key
           $columnKey = array_search($this->_columnNames[$i], $this->getFieldTitles());
           if (isset($this->_fieldUsed[$columnKey])) {
-            $defaults["mapper[$i]"] = $columnKey;
+            $defaults["mapper[$i]"] = [$columnKey];
             $this->_fieldUsed[$key] = TRUE;
           }
           else {

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -536,47 +536,6 @@ class CRM_Import_ImportProcessor {
   }
 
   /**
-   * Get the relevant js for quickform.
-   *
-   * @param int $column
-   *
-   * @return string
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function getQuickFormJSForField($column) {
-    $columnNumbersToHide = [];
-    if ($this->getFieldName($column) === 'do_not_import') {
-      $columnNumbersToHide = [1, 2, 3];
-    }
-    elseif ($this->getRelationshipKey($column)) {
-      if (!$this->getWebsiteTypeID($column) && !$this->getLocationTypeID($column)) {
-        $columnNumbersToHide[] = 2;
-      }
-      if (!$this->getFieldName($column)) {
-        $columnNumbersToHide[] = 1;
-      }
-      if (!$this->getPhoneOrIMTypeID($column)) {
-        $columnNumbersToHide[] = 3;
-      }
-    }
-    else {
-      if (!$this->getLocationTypeID($column) && !$this->getWebsiteTypeID($column)) {
-        $columnNumbersToHide[] = 1;
-      }
-      if (!$this->getPhoneOrIMTypeID($column)) {
-        $columnNumbersToHide[] = 2;
-      }
-      $columnNumbersToHide[] = 3;
-    }
-
-    $jsClauses = [];
-    foreach ($columnNumbersToHide as $columnNumber) {
-      $jsClauses[] = $this->getFormName() . "['mapper[$column][" . $columnNumber . "]'].style.display = 'none';";
-    }
-    return empty($jsClauses) ? '' : implode("\n", $jsClauses) . "\n";
-  }
-
-  /**
    * Get the defaults for the column from the saved mapping.
    *
    * @param int $column

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -237,31 +237,31 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     return [
       [
         ['name' => 'first_name', 'contact_type' => 'Individual', 'column_number' => 0],
-        "document.forms.MapField['mapper[0][1]'].style.display = 'none';
-document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "cj('#mapper_0_1').hide();
+cj('#mapper_0_2').hide();
+cj('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['first_name', 0, NULL]],
       ],
       [
         ['name' => 'phone', 'contact_type' => 'Individual', 'column_number' => 0, 'phone_type_id' => 1, 'location_type_id' => 2],
-        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "cj('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['phone', 2, 1]],
       ],
       [
         ['name' => 'im', 'contact_type' => 'Individual', 'column_number' => 0, 'im_provider_id' => 1, 'location_type_id' => 2],
-        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "cj('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['im', 2, 1]],
       ],
       [
         ['name' => 'url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1],
-        "document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "cj('#mapper_0_2').hide();
+cj('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['url', 1]],
       ],
       [
         // Yes, the relationship mapping really does use url whereas non relationship uses website because... legacy
         ['name' => 'url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1, 'relationship_type_id' => 1, 'relationship_direction' => 'a_b'],
-        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "cj('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['1_a_b', 'url', 1]],
       ],
       [
@@ -271,9 +271,9 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
       ],
       [
         ['name' => 'do_not_import', 'contact_type' => 'Individual', 'column_number' => 0],
-        "document.forms.MapField['mapper[0][1]'].style.display = 'none';
-document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "cj('#mapper_0_1').hide();
+cj('#mapper_0_2').hide();
+cj('#mapper_0_3').hide();\n",
         ['mapper[0]' => []],
       ],
     ];
@@ -354,9 +354,8 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
 
     $defaults = [];
     $defaults["mapper[$columnNumber]"] = $processor->getSavedQuickformDefaultsForColumn($columnNumber);
-    $js = $processor->getQuickFormJSForField($columnNumber);
 
-    return ['defaults' => $defaults, 'js' => $js];
+    return ['defaults' => $defaults];
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -237,31 +237,31 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     return [
       [
         ['name' => 'first_name', 'contact_type' => 'Individual', 'column_number' => 0],
-        "cj('#mapper_0_1').hide();
-cj('#mapper_0_2').hide();
-cj('#mapper_0_3').hide();\n",
+        "CRM.$('#mapper_0_1').hide();
+CRM.$('#mapper_0_2').hide();
+CRM.$('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['first_name', 0, NULL]],
       ],
       [
         ['name' => 'phone', 'contact_type' => 'Individual', 'column_number' => 0, 'phone_type_id' => 1, 'location_type_id' => 2],
-        "cj('#mapper_0_3').hide();\n",
+        "CRM.$('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['phone', 2, 1]],
       ],
       [
         ['name' => 'im', 'contact_type' => 'Individual', 'column_number' => 0, 'im_provider_id' => 1, 'location_type_id' => 2],
-        "cj('#mapper_0_3').hide();\n",
+        "CRM.$('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['im', 2, 1]],
       ],
       [
         ['name' => 'url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1],
-        "cj('#mapper_0_2').hide();
-cj('#mapper_0_3').hide();\n",
+        "CRM.$('#mapper_0_2').hide();
+CRM.$('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['url', 1]],
       ],
       [
         // Yes, the relationship mapping really does use url whereas non relationship uses website because... legacy
         ['name' => 'url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1, 'relationship_type_id' => 1, 'relationship_direction' => 'a_b'],
-        "cj('#mapper_0_3').hide();\n",
+        "CRM.$('#mapper_0_3').hide();\n",
         ['mapper[0]' => ['1_a_b', 'url', 1]],
       ],
       [
@@ -271,9 +271,9 @@ cj('#mapper_0_3').hide();\n",
       ],
       [
         ['name' => 'do_not_import', 'contact_type' => 'Individual', 'column_number' => 0],
-        "cj('#mapper_0_1').hide();
-cj('#mapper_0_2').hide();
-cj('#mapper_0_3').hide();\n",
+        "CRM.$('#mapper_0_1').hide();
+CRM.$('#mapper_0_2').hide();
+CRM.$('#mapper_0_3').hide();\n",
         ['mapper[0]' => []],
       ],
     ];

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1113,6 +1113,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       ['5_a_b', 'organization_name'],
       ['contact_sub_type'],
       ['5_a_b', 'contact_sub_type'],
+      ['do_not_import'],
     ];
     $csv = 'individual_contact_sub_types.csv';
     $field = 'contact_sub_type';


### PR DESCRIPTION
Overview
----------------------------------------
Fix Field mapping bug - forgets related fields

I hit this during r-run on imports and initially thought it was a regression but it is there in 5.48 too.

To replicate
1) do an import with a contact where some of the fields are for a related contact - [here is the csv I used for testing](https://drive.google.com/file/d/1Qnxs5uQv6hpBgfJw-hYbIRzU1WMjEoia/view?usp=sharing)
2) do NOT save the mapping, do not collect $200
3) once you hit the preview field go back (still no $200)
4) check if the related contact's field is still populated

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/169634415-3ea7cd8b-7c7d-4ae3-abf5-47ca73b34d03.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/169634404-9f829920-10a7-45ba-b6a4-442b73071ce1.png)

Technical Details
----------------------------------------
I think I got to the bottom of what the js was doing & switched to a simple jquery hide (well a whole tonne of them - I'm sure it could be more elegant at the jquery end but figuring out this much was a lot....

Comments
----------------------------------------
