### PR TITLE
dev/core#3656 Translations - if a message_template has been translated then get/render the translated version

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -524,7 +524,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
       $mailContent['subject'] = $subjectOverride;
     }
 
-    return $mailContent;
+    return [$mailContent, $apiCall->getTranslationLanguage()];
   }
 
 }

--- a/CRM/Core/BAO/TranslateGetWrapper.php
+++ b/CRM/Core/BAO/TranslateGetWrapper.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_Core_BAO_TranslateGetWrapper {
+
+  protected $fields;
+  protected $translatedLanguage;
+
+  /**
+   * CRM_Core_BAO_TranslateGetWrapper constructor.
+   *
+   * This wrapper replaces values with configured translated values, if any exist.
+   *
+   * @param array $translated
+   */
+  public function __construct($translated) {
+    $this->fields = $translated['fields'];
+    $this->translatedLanguage = $translated['language'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function fromApiInput($apiRequest) {
+    return $apiRequest;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function toApiOutput($apiRequest, $result) {
+    foreach ($result as &$value) {
+      if (!isset($value['id'], $this->fields[$value['id']])) {
+        continue;
+      }
+      $toSet = array_intersect_key($this->fields[$value['id']], $value);
+      $value = array_merge($value, $toSet);
+      $value['actual_language'] = $this->translatedLanguage;
+    }
+    return $result;
+  }
+
+}

--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Translation;
+
 /**
  *
  * @package CRM
@@ -142,6 +145,124 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi
         $e->addError($r, 'entity_id', 'nonexistent_id', ts('Entity does not exist'));
       }
     }
+  }
+
+  /**
+   * Callback for hook_civicrm_post().
+   *
+   * Flush out cached values.
+   *
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event): void {
+    unset(Civi::$statics[__CLASS__]);
+  }
+
+  /**
+   * Implements hook_civicrm_apiWrappers().
+   *
+   * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/
+   *
+   * @see \CRM_Utils_Hook::apiWrappers()
+   * @throws \CRM_Core_Exception
+   */
+  public static function hook_civicrm_apiWrappers(&$wrappers, $apiRequest): void {
+    // Only implement for apiv4 & not in a circular way.
+    if ($apiRequest['entity'] === 'Translation'
+      || $apiRequest['entity'] === 'Entity'
+      || !$apiRequest instanceof AbstractAction
+      // Only intervene in 'get'. Code handling save type actions left out of scope.
+      || $apiRequest['action'] !== 'get'
+    ) {
+      return;
+    }
+
+    $apiLanguage = $apiRequest->getPreferredLanguage();
+    if (!$apiLanguage || $apiRequest->getPreferredLanguage() === Civi::settings()->get('lcMessages')) {
+      return;
+    }
+
+    if ($apiRequest['action'] === 'get') {
+      if (!isset(\Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$apiRequest->getPreferredLanguage()])) {
+        $translated = self::getTranslatedFieldsForRequest($apiRequest);
+        // @todo - once https://github.com/civicrm/civicrm-core/pull/24063 is merged
+        // this could set any defined translation fields that don't have a translation
+        // for one or more fields in the set to '' - ie 'if any are defined for
+        // an entity/language then all must be' - it seems like being strict on this
+        // now will make it easier later....
+        if (!empty($translated['fields']['msg_html']) && !isset($translated['fields']['msg_text'])) {
+          $translated['fields']['msg_text'] = '';
+        }
+        foreach ($translated['fields'] as $field) {
+          \Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$apiRequest->getPreferredLanguage()]['fields'][$field['entity_id']][$field['entity_field']] = $field['string'];
+          \Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$apiRequest->getPreferredLanguage()]['language'] = $translated['language'];
+        }
+      }
+      if (!empty(\Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$apiRequest->getPreferredLanguage()])) {
+        $wrappers[] = new CRM_Core_BAO_TranslateGetWrapper(\Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$apiRequest->getPreferredLanguage()]);
+      }
+
+    }
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\AbstractAction $apiRequest
+   * @return array translated fields.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected static function getTranslatedFieldsForRequest(AbstractAction $apiRequest): array {
+    $translations = Translation::get()
+      ->addWhere('entity_table', '=', CRM_Core_DAO_AllCoreTables::getTableForEntityName($apiRequest['entity']))
+      ->setCheckPermissions(FALSE)
+      ->setSelect(['entity_field', 'entity_id', 'string', 'language']);
+    if ((substr($apiRequest->getPreferredLanguage(), '-3', '3') !== '_NO')) {
+      // Generally we want to check for any translations of the base language
+      // and prefer, for example, French French over US English for French Canadians.
+      // Sites that genuinely want to cater to both will add translations for both
+      // and we work through preferences below.
+      $translations->addWhere('language', 'LIKE', substr($apiRequest->getPreferredLanguage(), 0, 2) . '%');
+    }
+    else {
+      // And here we have ... the Norwegians. They have three main variants which
+      // share the same country suffix but not language prefix. As with other languages
+      // any Norwegian is better than no Norwegian and sites that care will do multiple
+      $translations->addWhere('language', 'LIKE', '%_NO');
+    }
+    $fields = $translations->execute();
+    $languages = [];
+    foreach ($fields as $index => $field) {
+      $languages[$field['language']][$index] = $field;
+    }
+    if (isset($languages[$apiRequest->getPreferredLanguage()])) {
+      return ['fields' => $languages[$apiRequest->getPreferredLanguage()()], 'language' => $apiRequest->getPreferredLanguage()];
+    }
+    if (count($languages) === 1) {
+      return ['fields' => reset($languages), 'language' => key($languages)];
+    }
+    if (count($languages) > 1) {
+      // In this situation we have multiple language options but no exact match.
+      // This might be, for example, a case where we have, for example, a US English and
+      // a British English, but no Kiwi English. In that case the best is arguable
+      // but I think we all agree that we want to avoid Aussie English here.
+      $defaultLanguages = [
+        'de' => 'de_DE',
+        'en' => 'en_US',
+        'fr' => 'fr_FR',
+        'es' => 'es_ES',
+        'nl' => 'nl_NL',
+        'pt' => 'pt_PT',
+        'zh' => 'zh_TW',
+      ];
+      $defaultLanguage = $defaultLanguages[substr($apiRequest->getPreferredLanguage()(), 0, 2)] ?? NULL;
+      if (isset($languages[$defaultLanguage])) {
+        return ['fields' => $languages[$defaultLanguage], 'language' => $defaultLanguage];
+      }
+      // We have no way to determine which is best from the available variants.
+      // If the site wants more control they can translate to the variants.
+      return ['fields' => reset($languages), 'language' => key($languages)];
+    }
+    return [];
   }
 
 }

