### PR TITLE
Decode HTML entities in iCalendar text

### DIFF
--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -33,6 +33,7 @@ class CRM_Utils_ICalendar {
    */
   public static function formatText($text) {
     $text = strip_tags($text);
+    $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML401, 'UTF-8');
     $text = str_replace("\\", "\\\\", $text);
     $text = str_replace(',', '\,', $text);
     $text = str_replace(';', '\;', $text);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#1541](https://lab.civicrm.org/dev/core/-/issues/1541) (and the much older https://issues.civicrm.org/jira/browse/CRM-13645). iCal event description contains encoded HTML entities when it should be plain text. This PR decodes HTML entities.

Before
----------------------------------------
Text in iCalendar file contains HTML entities like `&uuml;` or `&npsp;`.

After
----------------------------------------
HTML entites are decoded to plain text.

Technical Details
----------------------------------------
Note from user `pminf`:
> Note that html in iCalendar is fine if the "Alternate Text Representation" points to a "text/html" content portion (see https://tools.ietf.org/html/rfc5545#section-3.2.1 for details).

Comments
----------------------------------------
This is basically just the patch that had been provided in the issue by user `pminf`.
