### PR TITLE
APIv4 - Exclude disabled custom fields

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -122,6 +122,7 @@ class SpecGatherer {
 
     $query = CustomField::get(FALSE)
       ->setSelect(['custom_group_id.name', 'custom_group_id.title', '*'])
+      ->addWhere('is_active', '=', TRUE)
       ->addWhere('custom_group_id.is_multiple', '=', '0');
 
     // Contact custom groups are extra complicated because contact_type can be a value for extends
@@ -196,6 +197,7 @@ class SpecGatherer {
   private function getCustomGroupFields($customGroup, RequestSpec $specification) {
     $customFields = CustomField::get(FALSE)
       ->addWhere('custom_group_id.name', '=', $customGroup)
+      ->addWhere('is_active', '=', TRUE)
       ->setSelect(['custom_group_id.name', 'custom_group_id.table_name', 'custom_group_id.title', '*'])
       ->execute();
 

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -95,6 +95,25 @@ class BasicCustomFieldTest extends CustomTestBase {
       ->execute()
       ->first();
     $this->assertEquals(NULL, $contact['MyIndividualFields.FavColor']);
+
+    // Disable the field and it disappears from getFields and from the API output.
+    CustomField::update(FALSE)
+      ->addWhere('custom_group_id:name', '=', 'MyIndividualFields')
+      ->addWhere('name', '=', 'FavColor')
+      ->addValue('is_active', FALSE)
+      ->execute();
+
+    $getFields = Contact::getFields(FALSE)
+      ->execute()->column('name');
+    $this->assertContains('first_name', $getFields);
+    $this->assertNotContains('MyIndividualFields.FavColor', $getFields);
+
+    $contact = Contact::get(FALSE)
+      ->addSelect('MyIndividualFields.FavColor')
+      ->addWhere('id', '=', $contactId)
+      ->execute()
+      ->first();
+    $this->assertArrayNotHasKey('MyIndividualFields.FavColor', $contact);
   }
 
   public function testWithTwoFields() {

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -90,7 +90,7 @@ class CustomValueTest extends CustomTestBase {
     $this->assertEquals('secondary', $entity['searchable']);
 
     // Retrieve and check the fields of CustomValue = Custom_$group
-    $fields = CustomValue::getFields($group)->setLoadOptions(TRUE)->setCheckPermissions(FALSE)->execute();
+    $fields = CustomValue::getFields($group, FALSE)->setLoadOptions(TRUE)->execute();
     $expectedResult = [
       [
         'custom_group' => $group,
@@ -251,6 +251,16 @@ class CustomValueTest extends CustomTestBase {
         $this->assertEquals($expectedResult[$key][$attr], $result[$key][$attr]);
       }
     }
+
+    // Disable a field
+    CustomField::update(FALSE)
+      ->addValue('is_active', FALSE)
+      ->addWhere('id', '=', $multiField['id'])
+      ->execute();
+
+    $result = CustomValue::get($group)->execute()->single();
+    $this->assertArrayHasKey($colorFieldName, $result);
+    $this->assertArrayNotHasKey($multiFieldName, $result);
 
     // CASE 4: Test CustomValue::delete
     // There is only record left whose id = 3, delete that record on basis of criteria id = 3


### PR DESCRIPTION
Overview
----------------------------------------
Ensures that disabled custom fields do not show up in API results or in Search Kit.

Before
----------------------------------------
Disabled custom fields available in SearchKit.

After
----------------------------------------
Disabled fields hidden.