### PR TITLE
dev/core#3667 fix failure to match existing contacts in skip mode

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1742,7 +1742,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         unset($params['relationship']);
       }
       $id = $this->getPossibleContactMatch($params, $extIDMatch, $this->getSubmittedValue('dedupe_rule_id') ?: NULL);
-      if ($id && $this->isSkipDuplicates()) {
+      if ($id && $isMainContact && $this->isSkipDuplicates()) {
         throw new CRM_Core_Exception(ts('Contact matched by dedupe rule already exists in the database.'), CRM_Import_Parser::DUPLICATE);
       }
       return $id;

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_related_create.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_related_create.csv
@@ -1,0 +1,3 @@
+First Name,Last Name,Dad first name,Dad Last name,Dad email
+Bob,Smith,William,The Kid,billy-the-kid@example.com
+Sarah,Smith,Bill,The Grandkid,Billy-the-grand-kid@example.com

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -94,4 +94,11 @@ trait CRMTraits_Import_ParserTrait {
     return $mapper;
   }
 
+  /**
+   * @return \CRM_Import_DataSource
+   */
+  protected function getDataSource(): CRM_Import_DataSource {
+    return new CRM_Import_DataSource_CSV($this->userJobID);
+  }
+
 }


### PR DESCRIPTION
As reported by Andy C and verified by me 5.48 does create new related
contacts in skip mode - test added. See https://lab.civicrm.org/dev/core/-/issues/3667
