### PR TITLE
dev/core#3467 - Drupal 8 - Skip requirement for password when changing your own civi contact's email

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -114,6 +114,9 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     if ($user && $user->getEmail() != $email) {
       $user->setEmail($email);
 
+      // Skip requirement for password when changing the current user fields
+      $user->_skipProtectedUserFieldConstraint = TRUE;
+
       if (!count($user->validate())) {
         $user->save();
       }


### PR DESCRIPTION
Overview
----------------------------------------

Modifying your own email from civi does not modify it in drupal, but you can modify any email of any contact and its sync fine. It works fine in D7.

This is happening in both Drupal 8 and 9.

I found this validation when contact is updated and Symfony throws the error:

```
Your current password is missing or incorrect; it's required to change the %name.
```

Source: https://github.com/civicrm/civicrm-core/blob/5.45.1/CRM/Utils/System/Drupal8.php#L117


Before
----------------------------------------
The logged in user cannot update his own email in drupal from CiviCRM.

After
----------------------------------------
The logged in user can update his own email in drupal from CiviCRM.


Technical Details
----------------------------------------
I found this parameter `$user->_skipProtectedUserFieldConstraint = TRUE;` that allows to skip the validation or at least does not ask for the password, I have doubts if this can cause any unwanted behavior.

Comments
----------------------------------------
issue: https://lab.civicrm.org/dev/core/-/issues/3467

Tested with D9 with CiviCRM 5.45

Thanks!