### PR TITLE
(dev/core#3479) make the alterReportVar hook usable by passing the sql

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3067,9 +3067,10 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     if ($applyLimit && empty($this->_params['charts'])) {
       $this->limit();
     }
-    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
 
     $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy} {$this->_limit}";
+    CRM_Utils_Hook::alterReportVar('sql', $sql, $this);
+
     $this->addToDeveloperTab($sql);
     return $sql;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Currently, we are not passing the sql in the _alterReportVar_ hook.
`CRM_Utils_Hook::alterReportVar('sql', $this, $this);`

Objective is to make the hook usable by passing the sql instead of redundant params.

Before
----------------------------------------
no sql available in the _alterReportVar_ hook

After
----------------------------------------
sql available in the _alterReportVar_ hook


Comments
----------------------------------------
@eileenmcnaughton this is in keeping with what I did for https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/pull/508
