### PR TITLE
[Import] Add some not-yet-used `getParser` functions that are prone to conflict

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -56,4 +56,16 @@ class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->submitFileForMapping('CRM_Activity_Import_Parser_Activity');
   }
 
+  /**
+   * @return CRM_Activity_Import_Parser_Activity
+   */
+  protected function getParser(): CRM_Activity_Import_Parser_Activity {
+    if (!$this->parser) {
+      $this->parser = new CRM_Activity_Import_Parser_Activity();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -395,4 +395,16 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
     $parser->set($this);
   }
 
+  /**
+   * @return CRM_Activity_Import_Parser_Activity
+   */
+  protected function getParser(): CRM_Activity_Import_Parser_Activity {
+    if (!$this->parser) {
+      $this->parser = new CRM_Activity_Import_Parser_Activity();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Activity/Import/Form/Preview.php
+++ b/CRM/Activity/Import/Form/Preview.php
@@ -126,4 +126,16 @@ class CRM_Activity_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
   }
 
+  /**
+   * @return CRM_Activity_Import_Parser_Activity
+   */
+  protected function getParser(): CRM_Activity_Import_Parser_Activity {
+    if (!$this->parser) {
+      $this->parser = new CRM_Activity_Import_Parser_Activity();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -59,4 +59,16 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->submitFileForMapping('CRM_Contribute_Import_Parser_Contribution');
   }
 
+  /**
+   * @return \CRM_Contribute_Import_Parser_Contribution
+   */
+  protected function getParser(): CRM_Contribute_Import_Parser_Contribution {
+    if (!$this->parser) {
+      $this->parser = new CRM_Contribute_Import_Parser_Contribution();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -496,9 +496,12 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @return \CRM_Contribute_Import_Parser_Contribution
    */
   protected function getParser(): CRM_Contribute_Import_Parser_Contribution {
-    $parser = new CRM_Contribute_Import_Parser_Contribution();
-    $parser->setUserJobID($this->getUserJobID());
-    return $parser;
+    if (!$this->parser) {
+      $this->parser = new CRM_Contribute_Import_Parser_Contribution();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
   }
 
 }

--- a/CRM/Contribute/Import/Form/Preview.php
+++ b/CRM/Contribute/Import/Form/Preview.php
@@ -139,4 +139,16 @@ class CRM_Contribute_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
   }
 
+  /**
+   * @return \CRM_Contribute_Import_Parser_Contribution
+   */
+  protected function getParser(): CRM_Contribute_Import_Parser_Contribution {
+    if (!$this->parser) {
+      $this->parser = new CRM_Contribute_Import_Parser_Contribution();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -96,4 +96,16 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->submitFileForMapping('CRM_Custom_Import_Parser_Api', 'multipleCustomData');
   }
 
+  /**
+   * @return CRM_Custom_Import_Parser_Api
+   */
+  protected function getParser(): CRM_Custom_Import_Parser_Api {
+    if (!$this->parser) {
+      $this->parser = new CRM_Custom_Import_Parser_Api();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Custom/Import/Form/Preview.php
+++ b/CRM/Custom/Import/Form/Preview.php
@@ -115,4 +115,16 @@ class CRM_Custom_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
   }
 
+  /**
+   * @return CRM_Custom_Import_Parser_Api
+   */
+  protected function getParser(): CRM_Custom_Import_Parser_Api {
+    if (!$this->parser) {
+      $this->parser = new CRM_Custom_Import_Parser_Api();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -59,4 +59,16 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->submitFileForMapping('CRM_Event_Import_Parser_Participant');
   }
 
+  /**
+   * @return CRM_Event_Import_Parser_Participant
+   */
+  protected function getParser(): CRM_Event_Import_Parser_Participant {
+    if (!$this->parser) {
+      $this->parser = new CRM_Event_Import_Parser_Participant();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -430,4 +430,16 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     $parser->set($this);
   }
 
+  /**
+   * @return CRM_Event_Import_Parser_Participant
+   */
+  protected function getParser(): CRM_Event_Import_Parser_Participant {
+    if (!$this->parser) {
+      $this->parser = new CRM_Event_Import_Parser_Participant();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -128,4 +128,16 @@ class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
   }
 
+  /**
+   * @return CRM_Event_Import_Parser_Participant
+   */
+  protected function getParser(): CRM_Event_Import_Parser_Participant {
+    if (!$this->parser) {
+      $this->parser = new CRM_Event_Import_Parser_Participant();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -64,6 +64,11 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected $userJob;
 
   /**
+   * @var \CRM_Import_Parser
+   */
+  protected $parser;
+
+  /**
    * Get User Job.
    *
    * API call to retrieve the userJob row.

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -59,4 +59,16 @@ class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->submitFileForMapping('CRM_Member_Import_Parser_Membership');
   }
 
+  /**
+   * @return \CRM_Member_Import_Parser_Membership
+   */
+  protected function getParser(): CRM_Member_Import_Parser_Membership {
+    if (!$this->parser) {
+      $this->parser = new CRM_Member_Import_Parser_Membership();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -459,4 +459,16 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $parser->set($this);
   }
 
+  /**
+   * @return \CRM_Member_Import_Parser_Membership
+   */
+  protected function getParser(): CRM_Member_Import_Parser_Membership {
+    if (!$this->parser) {
+      $this->parser = new CRM_Member_Import_Parser_Membership();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }

--- a/CRM/Member/Import/Form/Preview.php
+++ b/CRM/Member/Import/Form/Preview.php
@@ -148,4 +148,16 @@ class CRM_Member_Import_Form_Preview extends CRM_Import_Form_Preview {
     }
   }
 
+  /**
+   * @return \CRM_Member_Import_Parser_Membership
+   */
+  protected function getParser(): CRM_Member_Import_Parser_Membership {
+    if (!$this->parser) {
+      $this->parser = new CRM_Member_Import_Parser_Membership();
+      $this->parser->setUserJobID($this->getUserJobID());
+      $this->parser->init();
+    }
+    return $this->parser;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
[Import] Add some not-yet-used functions that are prone to conflict

Before
----------------------------------------
Conflicts keep happening on these functions when I add them in 'thematic' PRs

After
----------------------------------------
The functions are there....

Technical Details
----------------------------------------
None of these are used yet 

Note that there are not other functions to be shared between the Entity-specific classes - eg. `Contribution_MapField` `Contribution_Preview` `Contribution_DataSource` - so repeating this small function makes more sense than a trait

Comments
----------------------------------------