--- a/Civi/Api4/Action/WorkflowMessage/Render.php
+++ b/Civi/Api4/Action/WorkflowMessage/Render.php
@@ -75,13 +75,24 @@ class Render extends \Civi\Api4\Generic\AbstractAction {
 
   public function _run(\Civi\Api4\Generic\Result $result) {
     $this->validateValues();
+    global $moneyFormatLocale;
+    $separatorConfig = \CRM_Utils_Constant::value('IGNORE_SEPARATOR_CONFIG');
+    $originalValue = $moneyFormatLocale;
 
+    if ($this->getTranslationLanguage()) {
+      // Passing in translation language forces money formatting, useful when the
+      // template is previewed before being saved.
+      $moneyFormatLocale = $this->getTranslationLanguage();
+      putenv('IGNORE_SEPARATOR_CONFIG=' . 1);
+    }
     $r = \CRM_Core_BAO_MessageTemplate::renderTemplate([
       'model' => $this->_model,
       'messageTemplate' => $this->getMessageTemplate(),
       'messageTemplateId' => $this->getMessageTemplateId(),
+      'language' => $this->getPreferredLanguage(),
     ]);
-
+    $moneyFormatLocale = $originalValue;
+    putenv('IGNORE_SEPARATOR_CONFIG=' . $separatorConfig);
     $result[] = \CRM_Utils_Array::subset($r, ['subject', 'html', 'text']);
   }
 

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -32,6 +32,8 @@ use Civi\Api4\Utils\ReflectionUtils;
  * @method bool getDebug()
  * @method $this setChain(array $chain)
  * @method array getChain()
+ * @method $this setPreferredLanguage(string|null $language)
+ * @method string|null getPreferredLanguage()
  */
 abstract class AbstractAction implements \ArrayAccess {
 
@@ -43,6 +45,16 @@ abstract class AbstractAction implements \ArrayAccess {
    * @var int
    */
   protected $version = 4;
+
+  /**
+   * Preferred Language (optional).
+   *
+   * If set then listeners such as the Translation subsystem may alter
+   * the output.
+   *
+   * @var string
+   */
+  protected $preferredLanguage;
 
   /**
    * Additional api requests - will be called once per result.

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -43,7 +43,8 @@ class Format {
       $currency = Civi::settings()->get('defaultCurrency');
     }
     if (!isset($locale)) {
-      $locale = Civi::settings()->get('format_locale') ?? CRM_Core_I18n::getLocale();
+      global $moneyFormatLocale;
+      $locale = $moneyFormatLocale ?? (Civi::settings()->get('format_locale') ?? CRM_Core_I18n::getLocale());
     }
     $money = Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
     $formatter = $this->getMoneyFormatter($currency, $locale);

--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -271,6 +271,7 @@
       crmApi4({
         examples: ['ExampleData', 'get', {
           // FIXME: workflow name
+          language: $ctrl.lang,
           where: [["tags", "CONTAINS", "preview"], ["name", "LIKE", "workflow/" + $ctrl.records.main.workflow_name + "/%"]],
           select: ['name', 'title', 'data']
         }],
@@ -279,7 +280,6 @@
           format: 'example'
         }]
       }).then(function(resp) {
-        console.log('resp',resp);
         if ((!resp.examples || resp.examples.length === 0) && resp.adhoc) {
           // In the future, if Preview dialog allows editing adhoc examples, then we can show the dialog. But for now, it won't work without explicit examples.
           crmUiAlert({

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -1,10 +1,14 @@
 (function(angular, $, _) {
 
-  angular.module('crmMsgadm').controller('MsgtpluiPreviewCtrl', function($scope, crmUiHelp, crmStatus, crmApi4, crmUiAlert, $timeout, $q, dialogService) {
+  angular.module('crmMsgadm').controller('MsgtpluiPreviewCtrl', function($scope, crmUiHelp, crmStatus, crmApi4, crmUiAlert, $timeout, $q, dialogService, $location) {
     var ts = $scope.ts = CRM.ts('crmMsgadm');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/MessageAdmin/crmMsgadm'}); // See: templates/CRM/MessageAdmin/crmMsgadm.hlp
 
     var $ctrl = this, model = $scope.model;
+    var args = $location.search();
+    if (args.lang) {
+      $ctrl.lang = args.lang;
+    }
 
     $ctrl.exampleId = parseInt(_.findKey(model.examples, {name: model.exampleName}));
     $ctrl.revisionId = parseInt(_.findKey(model.revisions, {name: model.revisionName}));
@@ -35,6 +39,7 @@
       dlgModel.refresh = function(){
         return crmApi4('ExampleData', 'get', {
           where: [["name", "=", model.examples[$ctrl.exampleId].name]],
+          language: $ctrl.lang,
           select: ['name', 'file', 'title', 'data']
         }).then(function(response){
           dlgModel.title = ts('Example: %1', {1: response[0].title || response[0].name});
@@ -64,6 +69,7 @@
     function requestStoredExample() {
       return crmApi4('ExampleData', 'get', {
         where: [["name", "=", model.examples[$ctrl.exampleId].name]],
+        language: $ctrl.lang,
         select: ['data']
       }).then(function(response) {
         return response[0].data;
@@ -82,6 +88,8 @@
       rendering.then(function(exampleData) {
         var filteredData = model.filterData ? model.filterData(exampleData) : exampleData;
         return crmApi4('WorkflowMessage', 'render', {
+          language: $ctrl.lang,
+          translationLanguage: $ctrl.lang,
           workflow: filteredData.workflow,
           values: filteredData.modelProps,
           messageTemplate: model.revisions[$ctrl.revisionId].rec

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -16,9 +16,6 @@
   </urls>
   <releaseDate>2021-06-12</releaseDate>
   <version>5.53.alpha1</version>
-  <tags>
-    <tag>mgmt:hidden</tag>
-  </tags>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.53</ver>

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -40,6 +40,9 @@ return new class() extends EventCheck implements HookInterface {
     'Precedence' => ['type' => 'string|NULL', 'for' => ['civimail', 'flexmailer'], 'regex' => '/(bulk|first-class|list)/'],
     'job_id' => ['type' => 'int|NULL', 'for' => ['civimail', 'flexmailer']],
 
+    // ## Language
+    'language' => ['type' => 'string|NULL', 'for' => ['messageTemplate']],
+
     // ## Content
 
     'subject' => ['for' => ['messageTemplate', 'singleEmail'], 'type' => 'string'],

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -3,6 +3,7 @@
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\MessageTemplate;
+use Civi\Api4\Translation;
 use Civi\Token\TokenProcessor;
 
 /**
@@ -198,6 +199,40 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertEquals('[case #' . $msg->getIdHash() . '] Test 123', $subject);
     $this->assertStringContainsString('Your Case Role(s) : Sand grain counter', $message);
     $this->assertStringContainsString('Case ID : 1234', $message);
+  }
+
+  /**
+   * Test that translated strings are rendered for templates where they exist.
+   *
+   * @throws \API_Exception|\CRM_Core_Exception
+   */
+  public function testGetTranslatedTemplate(): void {
+    $this->individualCreate(['preferred_language' => 'fr_FR']);
+    $this->contributionCreate(['contact_id' => $this->ids['Contact']['individual_0']]);
+    $this->addTranslation();
+
+    $messageTemplate = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
+      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
+      ->setPreferredLanguage('fr_FR')
+      ->execute()->indexBy('workflow_name');
+
+    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+
+    $this->assertStringContainsString('{ts}Contribution Receipt{/ts}', $messageTemplate['contribution_offline_receipt']['msg_subject']);
+    $this->assertStringContainsString('Below you will find a receipt', $messageTemplate['contribution_offline_receipt']['msg_html']);
+    $this->assertArrayNotHasKey('actual_language', $messageTemplate['contribution_offline_receipt']);
+
+    $messageTemplate = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
+      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
+      ->setPreferredLanguage('ca_FR')
+      ->execute()->indexBy('workflow_name');
+
+    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+
   }
 
   /**
@@ -917,6 +952,40 @@ id |' . $tokenData['contact_id'] . '
 t_stuff.favourite_emoticon |
 ';
     return $expected;
+  }
+
+  /**
+   * @return mixed
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function addTranslation() {
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila!'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_FR',
+    ])->execute();
+    return $messageTemplateID;
+  }
+
+  /**
+   * @param $contribution_online_receipt
+   */
+  private function assertFrenchTranslationRetrieved($contribution_online_receipt): void {
+    $this->assertEquals('Bonjour', $contribution_online_receipt['msg_subject']);
+    $this->assertEquals('Voila!', $contribution_online_receipt['msg_html']);
+    $this->assertEquals('fr_FR', $contribution_online_receipt['actual_language']);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -47,6 +47,94 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that translated strings are rendered for templates where they exist.
+   *
+   * @throws \API_Exception|\CRM_Core_Exception
+   */
+  public function testRenderTranslatedTemplate(): void {
+    $this->individualCreate(['preferred_language' => 'fr_FR']);
+    $contributionID = $this->contributionCreate(['contact_id' => $this->ids['Contact']['individual_0']]);
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila!'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_FR',
+    ])->execute();
+
+    $messageTemplateFrench = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id', 'msg_subject', 'msg_html')
+      ->setLanguage('fr_FR')
+      ->execute()->first();
+
+    $this->assertEquals('Bonjour', $messageTemplateFrench['msg_subject']);
+    $this->assertEquals('Voila!', $messageTemplateFrench['msg_html']);
+
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'workflow' => 'contribution_online_receipt',
+      'tokenContext' => [
+        'contactId' => $this->ids['Contact']['individual_0'],
+        'contributionId' => $contributionID,
+      ],
+    ]);
+    $this->assertEquals('Bonjour', $rendered['subject']);
+    $this->assertEquals('Voila!', $rendered['html']);
+    $this->assertEquals('100,00 $US', $rendered['text']);
+
+    // French Canadian should ALSO pick up French if there
+    //is no specific French Canadian.
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'workflow' => 'contribution_online_receipt',
+      'tokenContext' => [
+        'contactId' => $this->ids['Contact']['individual_0'],
+        'contributionId' => $contributionID,
+      ],
+      'language' => 'fr_CA',
+    ]);
+    $this->assertEquals('Bonjour', $rendered['subject']);
+    $this->assertEquals('Voila!', $rendered['html']);
+    // Money is formatted per fr_FR locale as that is the found-template-locale.
+    $this->assertEquals('100,00 $US', $rendered['text']);
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour Canada'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila! Canada'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_CA',
+    ])->execute();
+
+    // But, prefer French Canadian where both exist.
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'workflow' => 'contribution_online_receipt',
+      'tokenContext' => [
+        'contactId' => $this->ids['Contact']['individual_0'],
+        'contributionId' => $contributionID,
+      ],
+      'language' => 'fr_CA',
+    ]);
+    $this->assertEquals('Bonjour Canada', $rendered['subject']);
+    $this->assertEquals('Voila! Canada', $rendered['html']);
+    // Note that as there was a native-Canada format the money-formatting is
+    // also subtly different.
+    $this->assertEquals('100,00 $ US', $rendered['text']);
+  }
+
+  /**
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -67,6 +67,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
       'civicrm_participant',
       'civicrm_batch',
       'civicrm_product',
+      'civicrm_translation',
     ];
     $this->cleanup(['tablesToTruncate' => $tablesToTruncate]);
     parent::tearDown();


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#3656 Translations - if a message_template has been translated then get/render the translated version

The core extension - `message_admin` is intended to eventually replace the quick form forms with the following benefits
- part of our deprecation of quick form and smarty
- it supports an approval workflow  with the opportunity to have draft versions
- it (as of now almost) supports users being able to select entity-appropriate tokens
- it utilises apis that we have added test cover to & that we can extend
- it provides preview screens (these are not a hugely obvious feature, which is good as we still have a bit of work to do to upgrade the workflow templates to work with them)
- it provides the ability to have alternate templates for different languages
- it provides a more fully featured editor (with syntax highlighting)

Although many of these features are useful it has been hidden until now because the presence of the ability to translate messages gave the false impression the messages would be sent out using these. This PR fixes that gap and unhides the extension

 
Before
----------------------------------------
Even when a translation exists the various methods to load and send it would not use the translation

After
----------------------------------------
The translation is used. The `render` function will load it from a passed in language or, if none, from the `contactID`, if available.
eg.

```
    $messageTemplateFrench = MessageTemplate::get()
      ->addWhere('is_default', '=', 1)
      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
      ->addSelect('id', 'msg_subject', 'msg_html')
      ->setLanguage('fr_CA')
      ->execute()->first();
```

with return the French Canadian translation, if it exists. If not it will prefer a French French translation over an English one. Note that based on production experience the same is true of Norwegian - despite - .... Norwegian.

Likewise the following function will render a translated value - based on the contact's language, if possible. (Note this function is not supported as accessible from outside core but I will take a look & see if I can figure out the api4 call that is, assuming there is one)

```
    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
      'workflow' => 'contribution_online_receipt',
      'tokenContext' => [
        'contactId' => $this->ids['Contact']['individual_0'],
        'contributionId' => $contributionID,
      ],
    ]);
```

Technical Details
----------------------------------------
This was in the original spec fof this extension & the for the usage of the `translation` entity. However, it fell out of scope because or a perceived need to support more complex api usage - ie making the translated field work in the `where` clause - there isn't any particular reason this should be possible. The original design also handled saving translations from the `create` action, when the language was set. While there is a case for this there isn't a current use-case since `message_admin` doesn't use it so it is entirely out of scope

@totten this is the first step - as I have brought in the existing code I have a suspicion there might be a better way to do the api-wrappers. There are a couple more bits I need to work on that I can do in paralell to this

- making message_ui save without a text version 
- setting a `moneyFormatLocale`
- extending the search range for workflow templates
- stretch goal - other tokens 

Comments
----------------------------------------

