### PR TITLE
SearchKit - Fix pager & tab count after creating a new record in a popup

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -46,7 +46,10 @@
         }
 
         // Popup forms in this display or surrounding Afform trigger a refresh
-        $element.closest('form').on('crmPopupFormSuccess', this.getResults);
+        $element.closest('form').on('crmPopupFormSuccess', function() {
+          ctrl.rowCount = null;
+          ctrl.getResults();
+        });
 
         function onChangeFilters() {
           ctrl.page = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Ensures the pager & tab count stays up-to-date with new records created on the fly.

Before
----------------------------------------
Create a new SearchSegment, observe that the "Data Segments" tab does not update count after saving.

After
----------------------------------------
Fixed.