### PR TITLE
SearchKit - Add "administer search_kit" permission

### DIFF
--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -25,8 +25,8 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay {
    */
   public static function _checkAccess(string $entityName, string $action, array $record, int $userCID) {
     // If we hit this function at all, the user is not a super-admin
-    // But they must be at least a regular administrator
-    if (!CRM_Core_Permission::check('administer CiviCRM data')) {
+    // But they must be at least a SearchKit administrator
+    if (!CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']])) {
       return FALSE;
     }
     if (in_array($action, ['create', 'update'], TRUE)) {

--- a/ext/search_kit/CRM/Search/Upgrader.php
+++ b/ext/search_kit/CRM/Search/Upgrader.php
@@ -7,32 +7,6 @@ use CRM_Search_ExtensionUtil as E;
 class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
 
   /**
-   * Add menu item when enabled.
-   */
-  public function enable() {
-    \Civi\Api4\Navigation::create(FALSE)
-      ->addValue('parent_id:name', 'Search')
-      ->addValue('label', E::ts('Search Kit'))
-      ->addValue('name', 'search_kit')
-      ->addValue('url', 'civicrm/admin/search')
-      ->addValue('icon', 'crm-i fa-search-plus')
-      ->addValue('has_separator', 2)
-      ->addValue('weight', 99)
-      ->addValue('permission', ['administer CiviCRM data'])
-      ->execute();
-  }
-
-  /**
-   * Delete menu item when disabled.
-   */
-  public function disable() {
-    \Civi\Api4\Navigation::delete(FALSE)
-      ->addWhere('name', '=', 'search_kit')
-      ->addWhere('domain_id', '=', 'current_domain')
-      ->execute();
-  }
-
-  /**
    * Upgrade 1000 - install schema
    * @return bool
    */
@@ -42,7 +16,6 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
     if (!CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE 'civicrm_search_display'")) {
       $this->executeSqlFile('sql/auto_install.sql');
     }
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET url = 'civicrm/admin/search', name = 'search_kit' WHERE url = 'civicrm/search'");
     return TRUE;
   }
 
@@ -139,16 +112,6 @@ class CRM_Search_Upgrader extends CRM_Search_Upgrader_Base {
           ->execute();
       }
     }
-    return TRUE;
-  }
-
-  /**
-   * Upgrade 1004 - fix menu permission.
-   * @return bool
-   */
-  public function upgrade_1004(): bool {
-    $this->ctx->log->info('Applying update 1004 - fix menu permission.');
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET permission = 'administer CiviCRM data' WHERE url = 'civicrm/admin/search'");
     return TRUE;
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -90,8 +90,11 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @throws \API_Exception
    */
   public function _run(\Civi\Api4\Generic\Result $result) {
-    // Only administrators can use this in unsecured "preview mode"
-    if ((is_array($this->savedSearch) || is_array($this->display)) && $this->checkPermissions && !\CRM_Core_Permission::check('administer CiviCRM data')) {
+    // Only SearchKit admins can use this in unsecured "preview mode"
+    if (
+      (is_array($this->savedSearch) || is_array($this->display)) && $this->checkPermissions &&
+      !\CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']])
+    ) {
       throw new UnauthorizedException('Access denied');
     }
     $this->loadSavedSearch();

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -42,8 +42,11 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
    * @throws \API_Exception
    */
   public function _run(\Civi\Api4\Generic\Result $result) {
-    // Only administrators can use this in unsecured "preview mode"
-    if (is_array($this->savedSearch) && $this->checkPermissions && !\CRM_Core_Permission::check('administer CiviCRM data')) {
+    // Only SearchKit admins can use this in unsecured "preview mode"
+    if (
+      is_array($this->savedSearch) && $this->checkPermissions &&
+      !\CRM_Core_Permission::check([['administer CiviCRM data', 'administer search_kit']])
+    ) {
       throw new UnauthorizedException('Access denied');
     }
     $this->loadSavedSearch();

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchKitSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchKitSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber to check extra permission for SavedSearches
+ */
+class SearchKitSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api.authorize' => [
+        ['onApiAuthorize', -200],
+      ],
+    ];
+  }
+
+  /**
+   * Alters APIv4 permissions to allow users with 'administer search_kit' to create/delete a SavedSearch
+   *
+   * @param \Civi\API\Event\AuthorizeEvent $event
+   *   API authorization event.
+   */
+  public function onApiAuthorize(\Civi\API\Event\AuthorizeEvent $event) {
+    /* @var \Civi\Api4\Generic\AbstractAction $apiRequest */
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] == 4 && $apiRequest->getEntityName() === 'SavedSearch') {
+      if (\CRM_Core_Permission::check('administer search_kit')) {
+        $event->authorize();
+        $event->stopPropagation();
+      }
+    }
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -51,7 +51,7 @@ class SearchDisplay extends Generic\DAOEntity {
 
   public static function permissions() {
     $permissions = parent::permissions();
-    $permissions['default'] = ['administer CiviCRM data'];
+    $permissions['default'] = [['administer CiviCRM data', 'administer search_kit']];
     // Anyone with access to CiviCRM can view search displays (but not necessarily the results)
     $permissions['get'] = $permissions['getDefault'] = ['access CiviCRM'];
     // Anyone with access to CiviCRM can do search tasks (but not necessarily all of them)

--- a/ext/search_kit/Civi/Api4/SearchSegment.php
+++ b/ext/search_kit/Civi/Api4/SearchSegment.php
@@ -9,4 +9,10 @@ namespace Civi\Api4;
 class SearchSegment extends Generic\DAOEntity {
   use \Civi\Api4\Generic\Traits\ManagedEntity;
 
+  public static function permissions() {
+    $permissions = parent::permissions();
+    $permissions['default'] = [['administer CiviCRM data', 'administer search_kit']];
+    return $permissions;
+  }
+
 }

--- a/ext/search_kit/managed/Navigation_search_kit.mgd.php
+++ b/ext/search_kit/managed/Navigation_search_kit.mgd.php
@@ -1,0 +1,36 @@
+<?php
+use CRM_Search_ExtensionUtil as E;
+
+$menuItems = [];
+$domains = \Civi\Api4\Domain::get(FALSE)
+  ->addSelect('id')
+  ->execute();
+foreach ($domains as $domain) {
+  $menuItems[] = [
+    'name' => 'Navigation_search_kit_domain_' . $domain['id'],
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('Search Kit'),
+        'name' => 'search_kit',
+        'url' => 'civicrm/admin/search',
+        'icon' => 'crm-i fa-search-plus',
+        'permission' => [
+          'administer CiviCRM data',
+          'administer search_kit',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Search',
+        'is_active' => TRUE,
+        'has_separator' => 2,
+        'weight' => 13,
+        'domain_id' => $domain['id'],
+      ],
+      'match' => ['domain_id', 'name'],
+    ],
+  ];
+}
+return $menuItems;

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'search_kit.civix.php';
+use CRM_Search_ExtensionUtil as E;
 
 /**
  * Implements hook_civicrm_config().
@@ -10,6 +11,7 @@ require_once 'search_kit.civix.php';
 function search_kit_civicrm_config(&$config) {
   _search_kit_civix_civicrm_config($config);
   Civi::dispatcher()->addListener('hook_civicrm_alterAngular', ['\Civi\Search\AfformSearchMetadataInjector', 'preprocess'], 1000);
+  Civi::dispatcher()->addSubscriber(new Civi\Api4\Event\Subscriber\SearchKitSubscriber());
 }
 
 /**
@@ -21,6 +23,18 @@ function search_kit_civicrm_container($container) {
       'civi.api4.authorizeRecord::SavedSearch',
       ['CRM_Search_BAO_SearchDisplay', 'savedSearchCheckAccessByDisplay'],
     ]);
+}
+
+/**
+ * Implements hook_civicrm_permission().
+ *
+ * Define SearchKit permissions.
+ */
+function search_kit_civicrm_permission(&$permissions) {
+  $permissions['administer search_kit'] = [
+    E::ts('Search Kit: edit and delete searches'),
+    E::ts('Gives non-admin users access to the Search Kit UI to create, update and delete searches and displays'),
+  ];
 }
 
 /**

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -712,7 +712,7 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     }
     $this->assertStringContainsString('failed', $error);
 
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'administer CiviCRM data'];
+    $config->userPermissionClass->permissions = ['access CiviCRM', 'administer search_kit'];
 
     // Admins can edit the search and the display
     SavedSearch::update()->addWhere('name', '=', $searchName)

--- a/ext/search_kit/xml/Menu/search_kit.xml
+++ b/ext/search_kit/xml/Menu/search_kit.xml
@@ -8,6 +8,6 @@
   <item>
     <path>civicrm/admin/search</path>
     <page_callback>CRM_Search_Page_Admin</page_callback>
-    <access_arguments>administer CiviCRM data</access_arguments>
+    <access_arguments>administer CiviCRM data;administer search_kit</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a permission which allows non-admins to use Search Kit.

See https://lab.civicrm.org/dev/core/-/issues/3457

Before
----------------------------------------
Previously the user needed 'administer CiviCRM data' permission to use Search Kit.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/171652563-10b6e1cb-778e-4930-ae4b-34665a95ac62.png)

Technical Details
-----------------------
When updating the navigation menu permissions, I switched it over to use a `.mgd.php` to insert the menu item instead of creating it with the installer. This should also work better for multi-domain sites.