### PR TITLE
dev/core#3160 fix inability to import 'just contactid' and add to group

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -194,7 +194,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         $extraFields['related_contact_matched']++;
       }
     }
-    $this->setImportStatus($rowNumber, $this->getStatus(CRM_Import_Parser::VALID), $this->getSuccessMessage(), $contactID, $extraFields);
+    $this->setImportStatus($rowNumber, $this->getStatus(CRM_Import_Parser::VALID), $this->getSuccessMessage(), $contactID, $extraFields, [$contactID]);
     return CRM_Import_Parser::VALID;
   }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1994,11 +1994,18 @@ abstract class CRM_Import_Parser {
    *   Optional created entity ID
    * @param array $additionalFields
    *  Additional fields to be tracked
+   * @param array $createdContactIDs
    *
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
    */
-  protected function setImportStatus(int $id, string $status, string $message = '', ?int $entityID = NULL, $additionalFields = []): void {
+  protected function setImportStatus(int $id, string $status, string $message = '', ?int $entityID = NULL, $additionalFields = [], $createdContactIDs = []): void {
+    foreach ($createdContactIDs as $createdContactID) {
+      // Store any created contacts for post_actions like tag or add to group.
+      // These are done on a 'per-batch' status in processPorstActions
+      // so holding in a property is OK.
+      $this->createdContacts[$createdContactID] = $createdContactID;
+    }
     $this->getDataSourceObject()->updateStatus($id, $status, $message, $entityID, $additionalFields);
   }
 

--- a/tests/phpunit/CRM/Contact/Import/Form/data/contact_id_only.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/contact_id_only.csv
@@ -1,0 +1,2 @@
+Contact ID
+3

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -18,6 +18,8 @@ use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\ContactType;
 use Civi\Api4\Email;
+use Civi\Api4\Group;
+use Civi\Api4\GroupContact;
 use Civi\Api4\IM;
 use Civi\Api4\LocationType;
 use Civi\Api4\OpenID;
@@ -1069,6 +1071,22 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportContactToGroup(): void {
+    $this->individualCreate();
+    $this->importCSV('contact_id_only.csv', [['id']], [
+      'newGroupName' => 'My New Group',
+    ]);
+    $dataSource = new CRM_Import_DataSource_CSV(UserJob::get(FALSE)->setSelect(['id'])->execute()->first()['id']);
+    $row = $dataSource->getRow();
+    $this->assertEquals('IMPORTED', $row['_status']);
+    $group = Group::get()->addWhere('title', '=', 'My New Group')->execute()->first();
+    $this->assertCount(1, GroupContact::get()->addWhere('group_id', '=', $group['id'])->execute());
+  }
+
+  /**
    * Get combinations to test for validation.
    *
    * @return array[]
@@ -2059,11 +2077,18 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'groups' => [],
     ], $submittedValues);
     $form = $this->getFormObject('CRM_Contact_Import_Form_DataSource', $submittedValues);
+    $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
+
     $form->buildForm();
     $form->postProcess();
     $this->userJobID = $form->getUserJobID();
+
+    // This gets reset in DataSource so re-do....
+    $_SESSION['_' . $form->controller->_name . '_container']['values'] = $values;
+
     /* @var CRM_Contact_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_MapField', $submittedValues);
+
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
     $form->postProcess();


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3160 fix inability to import 'just contactid' and add to group

Before
----------------------------------------
- pre 5.51 - trying to import just  a  contact ID and add to group fails due to missing mandatory fields
- 5.51 rc without this - the add to group stopped happening very recently stopped working
- no test

After
----------------------------------------
Importing 'just an id' works, tested

Technical Details
----------------------------------------
The add to group happens per batch in the post_actions

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3160