### PR TITLE
dev/core#3653 Fix on queue runner not working in upgrade

### DIFF
--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -184,10 +184,16 @@ class CRM_Queue_Runner {
   public function runAllViaWeb() {
     $_SESSION['queueRunners'][$this->qrid] = serialize($this);
     $url = CRM_Utils_System::url($this->pathPrefix . '/runner', 'reset=1&qrid=' . urlencode($this->qrid));
-    // If this was persistent/registered queue, ensure that no one else tries to execute it.
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_queue SET status = NULL WHERE name = %1', [
-      1 => [$this->queue->getName(), 'String'],
-    ]);
+    try {
+      // If this was persistent/registered queue, ensure that no one else tries to execute it.
+      CRM_Core_DAO::executeQuery('UPDATE civicrm_queue SET status = NULL WHERE name = %1', [
+        1 => [$this->queue->getName(), 'String'],
+      ]);
+    }
+    catch (PEAR_Exception $e) {
+      // For sites being upgraded the field may not exist as yet.
+      // https://lab.civicrm.org/dev/core/-/issues/3653
+    }
     CRM_Utils_System::redirect($url);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
I just tested and this gets us past https://lab.civicrm.org/dev/core/-/issues/3653

Before
----------------------------------------
Can't upgrade to 5.51 using the UI

After
----------------------------------------
it works - my r-run succeeds

Technical Details
----------------------------------------
the fix could perhaps be more sophisticated - but I think getting a quick fix is important here as multiple reports of this have been made so not having a fix is a time-suck

@demeritcowboy or @seamuslee001 could one of you OK this & if @totten wants something more elegant we can follow up

Comments
----------------------------------------
