### PR TITLE
New domain token base_url

### DIFF
--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -56,6 +56,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       'id' => ts('Domain ID'),
       'description' => ts('Domain Description'),
       'now' => ts('Current time/date'),
+      'base_url' => ts('Domain absolute base url'),
       'tax_term' => ts('Sales tax term (e.g VAT)'),
     ];
   }
@@ -125,6 +126,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       $email = reset($loc['email']);
       $tokens['phone'] = $phone['phone'] ?? '';
       $tokens['email'] = $email['email'] ?? '';
+      $tokens['base_url'] = Civi::paths()->getVariable('cms.root', 'url');
       $tokens['tax_term'] = (string) Civi::settings()->get('tax_term');
       Civi::cache('metadata')->set($cacheKey, $tokens);
     }

--- a/api/v3/examples/Mailing/GetTokens.ex.php
+++ b/api/v3/examples/Mailing/GetTokens.ex.php
@@ -73,6 +73,7 @@ function mailing_gettokens_expectedresult() {
       '{domain.id}' => 'Domain ID',
       '{domain.description}' => 'Domain Description',
       '{domain.now}' => 'Current time/date',
+      '{domain.base_url}' => 'Domain absolute base url',
       '{domain.tax_term}' => 'Sales tax term (e.g VAT)',
       '{contact.checksum}' => 'Checksum',
       '{contact.current_employer}' => 'Current Employer',

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -798,6 +798,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{domain.id}' => ts('Domain ID'),
       '{domain.description}' => ts('Domain Description'),
       '{domain.now}' => 'Current time/date',
+      '{domain.base_url}' => 'Domain absolute base url',
       '{domain.tax_term}' => 'Sales tax term (e.g VAT)',
       '{domain.street_address}' => 'Domain (Organization) Street Address',
       '{domain.supplemental_address_1}' => 'Domain (Organization) Supplemental Address',


### PR DESCRIPTION
Overview
----------------------------------------
Small chang to allow using site url as token in email templates. 
When testing email messages between dev site and production, we can use token instead of hard code production url

Before
----------------------------------------
No existing token base_url

After
----------------------------------------
New toke base_url created from absolute base url

Technical Details
----------------------------------------
None

Comments
----------------------------------------
None
