### PR TITLE
(dev/core#3496) Missing extension leads to bootstrap error for "hook_civicrm_entityTypes"

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -712,9 +712,12 @@ class CRM_Extension_Manager {
    * @return CRM_Extension_Info|NULL
    */
   public function createInfoFromDB($key) {
-    $dao = new CRM_Core_DAO_Extension();
-    $dao->full_name = $key;
-    if ($dao->find(TRUE)) {
+    // System hasn't booted - and extension is missing. Need low-tech/no-hook SELECT to learn more about what's missing.
+    $select = CRM_Utils_SQL_Select::from('civicrm_extension')
+      ->where('full_name = @key', ['key' => $key])
+      ->select('full_name, type, name, label, file');
+    $dao = $select->execute();
+    if ($dao->fetch()) {
       $info = new CRM_Extension_Info($dao->full_name, $dao->type, $dao->name, $dao->label, $dao->file);
       return $info;
     }


### PR DESCRIPTION
Overview
----------------------------------------

Port of #23716 from 5.50-stable to 5.51-{dev,rc}