### PR TITLE
dev/core#2706 dev/core#2308 fix activity import to update multi-select fields

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -103,8 +103,9 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
             $disp = $params['external_identifier'];
           }
         }
-
-        throw new CRM_Core_Exception('No matching Contact found for (' . $disp . ')');
+        if (empty($params['id'])) {
+          throw new CRM_Core_Exception('No matching Contact found for (' . $disp . ')');
+        }
       }
       if (!empty($params['external_identifier'])) {
         $targetContactId = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2706 fix activity import to update multi-select fields


Before
----------------------------------------
I tried replicating the described bug in https://lab.civicrm.org/dev/core/-/issues/2706 and did not experience an issue. However, I noted that the issue had activity IDs in the file and so I tried to do an update mapping the ids and failed

After
----------------------------------------
Was also able to update

![image](https://user-images.githubusercontent.com/336308/173164050-3da83111-7d96-44ab-9f5a-cc5782f781fa.png)

![image](https://user-images.githubusercontent.com/336308/173164079-afb99b78-7175-4e37-b32b-fb29ae5e3676.png)


Technical Details
----------------------------------------
Note `activity_label` is no longer a mappable field -activity_type accepts id or label - this is consistent with pretty much every other importable field

Comments
----------------------------------------
Also is the fix for https://lab.civicrm.org/dev/core/-/issues/2308