### PR TITLE
AngularJS - Remove UI-Utils library

### DIFF
--- a/Civi/Angular/Manager.php
+++ b/Civi/Angular/Manager.php
@@ -117,7 +117,6 @@ class Manager {
       $angularModules['jsonFormatter'] = include "$civicrm_root/ang/jsonFormatter.ang.php";
       $angularModules['ngRoute'] = include "$civicrm_root/ang/ngRoute.ang.php";
       $angularModules['ngSanitize'] = include "$civicrm_root/ang/ngSanitize.ang.php";
-      $angularModules['ui.utils'] = include "$civicrm_root/ang/ui.utils.ang.php";
       $angularModules['ui.bootstrap'] = include "$civicrm_root/ang/ui.bootstrap.ang.php";
       $angularModules['ui.sortable'] = include "$civicrm_root/ang/ui.sortable.ang.php";
       $angularModules['unsavedChanges'] = include "$civicrm_root/ang/unsavedChanges.ang.php";

--- a/ang/crmCaseType.ang.php
+++ b/ang/crmCaseType.ang.php
@@ -7,5 +7,5 @@ return [
   'js' => ['ang/crmCaseType.js'],
   'css' => ['ang/crmCaseType.css'],
   'partials' => ['ang/crmCaseType'],
-  'requires' => ['ngRoute', 'ui.utils', 'crmUi', 'unsavedChanges', 'crmUtil', 'crmResource'],
+  'requires' => ['ngRoute', 'crmUi', 'unsavedChanges', 'crmUtil', 'crmResource'],
 ];

--- a/ang/crmCaseType.js
+++ b/ang/crmCaseType.js
@@ -239,7 +239,7 @@
     };
   });
 
-  crmCaseType.controller('CaseTypeCtrl', function($scope, crmApi, apiCalls, crmUiHelp) {
+  crmCaseType.controller('CaseTypeCtrl', function($scope, $timeout, crmApi, apiCalls, crmUiHelp) {
     var defaultAssigneeDefaultValue, ts;
 
     (function init () {
@@ -254,6 +254,10 @@
       initCaseType();
       initCaseTypeDefinition();
       initSelectedStatuses();
+
+      $timeout(function() {
+        $('form[name=editCaseTypeForm] .crmCaseType-acttab').tabs({show: true, hide: true});
+      });
     })();
 
     /// Stores the api calls results in the $scope object

--- a/ang/crmCaseType/edit.html
+++ b/ang/crmCaseType/edit.html
@@ -13,7 +13,7 @@ Required vars: caseType
 
   <div ng-include="'~/crmCaseType/caseTypeDetails.html'"></div>
 
-  <div ng-show="isForkable()" class="crmCaseType-acttab" ui-jq="tabs" ui-options="{show: true, hide: true}">
+  <div ng-show="isForkable()" class="crmCaseType-acttab">
     <ul>
       <li><a href="#acttab-roles">{{:: ts('Case Roles') }}</a></li>
       <li><a href="#acttab-statuses">{{:: ts('Case Statuses') }}</a></li>

--- a/ang/crmCaseType/timelineTable.html
+++ b/ang/crmCaseType/timelineTable.html
@@ -27,8 +27,7 @@ Required vars: activitySet
     </td>
     <td>
       <select
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth: true}"
+        crm-ui-select="{dropdownAutoWidth: true}"
         ng-model="activity.status"
         ng-options="actStatus.name as actStatus.label for actStatus in activityStatuses|orderBy:'label'"
         >
@@ -37,8 +36,7 @@ Required vars: activitySet
     </td>
     <td>
       <select
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth: true}"
+        crm-ui-select="{dropdownAutoWidth: true}"
         ng-model="activity.reference_activity"
         ng-options="activityType.name as activityType.label for activityType in caseType.definition.timelineActivityTypes"
         >
@@ -55,8 +53,7 @@ Required vars: activitySet
     </td>
     <td>
       <select
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth: true}"
+        crm-ui-select="{dropdownAutoWidth: true}"
         ng-model="activity.reference_select"
         ng-options="key as value for (key,value) in {newest: ts('Newest'), oldest: ts('Oldest')}"
         >
@@ -64,8 +61,7 @@ Required vars: activitySet
     </td>
     <td>
       <select
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth: true}"
+        crm-ui-select="{dropdownAutoWidth: true}"
         ng-model="activity.default_assignee_type"
         ng-options="option.value as option.label for option in defaultAssigneeTypes"
         ng-change="clearActivityDefaultAssigneeValues(activity)"
@@ -73,8 +69,7 @@ Required vars: activitySet
 
       <p ng-if="activity.default_assignee_type === defaultAssigneeTypeValues.BY_RELATIONSHIP">
         <select
