### PR TITLE
Contact import - extract common code, make tags & groups queue-friendly

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -101,17 +101,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     // retrieve and highlight required custom fields
     $formattedFieldNames = $this->formatCustomFieldName($this->_mapperFields);
 
-    $this->assign('highlightedFields', $this->getHighlightedFields());
     $this->_formattedFieldNames[$contactType] = $this->_mapperFields = array_merge($this->_mapperFields, $formattedFieldNames);
-
-    $columnNames = $this->getColumnHeaders();
-
-    $this->_columnCount = $this->getNumberOfColumns();
-    $this->_columnNames = $columnNames;
-    $this->assign('columnNames', $this->getColumnHeaders());
-    $this->assign('columnCount', $this->_columnCount);
-    $this->_dataValues = array_values($this->getDataRows([], 2));
-    $this->assign('dataValues', $this->_dataValues);
+    $this->assignMapFieldVariables();
   }
 
   /**
@@ -512,7 +503,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @throws \CRM_Core_Exception
    */
-  private function getHighlightedFields(): array {
+  protected function getHighlightedFields(): array {
     $entityFields = [
       'Individual' => ['first_name', 'last_name'],
       'Organization' => ['organization_name'],

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -34,22 +34,8 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $columnNames = $this->getColumnHeaders();
+    parent::preProcess();
     $this->_disableUSPS = $this->getSubmittedValue('disableUSPS');
-
-    //assign column names
-    $this->assign('columnNames', $columnNames);
-
-    //get the mapping name displayed if the mappingId is set
-    $mappingId = $this->get('loadMappingId');
-    if ($mappingId) {
-      $mapDAO = new CRM_Core_DAO_Mapping();
-      $mapDAO->id = $mappingId;
-      $mapDAO->find(TRUE);
-    }
-    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
-
-    $this->assign('rowDisplayCount', 2);
 
     $groups = CRM_Core_PseudoConstant::nestedGroup();
     $this->set('groups', $groups);
@@ -58,13 +44,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     if ($tag) {
       $this->set('tag', $tag);
     }
-
-    $this->assign('downloadErrorRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::ERROR));
-    $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
-    $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
-    $this->assign('totalRowCount', $this->getRowCount([]));
-    $this->assign('mapper', $this->getMappedFieldLabels());
-    $this->assign('dataValues', $this->getDataRows([], 2));
 
     $this->setStatusUrl();
   }

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -15,6 +15,9 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Group;
+use Civi\Api4\Tag;
+
 /**
  * This class previews the uploaded file and returns summary statistics.
  */
@@ -36,15 +39,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
   public function preProcess() {
     parent::preProcess();
     $this->_disableUSPS = $this->getSubmittedValue('disableUSPS');
-
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
-    $this->set('groups', $groups);
-
-    $tag = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', array('onlyActive' => FALSE));
-    if ($tag) {
-      $this->set('tag', $tag);
-    }
-
     $this->setStatusUrl();
   }
 
@@ -63,24 +57,25 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       );
     }
 
-    $groups = $this->get('groups');
+    $groups = CRM_Core_PseudoConstant::nestedGroup();;
 
     if (!empty($groups)) {
-      $this->addElement('select', 'groups', ts('Add imported records to existing group(s)'), $groups, array(
+      $this->addElement('select', 'groups', ts('Add imported records to existing group(s)'), $groups, [
         'multiple' => "multiple",
         'class' => 'crm-select2',
-      ));
+      ]);
     }
 
     //display new tag
     $this->addElement('text', 'newTagName', ts('Tag'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_Tag', 'name'));
     $this->addElement('text', 'newTagDesc', ts('Description'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_Tag', 'description'));
 
-    $tag = $this->get('tag');
+    $tag = CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', ['onlyActive' => FALSE]);
     if (!empty($tag)) {
-      foreach ($tag as $tagID => $tagName) {
-        $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
-      }
+      $this->addElement('select', 'tag', ts(' Tag imported records'), $tag, [
+        'multiple' => 'multiple',
+        'class' => 'crm-select2',
+      ]);
     }
 
     $this->addFormRule(array('CRM_Contact_Import_Form_Preview', 'formRule'), $this);
@@ -142,37 +137,71 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
   /**
    * Process the mapped fields and map it into the uploaded file.
    *
-   * @throws \API_Exception
+   * @throws \API_Exception|\CRM_Core_Exception
    */
-  public function postProcess() {
+  public function postProcess(): void {
+    $groupsToAddTo = (array) $this->getSubmittedValue('groups');
+    $summaryInfo = ['groups' => [], 'tags' => []];
+    foreach ($groupsToAddTo as $groupID) {
+      // This is a convenience for now - really url & name should be determined at
+      // presentation stage - ie the summary screen. The only info we are really
+      // preserving is which groups were created vs already existed.
+      $summaryInfo['groups'][$groupID] = [
+        'url' => CRM_Utils_System::url('civicrm/group/search', 'reset=1&force=1&context=smog&gid=' . $groupID),
+        'name' => Group::get(FALSE)->addWhere('id', '=', $groupID)->addSelect('name')->execute()->first()['name'],
+        'new' => FALSE,
+        'added' => 0,
+        'notAdded' => 0,
+      ];
+    }
 
-    $importJobParams = array(
-      'doGeocodeAddress' => $this->getSubmittedValue('doGeocodeAddress'),
-      'invalidRowCount' => $this->getRowCount(CRM_Import_Parser::ERROR),
-      'onDuplicate' => $this->getSubmittedValue('onDuplicate'),
-      'dedupe' => $this->getSubmittedValue('dedupe_rule_id'),
-      'newGroupName' => $this->controller->exportValue($this->_name, 'newGroupName'),
-      'newGroupDesc' => $this->controller->exportValue($this->_name, 'newGroupDesc'),
-      'newGroupType' => $this->controller->exportValue($this->_name, 'newGroupType'),
-      'groups' => $this->controller->exportValue($this->_name, 'groups'),
-      'allGroups' => $this->get('groups'),
-      'newTagName' => $this->controller->exportValue($this->_name, 'newTagName'),
-      'newTagDesc' => $this->controller->exportValue($this->_name, 'newTagDesc'),
-      'tag' => $this->controller->exportValue($this->_name, 'tag'),
-      'allTags' => $this->get('tag'),
-      'mapper' => $this->controller->exportValue('MapField', 'mapper'),
-      'mapFields' => $this->getAvailableFields(),
-      'contactType' => $this->getContactType(),
-      'contactSubType' => $this->getSubmittedValue('contactSubType'),
-      'primaryKeyName' => '_id',
-      'statusFieldName' => '_status',
-      'statusID' => $this->get('statusID'),
-      'totalRowCount' => $this->getRowCount([]),
-      'userJobID' => $this->getUserJobID(),
-    );
-
-    $importJob = new CRM_Contact_Import_ImportJob();
-    $importJob->setJobParams($importJobParams);
+    if ($this->getSubmittedValue('newGroupName')) {
+      /* Create a new group */
+      $groupsToAddTo[] = $groupID = Group::create(FALSE)->setValues([
+        'title' => $this->getSubmittedValue('newGroupName'),
+        'description' => $this->getSubmittedValue('newGroupDesc'),
+        'group_type' => $this->getSubmittedValue('newGroupType') ?? [],
+        'is_active' => TRUE,
+      ])->execute()->first()['id'];
+      $summaryInfo['groups'][$groupID] = [
+        'url' => CRM_Utils_System::url('civicrm/group/search', 'reset=1&force=1&context=smog&gid=' . $groupID),
+        'name' => $this->getSubmittedValue('newGroupName'),
+        'new' => TRUE,
+        'added' => 0,
+        'notAdded' => 0,
+      ];
+    }
+    $tagsToAdd = (array) $this->getSubmittedValue('tag');
+    foreach ($tagsToAdd as $tagID) {
+      // This is a convenience for now - really url & name should be determined at
+      // presentation stage - ie the summary screen. The only info we are really
+      // preserving is which tags were created vs already existed.
+      $summaryInfo['tags'][$tagID] = [
+        'url' => CRM_Utils_System::url('civicrm/contact/search', 'reset=1&force=1&context=smog&id=' . $tagID),
+        'name' => Tag::get(FALSE)->addWhere('id', '=', $tagID)->addSelect('name')->execute()->first()['name'],
+        'new' => TRUE,
+        'added' => 0,
+        'notAdded' => 0,
+      ];
+    }
+    if ($this->getSubmittedValue('newTagName')) {
+      $tagsToAdd[] = $tagID = Tag::create(FALSE)->setValues([
+        'name' => $this->getSubmittedValue('newTagName'),
+        'description' => $this->getSubmittedValue('newTagDesc'),
+        'is_selectable' => TRUE,
+        'used_for' => 'civicrm_contact',
+      ])->execute()->first()['id'];
+      $summaryInfo['tags'][$tagID] = [
+        'url' => CRM_Utils_System::url('civicrm/contact/search', 'reset=1&force=1&context=smog&id=' . $tagID),
+        'name' => $this->getSubmittedValue('newTagName'),
+        'new' => FALSE,
+        'added' => 0,
+        'notAdded' => 0,
+      ];
+    }
+    // Store the actions to take on each row & the data to present at the end to the userJob.
+    $this->updateUserJobMetadata('post_actions', ['group' => $groupsToAddTo, 'tag' => $tagsToAdd]);
+    $this->updateUserJobMetadata('summary_info', $summaryInfo);
 
     // If ACL applies to the current user, update cache before running the import.
     if (!CRM_Core_Permission::check('view all contacts')) {
@@ -184,16 +213,20 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
     CRM_Utils_Address_USPS::disable($this->_disableUSPS);
 
     // run the import
-    $importJob->runImport($this);
+
+    $this->_parser = $this->getParser();
+    $this->_parser->run(
+      [],
+      CRM_Import_Parser::MODE_IMPORT,
+      $this->get('statusID')
+    );
 
     // Clear all caches, forcing any searches to recheck the ACLs or group membership as the import
     // may have changed it.
     CRM_Contact_BAO_Contact_Utils::clearContactCaches(TRUE);
 
-    // add all the necessary variables to the form
-    $importJob->setFormVariables($this);
-
     // check if there is any error occurred
+    // @todo - it's really unclear that this error code should still exist...
     $errorStack = CRM_Core_Error::singleton();
     $errors = $errorStack->getErrors();
     $errorMessage = [];
@@ -214,10 +247,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
       $this->set('errorFile', $errorFile);
     }
-
-    //hack to clean db
-    //if job complete drop table.
-    $importJob->isComplete();
   }
 
   /**

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -27,7 +27,8 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    // set the error message path to display
+    // @todo - totally unclear that this errorFile could ever be set / render.
+    // Probably it can go.
     $this->assign('errorFile', $this->get('errorFile'));
     $onDuplicate = $this->getSubmittedValue('onDuplicate');
     $this->assign('dupeError', FALSE);
@@ -44,8 +45,8 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Form_Summary {
       $this->assign('dupeError', TRUE);
     }
 
-    $this->assign('groupAdditions', $this->get('groupAdditions'));
-    $this->assign('tagAdditions', $this->get('tagAdditions'));
+    $this->assign('groupAdditions', $this->getUserJob()['metadata']['summary_info']['groups']);
+    $this->assign('tagAdditions', $this->getUserJob()['metadata']['summary_info']['tags']);
     $this->assign('totalRowCount', $this->getRowCount());
     $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID) + $this->getRowCount(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
     $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));

--- a/CRM/Contact/Import/ImportJob.php
+++ b/CRM/Contact/Import/ImportJob.php
@@ -23,14 +23,10 @@ class CRM_Contact_Import_ImportJob {
   protected $_onDuplicate;
   protected $_dedupe;
   protected $_newGroupName;
-  protected $_newGroupDesc;
-  protected $_newGroupType;
   protected $_groups;
   protected $_allGroups;
   protected $_newTagName;
-  protected $_newTagDesc;
   protected $_tag;
-  protected $_allTags;
 
   protected $_mapper;
   protected $_mapperKeys = [];
@@ -72,44 +68,6 @@ class CRM_Contact_Import_ImportJob {
       $this->_mapperKeys[$key] = $mapper[$key][0] ?? NULL;
     }
 
-    $this->_parser = new CRM_Contact_Import_Parser_Contact(
-      $this->_mapperKeys
-    );
-    $this->_parser->setUserJobID($this->_userJobID);
-    $this->_parser->run(
-      [],
-      CRM_Import_Parser::MODE_IMPORT,
-      $this->_statusID
-    );
-
-    $contactIds = $this->_parser->getImportedContacts();
-
-    //get the related contactIds. CRM-2926
-    $relatedContactIds = $this->_parser->getRelatedImportedContacts();
-    if ($relatedContactIds) {
-      $contactIds = array_merge($contactIds, $relatedContactIds);
-    }
-
-    if ($this->_newGroupName || count($this->_groups)) {
-      $groupAdditions = $this->_addImportedContactsToNewGroup($contactIds,
-        $this->_newGroupName,
-        $this->_newGroupDesc,
-        $this->_newGroupType
-      );
-      if ($form) {
-        $form->set('groupAdditions', $groupAdditions);
-      }
-    }
-
-    if ($this->_newTagName || !empty($this->_tag)) {
-      $tagAdditions = $this->_tagImportedContactsWithNewTag($contactIds,
-        $this->_newTagName,
-        $this->_newTagDesc
-      );
-      if ($form) {
-        $form->set('tagAdditions', $tagAdditions);
-      }
-    }
   }
 
   /**
@@ -117,120 +75,6 @@ class CRM_Contact_Import_ImportJob {
    */
   public function setFormVariables($form) {
     $this->_parser->set($form, CRM_Import_Parser::MODE_IMPORT);
-  }
-
-  /**
-   * Add imported contacts.
-   *
-   * @param array $contactIds
-   * @param string $newGroupName
-   * @param string $newGroupDesc
-   * @param string $newGroupType
-   *
-   * @return array|bool
-   */
-  private function _addImportedContactsToNewGroup(
-    $contactIds,
-    $newGroupName, $newGroupDesc, $newGroupType
-  ) {
-
-    $newGroupId = NULL;
-
-    if ($newGroupName) {
-      /* Create a new group */
-      $newGroupType = $newGroupType ?? [];
-      $gParams = array(
-        'title' => $newGroupName,
-        'description' => $newGroupDesc,
-        'group_type' => $newGroupType,
-        'is_active' => TRUE,
-      );
-      $group = CRM_Contact_BAO_Group::create($gParams);
-      $this->_groups[] = $newGroupId = $group->id;
-    }
-
-    if (is_array($this->_groups)) {
-      $groupAdditions = [];
-      foreach ($this->_groups as $groupId) {
-        $addCount = CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIds, $groupId);
-        $totalCount = $addCount[1];
-        if ($groupId == $newGroupId) {
-          $name = $newGroupName;
-          $new = TRUE;
-        }
-        else {
-          $name = $this->_allGroups[$groupId];
-          $new = FALSE;
-        }
-        $groupAdditions[] = array(
-          'url' => CRM_Utils_System::url('civicrm/group/search',
-            'reset=1&force=1&context=smog&gid=' . $groupId
-          ),
-          'name' => $name,
-          'added' => $totalCount,
-          'notAdded' => $addCount[2],
-          'new' => $new,
-        );
-      }
-      return $groupAdditions;
-    }
-    return FALSE;
-  }
-
-  /**
-   * @param $contactIds
-   * @param string $newTagName
-   * @param $newTagDesc
-   *
-   * @return array|bool
-   * @throws \CRM_Core_Exception
-   */
-  private function _tagImportedContactsWithNewTag(
-    $contactIds,
-    $newTagName, $newTagDesc
-  ) {
-
-    $newTagId = NULL;
-    if ($newTagName) {
-      /* Create a new Tag */
-
-      $tagParams = array(
-        'name' => $newTagName,
-        'description' => $newTagDesc,
-        'is_selectable' => TRUE,
-        'used_for' => 'civicrm_contact',
-      );
-      $addedTag = CRM_Core_BAO_Tag::add($tagParams);
-      $this->_tag[$addedTag->id] = 1;
-    }
-    //add Tag to Import
-
-    if (is_array($this->_tag)) {
-      $tagAdditions = [];
-      foreach ($this->_tag as $tagId => $val) {
-        $addTagCount = CRM_Core_BAO_EntityTag::addEntitiesToTag($contactIds, $tagId, 'civicrm_contact', FALSE);
-        $totalTagCount = $addTagCount[1];
-        if (isset($addedTag) && $tagId == $addedTag->id) {
-          $tagName = $newTagName;
-          $new = TRUE;
-        }
-        else {
-          $tagName = $this->_allTags[$tagId];
-          $new = FALSE;
-        }
-        $tagAdditions[] = array(
-          'url' => CRM_Utils_System::url('civicrm/contact/search',
-            'reset=1&force=1&context=smog&id=' . $tagId
-          ),
-          'name' => $tagName,
-          'added' => $totalTagCount,
-          'notAdded' => $addTagCount[2],
-          'new' => $new,
-        );
-      }
-      return $tagAdditions;
-    }
-    return FALSE;
   }
 
 }

--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -81,7 +81,7 @@ trait CRM_Contact_Import_MetadataTrait {
    *
    * @return array
    */
-  public function getHeaderPatterns() {
+  public function getHeaderPatterns(): array {
     return CRM_Utils_Array::collect('headerPattern', $this->getContactImportMetadata());
   }
 
@@ -90,7 +90,7 @@ trait CRM_Contact_Import_MetadataTrait {
    *
    * @return array
    */
-  public function getDataPatterns() {
+  public function getDataPatterns(): array {
     return CRM_Utils_Array::collect('dataPattern', $this->getContactImportMetadata());
   }
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1358,24 +1358,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * Update the status of the import row to reflect the processing outcome.
-   *
-   * @param int $id
-   * @param string $status
-   * @param string $message
-   * @param int|null $entityID
-   *   Optional created entity ID
-   * @param array $relatedEntityIDs
-   *   Optional array e.g ['related_contact' => 4]
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   */
-  public function setImportStatus(int $id, string $status, string $message, ?int $entityID = NULL, array $relatedEntityIDs = []): void {
-    $this->getDataSourceObject()->updateStatus($id, $status, $message, $entityID, $relatedEntityIDs);
-  }
-
-  /**
    * Format contact parameters.
    *
    * @todo this function needs re-writing & re-merging into the main function.

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -67,6 +67,14 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   }
 
   /**
+   * Shared preProcess code.
+   */
+  public function preProcess() {
+    $this->assignMapFieldVariables();
+    parent::preProcess();
+  }
+
+  /**
    * Attempt to match header labels with our mapper fields.
    *
    * @param string $header

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -36,8 +36,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
    * Assign common values to the template.
    */
   public function preProcess() {
-    $this->assign('skipColumnHeader', $this->getSubmittedValue('skipColumnHeader'));
-    $this->assign('rowDisplayCount', $this->getSubmittedValue('skipColumnHeader') ? 3 : 2);
+    $this->assignPreviewVariables();
   }
 
   /**
@@ -89,6 +88,33 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     }
     $statusUrl = CRM_Utils_System::url('civicrm/ajax/status', "id={$statusID}", FALSE, NULL, FALSE);
     $this->assign('statusUrl', $statusUrl);
+  }
+
+  /**
+   * Assign smarty variables for the preview screen.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function assignPreviewVariables(): void {
+    $this->assign('downloadErrorRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::ERROR));
+    $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
+    $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
+    $this->assign('totalRowCount', $this->getRowCount([]));
+    $this->assign('mapper', $this->getMappedFieldLabels());
+    $this->assign('dataValues', $this->getDataRows([], 2));
+    $this->assign('columnNames', $this->getColumnHeaders());
+    //get the mapping name displayed if the mappingId is set
+    $mappingId = $this->get('loadMappingId');
+    if ($mappingId) {
+      $mapDAO = new CRM_Core_DAO_Mapping();
+      $mapDAO->id = $mappingId;
+      $mapDAO->find(TRUE);
+    }
+    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
+    $this->assign('skipColumnHeader', $this->getSubmittedValue('skipColumnHeader'));
+    // rowDisplayCount is deprecated - it used to be used with {section} but we have nearly gotten rid of it.
+    $this->assign('rowDisplayCount', $this->getSubmittedValue('skipColumnHeader') ? 3 : 2);
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -586,4 +586,53 @@ class CRM_Import_Forms extends CRM_Core_Form {
     return $mapper;
   }
 
+  /**
+   * Assign variables required for the MapField form.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function assignMapFieldVariables(): void {
+    $this->addExpectedSmartyVariable('highlightedRelFields');
+    $this->_columnCount = $this->getNumberOfColumns();
+    $this->_columnNames = $this->getColumnHeaders();
+    $this->_dataValues = array_values($this->getDataRows([], 2));
+    $this->assign('columnNames', $this->getColumnHeaders());
+    $this->assign('highlightedFields', $this->getHighlightedFields());
+    $this->assign('columnCount', $this->_columnCount );
+    $this->assign('dataValues', $this->_dataValues);
+  }
+
+  /**
+   * Get the fields to be highlighted in the UI.
+   *
+   * The highlighted fields are those used to match
+   * to an existing entity.
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getHighlightedFields(): array {
+    return [];
+  }
+
+  /**
+   * Get the data patterns to pattern match the incoming data.
+   *
+   * @return array
+   */
+  public function getDataPatterns(): array {
+    return $this->getParser()->getDataPatterns();
+  }
+
+  /**
+   * Get the data patterns to pattern match the incoming data.
+   *
+   * @return array
+   */
+  public function getHeaderPatterns(): array {
+    return $this->getParser()->getHeaderPatterns();
+  }
+
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -599,7 +599,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $this->_dataValues = array_values($this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());
     $this->assign('highlightedFields', $this->getHighlightedFields());
-    $this->assign('columnCount', $this->_columnCount );
+    $this->assign('columnCount', $this->_columnCount);
     $this->assign('dataValues', $this->_dataValues);
   }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1608,6 +1608,30 @@ abstract class CRM_Import_Parser {
     return !empty($this->ambiguousOptions[$fieldName][mb_strtolower($importedValue)]);
   }
 
+
+  /**
+   * Get the civicrm_mapping_field appropriate layout for the mapper input.
+   *
+   * For simple parsers (not contribution or contact) the input looks like
+   * ['first_name', 'custom_32']
+   * and it is converted to
+   *
+   *  ['name' => 'first_name', 'mapping_id' => 1, 'column_number' => 5],
+   *
+   * @param array $fieldMapping
+   * @param int $mappingID
+   * @param int $columnNumber
+   *
+   * @return array
+   */
+  public function getMappingFieldFromMapperInput(array $fieldMapping, int $mappingID, int $columnNumber): array {
+    return [
+      'name' => $fieldMapping[0],
+      'mapping_id' => $mappingID,
+      'column_number' => $columnNumber,
+    ];
+  }
+
   /**
    * Get the field mappings for the import.
    *

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1608,7 +1608,6 @@ abstract class CRM_Import_Parser {
     return !empty($this->ambiguousOptions[$fieldName][mb_strtolower($importedValue)]);
   }
 
-
   /**
    * Get the civicrm_mapping_field appropriate layout for the mapper input.
    *
@@ -1725,6 +1724,22 @@ abstract class CRM_Import_Parser {
       }
     }
     return $subTypes;
+  }
+
+  /**
+   * Update the status of the import row to reflect the processing outcome.
+   *
+   * @param int $id
+   * @param string $status
+   * @param string $message
+   * @param int|null $entityID
+   *   Optional created entity ID
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  protected function setImportStatus(int $id, string $status, string $message, ?int $entityID = NULL): void {
+    $this->getDataSourceObject()->updateStatus($id, $status, $message, $entityID);
   }
 
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -510,7 +510,7 @@ abstract class CRM_Import_Parser {
   /**
    * @return array
    */
-  public function getHeaderPatterns() {
+  public function getHeaderPatterns(): array {
     $values = [];
     foreach ($this->_fields as $name => $field) {
       if (isset($field->_headerPattern)) {
@@ -523,7 +523,7 @@ abstract class CRM_Import_Parser {
   /**
    * @return array
    */
-  public function getDataPatterns() {
+  public function getDataPatterns():array {
     $values = [];
     foreach ($this->_fields as $name => $field) {
       $values[$name] = $field->_dataPattern;

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -7,111 +7,26 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-import-maptable-form-block">
+{include file="CRM/Import/Form/MapTableCommon.tpl"}
 
-{* Import Wizard - Data Mapping table used by MapFields.tpl and Preview.tpl *}
-  <div id="map-field">
-    {strip}
-    <table class="selector">
-    {if $savedMappingName}
-      <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
-    {/if}
-
-    {* Header row - has column for column names if they have been supplied *}
-    <tr class="columnheader">
-      {if $columnNames}
-        <td>{ts}Column Names{/ts}</td>
-      {/if}
-      {foreach from=$dataValues item=row key=index}
-        {math equation="x + y" x=$index y=1 assign="rowNumber"}
-        <td>{ts 1=$rowNumber}Import Data (row %1){/ts}</td>
-      {/foreach}
-      <td>{ts}Matching CiviCRM Field{/ts}</td>
-    </tr>
-
-    {*Loop on columns parsed from the import data rows*}
-    {foreach from=$mapper key=i item=mapperField}
-      <tr style="border: 1px solid #DDDDDD;">
-        {if array_key_exists($i, $columnNames)}
-          <td class="even-row labels">{$columnNames[$i]}</td>
-        {/if}
-        {foreach from=$dataValues item=row key=index}
-          <td class="odd-row">{$row[$i]|escape}</td>
-        {/foreach}
-
-        {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
-        <td class="form-item even-row{if $wizard.currentStepName == 'Preview'} labels{/if}">
-          {if $wizard.currentStepName == 'Preview'}
-            {$mapperField}
-          {else}
-            {$mapperField.html|smarty:nodefaults}
-          {/if}
-        </td>
-      </tr>
-    {/foreach}
-  </table>
-  {/strip}
-
-  {if $wizard.currentStepName != 'Preview'}
-    <div>
-      {if $savedMappingName}
-        <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
-      {/if}
-      <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>
-      <div id="saveDetails" class="form-item">
-        <table class="form-layout-compressed">
-          <tr class="crm-import-maptable-form-block-saveMappingName">
-            <td class="label">{$form.saveMappingName.label}</td>
-            <td>{$form.saveMappingName.html}</td>
-          </tr>
-          <tr class="crm-import-maptable-form-block-saveMappingName">
-            <td class="label">{$form.saveMappingDesc.label}</td>
-            <td>{$form.saveMappingDesc.html}</td>
-          </tr>
-        </table>
-      </div>
-        {literal}
-        <script type="text/javascript">
-          if (cj('#saveMapping').prop('checked')) {
-            cj('#saveDetails').show();
-          } else {
-            cj('#saveDetails').hide();
-          }
-
-          function showSaveDetails(chkbox) {
-            if (chkbox.checked) {
-              document.getElementById("saveDetails").style.display = "block";
-              document.getElementById("saveMappingName").disabled = false;
-              document.getElementById("saveMappingDesc").disabled = false;
-            } else {
-              document.getElementById("saveDetails").style.display = "none";
-              document.getElementById("saveMappingName").disabled = true;
-              document.getElementById("saveMappingDesc").disabled = true;
-             }
-          }
-          cj('select[id^="mapper"][id$="[0]"]').addClass('huge');
-        {/literal}
-        {include file="CRM/common/highLightImport.tpl" relationship=true}
-
-        {* // Set default location type *}
-        {literal}
-        CRM.$(function($) {
-          var defaultLocationType = "{/literal}{$defaultLocationType}{literal}";
-          if (defaultLocationType.length) {
-            $('#map-field').on('change', 'select[id^="mapper"][id$="_0"]', function() {
-              var select = $(this).next();
-              $('option', select).each(function() {
-              if ($(this).attr('value') == defaultLocationType
-                && $(this).text() == {/literal}{$defaultLocationTypeLabel|@json_encode}{literal}) {
-                select.val(defaultLocationType);
-              }
-            });
+{if $wizard.currentStepName != 'Preview'}
+  {* // Set default location type *}
+  {literal}
+    <script type="text/javascript">
+    CRM.$(function($) {
+      var defaultLocationType = "{/literal}{$defaultLocationType}{literal}";
+      if (defaultLocationType.length) {
+        $('#map-field').on('change', 'select[id^="mapper"][id$="_0"]', function() {
+          var select = $(this).next();
+          $('option', select).each(function() {
+            if ($(this).attr('value') == defaultLocationType  && $(this).text() == {/literal}{
+              $defaultLocationTypeLabel|@json_encode}{literal}) {
+              select.val(defaultLocationType);
+            }
           });
-        }
-      });
-      {/literal}
-      </script>
-    </div>
-    {/if}
-  </div>
-</div>
+        });
+      }
+    });
+    </script>
+  {/literal}
+{/if}

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -128,9 +128,7 @@
         <table class="form-layout-compressed">
             <tr><td style="width: 14em;"></td>
              <td class="listing-box" style="margin-bottom: 0em; width: 15em;">
-        {foreach from=$form.tag item="tag_val"}
-          <div>{$tag_val.html}</div>
-        {/foreach}
+               {$form.tag.html}
             </td>
           </tr>
         </table>

--- a/templates/CRM/Import/Form/MapTableCommon.tpl
+++ b/templates/CRM/Import/Form/MapTableCommon.tpl
@@ -1,0 +1,92 @@
+<div class="crm-block crm-form-block crm-import-maptable-form-block">
+
+    {* Import Wizard - Data Mapping table used by MapFields.tpl and Preview.tpl *}
+  <div id="map-field">
+      {strip}
+        <table class="selector">
+            {if $savedMappingName}
+              <tr class="columnheader-dark"><th colspan="4">{ts 1=$savedMappingName}Saved Field Mapping: %1{/ts}</td></tr>
+            {/if}
+
+            {* Header row - has column for column names if they have been supplied *}
+          <tr class="columnheader">
+              {if $columnNames}
+                <td>{ts}Column Names{/ts}</td>
+              {/if}
+              {foreach from=$dataValues item=row key=index}
+                  {math equation="x + y" x=$index y=1 assign="rowNumber"}
+                <td>{ts 1=$rowNumber}Import Data (row %1){/ts}</td>
+              {/foreach}
+            <td>{ts}Matching CiviCRM Field{/ts}</td>
+          </tr>
+
+            {*Loop on columns parsed from the import data rows*}
+            {foreach from=$mapper key=i item=mapperField}
+              <tr style="border: 1px solid #DDDDDD;">
+                  {if array_key_exists($i, $columnNames)}
+                    <td class="even-row labels">{$columnNames[$i]}</td>
+                  {/if}
+                  {foreach from=$dataValues item=row key=index}
+                    <td class="odd-row">{$row[$i]|escape}</td>
+                  {/foreach}
+
+                  {* Display mapper <select> field for 'Map Fields', and mapper value for 'Preview' *}
+                <td class="form-item even-row{if $wizard.currentStepName == 'Preview'} labels{/if}">
+                    {if $wizard.currentStepName == 'Preview'}
+                        {$mapperField}
+                    {else}
+                        {$mapperField.html|smarty:nodefaults}
+                    {/if}
+                </td>
+              </tr>
+            {/foreach}
+        </table>
+      {/strip}
+
+      {if $wizard.currentStepName != 'Preview'}
+        <div>
+            {if $savedMappingName}
+              <span>{$form.updateMapping.html} &nbsp;&nbsp; {$form.updateMapping.label}</span>
+            {/if}
+          <span>{$form.saveMapping.html} &nbsp;&nbsp; {$form.saveMapping.label}</span>
+          <div id="saveDetails" class="form-item">
+            <table class="form-layout-compressed">
+              <tr class="crm-import-maptable-form-block-saveMappingName">
+                <td class="label">{$form.saveMappingName.label}</td>
+                <td>{$form.saveMappingName.html}</td>
+              </tr>
+              <tr class="crm-import-maptable-form-block-saveMappingName">
+                <td class="label">{$form.saveMappingDesc.label}</td>
+                <td>{$form.saveMappingDesc.html}</td>
+              </tr>
+            </table>
+          </div>
+            {literal}
+          <script type="text/javascript">
+            if (cj('#saveMapping').prop('checked')) {
+              cj('#saveDetails').show();
+            } else {
+              cj('#saveDetails').hide();
+            }
+
+            function showSaveDetails(chkbox) {
+              if (chkbox.checked) {
+                document.getElementById("saveDetails").style.display = "block";
+                document.getElementById("saveMappingName").disabled = false;
+                document.getElementById("saveMappingDesc").disabled = false;
+              } else {
+                document.getElementById("saveDetails").style.display = "none";
+                document.getElementById("saveMappingName").disabled = true;
+                document.getElementById("saveMappingDesc").disabled = true;
+              }
+            }
+            cj('select[id^="mapper"][id$="[0]"]').addClass('huge');
+            {/literal}
+            {include file="CRM/common/highLightImport.tpl"}
+          </script>
+        </div>
+      {/if}
+
+
+  </div>
+</div>

--- a/templates/CRM/common/highLightImport.tpl
+++ b/templates/CRM/common/highLightImport.tpl
@@ -14,7 +14,7 @@ CRM.$(function($) {
   $.each(highlightedFields, function() {
     $('select[id^="mapper"][id$="_0"] option[value='+ this + ']').append(' *').css({"color":"#FF0000"});
   });
-  {/literal}{if $relationship}{literal}
+  {/literal}{if $highlightedRelFields}{literal}
   var highlightedRelFields = {/literal}{$highlightedRelFields|@json_encode}{literal};
   function highlight() {
     var select, fields = highlightedRelFields[$(this).val()];


### PR DESCRIPTION
Overview
----------------------------------------
Extract common part of MapTable.tpl

Before
----------------------------------------
Most of the file is generic & could be shared with other imports - but there is just one bit of js plonked in the middle holding us back

After
----------------------------------------
The js is still in the contact specific file - but the rest is in CRM/Import/MapTableCommon.tpl

Screenshots from my after r-run

![image](https://user-images.githubusercontent.com/336308/171779399-83286de9-7c1f-4f39-84f7-82b1c6f045b1.png)

![image](https://user-images.githubusercontent.com/336308/171779444-cca73e07-fba5-4ba3-a90f-05b3908313d0.png)

Technical Details
----------------------------------------
Any issues would be very obvious on r-run - which I did

There is already `MapTable` in `CRM/Import/`  - it is awful - `{section}` anyone? This is the path to migrate off

Comments
----------------------------------------
Putting up a separate PR to use this in Contribution flow - which has a bug to fix - but that is a separate r-run flow