### PR TITLE
[REGRESSION] SearchKit - Fix angular console error when totalCount is not given

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -8,7 +8,7 @@
       display: '<',
       settings: '<',
       filters: '<',
-      totalCount: '='
+      totalCount: '<'
     },
     require: {
       afFieldset: '?^^afFieldset'


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a recent regression causing a js console error in SearchKit.

Before
----------------------------------------
1. Enable CiviGrant
2. Visit any contact summary page, and see this in the console:

```
 Error: [$compile:nonassign] Expression 'undefined' in attribute 'totalCount' used with directive 'crmSearchDisplayTable' is non-assignable!
```

After
----------------------------------------
Fixed, and totalCount still functions correctly for its intended purpose with SearchSegments.