### PR TITLE
[REF][PHP8.1] Fix a couple of deprecations in php8.1 by specifying th…

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -801,7 +801,7 @@ function ts($text, $params = []) {
     if ($bootstrapReady) {
       // just got ready: determine whether there is a working custom translation function
       $config = CRM_Core_Config::singleton();
-      if (isset($config->customTranslateFunction) and function_exists($config->customTranslateFunction)) {
+      if (!empty($config->customTranslateFunction) && function_exists($config->customTranslateFunction)) {
         $function = $config->customTranslateFunction;
       }
     }

--- a/CRM/Utils/SQL/BaseParamQuery.php
+++ b/CRM/Utils/SQL/BaseParamQuery.php
@@ -184,7 +184,7 @@ class CRM_Utils_SQL_BaseParamQuery implements ArrayAccess {
    *
    * @return bool
    */
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->params[$offset]);
   }
 
@@ -202,6 +202,7 @@ class CRM_Utils_SQL_BaseParamQuery implements ArrayAccess {
    * @see param()
    * @see ArrayAccess::offsetGet
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return $this->params[$offset];
   }
@@ -223,7 +224,7 @@ class CRM_Utils_SQL_BaseParamQuery implements ArrayAccess {
    * @see param()
    * @see ArrayAccess::offsetSet
    */
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     $this->param($offset, $value);
   }
 
@@ -234,7 +235,7 @@ class CRM_Utils_SQL_BaseParamQuery implements ArrayAccess {
    * @see param()
    * @see ArrayAccess::offsetUnset
    */
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     unset($this->params[$offset]);
   }
 


### PR DESCRIPTION
…at return type may change in BaseParamQuery and by ensuring that we don't pass null into function_exists in I18n class

Overview
----------------------------------------
This fixes 2 deprecations in php8.1

1. Deprecation notices like 
```
Deprecated: Return type of CRM_Utils_SQL_BaseParamQuery::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Utils/SQL/BaseParamQuery.php on line 237
```

2. Deprecation notice `Deprecated: function_exists(): Passing null to parameter #1 ($function) of type string is deprecated in /home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Core/I18n.php on line 804`

Before
----------------------------------------
Notices shown during boot to run tests

After
----------------------------------------
Less notices 

ping @totten @eileenmcnaughton @demeritcowboy 