### PR TITLE
Handle empty date token gracefully

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -500,6 +500,9 @@ class TokenProcessor {
           require_once 'CRM/Core/Smarty/plugins/modifier.crmDate.php';
           return \smarty_modifier_crmDate($value->format('Y-m-d H:i:s'), $filter[1] ?? NULL);
         }
+        if ($value === '') {
+          return $value;
+        }
 
       default:
         throw new \CRM_Core_Exception("Invalid token filter: $filter");


### PR DESCRIPTION
Overview
----------------------------------------
Handle empty date token gracefully

Before
----------------------------------------
Error on date tokens that are empty

After
----------------------------------------
Handled

Technical Details
----------------------------------------
@totten this is the issue you hit - I will put up for 5.50 too -  since the fix is safe & sensible & this could pop up as a hard-to-find regression in various workflows

Comments
----------------------------------------
