### PR TITLE
FiveFiftyOne - Enable snapshots for data modified data

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyOne.php
@@ -30,6 +30,10 @@ class CRM_Upgrade_Incremental_php_FiveFiftyOne extends CRM_Upgrade_Incremental_B
    *   The version number matching this function name
    */
   public function upgrade_5_51_alpha1($rev): void {
+    $this->addSnapshotTask('mappings', CRM_Utils_SQL_Select::from('civicrm_mapping'));
+    $this->addSnapshotTask('fields', CRM_Utils_SQL_Select::from('civicrm_mapping_field'));
+    $this->addSnapshotTask('queues', CRM_Utils_SQL_Select::from('civicrm_queue'));
+
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask(ts('Convert import mappings to use names'), 'convertMappingFieldLabelsToNames', $rev);
     $this->addTask('Add column "civicrm_queue.status"', 'addColumn', 'civicrm_queue',


### PR DESCRIPTION
Before
------

The 5.51.alpha upgrade modifies a some data-structures (`civicrm_mapping_*`, `civicrm_queue`),
but it doesn't take any snapshots.

After
-----

It does snapshots.

Comments
--------

Both tables should generally be quite small.

Strictly, the `civicrm_mapping_*` updates are more in-place modifications,
so that's more important.  The `civicrm_queue` changes are only adding new
columns.  But the table is so small - it doesn't hurt.

I suppose one could argue that these particular fields aren't likely to have
problems - but it's important to get in the habit of enabling snapshots so
that we have them when they do matter.

