### PR TITLE
Allow permissions with colons

### DIFF
--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -70,7 +70,7 @@ class CRM_Core_Permission_Base {
         return $name;
 
       default:
-        return CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
+        return $perm;
     }
   }
 

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -20,8 +20,8 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
     $cases[] = ['cms:universal name2', 'local name2'];
     $cases[] = ['cms:unknown universal name', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
     $cases[] = ['myruntime:foo', 'foo'];
-    $cases[] = ['otherruntime:foo', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
-    $cases[] = ['otherruntime:foo:bar', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];
+    $cases[] = ['otherruntime:foo', 'otherruntime:foo'];
+    $cases[] = ['otherruntime:foo:bar', 'otherruntime:foo:bar'];
     $cases[] = [CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION, CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION];
 
     return $cases;


### PR DESCRIPTION
Overview
----------------------------------------
When checking permissions on a permission names that includes a `:` (e.g. financial types with colons with Financial ACLs), the permission is always denied.  `CRM_Core_Permission_Base::translatePermissions()` treats them as a special case.

Before
----------------------------------------
With Financial ACLs enabled, a permission like `Event Fees: Canada` will always be denied.

After
----------------------------------------
With Financial ACLs enabled, a permission like `Event Fees: Canada` will be evaluated correctly.

Technical Details
----------------------------------------
It seems to me that this is the only scenario in which `translatePermissions()`'s `switch` statement will branch to the default option. I also can't see any security implication to changing this behavior - I believe the `ALWAYS_DENY_PERMISSION` is intended as a performance shortcut for a scenario that doesn't happen (except in tests).  If there IS another scenario in which this branch is executed, the permission is still evaluated against the CMS.  I also don't see a way to manipulate this to escalate permissions.

Comments
----------------------------------------
**I have changed tests** to what I believe should be the correct output of this method.
