### PR TITLE
Print report or export report if user have access report permission

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3014,7 +3014,9 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     // fields array is missing because form building etc is skipped
     // in dashboard mode for report
     //@todo - this could be done in the dashboard no we have a setter
-    if (empty($this->_params['fields']) && !$this->_noFields) {
+    if (empty($this->_params['fields']) && !$this->_noFields
+      && empty($this->_params['task'])
+    ) {
       $this->setParams($this->_formValues);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2540

Before
----------------------------------------
when disabling the “access Report Criteria” permission, the "Print report" and "Print to PDF" functions on a report appear, but do not function.
After
----------------------------------------
when disabling the “access Report Criteria” permission, the "Print report" and "Print to PDF" functions on a report appear to work

Technical Details
----------------------------------------
When “access Report Criteria”  is not set to user role, $this->_params['fields'] is empty hence $this->_noFields is not set causing $this->_params to get over-ridden with formvalues stored in the database, hence _task_ parameter is lost is $this->_params which is used to set report mode in processReportMode().
