### PR TITLE
[REF] Improve Get Coordinates by supporting other geocoding providers…

### DIFF
--- a/CRM/Utils/GeocodeProvider.php
+++ b/CRM/Utils/GeocodeProvider.php
@@ -89,11 +89,10 @@ class CRM_Utils_GeocodeProvider {
   }
 
   /**
-   * Reset geoprovider (after it has been disabled).
+   * Reset geoprovider (after settting has been changed).
    */
   public static function reset() {
     self::$providerClassName = NULL;
-    self::getUsableClassName();
   }
 
 }

--- a/Civi/Api4/Action/Address/GetCoordinates.php
+++ b/Civi/Api4/Action/Address/GetCoordinates.php
@@ -31,12 +31,12 @@ class GetCoordinates extends \Civi\Api4\Generic\AbstractAction {
   protected $address;
 
   public function _run(Result $result) {
-    $gecodingClassName = CRM_Utils_GeocodeProvider::getUsableClassName();
-    $geocodingProvider = CRM_Utils_GeocodeProvider::getConfiguredProvider();
+    $geocodingClassName = \CRM_Utils_GeocodeProvider::getUsableClassName();
+    $geocodingProvider = \CRM_Utils_GeocodeProvider::getConfiguredProvider();
     if (!is_callable([$geocodingProvider, 'getCoordinates'])) {
       throw new \API_Exception('Geocoding provider does not support getCoordinates');
     }
-    $coord = \$geocodingClassName::getCoordinates($this->address);
+    $coord = $geocodingClassName::getCoordinates($this->address);
     if (isset($coord['geo_code_1'], $coord['geo_code_2'])) {
       $result[] = $coord;
     }

--- a/Civi/Api4/Action/Address/GetCoordinates.php
+++ b/Civi/Api4/Action/Address/GetCoordinates.php
@@ -31,7 +31,12 @@ class GetCoordinates extends \Civi\Api4\Generic\AbstractAction {
   protected $address;
 
   public function _run(Result $result) {
-    $coord = \CRM_Utils_Geocode_Google::getCoordinates($this->address);
+    $gecodingClassName = CRM_Utils_GeocodeProvider::getUsableClassName();
+    $geocodingProvider = CRM_Utils_GeocodeProvider::getConfiguredProvider();
+    if (!is_callable([$geocodingProvider, 'getCoordinates'])) {
+      throw new \API_Exception('Geocoding provider does not support getCoordinates');
+    }
+    $coord = \$geocodingClassName::getCoordinates($this->address);
     if (isset($coord['geo_code_1'], $coord['geo_code_2'])) {
       $result[] = $coord;
     }

--- a/settings/Map.setting.php
+++ b/settings/Map.setting.php
@@ -52,6 +52,9 @@ return [
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::geoProvider',
     ],
+    'on_change' => [
+      'CRM_Utils_GeocodeProvider::reset',
+    ],
     'default' => NULL,
     'title' => ts('Geocoding Provider'),
     'description' => ts('This can be the same or different from the mapping provider selected.'),

--- a/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
+++ b/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
@@ -3,9 +3,25 @@
 class CRM_Utils_Geocode_TestProvider {
 
   public static function format(&$values, $stateName = FALSE) {
-    if ($values['street_address'] == 'Does not exist') {
-      $values['geo_code_1'] = $values['geo_code_2'] = 'null';
+    $address = ($values['street_address'] ?? '') . ($values['city'] ?? '');
+
+    $coord = self::getCoordinates($address);
+
+    $values['geo_code_1'] = $coord['geo_code_1'] ?? 'null';
+    $values['geo_code_2'] = $coord['geo_code_2'] ?? 'null';
+
+    if (isset($coord['geo_code_error'])) {
+      $values['geo_code_error'] = $coord['geo_code_error'];
     }
+
+    return isset($coord['geo_code_1'], $coord['geo_code_2']);
+  }
+
+  public static function getCoordinates($address): array {
+    if (strpos($address, '600 Pennsylvania Avenue NW, Washington') === 0) {
+      return ['geo_code_1' => '38.897957', 'geo_code_2' => '-77.036560'];
+    }
+    return [];
   }
 
 }

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -52,6 +52,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->locationTypeDelete($this->_locationTypeID);
     $this->contactDelete($this->_contactID);
     $this->quickCleanup(['civicrm_address', 'civicrm_relationship']);
+    $this->callAPISuccess('Setting', 'create', ['geoProvider' => NULL]);
     parent::tearDown();
   }
 

--- a/tests/phpunit/api/v4/Action/AddressGetCoordinatesTest.php
+++ b/tests/phpunit/api/v4/Action/AddressGetCoordinatesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Address;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class AddressGetCoordinatesTest extends Api4TestBase implements TransactionalInterface {
+
+  public function setUp(): void {
+    parent::setUp();
+    \Civi\Api4\Setting::set()
+      ->addValue('geoProvider', 'TestProvider')
+      ->execute();
+  }
+
+  public function tearDown(): void {
+    parent::tearDown();
+    \Civi\Api4\Setting::revert()
+      ->addSelect('geoProvider')
+      ->execute();
+  }
+
+  public function testGetCoordinatesWhiteHouse(): void {
+    $coordinates = Address::getCoordinates()->setAddress('600 Pennsylvania Avenue NW, Washington, DC, USA')->execute()->first();
+    $this->assertEquals('38.897957', $coordinates['geo_code_1']);
+    $this->assertEquals('-77.036560', $coordinates['geo_code_2']);
+  }
+
+  public function testGetCoordinatesNoAddress(): void {
+    $coorindates = Address::getCoordinates()->setAddress('Does not exist, Washington, DC, USA')->execute()->first();
+    $this->assertEmpty($coorindates);
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/AddressTest.php
+++ b/tests/phpunit/api/v4/Entity/AddressTest.php
@@ -30,6 +30,13 @@ use Civi\Test\TransactionalInterface;
  */
 class AddressTest extends Api4TestBase implements TransactionalInterface {
 
+  public function setUp():void {
+    \Civi\Api4\Setting::revert()
+      ->addSelect('geoProvider')
+      ->execute();
+    parent::setUp();
+  }
+
   /**
    * Check that 2 addresses for the same contact can't both be primary
    */


### PR DESCRIPTION
Overview
----------------------------------------
This improves the handling in getCoordinates API action to allow for providers other than Google.

Improves on https://github.com/civicrm/civicrm-core/pull/23597

Before
----------------------------------------
Only Google provider supported which not all users use

After
----------------------------------------
Any Provider e.g. Google or [OSM](https://github.com/systopia/de.systopia.osm) can be used for the proximity search if appropriately supported