### PR TITLE
dev/core#3673 do not attempt to import empty related contact

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1436,14 +1436,16 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       $locationValues = array_filter(array_intersect_key($mappedField, array_fill_keys($locationFields, 1)));
 
       if ($relatedContactKey) {
-        if (!isset($params['relationship'][$relatedContactKey])) {
-          $params['relationship'][$relatedContactKey] = [
-            // These will be over-written by any the importer has chosen but defaults are based on the relationship.
-            'contact_type' => $this->getRelatedContactType($mappedField['relationship_type_id'], $mappedField['relationship_direction']),
-            'contact_sub_type' => $this->getRelatedContactSubType($mappedField['relationship_type_id'], $mappedField['relationship_direction']),
-          ];
+        if ($importedValue !== '') {
+          if (!isset($params['relationship'][$relatedContactKey])) {
+            $params['relationship'][$relatedContactKey] = [
+              // These will be over-written by any the importer has chosen but defaults are based on the relationship.
+              'contact_type' => $this->getRelatedContactType($mappedField['relationship_type_id'], $mappedField['relationship_direction']),
+              'contact_sub_type' => $this->getRelatedContactSubType($mappedField['relationship_type_id'], $mappedField['relationship_direction']),
+            ];
+          }
+          $this->addFieldToParams($params['relationship'][$relatedContactKey], $locationValues, $fieldName, $importedValue);
         }
-        $this->addFieldToParams($params['relationship'][$relatedContactKey], $locationValues, $fieldName, $importedValue);
       }
       else {
         $this->addFieldToParams($params, $locationValues, $fieldName, $importedValue);

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_related_create.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_related_create.csv
@@ -1,3 +1,5 @@
 First Name,Last Name,Dad first name,Dad Last name,Dad email
 Bob,Smith,William,The Kid,billy-the-kid@example.com
 Sarah,Smith,Bill,The Grandkid,Billy-the-grand-kid@example.com
+Jenny ,Smith,,,
+Julie,Smith,Bill,,

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -334,6 +334,11 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->assertEquals('IMPORTED', $row['_status']);
     $row = $dataSource->getRow();
     $this->assertEquals('IMPORTED', $row['_status']);
+    $row = $dataSource->getRow();
+    $this->assertEquals('IMPORTED', $row['_status']);
+    $row = $dataSource->getRow();
+    // currently Error with the message (Dad to) Missing required fields: Last Name OR Email Address OR External Identifier
+    // $this->assertEquals('IMPORTED', $row['_status']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3673 do not attempt to report empty related contact


Before
----------------------------------------
Importing a csv with some related contacts empty will reject those rows

After
----------------------------------------
Any empty related contact fields are ignored

Technical Details
----------------------------------------
This is a partial fix for https://lab.civicrm.org/dev/core/-/issues/3673 which addresses the part of the regression which is easiest to fix (and most annoying for the user).

The second part of the regression is that at this stage attempting to import a contact with insufficient information to create / link a related contact results in the row being rejected at the validation stage with an error such as 

'(Dad to) Missing required fields: Last Name OR Email Address OR External Identifier'

The expected behaviour from the discussion is that the row WOULD be imported - the tricky part is that all the code around reporting that partial success feels inadequate to me at the moment - so I'm picking off the easy part first

Comments
----------------------------------------
