### PR TITLE
Move creating of nav & menu items to legacycustomsearches extension

### DIFF
--- a/CRM/Core/xml/Menu/Contact.xml
+++ b/CRM/Core/xml/Menu/Contact.xml
@@ -60,13 +60,6 @@
      <weight>14</weight>
   </item>
   <item>
-     <path>civicrm/contact/search/custom/list</path>
-     <title>Custom Searches</title>
-     <page_callback>CRM_Contact_Page_CustomSearch</page_callback>
-     <page_type>1</page_type>
-     <weight>16</weight>
-  </item>
-  <item>
      <path>civicrm/contact/add</path>
      <title>New Contact</title>
      <access_callback>CRM_Core_Permission::checkMenu</access_callback>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -30,8 +30,10 @@
   </classloader>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
+    <mixin>mgd-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Legacycustomsearches</namespace>
+    <format>22.05.2</format>
   </civix>
 </extension>

--- a/ext/legacycustomsearches/legacycustomsearches.php
+++ b/ext/legacycustomsearches/legacycustomsearches.php
@@ -78,31 +78,3 @@ function legacycustomsearches_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL
 function legacycustomsearches_civicrm_entityTypes(&$entityTypes) {
   _legacycustomsearches_civix_civicrm_entityTypes($entityTypes);
 }
-
-// --- Functions below this ship commented out. Uncomment as required. ---
-
-/**
- * Implements hook_civicrm_preProcess().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
- */
-//function legacycustomsearches_civicrm_preProcess($formName, &$form) {
-//
-//}
-
-/**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
- */
-//function legacycustomsearches_civicrm_navigationMenu(&$menu) {
-//  _legacycustomsearches_civix_insert_navigation_menu($menu, 'Mailings', array(
-//    'label' => E::ts('New subliminal message'),
-//    'name' => 'mailing_subliminal_message',
-//    'url' => 'civicrm/mailing/subliminal',
-//    'permission' => 'access CiviMail',
-//    'operator' => 'OR',
-//    'separator' => 0,
-//  ));
-//  _legacycustomsearches_civix_navigationMenu($menu);
-//}

--- a/ext/legacycustomsearches/managed/Navigation.mgd.php
+++ b/ext/legacycustomsearches/managed/Navigation.mgd.php
@@ -1,0 +1,55 @@
+<?php
+
+use Civi\Api4\Domain;
+use CRM_Legacycustomsearches_ExtensionUtil as E;
+
+$menuItems = [];
+$domains = Domain::get(FALSE)
+  ->addSelect('id')
+  ->execute();
+foreach ($domains as $domain) {
+  $menuItems[] = [
+    'name' => 'Custom Searches' . $domain['id'],
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('Custom Searches'),
+        'name' => 'Custom Searches',
+        'url' => 'civicrm/contact/search/custom/list?reset=1',
+        'permission' => NULL,
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Search',
+        'is_active' => TRUE,
+        'has_separator' => 2,
+        'weight' => 15,
+        'domain_id' => $domain['id'],
+      ],
+      'match' => ['domain_id', 'name'],
+    ],
+  ];
+  $menuItems[] = [
+    'name' => 'Manage Custom Searches' . $domain['id'],
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('Manage Custom Searches'),
+        'name' => 'Manage Custom Searches',
+        'url' => 'civicrm/admin/options/custom_search?reset=1',
+        'permission' => 'administer CiviCRM',
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Customize Data and Screens',
+        'is_active' => TRUE,
+        'weight' => 15,
+        'domain_id' => $domain['id'],
+      ],
+      'match' => ['domain_id', 'name'],
+    ],
+  ];
+}
+return $menuItems;

--- a/ext/legacycustomsearches/xml/Menu/Search.xml
+++ b/ext/legacycustomsearches/xml/Menu/Search.xml
@@ -9,4 +9,11 @@
     <weight>10</weight>
     <page_type>1</page_type>
   </item>
+  <item>
+    <path>civicrm/contact/search/custom/list</path>
+    <title>Custom Searches</title>
+    <page_callback>CRM_Contact_Page_CustomSearch</page_callback>
+    <page_type>1</page_type>
+    <weight>16</weight>
+  </item>
 </menu>

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -95,11 +95,6 @@ VALUES
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
-    ( @domainID, 'civicrm/contact/search/custom/list&reset=1',              'Custom Searches', 'Custom Searches', NULL, '',                 @searchlastID, '1', NULL, 12 );
-
-INSERT INTO civicrm_navigation
-    ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
-VALUES
     ( @domainID, NULL,  'Contacts', 'Contacts', NULL, '', NULL, '1', NULL, 20 );
 
 SET @contactlastID:=LAST_INSERT_ID();
