### PR TITLE
Alternate to 23826 - Events RSS feed does not output a pubDate for each Event

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmRSSPubDate.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmRSSPubDate.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Format the given date to RSS pubDate RFC822 format,
+ * http://www.w3.org/Protocols/rfc822/#z28
+ *
+ * @param string $dateString
+ *   Date which needs to converted to RFC822 format.
+ *
+ * @return string
+ *   formatted text
+ */
+function smarty_modifier_crmRSSPubDate($dateString): string {
+  // Use CRM_Utils_Time to avoid rollover problems in unit testing
+  $now = new DateTime(CRM_Utils_Time::date('Y-m-d H:i:s'));
+
+  if ($dateString) {
+    try {
+      $date = new DateTime($dateString);
+      return $date->format($date::RSS);
+    }
+    catch (Exception $e) {
+      // fall through
+    }
+  }
+  return $now->format($now::RSS);
+}

--- a/templates/CRM/Core/Calendar/Rss.tpl
+++ b/templates/CRM/Core/Calendar/Rss.tpl
@@ -19,6 +19,8 @@
 {foreach from=$events key=uid item=event}
 <item>
 <title>{$event.title|escape:'html'}</title>
+{* pubDate must follow RFC822 format *}
+<pubDate>{$event.start_date|crmRSSPubDate}</pubDate>
 <link>{crmURL p='civicrm/event/info' q="reset=1&id=`$event.event_id`" fe=1 a=1}</link>
 <description>
 {if $event.summary}{$event.summary|escape:'html'}

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmRSSPubDateTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmRSSPubDateTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Class CRM_Core_Smarty_plugins_CrmRSSPubDateTest
+ * @group headless
+ */
+class CRM_Core_Smarty_plugins_CrmRSSPubDateTest extends CiviUnitTestCase {
+
+  const FIXED_DATE = '2022-06-20 13:14:15';
+  const FIXED_DATE_RSS = 'Mon, 20 Jun 2022 13:14:15';
+
+  /**
+   * DataProvider for testRSSPubDate
+   * @return array
+   */
+  public function dateList(): array {
+    // explicit indexes to make it easier to see which one failed
+    return [
+      // Note we need to calculate the timezone offset each time based on the
+      // date in question, because DST.
+      0 => ['2021-02-03 13:14:15', 'Wed, 03 Feb 2021 13:14:15 ' . (new DateTime('2021-02-03 13:14:15'))->format('O')],
+      1 => ['2021-02-03', 'Wed, 03 Feb 2021 00:00:00 ' . (new DateTime('2021-02-03'))->format('O')],
+      2 => ['2021-12-13 04:05:06', 'Mon, 13 Dec 2021 04:05:06 ' . (new DateTime('2021-12-13 04:05:06'))->format('O')],
+      3 => ['2021-12-13 04:05', 'Mon, 13 Dec 2021 04:05:00 ' . (new DateTime('2021-12-13 04:05'))->format('O')],
+    ];
+  }
+
+  /**
+   * @dataProvider dateList
+   * @param string $input
+   * @param string $expected
+   */
+  public function testRSSPubDate(string $input, string $expected) {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('the_date', $input);
+    $actual = $smarty->fetch('string:{$the_date|crmRSSPubDate}');
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * DataProvider for testRSSPubDateBad
+   * @return array
+   */
+  public function dateListBad(): array {
+    $fixedDate = self::FIXED_DATE_RSS . ' ' . (new DateTime(self::FIXED_DATE))->format('O');
+    // explicit indexes to make it easier to see which one failed
+    return [
+      0 => ['', $fixedDate],
+      1 => [NULL, $fixedDate],
+      // smarty itself gives an error here before even getting to the modifier function, so we can't easily test this
+      // 2 => [[], ''],
+      2 => ['nap time', $fixedDate],
+      3 => ['0', $fixedDate],
+      4 => [0, $fixedDate],
+      5 => [1, $fixedDate],
+    ];
+  }
+
+  /**
+   * Test that invalid inputs return "today"'s date.
+   *
+   * @dataProvider dateListBad
+   * @param mixed $input
+   * @param string $expected
+   */
+  public function testRSSPubDateBad($input, string $expected) {
+    putenv('TIME_FUNC=frozen');
+    CRM_Utils_Time::setTime(self::FIXED_DATE);
+
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('the_date', $input);
+    $actual = $smarty->fetch('string:{$the_date|crmRSSPubDate}');
+    $this->assertEquals($expected, $actual);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Pretty much the same as #23826 but with some minor differences:

* Unit test
* Uses DateTime::RSS instead, which seems more appropriate, and 4 digit years is preferred as per https://validator.w3.org/feed/docs/rss2.html#optionalChannelElements
* Uses CRM_Utils_Time instead of "now" to avoid rollover problems in unit tests.

@agileware-justin 