### PR TITLE
dev/core#3502 - CiviEventDispatcher - Softer errors for `not-ready`. More comments.

### DIFF
--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -187,7 +187,13 @@ class CiviEventDispatcher extends EventDispatcher {
           throw new \RuntimeException("The dispatch policy prohibits event \"$eventName\".");
 
         case 'not-ready':
-          throw new \RuntimeException("CiviCRM has not bootstrapped sufficiently to fire event \"$eventName\".");
+          // The system is not ready to run hooks -- eg it has not finished loading the extension main-files.
+          // If you fire a hook at this point, it will not be received by the intended listeners.
+          // In practice, many hooks involve cached data-structures, so a premature hook is liable to have spooky side-effects.
+          // This condition indicates a structural problem and merits a consistent failure-mode.
+          // If you believe some special case merits an exemption, then you could add it to `$bootDispatchPolicy`.
+
+          throw new \RuntimeException("The event \"$eventName\" attempted to fire before CiviCRM was fully loaded. Skipping.");
 
         default:
           throw new \RuntimeException("The dispatch policy for \"$eventName\" is unrecognized ($mode).");

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -193,7 +193,12 @@ class CiviEventDispatcher extends EventDispatcher {
           // This condition indicates a structural problem and merits a consistent failure-mode.
           // If you believe some special case merits an exemption, then you could add it to `$bootDispatchPolicy`.
 
-          throw new \RuntimeException("The event \"$eventName\" attempted to fire before CiviCRM was fully loaded. Skipping.");
+          // An `Exception` would be ideal for preventing new bugs, but it can be too noisy for systems with pre-existing bugs.
+          // throw new \RuntimeException("The event \"$eventName\" attempted to fire before CiviCRM was fully loaded. Skipping.");
+          // Complain to web-user and sysadmin. Log a backtrace. We're pre-boot, so don't use high-level services.
+          error_log("The event \"$eventName\" attempted to fire before CiviCRM was fully loaded. Skipping.\n" . \CRM_Core_Error::formatBacktrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), FALSE));
+          trigger_error("The event \"$eventName\" attempted to fire before CiviCRM was fully loaded. Skipping.", E_USER_WARNING);
+          return $event;
 
         default:
           throw new \RuntimeException("The dispatch policy for \"$eventName\" is unrecognized ($mode).");


### PR DESCRIPTION
Overview
----------------------------------------

v5.50 is more likely to raise complaints about hooks that fire during bootstrap (as in the case of https://lab.civicrm.org/dev/core/-/issues/3502). This patch tries to turn-down the volume on such errors.

(This is the 5.50-stable variant of the patch. RC patch is #23785.)

Before
----------------------------------------

* Throws exception.

After
----------------------------------------

* Shows a message to the web-user (`trigger_error(...E_USER_WARNING)`)
* Logs a message for sysadmin (`error_log()`) with backtrace.

Comments
----------------------------------------

Two use-cases:

1.  The easiest way to trigger an error is to hack `boot()` function, eg

    ```diff
     \CRM_Utils_Hook::singleton()->commonBuildModuleList('civicrm_boot');
    +\CRM_Utils_Hook::entityTypes($x);
     $bootServices['dispatcher.boot']->setDispatchPolicy($mainDispatchPolicy);
    ```
2. I also managed to [reproduce the same error as @francescbassas](https://lab.civicrm.org/dev/core/-/issues/3502#note_75272. Activating `rules` wasn't enough -- I needed also needed a *rule* to specifically react to logs.

~~Trying out these two cases with each way of recording the error, I'm a little torn:~~

* ~~With `error_log()`, it was really quiet. There was no hint of the problem -- unless you dig into server logs. But I do think it's good to have it in the server log (eg to get backtrace).~~
* ~~With `trigger_error()`, it's... somewhat softer, but not as much as I hoped. Case `#1` definitely softened. However, case `#2` still produced a crash -- because `trigger_error()` still activates Drupal watchdog (watchdog=>rules=>entity=>civicrm_entity=>hook).~~

UPDATE: My last comment was probably misplaced - eg I had used `trigger_error(...E_USER_ERROR)`, which caused a full stop (*sometimes*). Changing to `trigger_error(...E_USER_WARNING)` seems to produce more desirable+consistent behavior (ie in all configurations that I tested on D7+WP, it showed the warning to the user - but continued executing).