### PR TITLE
[Import] [ref] Move function to parent for use by siblings

### DIFF
--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -242,26 +242,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
   }
 
   /**
-   * Get the mapped fields as an array of labels.
-   *
-   * e.g
-   * ['First Name', 'Employee Of - First Name', 'Home - Street Address']
-   *
-   * @return array
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   */
-  protected function getMappedFieldLabels(): array {
-    $mapper = [];
-    $parser = new CRM_Contact_Import_Parser_Contact();
-    $parser->setUserJobID($this->getUserJobID());
-    foreach ($this->getSubmittedValue('mapper') as $columnNumber => $mappedField) {
-      $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput($mappedField, 0, $columnNumber));
-    }
-    return $mapper;
-  }
-
-  /**
    * @return \CRM_Contact_Import_Parser_Contact
    */
   protected function getParser(): CRM_Contact_Import_Parser_Contact {

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -245,9 +245,11 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @return \CRM_Contact_Import_Parser_Contact
    */
   protected function getParser(): CRM_Contact_Import_Parser_Contact {
-    $parser = new CRM_Contact_Import_Parser_Contact();
-    $parser->setUserJobID($this->getUserJobID());
-    return $parser;
+    if (!$this->parser) {
+      $this->parser = new CRM_Contact_Import_Parser_Contact();
+      $this->parser->setUserJobID($this->getUserJobID());
+    }
+    return $this->parser;
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -567,4 +567,24 @@ class CRM_Import_Forms extends CRM_Core_Form {
     return NULL;
   }
 
+  /**
+   * Get the mapped fields as an array of labels.
+   *
+   * e.g
+   * ['First Name', 'Employee Of - First Name', 'Home - Street Address']
+   *
+   * @return array
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function getMappedFieldLabels(): array {
+    $mapper = [];
+    $parser = new CRM_Contact_Import_Parser_Contact();
+    $parser->setUserJobID($this->getUserJobID());
+    foreach ($this->getSubmittedValue('mapper') as $columnNumber => $mappedField) {
+      $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput($mappedField, 0, $columnNumber));
+    }
+    return $mapper;
+  }
+
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -579,8 +579,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function getMappedFieldLabels(): array {
     $mapper = [];
-    $parser = new CRM_Contact_Import_Parser_Contact();
-    $parser->setUserJobID($this->getUserJobID());
+    $parser = $this->getParser();
     foreach ($this->getSubmittedValue('mapper') as $columnNumber => $mappedField) {
       $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput($mappedField, 0, $columnNumber));
     }


### PR DESCRIPTION
Overview
----------------------------------------
[Import] [ref] Move function to parent for use by siblings

Before
----------------------------------------
Hogged by one child

After
----------------------------------------
Just like my spotify account anyone in the family can use it ... if Jack isn't using it ... so never

Technical Details
----------------------------------------
I switched to using `getParser` rather than 
```
   $parser = new CRM_Contact_Import_Parser_Contact();
    $parser->setUserJobID($this->getUserJobID());
```

That function is already on the class the function is being moved from (and is added to the others in https://github.com/civicrm/civicrm-core/pull/23590 ) 

- the others have a call to `init` but I didn't add that here as I didn't want to make any changes that would require a full r-run in this PR

Comments
----------------------------------------
