### PR TITLE
Make it clear what "record refund" form does

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -23,6 +23,11 @@
       {icon icon="fa-info-circle"}{/icon}{ts}You will not be able to send an automatic email receipt for this payment because there is no email address recorded for this contact. If you want a receipt to be sent when this payment is recorded, click Cancel and then click Edit from the Summary tab to add an email address before recording the payment.{/ts}
     </div>
   {/if}
+  {if $paymentType EQ 'refund'}
+    <div class="messages status no-popup">
+      {icon icon="fa-info-circle"}{/icon} {ts}Use this form to record a manual refund. If a payment processor was used to make payment it will not be notified.{/ts}
+    </div>
+  {/if}
   {if $newCredit AND $contributionMode EQ null}
     {if $contactId}
       {capture assign=ccModeLink}{crmURL p='civicrm/payment/add' q="reset=1&action=add&cid=`$contactId`&id=`$id`&component=`$component`&mode=live"}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
It was not clear to me if the "Record refund" form was capable of talking to payment processors etc. - it's not.

Before
----------------------------------------
Not clear as to whether this form might talk to a payment processor or not.

After
----------------------------------------
Clear:
![image](https://user-images.githubusercontent.com/2052161/173657643-f9b6cdd2-37d1-4f69-bce2-04e77cbcc7ca.png)

Technical Details
----------------------------------------


Comments
----------------------------------------
@adixon @JoeMurray @eileenmcnaughton Just wanted to ping you here to check my assumption is correct? Eg. IATs doesn't have any overrides/hooks for that form that actually allows a refund to be requested for example?
