### PR TITLE
[NFC] Remove duplicate unit test data file

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.CSV
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.CSV
@@ -1,2 +1,0 @@
-External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to
-bob,65,2008-09-20,Donation,mum@example.com


### PR DESCRIPTION
Overview
----------------------------------------
Causes a problem on windows which is not case-sensitive. And also just don't need a duplicate file - it's the same as contributions.csv