### PR TITLE
SearchKit - Remove confusing extra joins between Contact & Related Contacts

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -239,8 +239,12 @@
         function addEntityJoins(entity, stack, baseEntity) {
           return _.transform(CRM.crmSearchAdmin.joins[entity], function(joinEntities, join) {
             var num = 0;
-            // Add all joins that don't just point directly back to the original entity
-            if (!(baseEntity === join.entity && !join.multi)) {
+            if (
+              // Exclude joins that singly point back to the original entity
+              !(baseEntity === join.entity && !join.multi) &&
+              // Exclude joins to bridge tables
+              !searchMeta.getEntity(join.entity).bridge
+            ) {
               do {
                 appendJoin(joinEntities, join, ++num, stack, entity);
               } while (addNum((stack ? stack + '_' : '') + join.alias, num) in existingJoins);


### PR DESCRIPTION
Overview
----------------------------------------
The option to use RelationshipCache as a base entity was added in #23066 but a side-effect was the addition of some confusing extra join options. This fixes the side-effect.

Before
----------------------------------------
Selecting Contact as the base entity, there are 3 joins available to "Contact Related Contact"
![image](https://user-images.githubusercontent.com/2874912/171411039-33b113e6-ea71-4343-b1d7-e5e6264c31b7.png)


After
----------------------------------------
Only one join available to related contacts.
![image](https://user-images.githubusercontent.com/2874912/171410887-d3194e73-1a2f-4c1a-876d-3c16b827445f.png)

