### PR TITLE
Fixes for contact matching - unreleased regression

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -781,46 +781,6 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    *
    */
   public static function resolveDefaults(&$defaults, $reverse = FALSE) {
-
-    $blocks = ['address'];
-    foreach ($blocks as $name) {
-      if (!array_key_exists($name, $defaults) || !is_array($defaults[$name])) {
-        continue;
-      }
-      foreach ($defaults[$name] as $count => & $values) {
-
-        //get location type id.
-        CRM_Utils_Array::lookupValue($values, 'location_type', CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id'), $reverse);
-
-        if ($name == 'address') {
-          // FIXME: lookupValue doesn't work for vcard_name
-          if (!empty($values['location_type_id'])) {
-            $vcardNames = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'vcard_name']);
-            $values['vcard_name'] = $vcardNames[$values['location_type_id']];
-          }
-
-          $stateProvinceID = self::resolveStateProvinceID($values, $values['country_id'] ?? NULL);
-          if ($stateProvinceID) {
-            $values['state_province_id'] = $stateProvinceID;
-          }
-
-          if (!empty($values['state_province_id'])) {
-            $countyList = CRM_Core_PseudoConstant::countyForState($values['state_province_id']);
-          }
-          else {
-            $countyList = CRM_Core_PseudoConstant::county();
-          }
-          CRM_Utils_Array::lookupValue($values,
-            'county',
-            $countyList,
-            $reverse
-          );
-        }
-
-        // Kill the reference.
-        unset($values);
-      }
-    }
   }
 
   /**

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -114,6 +114,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     'postal_greeting_id',
     'addressee',
     'addressee_id',
+    'geo_code_1',
+    'geo_code_2',
   ];
 
   /**
@@ -947,32 +949,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
                   if (!empty($county['county']) && !in_array($county['county'], $countyNames)) {
                     $errors[] = ts('County input value not in county table: The County value appears to be invalid. It does not match any value in CiviCRM table of counties.');
                   }
-                }
-              }
-            }
-            break;
-
-          case 'geo_code_1':
-            if (!empty($value)) {
-              foreach ($value as $codeValue) {
-                if (!empty($codeValue['geo_code_1'])) {
-                  if (CRM_Utils_Rule::numeric($codeValue['geo_code_1'])) {
-                    continue;
-                  }
-                  $errors[] = ts('Geo code 1');
-                }
-              }
-            }
-            break;
-
-          case 'geo_code_2':
-            if (!empty($value)) {
-              foreach ($value as $codeValue) {
-                if (!empty($codeValue['geo_code_2'])) {
-                  if (CRM_Utils_Rule::numeric($codeValue['geo_code_2'])) {
-                    continue;
-                  }
-                  $errors[] = ts('Geo code 2');
                 }
               }
             }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1186,6 +1186,9 @@ abstract class CRM_Import_Parser {
       return CRM_Utils_Rule::email($importedValue) ? $importedValue : 'invalid_import_value';
     }
 
+    if ($fieldMetadata['type'] === CRM_Utils_Type::T_FLOAT) {
+      return CRM_Utils_Rule::numeric($importedValue) ? $importedValue : 'invalid_import_value';
+    }
     if ($fieldMetadata['type'] === CRM_Utils_Type::T_BOOLEAN) {
       $value = CRM_Utils_String::strtoboolstr($importedValue);
       if ($value !== FALSE) {

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
@@ -5,3 +5,4 @@ Susie,Jones,susie@example.com,,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jon
 Susie,Jones,susie@example.com,,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,,AU,New South Wales,Australia,New South Wales,Valid,
 Susie,Jones,susie@example.com,,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,,1013,New South Wales,1013,New South Wales,Valid,
 Susie,Jones,susie@example.com,,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,,,,,,Valid,
+Susie,Jones,susie@example.com,,AU,NEW South Wales,NEW South Wales,AU,AU,NEW South Wales,Mum,Jones,mum@example.com,NEW South Wales,AU,,AU,NEW South Wales,Australia,NEW South Wales,Valid,

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_geocode.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_geocode.csv
@@ -1,0 +1,4 @@
+first_name,last_name,geocodeone,GeoCodetwo,expected
+Madame,1,1,-1,Valid
+Madame,2,a,b,Invalid
+Madame,3,1.1123,-1.1123,Valid

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -2111,10 +2111,6 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   /**
    * Test that import parser will not throw error if Related Contact is not found via passed in External ID.
    *
-   * Currently fails because validation assumes the Related contact will be found.
-   * When it is later not found creating the contact via the API throws an
-   * error for missing required fields.
-   *
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
@@ -2124,12 +2120,14 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'first_name' => 'Alok',
       'last_name' => 'Patel',
       'Employee of' => 'related external identifier',
+      'organization_name' => 'Big shop',
     ];
 
     $mapper = [
       ['first_name'],
       ['last_name'],
       ['5_a_b', 'external_identifier'],
+      ['5_a_b', 'organization_name'],
     ];
     $fields = array_keys($contactImportValues);
     $values = array_values($contactImportValues);
@@ -2142,6 +2140,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $parser->init();
 
     $parser->import(CRM_Import_Parser::DUPLICATE_UPDATE, $values);
+    $this->callAPISuccessGetCount('Contact', ['organization_name' => 'Big shop'], 2);
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1978,6 +1978,23 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test geocode validation.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportGeocodes(): void {
+    $mapper = [
+      ['first_name'],
+      ['last_name'],
+      ['geo_code_1', 1],
+      ['geo_code_2', 1],
+    ];
+    $csv = 'individual_geocode.csv';
+    $this->validateMultiRowCsv($csv, $mapper, 'GeoCode2');
+  }
+
+  /**
    * Validate the csv file values.
    *
    * @param string $csv Name of csv file.

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1121,12 +1121,14 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   public function testImportCountryStateCounty(): void {
     $childKey = $this->getRelationships()['Child of']['id'] . '_a_b';
     // @todo - rows that don't work yet are set to do_not_import.
-    // $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
-    // $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);
-    // $addressCustomFieldID = $this->createCountryCustomField(['custom_group_id' => $addressCustomGroupID])['id'];
-    // $contactCustomFieldID = $this->createMultiCountryCustomField(['custom_group_id' => $contactCustomGroupID])['id'];
-    // $customField = 'custom_' . $contactCustomFieldID;
-    // $addressCustomField = 'custom_' . $addressCustomFieldID;
+    $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
+    $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);
+    $addressCustomFieldID = $this->createCountryCustomField(['custom_group_id' => $addressCustomGroupID])['id'];
+    $contactCustomFieldID = $this->createMultiCountryCustomField(['custom_group_id' => $contactCustomGroupID])['id'];
+    $contactStateCustomFieldID = $this->createStateCustomField(['custom_group_id' => $contactCustomGroupID])['id'];
+    $customField = 'custom_' . $contactCustomFieldID;
+    $addressCustomField = 'custom_' . $addressCustomFieldID;
+    $contactStateCustomField = 'custom_' . $contactStateCustomFieldID;
 
     $mapper = [
       ['first_name'],
@@ -1135,12 +1137,9 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       ['county'],
       ['country'],
       ['state_province'],
-      // [$customField, 'state_province'],
-      ['do_not_import'],
-      // [$customField, 'country'],
-      ['do_not_import'],
-      // [$addressCustomField, 'country'],
-      ['do_not_import'],
+      [$contactStateCustomField],
+      [$customField],
+      [$addressCustomField],
       // [$addressCustomField, 'state_province'],
       ['do_not_import'],
       [$childKey, 'first_name'],
@@ -1168,6 +1167,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $contacts = $this->getImportedContacts();
     foreach ($contacts as $contact) {
       $this->assertEquals(1013, $contact['address'][0]['country_id']);
+      $this->assertEquals(1640, $contact['address'][0]['state_province_id']);
     }
     $this->assertCount(2, $contacts);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes for contact matching

Before
----------------------------------------
Now that the params formatting is 'mostly' handled and in place before `processContact` is called I'm going through to validate the contact lookup behaviour. I found that I had misunderstood the goal in @darrick's test & made it pass in a way that did bad

`testImportParserWithExternalIdForRelationship`

Unlike in 5.48 in current master it's not possible to import in skip mode with an ext id. For relationships it is also not possible. This fixes to permit

- an external id in skip mode which will import as long as it does not match anything
- an external id on the related in update mode - which will still create a related even if there is no match - if it has the mandatory fields


After
----------------------------------------

Technical Details
----------------------------------------
@darrick @monishdeb this is an unreleased regression but I still need to prod the edges further on the behaviour on update - I was hoping to start on that last week but the PRs I was wanting to get sorted to build on are not yet merged (hence they are in the 'chain' for this PR).



Comments
----------------------------------------
