### PR TITLE
SearchKit - Make loading placeholders configurable

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -72,6 +72,7 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
           'show_count' => TRUE,
           'expose_limit' => TRUE,
         ],
+        'placeholder' => 5,
         'sort' => [],
         'columns' => [],
       ],

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.component.js
@@ -1,0 +1,27 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('searchAdminPlaceholderConfig', {
+    bindings: {
+      display: '<',
+    },
+    templateUrl: '~/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.html',
+    controller: function($scope) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.$onInit = function() {
+        // Legacy support
+        if (!('placeholder' in this.display.settings)) {
+          this.display.settings.placeholder = 5;
+        }
+      };
+
+      this.togglePlaceholder = function() {
+        this.display.settings.placeholder = this.display.settings.placeholder ? 0 : 5;
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.html
@@ -1,0 +1,9 @@
+<div class="form-inline">
+  <div class="checkbox-inline form-control" title="{{:: ts('Show wireframe placeholder results while waiting for data') }}">
+    <label>
+      <input type="checkbox" ng-checked="$ctrl.display.settings.placeholder" ng-click="$ctrl.togglePlaceholder()">
+      <span>{{:: ts('Loading Placeholders') }}</span>
+    </label>
+    <input ng-if="$ctrl.display.settings.placeholder" type="number" min="0" step="1" class="form-control" ng-model="$ctrl.display.settings.placeholder" ng-model-options="{updateOn: 'blur'}">
+  </div>
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
@@ -11,6 +11,7 @@
     <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
   </div>
   <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+  <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
 </fieldset>
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -15,6 +15,7 @@
     <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
   </div>
   <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+  <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
 </fieldset>
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -28,6 +28,7 @@
   </div>
   <search-admin-css-rules label="{{:: ts('Row Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
   <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+  <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
   <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the table is empty.') }}">
     <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
     <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -21,6 +21,11 @@
         this.limit = this.settings.limit;
         this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
         this.seed = Date.now();
+        this.placeholders = [];
+        var placeholderCount = 'placeholder' in this.settings ? this.settings.placeholder : 5;
+        for (var p=0; p < placeholderCount; ++p) {
+          this.placeholders.push({});
+        }
 
         this.getResults = _.debounce(function() {
           $scope.$apply(function() {

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridLoading.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridLoading.html
@@ -1,4 +1,4 @@
 <!-- Placeholder shown during ajax loading -->
-<div ng-repeat="num in [1,2,3,4,5] track by $index" style="width: 100px; height: 50px;">
+<div ng-repeat="num in $ctrl.placeholders" style="width: 100px; height: 50px;">
   <div class="crm-search-loading-placeholder"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListLoading.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListLoading.html
@@ -1,4 +1,4 @@
 <!-- Placeholder shown during ajax loading -->
-<li ng-repeat="num in [1,2,3,4,5] track by $index">
+<li ng-repeat="num in $ctrl.placeholders">
   <div class="crm-search-loading-placeholder"></div>
 </li>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableLoading.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableLoading.html
@@ -1,5 +1,5 @@
 <!-- Placeholder table rows shown during ajax loading -->
-<tr ng-repeat="num in [1,2,3,4,5] track by $index">
+<tr ng-repeat="num in $ctrl.placeholders">
   <td ng-if=":: $ctrl.hasExtraFirstColumn()">
     <input ng-if=":: $ctrl.settings.actions" type="checkbox" disabled>
   </td>

--- a/ext/search_kit/css/crmSearchDisplay.css
+++ b/ext/search_kit/css/crmSearchDisplay.css
@@ -26,7 +26,7 @@
   width: 80%;
   position: relative;
   overflow: hidden;
-  background-color: rgba(0,0,0,.04);
+  background-color: rgba(0,0,0,.03);
   display: inline-block;
 }
 #bootstrap-theme .crm-search-loading-placeholder::before {
@@ -37,7 +37,7 @@
   top: 0;
   height: 100%;
   width: 150px;
-  background: linear-gradient(to right, transparent 0%, rgba(0,0,0,.1) 50%, transparent 100%);
+  background: linear-gradient(to right, transparent 0%, rgba(0,0,0,.05) 50%, transparent 100%);
   animation: searchKitLoadingAnimation 1s cubic-bezier(0.4, 0.0, 0.2, 1) infinite;
 }
 @keyframes searchKitLoadingAnimation {


### PR DESCRIPTION
Overview
----------------------------------------
This allows the admin to control how many (if any) skeleton results are shown during ajax loading.

It also lightens the colors to make the animation a bit more subtle.

Before
-------------------------
Five placeholders always shown. Animation was reportedly a bit distracting.

After
----------------------------
Colors lightened to be less distracting. Configurable number, or can be disabled completely.
![image](https://user-images.githubusercontent.com/2874912/172182011-5e86e8e9-d612-48b9-8b98-95087ccbc466.png)
