### PR TITLE
[Joomla 4.0] Fatal error on submitting Profile with CMS username/password

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -38,10 +38,17 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function createUser(&$params, $mail) {
     $baseDir = JPATH_SITE;
-    require_once $baseDir . '/components/com_users/models/registration.php';
-
     $userParams = JComponentHelper::getParams('com_users');
-    $model = new UsersModelRegistration();
+
+    if (version_compare(JVERSION, '4.0.0', 'ge')) {
+      $model = JFactory::getApplication()->bootComponent('com_users')->getMVCFactory()->createModel('Registration', 'Site');
+      $model->set('data', new \stdClass());
+    }
+    else {
+      require_once $baseDir . '/components/com_users/models/registration.php';
+      $model = new UsersModelRegistration();
+    }
+
     $ufID = NULL;
 
     // get the default usertype


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:   
      - Choose any Profile and enable 'User Registration'
      - Open the Profile in create mode and submit as a anonymous user.

Before
----------------------------------------
Result: Fatal error and the joomla user account is not created


After
----------------------------------------
CMS User and civicrm contact is created successfully 


Comments
----------------------------------------
Ref : https://lab.civicrm.org/dev/joomla/-/issues/39