### PR TITLE
Towards consistency for displaying test entities. Stop hiding test entities on some dashboards

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -180,11 +180,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
     }
 
-    // We don't show test records in summaries or dashboards
-    if (empty($this->_formValues['activity_test']) && $this->_force) {
-      $this->_formValues['activity_test'] = 0;
-    }
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Contribute/Form/Search.php
+++ b/CRM/Contribute/Form/Search.php
@@ -253,11 +253,6 @@ class CRM_Contribute_Form_Search extends CRM_Core_Form_Search {
     // @todo - stop changing formValues - respect submitted form values, change a working array.
     $this->fixFormValues();
 
-    // We don't show test records in summaries or dashboards
-    if (empty($this->_formValues['contribution_test']) && $this->_force && !empty($this->_context) && $this->_context === 'dashboard') {
-      // @todo - stop changing formValues - respect submitted form values, change a working array.
-      $this->_formValues['contribution_test'] = 0;
-    }
     // We don't show template records in summaries or dashboards
     if (empty($this->_formValues['is_template']) && $this->_force && !empty($this->_context) && ($this->_context === 'dashboard' || $this->_context === 'contribution')) {
       // @todo - stop changing formValues - respect submitted form values, change a working array.

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -283,11 +283,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
     }
 
-    // We don't show test records in summaries or dashboards
-    if (empty($this->_formValues['participant_test']) && $this->_force) {
-      $this->_formValues["participant_test"] = 0;
-    }
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, ['event_id']);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -220,11 +220,6 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $this->fixFormValues();
 
-    // We don't show test records in summaries or dashboards
-    if (empty($this->_formValues['member_test']) && $this->_force) {
-      $this->_formValues["member_test"] = 0;
-    }
-
     $this->_queryParams = CRM_Contact_BAO_Query::convertFormValues($this->_formValues, 0, FALSE, NULL, $this->entityReferenceFields);
 
     $this->set('queryParams', $this->_queryParams);

--- a/CRM/Pledge/Form/Search.php
+++ b/CRM/Pledge/Form/Search.php
@@ -190,11 +190,6 @@ class CRM_Pledge_Form_Search extends CRM_Core_Form_Search {
 
     $this->fixFormValues();
 
-    // We don't show test records in summaries or dashboards
-    if (empty($this->_formValues['pledge_test']) && $this->_force) {
-      $this->_formValues["pledge_test"] = 0;
-    }
-
     foreach (['pledge_amount_low', 'pledge_amount_high'] as $f) {
       if (isset($this->_formValues[$f])) {
         $this->_formValues[$f] = CRM_Utils_Rule::cleanMoney($this->_formValues[$f]);

--- a/CRM/Pledge/Selector/Search.php
+++ b/CRM/Pledge/Selector/Search.php
@@ -291,6 +291,12 @@ class CRM_Pledge_Selector_Search extends CRM_Core_Selector_Base {
 
     while ($result->fetch()) {
       $row = [];
+
+      // Ignore rows where we dont have an id.
+      if (empty($result->pledge_id)) {
+        continue;
+      }
+
       // the columns we are interested in
       foreach (self::$_properties as $property) {
         if (isset($result->$property)) {


### PR DESCRIPTION
Overview
----------------------------------------
There is no consistency as to whether test entities are shown on (eg. contact tabs). Some do and some don't. This makes test entities rather less useful because you can't see the results.
Eg. in the case of an event signup you don't see the participant record in the contact events tab if it is a test. But you do see the test contributions (but not in the user dashboard..).

This PR changes those that were hidden based on the "force" parameter so that test entities are *not* filtered out and are displayed. This provides consistency and standardisation.

In most cases the UI will already show `( test )` or make it clear in some way that the entity is a test.

Before
----------------------------------------
Very inconsistent display of test entities.

After
----------------------------------------
Consistent display of test entities.

Technical Details
----------------------------------------
This has always annoyed me, using the "_force" param (which is meant for triggering an immediate search) to decide whether to show test entities in some situations. And makes for some awkward conversations when training people on CiviCRM - eg. "You'll see that it's created a test contribution but you won't see the event registration because that's a test and Civi hides those. So why can I see the contribution? Because civi doesn't hide those? But it does in the dashboard? Yes, but only for contriubutions..."

Comments
----------------------------------------
