### PR TITLE
dev/core#2325 import second-handling fix

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1353,8 +1353,8 @@ abstract class CRM_Import_Parser {
       return 'invalid_import_value';
     }
     if ($fieldMetadata['type'] === CRM_Utils_Type::T_DATE || $fieldMetadata['type'] === (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME) || $fieldMetadata['type'] === CRM_Utils_Type::T_TIMESTAMP) {
-      $value = CRM_Utils_Date::formatDate($importedValue, $this->getSubmittedValue('dateFormats'));
-      return ($value) ?: 'invalid_import_value';
+      $value = CRM_Utils_Date::formatDate($importedValue, (int) $this->getSubmittedValue('dateFormats'));
+      return $value ?: 'invalid_import_value';
     }
     $options = $this->getFieldOptions($fieldName);
     if ($options !== FALSE) {

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -68,7 +68,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     $cases = $this->fromToData();
     foreach ($cases as $caseDescription => $case) {
       $obj = new CRM_Utils_Date();
-      list($calculatedFrom, $calculatedTo) = $obj->getFromTo($case['relative'], $case['from'], $case['to']);
+      [$calculatedFrom, $calculatedTo] = $obj->getFromTo($case['relative'], $case['from'], $case['to']);
       $this->assertEquals($case['expectedFrom'], $calculatedFrom, "Expected From failed for case $caseDescription");
       $this->assertEquals($case['expectedTo'], $calculatedTo, "Expected To failed for case $caseDescription");
     }
@@ -322,6 +322,31 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       $this->assertEquals($expectNames, $actualNames, "Check temporal names in $lang");
       unset($useLocale);
     }
+  }
+
+  /**
+   * Test formatDate function.
+   *
+   * @dataProvider dateDataProvider
+   *
+   * Test the format function used in imports. Note most forms
+   * are able to format pre-submit but the import needs to parse the date.
+   */
+  public function testFormatDate($date, $format, $expected): void {
+    $this->assertEquals($expected, CRM_Utils_Date::formatDate($date, $format));
+  }
+
+  /**
+   * Data provider for date formats.
+   *
+   * @return array[]
+   */
+  public function dateDataProvider(): array {
+    return [
+      ['date' => '2022-10-01', 'format' => CRM_Core_Form_Date::DATE_yyyy_mm_dd, 'expected' => '20221001'],
+      ['date' => '2022-10-01 15:54', 'format' => CRM_Core_Form_Date::DATE_yyyy_mm_dd, 'expected' => '20221001155400'],
+      ['date' => '2022-10-01 15:54:56', 'format' => CRM_Core_Form_Date::DATE_yyyy_mm_dd, 'expected' => '20221001155456'],
+    ];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2325 import second-handling fix

Before
----------------------------------------
Seconds dropped when importing dates

After
----------------------------------------
Seconds retained

Technical Details
----------------------------------------
This patch only works for `     if ($dateType === 1) ` - which has it's own if - I haven't looked at other types

https://lab.civicrm.org/dev/core/-/issues/2325

Comments
----------------------------------------
@demeritcowboy @monishdeb this improves the earlier fix - and I think can close the issue even thought I kept the scope narrow. The regex is still a bit wonky per @demeritcowboy's comments - but I at least code commented to that effect