### PR TITLE
Call hooks when deleting an option value from CustomOption BAO

### DIFF
--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -194,12 +194,7 @@ AND    g.id    = v.option_group_id";
       self::updateValue($optionId, $value);
 
       // also delete this option value
-      $query = "
-DELETE
-FROM   civicrm_option_value
-WHERE  id = %1";
-      $params = [1 => [$optionId, 'Integer']];
-      CRM_Core_DAO::executeQuery($query, $params);
+      CRM_Core_BAO_OptionValue::deleteRecord(['id' => $optionId]);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3668](https://lab.civicrm.org/dev/core/-/issues/3668) by ensuring hooks are called.
Replaces #23833

Before
----------------------------------------
No hooks called when `CRM_Core_BAO_CustomOption` deletes an OptionValue.

After
----------------------------------------
Hooks called
