### PR TITLE
[NFC] Fix Since version in Price Set Entity APIv4

### DIFF
--- a/Civi/Api4/PriceSetEntity.php
+++ b/Civi/Api4/PriceSetEntity.php
@@ -14,7 +14,7 @@ namespace Civi\Api4;
  * PriceSetEntity entity.
  *
  * @searchable secondary
- * @since 5.27
+ * @since 5.51
  * @package Civi\Api4
  */
 class PriceSetEntity extends Generic\DAOEntity {


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that the correct version that this APIv4 entity was added is recorded in the @since tag. which is 5.51 as it was just merged to master

ping @eileenmcnaughton @colemanw 