### PR TITLE
dev/core#3665 import summary fixes

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -92,8 +92,18 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    */
   public function getTrackingFields(): array {
     return [
-      'related_contact_created' => 'INT COMMENT "Number of related contacts created"',
-      'related_contact_matched' => 'INT COMMENT "Number of related contacts found (& potentially updated)"',
+      'related_contact_created' => [
+        'name' => 'related_contact_created',
+        'operation' => 'SUM',
+        'type' => 'INT',
+        'description' => ts('Number of related contacts created'),
+      ],
+      'related_contact_matched' => [
+        'name' => 'related_contact_matched',
+        'operation' => 'SUM',
+        'type' => 'INT',
+        'description' => ts('Number of related contacts found (and potentially updated)'),
+      ],
     ];
   }
 

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -208,7 +208,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         $extraFields['related_contact_matched']++;
       }
     }
-    $this->setImportStatus($rowNumber, $this->getStatus(CRM_Import_Parser::VALID), $this->getSuccessMessage(), $contactID, $extraFields, [$contactID]);
+    $this->setImportStatus($rowNumber, $this->getStatus(CRM_Import_Parser::VALID), $this->getSuccessMessage(), $contactID, $extraFields, array_merge(array_keys($relatedContacts), [$contactID]));
     return CRM_Import_Parser::VALID;
   }
 

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -75,6 +75,13 @@ abstract class CRM_Import_DataSource {
   private $selectFields;
 
   /**
+   * Fields to select as aggregates.
+   *
+   * @var array
+   */
+  private $aggregateFields;
+
+  /**
    * The name of the import table.
    *
    * @var string
@@ -96,6 +103,23 @@ abstract class CRM_Import_DataSource {
   public function setSelectFields(array $selectFields): CRM_Import_DataSource {
     $this->selectFields = $selectFields;
     return $this;
+  }
+
+  /**
+   * @param array $fields
+   *
+   * @return CRM_Import_DataSource
+   */
+  public function setAggregateFields(array $fields): CRM_Import_DataSource {
+    $this->aggregateFields = $fields;
+    return $this;
+  }
+
+  /**
+   * @return array|null
+   */
+  public function getAggregateFields(): ?array {
+    return $this->aggregateFields;
   }
 
   /**
@@ -521,7 +545,7 @@ abstract class CRM_Import_DataSource {
     $sql = '';
     $fields = $this->getParser()->getTrackingFields();
     foreach ($fields as $fieldName => $spec) {
-      $sql .= 'ADD COLUMN  _' . $fieldName . ' ' . $spec . ',';
+      $sql .= 'ADD COLUMN  _' . $fieldName . ' ' . $spec['type'] . ',';
     }
     return $sql;
   }
@@ -606,6 +630,13 @@ abstract class CRM_Import_DataSource {
    * @return string
    */
   private function getSelectClause(): string {
+    if ($this->getAggregateFields()) {
+      $fields = [];
+      foreach ($this->getAggregateFields() as $field) {
+        $fields[] = $field['operation'] . '(_' . $field['name'] . ') as ' . $field['name'];
+      }
+      return implode(',', $fields);
+    }
     return $this->getSelectFields() ? '`' . implode('`, `', $this->getSelectFields()) . '`' : '*';
   }
 

--- a/CRM/Import/Form/Summary.php
+++ b/CRM/Import/Form/Summary.php
@@ -62,6 +62,8 @@ abstract class CRM_Import_Form_Summary extends CRM_Import_Forms {
       $this->assign('downloadAddressRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
       $this->assign('downloadPledgePaymentErrorRecordsUrl', $this->getDownloadURL(CRM_Contribute_Import_Parser_Contribution::PLEDGE_PAYMENT_ERROR));
       $this->assign('downloadSoftCreditErrorRecordsUrl', $this->getDownloadURL(CRM_Contribute_Import_Parser_Contribution::SOFT_CREDIT_ERROR));
+      $this->assign('trackingSummary', $this->getTrackingSummary());
+
       $userJobID = CRM_Utils_Request::retrieve('user_job_id', 'String', $this, TRUE);
       $userJob = UserJob::get(TRUE)
         ->addWhere('id', '=', $userJobID)

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -545,6 +545,32 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
+   * Get the url to download the relevant csv file.
+   * @param string $status
+   *
+   * @return string
+   */
+
+  /**
+   *
+   * @return array
+   */
+  public function getTrackingSummary(): array {
+    $summary = [];
+    $fields = $this->getParser()->getTrackingFields();
+    $row = $this->getDataSourceObject()->setAggregateFields($fields)->getRow();
+    foreach ($fields as $fieldName => $field) {
+      $summary[] = [
+        'field_name' => $fieldName,
+        'description' => $field['description'],
+        'value' => $row[$fieldName],
+      ];
+    }
+
+    return $summary;
+  }
+
+  /**
    * Get the fields available for import selection.
    *
    * @return array
@@ -562,6 +588,14 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @return \CRM_Contact_Import_Parser_Contact|\CRM_Contribute_Import_Parser_Contribution
    */
   protected function getParser() {
+    foreach (CRM_Core_BAO_UserJob::getTypes() as $jobType) {
+      if ($jobType['id'] === $this->getUserJob()['type_id']) {
+        $className = $jobType['class'];
+        $classObject = new $className();
+        $classObject->setUserJobID($this->getUserJobID());
+        return $classObject;
+      };
+    }
     return NULL;
   }
 

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -90,10 +90,17 @@
     {/if}
 
     <tr>
-      <td class="label crm-grid-cell">{ts}Total Contacts{/ts}</td>
+      <td class="label crm-grid-cell">{ts}Total Rows Imported{/ts}</td>
       <td class="data">{$validRowCount}</td>
-      <td class="explanation">{ts}Total number of contact records created or modified during the import.{/ts}</td>
+      <td class="explanation">{ts}Total number of primary records created or modified during the import.{/ts}</td>
     </tr>
+    {foreach from=$trackingSummary item="summaryRow"}
+      <tr>
+        <td class="label crm-grid-cell"></td>
+        <td class="data">{$summaryRow.value}</td>
+        <td class="explanation">{$summaryRow.description}</td>
+      </tr>
+    {/foreach}
 
     {if $groupAdditions}
     <tr><td class="label crm-grid-cell">{ts}Import to Groups{/ts}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This addresses a reported regression in the reporting on imported contacts - it also changes the language to be a bit less contact specific.

Note that since we can report on created vs updated related contacts I added it in - but I'm open to changing back to closer to previous if we can't make this work on the word-smithing

I also noted we stopped adding related contacts to the group so this addresses


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/174531458-245f4333-a5ea-43e5-9bb7-2b4f537eb24d.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/174533423-2c3986ba-b9a9-4005-a420-9f0673b6f6ce.png)


Technical Details
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/3665 the pre-import cleanup behaviour seems to be 
![image](https://lab.civicrm.org/dev/core/uploads/f47b789a2c0b93f7764d0f9d2a9adf7e/image.png)

Comments
----------------------------------------
A couple of related issues popped up
- it's really useful to be able to to navigate to the summary page during QA - I made that change separately at https://github.com/civicrm/civicrm-core/pull/23838 but incorporated it here
- this is hard to QA without this fix https://github.com/civicrm/civicrm-core/pull/23835 so that is also included
- I would really rather do another cleanup where it attempts to match all contacts before creating any - having a row fully pass or fully fail seems better to me & avoids other weirdnesses - but will check that I can get some review on that & these things merged before working on that
