### PR TITLE
Fix bug whereby editing contribution_recur.amount was not updating single-line-item-template-contributions

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -9,7 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
 use Civi\Api4\ContributionRecur;
+use Civi\Api4\LineItem;
 
 /**
  * Class CRM_Contribute_BAO_ContributionRecurTest
@@ -284,7 +286,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     // Make sure a template contribution exists.
     $templateContributionId = CRM_Contribute_BAO_ContributionRecur::ensureTemplateContributionExists($contributionRecur['id']);
     $fetchedTemplate = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($contributionRecur['id']);
-    $templateContribution = \Civi\Api4\Contribution::get(FALSE)
+    $templateContribution = Contribution::get(FALSE)
       ->addSelect('*', 'custom.*')
       ->addWhere('contribution_recur_id', '=', $contributionRecur['id'])
       ->addWhere('is_template', '=', 1)
@@ -378,7 +380,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);
     $contributionRecur = reset($contributionRecur['values']);
     // Create the template
-    $templateContrib = $this->callAPISuccess('Contribution', 'create', [
+    $templateContribution = $this->callAPISuccess('Contribution', 'create', [
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '3.00',
       'financial_type_id' => 1,
@@ -390,13 +392,14 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       'receive_date' => 'yesterday',
       'is_template' => 1,
     ]);
+    // Now update the template amount so we can test that this route updates the recur.
     $this->callAPISuccess('Contribution', 'create', [
-      'id' => $templateContrib['id'],
+      'id' => $templateContribution['id'],
       'contribution_recur_id' => $contributionRecur['id'],
       'total_amount' => '2.00',
       'currency' => 'USD',
     ]);
-    $updatedContributionRecur = \Civi\Api4\ContributionRecur::get(FALSE)
+    $updatedContributionRecur = ContributionRecur::get()
       ->addWhere('id', '=', $contributionRecur['id'])
       ->execute()
       ->first();
@@ -406,6 +409,20 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
       strtotime($contributionRecur['modified_date']),
       strtotime($updatedContributionRecur['modified_date'])
     );
+    // Now check the reverse - update the recur & the template should update as there
+    // is a single line item.
+    ContributionRecur::update()
+      ->addWhere('id', '=', $contributionRecur['id'])
+      ->setValues(['amount' => 6])
+      ->execute();
+
+    $this->assertEquals(6, Contribution::get()
+      ->addWhere('id', '=', $templateContribution['id'])
+      ->addSelect('total_amount')->execute()->first()['total_amount']);
+    $this->assertEquals(6, LineItem::get()
+      ->addWhere('contribution_id', '=', $templateContribution['id'])
+      ->addGroupBy('contribution_id')
+      ->addSelect('SUM(line_total) AS total_amount')->execute()->first()['total_amount']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix bug whereby editing contribution_recur.amount was not updating single-row line items

Before
----------------------------------------
Updates to `contribution_recur.amount` were not updating the total of the template contribution - this is permitted and appropriate in the case of single row line items


After
----------------------------------------
If `contribution_recur.amount` is updated it checks to see if it is a single row line item and if so if the total has changed. If so it updates the contribution. The restores us to the situation which regressed sometime in ? the last eleven months ? where the changes to  `contribution_recur.amount` stopped affecting future contributions

Technical Details
----------------------------------------
We have permitted changing the amount on single line items for many years through the UI. But we block them on multiple rows. Ideally we would block them through the api too - but then we have the situation where the lines have already been updated and the post hook in that process is calling this - which is out of scope for this PR

Comments
----------------------------------------
Note this is needed for Api initiated changes regardless of whether we re-freeze the UI and there is no need to freeze the UI with this change made - however, if people really want to force users to use `lineitemeditor` we can have that discussion via the dev-digest

Also note that we ideally would figure out when the `civicrm_contribution_recur.amount` stopped being authoritative (if set) in the specific `repeattransaction` flow - & figure out if data issues need fixing - but at this stage I think that is probably outside the 'recent regression' timeframe

@mattwire @KarinG @adixon @seamuslee001 