### PR TITLE
[NFC] Add unit test to lock in the sequential behaviour in chanining

### DIFF
--- a/tests/phpunit/api/v3/CountryTest.php
+++ b/tests/phpunit/api/v3/CountryTest.php
@@ -104,4 +104,26 @@ class api_v3_CountryTest extends CiviUnitTestCase {
     $this->assertEquals(1, $check);
   }
 
+  public function testGetStatesWithChaining(): void {
+    $result = $this->callAPISuccess('Country', 'getsingle', [
+      'iso_code' => 'US',
+      'api.Address.getoptions' => [
+        'field' => 'state_province_id',
+        'country_id' => '$value.id',
+        'sequential' => 0,
+      ],
+    ]);
+    // Ensure that when Sequential is passed as part of the chain params it is respected
+    $this->assertEquals('Alabama', $result['api.Address.getoptions']['values'][1000]);
+    $result = $this->callAPISuccess('Country', 'getsingle', [
+      'iso_code' => 'US',
+      'api.Address.getoptions' => [
+        'field' => 'state_province_id',
+        'country_id' => '$value.id',
+      ],
+    ]);
+    $this->assertEquals('Alabama', $result['api.Address.getoptions']['values'][0]['value']);
+    $this->assertEquals(1000, $result['api.Address.getoptions']['values'][0]['key']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a unit test to lock in the fix for #23671 

Before
----------------------------------------
No unit test

After
----------------------------------------
Unit test

Technical Details
----------------------------------------
If i manually revert the fix I get the following error on this UT

```
seamus@civicrmdevelopment:~/buildkit/build/47-test/web/sites/all/modules/civicrm$ ./tools/scripts/phpunit 'api_v3_CountryTest'
Parsing schema description /home/seamus/buildkit/build/47-test/web/sites/all/modules/civicrm/xml/schema/Schema.xml
Extracting database information
Extracting table information
PHPUnit 8.5.15 by Sebastian Bergmann and contributors.

.
Installing 47testtest_6zv9y database
...........E                                                     13 / 13 (100%)

Time: 19.28 seconds, Memory: 62.50 MB

There was 1 error:

1) api_v3_CountryTest::testGetStatesWithChaining
Undefined offset: 1000

/home/seamus/buildkit/build/47-test/web/sites/all/modules/civicrm/tests/phpunit/api/v3/CountryTest.php:117
/home/seamus/buildkit/build/47-test/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:262
/home/seamus/buildkit/extern/phpunit8/phpunit8.phar:671

ERRORS!
Tests: 13, Assertions: 102, Errors: 1.
```

ping @eileenmcnaughton @demeritcowboy 