### PR TITLE
Afform - Require Authx

### DIFF
--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -25,6 +25,9 @@
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
+  <requires>
+    <ext>authx</ext>
+  </requires>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>mgd-php@1.1.0</mixin>


### PR DESCRIPTION
Overview
----------------------------------------
Form Builder (Afform) depends on functionality provided by the Authx extension. This adds it as a requirement.

Before
----------------------------------------
Afform doesn't require Authx but if you don't install it, email tokens won't work, and neither will form submissions in some cases.

After
----------------------------------------
Required.