### PR TITLE
Another always-true-if

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -466,8 +466,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     //format common data, CRM-4062
     $this->formatCommonData($params, $formatted, $contactFields);
 
-    $relationship = FALSE;
-
     //fixed CRM-4148
     //now we create new contact in update/fill mode also.
     $contactID = NULL;
@@ -499,7 +497,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     }
 
     if (isset($newContact) && is_object($newContact) && ($newContact instanceof CRM_Contact_BAO_Contact)) {
-      $relationship = TRUE;
       $newContact = clone($newContact);
       $contactID = $newContact->id;
       $this->_newContacts[] = $contactID;
@@ -518,7 +515,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         return CRM_Import_Parser::DUPLICATE;
       }
 
-      $relationship = TRUE;
       // CRM-10433/CRM-20739 - IDs could be string or array; handle accordingly
       if (!is_array($dupeContactIDs = $newContact['error_message']['params'][0])) {
         $dupeContactIDs = explode(',', $dupeContactIDs);
@@ -550,7 +546,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       CRM_Utils_Hook::import('Contact', 'process', $this, $hookParams);
     }
 
-    if ($relationship) {
+    if (1) {
       $primaryContactId = NULL;
       if (CRM_Core_Error::isAPIError($newContact, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
         if ($dupeCount == 1 && CRM_Utils_Rule::integer($contactID)) {


### PR DESCRIPTION
Overview
----------------------------------------
Another always-true-if

Before
----------------------------------------
We can see that both the `if` and the `else` set relationship to `TRUE` - the only exception is if it returns - in which case the if isn't reache

![image](https://user-images.githubusercontent.com/336308/169946321-703cb999-4354-47b8-be68-6a4402e5092c.png)

After
----------------------------------------
Clarified - whitespace change pending

Technical Details
----------------------------------------
I have a couple of places like this now waiting for potentially conflicting PRs to be merged before cleaning up the whitespace

Comments
----------------------------------------
