### PR TITLE
[REF] Remove param that has a set value

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1418,12 +1418,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param array $membershipParams
    * @param int $contactID
    * @param array $customFieldsFormatted
-   * @param array $fieldTypes
    * @param array $premiumParams
    * @param array $membershipLineItems
    *   Line items specifically relating to memberships.
    */
-  protected function processMembership($membershipParams, $contactID, $customFieldsFormatted, $fieldTypes, $premiumParams,
+  protected function processMembership($membershipParams, $contactID, $customFieldsFormatted, $premiumParams,
                                 $membershipLineItems): void {
 
     $membershipTypeIDs = (array) $membershipParams['selectMembership'];
@@ -1454,7 +1453,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $membershipParams['contribution_source'] = $this->_params['membership_source'];
     }
 
-    $this->postProcessMembership($membershipParams, $contactID, $premiumParams, $customFieldsFormatted, $fieldTypes, $membershipType, $membershipTypeIDs, $isPaidMembership, $this->_membershipId, $isProcessSeparateMembershipTransaction, $financialTypeID,
+    $this->postProcessMembership($membershipParams, $contactID, $premiumParams, $customFieldsFormatted, $membershipType, $membershipTypeIDs, $isPaidMembership, $this->_membershipId, $isProcessSeparateMembershipTransaction, $financialTypeID,
       $membershipLineItems);
 
     $this->assign('membership_assign', TRUE);
@@ -1471,7 +1470,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param array $premiumParams
    * @param null $customFieldsFormatted
-   * @param null $includeFieldTypes
    *
    * @param array $membershipDetails
    *
@@ -1492,7 +1490,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   protected function postProcessMembership(
     $membershipParams, $contactID, $premiumParams,
-    $customFieldsFormatted, $includeFieldTypes, $membershipDetails, $membershipTypeIDs, $isPaidMembership, $membershipID,
+    $customFieldsFormatted, $membershipDetails, $membershipTypeIDs, $isPaidMembership, $membershipID,
     $isProcessSeparateMembershipTransaction, $financialTypeID, $unprocessedLineItems) {
     // Assign $this to $form while we eliminate it.
     $form = $this;
@@ -1781,7 +1779,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     CRM_Contribute_BAO_ContributionPage::sendMail($contactID,
       $emailValues,
       $isTest, FALSE,
-      $includeFieldTypes
+      ['Contact', 'Organization', 'Membership']
     );
   }
 
@@ -2523,7 +2521,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->_params['campaign_id'] = $membershipParams['onbehalf']['member_campaign_id'];
     }
 
-    $customFieldsFormatted = $fieldTypes = [];
+    $customFieldsFormatted = [];
     if (!empty($membershipParams['onbehalf']) &&
       is_array($membershipParams['onbehalf'])
     ) {
@@ -2540,7 +2538,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           );
         }
       }
-      $fieldTypes = ['Contact', 'Organization', 'Membership'];
     }
 
     $membershipParams = $this->getMembershipParamsFromPriceSet($membershipParams);
@@ -2559,7 +2556,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
       }
       try {
-        $this->processMembership($membershipParams, $contactID, $customFieldsFormatted, $fieldTypes, $premiumParams, $membershipLineItems);
+        $this->processMembership($membershipParams, $contactID, $customFieldsFormatted, $premiumParams, $membershipLineItems);
       }
       catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
         CRM_Core_Session::singleton()->setStatus($e->getMessage());


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Remove param that has a set value

Before
----------------------------------------
Parameter is conditionally calculated & passed around - but does not need to be

After
----------------------------------------
Consistently passed in to the function that uses it

Technical Details
----------------------------------------
`

$fieldTypes`  is only ever used  in `CRM_Contribute_BAO_ContributionPage::sendMail` so it is calculated & eventually passed to that function

![image](https://user-images.githubusercontent.com/336308/173706584-32478b08-1a29-4eeb-bff5-17c27ba7a98e.png)

In terms of original calculation - it is empty unless `$membershipParams['onbehalf']` is true

![image](https://user-images.githubusercontent.com/336308/173706932-7390ec7d-bb98-426e-8a8a-0d34b0f0b924.png)

- so we can just pass in the values for this flow - without worrying if they should be set or null

Comments
----------------------------------------

