### PR TITLE
dev/core#3651 dev/core#1337 Fix failure to show last column data in output, spaces in names

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -68,6 +68,30 @@ abstract class CRM_Import_DataSource {
   private $statuses = [];
 
   /**
+   * Fields to select.
+   *
+   * @var array
+   */
+  private $selectFields;
+
+  /**
+   * @return array|null
+   */
+  public function getSelectFields(): ?array {
+    return $this->selectFields;
+  }
+
+  /**
+   * @param array $selectFields
+   *
+   * @return CRM_Import_DataSource
+   */
+  public function setSelectFields(array $selectFields): CRM_Import_DataSource {
+    $this->selectFields = $selectFields;
+    return $this;
+  }
+
+  /**
    * Current row.
    *
    * @var array
@@ -537,11 +561,18 @@ abstract class CRM_Import_DataSource {
    * @throws \CRM_Core_Exception
    */
   private function instantiateQueryObject(): void {
-    $query = 'SELECT * FROM ' . $this->getTableName() . ' ' . $this->getStatusClause();
+    $query = 'SELECT ' . $this->getSelectClause() . ' FROM ' . $this->getTableName() . ' ' . $this->getStatusClause();
     if ($this->limit) {
       $query .= ' LIMIT ' . $this->limit . ($this->offset ? (' OFFSET ' . $this->offset) : NULL);
     }
     $this->queryResultObject = CRM_Core_DAO::executeQuery($query);
+  }
+
+  /**
+   * @return string
+   */
+  private function getSelectClause(): string {
+    return $this->getSelectFields() ? implode(', ', $this->getSelectFields()) : '*';
   }
 
   /**

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -124,7 +124,6 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     }
 
     $firstrow = fgetcsv($fd, 0, $fieldSeparator);
-    $result['column_headers'] = array_fill(0, count($firstrow), '');
     // create the column names from the CSV header or as col_0, col_1, etc.
     if ($headers) {
       //need to get original headers.
@@ -169,8 +168,9 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     else {
       $columns = [];
       foreach ($firstrow as $i => $_) {
-        $columns[] = "col_$i";
+        $columns[] = "column_$i";
       }
+      $result['column_headers'] = $columns;
     }
 
     $table = CRM_Utils_SQL_TempTable::build()->setDurable();

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -92,7 +92,17 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
 
     $columnNames = [];
     while ($columnsResult->fetch()) {
-      $columnNames[] = $columnsResult->Field;
+      if (strpos($columnsResult->Field, ' ') !== FALSE) {
+        // Remove spaces as the Database object does this
+        // $keys = str_replace(array(".", " "), "_", array_keys($array));
+        // https://lab.civicrm.org/dev/core/-/issues/1337
+        $usableColumnName = str_replace(' ', '_', $columnsResult->Field);
+        CRM_Core_DAO::executeQuery('ALTER TABLE ' . $tableName . ' CHANGE `' . $columnsResult->Field . '` ' . $usableColumnName . ' ' . $columnsResult->Type);
+        $columnNames[] = $usableColumnName;
+      }
+      else {
+        $columnNames[] = $columnsResult->Field;
+      }
     }
 
     $this->addTrackingFieldsToTable($tableName);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3651 dev/core#1337 Fix failure to show last column data in output, spaces in names

Fixes an RC regression whereby the outputting of import results was not putting data in the last column

In addition, as this required testing the sql datasource I used a query that was failing per https://lab.civicrm.org/dev/core/-/issues/1337 and included the fix for that in here. The query I used was

`SELECT id, first_name as 'First Name', last_name as 'LAST NAME' from civicrm_contact`;

(Note that there are other pre-existing issues with the sql that I obsevered in that some sql operators are htmlised - ignoring)

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/3651

After
----------------------------------------
It's baa-aack

Technical Details
----------------------------------------

Comments
----------------------------------------
