### PR TITLE
SearchKit - Fix 'undefined var' error after import

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -110,7 +110,7 @@
         crmApi4(apiCalls)
           .then(function(result) {
             CRM.alert(
-              result.length === 1 ? ts('1 record successfully imported.') : ts('%1 records successfully imported.', {1: results.length}),
+              result.length === 1 ? ts('1 record successfully imported.') : ts('%1 records successfully imported.', {1: result.length}),
               ts('Saved'),
               'success'
             );


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an unresponsive screen after importing multiple records into SearchKit (using the Import dialog).

Before
----------------------------------------
After pasting code for e.g. a SavedSearch + SearchDisplay into the Import dialog, the screen will hang even though the records imported sucessfully.

After
----------------------------------------
Fixed.