### PR TITLE
Extend import option handling to prefix, suffix, language, communication_style

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -778,16 +778,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    *
    */
   public static function resolveDefaults(&$defaults, $reverse = FALSE) {
-    // Hack for birth_date.
-    if (!empty($defaults['birth_date'])) {
-      if (is_array($defaults['birth_date'])) {
-        $defaults['birth_date'] = CRM_Utils_Date::format($defaults['birth_date'], '-');
-      }
-    }
-
-    CRM_Utils_Array::lookupValue($defaults, 'prefix', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'prefix_id'), $reverse);
-    CRM_Utils_Array::lookupValue($defaults, 'suffix', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'suffix_id'), $reverse);
-    CRM_Utils_Array::lookupValue($defaults, 'communication_style', CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'communication_style_id'), $reverse);
 
     //lookup value of email/postal greeting, addressee, CRM-4575
     foreach (self::$_greetingTypes as $greeting) {

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -12,7 +12,6 @@
 use Civi\Api4\Contact;
 use Civi\Api4\RelationshipType;
 
-require_once 'CRM/Utils/DeprecatedUtils.php';
 require_once 'api/v3/utils.php';
 
 /**
@@ -98,6 +97,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     'birth_date',
     'deceased_date',
     'is_deceased',
+    'prefix_id',
+    'suffix_id',
+    'communication_style',
+    'preferred_language',
   ];
 
   /**
@@ -476,25 +479,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     //now we create new contact in update/fill mode also.
     $contactID = NULL;
     if (1) {
-      // @todo - there are multiple places where formatting is done that need consolidation.
-      // This handles where the label has been passed in and it has gotten this far.
-      // probably a bunch of hard-coded stuff could be removed to rely on this.
-      $fields = Contact::getFields(FALSE)
-        ->addWhere('options', '=', TRUE)
-        ->setLoadOptions(TRUE)
-        ->execute()->indexBy('name');
-      foreach ($fields as $fieldName => $fieldSpec) {
-        if (isset($formatted[$fieldName]) && is_array($formatted[$fieldName])) {
-          // If we have an array at this stage, it's probably a multi-select
-          // field that has already been parsed properly into the value that
-          // should be inserted into the database.
-          continue;
-        }
-        if (!empty($formatted[$fieldName])
-          && empty($fieldSpec['options'][$formatted[$fieldName]])) {
-          $formatted[$fieldName] = array_search($formatted[$fieldName], $fieldSpec['options'], TRUE) ?? $formatted[$fieldName];
-        }
-      }
       //CRM-4430, don't carry if not submitted.
       if ($this->_updateWithId && !empty($params['id'])) {
         $contactID = $params['id'];
@@ -1184,20 +1168,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           case 'preferred_mail_format':
             if (!array_key_exists(strtolower($value), array_change_key_case(CRM_Core_SelectValues::pmf(), CASE_LOWER))) {
               $errors[] = ts('Preferred Mail Format');
-            }
-            break;
-
-          case 'individual_prefix':
-          case 'prefix_id':
-            if (!self::in_value($value, CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'prefix_id'))) {
-              $errors[] = ts('Individual Prefix');
-            }
-            break;
-
-          case 'individual_suffix':
-          case 'suffix_id':
-            if (!self::in_value($value, CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'suffix_id'))) {
-              $errors[] = ts('Individual Suffix');
             }
             break;
 

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -500,11 +500,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
    * Test all pseudoConstant, stateProvince, country.
    */
   public function testResolveDefaults() {
-    $params = [
-      'prefix_id' => 3,
-      'suffix_id' => 2,
-      'birth_date' => '1983-12-13',
-    ];
+    $params = [];
 
     $params['address'][1] = [
       'location_type_id' => 1,
@@ -515,11 +511,6 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     // @todo - we are testing this with $reverse = FALSE but it is never called that way!
     CRM_Contact_BAO_Contact::resolveDefaults($params);
 
-    //check the resolve values.
-    $prefix = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'prefix_id');
-    $this->assertEquals($prefix[$params['prefix_id']], $params['prefix'], 'Check for prefix.');
-    $suffix = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'suffix_id');
-    $this->assertEquals($suffix[$params['suffix_id']], $params['suffix'], 'Check for suffix.');
     $this->assertEquals(1004, $params['address'][1]['state_province_id']);
     $this->assertEquals(CRM_Core_PseudoConstant::country($params['address'][1]['country_id']),
       $params['address'][1]['country'],


### PR DESCRIPTION


Overview
----------------------------------------
Extend import option handling to prefix, suffix, language, communication_style

This extends a pattern thoroughly tested for gender to
other single-option-value fields & removes duplicate handling.

Test cover in

`CRM_Contact_Import_Parser_ContactTest::testPrefixLabel`
`CRM_Contact_Import_Parser_ContactTest::testPreferredLanguageImport`

Before
----------------------------------------
Complicated handling

After
----------------------------------------
Leverages metadata based handling thoroughly tested for gender

Technical Details
----------------------------------------

Comments
----------------------------------------
