### PR TITLE
core 3459 getlist leading zero fix

### DIFF
--- a/api/v3/Generic/Getlist.php
+++ b/api/v3/Generic/Getlist.php
@@ -27,7 +27,7 @@ function civicrm_api3_generic_getList($apiRequest) {
   $meta = civicrm_api3_generic_getfields(['action' => 'get'] + $apiRequest, FALSE)['values'];
 
   // If the user types an integer into the search
-  $forceIdSearch = empty($request['id']) && !empty($request['input']) && !empty($meta['id']) && CRM_Utils_Rule::positiveInteger($request['input']);
+  $forceIdSearch = empty($request['id']) && !empty($request['input']) && !empty($meta['id']) && CRM_Utils_Rule::positiveInteger($request['input']) && (substr($request['input'], 0, 1) !== '0');
   // Add an extra page of results for the record with an exact id match
   if ($forceIdSearch) {
     $request['page_num'] = ($request['page_num'] ?? 1) - 1;

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -923,4 +923,16 @@ class api_v3_EventTest extends CiviUnitTestCase {
     }
   }
 
+  public function testGetListLeadingZero() {
+    $this->callAPISuccess('Event', 'create', [
+      'title' => "0765",
+      'start_date' => "2022-04-04",
+      'event_type_id' => "Conference",
+    ]);
+    $result = $this->callAPISuccess('Event', 'getlist', [
+      'input' => "0765",
+    ]);
+    $this->assertEquals(1, $result['count']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Full details on: https://lab.civicrm.org/dev/core/-/issues/3459

Before
----------------------------------------
When a user searched for am event that started with a zero it would not return any results.

After
----------------------------------------
Now, when a user searches for an event with a leading zero in the title, the results are properly returned.

Technical Details
----------------------------------------
Adding a condition that does not cause a forcedIDSearch 