### PR TITLE
SearchKit - Allow SearchSegments to be packaged as .mgd.php

### DIFF
--- a/ext/search_kit/Civi/Api4/SearchSegment.php
+++ b/ext/search_kit/Civi/Api4/SearchSegment.php
@@ -7,5 +7,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class SearchSegment extends Generic\DAOEntity {
+  use \Civi\Api4\Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This allows SearchSegments to be packaged and distributed in extensions, along with Saved Searches and Search Displays.

Comments
-----------------
This would allow, e.g. a [SearchKit-based Case Dashboard](https://lab.civicrm.org/dev/core/-/issues/3477) to be packaged.