### PR TITLE
CiviCRM, Events RSS feed does not output a pubDate for each Event, use the Event Start Date as the pubDate which is generally how other Event systems use RSS

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmRSSPubDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmRSSPubDate.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Format the given date to RSS pubDate RFC822 format,
+ * http://www.w3.org/Protocols/rfc822/#z28
+ *
+ * @param string $dateString
+ *   Date which needs to converted to RFC822 format.
+ *
+ * @return string
+ *   formatted text
+ */
+function smarty_modifier_crmRSSPubDate($dateString): string {
+  $now = new DateTime('Now');
+
+  if ($dateString) {
+    try {
+      $date = new DateTime($dateString);
+      return $date->format($date::RFC822);
+    }
+    catch (Exception $e) {
+      return $now->format($now::RFC822);
+    }
+  }
+  return $now->format($now::RFC822);
+}

--- a/templates/CRM/Core/Calendar/Rss.tpl
+++ b/templates/CRM/Core/Calendar/Rss.tpl
@@ -19,6 +19,8 @@
 {foreach from=$events key=uid item=event}
 <item>
 <title>{$event.title|escape:'html'}</title>
+{* pubDate must follow RFC822 format *}
+<pubDate>{$event.start_date|crmRSSPubDate}</pubDate>
 <link>{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`" fe=1 a=1}</link>
 <description>
 {if $event.summary}{$event.summary|escape:'html'}


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM, Events RSS feed does not output a pubDate for each Event, use the Event Start Date as the pubDate which is generally how other Event systems use RSS.

If there is a system consuming the RSS feed, for example to display a list of events on the website. Then the Event Date is not exposed in a machine readable way in the RSS feed.

Before
----------------------------------------
No pubDate. RSS feed has no temporal data.

After
----------------------------------------
pubDate is set and uses Event Start DAte. RSS feed has temporal data. Event Start Date can easily be extracted.

Technical Details
----------------------------------------

Comments
----------------------------------------
And no, I am not writing a unit test for RSS feeds.

Agileware Ref: CIVICRM-1998