### PR TITLE
only check batch currency match when adding a financial_trxn

### DIFF
--- a/CRM/Batch/BAO/EntityBatch.php
+++ b/CRM/Batch/BAO/EntityBatch.php
@@ -26,6 +26,7 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
     // Only write the EntityBatch record if the financial trxn and batch match on currency and payment instrument.
     $batchId = $params['batch_id'] ?? NULL;
     $entityId = $params['entity_id'] ?? NULL;
+    $entityTable = $params['entity_table'] ?? 'civicrm_financial_trxn';
     // Not having a batch ID and entity ID is only acceptable on an update.
     if (!$batchId) {
       $existingEntityBatch = \Civi\Api4\EntityBatch::get(FALSE)
@@ -36,7 +37,7 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
       $entityId = $existingEntityBatch['entity_id'] ?? NULL;
     }
     // There should never be a legitimate case where a record has an ID but no batch ID but SyntaxConformanceTest says otherwise.
-    if ($batchId) {
+    if ($batchId && $entityTable === 'civicrm_financial_trxn') {
       $batchCurrency = self::getBatchCurrency($batchId);
       $batchPID = (int) CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $batchId, 'payment_instrument_id');
       $trxn = \Civi\Api4\FinancialTrxn::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Fix for regression(?) on Gift Aid extension https://lab.civicrm.org/extensions/ukgiftaid/-/issues/30 resulting from https://github.com/civicrm/civicrm-core/pull/20884 .

Before
----------------------------------------
The check for currency match looks up a financial_trxn using the `entity_id`  parameter. But this is only a `financial_trxn_id` in the case where `entity_table` is adding financial transactions to the batch.

This leads to errors when batching contributions (e.g. https://lab.civicrm.org/extensions/ukgiftaid/-/issues/30#note_75292 ) and I imagine memberships too.

After
----------------------------------------
Only checks the currency matches when adding a `financial_trxn`. 


Comments
----------------------------------------
I'm not sure whether it makes sense to write a separate check that works for checking contribution currencies. For other entities that can be batched (memberships?) I don't think it would make any sense, but I'm not really sure how these are used.