-          ui-jq="select2"
-          ui-options="{dropdownAutoWidth: true}"
+          crm-ui-select="{dropdownAutoWidth: true}"
           ng-model="activity.default_assignee_relationship"
           ng-options="option.id as option.text for option in relationshipTypeOptions"
           required

--- a/ang/crmCxn.ang.php
+++ b/ang/crmCxn.ang.php
@@ -5,5 +5,5 @@ return [
   'js' => ['ang/crmCxn.js', 'ang/crmCxn/*.js'],
   'css' => ['ang/crmCxn.css'],
   'partials' => ['ang/crmCxn'],
-  'requires' => ['crmUtil', 'ngRoute', 'ngSanitize', 'ui.utils', 'crmUi', 'dialogService', 'crmResource'],
+  'requires' => ['crmUtil', 'ngRoute', 'ngSanitize', 'crmUi', 'dialogService', 'crmResource'],
 ];

--- a/ang/crmMailing.ang.php
+++ b/ang/crmMailing.ang.php
@@ -11,7 +11,7 @@ return [
   'css' => ['ang/crmMailing.css'],
   'partials' => ['ang/crmMailing'],
   'settingsFactory' => ['CRM_Mailing_Info', 'createAngularSettings'],
-  'requires' => ['crmUtil', 'crmAttachment', 'crmAutosave', 'ngRoute', 'ui.utils', 'crmUi', 'dialogService', 'crmResource'],
+  'requires' => ['crmUtil', 'crmAttachment', 'crmAutosave', 'ngRoute', 'crmUi', 'dialogService', 'crmResource'],
   'permissions' => [
     'view all contacts',
     'edit all contacts',

--- a/ang/crmMailing/BlockHeaderFooter.html
+++ b/ang/crmMailing/BlockHeaderFooter.html
@@ -8,8 +8,7 @@ Required vars: mailing, crmMailingConst
       <select
         crm-ui-id="subform.header_id"
         name="header_id"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true, allowClear: true}"
+        crm-ui-select="{dropdownAutoWidth : true, allowClear: true}"
         ng-change="checkTokens(mailing, '*')"
         ng-model="mailing.header_id"
         ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Header'} | orderBy:'name'">
@@ -20,8 +19,7 @@ Required vars: mailing, crmMailingConst
       <select
         crm-ui-id="subform.footer_id"
         name="footer_id"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true, allowClear: true}"
+        crm-ui-select="{dropdownAutoWidth : true, allowClear: true}"
         ng-change="checkTokens(mailing, '*')"
         ng-model="mailing.footer_id"
         ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Footer'} | orderBy:'name'">

--- a/ang/crmMailing/BlockPublication.html
+++ b/ang/crmMailing/BlockPublication.html
@@ -4,8 +4,7 @@
       <select
         crm-ui-id="subform.visibility"
         name="visibility"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        crm-ui-select="{dropdownAutoWidth : true}"
         ng-model="mailing.visibility"
         ng-options="v.key as v.value for v in crmMailingConst.visibility"
         required

--- a/ang/crmMailing/BlockResponses.html
+++ b/ang/crmMailing/BlockResponses.html
@@ -34,8 +34,7 @@ Required vars: mailing, crmMailingConst
       <select
         crm-ui-id="subform.reply_id"
         name="reply_id"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        crm-ui-select="{dropdownAutoWidth : true}"
         ng-model="mailing.reply_id"
         ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Reply'}"
         required>
@@ -46,8 +45,7 @@ Required vars: mailing, crmMailingConst
       <select
         crm-ui-id="subform.optout_id"
         name="optout_id"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        crm-ui-select="{dropdownAutoWidth : true}"
         ng-model="mailing.optout_id"
         ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'OptOut'}"
         required>
@@ -58,8 +56,7 @@ Required vars: mailing, crmMailingConst
       <select
         crm-ui-id="subform.resubscribe_id"
         name="resubscribe_id"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        crm-ui-select="{dropdownAutoWidth : true}"
         ng-model="mailing.resubscribe_id"
         ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Resubscribe'}"
         required>
@@ -70,8 +67,7 @@ Required vars: mailing, crmMailingConst
       <select
         crm-ui-id="subform.unsubscribe_id"
         name="unsubscribe_id"
-        ui-jq="select2"
-        ui-options="{dropdownAutoWidth : true}"
+        crm-ui-select="{dropdownAutoWidth : true}"
         ng-model="mailing.unsubscribe_id"
         ng-options="mc.id as mc.name for mc in crmMailingConst.headerfooterList | filter:{component_type: 'Unsubscribe'}"
         required>

--- a/ang/crmMailingAB.ang.php
+++ b/ang/crmMailingAB.ang.php
@@ -11,5 +11,5 @@ return [
   ],
   'css' => ['ang/crmMailingAB.css'],
   'partials' => ['ang/crmMailingAB'],
