### PR TITLE
Add not-yet-used function to allow the import to run in static (queue) context

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -25,6 +25,15 @@ class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   const IMPORT_ENTITY = 'Activity';
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'activity_import';
+  }
+
+  /**
    * @var bool
    */
   public $submitOnce = TRUE;

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -21,6 +21,15 @@
 class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'contact_import';
+  }
+
+  /**
    * Get any smarty elements that may not be present in the form.
    *
    * To make life simpler for smarty we ensure they are set to null

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -25,6 +25,15 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   const IMPORT_ENTITY = 'Contribution';
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'contribution_import';
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -86,6 +86,37 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob {
         'id' => 1,
         'name' => 'contact_import',
         'label' => ts('Contact Import'),
+        'class' => 'CRM_Contact_Import_Parser_Contact',
+      ],
+      [
+        'id' => 2,
+        'name' => 'contribution_import',
+        'label' => ts('Contribution Import'),
+        'class' => 'CRM_Contribute_Import_Parser_Contribution',
+      ],
+      [
+        'id' => 3,
+        'name' => 'membership_import',
+        'label' => ts('Membership Import'),
+        'class' => 'CRM_Member_Import_Parser_Membership',
+      ],
+      [
+        'id' => 4,
+        'name' => 'activity_import',
+        'label' => ts('Activity Import'),
+        'class' => 'CRM_Activity_Import_Parser_Activity',
+      ],
+      [
+        'id' => 5,
+        'name' => 'participant_import',
+        'label' => ts('Participant Import'),
+        'class' => 'CRM_Event_Import_Parser_Participant',
+      ],
+      [
+        'id' => 6,
+        'name' => 'custom_field_import',
+        'label' => ts('Multiple Value Custom Field Import'),
+        'class' => 'CRM_Custom_Import_Parser_Api',
       ],
     ];
   }

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -25,6 +25,15 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   const IMPORT_ENTITY = 'Multi value custom data';
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'custom_field_import';
+  }
+
+  /**
    * Get the import entity (translated).
    *
    * Used for template layer text.

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -25,6 +25,15 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   const IMPORT_ENTITY = 'Participant';
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'participant_import';
+  }
+
+  /**
    * Build the form object.
    *
    * @return void

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -376,7 +376,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $id = UserJob::create(FALSE)
       ->setValues([
         'created_id' => CRM_Core_Session::getLoggedInContactID(),
-        'type_id:name' => 'contact_import',
+        'type_id:name' => $this->getUserJobType(),
         'status_id:name' => 'draft',
         // This suggests the data could be cleaned up after this.
         'expires_date' => '+ 1 week',

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1653,6 +1653,52 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Run import.
+   *
+   * @param \CRM_Queue_TaskContext $taskContext
+   *
+   * @param int $userJobID
+   * @param int $limit
+   *
+   * @return bool
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public static function runImport($taskContext, $userJobID, $limit) {
+    $userJob = UserJob::get()->addWhere('id', '=', $userJobID)->addSelect('type_id')->execute()->first();
+    $parserClass = NULL;
+    foreach (CRM_Core_BAO_UserJob::getTypes() as $userJobType) {
+      if ($userJob['type_id'] === $userJobType['id']) {
+        $parserClass = $userJobType['class'];
+      }
+    }
+    $parser = new $parserClass();
+    $parser->setUserJobID($userJobID);
+    // Not sure if we still need to init....
+    $parser->init();
+    $dataSource = $parser->getDataSourceObject();
+    $dataSource->setStatuses(['new']);
+    $dataSource->setLimit($limit);
+
+    while ($row = $dataSource->getRow()) {
+      $values = array_values($row);
+
+      try {
+        $parser->import($parser->getSubmittedValue('onDuplicate'), $values);
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        // When we catch errors here we are not adding to the errors array - mostly
+        // because that will become obsolete once https://github.com/civicrm/civicrm-core/pull/23292
+        // is merged and this will replace it as the main way to handle errors (ie. update the table
+        // and move on).
+        $parser->setImportStatus((int) $values[count($values) - 1], 'ERROR', $e->getMessage());
+      }
+    }
+    $parser->doPostImportActions();
+    return TRUE;
+  }
+
+  /**
    * Check if an error in custom data.
    *
    * @deprecated all of this is duplicated if getTransformedValue is used.

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -25,6 +25,15 @@ class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   const IMPORT_ENTITY = 'Membership';
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'membership_import';
+  }
+
+  /**
    * Build the form object.
    *
    * @return void


### PR DESCRIPTION
Overview
----------------------------------------
Add not-yet-used function to allow the import to run in static (queue) context

This adds the import function from https://github.com/civicrm/civicrm-core/pull/23669  - so that that PR not being merged doesn't hold up fixes on the other classes. Note that this part (or any part as far as I know) of that PR is not under question - I think the discussion is all centred on the follow on steps to be worked on once that PR is merged.

Before
----------------------------------------
- the different import classes all use the same `type_id` when creating user jobs

After
----------------------------------------
Different one per import

Technical Details
----------------------------------------
At this stage the list is still very much static - it probably will be hookable or similar in future

Comments
----------------------------------------
