### PR TITLE
Remove do-nothing deprecated line

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -934,11 +934,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
             if (!empty($value['location_type_id'])) {
               $this->formatLocationBlock($value, $formatted);
             }
-            else {
-              // @todo - this is still reachable - e.g. import with related contact info like firstname,lastname,spouse-first-name,spouse-last-name,spouse-home-phone
-              CRM_Core_Error::deprecatedFunctionWarning('this is not expected to be reachable now');
-              $this->formatContactParameters($value, $formatted);
-            }
           }
         }
         if (!$isAddressCustomField) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove do-nothing deprecated line

Before
----------------------------------------
This line was originally deprecated under the believe it was no longer needed. Later a comment was added to point out it it is still hit - 2 things can be true at once.

The line IS hit and is a blocker to adding test cover. However, it is also unnecessary - the line is in `formatCommonData` and is hit when iterating through a relationship key within the main contact params array & causes it to call itself to process that key - however, the line is ALSO called later with just the relationship data  - achieving the same thing that the nested call does, but without the deprecated warning & extra loop

After
----------------------------------------
poof

Technical Details
----------------------------------------
I have tests locally covering this but as this is the blocker to those tests, not the focus of them - I need to merge this first

Comments
----------------------------------------
