### PR TITLE
PHP8.1 - Fix deprecated passing null to glob

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -307,7 +307,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
    *   List of matching files, relative to the extension base dir.
    * @see glob()
    */
-  public function glob($ext, $patterns, $flags = NULL) {
+  public function glob($ext, $patterns, $flags = 0) {
     $path = $this->getPath($ext);
     $patterns = (array) $patterns;
     $files = [];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a deprecation notice in PHP 8.1.

Before
----------------------------------------
`Deprecated function: glob(): Passing null to parameter #2 ($flags) of type int is deprecated in CRM_Core_Resources->glob() (line 324 of /path/vendor/civicrm/civicrm-core/CRM/Core/Resources.php)`

After
----------------------------------------
Fixed

Technical details
--------------
The default value for the 2nd param of `glob()` is `0` not `null`.