### PR TITLE
Add integer validation to import

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1385,6 +1385,10 @@ abstract class CRM_Import_Parser {
         return Civi::$statics[__CLASS__][$fieldName][$importedValue] ?? 'invalid_import_value';
       }
     }
+    if ($fieldMetadata['type'] === CRM_Utils_Type::T_INT) {
+      // We have resolved the options now so any remaining ones should be integers.
+      return CRM_Utils_Rule::numeric($importedValue) ? $importedValue : 'invalid_import_value';
+    }
     return $importedValue;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add integer validation to import

Before
----------------------------------------
passing in a non-integer to an integer field is not rejected in `validate`/`getTransformedValues` - it probably bounces later on though

After
----------------------------------------
Actively validate integers (once fields with option values have been resolved) in  `validate`/`getTransformedValues`

Technical Details
----------------------------------------
I spotted that there used to be a security issue with the checks on contact id - that was fixed but it made me think we should harden this now while there is QA attention on imports.


Comments
----------------------------------------
