### PR TITLE
Queue - When UserJob has no more tasks, update status & fire hook

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -18,7 +18,66 @@
 /**
  * This class contains user jobs functionality.
  */
-class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob {
+class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\HookInterface {
+
+  /**
+   * Check on the status of a queue.
+   *
+   * Queues that are attached to a UserJob are necessarily finite - so we can mark them 'completed'
+   * when the task-list reaches empty.
+   *
+   * Note that this runs after processing *every item* in *every queue* (foreground, background,
+   * import, upgrade, ad nauseum). The capacity to handle heavy tasks here is subjective (depending
+   * on the specific queue/use-case). We try to be conservative about I/O until we know that
+   * we're in a suitable context.
+   */
+  public static function on_civi_queue_check(\Civi\Core\Event\GenericHookEvent $e) {
+    /** @var \CRM_Queue_Queue $queue */
+    $queue = $e->queue;
+    $userJobId = static::findUserJobId($queue->getName());
+    if ($userJobId && $queue->numberOfItems() < 1) {
+      $queue->setStatus('completed');
+    }
+  }
+
+  /**
+   * If the `civicrm_queue` changes status, then the `civicrm_user_job` should also change status.
+   *
+   * @param \CRM_Queue_Queue $queue
+   * @param string $status
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   * @see \CRM_Utils_Hook::queueStatus()
+   */
+  public static function hook_civicrm_queueStatus(CRM_Queue_Queue $queue, string $status) {
+    $userJobId = static::findUserJobId($queue->getName());
+    if ($userJobId && $status === 'completed') {
+      \Civi\Api4\UserJob::update()
+        ->addWhere('id', '=', $userJobId)
+        ->setValues(['status_id' => 1])
+        ->execute();
+    }
+  }
+
+  private static function findUserJobId(string $queueName): ?int {
+    if (CRM_Core_Config::isUpgradeMode()) {
+      return NULL;
+    }
+
+    $key = 'userJobId_' . $queueName;
+    if (!isset(Civi::$statics[__CLASS__][$key])) {
+      // Part of the primary structure/purpose of the queue. Shouldn't change.
+      $userJobId = CRM_Core_DAO::singleValueQuery('
+        SELECT uj.id FROM civicrm_queue q
+        INNER JOIN civicrm_user_job uj ON q.id = uj.queue_id
+        WHERE q.name = %1
+      ', [
+        1 => [$queueName, 'String'],
+      ]);
+      Civi::$statics[__CLASS__][$key] = $userJobId;
+    }
+    return Civi::$statics[__CLASS__][$key];
+  }
 
   /**
    * Restrict access to the relevant user.

--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Core\Event\GenericHookEvent;
+
 /**
  * `CRM_Queue_Runner` runs a list tasks from a queue. It originally supported the database-upgrade
  * queue. Consequently, this runner is optimal for queues which are:
@@ -228,6 +230,10 @@ class CRM_Queue_Runner {
       else {
         $this->releaseErrorItem($item);
       }
+
+      \Civi::dispatcher()->dispatch('civi.queue.check', GenericHookEvent::create([
+        'queue' => $this->queue,
+      ]));
 
       return $this->formatTaskResult($isOK, $exception);
     }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2756,6 +2756,21 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * Fired if the status of a queue changes.
+   *
+   * @param \CRM_Queue_Queue $queue
+   * @param string $status
+   *   New status.
+   *   Ex: 'completed', 'active', 'aborted'
+   */
+  public static function queueStatus(CRM_Queue_Queue $queue, string $status): void {
+    self::singleton()->invoke(['queue', 'status'], $queue, $status,
+      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      'civicrm_queueStatus'
+    );
+  }
+
+  /**
    * This is called if automatic execution of a queue-task fails.
    *
    * The `$outcome` may be modified. For example, you might inspect the $item and $exception -- and then

--- a/Civi/Api4/Action/Queue/RunItems.php
+++ b/Civi/Api4/Action/Queue/RunItems.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Api4\Action\Queue;
 
+use Civi\Core\Event\GenericHookEvent;
+
 /**
  * Run an enqueued item (task).
  *
@@ -91,6 +93,10 @@ class RunItems extends \Civi\Api4\Generic\AbstractAction {
     foreach ($items as $itemPos => $item) {
       $result[] = ['outcome' => $outcomes[$itemPos], 'item' => $this->createItemStub($item)];
     }
+
+    \Civi::dispatcher()->dispatch('civi.queue.check', GenericHookEvent::create([
+      'queue' => $queue,
+    ]));
   }
 
   private function validateItemStubs(): void {

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -462,4 +462,35 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->assertEquals(0, $this->queue->numberOfItems());
   }
 
+  public function testSetStatus() {
+    $fired = ['status-changes' => []];
+    \Civi::dispatcher()->addListener('hook_civicrm_queueStatus', function ($e) use (&$fired) {
+      $fired[$e->queue->getName()][] = $e->status;
+    });
+
+    $q = Civi::queue('status-changes', [
+      'type' => 'Sql',
+    ]);
+    $this->assertEquals([], $fired['status-changes']);
+
+    $q->setStatus('draft');
+    $this->assertEquals(['draft'], $fired['status-changes']);
+
+    $q->setStatus('draft');
+    $q->setStatus('draft');
+    $q->setStatus('draft');
+    $this->assertEquals(['draft'], $fired['status-changes']);
+
+    $q->setStatus('active');
+    $this->assertEquals(['draft', 'active'], $fired['status-changes']);
+
+    $q->setStatus('active');
+    $q->setStatus('active');
+    $q->setStatus('active');
+    $this->assertEquals(['draft', 'active'], $fired['status-changes']);
+
+    $q->setStatus('completed');
+    $this->assertEquals(['draft', 'active', 'completed'], $fired['status-changes']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------

Suppose you setup a queue with several tasks and then run them all. What happens to the queue's status?

@eileenmcnaughton - This allows the `civicrm_queue.status` to actually become `completed`. This serves a couple purposes:

* On finite/fixed-purpose queues (UserJobs), the queue-status should flip from `active` to `completed` so that the background-worker can stop polling for new tasks.
* It's a step toward allowing jobs that can move between AJAX+background. The issue is that background workers don't (and shouldn't) support the same `onEnd` callback as AJAX. This provides a safer mechanism (`hook_queueStatus`) which works in both media.

Before
------

The `civicrm_queue.status` always remains `active`.

After
-----

Depends on the use-case:

* If you have an open-ended queue providing an on-going service (no `UserJob`), then the status remains `active`.
* If you have a finite/fixed-purpose queue attached to a `UserJob`, then the status changes from `active` to `completed`, and it fires an event:
    ```
    function hook_civicrm_queueStatus(CRM_Queue_Queue $queue, string $status)
    ```

Technical Details
-----------------

* Also fixes an incidental bug in `setStatus()`.
* There are two main ways that items get removed from a queue (`Queue.runNext` API and `civicrm/queue/ajax/runNext`).  Both of these fire an internal event (`civi.queue.check`) to consult the status. The nice thing is that it's easy to incorporate this into both AJAX+background workflows.
* The contact-importer doesn't currently store the `queue_id` relation, so this doesn't affect statuses on there. For `r-run`, I used `demoqueue`, eg
    ```
    cv en demoqueue
    cv open civicrm/demo-queue
    cv sql
    ## Periodically run these queries (while job is active; and again after completion)
    ## - select * from civicrm_queue; 
    ## - select id, queue_id, status_id from civicrm_user_job;
    ```
 