### PR TITLE
Added back 'Renewal Message' field on Membership renewal form

### DIFF
--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -120,11 +120,11 @@
           <td class="label">{$form.from_email_address.label}</td>
           <td>{$form.from_email_address.html}  {help id="id-from_email" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
         </tr>
-        <tr id="notice" class="crm-member-membershiprenew-form-block-receipt_text_renewal">
-          <td class="label">{$form.receipt_text_renewal.label}</td>
+        <tr id="notice" class="crm-member-membershiprenew-form-block-receipt_text">
+          <td class="label">{$form.receipt_text.label}</td>
           <td><span
               class="description">{ts}Enter a message you want included at the beginning of the emailed receipt. EXAMPLE: 'Thanks for supporting our organization with your membership.'{/ts}</span><br/>
-            {$form.receipt_text_renewal.html|crmAddClass:huge}</td>
+            {$form.receipt_text.html|crmAddClass:huge}</td>
         </tr>
       </table>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3499

Before
----------------------------------------
Renewal Message field missing on Membership renewal form after upgrade

After
----------------------------------------
Renewal Message field appears on Membership renewal form after upgrade
