### PR TITLE
Afform - Add 'administer afform' permission

### DIFF
--- a/ext/afform/admin/CRM/AfformAdmin/Upgrader.php
+++ b/ext/afform/admin/CRM/AfformAdmin/Upgrader.php
@@ -7,59 +7,13 @@ use CRM_AfformAdmin_ExtensionUtil as E;
 class CRM_AfformAdmin_Upgrader extends CRM_AfformAdmin_Upgrader_Base {
 
   /**
-   * Setup navigation item on new installs.
-   *
-   * Note: this path is not in the menu.xml because routing is handled by afform
-   */
-  public function install() {
-    try {
-      $existing = civicrm_api3('Navigation', 'getcount', [
-        'name' => 'afform_gui',
-        'domain_id' => CRM_Core_Config::domainID(),
-      ]);
-      if (!$existing) {
-        civicrm_api3('Navigation', 'create', [
-          'parent_id' => 'Customize Data and Screens',
-          'label' => E::ts('Form Builder'),
-          'weight' => 1,
-          'name' => 'afform_admin',
-          'permission' => 'administer CiviCRM',
-          'url' => 'civicrm/admin/afform',
-          'is_active' => 1,
-          'icon' => 'crm-i fa-list-alt',
-        ]);
-      }
-    }
-    catch (Exception $e) {
-      // Couldn't create menu item.
-    }
-  }
-
-  /**
-   * Cleanup navigation upon removal
-   */
-  public function uninstall() {
-    civicrm_api3('Navigation', 'get', [
-      'name' => 'afform_gui',
-      'return' => ['id'],
-      'api.Navigation.delete' => [],
-    ]);
-  }
-
-  /**
-   * Update menu item
+   * Obsolete upgrade step, no longer does anything
    *
    * @return bool
    * @throws Exception
    */
   public function upgrade_0001(): bool {
     $this->ctx->log->info('Applying update 0001');
-    \Civi\Api4\Navigation::update(FALSE)
-      ->addValue('icon', 'crm-i fa-list-alt')
-      ->addValue('label', E::ts('Form Builder'))
-      ->addValue('name', 'afform_admin')
-      ->addWhere('name', '=', 'afform_gui')
-      ->execute();
     return TRUE;
   }
 

--- a/ext/afform/admin/ang/afAdminFormSubmissionList.aff.json
+++ b/ext/afform/admin/ang/afAdminFormSubmissionList.aff.json
@@ -1,6 +1,6 @@
 {
-    "type": "search",
+    "type": "system",
     "title": "Submissions",
     "server_route": "civicrm/admin/afform/submissions",
-    "permission": "administer CiviCRM"
+    "permission": [["administer CiviCRM", "administer afform"]]
 }

--- a/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
+++ b/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
@@ -1,0 +1,35 @@
+<?php
+use CRM_AfformAdmin_ExtensionUtil as E;
+
+$menuItems = [];
+$domains = \Civi\Api4\Domain::get(FALSE)
+  ->addSelect('id')
+  ->execute();
+foreach ($domains as $domain) {
+  $menuItems[] = [
+    'name' => 'Navigation_afform_admin_domain_' . $domain['id'],
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'afform_admin',
+        'label' => E::ts('Form Builder'),
+        'permission' => [
+          'administer CiviCRM',
+          'administer afform',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Customize Data and Screens',
+        'weight' => 1,
+        'url' => 'civicrm/admin/afform',
+        'is_active' => 1,
+        'icon' => 'crm-i fa-list-alt',
+        'domain_id' => $domain['id'],
+      ],
+      'match' => ['domain_id', 'name'],
+    ],
+  ];
+}
+return $menuItems;

--- a/ext/afform/admin/xml/Menu/afform_admin.xml
+++ b/ext/afform/admin/xml/Menu/afform_admin.xml
@@ -3,6 +3,6 @@
   <item>
     <path>civicrm/admin/afform</path>
     <page_callback>CRM_AfformAdmin_Page_Base</page_callback>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;administer afform</access_arguments>
   </item>
 </menu>

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -236,8 +236,8 @@ class Afform extends Generic\AbstractEntity {
    */
   public static function permissions() {
     return [
-      "meta" => ["access CiviCRM"],
-      "default" => ["administer CiviCRM"],
+      'meta' => ['access CiviCRM'],
+      'default' => [['administer CiviCRM', 'administer afform']],
       // These all check form-level permissions
       'get' => [],
       'getOptions' => [],

--- a/ext/afform/core/Civi/Api4/AfformSubmission.php
+++ b/ext/afform/core/Civi/Api4/AfformSubmission.php
@@ -11,4 +11,14 @@ namespace Civi\Api4;
  */
 class AfformSubmission extends Generic\DAOEntity {
 
+  /**
+   * @return array
+   */
+  public static function permissions() {
+    return [
+      'meta' => ['access CiviCRM'],
+      'default' => [['administer CiviCRM', 'administer afform']],
+    ];
+  }
+
 }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -383,6 +383,18 @@ function afform_civicrm_alterMenu(&$items) {
 }
 
 /**
+ * Implements hook_civicrm_permission().
+ *
+ * Define Afform permissions.
+ */
+function afform_civicrm_permission(&$permissions) {
+  $permissions['administer afform'] = [
+    E::ts('Form Builder: edit and delete forms'),
+    E::ts('Allows non-admin users to create, update and delete forms'),
+  ];
+}
+
+/**
  * Implements hook_civicrm_permission_check().
  *
  * This extends the list of permissions available in `CRM_Core_Permission:check()`

--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -17,5 +17,9 @@ return [
   'basePages' => ['civicrm/admin/search'],
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'api4', 'crmSearchTasks', 'crmRouteBinder', 'crmDialog'],
   'settingsFactory' => ['\Civi\Search\Admin', 'getAdminSettings'],
-  'permissions' => ['all CiviCRM permissions and ACLs'],
+  'permissions' => [
+    'all CiviCRM permissions and ACLs',
+    'administer CiviCRM',
+    'administer afform',
+  ],
 ];

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -13,7 +13,8 @@
         fieldsForJoinGetters = {};
 
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
-      this.afformAdminEnabled = 'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
+      this.afformAdminEnabled = (CRM.checkPerm('administer CiviCRM') || CRM.checkPerm('administer afform')) &&
+        'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
       this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'id');
       this.searchDisplayPath = CRM.url('civicrm/search');
       this.afformPath = CRM.url('civicrm/admin/afform');

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -17,7 +17,8 @@
       this.searchDisplayPath = CRM.url('civicrm/search');
       this.afformPath = CRM.url('civicrm/admin/afform');
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
-      this.afformAdminEnabled = 'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
+      this.afformAdminEnabled = (CRM.checkPerm('administer CiviCRM') || CRM.checkPerm('administer afform')) &&
+        'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
 
       this.apiEntity = 'SavedSearch';
       this.search = {


### PR DESCRIPTION
Overview
----------------------------------------
Similar to #23670 this adds a new permission to allow non-system-admins to access Form Builder

Before
----------------------------------------
Form Builder required "administer CiviCRM" permission.

After
----------------------------------------
A non-administrator can be granted permission to access Form Builder.