@@ -287,8 +282,7 @@ VALUES
     ( @domainID, 'civicrm/admin/setting/preferences/display&reset=1',   'Display Preferences', 'Display Preferences',     'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 9 ),
     ( @domainID, 'civicrm/admin/setting/search&reset=1',    'Search Preferences',    'Search Preferences',                'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 10 ),
     ( @domainID, 'civicrm/admin/menu&reset=1',              'Navigation Menu', 'Navigation Menu',                         'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 11 ),
-    ( @domainID, 'civicrm/admin/options/wordreplacements&reset=1','Word Replacements','Word Replacements',                'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 12 ),
-    ( @domainID, 'civicrm/admin/options/custom_search&reset=1&group=custom_search', 'Manage Custom Searches', 'Manage Custom Searches', 'administer CiviCRM', '', @CustomizelastID, '1', NULL, 13 );
+    ( @domainID, 'civicrm/admin/options/wordreplacements&reset=1','Word Replacements','Word Replacements',                'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 12 );
 
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3934,4 +3934,33 @@ WHERE a1.is_primary = 0
     ])->execute()->first();
   }
 
+  /**
+   * Get an array of tables with rows - useful for diagnosing cleanup issues.
+   *
+   * @return array
+   */
+  protected function getTablesWithData(): array {
+    $dataObject = new CRM_Core_DAO();
+    $data = [];
+    $sql = CRM_Core_DAO::singleValueQuery("SELECT GROUP_CONCAT(
+      'SELECT \"',
+      table_name,
+      '\" AS table_name, COUNT(*) AS row_count FROM `',
+      table_schema,
+      '`.`',
+      table_name,
+      '`' SEPARATOR ' UNION  '
+    )
+FROM INFORMATION_SCHEMA.TABLES
+WHERE table_schema = '$dataObject->_database'");
+    $result = CRM_Core_DAO::executeQuery($sql);
+    while ($result->fetch()) {
+      $count = (int) $result->row_count;
+      if ($count > 0) {
+        $data[$result->table_name] = $count;
+      }
+    }
+    return $data;
+  }
+
 }

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -23,11 +23,9 @@
  */
 class api_v3_SettingTest extends CiviUnitTestCase {
 
-  protected $_contactID;
-  protected $_params;
-  protected $_currentDomain;
-  protected $_domainID2;
-  protected $_domainID3;
+  protected $currentDomain;
+  protected $domainID2;
+  protected $domainID3;
 
   public function setUp(): void {
     parent::setUp();
@@ -39,14 +37,14 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     if (empty($result['id'])) {
       $result = $this->callAPISuccess('domain', 'create', $params);
     }
-    $this->_domainID2 = $result['id'];
+    $this->domainID2 = $result['id'];
     $params['name'] = __CLASS__ . 'Third domain';
     $result = $this->callAPISuccess('domain', 'get', $params);
     if (empty($result['id'])) {
       $result = $this->callAPISuccess('domain', 'create', $params);
     }
-    $this->_domainID3 = $result['id'];
-    $this->_currentDomain = CRM_Core_Config::domainID();
+    $this->domainID3 = $result['id'];
+    $this->currentDomain = CRM_Core_Config::domainID();
     $this->hookClass = CRM_Utils_Hook::singleton();
   }
 
@@ -72,11 +70,10 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    */
   public function testGetFields($version) {
     $this->_apiversion = $version;
-    $description = 'Demonstrate return from getfields - see subfolder for variants';
+    $description = 'Demonstrate return from getfields - see sub-folder for variants';
     $result = $this->callAPIAndDocument('setting', 'getfields', [], __FUNCTION__, __FILE__, $description);
     $this->assertArrayHasKey('customCSSURL', $result['values']);
 
-    $description = 'Demonstrate return from getfields';
     $result = $this->callAPISuccess('setting', 'getfields', []);
     $this->assertArrayHasKey('customCSSURL', $result['values']);
     $this->callAPISuccess('system', 'flush', []);
@@ -84,13 +81,15 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * Let's check it's loading from cache by meddling with the cache
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetFieldsCaching($version) {
+  public function testGetFieldsCaching(int $version): void {
     $this->_apiversion = $version;
     $settingsMetadata = [];
-    Civi::cache('settings')->set('settingsMetadata_' . \CRM_Core_Config::domainID() . '_', $settingsMetadata);
+    Civi::cache('settings')->set('settingsMetadata_' . CRM_Core_Config::domainID() . '_', $settingsMetadata);
     $result = $this->callAPISuccess('setting', 'getfields', []);
     $this->assertArrayNotHasKey('customCSSURL', $result['values']);
     $this->quickCleanup(['civicrm_cache']);
@@ -99,9 +98,10 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetFieldsFilters($version) {
+  public function testGetFieldsFilters(int $version): void {
     $this->_apiversion = $version;
     $params = ['name' => 'advanced_search_options'];
     $result = $this->callAPISuccess('setting', 'getfields', $params);
@@ -112,7 +112,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   /**
    * Test that getfields will filter on group.
    */
-  public function testGetFieldsGroupFilters() {
+  public function testGetFieldsGroupFilters(): void {
     $this->_apiversion = 3;
     $params = ['filters' => ['group' => 'multisite']];
     $result = $this->callAPISuccess('setting', 'getfields', $params);
@@ -124,12 +124,14 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    * Ensure that on_change callbacks fire.
    *
    * Note: api_v3_SettingTest::testOnChange and CRM_Core_BAO_SettingTest::testOnChange
-   * are very similar, but they exercise different codepaths. The first uses the API
+   * are very similar, but they exercise different code paths. The first uses the API
    * and setItems [plural]; the second uses setItem [singular].
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testOnChange($version) {
+  public function testOnChange(int $version): void {
     $this->_apiversion = $version;
     global $_testOnChange_hookCalls;
     $this->setMockSettingsMetaData([
@@ -181,7 +183,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    * @param $newValue
    * @param $metadata
    */
-  public static function _testOnChange_onChangeExample($oldValue, $newValue, $metadata) {
+  public static function _testOnChange_onChangeExample($oldValue, $newValue, $metadata): void {
     global $_testOnChange_hookCalls;
     $_testOnChange_hookCalls['count']++;
     $_testOnChange_hookCalls['oldValue'] = $oldValue;
@@ -191,100 +193,104 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testCreateSetting($version) {
+  public function testCreateSetting(int $version): void {
     $this->_apiversion = $version;
-    $description = "Shows setting a variable for a given domain - if no domain is set current is assumed.";
-
     $params = [
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
       'uniq_email_per_site' => 1,
     ];
-    $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__);
 
     $params = ['uniq_email_per_site' => 1];
-    $description = "Shows setting a variable for a current domain.";
+    $description = 'Shows setting a variable for a current domain.';
     $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateSettingCurrentDomain');
     $this->assertArrayHasKey(CRM_Core_Config::domainID(), $result['values']);
   }
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testCreateInvalidSettings($version) {
+  public function testCreateInvalidSettings(int $version): void {
     $this->_apiversion = $version;
     $params = [
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
       'invalid_key' => 1,
     ];
-    $result = $this->callAPIFailure('setting', 'create', $params);
+    $this->callAPIFailure('Setting', 'create', $params);
   }
 
   /**
    * Check invalid settings rejected -
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testCreateInvalidURLSettings($version) {
+  public function testCreateInvalidURLSettings(int $version): void {
     $this->_apiversion = $version;
     $params = [
-      'domain_id' => $this->_domainID2,
-      'userFrameworkResourceURL' => 'dfhkd hfd',
+      'domain_id' => $this->domainID2,
+      'userFrameworkResourceURL' => 'blah blah',
     ];
-    $result = $this->callAPIFailure('setting', 'create', $params);
+    $this->callAPIFailure('Setting', 'create', $params);
     $params = [
-      'domain_id' => $this->_domainID2,
-      'userFrameworkResourceURL' => 'http://blah.com',
+      'domain_id' => $this->domainID2,
+      'userFrameworkResourceURL' => 'https://blah.com',
     ];
-    $result = $this->callAPISuccess('setting', 'create', $params);
+    $this->callAPISuccess('Setting', 'create', $params);
   }
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testCreateInvalidBooleanSettings($version) {
+  public function testCreateInvalidBooleanSettings(int $version): void {
     $this->_apiversion = $version;
     $params = [
-      'domain_id' => $this->_domainID2,
-      'track_civimail_replies' => 'dfhkdhfd',
+      'domain_id' => $this->domainID2,
+      'track_civimail_replies' => 'blah',
     ];
-    $result = $this->callAPIFailure('setting', 'create', $params);
+    $this->callAPIFailure('Setting', 'create', $params);
 
     $params = ['track_civimail_replies' => '0'];
-    $result = $this->callAPISuccess('setting', 'create', $params);
-    $getResult = $this->callAPISuccess('setting', 'get');
-    $this->assertEquals(0, $getResult['values'][$this->_currentDomain]['track_civimail_replies']);
+    $this->callAPISuccess('Setting', 'create', $params);
+    $getResult = $this->callAPISuccess('Setting', 'get');
+    $this->assertEquals(0, $getResult['values'][$this->currentDomain]['track_civimail_replies']);
 
-    $getResult = $this->callAPISuccess('setting', 'get');
-    $this->assertEquals(0, $getResult['values'][$this->_currentDomain]['track_civimail_replies']);
+    $getResult = $this->callAPISuccess('Setting', 'get');
+    $this->assertEquals(0, $getResult['values'][$this->currentDomain]['track_civimail_replies']);
     $params = [
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
       'track_civimail_replies' => '1',
     ];
-    $result = $this->callAPISuccess('setting', 'create', $params);
-    $getResult = $this->callAPISuccess('setting', 'get', ['domain_id' => $this->_domainID2]);
-    $this->assertEquals(1, $getResult['values'][$this->_domainID2]['track_civimail_replies']);
+    $this->callAPISuccess('Setting', 'create', $params);
+    $getResult = $this->callAPISuccess('Setting', 'get', ['domain_id' => $this->domainID2]);
+    $this->assertEquals(1, $getResult['values'][$this->domainID2]['track_civimail_replies']);
 
     $params = [
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
       'track_civimail_replies' => 'TRUE',
     ];
-    $result = $this->callAPISuccess('setting', 'create', $params);
-    $getResult = $this->callAPISuccess('setting', 'get', ['domain_id' => $this->_domainID2]);
+    $this->callAPISuccess('Setting', 'create', $params);
+    $getResult = $this->callAPISuccess('Setting', 'get', ['domain_id' => $this->domainID2]);
 
-    $this->assertEquals(1, $getResult['values'][$this->_domainID2]['track_civimail_replies'], "check TRUE is converted to 1");
+    $this->assertEquals(1, $getResult['values'][$this->domainID2]['track_civimail_replies'], 'check TRUE is converted to 1');
   }
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testCreateSettingMultipleDomains($version) {
+  public function testCreateSettingMultipleDomains(int $version): void {
     $this->_apiversion = $version;
-    $description = "Shows setting a variable for all domains.";
+    $description = 'Shows setting a variable for all domains.';
 
     $params = [
       'domain_id' => 'all',
@@ -292,89 +298,92 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     ];
     $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateAllDomains');
 
-    $this->assertEquals(1, $result['values'][$this->_domainID2]['uniq_email_per_site']);
-    $this->assertEquals(1, $result['values'][$this->_currentDomain]['uniq_email_per_site']);
-    $this->assertArrayHasKey($this->_domainID3, $result['values'], 'Domain create probably failed Debug this IF domain test is passing');
-    $this->assertEquals(1, $result['values'][$this->_domainID3]['uniq_email_per_site'], 'failed to set setting for domain 3.');
+    $this->assertEquals(1, $result['values'][$this->domainID2]['uniq_email_per_site']);
+    $this->assertEquals(1, $result['values'][$this->currentDomain]['uniq_email_per_site']);
+    $this->assertArrayHasKey($this->domainID3, $result['values'], 'Domain create probably failed Debug this IF domain test is passing');
+    $this->assertEquals(1, $result['values'][$this->domainID3]['uniq_email_per_site'], 'failed to set setting for domain 3.');
 
     $params = [
       'domain_id' => 'all',
       'return' => 'uniq_email_per_site',
     ];
     // we'll check it with a 'get'
-    $description = "Shows getting a variable for all domains.";
+    $description = 'Shows getting a variable for all domains.';
     $result = $this->callAPIAndDocument('setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetAllDomains');
 
-    $this->assertEquals(1, $result['values'][$this->_domainID2]['uniq_email_per_site']);
-    $this->assertEquals(1, $result['values'][$this->_currentDomain]['uniq_email_per_site']);
-    $this->assertEquals(1, $result['values'][$this->_domainID3]['uniq_email_per_site']);
+    $this->assertEquals(1, $result['values'][$this->domainID2]['uniq_email_per_site']);
+    $this->assertEquals(1, $result['values'][$this->currentDomain]['uniq_email_per_site']);
+    $this->assertEquals(1, $result['values'][$this->domainID3]['uniq_email_per_site']);
 
     $params = [
-      'domain_id' => [$this->_currentDomain, $this->_domainID3],
+      'domain_id' => [$this->currentDomain, $this->domainID3],
       'uniq_email_per_site' => 0,
     ];
-    $description = "Shows setting a variable for specified domains.";
+    $description = 'Shows setting a variable for specified domains.';
     $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateSpecifiedDomains');
 
-    $this->assertEquals(0, $result['values'][$this->_domainID3]['uniq_email_per_site']);
-    $this->assertEquals(0, $result['values'][$this->_currentDomain]['uniq_email_per_site']);
+    $this->assertEquals(0, $result['values'][$this->domainID3]['uniq_email_per_site']);
+    $this->assertEquals(0, $result['values'][$this->currentDomain]['uniq_email_per_site']);
     $params = [
-      'domain_id' => [$this->_currentDomain, $this->_domainID2],
+      'domain_id' => [$this->currentDomain, $this->domainID2],
       'return' => ['uniq_email_per_site'],
     ];
-    $description = "Shows getting a variable for specified domains.";
+    $description = 'Shows getting a variable for specified domains.';
     $result = $this->callAPIAndDocument('setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetSpecifiedDomains');
-    $this->assertEquals(1, $result['values'][$this->_domainID2]['uniq_email_per_site']);
-    $this->assertEquals(0, $result['values'][$this->_currentDomain]['uniq_email_per_site']);
+    $this->assertEquals(1, $result['values'][$this->domainID2]['uniq_email_per_site']);
+    $this->assertEquals(0, $result['values'][$this->currentDomain]['uniq_email_per_site']);
 
   }
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetSetting($version) {
+  public function testGetSetting(int $version): void {
     $this->_apiversion = $version;
     $params = [
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
       'return' => 'uniq_email_per_site',
     ];
-    $description = "Shows get setting a variable for a given domain - if no domain is set current is assumed.";
 
-    $result = $this->callAPIAndDocument('setting', 'get', $params, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('Setting', 'get', $params, __FUNCTION__, __FILE__);
 
     $params = [
       'return' => 'uniq_email_per_site',
     ];
-    $description = "Shows getting a variable for a current domain.";
-    $result = $this->callAPIAndDocument('setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetSettingCurrentDomain');
+    $description = 'Shows getting a variable for a current domain.';
+    $result = $this->callAPIAndDocument('Setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetSettingCurrentDomain');
     $this->assertArrayHasKey(CRM_Core_Config::domainID(), $result['values']);
   }
 
   /**
    * Check that setting defined in extension can be retrieved.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetExtensionSetting($version) {
+  public function testGetExtensionSetting(int $version): void {
     $this->_apiversion = $version;
     $this->hookClass->setHook('civicrm_alterSettingsFolders', [$this, 'setExtensionMetadata']);
-    $data = NULL;
     Civi::cache('settings')->flush();
     $fields = $this->callAPISuccess('setting', 'getfields');
     $this->assertArrayHasKey('test_key', $fields['values']);
-    $this->callAPISuccess('setting', 'create', ['test_key' => 'keyset']);
-    $this->assertEquals('keyset', Civi::settings()->get('test_key'));
+    $this->callAPISuccess('setting', 'create', ['test_key' => 'key_set']);
+    $this->assertEquals('key_set', Civi::settings()->get('test_key'));
     $result = $this->callAPISuccess('setting', 'getvalue', ['name' => 'test_key']);
-    $this->assertEquals('keyset', $result);
+    $this->assertEquals('key_set', $result);
   }
 
   /**
    * Setting api should set & fetch settings stored in config as well as those in settings table
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetConfigSetting($version) {
+  public function testGetConfigSetting(int $version): void {
     $this->_apiversion = $version;
     $settings = $this->callAPISuccess('setting', 'get', [
       'name' => 'defaultCurrency',
@@ -385,35 +394,39 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * Setting api should set & fetch settings stored in config as well as those in settings table
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetSetConfigSettingMultipleDomains($version) {
+  public function testGetSetConfigSettingMultipleDomains(int $version): void {
     $this->_apiversion = $version;
-    $settings = $this->callAPISuccess('setting', 'create', [
+    $this->callAPISuccess('setting', 'create', [
       'defaultCurrency' => 'USD',
-      'domain_id' => $this->_currentDomain,
+      'domain_id' => $this->currentDomain,
     ]);
-    $settings = $this->callAPISuccess('setting', 'create', [
+    $this->callAPISuccess('setting', 'create', [
       'defaultCurrency' => 'CAD',
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
     ]);
     $settings = $this->callAPISuccess('setting', 'get', [
       'return' => 'defaultCurrency',
       'domain_id' => 'all',
     ]);
-    $this->assertEquals('USD', $settings['values'][$this->_currentDomain]['defaultCurrency']);
-    $this->assertEquals('CAD', $settings['values'][$this->_domainID2]['defaultCurrency'],
-      "second domain (id {$this->_domainID2} ) should be set to CAD. First dom was {$this->_currentDomain} & was USD");
+    $this->assertEquals('USD', $settings['values'][$this->currentDomain]['defaultCurrency']);
+    $this->assertEquals('CAD', $settings['values'][$this->domainID2]['defaultCurrency'],
+      "second domain (id $this->domainID2 ) should be set to CAD. First dom was $this->currentDomain & was USD");
 
   }
 
   /**
    * Use getValue against a config setting.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetValueConfigSetting($version) {
+  public function testGetValueConfigSetting(int $version): void {
     $this->_apiversion = $version;
     $params = [
       'name' => 'monetaryThousandSeparator',
@@ -425,15 +438,16 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testGetValue($version) {
+  public function testGetValue(int $version): void {
     $this->_apiversion = $version;
     $params = [
       'name' => 'petition_contacts',
       'group' => 'Campaign Preferences',
     ];
-    $description = "Demonstrates getvalue action - intended for runtime use as better caching than get.";
+    $description = 'Demonstrates getvalue action - intended for runtime use as better caching than get.';
 
     $result = $this->callAPIAndDocument('setting', 'getvalue', $params, __FUNCTION__, __FILE__, $description);
     $this->assertEquals('Petition Contacts', $result);
@@ -442,13 +456,13 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   /**
    * V3 only - no api4 equivalent.
    */
-  public function testGetDefaults() {
-    $description = "Gets defaults setting a variable for a given domain - if no domain is set current is assumed.";
+  public function testGetDefaults(): void {
+    $description = 'Gets defaults setting a variable for a given domain - if no domain is set current is assumed.';
 
     $params = [
       'name' => 'address_format',
     ];
-    $result = $this->callAPIAndDocument('setting', 'getdefaults', $params, __FUNCTION__, __FILE__, $description, 'GetDefaults');
+    $result = $this->callAPIAndDocument('Setting', 'getdefaults', $params, __FUNCTION__, __FILE__, $description, 'GetDefaults');
     $this->assertEquals("{contact.address_name}\n{contact.street_address}\n{contact.supplemental_address_1}\n{contact.supplemental_address_2}\n{contact.supplemental_address_3}\n{contact.city}{, }{contact.state_province}{ }{contact.postal_code}\n{contact.country}", $result['values'][CRM_Core_Config::domainID()]['address_format']);
     $params = ['name' => 'mailing_format'];
     $result = $this->callAPISuccess('setting', 'getdefaults', $params);
@@ -458,25 +472,27 @@ class api_v3_SettingTest extends CiviUnitTestCase {
 
   /**
    * Function tests reverting a specific parameter.
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testRevert($version) {
+  public function testRevert(int $version): void {
     $this->_apiversion = $version;
     $params = [
       'address_format' => 'xyz',
       'mailing_format' => 'bcs',
     ];
     $result = $this->callAPISuccess('setting', 'create', $params);
-    $this->assertAPISuccess($result, "in line " . __LINE__);
+    $this->assertAPISuccess($result, 'in line ' . __LINE__);
     $revertParams = [
       'name' => 'address_format',
     ];
     $result = $this->callAPISuccess('setting', 'get');
     //make sure it's set
     $this->assertEquals('xyz', $result['values'][CRM_Core_Config::domainID()]['address_format']);
-    $description = "Demonstrates reverting a parameter to default value.";
-    $result = $this->callAPIAndDocument('setting', 'revert', $revertParams, __FUNCTION__, __FILE__, $description, '');
+    $description = 'Demonstrates reverting a parameter to default value.';
+    $this->callAPIAndDocument('setting', 'revert', $revertParams, __FUNCTION__, __FILE__, $description, '');
     //make sure it's reverted
     $result = $this->callAPISuccess('setting', 'get');
     $this->assertEquals("{contact.address_name}\n{contact.street_address}\n{contact.supplemental_address_1}\n{contact.supplemental_address_2}\n{contact.supplemental_address_3}\n{contact.city}{, }{contact.state_province}{ }{contact.postal_code}\n{contact.country}", $result['values'][CRM_Core_Config::domainID()]['address_format']);
@@ -492,18 +508,18 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    * Tests reverting ALL parameters (specific domain)
    * Api3 only.
    */
-  public function testRevertAll() {
+  public function testRevertAll(): void {
     $params = [
       'address_format' => 'xyz',
       'mailing_format' => 'bcs',
     ];
-    $result = $this->callAPISuccess('setting', 'create', $params);
+    $this->callAPISuccess('Setting', 'create', $params);
     $revertParams = [];
-    $result = $this->callAPISuccess('setting', 'get', $params);
+    $result = $this->callAPISuccess('Setting', 'get', $params);
     //make sure it's set
     $this->assertEquals('xyz', $result['values'][CRM_Core_Config::domainID()]['address_format']);
 
-    $this->callAPISuccess('setting', 'revert', $revertParams);
+    $this->callAPISuccess('Setting', 'revert', $revertParams);
     //make sure it's reverted
     $result = $this->callAPISuccess('setting', 'get', ['group' => 'core']);
     $this->assertEquals("{contact.address_name}\n{contact.street_address}\n{contact.supplemental_address_1}\n{contact.supplemental_address_2}\n{contact.supplemental_address_3}\n{contact.city}{, }{contact.state_province}{ }{contact.postal_code}\n{contact.country}", $result['values'][CRM_Core_Config::domainID()]['address_format']);
@@ -513,50 +529,51 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   /**
    * Settings should respect their defaults
    * V3 only - no fill action in v4
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testDefaults() {
-    $domparams = [
+  public function testDefaults(): void {
+    $domain = $this->callAPISuccess('Domain', 'create', [
       'name' => __CLASS__ . 'B Team Domain',
       'domain_version' => CRM_Utils_System::version(),
-    ];
-    $dom = $this->callAPISuccess('domain', 'create', $domparams);
-    $params = [
-      'domain_id' => 'all',
-    ];
-    $result = $this->callAPISuccess('setting', 'get', $params);
+    ]);
+
+    $this->callAPISuccess('Setting', 'get', ['domain_id' => 'all']);
     $params = [
       'address_format' => 'xyz',
       'mailing_format' => 'bcs',
-      'domain_id' => $this->_domainID2,
+      'domain_id' => $this->domainID2,
     ];
-    $result = $this->callAPISuccess('setting', 'create', $params);
+    $this->callAPISuccess('Setting', 'create', $params);
     $params = [
-      'domain_id' => $dom['id'],
+      'domain_id' => $domain['id'],
     ];
     $result = $this->callAPISuccess('setting', 'get', $params);
-    $this->assertAPISuccess($result, "in line " . __LINE__);
-    $this->assertEquals('Unconfirmed', $result['values'][$dom['id']]['tag_unconfirmed']);
+    $this->assertAPISuccess($result);
+    $this->assertEquals('Unconfirmed', $result['values'][$domain['id']]['tag_unconfirmed']);
 
     // The 'fill' operation is no longer necessary, but third parties might still use it, so let's
     // make sure it doesn't do anything weird (crashing or breaking values).
-    $result = $this->callAPISuccess('setting', 'fill', $params);
-    $this->assertAPISuccess($result, "in line " . __LINE__);
-    $result = $this->callAPISuccess('setting', 'get', $params);
-    $this->assertAPISuccess($result, "in line " . __LINE__);
-    $this->assertArrayHasKey('tag_unconfirmed', $result['values'][$dom['id']]);
+    $result = $this->callAPISuccess('Setting', 'fill', $params);
+    $this->assertAPISuccess($result);
+    $result = $this->callAPISuccess('Setting', 'get', $params);
+    $this->assertAPISuccess($result);
+    $this->assertArrayHasKey('tag_unconfirmed', $result['values'][$domain['id']]);
 
     // Setting has NULL default. Not returned.
     //$this->assertArrayHasKey('extensionsDir', $result['values'][$dom['id']]);
 
-    $this->assertEquals('Unconfirmed', $result['values'][$dom['id']]['tag_unconfirmed']);
+    $this->assertEquals('Unconfirmed', $result['values'][$domain['id']]['tag_unconfirmed']);
   }
 
   /**
    * Test to set isProductionEnvironment
+   *
    * @param int $version
+   *
    * @dataProvider versionThreeAndFour
    */
-  public function testSetCivicrmEnvironment($version) {
+  public function testSetCivicrmEnvironment(int $version): void {
     $this->_apiversion = $version;
     global $civicrm_setting;
     unset($civicrm_setting[CRM_Core_BAO_Setting::DEVELOPER_PREFERENCES_NAME]['environment']);
@@ -564,7 +581,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     $params = [
       'environment' => 'Staging',
     ];
-    $result = $this->callAPISuccess('Setting', 'create', $params);
+    $this->callAPISuccess('Setting', 'create', $params);
     $params = [
       'name' => 'environment',
       'group' => 'Developer Preferences',

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -65,11 +65,6 @@ VALUES
     ( @domainID, 'civicrm/activity/search?reset=1',                         '{ts escape="sql" skip="true"}Find Activities{/ts}',    'Find Activities', NULL,  '',                   @searchlastID, '1', '1',  11 );
 
 INSERT INTO civicrm_navigation
-    ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
-VALUES
-    ( @domainID, 'civicrm/contact/search/custom/list?reset=1',              '{ts escape="sql" skip="true"}Custom Searches{/ts}', 'Custom Searches', NULL, '',                 @searchlastID, '1', NULL, 12 );
-
-INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight, icon )
 VALUES
     ( @domainID, NULL,  '{ts escape="sql" skip="true"}Contacts{/ts}', 'Contacts', NULL, '', NULL, '1', NULL, 20, 'crm-i fa-address-book-o' );
@@ -285,8 +280,7 @@ VALUES
     ( @domainID, 'civicrm/admin/setting/search?reset=1',    '{ts escape="sql" skip="true"}Search Preferences{/ts}',    'Search Preferences',                'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 10 ),
     ( @domainID, 'civicrm/admin/setting/preferences/date?reset=1', '{ts escape="sql" skip="true"}Date Preferences{/ts}', 'Date Preferences', 'administer CiviCRM', '', @CustomizelastID, '1', NULL, 11 ),
     ( @domainID, 'civicrm/admin/menu?reset=1',              '{ts escape="sql" skip="true"}Navigation Menu{/ts}', 'Navigation Menu',                         'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 12 ),
-    ( @domainID, 'civicrm/admin/options/wordreplacements?reset=1','{ts escape="sql" skip="true"}Word Replacements{/ts}','Word Replacements',                'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 13 ),
-    ( @domainID, 'civicrm/admin/options/custom_search?reset=1', '{ts escape="sql" skip="true"}Manage Custom Searches{/ts}', 'Manage Custom Searches', 'administer CiviCRM', '', @CustomizelastID, '1', NULL, 14 );
+    ( @domainID, 'civicrm/admin/options/wordreplacements?reset=1','{ts escape="sql" skip="true"}Word Replacements{/ts}','Word Replacements',                'administer CiviCRM', '',   @CustomizelastID, '1', NULL, 13 );
 
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )


### PR DESCRIPTION
Overview
----------------------------------------
Move creating of nav & menu items to legacycustomsearches extension

Before
----------------------------------------
Menu & navigation items for legacy custom searches declared in core code

After
----------------------------------------
Declared in the extension

Technical Details
----------------------------------------
As part of making it turn-offable....

Comments
----------------------------------------
