### PR TITLE
Fix 'Authorization Failed' regression when submitting eg. webform via checksum

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -244,7 +244,7 @@ class CRM_Utils_Recent {
       }
       elseif ($event->action === 'edit') {
         if (isset($event->object->is_deleted)) {
-          \Civi\Api4\RecentItem::update()
+          \Civi\Api4\RecentItem::update(FALSE)
             ->addWhere('entity_type', '=', $entityType)
             ->addWhere('entity_id', '=', $event->id)
             ->addValue('is_deleted', (bool) $event->object->is_deleted)


### PR DESCRIPTION
Overview
----------------------------------------
When a user accesses API3 (eg Activity.create, Case.create, EmailApi.send) and they are accessing via a checksum link (I tested using a drupal webform submission with a checksum) the API calls fail with "Authorization Failed". I traced this to the recently changed in #23099 API4 `RecentItems::update()`

I'm not certain if setting checkPermissions = FALSE is the correct thing to do here because this code is called on every post hook but I think that's effectively how it was working before.

Before
----------------------------------------
Cannot use API3 calls when "logged in" via a checksum.

After
----------------------------------------
Can use API3 calls when "logged in" via a checksum.

Technical Details
----------------------------------------
The user does not have "Access CiviCRM" but an "authenticated user" does have "Access AJAX API" and I think the checksum gives them "authenticated user" access?  An alternative might be to open up permissions on RecentItems to "Access AJAX API"?

Comments
----------------------------------------
@colemanw @eileenmcnaughton per discussion in product-maintenance. This is a regression on 5.49.
