### PR TITLE
Add extra shared import functions - attempt to unblock regression fixes dependent on 23689 (fixes participant import)

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -81,11 +81,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    * The initializer code, called before the processing.
    */
   public function init() {
-    $fields = CRM_Event_BAO_Participant::importableFields($this->_contactType, FALSE);
-    $fields['event_id']['title'] = 'Event ID';
-    $eventfields = &CRM_Event_BAO_Event::fields();
-    $fields['event_title'] = $eventfields['event_title'];
-
+    $this->setFieldMetadata();
+    $fields = $this->importableFieldsMetadata;
     foreach ($fields as $name => $field) {
       $field['type'] = CRM_Utils_Array::value('type', $field, CRM_Utils_Type::T_INT);
       $field['dataPattern'] = CRM_Utils_Array::value('dataPattern', $field, '//');
@@ -1035,6 +1032,21 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Set up field metadata.
+   *
+   * @return void
+   */
+  protected function setFieldMetadata(): void {
+    if (empty($this->importableFieldsMetadata)) {
+      $fields = CRM_Event_BAO_Participant::importableFields($this->_contactType, FALSE);
+      $fields['event_id']['title'] = 'Event ID';
+      $eventfields = CRM_Event_BAO_Event::fields();
+      $fields['event_title'] = $eventfields['event_title'];
+      $this->importableFieldsMetadata = $fields;
+    }
   }
 
 }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -77,6 +77,22 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   }
 
   /**
+   * Process the mapped fields and map it into the uploaded file
+   * preview the file and extract some summary statistics
+   *
+   * @return void
+   * @noinspection PhpDocSignatureInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function postProcess() {
+    $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
+    $this->saveMapping($this->getMappingTypeName());
+    $parser = $this->getParser();
+    $parser->init();
+    $parser->validate();
+  }
+
+  /**
    * Attempt to match header labels with our mapper fields.
    *
    * @param string $header
@@ -230,6 +246,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   protected function saveMappingField(int $mappingID, int $columnNumber, bool $isUpdate = FALSE): void {
     $fieldMapping = (array) $this->getSubmittedValue('mapper')[$columnNumber];
     $mappedField = $this->getMappedField($fieldMapping, $mappingID, $columnNumber);
+    if (empty($mappedField['name'])) {
+      $mappedField['name'] = 'do_not_import';
+    }
     if ($isUpdate) {
       Civi\Api4\MappingField::update(FALSE)
         ->setValues($mappedField)

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -117,4 +117,14 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     $this->assign('rowDisplayCount', $this->getSubmittedValue('skipColumnHeader') ? 3 : 2);
   }
 
+  /**
+   * Process the mapped fields and map it into the uploaded file
+   * preview the file and extract some summary statistics
+   *
+   * @return void
+   */
+  public function postProcess() {
+    CRM_Import_Parser::runImport(NULL, $this->getUserJobID(), 0);
+  }
+
 }

--- a/CRM/Import/Form/Summary.php
+++ b/CRM/Import/Form/Summary.php
@@ -24,6 +24,15 @@
 abstract class CRM_Import_Form_Summary extends CRM_Import_Forms {
 
   /**
+   * Set variables up before form is built.
+   *
+   * @return void
+   */
+  public function preProcess() {
+    $this->assignOutputURLs();
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {
@@ -43,6 +52,19 @@ abstract class CRM_Import_Form_Summary extends CRM_Import_Forms {
    */
   public function getTitle() {
     return ts('Summary');
+  }
+
+  protected function assignOutputURLs(): void {
+    $this->assign('totalRowCount', $this->getRowCount());
+    $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID) + $this->getRowCount(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
+    $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
+    $this->assign('duplicateRowCount', $this->getRowCount(CRM_Import_Parser::DUPLICATE));
+    $this->assign('unMatchCount', $this->getRowCount(CRM_Import_Parser::NO_MATCH));
+    $this->assign('unparsedAddressCount', $this->getRowCount(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
+    $this->assign('downloadDuplicateRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::DUPLICATE));
+    $this->assign('downloadErrorRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::ERROR));
+    $this->assign('downloadMismatchRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::NO_MATCH));
+    $this->assign('downloadAddressRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
   }
 
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1676,6 +1676,10 @@ abstract class CRM_Import_Parser {
    * @throws \API_Exception
    */
   public function getMappedFieldLabel(array $mappedField): string {
+    // doNotImport is on it's way out - skip fields will be '' once all is done.
+    if ($mappedField['name'] === 'doNotImport') {
+      return '';
+    }
     $this->setFieldMetadata();
     return $this->getFieldMetadata($mappedField['name'])['title'];
   }


### PR DESCRIPTION
This is an attempt to get away from fixing known breakage
being blocked by
https://github.com/civicrm/civicrm-core/pull/23689

These functions should be mostly as-yet-unused, or only minorly changed
but required to fix the known issues


@totten - I don't know tht this will fix the activity import breakage but it should unblock me fixing it rather than keeping waiting on #23689  & I can easily rebase that over this if merged