### PR TITLE
php8.1 - Check null first before sending to strlen

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmCountCharacters.php
@@ -19,13 +19,14 @@
  * @return integer
  */
 function smarty_modifier_crmCountCharacters($string, $include_spaces = FALSE) {
+  if (is_null($string)) {
+    return 0;
+  }
+
   if ($include_spaces) {
     return(strlen($string));
   }
 
-  if (is_null($string)) {
-    return 0;
-  }
   return preg_match_all("/[^\s]/", $string, $match);
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Recently added in https://github.com/civicrm/civicrm-core/pull/23318 which potentially sends null to strlen() generating an error in php8.1