### PR TITLE
Convert contribution search to use API4

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -467,6 +467,14 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
         CRM_Event_BAO_Participant::fixEventLevel($row['amount_level']);
       }
 
+      $balance = CRM_Contribute_BAO_Contribution::getContributionBalance($result->contribution_id, $result->total_amount);
+      if (($balance == $result->total_amount) || empty($balance)) {
+        $row['balance'] = NULL;
+      }
+      else {
+        $row['balance'] = CRM_Utils_Money::formatLocaleNumericRoundedByCurrency($balance, $row['currency']);
+      }
+
       $rows[] = $row;
     }
 
@@ -496,7 +504,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
     $pre = [];
     self::$_columnHeaders = [
       [
-        'name' => $this->_includeSoftCredits ? ts('Contribution Amount') : ts('Amount'),
+        'name' => ($this->_includeSoftCredits ? ts('Contribution Amount') : ts('Amount')) . ' (due)',
         'sort' => 'total_amount',
         'direction' => CRM_Utils_Sort::DONTCARE,
         'field_name' => 'total_amount',

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -48,6 +48,7 @@
              <a class="nowrap bold crm-expand-row" title="{ts}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}">
                &nbsp; {$row.total_amount|crmMoney:$row.currency}
             </a>
+            {if $row.balance}<span class="balance-due">({$row.balance})</span>{/if}
           {if $row.amount_level}<br/>({$row.amount_level}){/if}
           {if $row.contribution_recur_id && $row.is_template}
             <br/>{ts}(Recurring Template){/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Not sure if this is a sensible approach. Did this whilst working on showing contribution balance as an experiment..

"Converts" the contribution search selector to use API4 internally.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
