### PR TITLE
RelationshipCache - Set 'get' permissions

### DIFF
--- a/CRM/Contact/BAO/RelationshipCache.php
+++ b/CRM/Contact/BAO/RelationshipCache.php
@@ -155,4 +155,18 @@ class CRM_Contact_BAO_RelationshipCache extends CRM_Contact_DAO_RelationshipCach
     return $queries;
   }
 
+  /**
+   * @return array
+   */
+  public function addSelectWhereClause() {
+    // Permission for this entity depends on access to the two related contacts.
+    $contactClause = CRM_Utils_SQL::mergeSubquery('Contact');
+    $clauses = [
+      'near_contact_id' => $contactClause,
+      'far_contact_id' => $contactClause,
+    ];
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
 }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1052,6 +1052,11 @@ class CRM_Core_Permission {
         'edit all contacts',
       ],
     ];
+    // Readonly relationship_cache table
+    $permissions['relationship_cache'] = [
+      // get is managed by BAO::addSelectWhereClause
+      'get' => [],
+    ];
 
     // CRM-17741 - Permissions for RelationshipType.
     $permissions['relationship_type'] = [


### PR DESCRIPTION
Overview
----------------------------------------
This gives lesser-permissioned users access to the RelationshipCache entity, for Search Kit.

Before
----------------------------------------
Non-admins could not see related contacts in SearchKit, even if they had permission to view those contacts.

After
----------------------------------------
Fixed. Permissions for `RelationshipCache` are now the same as for `Relationship`.

Technical Details
----------------------------------------
This duplicates the logic used to check permissions for relationships in the `RelationshipCache` entity.
