### PR TITLE
dev/financial#199 - Add failing test to demonstrate the problem

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
@@ -57,4 +57,22 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
     ];
   }
 
+  /**
+   * Test the Additional Details pane loads for recurring contributions.
+   */
+  public function testAdditionalDetails() {
+    $this->addContribution();
+    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getContributionRecurID());
+    $_GET['q'] = $_REQUEST['q'] = 'civicrm/contact/view/contribution';
+    $_GET['snippet'] = $_REQUEST['snippet'] = 4;
+    $_GET['id'] = $_REQUEST['id'] = $templateContribution['id'];
+    $_GET['formType'] = $_REQUEST['formType'] = 'AdditionalDetail';
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution', []);
+    $form->buildForm();
+    unset($_GET['q'], $_REQUEST['q']);
+    unset($_GET['snippet'], $_REQUEST['snippet']);
+    unset($_GET['id'], $_REQUEST['id']);
+    unset($_GET['formType'], $_REQUEST['formType']);
+  }
+
 }

--- a/tests/phpunit/CRMTraits/Contribute/RecurFormsTrait.php
+++ b/tests/phpunit/CRMTraits/Contribute/RecurFormsTrait.php
@@ -58,6 +58,14 @@ trait CRMTraits_Contribute_RecurFormsTrait {
       'payment_processor_id' => $this->paymentProcessorId,
       'is_send_contribution_notification' => FALSE,
     ]);
+    $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $this->getContactID(),
+      'contribution_recur_id' => $this->getContributionRecurID(),
+      'financial_type_id' => 'Donation',
+      'total_amount' => 10,
+      'contribution_page_id' => $this->getContributionPageID(),
+      'contribution_status_id' => 'Template',
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Failing test for https://lab.civicrm.org/dev/financial/-/issues/199: Additional Details section when editing recurring contributions won't load.

Before
----------------------------------------
Won't load - spinning icon.

After
----------------------------------------
Still doesn't, but adds proof. This should output:

```
CRM_Contribute_Form_UpdateSubscriptionTest::testAdditionalDetails
Exception: PEAR_Exception: "QuickForm Error: nonexistent html element"
 * ERROR TYPE: HTML_QuickForm_Error
 * ERROR CODE: -3
 * ERROR MESSAGE: QuickForm Error: nonexistent html element
 * ERROR MODE: 16
 * ERROR USERINFO: Element 'contribution_status_id' does not exist in HTML_QuickForm::getElement()
```

Technical Details
----------------------------------------
There is no contribution_status_id, so trying to freeze() it throws an error. A simple fix would be to check elementExists() first, but feels awkward.

Comments
----------------------------------------
In real life recurring creates a mirror contribution record with a status of "Template". Updated the trait to do that.

There's also a problem with status_id when you save. Haven't addressed yet.