### PR TITLE
[Import] Clean up country validation and add unit test (addresses unreleased regression)

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -807,19 +807,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
             $values['vcard_name'] = $vcardNames[$values['location_type_id']];
           }
 
-          if (!CRM_Utils_Array::lookupValue($values,
-              'country',
-              CRM_Core_PseudoConstant::country(),
-              $reverse
-            ) &&
-            $reverse
-          ) {
-            CRM_Utils_Array::lookupValue($values,
-              'country',
-              CRM_Core_PseudoConstant::countryIsoCode(),
-              $reverse
-            );
-          }
           $stateProvinceID = self::resolveStateProvinceID($values, $values['country_id'] ?? NULL);
           if ($stateProvinceID) {
             $values['state_province_id'] = $stateProvinceID;

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -280,7 +280,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
 
     $params = $this->getMappedRow($values);
-    $formatted = array_filter(array_intersect_key($params, array_fill_keys($this->metadataHandledFields, 1)));
+    $formatted = array_filter(array_intersect_key($params, array_fill_keys($this->metadataHandledFields, 1)), 'strlen');
 
     $contactFields = CRM_Contact_DAO_Contact::import();
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1466,7 +1466,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
         $loc = CRM_Utils_Array::key($index, $locationType);
 
-        $blockName = $this->getLocationEntityForKey($fieldName);
+        $blockName = strtolower($this->getFieldEntity($fieldName));
 
         $data[$blockName][$loc]['location_type_id'] = $locTypeId;
 
@@ -1673,27 +1673,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
 
     return [$data, $contactDetails];
-  }
-
-  /**
-   * Get the relevant location entity for the array key.
-   *
-   * Based on the field name we determine which location entity
-   * we are dealing with. Apart from a few specific ones they
-   * are mostly 'address' (the default).
-   *
-   * @param string $fieldName
-   *
-   * @return string
-   */
-  private static function getLocationEntityForKey($fieldName) {
-    if (in_array($fieldName, ['email', 'phone', 'im', 'openid'])) {
-      return $fieldName;
-    }
-    if ($fieldName === 'phone_ext') {
-      return 'phone';
-    }
-    return 'address';
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1233,7 +1233,7 @@ abstract class CRM_Import_Parser {
       $value = CRM_Utils_Date::formatDate($importedValue, $this->getSubmittedValue('dateFormats'));
       return ($value) ?: 'invalid_import_value';
     }
-    return $this->getFieldOptions($fieldName)[$importedValue] ?? 'invalid_import_value';
+    return $this->getFieldOptions($fieldName)[is_numeric($importedValue) ? $importedValue : mb_strtolower($importedValue)] ?? 'invalid_import_value';
   }
 
   /**
@@ -1274,16 +1274,12 @@ abstract class CRM_Import_Parser {
           'select' => ['options'],
         ])->first()['options'];
         // We create an array of the possible variants - notably including
-        // name AND label as either might be used, and capitalisation variants.
+        // name AND label as either might be used. We also lower case before checking
         $values = [];
         foreach ($options as $option) {
           $values[$option['id']] = $option['id'];
-          $values[$option['label']] = $option['id'];
-          $values[$option['name']] = $option['id'];
-          $values[strtoupper($option['name'])] = $option['id'];
-          $values[strtolower($option['name'])] = $option['id'];
-          $values[strtoupper($option['label'])] = $option['id'];
-          $values[strtolower($option['label'])] = $option['id'];
+          $values[mb_strtolower($option['name'])] = $option['id'];
+          $values[mb_strtolower($option['label'])] = $option['id'];
         }
         $this->importableFieldsMetadata[$fieldName]['options'] = $values;
       }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1334,14 +1334,9 @@ abstract class CRM_Import_Parser {
 
       // check for values for custom fields for checkboxes and multiselect
       if ($isSerialized && $dataType != 'ContactReference') {
-        $value = trim($value);
-        $value = str_replace('|', ',', $value);
-        $mulValues = explode(',', $value);
+        $mulValues = array_filter(explode(',', str_replace('|', ',', trim($value))), 'strlen');
         $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
         foreach ($mulValues as $v1) {
-          if (strlen($v1) == 0) {
-            continue;
-          }
 
           $flag = FALSE;
           foreach ($customOption as $v2) {

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -512,10 +512,6 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     CRM_Contact_BAO_Contact::resolveDefaults($params);
 
     $this->assertEquals(1004, $params['address'][1]['state_province_id']);
-    $this->assertEquals(CRM_Core_PseudoConstant::country($params['address'][1]['country_id']),
-      $params['address'][1]['country'],
-      'Check for country.'
-    );
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
@@ -1,0 +1,7 @@
+First Name,Last Name,Email,County,Country,State,Custom field state,Custom Field Country,Address Custom Field Country,Address Custom field state,Mum Name,Mum Last name,Mum email,Mum State,Mum Country,Mum County,Address Mum Custom Field Country,Address Mum Custom field state,Mum Custom Field Country,Mum Custom field State,expected,error_value
+Susie,Jones,susie@example.com,,ABC,,,,,,Mum,Jones,mum@example.com,,,,,,,,Invalid,ABC
+Susie,Jones,susie@example.com,,,,,,,,Mum,Jones,mum@example.com,NSW,ABC,,,,,,Invalid,ABC
+Susie,Jones,susie@example.com,,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jones,mum@example.com,NSW,Australia,,Australia,NSW,Australia,NSW,Valid,
+Susie,Jones,susie@example.com,,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,,AU,New South Wales,Australia,New South Wales,Valid,
+Susie,Jones,susie@example.com,,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,,1013,New South Wales,1013,New South Wales,Valid,
+Susie,Jones,susie@example.com,,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,,,,,,Valid,

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -17,9 +17,14 @@
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\ContactType;
+use Civi\Api4\Email;
+use Civi\Api4\IM;
 use Civi\Api4\LocationType;
+use Civi\Api4\OpenID;
+use Civi\Api4\Phone;
 use Civi\Api4\RelationshipType;
 use Civi\Api4\UserJob;
+use Civi\Api4\Website;
 
 /**
  *  Test contact import parser.
@@ -36,6 +41,13 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @var string
    */
   protected $entity = 'Contact';
