### PR TITLE
dev/financial#197 Revert freezing on total_amount field on recurring form

### DIFF
--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -151,17 +151,9 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     if (count($lineItems) > 1) {
       $amtAttr += ['readonly' => TRUE];
     }
-    $amountField = $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,
+    $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,
       TRUE, 'currency', $this->_subscriptionDetails->currency, TRUE
     );
-
-    // The amount on the recurring contribution should not be updated directly. If we update the amount using a template contribution the recurring contribution
-    //   will be updated automatically.
-    $paymentProcessorObj = Civi\Payment\System::singleton()->getById(CRM_Contribute_BAO_ContributionRecur::getPaymentProcessorID($this->contributionRecurID));
-    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->contributionRecurID);
-    if (!empty($templateContribution['id']) && $paymentProcessorObj->supportsEditRecurringContribution()) {
-      $amountField->freeze();
-    }
 
     $this->add('text', 'installments', ts('Number of Installments'), ['size' => 20], FALSE);
 


### PR DESCRIPTION
Overview
----------------------------------------
[dev/financial#197](https://lab.civicrm.org/dev/financial/-/issues/197) Revert freezing on total_amount field on recurring form

Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/21473 results in the amount field being frozen for recurring contributions - it was reviewed as "PASS: The change would be intuitive or unnoticeable for a majority of users who work with this feature." - but that is pretty clearly wrong as users are used to editing the amount, and are unfamiliar with the template contribution - which often does NOT permit editing the amount

After
----------------------------------------
The field is editable again

Technical Details
----------------------------------------
This returns the field to the previous state. On checking the code this might mean the recurring amount is out of sync with the template contribution. However, that just takes us back to the status quo which was fine for most users. For single line item contributions the `contribution_recur.amount` field takes precedence and it doesn't matter if the two are out of sync.

Ideally we need to ensure that any changes to the `ContributionRecur.amount` are blocked for non-single row or cause a corresponding update for single row templates and this needs to happen regardless of whether the form or the api or BAO makes the update. (It currently IS the case on this form)

Comments
----------------------------------------
We agreed to underlying schema changes in Barcelona - which have been implemented. Since then UI changes have also been made to add the contribution template to the UI. UI changes definitely need more scrutiny but unfortunately I merged the PR that made this change based on the review, rather than my own analysis, and did not realise it made an important UI change that should have gone through the dev list. 

This implements a quick revert on the problematic part [(as suggested by Matt)](https://chat.civicrm.org/civicrm/pl/drb1xsqt7pd8dmd74bjgwgg4uw). We can re-discuss a fix in master but after testing this out I don't think the freeze is acceptable while we do this 

@KarinG @mattwire @adixon @seamuslee001 

