### PR TITLE
dev/core#3513 Remove 'done' from sumary/import monitoring page

### DIFF
--- a/CRM/Import/Form/Summary.php
+++ b/CRM/Import/Form/Summary.php
@@ -35,19 +35,6 @@ abstract class CRM_Import_Form_Summary extends CRM_Import_Forms {
   }
 
   /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    $this->addButtons(array(
-        array(
-          'type' => 'next',
-          'name' => ts('Done'),
-          'isDefault' => TRUE,
-        ),
-    ));
-  }
-
-  /**
    * Return a descriptive name for the page, used in wizard header.
    *
    * @return string

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -53,7 +53,6 @@
         </p>
     {/if}
 </div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
  {* Summary of Import Results (record counts) *}
   <table id="summary-counts" class="report">
     <tr><td class="label crm-grid-cell">{ts}Total Rows{/ts}</td>
@@ -124,5 +123,4 @@
 
  </table>
 
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#3513 Remove 'done' from sumary/import monitoring page

See dev/core#3513 for why it's confusing

https://lab.civicrm.org/dev/core/-/issues/3513