### PR TITLE
dev/core#1681 - Update requirements to MySQL 5.7+ and MariaDB 10.2+

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -442,7 +442,7 @@ SET    version = '$version'
         [
           1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER,
           2 => CRM_Utils_SQL::getDatabaseVersion(),
-          3 => '10.1',
+          3 => CRM_Upgrade_Incremental_General::MIN_INSTALL_MARIADB_VER,
           4 => $latestVer,
         ]);
     }

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -43,18 +43,30 @@ class CRM_Upgrade_Incremental_General {
   const MIN_INSTALL_PHP_VER = '7.2.0';
 
   /**
-   * The minimum recommended MySQL/MariaDB version.
+   * The minimum recommended MySQL version.
    *
-   * A site running an earlier version will be told to upgrade.
+   * A site running an earlier version will be encouraged to upgrade.
    */
   const MIN_RECOMMENDED_MYSQL_VER = '5.7';
 
   /**
-   * The minimum MySQL/MariaDB version required to install Civi.
+   * The minimum MySQL version required to install Civi.
    *
    * @see install/index.php
    */
   const MIN_INSTALL_MYSQL_VER = '5.7';
+
+  /**
+   * The minimum recommended MariaDB version.
+   *
+   * A site running an earlier version will be encouraged to upgrade.
+   */
+  const MIN_RECOMMENDED_MARIADB_VER = '10.4';
+
+  /**
+   * The minimum MariaDB version required to install Civi.
+   */
+  const MIN_INSTALL_MARIADB_VER = '10.2';
 
   /**
    * Compute any messages which should be displayed before upgrade.
@@ -82,7 +94,7 @@ class CRM_Upgrade_Incremental_General {
       $preUpgradeMessage .= ts('This system uses MySQL/MariaDB v%5. You may proceed with the upgrade, and CiviCRM v%1 will continue working normally. However, CiviCRM v%4 will require MySQL v%2 or MariaDB v%3.', [
         1 => $latestVer,
         2 => self::MIN_RECOMMENDED_MYSQL_VER . '+',
-        3 => '10.1' . '+',
+        3 => self::MIN_RECOMMENDED_MARIADB_VER . '+',
         4 => '5.34' . '+',
         5 => CRM_Utils_SQL::getDatabaseVersion(),
       ]);

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -54,7 +54,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * @see install/index.php
    */
-  const MIN_INSTALL_MYSQL_VER = '5.6.5';
+  const MIN_INSTALL_MYSQL_VER = '5.7';
 
   /**
    * Compute any messages which should be displayed before upgrade.

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -1009,7 +1009,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     $messages = [];
     $version = CRM_Utils_SQL::getDatabaseVersion();
     $minRecommendedVersion = CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_MYSQL_VER;
-    $mariaDbRecommendedVersion = '10.1';
+    $mariaDbRecommendedVersion = CRM_Upgrade_Incremental_General::MIN_RECOMMENDED_MARIADB_VER;
     $upcomingCiviChangeVersion = '5.34';
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), $minRecommendedVersion, '<')) {
       $messages[] = new CRM_Utils_Check_Message(


### PR DESCRIPTION
Overview
----------------------------------------

(NOTE: This patch should be aimed at v5.52, which will be the dev version during June.)

See: https://lab.civicrm.org/dev/core/-/issues/1681

Before
----------------------------------------

Requires MySQL 5.6. Recommends MySQL 5.7 / MariaDB 10.1.

<img width="553" alt="Screen Shot 2022-05-27 at 9 05 04 PM" src="https://user-images.githubusercontent.com/1336047/170809139-cca93530-9d18-4a4f-9e22-2ebc1d0943fd.png">

After
----------------------------------------

Requires MySQL 5.7. Recommends MySQL 5.7 / MariaDB 10.2.


<img width="1033" alt="Screen Shot 2022-05-27 at 9 04 40 PM" src="https://user-images.githubusercontent.com/1336047/170809138-5dfcb282-57d0-417f-b80c-64bdce1cf3a8.png">

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