+
+  /**
+   * Array of existing relationships.
+   *
+   * @var array
+   */
+  private $relationships = [];
 
   /**
    * Tear down after test.
@@ -1050,6 +1062,63 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test importing state country & county.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportCountryStateCounty(): void {
+    $childKey = $this->getRelationships()['Child of']['id'] . '_a_b';
+    // @todo - rows that don't work yet are set to do_not_import.
+    // $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
+    // $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);
+    // $addressCustomFieldID = $this->createCountryCustomField(['custom_group_id' => $addressCustomGroupID])['id'];
+    // $contactCustomFieldID = $this->createMultiCountryCustomField(['custom_group_id' => $contactCustomGroupID])['id'];
+    // $customField = 'custom_' . $contactCustomFieldID;
+    // $addressCustomField = 'custom_' . $addressCustomFieldID;
+
+    $mapper = [
+      ['first_name'],
+      ['last_name'],
+      ['email'],
+      ['county'],
+      ['country'],
+      ['state_province'],
+      // [$customField, 'state_province'],
+      ['do_not_import'],
+      // [$customField, 'country'],
+      ['do_not_import'],
+      // [$addressCustomField, 'country'],
+      ['do_not_import'],
+      // [$addressCustomField, 'state_province'],
+      ['do_not_import'],
+      [$childKey, 'first_name'],
+      [$childKey, 'last_name'],
+      [$childKey, 'email'],
+      [$childKey, 'state_province'],
+      [$childKey, 'country'],
+      [$childKey, 'county'],
+      // [$childKey, $addressCustomField, 'country'],
+      ['do_not_import'],
+      // [$childKey, $addressCustomField, 'state_province'],
+      ['do_not_import'],
+      // [$childKey, $customField, 'country'],
+      ['do_not_import'],
+      // [$childKey, $customField, 'state_province'],
+      ['do_not_import'],
+    ];
+    $csv = 'individual_country_state_county_with_related.csv';
+    $this->validateMultiRowCsv($csv, $mapper, 'error_value');
+
+    $this->importCSV($csv, $mapper);
+    $contacts = $this->getImportedContacts();
+    foreach ($contacts as $contact) {
+      $this->assertEquals(1013, $contact['address'][0]['country_id']);
+    }
+    $this->assertCount(2, $contacts);
+  }
+
+  /**
    * Test date validation.
    *
    * @dataProvider dateDataProvider
@@ -1152,11 +1221,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    */
   public function testImportLocations(): void {
     $csv = 'individual_locations_with_related.csv';
-    $relationships = (array) RelationshipType::get()->addSelect('name_a_b', 'id')->addWhere('name_a_b', 'IN', [
-      'Child of',
-      'Sibling of',
-      'Employee of',
-    ])->execute()->indexBy('name_a_b');
+    $relationships = $this->getRelationships();
 
     $childKey = $relationships['Child of']['id'] . '_a_b';
     $siblingKey = $relationships['Sibling of']['id'] . '_a_b';
@@ -1335,7 +1400,9 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   /**
    * CRM-19888 default country should be used if ambigous.
    *
+   * @throws \API_Exception
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function testImportAmbiguousStateCountry(): void {
     $this->callAPISuccess('Setting', 'create', ['defaultContactCountry' => 1228]);
@@ -1502,6 +1569,21 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * @return array
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function getRelationships(): array {
+    if (empty($this->relationships)) {
+      $this->relationships = (array) RelationshipType::get()
+        ->addSelect('name_a_b', 'id')
+        ->execute()
+        ->indexBy('name_a_b');
+    }
+    return $this->relationships;
+  }
+
+  /**
    * @param array $fields Array of fields to be imported
    * @param array $allfields Array of all fields which can be part of import
    */
@@ -1563,7 +1645,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->assertEquals([
       'first_name' => 'Bob',
       'phone' => [
-        [
+        '1_1' => [
           'phone' => '123',
           'location_type_id' => 1,
           'phone_type_id' => 1,
@@ -1571,32 +1653,34 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       ],
       '5_a_b' => [
         'contact_type' => 'Organization',
-        'url' =>
-          [
-
-            [
-              'url' => 'https://example.org',
-              'website_type_id' => 1,
-            ],
-          ],
-        'phone' =>
-          [
-            [
-              'phone' => '456',
-              'location_type_id' => 1,
-              'phone_type_id' => 1,
-            ],
-          ],
-      ],
-      'im' =>
-        [
-
-          [
-            'im' => 'my-handle',
-            'location_type_id' => 1,
-            'provider_id' => 1,
+        'website' => [
+          'https://example.org' => [
+            'url' => 'https://example.org',
+            'website_type_id' => 1,
           ],
         ],
+        // We still pump out the legacy key too - for now!
+        'url' => [
+          'https://example.org' => [
+            'url' => 'https://example.org',
+            'website_type_id' => 1,
+          ],
+        ],
+        'phone' => [
+          '1_1' => [
+            'phone' => '456',
+            'location_type_id' => 1,
+            'phone_type_id' => 1,
+          ],
+        ],
+      ],
+      'im' => [
+        '1_1' => [
+          'im' => 'my-handle',
+          'location_type_id' => 1,
+          'provider_id' => 1,
+        ],
+      ],
       'contact_type' => 'Individual',
     ], $params);
   }
@@ -1743,6 +1827,24 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         }
       }
     }
