### PR TITLE
Afform - allow ids to be passed directly into the directive

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -8,6 +8,7 @@
       var schema = {},
         data = {},
         status,
+        args,
         ctrl = this;
 
       this.$onInit = function() {
@@ -36,8 +37,8 @@
         return $scope.$parent.meta;
       };
       this.loadData = function() {
-        var toLoad = 0,
-          args = $scope.$parent.routeParams || {};
+        var toLoad = 0;
+        args = _.assign({}, $scope.$parent.routeParams || {}, $scope.$parent.options || {});
         _.each(schema, function(entity, entityName) {
           if (args[entityName] || entity.autofill) {
             toLoad++;
@@ -88,7 +89,7 @@
 
         crmApi4('Afform', 'submit', {
           name: ctrl.getFormMeta().name,
-          args: $scope.$parent.routeParams || {},
+          args: args,
           values: data}
         ).then(function(response) {
           if (ctrl.fileUploader.getNotUploadedItems().length) {


### PR DESCRIPTION
Overview
----------------------------------------
This gives Submit Forms the same feature as Search Forms, entity ids can be passed directly into the directive as 'options', allowing ids to be passed around internally.

Before
---------------------
With an Afform named MyForm and an entity named Contact 1, you could enable url-autofill for that entity and append `#/?Contact1=123` to the url to supply an existing contact id.

After
---------------
The above still works, but to facilitate embedding an afform into other places e.g. a block or a contact summary tab, you can pass the id directly into the directive e.g.:

`<my-form options="{Contact1: 123}"></my-form>`

Comments
-------------
Note that this same technique already works with Afforms of type "Search" so this just extends the functionality to work with submission forms as well.

Technical Details
-----------------
See discussion at https://github.com/systopia/de.systopia.eck/pull/48#discussion_r885661208