### PR TITLE
[Import] Cleanup Contribution flow - esp with regards to soft credits

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -753,7 +753,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
       $tmpContactField['external_identifier'] = $contactFields['external_identifier'];
       $tmpContactField['external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' ' . ts('(match to contact)');
-      $tmpFields['contribution_contact_id']['title'] = $tmpFields['contribution_contact_id']['title'] . ' ' . ts('(match to contact)');
+      $tmpFields['contribution_contact_id']['title'] = $tmpFields['contribution_contact_id']['html']['label'] = $tmpFields['contribution_contact_id']['title'] . ' ' . ts('(match to contact)');
       $fields = array_merge($fields, $tmpContactField);
       $fields = array_merge($fields, $tmpFields);
       $fields = array_merge($fields, $note);

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -166,7 +166,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     foreach ($mapperKeys as $key) {
       $this->_fieldUsed[$key] = FALSE;
     }
-    $this->_location_types = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
     $sel1 = $this->_mapperFields;
 
     if (!$this->get('onDuplicate')) {
@@ -420,8 +419,9 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       $this->controller->resetPage($this->_name);
       return;
     }
+    $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
 
-    $mapper = $mapperKeys = $mapperKeysMain = $mapperSoftCredit = $softCreditFields = $mapperPhoneType = $mapperSoftCreditType = [];
+    $mapper = $mapperKeysMain = $mapperSoftCredit = $softCreditFields = $mapperPhoneType = $mapperSoftCreditType = [];
     $mapperKeys = $this->controller->exportValue($this->_name, 'mapper');
 
     $softCreditTypes = CRM_Core_OptionGroup::values('soft_credit_type');
@@ -478,7 +478,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       $this->set('savedMapping', $saveMapping->id);
     }
 
