### PR TITLE
Fix unreleased regression from strict typing

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -2928,7 +2928,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     // Time to see if we can find an existing contact ID to make this an update
     // not a create.
     if ($extIDMatch || $this->isUpdateExistingContacts()) {
-      return $this->getPossibleContactMatch($params, $extIDMatch, $this->getSubmittedValue('dedupe_rule_id'));
+      return $this->getPossibleContactMatch($params, $extIDMatch, $this->getSubmittedValue('dedupe_rule_id') ?: NULL);
     }
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix unreleased regression from strict typing
- affects master branch only
- 
Before
----------------------------------------
When dedupe_rule_id is empty like this

![image](https://user-images.githubusercontent.com/336308/169645279-77cd6c44-f483-4ed3-815e-904f1ade0233.png)

it gets upset like this

![image](https://user-images.githubusercontent.com/336308/169645340-78a1a1c8-a4e7-4088-8463-9bcf0f88d916.png)


After
----------------------------------------
Works again


Technical Details
----------------------------------------

Comments
----------------------------------------
