### PR TITLE
CiviGrant - Add prefix to permission label

### DIFF
--- a/ext/civigrant/civigrant.php
+++ b/ext/civigrant/civigrant.php
@@ -74,15 +74,15 @@ function civigrant_civicrm_summaryActions(&$menu, $cid) {
  */
 function civigrant_civicrm_permission(&$permissions) {
   $permissions['access CiviGrant'] = [
-    E::ts('access CiviGrant'),
+    E::ts('CiviGrant:') . ' ' . E::ts('access CiviGrant'),
     E::ts('View all grants'),
   ];
   $permissions['edit grants'] = [
-    E::ts('edit grants'),
+    E::ts('CiviGrant:') . ' ' . E::ts('edit grants'),
     E::ts('Create and update grants'),
   ];
   $permissions['delete in CiviGrant'] = [
-    E::ts('delete in CiviGrant'),
+    E::ts('CiviGrant:') . ' ' . E::ts('delete in CiviGrant'),
     E::ts('Delete grants'),
   ];
 }


### PR DESCRIPTION
Overview
----------------------------------------
Makes CiviGrant permissions easier to read on the Manage Permissions page.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/171633800-b48b1fc6-9512-4175-9a94-7cd7360e0e67.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/171633517-6a450e2d-d033-4e9c-9611-701be0da7d66.png)

Comments
----------------------------------------
I think these prefixes were automatically added when CiviGrant was a component but now need to be manually added for the extension.
