### PR TITLE
dev/core#3663 fix output regression on csv output for import

### DIFF
--- a/CRM/Core/CodeGen/Main.php
+++ b/CRM/Core/CodeGen/Main.php
@@ -57,6 +57,23 @@ class CRM_Core_CodeGen_Main {
   public $sourceDigest;
 
   /**
+   * Should the specification be allowed to echo output.
+   *
+   * @var bool
+   */
+  protected $verbose = TRUE;
+
+  /**
+   * @param bool $verbose
+   *
+   * @return CRM_Core_CodeGen_Main
+   */
+  public function setVerbose(bool $verbose): CRM_Core_CodeGen_Main {
+    $this->verbose = $verbose;
+    return $this;
+  }
+
+  /**
    * @param $CoreDAOCodePath
    * @param $sqlCodePath
    * @param $phpCodePath
@@ -142,7 +159,7 @@ Alternatively you can get a version of CiviCRM that matches your PHP version
   public function init() {
     if (!$this->database || !$this->tables) {
       $specification = new CRM_Core_CodeGen_Specification();
-      $specification->parse($this->schemaPath, $this->buildVersion);
+      $specification->parse($this->schemaPath, $this->buildVersion, $this->verbose);
       $this->database = $specification->database;
       $this->tables = $specification->tables;
     }

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -273,6 +273,24 @@ abstract class CRM_Import_DataSource {
   }
 
   /**
+   * Get the field names of the fields holding data in the import tracking table.
+   *
+   * @return array
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   */
+  public function getDataFieldNames(): array {
+    $result = CRM_Core_DAO::executeQuery(
+      'SHOW FIELDS FROM ' . $this->getTableName() . "
+      WHERE Field NOT LIKE '\_%'");
+    $fields = [];
+    while ($result->fetch()) {
+      $fields[] = $result->Field;
+    }
+    return $fields;
+  }
+
+  /**
    * Get an array of column headers, if any.
    *
    * Null is returned when there are none - ie because a csv file does not
@@ -572,7 +590,7 @@ abstract class CRM_Import_DataSource {
    * @return string
    */
   private function getSelectClause(): string {
-    return $this->getSelectFields() ? implode(', ', $this->getSelectFields()) : '*';
+    return $this->getSelectFields() ? '`' . implode('`, `', $this->getSelectFields()) . '`' : '*';
   }
 
   /**

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -131,6 +131,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
 
       $strtolower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
       $columns = array_map($strtolower, $firstrow);
+      $columns = array_map('trim', $columns);
       $columns = str_replace(' ', '_', $columns);
       $columns = preg_replace('/[^a-z_]/', '', $columns);
 

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -84,11 +84,9 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
     $tableName = $table->getName();
     $table->createWithQuery($this->getSubmittedValue('sqlQuery'));
 
-    // Get the names of the fields to be imported. Any fields starting with an
-    // underscore are considered to be internal to the import process)
+    // Get the names of the fields to be imported.
     $columnsResult = CRM_Core_DAO::executeQuery(
-      'SHOW FIELDS FROM ' . $tableName . "
-      WHERE Field NOT LIKE '\_%'");
+      'SHOW FIELDS FROM ' . $tableName);
 
     $columnNames = [];
     while ($columnsResult->fetch()) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -795,7 +795,7 @@ abstract class CRM_Import_Parser {
   /**
    * Determines the file name based on error code.
    *
-   * @var $type error code constant
+   * @var int $type code constant
    * @return string
    */
   public static function saveFileName($type) {

--- a/CRM/Utils/PDF/Document.php
+++ b/CRM/Utils/PDF/Document.php
@@ -68,7 +68,7 @@ class CRM_Utils_PDF_Document {
       'marginBottom' => self::toTwip(CRM_Core_BAO_PdfFormat::getValue('margin_bottom', $format), $metric),
       'marginLeft' => self::toTwip(CRM_Core_BAO_PdfFormat::getValue('margin_left', $format), $metric),
     ];
-    if (CIVICRM_UF === 'UnitTests' && headers_sent()) {
+    if (CIVICRM_UF === 'UnitTests') {
       // Streaming content will 'die' in unit tests unless ob_start()
       // has been called.
       throw new CRM_Core_Exception_PrematureExitException('_html2doc called', [

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -190,12 +190,13 @@ class CRM_Utils_PDF_Utils {
     }
     // CRM-19183 remove .pdf extension from filename
     $fileName = basename($fileName, ".pdf");
-    if (CIVICRM_UF === 'UnitTests' && headers_sent()) {
+    if (CIVICRM_UF === 'UnitTests') {
       // Streaming content will 'die' in unit tests unless ob_start()
       // has been called.
       throw new CRM_Core_Exception_PrematureExitException('_html2pdf_dompdf called', [
         'html' => $html,
         'fileName' => $fileName,
+        'output' => 'pdf',
       ]);
     }
     $dompdf->stream($fileName);

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -117,7 +117,7 @@ class Test {
           throw new \RuntimeException("\\Civi\\Test::headless() requires CIVICRM_UF=UnitTests");
         }
         $dbName = \Civi\Test::dsn('database');
-        echo "Installing {$dbName} schema\n";
+        fprintf(STDERR, "Installing {$dbName} schema\n");
         \Civi\Test::schema()->dropAll();
       }, 'headless-drop')
       ->coreSchema()

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -166,6 +166,7 @@ class Test {
     if (!isset(self::$singletons['codeGen'])) {
       $civiRoot = str_replace(DIRECTORY_SEPARATOR, '/', dirname(__DIR__));
       $codeGen = new \CRM_Core_CodeGen_Main("$civiRoot/CRM/Core/DAO", "$civiRoot/sql", $civiRoot, "$civiRoot/templates", NULL, "UnitTests", NULL, "$civiRoot/xml/schema/Schema.xml", NULL);
+      $codeGen->setVerbose(FALSE);
       $codeGen->init();
       self::$singletons['codeGen'] = $codeGen;
     }

--- a/tests/phpunit/CRM/Contact/Import/Form/data/column_names_casing.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/column_names_casing.csv
@@ -1,0 +1,2 @@
+FIRSTNAME,LASTNAME,ID,IND/ORG,Do Not Mail,Valid Address
+Mary,Jones,1,Individual,0,Yes

--- a/tests/phpunit/CRM/Report/Utils/ReportTest.php
+++ b/tests/phpunit/CRM/Report/Utils/ReportTest.php
@@ -125,12 +125,7 @@ ENDOUTPUT;
    * Test when you choose PDF from the actions dropdown.
    *
    * We're not too concerned about the actual report rows - there's other
-   * tests for that - we're more interested in does it echo it in pdf
-   * format.
-   *
-   * This isn't great but otherwise dompdf complains about headers already sent.
-   * @runInSeparateProcess
-   * @preserveGlobalState disabled
+   * tests for that - we're more interested in does it hit the pdf output function.
    */
   public function testOutputPdf(): void {
     $contents = '';
@@ -159,11 +154,8 @@ ENDOUTPUT;
       $_SERVER['QUERY_STRING'] = 'reset=1';
     }
 
-    // A bit weird - it will send the output to the browser, which here is the
-    // console, then throw a specific exception. So we capture the output
-    // and the exception.
+    // In the unit text context it throws an exception for us to check.
     try {
-      ob_start();
       CRM_Report_Utils_Report::processReport([
         'instanceId' => $report_instance['id'],
         'format' => 'pdf',
@@ -171,9 +163,9 @@ ENDOUTPUT;
       ]);
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {
-      $contents = ob_get_clean();
+      $contents = $e->errorData['html'];
+      $this->assertEquals('pdf', $e->errorData['output']);
     }
-    $this->assertStringStartsWith('%PDF', $contents);
     $this->assertStringContainsString("id_value={$last_contact['id']}", $contents);
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
This fixes a very-recent rc regression whereby the file error output was
not correctly referring to the fields to be exported.


Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3663

After
----------------------------------------
Fixed, tested

Technical Details
----------------------------------------
Note that in order to make it testable I had to
- remove header-setting that duplicates work done by the csv package
- remove extraneous echos in the GenCode


Comments
----------------------------------------
