### PR TITLE
Afform - Trigger 'crmFormSuccess' event after submission

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -69,6 +69,11 @@
       function postProcess() {
         var metaData = ctrl.getFormMeta();
 
+        $element.trigger('crmFormSuccess', {
+          afform: metaData,
+          data: data
+        });
+
         if (metaData.redirect) {
           var url = metaData.redirect;
           if (url.indexOf('civicrm/') === 0) {


### PR DESCRIPTION
Overview
----------------------------------------
Allows other js apps to respond to the submission of an Afform.

Before
----------------------------------------
No event fired.

After
----------------------------------------
Event fired containing information about the afform and the submitted data.

Comments
----------------------------------------
This is our standard event to fire after an ajax form submits. Seems appropriate to keep doing so for Afforms, and this adds info to the event so apps can tell the difference between Afforms and other types of forms.
