### PR TITLE
Improve comparison for options in import

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1187,7 +1187,7 @@ abstract class CRM_Import_Parser {
       $value = CRM_Utils_Date::formatDate($importedValue, $this->getSubmittedValue('dateFormats'));
       return ($value) ?: 'invalid_import_value';
     }
-    return $this->getFieldOptions($fieldName)[$importedValue] ?? 'invalid_import_value';
+    return $this->getFieldOptions($fieldName)[is_numeric($importedValue) ? $importedValue : mb_strtolower($importedValue)] ?? 'invalid_import_value';
   }
 
   /**
@@ -1228,16 +1228,12 @@ abstract class CRM_Import_Parser {
           'select' => ['options'],
         ])->first()['options'];
         // We create an array of the possible variants - notably including
-        // name AND label as either might be used, and capitalisation variants.
+        // name AND label as either might be used. We also lower case before checking
         $values = [];
         foreach ($options as $option) {
           $values[$option['id']] = $option['id'];
-          $values[$option['label']] = $option['id'];
-          $values[$option['name']] = $option['id'];
-          $values[strtoupper($option['name'])] = $option['id'];
-          $values[strtolower($option['name'])] = $option['id'];
-          $values[strtoupper($option['label'])] = $option['id'];
-          $values[strtolower($option['label'])] = $option['id'];
+          $values[mb_strtolower($option['name'])] = $option['id'];
+          $values[mb_strtolower($option['label'])] = $option['id'];
         }
         $this->importableFieldsMetadata[$fieldName]['options'] = $values;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Improve comparison for options in import

Before
----------------------------------------
I had added handling for options to be 
- in their original case
- all upper
- all lower

And I had added tests for this for Gender.

However, I found lots of other places in import were doing strtolower comparision - allowing for 'something in between' - 

After
----------------------------------------
Does strtolower comparison - using `mb_strtolower` to be careful of other languages

Technical Details
----------------------------------------


Comments
----------------------------------------
