### PR TITLE
dev/core#3498 Fix mishandled option values

### DIFF
--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -1,7 +1,6 @@
 <?php
 
 use Civi\Api4\CustomField;
-use Civi\Api4\CustomGroup;
 
 /**
  * Class CRM_Custom_Import_Parser_Api
@@ -82,8 +81,8 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
       $importableFields = $this->getGroupFieldsForImport($customGroupID);
       $this->importableFieldsMetadata = array_merge([
         'do_not_import' => ['title' => ts('- do not import -')],
-        'contact_id' => ['title' => ts('Contact ID'), 'name' => 'contact_id', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE],
-        'external_identifier' => ['title' => ts('External Identifier'), 'name' => 'external_identifier', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE],
+        'contact_id' => ['title' => ts('Contact ID'), 'name' => 'contact_id', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE, 'headerPattern' => '/contact?|id$/i'],
+        'external_identifier' => ['title' => ts('External Identifier'), 'name' => 'external_identifier', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE, 'headerPattern' => '/external\s?id/i'],
       ], $importableFields);
     }
   }
@@ -196,7 +195,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
       $importableFields[$key] = [
         'name' => $key,
         'title' => $values['label'] ?? NULL,
-        'headerPattern' => '/' . preg_quote($regexp, '/') . '/',
+        'headerPattern' => '/' . preg_quote($regexp, '/') . '/i',
         'import' => 1,
         'custom_field_id' => $values['id'],
         'options_per_line' => $values['options_per_line'],

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -571,9 +571,9 @@ abstract class CRM_Import_Parser {
    */
   public function getHeaderPatterns(): array {
     $values = [];
-    foreach ($this->_fields as $name => $field) {
-      if (isset($field->_headerPattern)) {
-        $values[$name] = $field->_headerPattern;
+    foreach ($this->importableFieldsMetadata as $name => $field) {
+      if (isset($field['headerPattern'])) {
+        $values[$name] = $field['headerPattern'] ?: '//';
       }
     }
     return $values;

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -27,11 +27,6 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   protected $entity = 'Contribution';
 
   /**
-   * @var int
-   */
-  protected $userJobID;
-
-  /**
    * Cleanup function.
    *
    * @throws \API_Exception
@@ -363,21 +358,49 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * @param array $mappings
+   * Get the import's datasource form.
    *
-   * @return array
+   * Defaults to contribution - other classes should override.
+   *
+   * @param array $submittedValues
+   *
+   * @return \CRM_Contribute_Import_Form_DataSource|\CRM_Core_Form|\CRM_Custom_Import_Form_DataSource
+   * @noinspection PhpUnnecessaryLocalVariableInspection
    */
-  protected function getMapperFromFieldMappings(array $mappings): array {
-    $mapper = [];
-    foreach ($mappings as $mapping) {
-      $fieldInput = [$mapping['name']];
-      if (!empty($mapping['soft_credit_type_id'])) {
-        $fieldInput[1] = $mapping['soft_credit_match_field'];
-        $fieldInput[2] = $mapping['soft_credit_type_id'];
-      }
-      $mapper[] = $fieldInput;
-    }
-    return $mapper;
+  protected function getDataSourceForm(array $submittedValues) {
+    return $this->getFormObject('CRM_Contribute_Import_Form_DataSource', $submittedValues);
+  }
+
+  /**
+   * Get the import's mapField form.
+   *
+   * Defaults to contribution - other classes should override.
+   *
+   * @param array $submittedValues
+   *
+   * @return \CRM_Contribute_Import_Form_MapField
+   * @noinspection PhpUnnecessaryLocalVariableInspection
+   */
+  protected function getMapFieldForm(array $submittedValues): CRM_Contribute_Import_Form_MapField {
+    /* @var \CRM_Contribute_Import_Form_MapField $form */
+    $form = $this->getFormObject('CRM_Contribute_Import_Form_MapField', $submittedValues);
+    return $form;
+  }
+
+  /**
+   * Get the import's preview form.
+   *
+   * Defaults to contribution - other classes should override.
+   *
+   * @param array $submittedValues
+   *
+   * @return \CRM_Contribute_Import_Form_Preview
+   * @noinspection PhpUnnecessaryLocalVariableInspection
+   */
+  protected function getPreviewForm(array $submittedValues): CRM_Contribute_Import_Form_Preview {
+    /* @var CRM_Contribute_Import_Form_Preview $form */
+    $form = $this->getFormObject('CRM_Contribute_Import_Form_Preview', $submittedValues);
+    return $form;
   }
 
 }

--- a/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
+++ b/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @file
+ * File for the CRM_Custom_Import_Parser_ContributionTest class.
+ */
+
+/**
+ *  Test Contribution import parser.
+ *
+ * @package CiviCRM
+ * @group headless
+ */
+class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
+
+  use CRMTraits_Custom_CustomDataTrait;
+  use CRMTraits_Import_ParserTrait;
+
+  /**
+   * Test the full form-flow import.
+   */
+  public function testImport(): void {
+    $this->individualCreate();
+    $this->createCustomGroupWithFieldOfType(['is_multiple' => TRUE, 'extends' => 'Contact'], 'select', 'level');
+    $customGroupID = $this->ids['CustomGroup']['level'];
+    $dateFieldID = $this->createDateCustomField(['date_format' => 'yy', 'custom_group_id' => $customGroupID])['id'];
+    $this->importCSV('custom_data_date_select.csv', [
+      ['name' => 'contact_id'],
+      ['name' => $this->getCustomFieldName('levelselect')],
+      ['name' => 'do_not_import'],
+      ['name' => 'custom_' . $dateFieldID],
+    ], ['multipleCustomData' => $customGroupID]);
+    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
+    $row = $dataSource->getRow();
+    $this->assertEquals('IMPORTED', $row['_status']);
+    $row = $dataSource->getRow();
+    $this->assertEquals('IMPORTED', $row['_status']);
+    $row = $dataSource->getRow();
+    $this->assertEquals('ERROR', $row['_status']);
+  }
+
+
+  /**
+   * Get the import's datasource form.
+   *
+   * Defaults to contribution - other classes should override.
+   *
+   * @param array $submittedValues
+   *
+   * @return \CRM_Custom_Import_Form_DataSource
+   * @noinspection PhpUnnecessaryLocalVariableInspection
+   */
+  protected function getDataSourceForm(array $submittedValues): CRM_Custom_Import_Form_DataSource {
+    /* @var \CRM_Custom_Import_Form_DataSource $form */
+    $form = $this->getFormObject('CRM_Custom_Import_Form_DataSource', $submittedValues);
+    return $form;
+  }
+
+  /**
+   * Get the import's mapField form.
+   *
+   * Defaults to contribution - other classes should override.
+   *
+   * @param array $submittedValues
+   *
+   * @return \CRM_Custom_Import_Form_MapField
+   * @noinspection PhpUnnecessaryLocalVariableInspection
+   */
+  protected function getMapFieldForm(array $submittedValues): CRM_Custom_Import_Form_MapField {
+    /* @var \CRM_Custom_Import_Form_MapField $form */
+    $form = $this->getFormObject('CRM_Custom_Import_Form_MapField', $submittedValues);
+    return $form;
+  }
+
+  /**
+   * Get the import's preview form.
+   *
+   * Defaults to contribution - other classes should override.
+   *
+   * @param array $submittedValues
+   *
+   * @return \CRM_Custom_Import_Form_Preview
+   * @noinspection PhpUnnecessaryLocalVariableInspection
+   */
+  protected function getPreviewForm(array $submittedValues): CRM_Custom_Import_Form_Preview {
+    /* @var CRM_Custom_Import_Form_Preview $form */
+    $form = $this->getFormObject('CRM_Custom_Import_Form_Preview', $submittedValues);
+    return $form;
+  }
+
+}

--- a/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
+++ b/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
@@ -38,7 +38,6 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
     $this->assertEquals('ERROR', $row['_status']);
   }
 
-
   /**
    * Get the import's datasource form.
    *

--- a/tests/phpunit/CRM/Custom/Import/Parser/data/custom_data_date_select.csv
+++ b/tests/phpunit/CRM/Custom/Import/Parser/data/custom_data_date_select.csv
@@ -1,0 +1,4 @@
+The Contact ID,The Level,The School,The Start Year
+3,Red,Ah Ha,2010-12-01
+3,R,Bah bah,2022-01-02
+3,Aqua,Cah cah,2022-02-03

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -17,6 +17,11 @@
 trait CRMTraits_Import_ParserTrait {
 
   /**
+   * @var int
+   */
+  protected $userJobID;
+
+  /**
    * Import the csv file values.
    *
    * This function uses a flow that mimics the UI flow.
@@ -41,9 +46,13 @@ trait CRMTraits_Import_ParserTrait {
       'groups' => [],
     ], $submittedValues);
     $form = $this->getDataSourceForm($submittedValues);
+    $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
     $form->buildForm();
     $form->postProcess();
     $this->userJobID = $form->getUserJobID();
+    // This gets reset in DataSource so re-do....
+    $_SESSION['_' . $form->controller->_name . '_container']['values'] = $values;
+
     $form = $this->getMapFieldForm($submittedValues);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
@@ -57,51 +66,21 @@ trait CRMTraits_Import_ParserTrait {
   }
 
   /**
-   * Get the import's datasource form.
+   * @param array $mappings
    *
-   * Defaults to contribution - other classes should override.
-   *
-   * @param array $submittedValues
-   *
-   * @return \CRM_Contribute_Import_Form_DataSource
-   * @noinspection PhpUnnecessaryLocalVariableInspection
+   * @return array
    */
-  protected function getDataSourceForm(array $submittedValues): CRM_Contribute_Import_Form_DataSource {
-    /* @var \CRM_Contribute_Import_Form_DataSource $form */
-    $form = $this->getFormObject('CRM_Contribute_Import_Form_DataSource', $submittedValues);
-    return $form;
-  }
-
-  /**
-   * Get the import's mapField form.
-   *
-   * Defaults to contribution - other classes should override.
-   *
-   * @param array $submittedValues
-   *
-   * @return \CRM_Contribute_Import_Form_MapField
-   * @noinspection PhpUnnecessaryLocalVariableInspection
-   */
-  protected function getMapFieldForm(array $submittedValues): CRM_Contribute_Import_Form_MapField {
-    /* @var \CRM_Contribute_Import_Form_MapField $form */
-    $form = $this->getFormObject('CRM_Contribute_Import_Form_MapField', $submittedValues);
-    return $form;
-  }
-
-  /**
-   * Get the import's preview form.
-   *
-   * Defaults to contribution - other classes should override.
-   *
-   * @param array $submittedValues
-   *
-   * @return \CRM_Contribute_Import_Form_Preview
-   * @noinspection PhpUnnecessaryLocalVariableInspection
-   */
-  protected function getPreviewForm(array $submittedValues): CRM_Contribute_Import_Form_Preview {
-    /* @var CRM_Contribute_Import_Form_Preview $form */
-    $form = $this->getFormObject('CRM_Contribute_Import_Form_Preview', $submittedValues);
-    return $form;
+  protected function getMapperFromFieldMappings(array $mappings): array {
+    $mapper = [];
+    foreach ($mappings as $mapping) {
+      $fieldInput = [$mapping['name']];
+      if (!empty($mapping['soft_credit_type_id'])) {
+        $fieldInput[1] = $mapping['soft_credit_match_field'];
+        $fieldInput[2] = $mapping['soft_credit_type_id'];
+      }
+      $mapper[] = $fieldInput;
+    }
+    return $mapper;
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3279,6 +3279,18 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
         $_SESSION['_' . $form->controller->_name . '_container']['values']['Preview'] = $formValues;
         return $form;
 
+      case 'CRM_Custom_Import_Form_DataSource':
+      case 'CRM_Custom_Import_Form_MapField':
+      case 'CRM_Custom_Import_Form_Preview':
+        $form->controller = new CRM_Custom_Import_Controller();
+        $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
+        // The submitted values should be set on one or the other of the forms in the flow.
+        // For test simplicity we set on all rather than figuring out which ones go where....
+        $_SESSION['_' . $form->controller->_name . '_container']['values']['DataSource'] = $formValues;
+        $_SESSION['_' . $form->controller->_name . '_container']['values']['MapField'] = $formValues;
+        $_SESSION['_' . $form->controller->_name . '_container']['values']['Preview'] = $formValues;
+        return $form;
+
       case strpos($class, '_Form_') !== FALSE:
         $form->controller = new CRM_Core_Controller_Simple($class, $pageName);
         break;


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3498 Fix mishandled option values

Before
----------------------------------------
Options are not validated for multi-record custom import

After
----------------------------------------
Options are validated
'guessing' of fields is working better -in 5.50 looks like

![image](https://user-images.githubusercontent.com/336308/172759101-d9916816-d33c-448c-81b0-f45ef6b8b788.png)

but with this PR

![image](https://user-images.githubusercontent.com/336308/172763618-d9f7aed3-76cd-4d61-943a-861cb13457bd.png)


Technical Details
----------------------------------------
The issue was the code to load the valid options for each field was not working on multi-value custom record sets 

Comments
----------------------------------------

Data patterns -do they REALLY add any value? I feel like they make it more confusing...