### PR TITLE
Enable ability to require tags in profiles

### DIFF
--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -136,7 +136,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       $tags = CRM_Core_BAO_Tag::getColorTags('civicrm_contact');
 
       if (!empty($tags)) {
-        $form->add('select2', 'tag', ts('Tag(s)'), $tags, FALSE, ['class' => 'huge', 'placeholder' => ts('- select -'), 'multiple' => TRUE]);
+        $form->add('select2', 'tag', ts('Tag(s)'), $tags, $isRequired, ['class' => 'huge', 'placeholder' => ts('- select -'), 'multiple' => TRUE]);
       }
 
       // build tag widget

--- a/tests/phpunit/CRM/Profile/Form/EditTest.php
+++ b/tests/phpunit/CRM/Profile/Form/EditTest.php
@@ -46,4 +46,62 @@ class CRM_Profile_Form_EditTest extends CiviUnitTestCase {
     $this->assertEquals('civicrm/Mr. Anthony Anderson II', CRM_Core_Session::singleton()->popUserContext());
   }
 
+  /**
+   * Test that requiring tags on a profile works.
+   *
+   * @throws \API_Exception
+   */
+  public function testProfileRequireTag(): void {
+    $ufGroupParams = [
+      'group_type' => 'Individual,Contact',
+      'name' => 'test_individual_contact_tag_profile',
+      'title' => 'Gimme a tag',
+      'api.uf_field.create' => [
+        [
+          'field_name' => 'first_name',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Individual',
+          'label' => 'First Name',
+        ],
+        [
+          'field_name' => 'last_name',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Individual',
+          'label' => 'Last Name',
+        ],
+        [
+          'field_name' => 'tag',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Contact',
+          'label' => 'Tag',
+        ],
+      ],
+    ];
+
+    $profile = $this->callAPISuccess('uf_group', 'create', $ufGroupParams);
+    $profileID = $profile['id'];
+
+    // Configure the profile to be used as a standalone profile for data entry.
+    UFJoin::create(FALSE)->setValues([
+      'module' => 'Profile',
+      'uf_group_id' => $profileID,
+    ])->execute();
+
+    // Populate the form.
+    $formParams = [
+      'first_name' => 'Foo',
+      'last_name' => 'McGoo',
+      'gid' => $profileID,
+      'tag' => [],
+    ];
+    $form = $this->getFormObject('CRM_Profile_Form_Edit', $formParams);
+    $form->set('gid', $profileID);
+    $form->preProcess();
+    $form->buildQuickForm();
+    $this->assertFalse($form->validate(), 'Ensure tags can be required on a form.');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR enables the ability to make the Tag field required in a profile. For additional discussion, see [this stack exchange post](https://civicrm.stackexchange.com/questions/41986/why-cant-you-make-the-selection-of-at-least-one-tag-required-in-a-profile).

Before
----------------------------------------
If you:

- Create a profile with stand alone checked
- Include the Tags field
- Marks the Tags field as required

When you display the profile in create mode:

1. No red asterisk appears next to the Tags field
2. You are allowed to submit it without a Tag selected

After
----------------------------------------
A red asterisk appears when the form is displayed and you are not able to submit the form without entering at least one tag.

Technical Details
----------------------------------------
It seems that this has simply been overlooked and nobody noticed or decided it should be fixed.

Comments
----------------------------------------
I tried to write a test to ensure it continues to work, but alas, the Api V3 profile submit code does, in fact, enforce the tags requirement. But, create mode does not seem to use that Api v3 function. I'm open to suggestions on how to properly test this feature.
