### PR TITLE
Fix swapOptions writing over selected options on mapField page load.

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -299,7 +299,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       if (!empty($mapper)) {
         $last_key = array_key_last($mapper[$i]);
       }
-      else if ($this->getSubmittedValue('savedMapping') && $processor->getFieldName($i)) {
+      elseif ($this->getSubmittedValue('savedMapping') && $processor->getFieldName($i)) {
         $defaults["mapper[$i]"] = $processor->getSavedQuickformDefaultsForColumn($i);
         $last_key = array_key_last($defaults["mapper[$i]"]) ?? 0;
       }

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -564,18 +564,18 @@ class CRM_Import_ImportProcessor {
 
     if ($this->getValidRelationshipKey($column)) {
       $fieldMapping[] = $this->getValidRelationshipKey($column);
-    } 
-    
-    // $sel1 
+    }
+
+    // $sel1
     $fieldMapping[] = $this->getFieldName($column);
-  
+
     // $sel2
     if ($this->getWebsiteTypeID($column)) {
       $fieldMapping[] = $this->getWebsiteTypeID($column);
-    } 
-    else if ($this->getLocationTypeID($column)) {
+    }
+    elseif ($this->getLocationTypeID($column)) {
       $fieldMapping[] = $this->getLocationTypeID($column);
-    } 
+    }
 
     // $sel3
     if ($this->getPhoneOrIMTypeID($column)) {

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -237,31 +237,28 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     return [
       [
         ['name' => 'first_name', 'contact_type' => 'Individual', 'column_number' => 0],
-        "document.forms.MapField['mapper[0][1]'].style.display = 'none';
-document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
-        ['mapper[0]' => ['first_name', 0, NULL]],
+        "swapOptions(document.forms.MapField, 'mapper[0]', 0, 4, 'hs_mapper_0_');\n",
+        ['mapper[0]' => ['first_name']],
       ],
       [
         ['name' => 'phone', 'contact_type' => 'Individual', 'column_number' => 0, 'phone_type_id' => 1, 'location_type_id' => 2],
-        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "swapOptions(document.forms.MapField, 'mapper[0]', 2, 4, 'hs_mapper_0_');\n",
         ['mapper[0]' => ['phone', 2, 1]],
       ],
       [
         ['name' => 'im', 'contact_type' => 'Individual', 'column_number' => 0, 'im_provider_id' => 1, 'location_type_id' => 2],
-        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "swapOptions(document.forms.MapField, 'mapper[0]', 2, 4, 'hs_mapper_0_');\n",
         ['mapper[0]' => ['im', 2, 1]],
       ],
       [
         ['name' => 'url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1],
-        "document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "swapOptions(document.forms.MapField, 'mapper[0]', 1, 4, 'hs_mapper_0_');\n",
         ['mapper[0]' => ['url', 1]],
       ],
       [
         // Yes, the relationship mapping really does use url whereas non relationship uses website because... legacy
         ['name' => 'url', 'contact_type' => 'Individual', 'column_number' => 0, 'website_type_id' => 1, 'relationship_type_id' => 1, 'relationship_direction' => 'a_b'],
-        "document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "swapOptions(document.forms.MapField, 'mapper[0]', 2, 4, 'hs_mapper_0_');\n",
         ['mapper[0]' => ['1_a_b', 'url', 1]],
       ],
       [
@@ -271,9 +268,7 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
       ],
       [
         ['name' => 'do_not_import', 'contact_type' => 'Individual', 'column_number' => 0],
-        "document.forms.MapField['mapper[0][1]'].style.display = 'none';
-document.forms.MapField['mapper[0][2]'].style.display = 'none';
-document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
+        "swapOptions(document.forms.MapField, 'mapper[0]', 0, 4, 'hs_mapper_0_');\n",
         ['mapper[0]' => []],
       ],
     ];
@@ -354,9 +349,8 @@ document.forms.MapField['mapper[0][3]'].style.display = 'none';\n",
 
     $defaults = [];
     $defaults["mapper[$columnNumber]"] = $processor->getSavedQuickformDefaultsForColumn($columnNumber);
-    $js = $processor->getQuickFormJSForField($columnNumber);
 
-    return ['defaults' => $defaults, 'js' => $js];
+    return ['defaults' => $defaults];
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1106,6 +1106,9 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       ['do_not_import'],
       // [$childKey, $customField, 'state_province'],
       ['do_not_import'],
+      // mapField Form expects all fields to be mapped.
+      ['do_not_import'],
+      ['do_not_import'],
     ];
     $csv = 'individual_country_state_county_with_related.csv';
     $this->validateMultiRowCsv($csv, $mapper, 'error_value');
@@ -1182,6 +1185,10 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       ['5_a_b', 'organization_name'],
       ['contact_sub_type'],
       ['5_a_b', 'contact_sub_type'],
+      // mapField Form expects all fields to be mapped.
+      ['do_not_import'],
+      ['do_not_import'],
+      ['do_not_import'],
     ];
     $csv = 'individual_contact_sub_types.csv';
     $field = 'contact_sub_type';


### PR DESCRIPTION
Alternate solution to fix: #23534 "Fix Field mapping bug - forgets related fields"

- Simplifies js code that is acting on the mapField select elements (swapOptions handles the job of either adding the second, third or fourth select lists or hiding them if they are not required).  
- Only set Defaults on first loading of the form.  Either from the savedMapping or by guessing.
- Clean up loading the defaults from the savedMapping so only include the defaults required for the field mapping.

Unhandled:

- I don't think defaults should be guessed if a SavedMapping is used.   Otherwise someone could run a import with a savedMapping on a csv file with more fields then in the savedMapping not knowing that some of the fields on the end could have been magically guessed.  It should be Use submitted mapping or SavedMapping or Guess.  
- Setting default location types probably needs to happen in the swapOptions js somewhere.  

I hope I'm not derailing the conversation on this issue.   