### PR TITLE
APIv3 - Fix regression in handling chained calls with `sequential`

### DIFF
--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -182,7 +182,7 @@ class ChainSubscriber implements EventSubscriberInterface {
           $enforcedSubParams['version'] = $version;
           // Copy check_permissions from parent.
           $enforcedSubParams['check_permissions'] = $params['check_permissions'] ?? NULL;
-          $enforcedSubParams['sequential'] = 1;
+          $defaultSubParams['sequential'] = 1;
           $enforcedSubParams['api.has_parent'] = 1;
           // Inspect $newparams, the passed in params for the chain call.
           if (array_key_exists(0, $newparams)) {


### PR DESCRIPTION
…sage

Overview
----------------------------------------
This fixes a bug caused by the recent security release which forced any chained api calls to be outputted in sequential even if not requested.

Before
----------------------------------------
if Sequential was missing from the array or included the result was forced into a sequential array in the chain

After
----------------------------------------
sequential is correctly managed


@KarinG @demeritcowboy can you test this on your webform stuff?