-  'requires' => ['ngRoute', 'ui.utils', 'crmUi', 'crmAttachment', 'crmMailing', 'crmD3', 'crmResource'],
+  'requires' => ['ngRoute', 'crmUi', 'crmAttachment', 'crmMailing', 'crmD3', 'crmResource'],
 ];

--- a/ang/crmUi.ang.php
+++ b/ang/crmUi.ang.php
@@ -10,7 +10,6 @@ return [
   'requires' => array_merge(
     [
       'crmResource',
-      'ui.utils',
     ],
     // Only require the +10kb if we're likely to need it.
     $isPretty ? ['jsonFormatter'] : []

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -628,7 +628,12 @@
             }
           }
 
-          init();
+          // If using ngOptions, wait for them to load
+          if (attrs.ngOptions) {
+            $timeout(init);
+          } else {
+            init();
+          }
         }
       };
     })
@@ -759,14 +764,22 @@
         templateUrl: '~/crmUi/tabset.html',
         transclude: true,
         controllerAs: 'crmUiTabSetCtrl',
-        controller: function($scope, $parse) {
-          var tabs = $scope.tabs = []; // array<$scope>
+        controller: function($scope, $element, $timeout) {
+          var init;
+          $scope.tabs = [];
           this.add = function(tab) {
             if (!tab.id) throw "Tab is missing 'id'";
-            tabs.push(tab);
+            $scope.tabs.push(tab);
+
+            // Init jQuery.tabs() once all tabs have been added
+            if (init) {
+              $timeout.cancel(init);
+            }
+            init = $timeout(function() {
+              $element.find('.crm-tabset').tabs($scope.tabSetOptions);
+            });
           };
-        },
-        link: function (scope, element, attrs) {}
+        }
       };
     })
 

--- a/ang/crmUi/tabset.html
+++ b/ang/crmUi/tabset.html
@@ -1,4 +1,4 @@
-<div ui-jq="tabs" ui-options="{{tabSetOptions}}" class="crm-tabset">
+<div class="crm-tabset">
   <ul>
     <li ng-repeat="tab in tabs" class="ui-corner-all crm-tab-button crm-count-{{tab.count}}">
       <a href="#{{tab.id}}">

--- a/ang/ui.utils.ang.php
+++ b/ang/ui.utils.ang.php
@@ -1,6 +1,0 @@
-<?php
-// This file declares an Angular module which can be autoloaded
-return [
-  'ext' => 'civicrm',
-  'js' => ['bower_components/angular-ui-utils/ui-utils.min.js'],
-];

--- a/composer.json
+++ b/composer.json
@@ -162,9 +162,6 @@
       "angular-ui-sortable": {
         "url": "https://github.com/angular-ui/ui-sortable/archive/v0.19.0.zip"
       },
-      "angular-ui-utils": {
-        "url": "https://github.com/angular-ui/ui-utils/archive/v0.1.1.zip"
-      },
       "angular-unsavedChanges": {
         "url": "https://github.com/facultymatt/angular-unsavedChanges/archive/v0.1.1.zip",
         "ignore": [".*", "node_modules", "bower_components", "test", "tests"]

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -185,7 +185,6 @@ class ManagerTest extends \CiviUnitTestCase {
       'dialogService',
       'ngRoute',
       'ngSanitize',
-      'ui.utils',
     ];
     $ignore = [
       'jsonFormatter',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug reported in https://lab.civicrm.org/dev/core/-/issues/2688 by removing the problematic Angular library, which turned out to be unneeded.

Before
----------------------------------------
See bug report: https://lab.civicrm.org/dev/core/-/issues/2688

After
----------------------------------------
UI-Utils removed, which fixes the bug.

Technical Details
----------------------------------------
The [UI-Utils Library](https://github.com/angular-ui/ui-utils/tree/v0.1.1) is a large collection of utilities. It was added to CiviCRM during the experimental phase of trying out AngularJS, but never used for much of anything, and never upgraded when new releases came out. We've only used one of it's utils (`ui-jq`, which is a simple wrapper for jQuery) and for trivial purposes that I've refactored out in this PR.

The library was breaking jQuery widgets (notably Select2) by attempting to insert jqLite shims into jQuery, [based on faulty logic](https://github.com/angular-ui/ui-utils/blob/v0.1.1/ui-utils.js#L1275-L1277) to check if `window.jQuery` is present (which it's not since CiviCRM uses `noConflict()` mode). This bug was masked in most cases by the presence of the CMS's copy of jQuery. But the bug was manifesting on any page that lacked jQuery, such as front-end WP pages.

Comments
----------------------------------------
Since it's abandonware and not needed, it seems best to remove the library rather than try to patch it.