### PR TITLE
Refs: dev/core#3671 Fix regression involving CiviCRM Webform + Cases.

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -182,6 +182,7 @@ class CRM_Utils_Recent {
       $record = civicrm_api4($entityType, 'get', [
         'where' => [['id', '=', $entityId]],
         'select' => [$labelField],
+        'checkPermissions' => FALSE,
       ], 0);
       $title = $record[$labelField] ?? NULL;
     }


### PR DESCRIPTION
Ignores permissions on api4 call in Recent::getTitle()

Overview
----------------------------------------
Addresses regression identified by https://github.com/colemanw/webform_civicrm/pull/756

Before
----------------------------------------
Permissions check on api4 call when getting the default title.

After
----------------------------------------
Permissions ignored on api4 call when getting the default title.


Comments
----------------------------------------

Please review cautiously - I've not looked at ramifications of removing this permissions check on calls from elsewhere - merely followed the breadcrumbs from -> https://github.com/colemanw/webform_civicrm/pull/756 
