### PR TITLE
[REF] [PHP8.1] Replace usage of smarty's date_filter to ensure we don't call s…

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmDate.php
@@ -60,7 +60,9 @@ function smarty_modifier_crmDate($dateString, ?string $dateFormat = NULL, bool $
       $config = CRM_Core_Config::singleton();
       $dateFormat = $config->dateformatTime;
     }
-
+    if (is_int($dateString)) {
+      return CRM_Utils_Date::customFormatTs($dateString, $dateFormat);
+    }
     return CRM_Utils_Date::customFormat($dateString, $dateFormat);
   }
   return '';

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -369,7 +369,7 @@ class CRM_Utils_Date {
 
         $hour24 = (int) substr($dateString, 11, 2);
         $minute = (int) substr($dateString, 14, 2);
-        $second = (int) substr($dateString, 16, 2);
+        $second = (int) substr($dateString, 17, 2);
       }
       else {
         $year = (int) substr($dateString, 0, 4);
@@ -433,6 +433,7 @@ class CRM_Utils_Date {
         '%A' => $type,
         '%Y' => $year,
         '%s' => str_pad($second, 2, 0, STR_PAD_LEFT),
+        '%S' => str_pad($second, 2, 0, STR_PAD_LEFT),
       ];
 
       return strtr($format, $date);

--- a/templates/CRM/Activity/Calendar/ICal.tpl
+++ b/templates/CRM/Activity/Calendar/ICal.tpl
@@ -16,7 +16,7 @@ BEGIN:VEVENT
 UID:CIVICRMACTIVITY{$activity->id}
 SUMMARY:{$activity->subject|crmICalText}
 CALSCALE:GREGORIAN
-DTSTAMP;TZID={$timezone}:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
+DTSTAMP;TZID={$timezone}:{$smarty.now|crmDate:'%Y-%m-%d %H:%M:%S'|crmICalDate}
 DTSTART;TZID={$timezone}:{$activity->activity_date_time|crmICalDate}
 DURATION:PT{$activity->duration}M
 {if $activity->location}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -127,7 +127,7 @@
               {/if}
             {else}
               <div class="label">{$form.start_date.label}</div>
-              <div class="content">{$start_date_display|date_format}</div>
+              <div class="content">{$start_date_display|crmDate:'%b %e, %Y'}</div>
             {/if}
             <div class="clear"></div>
           </div>

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -37,7 +37,7 @@
                 <div id='help'>
                   {* Lifetime memberships have no end-date so current_membership array key exists but is NULL *}
                   {if $row.current_membership}
-                    {if $row.current_membership|date_format:"%Y%m%d" LT $smarty.now|date_format:"%Y%m%d"}
+                    {if $row.current_membership|crmDate:"%Y%m%d" LT $smarty.now|crmDate:"%Y%m%d"}
                       {ts 1=$row.current_membership|crmDate 2=$row.name}Your <strong>%2</strong> membership expired on %1.{/ts}<br />
                     {else}
                       {ts 1=$row.current_membership|crmDate 2=$row.name}Your <strong>%2</strong> membership expires on %1.{/ts}<br />
@@ -180,7 +180,7 @@
             {* Check if there is an existing membership of this type (current_membership NOT empty) and if the end-date is prior to today. *}
             {if array_key_exists( 'current_membership', $row ) AND $context EQ "makeContribution" }
               {if $row.current_membership}
-                {if $row.current_membership|date_format:"%Y%m%d" LT $smarty.now|date_format:"%Y%m%d"}
+                {if $row.current_membership|crmDate:"%Y%m%d" LT $smarty.now|crmDate:"%Y%m%d"}
                   <br /><em>{ts 1=$row.current_membership|crmDate 2=$row.name}Your <strong>%2</strong> membership expired on %1.{/ts}</em>
                 {else}
                   <br /><em>{ts 1=$row.current_membership|crmDate 2=$row.name}Your <strong>%2</strong> membership expires on %1.{/ts}</em>

--- a/templates/CRM/Core/Calendar/ICal.tpl
+++ b/templates/CRM/Core/Calendar/ICal.tpl
@@ -27,7 +27,7 @@ CALSCALE:GREGORIAN
 DTSTAMP;TZID={$timezone}:{$event.start_date|crmICalDate}
 DTSTART;TZID={$timezone}:{$event.start_date|crmICalDate}
 {else}
-DTSTAMP;TZID={$timezone}:{$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'|crmICalDate}
+DTSTAMP;TZID={$timezone}:{$smarty.now|crmDate:'%Y-%m-%d %H:%M:%S'|crmICalDate}
 {/if}
 {if $event.end_date}
 DTEND;TZID={$timezone}:{$event.end_date|crmICalDate}

--- a/templates/CRM/Core/Calendar/Rss.tpl
+++ b/templates/CRM/Core/Calendar/Rss.tpl
@@ -27,8 +27,8 @@
 {/if}
 {if $event.start_date}{ts}When{/ts}: {$event.start_date|crmDate}{if $event.end_date} {ts}through{/ts} {strip}
         {* Only show end time if end date = start date *}
-        {if $event.end_date|date_format:"%Y%m%d" == $event.start_date|date_format:"%Y%m%d"}
-            {$event.end_date|date_format:"%I:%M %p"}
+        {if $event.end_date|crmDate:"%Y%m%d" == $event.start_date|crmDate:"%Y%m%d"}
+            {$event.end_date|crmDate:"%I:%M %p"}
         {else}
             {$event.end_date|crmDate}
         {/if}{/strip}

--- a/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
+++ b/templates/CRM/Event/Form/Registration/EventInfoBlock.tpl
@@ -24,7 +24,7 @@
         {if $event.event_end_date}
             &nbsp; {ts}through{/ts} &nbsp;
             {* Only show end time if end date = start date *}
-            {if $event.event_end_date|date_format:"%Y%m%d" == $event.event_start_date|date_format:"%Y%m%d"}
+            {if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}
                 {$event.event_end_date|crmDate:0:1}
             {else}
                 {$event.event_end_date|crmDate}

--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -60,7 +60,7 @@
     <td class="right nowrap crm-participant-participant_fee_amount">{$row.participant_fee_amount|crmMoney:$row.participant_fee_currency}</td>
     <td class="crm-participant-participant_register_date">{$row.participant_register_date|truncate:10:''|crmDate}</td>
     <td class="crm-participant-event_start_date">{$row.event_start_date|truncate:10:''|crmDate}
-        {if $row.event_end_date && $row.event_end_date|date_format:"%Y%m%d" NEQ $row.event_start_date|date_format:"%Y%m%d"}
+        {if $row.event_end_date && $row.event_end_date|crmDate:"%Y%m%d" NEQ $row.event_start_date|crmDate:"%Y%m%d"}
             <br/>- {$row.event_end_date|truncate:10:''|crmDate}
         {/if}
    </td>

--- a/templates/CRM/Event/Form/Task/Print.tpl
+++ b/templates/CRM/Event/Form/Task/Print.tpl
@@ -43,7 +43,7 @@
         {/if}
         <td class="crm-event-print-event_participant_fee_amount">{$row.participant_fee_amount|crmMoney}</td>
         <td class="crm-event-print-event_date">{$row.event_start_date|truncate:10:''|crmDate}
-          {if $row.event_end_date && $row.event_end_date|date_format:"%Y%m%d" NEQ $row.event_start_date|date_format:"%Y%m%d"}
+          {if $row.event_end_date && $row.event_end_date|crmDate:"%Y%m%d" NEQ $row.event_start_date|crmDate:"%Y%m%d"}
               <br/>- {$row.event_end_date|truncate:10:''|crmDate}
           {/if}
         </td>

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -106,7 +106,7 @@
             {if $event.event_end_date}
                 &nbsp;{ts}through{/ts}&nbsp;
                 {* Only show end time if end date = start date *}
-                {if $event.event_end_date|date_format:"%Y%m%d" == $event.event_start_date|date_format:"%Y%m%d"}
+                {if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}
                     {$event.event_end_date|crmDate:0:1}
                 {else}
                     {$event.event_end_date|crmDate}

--- a/templates/CRM/Event/Page/List.tpl
+++ b/templates/CRM/Event/Page/List.tpl
@@ -32,7 +32,7 @@
         <td class="nowrap" data-order="{$event.start_date|crmDate:'%Y-%m-%d'}">
           {if $event.start_date}{$event.start_date|crmDate}{if $event.end_date}<br /><em>{ts}through{/ts}</em><br />{strip}
             {* Only show end time if end date = start date *}
-            {if $event.end_date|date_format:"%Y%m%d" == $event.start_date|date_format:"%Y%m%d"}
+            {if $event.end_date|crmDate:"%Y%m%d" == $event.start_date|crmDate:"%Y%m%d"}
               {$event.end_date|crmDate:0:1}
             {else}
               {$event.end_date|crmDate}

--- a/templates/CRM/Event/Page/UserDashboard.tpl
+++ b/templates/CRM/Event/Page/UserDashboard.tpl
@@ -31,7 +31,7 @@
                             {if $row.event_end_date}
                                 &nbsp; - &nbsp;
                                 {* Only show end time if end date = start date *}
-                                {if $row.event_end_date|date_format:"%Y%m%d" == $row.event_start_date|date_format:"%Y%m%d"}
+                                {if $row.event_end_date|crmDate:"%Y%m%d" == $row.event_start_date|crmDate:"%Y%m%d"}
                                     {$row.event_end_date|crmDate:0:1}
                                 {else}
                                     {$row.event_end_date|crmDate}

--- a/templates/CRM/common/l10n.js.tpl
+++ b/templates/CRM/common/l10n.js.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}// http://civicrm.org/licensing
-// <script> Generated {$smarty.now|date_format:'%d %b %Y %H:%M:%S'}
+// <script> Generated {$smarty.now|crmDate:'%d %b %Y %H:%M:%S'}
 {* This file should only contain strings and settings which rarely change *}
 (function($) {ldelim}
   // Config settings

--- a/templates/CRM/common/navigation.js.tpl
+++ b/templates/CRM/common/navigation.js.tpl
@@ -28,7 +28,7 @@
       </li>
     {$navigation}
   </ul>
-{/strip}{/capture}// <script> Generated {$smarty.now|date_format:'%d %b %Y %H:%M:%S'}
+{/strip}{/capture}// <script> Generated {$smarty.now|crmDate:'%d %b %Y %H:%M:%S'}
 {literal}
 (function($) {
   var menuMarkup = {/literal}{$menuMarkup|@json_encode}{literal};


### PR DESCRIPTION
…trftime which is deprecated in php8.1

Overview
----------------------------------------
This aims to eliminate from CiviCRM's code calls that generate calls to strftime by replacing the date_modifier calls with crmDate which handles similar sort of thing without the deprecated function

Before
----------------------------------------
Smarty Date Modifier used in these places

After
----------------------------------------
CiviCRM's date modifier is used

ping @totten @demeritcowboy 