### PR TITLE
Fix Automatic renewal membership from front end contribution forms

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/MainTest.php
@@ -93,7 +93,6 @@ class CRM_Contribute_Form_Contribution_MainTest extends CiviUnitTestCase {
     $priceFieldValueId = $this->getPriceFieldValue($membershipTypeID);
     $form->testSubmit(array_merge($this->getSubmitParams(), [
       'price_' . $this->priceSetId => $priceFieldValueId,
-      'is_recur' => 1,
     ]));
     $this->assertEquals(1, $form->_params['is_recur']);
   }
@@ -107,7 +106,7 @@ class CRM_Contribute_Form_Contribution_MainTest extends CiviUnitTestCase {
     $priceFieldValueId = $this->getPriceFieldValue($membershipTypeID);
     $form->testSubmit(array_merge($this->getSubmitParams(), [
       'price_' . $this->priceSetId => $priceFieldValueId,
-      'is_recur' => 0,
+      'auto_renew' => 0,
     ]));
     $this->assertEquals(0, $form->_params['is_recur']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug when you use allow optional automatic renewal signups for memberships on contribution pages, The Contribution Recur object doesn't get created properly when user opts into the automatic renewal.

Before
----------------------------------------
Contribution Recur object is not created for automatic renewal of memberships

After
----------------------------------------
Contribution Recur object is created when user opts into automatic renewal of memberships

ping @eileenmcnaughton @JoeMurray @monishdeb @andrew-cormick-dockery 