### PR TITLE
Deduepe - Fix form buttons (again)

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -328,14 +328,13 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     CRM_Core_Session::setStatus($message, ts('Contacts Merged'), 'success');
 
     $urlParams = ['reset' => 1, 'cid' => $this->_cid, 'rgid' => $this->_rgid, 'gid' => $this->_gid, 'limit' => $this->limit, 'criteria' => $this->criteria];
-    $contactViewUrl = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $this->_cid]);
 
+    // When clicking "Merge and go to listing"
     if (!empty($formValues['_qf_Merge_submit'])) {
       $urlParams['action'] = "update";
-      CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/dedupefind',
-        $urlParams
-      ));
+      CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/dedupefind', $urlParams));
     }
+    // When clicking "Merge and go to next pair"
     elseif ($this->next && $this->_mergeId && empty($formValues['_qf_Merge_done'])) {
       $cacheKey = CRM_Dedupe_Merger::getMergeCacheKeyString($this->_rgid, $this->_gid, json_decode($this->criteria, TRUE), TRUE, $this->limit);
 
@@ -353,12 +352,15 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         $urlParams['oid'] = $pos['next']['id2'];
         $urlParams['mergeId'] = $pos['next']['mergeId'];
         $urlParams['action'] = 'update';
-        CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/contact/merge', $urlParams));
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/merge', $urlParams));
       }
     }
-    else {
-      CRM_Core_Session::singleton()->pushUserContext($contactViewUrl);
-    }
+    // When clicking "Merge and View Result" or when used from search forms
+    // Note: search might load this action in a popup, so cannot use a redirect.
+    $contactViewUrl = CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $this->_cid]);
+    CRM_Core_Session::singleton()->pushUserContext($contactViewUrl);
+    // I think this bit is needed because this is a multi-step form.
+    $this->controller->setDestination($contactViewUrl);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Yet another fix for the dedupe form buttons. This feels like a duplicate of the duplicate fix in #23035 but hopefully fixed for real this time and we can stop duplicating these duplicate button fixes!

Before
----------------------------------------
See [dev/core#3421](https://lab.civicrm.org/dev/core/-/issues/3421)
Also see [dev/core#3135](https://lab.civicrm.org/dev/core/-/issues/3135)
And the original cause: a6f2a80

After
----------------------------------------
With this patch in place I've tried out all the buttons in all the different contexts and they all seem to be behaving correctly:

**Search Mode**
- :heavy_check_mark: Clicking merge from advanced search action redirects to the contact
- :heavy_check_mark: Clicking merge from search kit modal gives success msg and closes the modal

**Dedupe Find Mode**
- :heavy_check_mark: Clicking "Merge and View Result" takes you to the contact record.
- :heavy_check_mark: Clicking "Merge and go to listing" takes you back to the list of duplicates.
- :heavy_check_mark: Clicking "Merge and go to next pair" takes you to the next set of duplicates.

Technical Details
----------------------------------------
The problem is that the form is used in different contexts and it's a complex multi-step form, but it can also be used as a one-step form via search and it can also be loaded in an ajax modal. So getting the buttons to behave in every context is tricky.
