### PR TITLE
Release lock when deleting cache key

### DIFF
--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -115,7 +115,9 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
     }
 
     if (is_int($ttl) && $ttl <= 0) {
-      return $this->delete($key);
+      $result = $this->delete($key);
+      $lock->release();
+      return $result;
     }
 
     $dataExists = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM {$this->table} WHERE {$this->where($key)}");


### PR DESCRIPTION
Overview
----------------------------------------
I'm seeing `SqlGroup: Failed to acquire lock on cache key.` intermittently on a number of sites. I'm not able to trace the reason because it might happen once a day or less and the cause of the error is always the previous request - ie. the current request cannot get a lock because the previous request didn't release it.

Before
----------------------------------------
if `CRM_Utils_Cache_SqlGroup::set()` called with ttl<=0 cache key is deleted but lock is never released.

After
----------------------------------------
if `CRM_Utils_Cache_SqlGroup::set()` called with ttl<=0 cache key is deleted and lock is released.

Technical Details
----------------------------------------
You can see by tracing the function `delete()` that it performs various actions before returning but does not release the lock. The lock is only released at the bottom of the `set()` function but the code returns immediately after the call to delete and never reaches the lock release code.

Comments
----------------------------------------

