### PR TITLE
SearchKit - Fix default aggregate function for grand total rows

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -340,22 +340,20 @@
         fieldToColumn: fieldToColumn,
         // Supply default aggregate function appropriate to the data_type
         getDefaultAggregateFn: function(info) {
-          var ret = {flag_before: ''};
+          var arg = info.args[0] || {};
+          if (arg.suffix) {
+            return null;
+          }
           switch (info.data_type) {
             case 'Integer':
               // For the `id` field, default to COUNT, otherwise SUM
-              ret.fnName = (info.args[0] && info.args[0].field && info.args[0].field.name === 'id') ? 'COUNT' : 'SUM';
-              break;
+              return (!info.fn && arg.field && arg.field.name === 'id') ? 'COUNT' : 'SUM';
 
             case 'Float':
-              ret.fnName = 'SUM';
-              break;
-
-            default:
-              ret.fnName = 'GROUP_CONCAT';
-              ret.flag_before = 'DISTINCT ';
+            case 'Money':
+              return 'SUM';
           }
-          return ret;
+          return null;
         },
         // Find all possible search columns that could serve as contact_id for a smart group
         getSmartGroupColumns: function(api_entity, api_params) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -330,8 +330,9 @@
           if (ctrl.canAggregate(col)) {
             // Ensure all non-grouped columns are aggregated if using GROUP BY
             if (!info.fn || info.fn.category !== 'aggregate') {
-              var dfl = searchMeta.getDefaultAggregateFn(info);
-              ctrl.savedSearch.api_params.select[pos] = dfl.fnName + '(' + dfl.flag_before + fieldExpr + ') AS ' + dfl.fnName + '_' + fieldExpr.replace(/[.:]/g, '_');
+              var dflFn = searchMeta.getDefaultAggregateFn(info) || 'GROUP_CONCAT',
+                flagBefore = dflFn === 'GROUP_CONCAT' ? 'DISTINCT ' : '';
+              ctrl.savedSearch.api_params.select[pos] = dflFn + '(' + flagBefore + fieldExpr + ') AS ' + dflFn + '_' + fieldExpr.replace(/[.:]/g, '_');
             }
           } else {
             // Remove aggregate functions when no grouping

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -67,7 +67,7 @@
           _.each(ctrl.display.settings.columns, function(col) {
             if (col.type === 'field') {
               col.tally = {
-                fn: searchMeta.getDefaultAggregateFn(searchMeta.parseExpr(col.key)).fnName
+                fn: searchMeta.getDefaultAggregateFn(searchMeta.parseExpr(ctrl.parent.getExprFromSelect(col.key)))
               };
             }
           });


### PR DESCRIPTION
Overview
----------------------------------------
Fixes what was supposed to be clever defaults for #23454 but wasn't.

Before
----------------------------------------
When enabling "Show Totals in Footer" the aggregate function always uses "GROUP CONCAT" which is a weird default.

After
----------------------------------------
Selects default based on data type.
