### PR TITLE
Participant import fix - broken uniqueName fields, mapping saving, ev…

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -578,6 +578,10 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
    * @param bool $checkPermission
    *   Is this a permissioned retrieval?
    *
+   * @deprecated only called from event search, but without most of the details
+   * returned. Event search should call stop using this & get the metadata
+   * a better way.
+   *
    * @return array
    *   array of importable Fields
    */

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -41,7 +41,6 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   public function buildQuickForm() {
     parent::buildQuickForm();
 
-    $duplicateOptions = [];
     $this->addRadio('onDuplicate', ts('On Duplicate Entries'), [
       CRM_Import_Parser::DUPLICATE_SKIP => ts('Skip'),
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
@@ -50,22 +49,6 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->setDefaults(['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 
     $this->addContactTypeSelector();
-  }
-
-  /**
-   * Process the uploaded file.
-   *
-   * @return void
-   */
-  public function postProcess() {
-    $this->storeFormValues([
-      'onDuplicate',
-      'contactType',
-      'dateFormats',
-      'savedMapping',
-    ]);
-
-    $this->submitFileForMapping('CRM_Event_Import_Parser_Participant');
   }
 
   /**

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -85,7 +85,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
       // FIXME: should use the schema titles, not redeclare them
       $requiredFields = array(
-        'participant_contact_id' => ts('Contact ID'),
+        'contact_id' => ts('Contact ID'),
         'event_id' => ts('Event ID'),
       );
 
@@ -93,13 +93,13 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       foreach ($requiredFields as $field => $title) {
         if (!in_array($field, $importKeys)) {
-          if ($field == 'participant_contact_id') {
+          if ($field === 'contact_id') {
             if (!$contactFieldsBelowWeightMessage || in_array('external_identifier', $importKeys) ||
               in_array('participant_id', $importKeys)
             ) {
               continue;
             }
-            if ($self->_onDuplicate == CRM_Import_Parser::DUPLICATE_UPDATE) {
+            if ($self->isUpdateExisting()) {
               $errors['_qf_default'] .= ts('Missing required field: Provide Participant ID') . '<br />';
             }
             else {
@@ -166,16 +166,15 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
    * Get the fields to highlight.
    *
    * @return array
-   * @throws \CRM_Core_Exception
    */
   protected function getHighlightedFields(): array {
     $highlightedFields = [];
-    if ($this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_UPDATE) {
+    if ($this->isUpdateExisting()) {
       $highlightedFieldsArray = [
-        'participant_id',
+        'id',
         'event_id',
         'event_title',
-        'participant_status_id',
+        'status_id',
       ];
       foreach ($highlightedFieldsArray as $name) {
         $highlightedFields[] = $name;
@@ -184,14 +183,17 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
     elseif ($this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_SKIP ||
       $this->getSubmittedValue('onDuplicate') == CRM_Import_Parser::DUPLICATE_NOCHECK
     ) {
+      // this should be retrieved from the parser.
       $highlightedFieldsArray = [
-        'participant_contact_id',
+        'contact_id',
         'event_id',
         'email',
         'first_name',
         'last_name',
+        'organization_name',
+        'household_name',
         'external_identifier',
-        'participant_status_id',
+        'status_id',
       ];
       foreach ($highlightedFieldsArray as $name) {
         $highlightedFields[] = $name;
@@ -206,7 +208,7 @@ class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @return string
    */
   public function getMappingTypeName(): string {
-    return 'Import Participants';
+    return 'Import Participant';
   }
 
 }

--- a/CRM/Event/Import/Form/Preview.php
+++ b/CRM/Event/Import/Form/Preview.php
@@ -22,46 +22,6 @@
 class CRM_Event_Import_Form_Preview extends CRM_Import_Form_Preview {
 
   /**
-   * Process the mapped fields and map it into the uploaded file
-   * preview the file and extract some summary statistics
-   *
-   * @return void
-   */
-  public function postProcess() {
-    $fileName = $this->controller->exportValue('DataSource', 'uploadFile');
-    $separator = $this->controller->exportValue('DataSource', 'fieldSeparator');
-    $invalidRowCount = $this->get('invalidRowCount');
-    $onDuplicate = $this->get('onDuplicate');
-
-    $mapper = $this->controller->exportValue('MapField', 'mapper');
-    $mapperKeys = [];
-
-    foreach ($mapper as $key => $value) {
-      $mapperKeys[$key] = $mapper[$key][0];
-    }
-
-    $parser = new CRM_Event_Import_Parser_Participant($mapperKeys);
-    $parser->setUserJobID($this->getUserJobID());
-    $mapFields = $this->get('fields');
-
-    foreach ($mapper as $key => $value) {
-      $header = [];
-      if (isset($mapFields[$mapper[$key][0]])) {
-        $header[] = $mapFields[$mapper[$key][0]];
-      }
-      $mapperFields[] = implode(' - ', $header);
-    }
-    $parser->run($fileName, $separator,
-      $mapperFields,
-      $this->getSubmittedValue('skipColumnHeader'),
-      CRM_Import_Parser::MODE_IMPORT
-    );
-
-    // add all the necessary variables to the form
-    $parser->set($this, CRM_Import_Parser::MODE_IMPORT);
-  }
-
-  /**
    * @return CRM_Event_Import_Parser_Participant
    */
   protected function getParser(): CRM_Event_Import_Parser_Participant {

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -132,7 +132,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @param string $fieldName
    *
    * @return mixed|null
-   * @throws \CRM_Core_Exception
    */
   public function getSubmittedValue(string $fieldName) {
     if ($fieldName === 'dataSource') {
@@ -301,8 +300,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * This is called as a snippet in DataSourceConfig and
    * also from DataSource::buildForm to add the fields such
    * that quick form picks them up.
-   *
-   * @throws \CRM_Core_Exception
    */
   protected function getDataSourceFields(): array {
     $className = $this->getDataSourceClassName();
@@ -330,7 +327,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * all forms.
    *
    * @return string[]
-   * @throws \CRM_Core_Exception
    */
   protected function getSubmittableFields(): array {
     $dataSourceFields = array_fill_keys($this->getDataSourceFields(), 'DataSource');
@@ -637,6 +633,14 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   public function getHeaderPatterns(): array {
     return $this->getParser()->getHeaderPatterns();
+  }
+
+  /**
+   * Has the user chosen to update existing records.
+   * @return bool
+   */
+  protected function isUpdateExisting(): bool {
+    return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_UPDATE;
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveFiftyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyOne.php
@@ -140,14 +140,14 @@ class CRM_Upgrade_Incremental_php_FiveFiftyOne extends CRM_Upgrade_Incremental_B
 
     $fieldMap = [];
     foreach ($fields as $fieldName => $field) {
-      $fieldMap[$field['title']] = $fieldName;
+      $fieldMap[$field['title']] = $field['name'] ?? $fieldName;
       if (!empty($field['html']['label'])) {
-        $fieldMap[$field['html']['label']] = $fieldName;
+        $fieldMap[$field['html']['label']] = $field['name'] ?? $fieldName;
       }
     }
     $fieldMap[ts('- do not import -')] = 'do_not_import';
-    $fieldMap[ts('Participant Status')] = 'participant_status_id';
-    $fieldMap[ts('Participant Role')] = 'participant_role_id';
+    $fieldMap[ts('Participant Status')] = 'status_id';
+    $fieldMap[ts('Participant Role')] = 'role_id';
     $fieldMap[ts('Event Title')] = 'event_id';
 
     foreach ($mappings as $mapping) {


### PR DESCRIPTION
Overview
----------------------------------------
This addresses reviewer feedback by @aydun on the Participant import cleanup currently merged.
https://github.com/civicrm/civicrm-core/pull/23703#issuecomment-1150306056

It addresses
- mappings not being saved - I added a test to lock in the saving of new mappings
- event DOES work now for both id or title. Unit test locks this in
- the label 'event' is used on both mapping & preview screens
- the contact id label reverts to 'Contact ID (match to contact)'
- if contact type organization is selected then that field is offered up for matching (ditto household)

This also switches away from using unique names in the participant import - which simplifies the code a little

**Contact matching**

This is a pre-existing confusion that we would ideally come up with a good answer for it - I think this PR gets us to the pre-existing behaviour & we should pick up over here https://lab.civicrm.org/dev/core/-/issues/3180

Note to self - re-test :"update mapping" works - UPDATE - yep UI test worked to update a field in a mapping
