### PR TITLE
Avoid multiple log files in multi-language environments

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -660,7 +660,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // Use multiple (but stable) inputs for hash information.
     $md5inputs = [
       defined('CIVICRM_SITE_KEY') ? CIVICRM_SITE_KEY : 'NO_SITE_KEY',
-      $config->userFrameworkBaseURL,
+      CRM_Utils_System::languageNegotiationURL($config->userFrameworkBaseURL, FALSE, TRUE),
       md5($config->dsn),
       $config->dsn,
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core/3491](https://lab.civicrm.org/dev/core/-/issues/3491)

Before
----------------------------------------
Multiple log files (one per language) in multi-language environments when using path prefixes.

After
----------------------------------------
Only one log file per environment.

Technical Details
----------------------------------------
Removes language path prefixes from user framework base URL when generating log file name hash.

Comments
----------------------------------------
I dird not have the time to thoroughly test this, but wanted to provide it as a PR as requested by @jaapjansma in [the issue](https://lab.civicrm.org/dev/core/-/issues/3491#note_75116).