### PR TITLE
Remove never-true fields, and impossible property handling from previously shared function

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1511,7 +1511,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $formatted['updateBlankLocInfo'] = FALSE;
     }
 
-    [$data, $contactDetails] = $this->formatProfileContactParams($formatted, $contactFields, $contactId, NULL, $formatted['contact_type']);
+    [$data, $contactDetails] = $this->formatProfileContactParams($formatted, $contactFields, $contactId, $formatted['contact_type']);
 
     // manage is_opt_out
     if (array_key_exists('is_opt_out', $contactFields) && array_key_exists('is_opt_out', $formatted)) {
@@ -1564,9 +1564,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @param array $params
    * @param array $fields
    * @param int|null $contactID
-   * @param int|null $ufGroupId
    * @param string|null $ctype
-   * @param bool $skipCustom
    *
    * @return array
    */
@@ -1574,9 +1572,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     &$params,
     $fields,
     $contactID = NULL,
-    $ufGroupId = NULL,
-    $ctype = NULL,
-    $skipCustom = FALSE
+    $ctype = NULL
   ) {
 
     $data = $contactDetails = [];
@@ -1591,18 +1587,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
     else {
       //we should get contact type only if contact
-      if ($ufGroupId) {
-        $data['contact_type'] = CRM_Core_BAO_UFField::getProfileType($ufGroupId, TRUE, FALSE, TRUE);
-
-        //special case to handle profile with only contact fields
-        if ($data['contact_type'] == 'Contact') {
-          $data['contact_type'] = 'Individual';
-        }
-        elseif (CRM_Contact_BAO_ContactType::isaSubType($data['contact_type'])) {
-          $data['contact_type'] = CRM_Contact_BAO_ContactType::getBasicType($data['contact_type']);
-        }
-      }
-      elseif ($ctype) {
+      if ($ctype) {
         $data['contact_type'] = $ctype;
       }
       else {
@@ -1814,7 +1799,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           //save email/postal greeting and addressee values if any, CRM-4575
           $data[$key . '_id'] = $value;
         }
-        elseif (!$skipCustom && ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key))) {
+        elseif (($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key))) {
           // for autocomplete transfer hidden value instead of label
           if ($params[$key] && isset($params[$key . '_id'])) {
             $value = $params[$key . '_id'];
@@ -1833,20 +1818,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           }
 
           $valueId = NULL;
-          if (!empty($params['customRecordValues'])) {
-            if (is_array($params['customRecordValues']) && !empty($params['customRecordValues'])) {
-              foreach ($params['customRecordValues'] as $recId => $customFields) {
-                if (is_array($customFields) && !empty($customFields)) {
-                  foreach ($customFields as $customFieldName) {
-                    if ($customFieldName == $key) {
-                      $valueId = $recId;
-                      break;
-                    }
-                  }
-                }
-              }
-            }
-          }
 
           //CRM-13596 - check for contact_sub_type_hidden first
           if (array_key_exists('contact_sub_type_hidden', $params)) {


### PR DESCRIPTION

Overview
----------------------------------------
Follow up cleanup on https://github.com/civicrm/civicrm-core/pull/23542

Before
----------------------------------------
Function now only called from one place which passes `NULL` for `$ufGroupID` and `FALSE` for `$skipCustom`

Plus `customRecordValues` only ever set in the `Profile` path - which no longer shares this function

![image](https://user-images.githubusercontent.com/336308/169742280-64d1b763-edde-4317-ac15-c0edb19faed1.png)

 
After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
