### PR TITLE
dev/core#1541 Fix ICalendar random invalid utf8 (PHP <7.4 compat) and tests

### DIFF
--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -38,7 +38,9 @@ class CRM_Utils_ICalendar {
     $text = str_replace(',', '\,', $text);
     $text = str_replace(';', '\;', $text);
     $text = str_replace(["\r\n", "\n", "\r"], "\\n ", $text);
-    $text = implode("\n ", mb_str_split($text, 50));
+    // Remove this check after PHP 7.4 becomes a minimum requirement
+    $str_split = function_exists('mb_str_split') ? 'mb_str_split' : 'str_split';
+    $text = implode("\n ", $str_split($text, 50));
     return $text;
   }
 
@@ -51,6 +53,7 @@ class CRM_Utils_ICalendar {
    * @return string
    */
   public static function unformatText($text) {
+    $text = str_replace("\n ", "", $text);
     $text = str_replace('\n ', "\n", $text);
     $text = str_replace('\;', ';', $text);
     $text = str_replace('\,', ',', $text);

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -27,6 +27,8 @@ class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
 
     this is, a \"test\"!",
     ];
+    $cases[] = ["one, two, three; aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahh ahh ahhh"];
+    $cases[] = ["Bonjour! éèçô, этому скромному разработчику не нравится война на Украине 💓 💔 🌈 💕 💖"];
     return $cases;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

`mb_str_split` is new in PHP 7.4. This PR uses the mb function only if available (using the meh-convention found elsewhere in core). Also add tests, sort of. Follow-up to #23840.

Technical Details
----------------------------------------

`unformatText`  does not seem to be used other than in tests, but I found that it was not passing tests for long lines, since when lines are split (newline and space), then they were not unformatted correctly.

Also, the test admittedly does not check for broken unicode, because I guess it could be split/merged correctly.

Comments
----------------------------------------

sorry @agileware-justin for breaking your pending PR again.