### PR TITLE
(REF) TokenProcessor - Tweak error message

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -480,7 +480,7 @@ class TokenProcessor {
           return $value->getAmount();
 
         default:
-          throw new \CRM_Core_Exception("Invalid token filter: $filter");
+          throw new \CRM_Core_Exception("Invalid token filter: " . json_encode($filter, JSON_UNESCAPED_SLASHES));
       }
     }
 
@@ -502,7 +502,7 @@ class TokenProcessor {
         }
 
       default:
-        throw new \CRM_Core_Exception("Invalid token filter: $filter");
+        throw new \CRM_Core_Exception("Invalid token filter: " . json_encode($filter, JSON_UNESCAPED_SLASHES));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This is a small refinement to an error message.

Before
----------------------------------------

In some environments/error-scenarios, this old code produces a double-error...

```php
 throw new \CRM_Core_Exception("Invalid token filter: $filter");
```

i.e. there's the primary error that is intended to be thrown, and there is a secondary error because `$filter` is not a string (*it's an `array`*). (One supposes that more lenient environments would downcast `$filter` to string literal `'Array'`, but I haven't tested, and it's not good behavior either.)

After
----------------------------------------

The primary error is thrown with more readable data.

Comments
----------------------------------------

If you read the current code around in this function, it really looks like `$filter` should normally be an array.