### PR TITLE
APIv4 - Allow creator to read `UserJob` and `Queue` records

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -32,7 +32,11 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob {
    * @inheritDoc
    */
   public function addSelectWhereClause(): array {
-    $clauses['created_id'] = '= ' . (int) CRM_Core_Session::getLoggedInContactID();
+    $clauses = [];
+    if (!\CRM_Core_Permission::check('administer queues')) {
+      $clauses['created_id'] = '= ' . (int) CRM_Core_Session::getLoggedInContactID();
+    }
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
     return $clauses;
   }
 

--- a/CRM/Queue/BAO/Queue.php
+++ b/CRM/Queue/BAO/Queue.php
@@ -20,6 +20,16 @@
  */
 class CRM_Queue_BAO_Queue extends CRM_Queue_DAO_Queue implements \Civi\Core\HookInterface {
 
+  public function addSelectWhereClause(): array {
+    $clauses = [];
+    if (!\CRM_Core_Permission::check('administer queues')) {
+      $cid = (int) CRM_Core_Session::getLoggedInContactID();
+      $clauses['id'] = "IN (SELECT queue_id FROM `civicrm_user_job` WHERE created_id = $cid)";
+    }
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
   /**
    * Get a list of valid statuses.
    *

--- a/Civi/Api4/Queue.php
+++ b/Civi/Api4/Queue.php
@@ -34,6 +34,7 @@ class Queue extends \Civi\Api4\Generic\DAOEntity {
     return [
       'meta' => ['access CiviCRM'],
       'default' => ['administer queues'],
+      'get' => ['access CiviCRM'],
       'runItem' => [\CRM_Core_Permission::ALWAYS_DENY_PERMISSION],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------

Refine the permissions for `UserJob` and `Queue` records.

ping @eileenmcnaughton 

Before
------

* `Queue.get` requires permission `administer queues`
* `UserJob.*` requires permission `access CiviCRM`, but it only
   returns records if where the `created_id` matches current-user

After
-----

* `Queue.get` and `UserJob.*` follow similar rules
* Users with permission `administer queues` can view all
* Users with permission `access CiviCRM` can view items where `created_id` matches current-user

Technical Details
----------------------------------------

To `r-run`, I followed this approach:

* Make sure the local deployment had 3 users `admin`, `demo`, `advisor`. The `advisor` has `access CiviCRM` but no other relevant permissions (eg `administer CiviCRM`, `administer queues`).
    * ~~(Note: My local demo had some oddities in the `civicrm_uf_match` that needed to be cleaned-up before testing. This is entirely by-the-by.)~~
* Create a `UserJob` and associated `Queue` (eg api explorer)
* Alternate between CLI and SQL commands like:
    ```
    update civicrm_user_job set created_id = 123;
    update civicrm_user_job set created_id = 456;

    cv api4 -U advisor Queue.get checkPermissions=1 -T
    cv api4 -U admin Queue.get checkPermissions=1 -T
    cv api4 -U advisor UserJob.get checkPermissions=1 -T
    cv api4 -U admin UserJob.get checkPermissions=1 -T
    ```