-    $parser = new CRM_Contribute_Import_Parser_Contribution($mapperKeysMain, $mapperSoftCredit, $mapperPhoneType);
+    $parser = new CRM_Contribute_Import_Parser_Contribution($mapperKeysMain);
+    $parser->setUserJobID($this->getUserJobID());
     $parser->run(
       $this->getSubmittedValue('uploadFile'),
       $this->getSubmittedValue('fieldSeparator'),

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -69,28 +69,13 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public function postProcess() {
     $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $invalidRowCount = $this->get('invalidRowCount');
     $onDuplicate = $this->get('onDuplicate');
-    $mapperSoftCreditType = $this->get('mapperSoftCreditType');
-
+    $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $mapper = $this->controller->exportValue('MapField', 'mapper');
-    $mapperKeys = [];
-    $mapperSoftCredit = [];
-    $mapperPhoneType = [];
 
-    foreach ($mapper as $key => $value) {
-      $mapperKeys[$key] = $mapper[$key][0];
-      if (isset($mapper[$key][0]) && $mapper[$key][0] == 'soft_credit' && isset($mapper[$key])) {
-        $mapperSoftCredit[$key] = $mapper[$key][1] ?? '';
-        $mapperSoftCreditType[$key] = $mapperSoftCreditType[$key]['value'];
-      }
-      else {
-        $mapperSoftCredit[$key] = $mapperSoftCreditType[$key] = NULL;
-      }
-    }
-
-    $parser = new CRM_Contribute_Import_Parser_Contribution($mapperKeys, $mapperSoftCredit, $mapperPhoneType, $mapperSoftCreditType);
+    $parser = new CRM_Contribute_Import_Parser_Contribution();
     $parser->setUserJobID($this->getUserJobID());
+
     $mapFields = $this->get('fields');
 
     foreach ($mapper as $key => $value) {

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -27,9 +27,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     parent::preProcess();
     //get the data from the session
     $dataValues = $this->get('dataValues');
-    $mapper = $this->get('mapper');
-    $softCreditFields = $this->get('softCreditFields');
-    $mapperSoftCreditType = $this->get('mapperSoftCreditType');
     $invalidRowCount = $this->get('invalidRowCount');
 
     //get the mapping name displayed if the mappingId is set
@@ -47,9 +44,6 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
 
     $properties = [
-      'mapper',
-      'softCreditFields',
-      'mapperSoftCreditType',
       'dataValues',
       'columnCount',
       'totalRowCount',
@@ -58,10 +52,30 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
       'downloadErrorRecordsUrl',
     ];
     $this->setStatusUrl();
+    $this->assign('mapper', $this->getMappedFieldLabels());
 
     foreach ($properties as $property) {
       $this->assign($property, $this->get($property));
     }
+  }
+
+  /**
+   * Get the mapped fields as an array of labels.
+   *
+   * e.g
+   * ['First Name', 'Employee Of - First Name', 'Home - Street Address']
+   *
+   * @return array
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getMappedFieldLabels(): array {
+    $mapper = [];
+    $parser = $this->getParser();
+    foreach ($this->getSubmittedValue('mapper') as $columnNumber => $mappedField) {
+      $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput($mappedField, 0, $columnNumber));
+    }
+    return $mapper;
   }
 
   /**

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -739,8 +739,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     }
 
     $params = $this->getMappedRow($values);
-    $formatted = ['version' => 3, 'skipRecentView' => TRUE, 'skipCleanMoney' => FALSE];
-
+    $formatted = ['version' => 3, 'skipRecentView' => TRUE, 'skipCleanMoney' => FALSE, 'contribution_id' => $params['id'] ?? NULL];
     //CRM-10994
     if (isset($params['total_amount']) && $params['total_amount'] == 0) {
       $params['total_amount'] = '0.00';
@@ -1537,6 +1536,30 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       throw new CRM_Core_Exception(ts('Invalid email address(duplicate) %1 for Soft Credit. Row was skipped', [1 => $params['email']]));
     }
     return $emails->first()['contact_id'];
+  }
+
+  /**
+   * @param array $mappedField
+   *   Field detail as would be saved in field_mapping table
+   *   or as returned from getMappingFieldFromMapperInput
+   *
+   * @return string
+   * @throws \API_Exception
+   */
+  public function getMappedFieldLabel(array $mappedField): string {
+    if (empty($this->importableFieldsMetadata)) {
+      $this->setFieldMetadata();
+    }
+    $title = [];
+    $title[] = $this->getFieldMetadata($mappedField['name'])['title'];
+    if ($mappedField['soft_credit_match_field']) {
+      $title[] = $this->getFieldMetadata($mappedField['soft_credit_match_field'])['title'];
+    }
+    if ($mappedField['soft_credit_type_id']) {
+      $title[] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', $mappedField['soft_credit_type_id']);
+    }
+
+    return implode(' - ', $title);
   }
 
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -694,7 +694,7 @@ abstract class CRM_Import_Parser {
    */
   protected function checkContactDuplicate(&$formatValues) {
     //retrieve contact id using contact dedupe rule
-    $formatValues['contact_type'] = $formatValues['contact_type'] ?? $this->_contactType;
+    $formatValues['contact_type'] = $formatValues['contact_type'] ?? $this->getContactType();
     $formatValues['version'] = 3;
     require_once 'CRM/Utils/DeprecatedUtils.php';
     $params = $formatValues;
@@ -723,7 +723,7 @@ abstract class CRM_Import_Parser {
       }
       // CRM-17040, Considering only primary contact when importing contributions. So contribution inserts into primary contact
       // instead of soft credit contact.
-      if (is_array($field) && $key != "soft_credit") {
+      if (is_array($field) && $key !== "soft_credit") {
         foreach ($field as $value) {
           $break = FALSE;
           if (is_array($value)) {

--- a/templates/CRM/Contribute/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contribute/Import/Form/MapTable.tpl
@@ -44,11 +44,7 @@
                 {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
                 <td class="form-item even-row{if $wizard.currentStepName == 'Preview'} labels{/if}">
                     {if $wizard.currentStepName == 'Preview'}
-          {if $softCreditFields && $softCreditFields[$i] != ''}
-          {$mapper[$i]} - {$softCreditFields[$i]} {if $mapperSoftCreditType[$i]}({$mapperSoftCreditType[$i].label}){/if}
-      {else}
           {$mapper[$i]}
-      {/if}
                     {else}
                         {$form.mapper[$i].html|smarty:nodefaults}
                     {/if}

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -299,7 +299,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  protected function getUserJobID(array $submittedValues = []): array {
+  protected function getUserJobID(array $submittedValues = []): int {
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Cleanup Contribution flow - esp with regards to soft credits

This builds on https://github.com/civicrm/civicrm-core/pull/23586 and does significant clean up on handling for soft credit imports

Before
----------------------------------------
- multiple arrays need to be constructed to construct `CRM_Contribute_Import_Parser_Contribution`
- When importing a soft credit it says you can match on `email` - however this ONLY works if your dedupe rule is configured to match on email along

After
----------------------------------------
- most of the arrays are removed (working on the last one) - in favour of `user_job_id`
- since we are saying the email is used to match & we don't have any other fields it now does a simple lookup on email

Technical Details
----------------------------------------

Comments
----------------------------------------
