### PR TITLE
Fix unrelease regression - malformed MapField without skipColumnHeaders

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -74,7 +74,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    * @throws \CRM_Core_Exception
    */
   public function initialize(): void {
-    $result = self::_CsvToTable(
+    $result = $this->csvToTable(
       $this->getSubmittedValue('uploadFile')['name'],
       $this->getSubmittedValue('skipColumnHeader'),
       $this->getSubmittedValue('fieldSeparator') ?? ','
@@ -83,7 +83,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
 
     $this->updateUserJobMetadata('DataSource', [
       'table_name' => $result['import_table_name'],
-      'column_headers' => $this->getSubmittedValue('skipColumnHeader') ? $result['column_headers'] : [],
+      'column_headers' => $result['column_headers'],
       'number_of_columns' => $result['number_of_columns'],
     ]);
   }
@@ -102,7 +102,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    *   name of the created table
    * @throws \CRM_Core_Exception
    */
-  private static function _CsvToTable(
+  private function csvToTable(
     $file,
     $headers = FALSE,
     $fieldSeparator = ','
@@ -124,7 +124,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     }
 
     $firstrow = fgetcsv($fd, 0, $fieldSeparator);
-
+    $result['column_headers'] = array_fill(0, count($firstrow), '');
     // create the column names from the CSV header or as col_0, col_1, etc.
     if ($headers) {
       //need to get original headers.

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -113,6 +113,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     }
     $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
     $this->assign('skipColumnHeader', $this->getSubmittedValue('skipColumnHeader'));
+    $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader'));
     // rowDisplayCount is deprecated - it used to be used with {section} but we have nearly gotten rid of it.
     $this->assign('rowDisplayCount', $this->getSubmittedValue('skipColumnHeader') ? 3 : 2);
   }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -597,6 +597,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $this->_columnNames = $this->getColumnHeaders();
     $this->_dataValues = array_values($this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());
+    $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader'));
     $this->assign('highlightedFields', $this->getHighlightedFields());
     $this->assign('columnCount', $this->_columnCount);
     $this->assign('dataValues', $this->_dataValues);

--- a/templates/CRM/Import/Form/MapTableCommon.tpl
+++ b/templates/CRM/Import/Form/MapTableCommon.tpl
@@ -10,7 +10,7 @@
 
             {* Header row - has column for column names if they have been supplied *}
           <tr class="columnheader">
-              {if $columnNames}
+              {if $showColumnNames}
                 <td>{ts}Column Names{/ts}</td>
               {/if}
               {foreach from=$dataValues item=row key=index}
@@ -23,7 +23,7 @@
             {*Loop on columns parsed from the import data rows*}
             {foreach from=$mapper key=i item=mapperField}
               <tr style="border: 1px solid #DDDDDD;">
-                  {if array_key_exists($i, $columnNames)}
+                  {if $showColumnNames}
                     <td class="even-row labels">{$columnNames[$i]}</td>
                   {/if}
                   {foreach from=$dataValues item=row key=index}

--- a/templates/CRM/Member/Import/Form/MapField.tpl
+++ b/templates/CRM/Member/Import/Form/MapField.tpl
@@ -7,28 +7,4 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-member-import-mapfield-form-block">
-{* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
-{include file="CRM/common/WizardHeader.tpl"}
-<div class="help">
-    <p>{ts}Review the values shown below from the first 2 rows of your import file and select the matching CiviCRM database fields from the drop-down lists in the right-hand column. Select '- do not import -' for any columns in the import file that you want ignored.{/ts}</p>
-    <p>{ts}If you think you may be importing additional data from the same data source, check 'Save this field mapping' at the bottom of the page before continuing. The saved mapping can then be easily reused the next time data is imported.{/ts}</p>
-</div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-{* Membership Import Wizard - Step 2 (map incoming data fields) *}
-{* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller *}
-
- {* Table for mapping data to CRM fields *}
- {include file="CRM/Import/Form/MapTableCommon.tpl" mapper=$form.mapper}
-
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-</div>
- {$initHideBoxes|smarty:nodefaults}
-{literal}
-<script type="text/javascript" >
-if ( document.getElementsByName("saveMapping")[0].checked ) {
-    document.getElementsByName("updateMapping")[0].checked = true;
-    document.getElementsByName("saveMapping")[0].checked = false;
-}
-</script>
-{/literal}
+{include file="CRM/Import/Form/MapField.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Fix unrelease regression - malformed MapField without skipColumnHeaders

Before
----------------------------------------
Do NOT select  First row contains column headers

![image](https://user-images.githubusercontent.com/336308/172959448-9016e532-994a-468e-b95e-ecac3b9aafe2.png)

![image](https://user-images.githubusercontent.com/336308/172959530-b8d891c1-fd6f-476b-9e6b-6be243cdd8b1.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/172959199-9e0161b0-7fb2-42c4-9e89-6fd4fb31d9a8.png)


Technical Details
----------------------------------------
I tested this on membership - but they all use the same code now

Comments
----------------------------------------

