### PR TITLE
Authx - Mark extension as table

### DIFF
--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -16,7 +16,7 @@
   </urls>
   <releaseDate>2021-02-11</releaseDate>
   <version>5.51.alpha1</version>
-  <develStage>alpha</develStage>
+  <develStage>beta</develStage>
   <compatibility>
     <ver>5.51</ver>
   </compatibility>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -16,7 +16,7 @@
   </urls>
   <releaseDate>2021-02-11</releaseDate>
   <version>5.51.alpha1</version>
-  <develStage>beta</develStage>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>5.51</ver>
   </compatibility>


### PR DESCRIPTION
Overview
----------------------------------------
Marks the Authx core extension as "beta"

Before
----------------------------------------
"alpha"

After
----------------------------------------
"beta"

Comments
----------------------------------------
Since we are pushing notices from Afform telling people to install this extension, we should probably at least mark it as beta.

See https://civicrm.stackexchange.com/questions/41784/is-authx-really-alpha