### PR TITLE
Fix breakage in message preview on workflow contributions

### DIFF
--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.ex.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.ex.php
@@ -54,6 +54,10 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
   private function addExampleData(GenericWorkflowMessage $messageTemplate): void {
     $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
     $messageTemplate->setContribution(\Civi\Test::example('entity/Contribution/Euro5990/completed'));
+    $mockOrder = new CRM_Financial_BAO_Order();
+    $mockOrder->setTemplateContributionID(50);
+    $mockOrder->setPriceSetToDefault('contribution');
+    $messageTemplate->setOrder($mockOrder);
   }
 
 }

--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -17,7 +17,7 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
 
   /**
    * @var int
-   * @scope tokenContext as contribution_id
+   * @scope tokenContext as contributionId
    */
   public $contributionId;
 
@@ -41,7 +41,7 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    * @return \CRM_Financial_BAO_Order|null
    */
   private function getOrder(): ?CRM_Financial_BAO_Order {
-    if ($this->contributionId) {
+    if (!$this->order && $this->contributionId) {
       $this->order = new CRM_Financial_BAO_Order();
       $this->order->setTemplateContributionID($this->contributionId);
     }
@@ -65,6 +65,10 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    * @return bool
    */
   public function getIsShowLineItems(): bool {
+    if (isset($this->isShowLineItems)) {
+      return $this->isShowLineItems;
+    }
+
     $order = $this->getOrder();
     if (!$order) {
       // This would only be the case transitionally.
@@ -72,7 +76,7 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
       // always have the contribution ID available as well as migrated ones.
       return FALSE;
     }
-    return $this->order->getPriceSetMetadata()['is_quick_config'];
+    return !$this->order->getPriceSetMetadata()['is_quick_config'];
   }
 
   /**
@@ -87,6 +91,21 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
     if (!empty($contribution['id'])) {
       $this->contributionId = $contribution['id'];
     }
+    return $this;
+  }
+
+  /**
+   * Set order object.
+   *
+   * Note this is only supported for core use (specifically in example work flow)
+   * as the contract might change.
+   *
+   * @param CRM_Financial_BAO_Order $order
+   *
+   * @return $this
+   */
+  public function setOrder(CRM_Financial_BAO_Order $order): self {
+    $this->order = $order;
     return $this;
   }
 

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -451,6 +451,12 @@ class CRM_Financial_BAO_Order {
       foreach ($this->getPriceOptions() as $fieldID => $valueID) {
         $this->setPriceSetIDFromSelectedField($fieldID);
       }
+      if (!$this->priceSetID && $this->getTemplateContributionID()) {
+        // Load the line items from the contribution.
+        foreach ($this->getLineItems() as $lineItem) {
+          return $lineItem['price_field_id.price_set_id'];
+        }
+      }
     }
     return $this->priceSetID;
   }
@@ -1099,6 +1105,7 @@ class CRM_Financial_BAO_Order {
         'entity_id',
         'entity_table',
         'price_field_id',
+        'price_field_id.price_set_id',
         'price_field_value_id',
         'financial_type_id',
         'label',


### PR DESCRIPTION
Overview
----------------------------------------

Fix breakage in message preview on workflow contributions

Before
----------------------------------------
Failure to render message preview for offline contributions in message admin ui

After
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/173732609-dc298458-bb2e-44d6-92d2-3b52dd6b7cd5.png)

Technical Details
----------------------------------------
There is a sort-of regression fix in here - `isShowLineItems` was being assigned in reverse - but I don't think we encouraged that tpl change so probably no-one will be much affected - but I can switch to the rc if preferred. Perhaps there is a case for that since it will be the ESR & we will be stuck with it for longer - 

Comments
----------------------------------------
