### PR TITLE
dev/core#2983 - Make static function static - AJAX::caseDetails()

### DIFF
--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -83,7 +83,7 @@ class CRM_Case_Page_AJAX {
   /**
    * @throws \CiviCRM_API3_Exception
    */
-  public function caseDetails() {
+  public static function caseDetails() {
     $caseId = CRM_Utils_Type::escape($_GET['caseId'], 'Positive');
 
     $case = civicrm_api3('Case', 'getsingle', [
@@ -98,7 +98,7 @@ class CRM_Case_Page_AJAX {
                                   <tr><td>" . ts('Case Type') . "</td><td>{$caseTypes[$case['case_type_id']]}</td></tr>
                                   <tr><td>" . ts('Case Status') . "</td><td>{$caseStatuses[$case['status_id']]}</td></tr>
                                   <tr><td>" . ts('Case Start Date') . "</td><td>" . CRM_Utils_Date::customFormat($case['start_date']) . "</td></tr>
-                                  <tr><td>" . ts('Case End Date') . "</td><td></td></tr>" . CRM_Utils_Date::customFormat($case['end_date']) . "</table>";
+                                  <tr><td>" . ts('Case End Date') . "</td><td>" . (isset($case['end_date']) ? CRM_Utils_Date::customFormat($case['end_date']) : '') . "</td></tr></table>";
 
     if (CRM_Utils_Array::value('snippet', $_GET) == 'json') {
       CRM_Core_Page_AJAX::returnJsonResponse($caseDetails);


### PR DESCRIPTION
Overview
----------------------------------------
Related to https://lab.civicrm.org/dev/core/-/issues/2983

Deprecated function: Non-static method CRM_Case_Page_AJAX::caseDetails() should not be called statically in CRM_Core_Invoke::runItem() (line 285 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Invoke.php)

Also an error about end_date missing when there is no end_date. And the html is broken when there is one.

Before
----------------------------------------
1. Because ajax swallows it, you need to first turn off popups at administer - customize - display prefs, or install the loudnotices extension and then view the error 500 response in the network tab.
1. Create a case.
1. Run the case details civireport.
1. Click on the subject. (Because we turned off popups, this is going to seem like it's a useless feature, and there's an argument that even with popups on it's not that useful since normally you would add columns to the report, but just act like everything is fine.)
1. Now go to any other civi page. Now the error appears.

After
----------------------------------------
Better

Technical Details
----------------------------------------

Comments
----------------------------------------
The only other places this function is used is as described in the lab ticket, but other than handling the same error I'm not addressing the larger questions here.