### PR TITLE
dev/core#3662 increase length of import table status message

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -470,7 +470,7 @@ abstract class CRM_Import_DataSource {
        ADD COLUMN _entity_id INT,
        " . $this->getAdditionalTrackingFields() . "
        ADD COLUMN _status VARCHAR(32) DEFAULT 'NEW' NOT NULL,
-       ADD COLUMN _status_message TEXT,
+       ADD COLUMN _status_message LONGTEXT,
        ADD COLUMN _id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
        ADD INDEX(_id),
        ADD INDEX(_status)


### PR DESCRIPTION


Overview
----------------------------------------
This addresses https://lab.civicrm.org/dev/core/-/issues/3662 but
I think the underlying issue is that it has matched so many contacts, for
some reason, that the list of them is longer than 65,535 characters
so it is addressing a symptom, not the cause. 65,535 characters
feels like it should be long enough but changing to LONGTEXT
for a single field seems harmless so I'm a little on the
fence - but even if it just helps us debug....

Before
----------------------------------------
`_status_message` field in import tracking table is `TEXT`

After
----------------------------------------
`_status_message` field in import tracking table is `LONGTEXT`

Technical Details
----------------------------------------

Comments
----------------------------------------