### PR TITLE
[Import] [Activity] Fix fatal error regression

### DIFF
--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -296,10 +296,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
         ],
         'expected_error' => '',
       ],
-
-      // @todo This is also inconsistent. The map UI requires target contact
-      // but import is fine leaving it blank. In general civi is fine with
-      // a blank target so possibly map UI should not require it.
+      // a way to find the contact id is required.
       15 => [
         'input' => [
           'target_contact_id' => '',
@@ -307,7 +304,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
           'activity_date_time' => $some_date,
           'activity_subject' => 'asubj',
         ],
-        'expected_error' => '',
+        'expected_error' => 'No matching Contact found for ()',
       ],
 
     ];


### PR DESCRIPTION
Overview
----------------------------------------
The loss of a `require_once` somewhere has led to a fatal error regression on activity import


Before
----------------------------------------
Try an activity import using this csv - https://github.com/eileenmcnaughton/testdata/commit/b29b35a12530fe27b8441b14342287e9d49c2234#diff-3bc9d864b427143e8ae4acd47d294dd13712f830231205e3c73e22cca448e486 - accept all defaults but ALSO map 'email' (which isn't mapping by default) - on the import part it hits a fatal

![image](https://user-images.githubusercontent.com/336308/170646819-54541b7c-0083-4c54-a029-8532644cda49.png)


After
----------------------------------------
That part works - I think there might still be some issues


Technical Details
----------------------------------------
This just folds the part that is actually being run in `_civicrm_api3_deprecated_duplicate_formatted_contact` back into the function - we know that neither `id` or `external_identifier` are hit at this point so just the latter part runs

![image](https://user-images.githubusercontent.com/336308/170647278-3224bf2b-bb60-4bc7-a420-73f5434ba973.png)

#[23600](https://github.com/civicrm/civicrm-core/pull/23600) is also in this PR - I'm including it in all PRs at this stage as my conflict defence

Comments
----------------------------------------
