### PR TITLE
(dev/core#3496) Missing extension leads to bootstrap error for "hook_civicrm_entityTypes"

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -712,9 +712,12 @@ class CRM_Extension_Manager {
    * @return CRM_Extension_Info|NULL
    */
   public function createInfoFromDB($key) {
-    $dao = new CRM_Core_DAO_Extension();
-    $dao->full_name = $key;
-    if ($dao->find(TRUE)) {
+    // System hasn't booted - and extension is missing. Need low-tech/no-hook SELECT to learn more about what's missing.
+    $select = CRM_Utils_SQL_Select::from('civicrm_extension')
+      ->where('full_name = @key', ['key' => $key])
+      ->select('full_name, type, name, label, file');
+    $dao = $select->execute();
+    if ($dao->fetch()) {
       $info = new CRM_Extension_Info($dao->full_name, $dao->type, $dao->name, $dao->label, $dao->file);
       return $info;
     }


### PR DESCRIPTION
Overview
----------------------------------------

If you attempt to load CiviCRM 5.50 on a site with a missing/badly-uninstalled extension, then it crashes.

See also: https://lab.civicrm.org/dev/core/-/issues/3496

(This PR is against 5.50-stable. For 5.51+, see #23718.)

Steps to reproduce
-----------------------------------------

* Install 5.50
* Enable an extension
* Delete the extension
* Try to open any page (where CiviCRM is active)

Before
----------------------------------------

All page-loads fail due to unhandled exception:

> CiviCRM has not bootstrapped sufficiently to fire event "hook_civicrm_entityTypes"

After
----------------------------------------

CiviCRM is able to continue running. Of course, you should disable the missing extension completely.

Technical Details
----------------------------------------

The discussion on Stackexchange/Gitlab highlights the presence of `civicrm_entity`; however, I think this is incidental. I installed on D9/Civi 5.49/civicrm_entity and then upgraded to Civi 5.50 -- and did not encounter the problem. Additionally, one commenter mentioned a similar problem on WordPress (which means they don't have `civicrm_entity`). So I don't think it's causal -- but having `civicrm_entity` might amplify the problem (eg because it boots Civi more often).

There are two interesting backtraces - [one is a screenshot](https://lab.civicrm.org/dev/core/uploads/5b96cc9a779774d4fa6db72e453ea280/initialize-error.png) from the Gitlab issue, and the other was pasted into MM by @mattwire. There's a common element in both. Here's an annotated excerpt from Matt's:

```
>> Segment A -- It's attempting to read `civicrm_extension` via DAO, 
>> but that demands lots of metadata/hooks. 

#0 /path/to/web/sites/all/modules/civicrm/Civi/Core/CiviEventDispatcher.php(190): CRM_Core_Error::backtrace()
#1 /path/to/web/sites/all/modules/civicrm/CRM/Utils/Hook.php(167): Civi\Core\CiviEventDispatcher-&gt;dispatch(&quot;hook_civicrm_entityTypes&quot;, Object(Civi\Core\Event\GenericHookEvent))
#2 /path/to/web/sites/all/modules/civicrm/CRM/Utils/Hook.php(2199): CRM_Utils_Hook-&gt;invoke((Array:1), (Array:154), NULL, NULL, NULL, NULL, NULL, &quot;civicrm_entityTypes&quot;)
#3 /path/to/web/sites/all/modules/civicrm/CRM/Core/DAO/AllCoreTables.php(38): CRM_Utils_Hook::entityTypes((Array:154))
#4 /path/to/web/sites/all/modules/civicrm/CRM/Core/DAO/AllCoreTables.php(476): CRM_Core_DAO_AllCoreTables::init()
#5 /path/to/web/sites/all/modules/civicrm/CRM/Core/DAO/Extension.php(259): CRM_Core_DAO_AllCoreTables::invoke(&quot;CRM_Core_DAO_Extension&quot;, &quot;fields_callback&quot;, (Array:8))
#6 /path/to/web/sites/all/modules/civicrm/CRM/Core/DAO.php(613): CRM_Core_DAO_Extension::fields()
#7 /path/to/web/sites/all/modules/civicrm/packages/DB/DataObject.php(419): CRM_Core_DAO-&gt;table()

>> Segment B -- It's using an unusual function `createInfoFromDB()`; 
>> this function only runs if you have a missing extension

#8 /path/to/web/sites/all/modules/civicrm/CRM/Extension/Manager.php(717): DB_DataObject-&gt;find(TRUE)
#9 /path/to/web/sites/all/modules/civicrm/CRM/Extension/Mapper.php(180): CRM_Extension_Manager-&gt;createInfoFromDB(&quot;com.skvare.cmsuser&quot;)
#10 /path/to/web/sites/all/modules/civicrm/CRM/Extension/Mapper.php(216): CRM_Extension_Mapper-&gt;keyToInfo(&quot;com.skvare.cmsuser&quot;)
#11 /path/to/web/sites/all/modules/civicrm/CRM/Extension/Mapper.php(329): CRM_Extension_Mapper-&gt;keyToPath(&quot;com.skvare.cmsuser&quot;)
```

So I was able to reproduce by the error by deleting an active extension.

