### PR TITLE
Fixes core#3369 scheduled Reminder limited by Participant Role fails if any participant has multiple roles

### DIFF
--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -149,8 +149,9 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     if ($schedule->recipient_listing && $schedule->limit_to) {
       switch ($schedule->recipient) {
         case 'participant_role':
-          $query->where("e.role_id IN (#recipList)")
-            ->param('recipList', \CRM_Utils_Array::explodePadded($schedule->recipient_listing));
+          $regex = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', (array) $schedule->recipient_listing) . "([[:cntrl:]]|$)";
+          $query->where("e.role_id REGEXP (@regex)")
+            ->param('regex', $regex);
           break;
 
         default:

--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -149,7 +149,7 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
     if ($schedule->recipient_listing && $schedule->limit_to) {
       switch ($schedule->recipient) {
         case 'participant_role':
-          $regex = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', (array) $schedule->recipient_listing) . "([[:cntrl:]]|$)";
+          $regex = "([[:cntrl:]]|^)" . implode('([[:cntrl:]]|$)|([[:cntrl:]]|^)', \CRM_Utils_Array::explodePadded($schedule->recipient_listing)) . "([[:cntrl:]]|$)";
           $query->where("e.role_id REGEXP (@regex)")
             ->param('regex', $regex);
           break;

--- a/tests/phpunit/CRM/Event/ActionMappingTest.php
+++ b/tests/phpunit/CRM/Event/ActionMappingTest.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Event_ActionMappingTest
+ * @group ActionSchedule
+ *
+ * This class tests various configurations of event scheduled-reminders. It follows a design/pattern described in
+ * AbstractMappingTest.
+ *
+ * @see \Civi\ActionSchedule\AbstractMappingTest
+ * @group headless
+ */
+class CRM_Event_ActionMappingTest extends \Civi\ActionSchedule\AbstractMappingTest {
+
+  public function createTestCases() {
+  }
+
+  public function testLimitByRoleId() {
+    $participantId = $this->participantCreate(['role_id' => [1, 2]]);
+    $participant = $this->callAPISuccess('participant', 'getsingle', ['id' => $participantId]);
+    $eventId = $participant['event_id'];
+    $this->schedule->mapping_id = CRM_Event_ActionMapping::EVENT_NAME_MAPPING_ID;
+    $this->schedule->start_action_date = 'start_date';
+    $this->schedule->entity_value = $eventId;
+    $this->schedule->limit_to = 1;
+    $this->schedule->recipient_listing = 1;
+    $this->startWeekBefore();
+    $this->useHelloFirstName();
+    $this->schedule->save();
+    $this->callAPISuccess('job', 'send_reminder', []);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the following core issue https://lab.civicrm.org/dev/core/-/issues/3369. @MegaphoneJon created a PR See https://github.com/civicrm/civicrm-core/pull/20981. This PR is based on his work.

An addition in this PR is that it considers that a reminder can be configured to select two participant roles, and the way this is stored / (See comment https://github.com/civicrm/civicrm-core/pull/20981#issuecomment-902527545).

Technical Details
----------------------------------------
This PR contains a test of all the participant role and recipient_listing combinations.


