### PR TITLE
message_admin - Enable another preview mode ("HTML (Raw)")

### DIFF
--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -251,7 +251,8 @@
         formatName: 'msg_html',
         formats: [
           {id: 0, name: 'msg_html', label: ts('HTML')},
-          {id: 1, name: 'msg_text', label: ts('Text')}
+          {id: 1, name: 'msg_html_raw', label: ts('HTML (Raw)')},
+          {id: 2, name: 'msg_text', label: ts('Text')}
         ],
         revisionName: $ctrl.tab,
         revisions: _.reduce(revisionTypes, function(acc, revType){

--- a/ext/message_admin/ang/crmMsgadm/Preview.html
+++ b/ext/message_admin/ang/crmMsgadm/Preview.html
@@ -91,6 +91,16 @@
           </div>
         </div>
 
+        <div class="form-group" ng-if="!$ctrl.preview.loading && model.formats[$ctrl.formatId].name === 'msg_html_raw'">
+          <div class="jumbotron well col-sm-12">
+            <!-- <textarea ng-model="$ctrl.preview.html"></textarea> -->
+            <div ng-model="$ctrl.preview.html"
+                 ng-disabled="true"
+                 crm-monaco="$ctrl.monacoOptions({language: 'html', crmHeightPct: 0.5})"
+            ></div>
+          </div>
+        </div>
+
       </div>
 
     </div>


### PR DESCRIPTION
Overview
----------------------------------------

Adds another preview mode to `message_admin`. This is similar to the "HTML" preview, except it shows the raw HTML (with syntax highlighting) which may help debugging fiddly edits to the markup.

cc @eileenmcnaughton 

Before
----------------------------------------

Two formats, "HTML" and "Text":

<img width="1176" alt="Screen Shot 2022-06-15 at 6 07 38 PM" src="https://user-images.githubusercontent.com/1336047/173970164-8fb3302e-e52d-485a-9619-f53c607bdf68.png">

After
----------------------------------------

Three formats, "HTML", "HTML (Raw)", and "Text":

<img width="1164" alt="Screen Shot 2022-06-15 at 6 07 14 PM" src="https://user-images.githubusercontent.com/1336047/173970161-f8602a19-c258-43d2-a0e8-fd55c02fe218.png">

Comments
----------------------------------------

AFAICS, there would be no reason to add "Text (Raw)" format.

(Commit is mergeable with 5.51 or master, but master probably makes more sense.)