### PR TITLE
Add contribution balance

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -467,6 +467,14 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
         CRM_Event_BAO_Participant::fixEventLevel($row['amount_level']);
       }
 
+      $balance = CRM_Contribute_BAO_Contribution::getContributionBalance($result->contribution_id, $result->total_amount);
+      if (($balance == $result->total_amount) || empty($balance)) {
+        $row['balance'] = NULL;
+      }
+      else {
+        $row['balance'] = CRM_Utils_Money::formatLocaleNumericRoundedByCurrency($balance, $row['currency']);
+      }
+
       $rows[] = $row;
     }
 
@@ -496,7 +504,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     $pre = [];
     self::$_columnHeaders = [
       [
-        'name' => $this->_includeSoftCredits ? ts('Contribution Amount') : ts('Amount'),
+        'name' => ($this->_includeSoftCredits ? ts('Contribution Amount') : ts('Amount')) . ' (due)',
         'sort' => 'total_amount',
         'direction' => CRM_Utils_Sort::DONTCARE,
         'field_name' => 'total_amount',

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -48,6 +48,7 @@
              <a class="nowrap bold crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}">
                &nbsp; {$row.total_amount|crmMoney:$row.currency}
             </a>
+            {if $row.balance}<span class="balance-due">({$row.balance})</span>{/if}
           {if $row.amount_level}<br/>({$row.amount_level}){/if}
           {if $row.contribution_recur_id && $row.is_template}
             <br/>{ts}(Recurring Template){/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Related to https://lab.civicrm.org/dev/financial/-/issues/103

This shows the contribution balance on the list of contributions if it is not 0 (ie. `Pending`) and not fully paid (ie. `Completed`).

There is a separate issue (eg. see https://lab.civicrm.org/dev/financial/-/issues/87) that should probably trigger the contribution to change to `Partially Paid` when a partial refund has been made but a refund is not the only way to have a partially paid contribution.

Before
----------------------------------------
Balance of partially refunded contribution not shown.

After
----------------------------------------
Balance of partially refunded contribution shown:

![image](https://user-images.githubusercontent.com/2052161/173663933-5ae72ad4-b95a-46cd-bb18-f58573e3f795.png)

Note that I'm not sure what the best/clearest way to display this info is so I've gone for the simplest I could. It's wrapped in a class and I think it looks nice in red but have not included that here :-)

Technical Details
----------------------------------------
This calculates and adds an additional parameter containing the balance due for the contribution. If 0 or 100% it's not shown because it doesn't add anything useful. Otherwise it is shown.

Comments
----------------------------------------

