### PR TITLE
Mailing List Subscription: remove the cancel button

### DIFF
--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -119,10 +119,6 @@ ORDER BY title";
         'name' => ts('Subscribe'),
         'isDefault' => TRUE,
       ],
-      [
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-      ],
     ]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

The Mailing List Subscription form has a cancel button. I know there are a few places that have such buttons, but I am determined to get them removed whenever I see them (instead of just systematically hiding them in CSS).

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/172069015-3bfb0248-857a-4d24-8be3-b0a8138ebba9.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/172069028-c9c84db3-764a-483a-ac62-eee257914dc3.png)

Comments
----------------------------------------

It's even funnier, because "cancel" will not cancel your subscription.