### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -21,8 +21,13 @@ on:
         description: Autocommit to branch (y or n)
         required: false
         default: 'n'
+permissions:
+  contents: read
+
 jobs:
   runregen:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     name: Run Regen
     services:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
