### PR TITLE
dev/core#2325 Fix handling of seconds on import

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -2125,7 +2125,7 @@ class CRM_Utils_Date {
       $ruleName = 'date';
       if ($dateType == 1) {
         $matches = [];
-        if (preg_match("/(\s(([01]\d)|[2][0-3]):([0-5]\d))$/", $date, $matches)) {
+        if (preg_match("/(\s(([01]\d)|[2][0-3]):([0-5]\d):?[0-5]?\d?)$/", $date, $matches)) {
           $ruleName = 'dateTime';
           if (strpos($date, '-') !== FALSE) {
             $dateVal .= array_shift($matches);


### PR DESCRIPTION
This addresses an issue where the following date time has the time component
stripped

2012-12-12 07:12:56

Without the seconds - ie

2012-12-12 07:12

Note that an assert could be added to check the activity [here](https://github.com/civicrm/civicrm-core/pull/23707/files#diff-ed5f2e2276cf6f553a097e29f46c8fe6aeacb7990474de9caa5e105c9c428522R395) once that PR is merged (and that this can't be tested in the import context until it is as there is other breakage)
