### PR TITLE
(dev/core#3660) Ensure that rebuildMenuAndCaches has current mixins+classloaders

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -379,6 +379,10 @@ class CRM_Core_Invoke {
     $config = CRM_Core_Config::singleton();
     $config->clearModuleList();
 
+    // dev/core#3660 - Activate any new classloaders/mixins/etc before re-hydrating any data-structures.
+    CRM_Extension_System::singleton()->getClassLoader()->refresh();
+    CRM_Extension_System::singleton()->getMixinLoader()->run(TRUE);
+
     // also cleanup all caches
     $config->cleanupCaches($sessionReset || CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'));
 


### PR DESCRIPTION
Overview
--------

This fixes an issue in transitioning from `hook_managed` to `mixin/mgd-php@1`, wherein managed-entities are briefly deleted (but later recreated).

See also: https://lab.civicrm.org/dev/core/-/issues/3660

ping @colemanw 

Steps to Reproduce
------------------

1. (Web) Install an extension with a revision that uses `hook_managed` to load `*.mgd.php` files
2. (CLI) View contents of `civicrm_managed`
3. (CLI) Switch the extension to a revision that uses `mixin/mgd-php@1` to load `*.mgd.php` files
4. (Web) Run `civicrm/menu/rebuild`
5. (CLI) View contents of `civicrm_managed`
6. (Web) Run `civicrm/menu/rebuild`
7. (CLI) View contents of `civicrm_managed`

Before
------

While processing step 4 (`civicrm/menu/rebuild`), it fails to run the hooks for `mgd-php`.

Consequently, managed-entities are (temporarily) lost/destroyed  - and will be missing at step 5.

After
-----

While processing step 4 (`civicrm/menu/rebuild`), it activates the hooks for `mgd-php`.

Consequently, managed-entities are preserved.

Technical Details
------------------

When processing `civicrm/menu/rebuild`, there are a couple big substeps:

* `Civi\Core\Container::boot()` - During this process, it loads extensions. As usual,  this reads cached metadata, sets up classloaders, sets up mixins/hooks, etc.
* `CRM_Core_Invoke::rebuildMenuAndCaches()` - During this process, it clears out caches and rebuilds several things (menus, managed-entities, etc).

The problem is this:

* The cache used during `boot()` has stale metadata (specifically,  `civicrm_cache` has old values of `mixinScan` and `mixinBoot`).  So it doesn't setup any new mixins/hooks.
* Then `rebuildMenuAndCaches()` depends on the mixins/hooks that are already setup.  While the function does clear persistent caches, it assumes that the  PHP runtime environment is up-to-spec. But it's not -- because our hooks  were based on the old caches.

This patch uses the same `refresh()` mechanism as the extension-administration subsystem (which has to reset the classloaders+mixins after enabling or disabling an extension).
