### PR TITLE
Scan extension directories for workflow templates

### DIFF
--- a/Civi/Test/ExampleDataLoader.php
+++ b/Civi/Test/ExampleDataLoader.php
@@ -84,7 +84,10 @@ class ExampleDataLoader {
       $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.root]/'), 'Civi/*/WorkflowMessage', '\\'),
       $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.root]/'), 'Civi/WorkflowMessage', '\\'),
       $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.root]/tests/phpunit/'), 'CRM/*/WorkflowMessage', '_'),
-      $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.root]/tests/phpunit/'), 'Civi/*/WorkflowMessage', '\\')
+      $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.root]/tests/phpunit/'), 'Civi/*/WorkflowMessage', '\\'),
+      $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.ext]/'), 'Civi/*/WorkflowMessage', '\\'),
+      $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.ext]/'), 'Civi/WorkflowMessage', '\\'),
+      $this->scanExampleClasses(\Civi::paths()->getPath('[civicrm.ext]/tests/phpunit/'), 'Civi/*/WorkflowMessage', '\\')
     );
 
     $all = [];


### PR DESCRIPTION
Overview
----------------------------------------
Scan extension directories for workflow templates


Before
----------------------------------------
Workflow templates can only be defined in core, extensions cannot define their own & expect them to be found

After
----------------------------------------
Extensions can put workflow templates in `Civi\WorkflowTemplate` and they will be used

Technical Details
----------------------------------------
@totten this is actually WRONG and doesn't work - but I figured it would be easier to put this up & ask you here what the right code is

I don't think we need to search `CRM` in extensions - better to just have one way ....

Comments
----------------------------------------
