### PR TITLE
Fix for failing test in master

### DIFF
--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -167,8 +167,6 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test overriding a membership but not providing status.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testImportOverriddenMembershipButWithoutStatus(): void {
     $this->individualCreate(['email' => 'anthony_anderson2@civicrm.org']);
@@ -178,7 +176,6 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ]));
     $membershipImporter->init();
-    $membershipImporter->_contactType = 'Individual';
 
     $importValues = [
       'anthony_anderson2@civicrm.org',
@@ -186,18 +183,21 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       date('Y-m-d'),
       TRUE,
     ];
+    try {
+      $membershipImporter->validateValues($importValues);
+      $this->fail('validation error expected.');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertContains('Required parameter missing: Status', $e->getMessage());
+      return;
+    }
 
-    $importResponse = $membershipImporter->import($importValues);
-    $this->assertEquals(CRM_Import_Parser::ERROR, $importResponse);
-    $this->assertContains('Required parameter missing: Status', $importValues);
   }
 
   /**
    * Test that the passed in status is respected.
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function testImportOverriddenMembershipWithStatus() {
+  public function testImportOverriddenMembershipWithStatus(): void {
     $this->individualCreate(['email' => 'anthony_anderson3@civicrm.org']);
     $membershipImporter = $this->createImportObject([
       'email',
@@ -259,7 +259,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'abc',
     ];
     try {
-      $importResponse = $membershipImporter->validateValues($importValues);
+      $membershipImporter->validateValues($importValues);
     }
     catch (CRM_Core_Exception $e) {
       $this->assertEquals('Invalid value for field(s) : Status Override End Date', $e->getMessage());
@@ -272,9 +272,8 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   /**
    * Test that memberships can still be imported if the status is renamed.
    *
-   * @throws \CRM_Core_Exception
    */
-  public function testImportMembershipWithRenamedStatus() {
+  public function testImportMembershipWithRenamedStatus(): void {
     $this->individualCreate(['email' => 'anthony_anderson3@civicrm.org']);
 
     $this->callAPISuccess('MembershipStatus', 'get', [


### PR DESCRIPTION
Overview
----------------------------------------
Fix for failing test in master

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/172976049-d8461b6b-120a-45c6-9fcb-794427894756.png)


After
----------------------------------------
fixed

Technical Details
----------------------------------------
There is a failing test in master because of a sequence of events - two PRs were merged at once resulting in a real conflict - so we rush merged the PR that addressed that - but a test fail got in - the reason was the NOT `!`  got missed in the last patch - when converting
`$onDuplicate != CRM_Import_Parser::DUPLICATE_UPDATE`
to `$this-isUpdateExisting()` - 

However, in the fix I also moved it to the validate function as anything that can be determined without db look ups belongs in validate

![image](https://user-images.githubusercontent.com/336308/172976775-2149610b-84c2-4cd2-8948-9f915a50efd4.png)


Comments
----------------------------------------
