### PR TITLE
Import - make tracking fields import-specific

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -369,7 +369,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function validateValues(array $values): void {
+  public function validateValues(array $values): void {
     // Check required fields if this is not an update.
     if (!$this->getFieldValue($values, 'activity_id')) {
       if (!$this->getFieldValue($values, 'activity_label')

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -127,8 +127,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
   /**
    * Handle the values in import mode.
    *
-   * @param int $onDuplicate
-   *   The code for what action to take on duplicates.
    * @param array $values
    *   The array of values belonging to this line.
    *
@@ -138,7 +136,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
    *
    * @throws \CRM_Core_Exception
    */
-  public function import($onDuplicate, &$values) {
+  public function import(&$values) {
     // First make sure this is a valid line
     try {
       $this->validateValues($values);
@@ -493,8 +491,6 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
       }
 
       // Trim whitespace around the values.
-
-      $empty = TRUE;
       foreach ($values as $k => $v) {
         $values[$k] = trim($v, " \t\r\n");
       }
@@ -513,7 +509,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         $returnCode = $this->summary($values);
       }
       elseif ($mode == self::MODE_IMPORT) {
-        $returnCode = $this->import($onDuplicate, $values);
+        $returnCode = $this->import($values);
         if ($statusID && (($this->_lineCount % 50) == 0)) {
           $prevTimestamp = $this->progressImport($statusID, FALSE, $startTimestamp, $prevTimestamp, $totalRowCount);
         }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -568,7 +568,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if (!empty($value['relationship_type_id'])) {
         $requiredSubType = $this->getRelatedContactSubType($value['relationship_type_id'], $value['relationship_direction']);
         if ($requiredSubType && $value['contact_sub_type'] && $requiredSubType !== $value['contact_sub_type']) {
-          throw new CRM_Core_Exception($prefixString . ts('Mismatched or Invalid contact subtype found for this related contact.'));
+          // Tested in CRM_Contact_Import_Parser_ContactTest::testImportContactSubTypes
+          throw new CRM_Core_Exception($prefixString . ts('Mismatched or Invalid contact subtype found for this related contact.'), CRM_Import_Parser::ERROR);
         }
       }
     }
@@ -1138,7 +1139,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if (array_key_exists($extIDMatch, $possibleMatches['values'])) {
         return $extIDMatch;
       }
-      throw new CRM_Core_Exception(ts('Matching this contact based on the de-dupe rule would cause an external ID conflict'));
+      throw new CRM_Core_Exception(ts('Matching this contact based on the de-dupe rule would cause an external ID conflict'), CRM_Import_Parser::ERROR);
     }
     return $extIDMatch;
   }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -187,13 +187,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
     try {
       $params = $this->getMappedRow($values);
-      // it is questionable whether we need to do validate here
-      // - normally it has already been done in the form flow
-      // and generally only lines that passed that will
-      // get to the import function. It might be that it
-      // is really only here cos it used to be combined with getMappedRow
-      $this->validateParams($params);
-
       $formatted = [];
       foreach ($params as $key => $value) {
         if ($value !== '') {

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1575,21 +1575,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * Validate the import values.
-   *
-   * The values array represents a row in the datasource.
-   *
-   * @param array $values
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   */
-  public function validateValues(array $values): void {
-    $params = $this->getMappedRow($values);
-    $this->validateParams($params);
-  }
-
-  /**
    * Get the invalid values in the params for the given contact.
    *
    * @param array|int|string $value

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1129,7 +1129,8 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         return array_key_last($possibleMatches['values']);
       }
       if (count($possibleMatches['values']) > 1) {
-        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts'));
+        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts: ') . implode(',', array_keys($possibleMatches['values'])), CRM_Import_Parser::ERROR);
+
       }
       return NULL;
     }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1568,6 +1568,21 @@ abstract class CRM_Import_Parser {
   }
 
   /**
+   * Validate the import values.
+   *
+   * The values array represents a row in the datasource.
+   *
+   * @param array $values
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function validateValues(array $values): void {
+    $params = $this->getMappedRow($values);
+    $this->validateParams($params);
+  }
+
+  /**
    * Search the value for the string 'invalid_import_value'.
    *
    * If the string is found it indicates the fields was rejected

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -110,6 +110,14 @@ abstract class CRM_Import_Parser {
   private $availableCountries;
 
   /**
+   *
+   * @return array
+   */
+  public function getTrackingFields(): array {
+    return [];
+  }
+
+  /**
    * Get User Job.
    *
    * API call to retrieve the userJob row.
@@ -1842,12 +1850,16 @@ abstract class CRM_Import_Parser {
    * @param string $message
    * @param int|null $entityID
    *   Optional created entity ID
+   * @param array $additionalFields
+   *  Additional fields to be tracked
    *
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
-  protected function setImportStatus(int $id, string $status, string $message, ?int $entityID = NULL): void {
-    $this->getDataSourceObject()->updateStatus($id, $status, $message, $entityID);
+  protected function setImportStatus(int $id, string $status, string $message, ?int $entityID = NULL, $additionalFields = []): void {
+    $this->getDataSourceObject()->updateStatus($id, $status, $message, $entityID, $additionalFields);
   }
 
   /**

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -268,11 +268,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
    *
    * @param array $values
    *   The array of values belonging to this line.
-   *
-   * @return bool
-   *   the result of this processing
    */
-  public function validateValues($values) {
+  public function validateValues($values): void {
     $params = $this->getMappedRow($values);
     $errors = [];
     foreach ($params as $key => $value) {
@@ -281,7 +278,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
 
     if (empty($params['membership_type_id'])) {
       $errors[] = ts('Missing required fields');
-      return NULL;
+      return;
     }
 
     //To check whether start date or join date is provided
@@ -291,8 +288,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
     if ($errors) {
       throw new CRM_Core_Exception('Invalid value for field(s) : ' . implode(',', $errors));
     }
-
-    return CRM_Import_Parser::VALID;
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -50,10 +50,6 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    *
    * So far this is just testing the class constructor & preparing for more
    * tests.
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
   public function testImport(): void {
     $this->createCustomGroupWithFieldOfType(['extends' => 'Activity'], 'checkbox');
@@ -101,7 +97,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
     $importer = $this->createImportObject(array_keys($values));
     $params = array_values($values);
     CRM_Core_Session::singleton()->set('dateTypes', 1);
-    $outcome = $importer->import(NULL, $params);
+    $outcome = $importer->import($params);
     $this->assertEquals($expectedOutcome, $outcome);
     // If there was an error it's in element 0
     return $outcome === CRM_Import_Parser::VALID ? '' : $params[0];

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_external_identifier_email_mismatch.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_invalid_external_identifier_email_mismatch.csv
@@ -1,0 +1,4 @@
+first,last,email,external_identifier
+bob,dobbs,bob@null.com,123
+sue,davis,other@null.com,456
+mis,match,other@null.com,123

--- a/tests/phpunit/CRM/Contact/Import/Form/data/organization_multiple_duplicates_invalid.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/organization_multiple_duplicates_invalid.csv
@@ -1,0 +1,4 @@
+organization_name,email
+BobCo,
+Cindy,bobco@null.com
+BobCo,bobco@null.com

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1060,9 +1060,11 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  public function testImport($csv, $mapper, $expectedError, $expectedOutcomes = []): void {
+  public function testImport($csv, $mapper, $expectedError, $expectedOutcomes = [], $contactType = NULL): void {
     try {
-      $this->importCSV($csv, $mapper);
+      $this->importCSV($csv, $mapper, [
+        'contactType' => $contactType ?? CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      ]);
     }
     catch (CRM_Core_Exception $e) {
       $this->assertSame($expectedError, $e->getMessage());
@@ -1089,6 +1091,16 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         'mapper' => [['first_name'], ['last_name'], ['contact_sub_type']],
         'expected_error' => '',
         'expected_outcomes' => [CRM_Import_Parser::ERROR => 1],
+      ],
+      'organization_multiple_duplicates_invalid' => [
+        'csv' => 'organization_multiple_duplicates_invalid.csv',
+        'mapper' => [['organization_name'], ['email']],
+        'expected_error' => '',
+        'expected_outcomes' => [
+          CRM_Import_Parser::VALID => 2,
+          CRM_Import_Parser::ERROR => 1,
+        ],
+        'contact_type' => CRM_Import_Parser::CONTACT_ORGANIZATION,
       ],
     ];
   }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -2076,7 +2076,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       $form->postProcess();
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {
-      $queue = Civi::queue('user_job_' . $userJobID);
+      $queue = Civi::queue('user_job_' . $this->userJobID);
       $runner = new CRM_Queue_Runner([
         'queue' => $queue,
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,


### PR DESCRIPTION
Overview
----------------------------------------
Import - make tracking fields import-specific

Before
----------------------------------------

The import tracking table adds some fields to track what happens - but actually different imports have different things to report on 

After
----------------------------------------
The imports can define the fields they track - in the case of contact I've added 2 fields -  'related_contact_created' &  'related_contact_matched' - which are the count of related contacts created or matched. This comes out of discussion with @darrick https://github.com/civicrm/civicrm-core/commit/578e4db3773f70f13e0bc76c02f2768c37293528#r75332645 and is not necessarily the final conclusion of what is best to track  - but I think definite the tracking fields by import is a better structure 

Technical Details
----------------------------------------

Comments
----------------------------------------
