### PR TITLE
Allow (some) permissions with colons

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -692,18 +692,22 @@ class CRM_Utils_String {
    * @param string $string
    *   E.g. "view all contacts". Syntax: "[prefix:]name".
    * @param string|null $defaultPrefix
+   * @param string $validPrefixPattern
+   *   A regular expression used to determine if a prefix is valid.
+   *   To wit: Prefixes MUST be strictly alphanumeric.
    *
    * @return array
    *   (0 => string|NULL $prefix, 1 => string $value)
    */
-  public static function parsePrefix($delim, $string, $defaultPrefix = NULL) {
+  public static function parsePrefix($delim, $string, $defaultPrefix = NULL, $validPrefixPattern = '/^[A-Za-z0-9]+$/') {
     $pos = strpos($string, $delim);
     if ($pos === FALSE) {
       return [$defaultPrefix, $string];
     }
-    else {
-      return [substr($string, 0, $pos), substr($string, 1 + $pos)];
-    }
+
+    $lhs = substr($string, 0, $pos);
+    $rhs = substr($string, 1 + $pos);
+    return preg_match($validPrefixPattern, $lhs) ? [$lhs, $rhs] : [$defaultPrefix, $string];
   }
 
   /**

--- a/tests/phpunit/CRM/Core/Permission/BaseTest.php
+++ b/tests/phpunit/CRM/Core/Permission/BaseTest.php
@@ -16,6 +16,7 @@ class CRM_Core_Permission_BaseTest extends CiviUnitTestCase {
     $cases = [];
 
     $cases[] = ['administer CiviCRM', 'administer CiviCRM'];
+    $cases[] = ['create contributions of type Event Fee: Canada', 'create contributions of type Event Fee: Canada'];
     $cases[] = ['cms:universal name', 'local name'];
     $cases[] = ['cms:universal name2', 'local name2'];
     $cases[] = ['cms:unknown universal name', CRM_Core_Permission::ALWAYS_DENY_PERMISSION];

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -132,6 +132,7 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
   public function parsePrefixData(): array {
     $cases = [];
     $cases[] = ['administer CiviCRM', NULL, [NULL, 'administer CiviCRM']];
+    $cases[] = ['create contributions of type Event Fee: Canada', NULL, [NULL, 'create contributions of type Event Fee: Canada']];
     $cases[] = ['administer CiviCRM', 'com_civicrm', ['com_civicrm', 'administer CiviCRM']];
     $cases[] = ['Drupal:access user profiles', NULL, ['Drupal', 'access user profiles']];
     $cases[] = ['Joomla:component:perm', NULL, ['Joomla', 'component:perm']];


### PR DESCRIPTION
Overview
----------------------------------------

This resolves a bug where some permissions in `financialacls` don't work. The extension generates permission-names formulaically (from user-supplied data):

```
// Formula
{$actionName} contributions of type {$typeName}

// Examples
create contributions of type Donation
delete contributions of type Event Fee
delete contributions of type Event Fee: Canada
```

Specifically, `$typeName` comes from an open-ended field which may include a colon. But the colon has another meaning in permission (*eg it identifies namespaces/prefixes like `Drupal:` or `Joomla:`*) -- and the interpretation of `:` becomes mixed-up.

Alternative to @MegaphoneJon's #23732. 

Before
----------------------------------------

These expression are interpreted as follows:

```php
CRM_Core_Permission::check('access CiviMail');
// Interpreted as permission "access CiviMail" in default namespace

CRM_Core_Permission::check('create contributions of type Event Fee');
// Interpreted as permission "create contributions of type Event Fee" in default namespace

CRM_Core_Permission::check('create contributions of type Event Fee: Canada');
// Interpreted as permission " Canada" in namespace "create contributions of type Event Fee".
// Weird.
```

After
----------------------------------------

The last one changes to work more like the first two:

```php
CRM_Core_Permission::check('create contributions of type Event Fee: Canada');
// Interpreted as permission "create contributions of type Event Fee: Canada" in default namespace
```

Comment
----------------------------------------

This adds a couple tests - but I haven't `r-run` the configuration that was afflicted.
