### PR TITLE
Add Authx settings to navigation

### DIFF
--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -232,7 +232,7 @@ function authx_civicrm_permission(&$permissions) {
  */
 function authx_civicrm_navigationMenu(&$menu) {
   _authx_civix_insert_navigation_menu($menu, 'Administer/System Settings', [
-    'label' => E::ts('Configure Authentication'),
+    'label' => E::ts('Authentication'),
     'name' => 'authx_admin',
     'url' => 'civicrm/admin/setting/authx',
     'permission' => 'administer CiviCRM',

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -230,14 +230,14 @@ function authx_civicrm_permission(&$permissions) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
  */
-//function authx_civicrm_navigationMenu(&$menu) {
-//  _authx_civix_insert_navigation_menu($menu, 'Mailings', array(
-//    'label' => E::ts('New subliminal message'),
-//    'name' => 'mailing_subliminal_message',
-//    'url' => 'civicrm/mailing/subliminal',
-//    'permission' => 'access CiviMail',
-//    'operator' => 'OR',
-//    'separator' => 0,
-//  ));
-//  _authx_civix_navigationMenu($menu);
-//}
+function authx_civicrm_navigationMenu(&$menu) {
+  _authx_civix_insert_navigation_menu($menu, 'Administer/System Settings', [
+    'label' => E::ts('Configure Authentication'),
+    'name' => 'authx_admin',
+    'url' => 'civicrm/admin/setting/authx',
+    'permission' => 'administer CiviCRM',
+    'operator' => 'OR',
+    'separator' => 0,
+  ]);
+  _authx_civix_navigationMenu($menu);
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add Authx settings to navigation

Before
----------------------------------------
Docs say there is a settings page - but you have to grep to find it

After
----------------------------------------
Under system settings

Technical Details
----------------------------------------
I think this might be open to wordsmithing / moving within the menu - I don't have any strong feelings on the wording or location

Comments
----------------------------------------
