### PR TITLE
SearchKit - Only add filter values to Afform title if passed internally

### DIFF
--- a/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
+++ b/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
@@ -1,9 +1,8 @@
 <div af-fieldset="">
   <af-field name="source" />
-  <af-field name="contact_type" />
   <div class="af-container af-layout-inline">
     <af-field name="Contact_Email_contact_id_01.email" />
     <af-field name="Contact_Email_contact_id_01.location_type_id" defn="{input_attrs: {multiple: true}}" />
   </div>
-  <crm-search-display-table filters="{last_name: 'AfformTest'}" search-name="TestContactEmailSearch" display-name="TestContactEmailDisplay"></crm-search-display-table>
+  <crm-search-display-table filters="{last_name: 'AfformTest', contact_type: dummy_var}" search-name="TestContactEmailSearch" display-name="TestContactEmailDisplay"></crm-search-display-table>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This narrows the scope of contextual titles from #22319 to only those filters passed internally, as used in drilldown forms.

Before
----------------------------------------
Search form titles affected by exposed filters.

After
----------------------------------------
Search form titles only affected by internal filters.


Comments
----------------------------------------
It makes sense to exclude values from exposed filters because that can lead to a confusing UI.