### PR TITLE
APIv4 - Apply defaults from WHERE to the ON clause for joins

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -709,20 +709,19 @@ class Api4SelectQuery {
    */
   private function addExplicitJoins() {
     foreach ($this->getJoin() as $join) {
-      // First item in the array is the entity name
+      // First item in the array is the entity name...
       $entity = array_shift($join);
-      // Which might contain an alias. Split on the keyword "AS"
-      list($entity, $alias) = array_pad(explode(' AS ', $entity), 2, NULL);
+      // ...and alias. Split on the keyword "AS"
+      [$entity, $alias] = explode(' AS ', $entity);
       // Ensure permissions
       if (!$this->checkEntityAccess($entity)) {
         continue;
       }
-      // Ensure alias is a safe string, and supply default if not given
-      $alias = $alias ?: strtolower($entity);
+      // Ensure alias is a safe string
       if ($alias === self::MAIN_TABLE_ALIAS || !preg_match('/^[-\w]{1,256}$/', $alias)) {
         throw new \API_Exception('Illegal join alias: "' . $alias . '"');
       }
-      // First item in the array is a boolean indicating if the join is required (aka INNER or LEFT).
+      // First item in the array is a string indicating if the join is required (aka INNER or LEFT).
       // The rest are join conditions.
       $side = array_shift($join);
       // If omitted, supply default (LEFT); and legacy support for boolean values

--- a/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
+++ b/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
@@ -20,30 +20,14 @@
 namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Contact;
+use Civi\Api4\Email;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
 class ContactIsDeletedTest extends Api4TestBase implements TransactionalInterface {
-
-  public function setUpHeadless() {
-    $relatedTables = [
-      'civicrm_address',
-      'civicrm_email',
-      'civicrm_phone',
-      'civicrm_openid',
-      'civicrm_im',
-      'civicrm_website',
-      'civicrm_activity',
-      'civicrm_activity_contact',
-    ];
-    $this->cleanup(['tablesToTruncate' => $relatedTables]);
-    $displayNameFormat = '{contact.first_name}{ }{contact.last_name}';
-    \Civi::settings()->set('display_name_format', $displayNameFormat);
-
-    return parent::setUpHeadless();
-  }
 
   /**
    * This locks in a fix to ensure that if a user doesn't have permission to view the is_deleted field that doesn't hard fail if that field happens to be in an APIv4 call.
@@ -77,6 +61,57 @@ class ContactIsDeletedTest extends Api4TestBase implements TransactionalInterfac
     catch (\API_Exception $e) {
       $this->fail('An Exception Should not have been raised');
     }
+  }
+
+  public function testIsDeletedDefault() {
+    $lastName = uniqid(__FUNCTION__);
+    $c1 = $this->createTestRecord('Contact', ['last_name' => $lastName]);
+    $c2 = $this->createTestRecord('Contact', ['last_name' => $lastName, 'is_deleted' => TRUE]);
+    $this->createTestRecord('Email', ['contact_id' => $c1['id'], 'email' => "$lastName@example.com"]);
+    $this->createTestRecord('Email', ['contact_id' => $c2['id'], 'email' => "$lastName@example.com"]);
+
+    // By default, deleted contacts are not shown, so expect only one record
+    $simpleGet = Contact::get(FALSE)->addWhere('last_name', '=', $lastName)
+      ->execute()->single();
+    $this->assertEquals($c1['id'], $simpleGet['id']);
+
+    $getDeleted = Contact::get(FALSE)->addWhere('last_name', '=', $lastName)
+      ->addWhere('is_deleted', '=', TRUE)
+      ->execute()->single();
+    $this->assertEquals($c2['id'], $getDeleted['id']);
+
+    $getAll = Contact::get(FALSE)->addWhere('last_name', '=', $lastName)
+      ->addWhere('is_deleted', 'IN', [TRUE, FALSE])
+      ->execute();
+    $this->assertCount(2, $getAll);
+
+    $emailGet = Email::get(FALSE)
+      ->addJoin('Contact AS contact', 'INNER')
+      ->addWhere('contact.last_name', '=', $lastName)
+      ->execute()->single();
+    $this->assertEquals($c1['id'], $emailGet['contact_id']);
+
+    // Adding 'contact.is_deleted' to the ON clause overrides the default
+    $emailGetDeleted = Email::get(FALSE)
+      ->addJoin('Contact AS contact', 'INNER', ['contact.is_deleted', '=', TRUE])
+      ->addWhere('contact.last_name', '=', $lastName)
+      ->execute()->single();
+    $this->assertEquals($c2['id'], $emailGetDeleted['contact_id']);
+
+    // Adding 'contact.is_deleted' to the ON clause overrides the default
+    $emailGetAll = Email::get(FALSE)
+      ->addJoin('Contact AS contact', 'INNER', ['contact.is_deleted', 'IN', [TRUE, FALSE]])
+      ->addWhere('contact.last_name', '=', $lastName)
+      ->execute();
+    $this->assertCount(2, $emailGetAll);
+
+    // Adding 'contact.is_deleted' to the WHERE clause also overrides the default
+    $emailGetAll = Email::get(FALSE)
+      ->addJoin('Contact AS contact', 'INNER')
+      ->addWhere('contact.last_name', '=', $lastName)
+      ->addWhere('contact.is_deleted', 'IN', [TRUE, FALSE])
+      ->execute();
+    $this->assertCount(2, $emailGetAll);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This ensures that e.g. if the API doesn't get deleted contacts by default, that the same rule applies when fetching those contacts via a join.

See discussion at https://lab.civicrm.org/extensions/casesummary/-/issues/1

Before
----------------------------------------
Defaults inconsistently applied for API.Get. Applied for the main entity but not for joined entities.

After
----------------------------------------
Defaults consistently applied for both.