+  }
+
+  /**
+   * Get the contacts we imported (Susie Jones & family).
+   *
+   * @return array
+   * @throws \API_Exception
+   */
+  public function getImportedContacts(): array {
+    return (array) Contact::get()
+      ->addWhere('display_name', 'IN', ['Susie Jones', 'Mum Jones', 'sis@example.com', 'Soccer Superstars'])
+      ->addChain('phone', Phone::get()->addWhere('contact_id', '=', '$id'))
+      ->addChain('address', Address::get()->addWhere('contact_id', '=', '$id'))
+      ->addChain('website', Website::get()->addWhere('contact_id', '=', '$id'))
+      ->addChain('im', IM::get()->addWhere('contact_id', '=', '$id'))
+      ->addChain('email', Email::get()->addWhere('contact_id', '=', '$id'))
+      ->addChain('openid', OpenID::get()->addWhere('contact_id', '=', '$id'))
+      ->execute()->indexBy('display_name');
   }
 
 }


### PR DESCRIPTION


Overview
----------------------------------------
Clean up country validation and add unit test

Before
----------------------------------------
Support for 'AUSTRALIA' as a country had slipped in previous cleanups ('Australia' was OK) . Country handling was still the wild west

After
----------------------------------------
Unit tests to cover the 3 accepted variations - 1013, AU and Australia + case insentivitiy. Ground work for for the same for State & County

Technical Details
----------------------------------------
This DOES reduce some message nuance for the country - ie it doesn't tell you that the country might not be enabled - but instead it tells you WHICH contact the error refers to. This seemed worth the trade off & I kinda feel help text should be in the UI or docs, not a csv output

Comments
----------------------------------------
Note there are multiple PRs I opened while building up to this that are mergeable & will simplify this - I want to continue on with state & county but need to be sure I can get this through first