### PR TITLE
dev/core#1541 Fix ICalendar random invalid utf8

### DIFF
--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -38,7 +38,7 @@ class CRM_Utils_ICalendar {
     $text = str_replace(',', '\,', $text);
     $text = str_replace(';', '\;', $text);
     $text = str_replace(["\r\n", "\n", "\r"], "\\n ", $text);
-    $text = implode("\n ", str_split($text, 50));
+    $text = implode("\n ", mb_str_split($text, 50));
     return $text;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #23638 by @jensschuppe, which fixes many accent problems, but I was still running into randomly chopped invalid utf8 characters.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/174636708-286c4f09-c5cf-4f14-9e91-2c2a66a656b0.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/174636760-d75960a3-ee51-4a45-abdd-97118557efb6.png)

Technical Details
----------------------------------------

The RFC states:

>    Lines of text SHOULD NOT be longer than 75 octets, excluding the line break.  Long content lines SHOULD be split into a multiple line   representations using a line "folding" technique.  That is, a long   line can be split between any two characters by inserting a CRLF  [...]

Although it's a "SHOULD" and not "MUST", so the folding is optional, and it's a silly rule, because is says "octets" and not "characters". Folding a non-latin script is hard if counting octets (a character will typically be at least 2 octets, but it could be more, emojis, etc).

So.. rather than write really complicated logic, I think using `mb_str_split` is good enough.

@jensschuppe Could you review this patch?