### PR TITLE
Setup - Remove CiviGrant from available components

### DIFF
--- a/setup/plugins/blocks/components.civi-setup.php
+++ b/setup/plugins/blocks/components.civi-setup.php
@@ -26,7 +26,6 @@ if (!defined('CIVI_SETUP')) {
         'CiviPledge' => ts('Accept pledges'),
         'CiviReport' => ts('Generate reports'),
         'CiviCampaign' => ts('Organize campaigns, surveys, and petitions'),
-        'CiviGrant' => ts('Receive grant applications'),
       ),
     );
 

--- a/setup/plugins/init/AvailableComponents.civi-setup.php
+++ b/setup/plugins/init/AvailableComponents.civi-setup.php
@@ -26,7 +26,6 @@ if (!defined('CIVI_SETUP')) {
       'CiviPledge',
       'CiviReport',
       'CiviCampaign',
-      'CiviGrant',
     );
     $m->setField('components', 'options', array_combine($comps, $comps));
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3485](https://lab.civicrm.org/dev/core/-/issues/3485) by removing CiviGrant as an option during install.

Before
----------------------------------------
CiviGrant listed among components.

After
----------------------------------------
Gone from installer, which does not install extensions. Extensions like CiviGrant can be added post-install.
