### PR TITLE
Fix issue where relatedContacts fields were added to the mainContact …

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -237,7 +237,12 @@ class CRM_Dedupe_Finder {
 
     // if the key is dotted, keep just the last part of it
     foreach ($flat as $key => $value) {
-      if (substr_count($key, '.')) {
+      // check if there is a _a_b or _b_a in the key
+      if (strpos($key, '_a_b') || strpos($key, '_b_a')) {
+        // Relationship key from an import.
+        unset($flat[$key]);
+      }
+      elseif (substr_count($key, '.')) {
         $last = explode('.', $key);
         $last = array_pop($last);
         // make sure the first occurrence is kept, not the last

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1891,19 +1891,16 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $contactImportValues = [
       'first_name' => 'Alok',
       'last_name' => 'Patel',
-      'Employee of' => 'email',
+      'Child of' => 'tim.cook@apple.com',
     ];
 
     $mapper = [
       ['first_name'],
       ['last_name'],
-      ['5_a_b', 'email'],
+      ['1_a_b', 'email'],
     ];
     $fields = array_keys($contactImportValues);
     $values = array_values($contactImportValues);
-    $values[] = 'tim.cook@apple.com';
-    // Stand in for row number.
-    $values[] = 1;
 
     $userJobID = $this->getUserJobID([
       'mapper' => $mapper,
@@ -1912,11 +1909,10 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
 
     $parser = new CRM_Contact_Import_Parser_Contact($fields);
     $parser->setUserJobID($userJobID);
-    $dataSource = new CRM_Import_DataSource_CSV($userJobID);
 
     $parser->init();
     $parser->import(CRM_Import_Parser::DUPLICATE_UPDATE, $values);
-    $this->assertEquals(1, $dataSource->getRowCount([CRM_Import_Parser::ERROR]));
+
     $this->callAPISuccessGetSingle('Contact', [
       'first_name' => 'Bob',
       'last_name' => 'Dobbs',


### PR DESCRIPTION
…when searching for duplicates on import.

Overview
----------------------------------------
When importing contacts if the user maps a field to a relationship those fields were being added to the main contact field when searching for a duplicate main contact.  If a duplicate was found it was updated with the main contact values.  

Given the existing contact ...
<img width="536" alt="image" src="https://user-images.githubusercontent.com/755624/171542878-3a592456-ef56-4126-9cfb-00bc4520f001.png">

Importing in the following ... 
<img width="637" alt="image" src="https://user-images.githubusercontent.com/755624/171541763-f12853fd-644f-4b4e-9a25-47233b9dd64f.png">


Before
----------------------------------------

If skipping on duplicates ...
<img width="614" alt="image" src="https://user-images.githubusercontent.com/755624/171542004-026d018e-c2e4-4f19-ae60-e18282307b1f.png">

No relationship is created nor related contacted contact created as the imported contacted matched via email ... 
<img width="579" alt="image" src="https://user-images.githubusercontent.com/755624/171542056-6b5ac28a-7aad-4ed6-8344-e93c02269a32.png">

<img width="635" alt="image" src="https://user-images.githubusercontent.com/755624/171542086-3372c698-0c1f-4978-afaa-0d80476bc833.png">

If updating the related contacts first and last name replaces the existing contacts name and no relationship is created ...
<img width="574" alt="image" src="https://user-images.githubusercontent.com/755624/171542677-3f86d24a-2cdb-4630-ba9e-7cbd89dda713.png">

After
----------------------------------------

The relationship and related contact is created as no duplicate was found ...
<img width="517" alt="image" src="https://user-images.githubusercontent.com/755624/171542147-d6a2905e-837a-41b8-ab81-b5781e9c73c2.png">

Technical Details
----------------------------------------
Currently fails because CRM_Dedupe_Finder::formatParams($input, $contactType); called in getDuplicateContacts flattens the contact array adding the related contacts values to the primary contact.
   
https://github.com/civicrm/civicrm-core/blob/ca13ec46eae2042604e4e106c6cb3dc0439db3e2/CRM/Dedupe/Finder.php#L238

