### PR TITLE
dev/core#3505, dev/core#3506 dev/core#3052 Import fixes for unicode url, Côte d’Ivoire

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -221,7 +221,7 @@ class CRM_Utils_Rule {
       // allow relative URL's (CRM-15598)
       $url = 'http://' . $_SERVER['HTTP_HOST'] . $url;
     }
-    return (bool) filter_var($url, FILTER_VALIDATE_URL);
+    return (bool) filter_var(self::idnToAsci($url), FILTER_VALIDATE_URL);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_unicode.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_unicode.csv
@@ -1,0 +1,2 @@
+first_name,Last Name,Website,Country
+Iron,Man,https://কানাডা.com,Côte d'Ivoire

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1075,6 +1075,12 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    */
   public function importDataProvider(): array {
     return [
+      'individual_unicode.csv' => [
+        'csv' => 'individual_unicode.csv',
+        'mapper' => [['first_name'], ['last_name'], ['url', 1], ['country', 1]],
+        'expected_error' => '',
+        'expected_outcomes' => [CRM_Import_Parser::VALID => 1],
+      ],
       'individual_invalid_sub_type' => [
         'csv' => 'individual_invalid_contact_sub_type.csv',
         'mapper' => [['first_name'], ['last_name'], ['contact_sub_type']],


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3505, dev/core#3506 dev/core#3052 Import fixes for unicode url, Côte d’Ivoire

Before
----------------------------------------
Import rejects the following
- Country "Côte d'Ivoire"
- Website "https://কানাডা.com"

The UI also rejects the website

After
----------------------------------------
Both work and are tested in import context, website ok from UI also

Technical Details
----------------------------------------
The fix for them turned out to be different but as the test captured both they are combined. Also as 5.51 is the 'import change release' I will target the rc if it is cut before this is merged.

Fix details
- For "Côte d'Ivoire" there is a difference between the db version of the single quote and that which I hit on my keyboard. We could update in the DB & possibly should but it is reasonable to handle it for all options as it could occur elsewhere
- for the website the main `CRM_Utils_Rule::url()` is updated to call `self::idnToAsci` - which is already done for emails. This function will not work on all sites

![image](https://user-images.githubusercontent.com/336308/173027242-3bd19a5f-0670-4289-a7eb-bf1dd18566ad.png)



Comments
----------------------------------------