### PR TITLE
Issue #3483: parent_id not always available as index

### DIFF
--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -166,7 +166,7 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
     $session = CRM_Core_Session::singleton();
     $params['contact_id'] = $session->get('userID');
 
-    if ($params['parent_id']) {
+    if (!empty($params['parent_id'])) {
       $params['entity_table'] = 'civicrm_note';
       $params['entity_id'] = $params['parent_id'];
     }


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/3483

Overview
----------------------------------------

Don't need parent_id when deleting a note, even if it's a child note aka "comment". In fact, it's not even available. So check if it is empty or not.

