### PR TITLE
Remove no-longer-worthwhile code -  40 points

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -896,47 +896,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * Check if an error in Core( non-custom fields ) field
-   *
-   * @param array $params
-   * @param string $errorMessage
-   *   A string containing all the error-fields.
-   */
-  public function isErrorInCoreData($params, &$errorMessage) {
-    $errors = [];
-    if (!empty($params['contact_sub_type']) && !CRM_Contact_BAO_ContactType::isExtendsContactType($params['contact_sub_type'], $params['contact_type'])) {
-      $errors[] = ts('Mismatched or Invalid Contact Subtype.');
-    }
-
-    foreach ($params as $key => $value) {
-      if ($value) {
-
-        switch ($key) {
-          case 'do_not_email':
-          case 'do_not_phone':
-          case 'do_not_mail':
-          case 'do_not_sms':
-          case 'do_not_trade':
-            if (CRM_Utils_Rule::boolean($value) == FALSE) {
-              $key = ucwords(str_replace("_", " ", $key));
-              $errors[] = $key;
-            }
-            break;
-
-          default:
-            if (is_array($params[$key]) && isset($params[$key]["contact_type"])) {
-              //check for any relationship data ,FIX ME
-              self::isErrorInCoreData($params[$key], $errorMessage);
-            }
-        }
-      }
-    }
-    if ($errors) {
-      $errorMessage .= ($errorMessage ? '; ' : '') . implode('; ', $errors);
-    }
-  }
-
-  /**
    * Ckeck a value present or not in a array.
    *
    * @param $value
@@ -2231,6 +2190,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           throw new CRM_Core_Exception($prefixString . ts('Mismatched or Invalid contact subtype found for this related contact.'));
         }
       }
+      if (!empty($value['contact_sub_type']) && !CRM_Contact_BAO_ContactType::isExtendsContactType($value['contact_sub_type'], $value['contact_type'])) {
+        $errors[] = ts('Mismatched or Invalid Contact Subtype.');
+      }
     }
 
     //check for duplicate external Identifier
@@ -2250,8 +2212,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
     $errorMessage = implode(', ', $errors);
 
-    //checking error in core data
-    $this->isErrorInCoreData($params, $errorMessage);
     if ($errorMessage) {
       $tempMsg = "Invalid value for field(s) : $errorMessage";
       throw new CRM_Core_Exception($tempMsg);


### PR DESCRIPTION
Overview
----------------------------------------
Remove no-longer-worthwhile code

Before
----------------------------------------
All the 'work' from this function has been moved to `getTransformedValue` - the only remaining part is validating some booleans - but that has already been done HERE https://github.com/civicrm/civicrm-core/blob/018c9e26c8b65405abc8f026eb244ae9ac22d68e/CRM/Import/Parser.php#L1206-L1212 by the time it reaches this point

![image](https://user-images.githubusercontent.com/336308/171315366-58fdbc4f-34cb-4dac-b6a1-5201354c4035.png)

(The function also self-calls itself for related contacts - but their bools have also been validated ^^)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
