### PR TITLE
Add hook to modify 'contribution payment links'

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4346,6 +4346,9 @@ LIMIT 1;";
         'extra' => '',
       ];
     }
+
+    CRM_Utils_Hook::links('contribution.edit.action', 'Contribution', $id, $actionLinks);
+
     return $actionLinks;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Let's you modify "contribution payment links" via existing hook_civicrm_links.

Before
----------------------------------------
Not possible to add/remove/modify links
![image](https://user-images.githubusercontent.com/2052161/173653027-1bf246c2-1704-4ab4-a018-06f523288705.png)


After
----------------------------------------
Can be modified
Example:
![image](https://user-images.githubusercontent.com/2052161/173649982-de0e3e84-cf38-46c9-bf5f-30c59187a7a0.png)

Technical Details
----------------------------------------


Comments
----------------------------------------

