### PR TITLE
dev/core#3481 - Don't translate css classes

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -26,7 +26,7 @@
   {/if}
   {foreach from=$email key="blockId" item=item}
     {if $item.email}
-    <div class="crm-summary-row {if !empty($item.is_primary)}{ts}primary{/ts}{/if}">
+    <div class="crm-summary-row {if !empty($item.is_primary)}primary{/if}">
       <div class="crm-label">
         {$item.location_type} {ts}Email{/ts}
         {privacyFlag field=do_not_email condition=$privacy.do_not_email}{privacyFlag field=on_hold condition=$item.on_hold}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3481

Primary email is not bolded on contact summary when using non-english

Before
----------------------------------------
<img width="280" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/171931022-07f0d306-45ec-44eb-a16c-ee7a5b78092a.png">


After
----------------------------------------
<img width="183" alt="Untitled3" src="https://user-images.githubusercontent.com/2967821/171931028-62d88ed8-c038-4679-a791-f2ba71ae64a4.png">

(Italian isn't a good example since it doesn't have "primary" translated in the .po, but I'd already taken the screenshot before noticing.)

Technical Details
----------------------------------------


Comments
----------------------------------------

