### PR TITLE
Greeting handling - if email_greeting_custom (etc) isset & email_greeting_id is not, set to 'Customized'

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -506,6 +506,9 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
     $missingGreetingParams = [];
 
     foreach ($allGreetingParams as $greetingIndex => $greetingParam) {
+      if (!empty($params[$greetingIndex . '_custom']) && empty($params[$greetingParam])) {
+        $params[$greetingParam] = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greetingParam, 'Customized');
+      }
       // An empty string means NULL
       if (($params[$greetingParam] ?? NULL) === '') {
         $params[$greetingParam] = 'null';

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -892,19 +892,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $addressCustomFields = CRM_Core_BAO_CustomField::getFields('Address');
     $customFields = $customFields + $addressCustomFields;
 
-    //if a Custom Email Greeting, Custom Postal Greeting or Custom Addressee is mapped, and no "Greeting / Addressee Type ID" is provided, then automatically set the type = Customized, CRM-4575
-    $elements = [
-      'email_greeting_custom' => 'email_greeting',
-      'postal_greeting_custom' => 'postal_greeting',
-      'addressee_custom' => 'addressee',
-    ];
-    foreach ($elements as $k => $v) {
-      if (array_key_exists($k, $params) && !(array_key_exists($v, $params))) {
-        $label = key(CRM_Core_OptionGroup::values($v, TRUE, NULL, NULL, 'AND v.name = "Customized"'));
-        $params[$v] = $label;
-      }
-    }
-
     //format date first
     $session = CRM_Core_Session::singleton();
     $dateType = $session->get("dateTypes");
@@ -1600,18 +1587,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if (array_key_exists($key, $locationFields)) {
         continue;
       }
-      if (in_array($key, [
-        'email_greeting',
-        'postal_greeting',
-        'addressee',
-      ])) {
-        // CRM-4575, need to null custom
-        if ($params["{$key}_id"] != 4) {
-          $params["{$key}_custom"] = 'null';
-        }
-        unset($params[$key]);
-      }
-      else {
+
+      if (1) {
         if ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key)) {
           $custom_params = ['id' => $contact['id'], 'return' => $key];
           $getValue = civicrm_api3('Contact', 'getvalue', $custom_params);


### PR DESCRIPTION
Overview
----------------------------------------
This tests BAO greeting handling to ensure that 

1) if the id (eg postal_greeting_id) is NOT for a Customized option then NULL out the custom field (was already working, added test to ensure)
2) if no id is set but (eg) `postal_greeting_custom` IS set THEN assume the `Customized` option

With this working in the BAO it is removed from the import class

Before
----------------------------------------
Unclear if the above works, no specific tests


After
----------------------------------------
Tests added, alteration in BAO to 'figure out' the id if the _custom field is set

Technical Details
----------------------------------------

Comments
----------------------------------------
