### PR TITLE
dev/core#3495 - Fix fields with wildcards in Advanced Search

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6309,15 +6309,13 @@ AND   displayRelType.is_active = 1
   public static function getWildCardedValue($wildcard, $op, $value) {
     if ($wildcard && $op === 'LIKE') {
       if (CRM_Core_Config::singleton()->includeWildCardInName && (substr($value, 0, 1) != '%')) {
-        return "%$value%";
+        $value = "%$value";
       }
-      else {
-        return "$value%";
+      if (substr($value, -1, 1) != '%') {
+        $value = "$value%";
       }
     }
-    else {
-      return "$value";
-    }
+    return "$value";
   }
 
   /**

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -332,7 +332,11 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       foreach ($fields as $fieldName => $field) {
         if (!empty($this->_formValues[$fieldName]) && empty($field['options']) && empty($field['pseudoconstant'])) {
           if (in_array($field['type'], [CRM_Utils_Type::T_STRING, CRM_Utils_Type::T_TEXT])) {
-            $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', trim($this->_formValues[$fieldName]))];
+            $val = $this->_formValues[$fieldName];
+            if (is_array($val)) {
+              $val = $val['LIKE'];
+            }
+            $this->_formValues[$fieldName] = ['LIKE' => CRM_Contact_BAO_Query::getWildCardedValue(TRUE, 'LIKE', trim($val))];
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
In the affected function, some fields are arrays, e.g. ['LIKE' => 'field-value'], rather than strings as was expected. Modified to now check for that and handle correctly.

Before
----------------------------------------
1. Some search terms, e.g. Contribution Source, are changed to '%%' upon sorting or paging the results.
2. After fixing the above, an extraneous trailing '%' on search terms was appending on each sort of paging of the results.

After
----------------------------------------
1. All search terms are preserved.
2. Extraneous wildcards are no longer appended.

Technical Details
----------------------------------------

Comments
----------------------------------------
