### PR TITLE
dev/core#3671 - CRM_Utils_Recent - Alternate fix for handling unauthorized records

### DIFF
--- a/CRM/Utils/Recent.php
+++ b/CRM/Utils/Recent.php
@@ -179,12 +179,16 @@ class CRM_Utils_Recent {
     $labelField = CoreUtil::getInfoItem($entityType, 'label_field');
     $title = NULL;
     if ($labelField) {
-      $record = civicrm_api4($entityType, 'get', [
-        'where' => [['id', '=', $entityId]],
-        'select' => [$labelField],
-        'checkPermissions' => FALSE,
-      ], 0);
-      $title = $record[$labelField] ?? NULL;
+      try {
+        $record = civicrm_api4($entityType, 'get', [
+          'where' => [['id', '=', $entityId]],
+          'select' => [$labelField],
+        ])->first();
+      }
+      catch (\API_Exception $e) {
+        $record = [];
+      }
+      $title = $record[$labelField] ?? ts('Unknown record');
     }
     return $title ?? (CoreUtil::getInfoItem($entityType, 'label_field'));
   }


### PR DESCRIPTION
(@stesi561 @demeritcowboy @eileenmcnaughton  @colemanw - This is a proposed revision/alternative for #23836.)

Use cases
---------

1. You have a user with lesser privileges who makes a request with escalated   privileges (eg `civicrm_api4('Contact', 'create', ['checkPermisisons'=>FALSE])`).   For example, submitting a webform.

   This action triggers (by way of hook or BAO) the creation of a new `RecentItem`.   But the user doesn't have permission for this item.

   (Note that this is usually academic -- such users generally don't actually   see 'Recent Items', because the webform is targeted at constituents while   'Recent Items' is targeted at staffers.)

2. Log in as a user with permission to `access CiviCRM` but with only limited   visibility to specific contacts. Use the console to add a `RecentItem`   that you should not have access to.

    ```javascript
    CRM.api4('RecentItem', 'create', {values: {"entity_type":"Contact", "entity_id":172}})
    ```

Before (last release)
---------------------

* (Use case 1) Creating the `RecentItem` fails because it cannot figure  out the name/title.  The whole request fails.

* (Use case 2) Creating the `RecentItem` fails because it cannot figure  out the name/title.  The AJAX call fails.

Before (current/unreleased head):
---------------------

* (Use case 1) The `RecentItem` is created. The name/title is populated, even if you don't have permission to view it. (Unverified by `r-run`, but strongly expected: The link in `RecentItems` is broken.)

* (Use case 2) The `RecentItem` is created. The name/title is populated, even  if you don't have permission to view it. You can use this to poll for the  names of all contacts.

After (this patch):
---------------------

* (Use case 1) The `RecentItem` is created. The name/title is a dummy placeholder. (Unverified by `r-run`, but strongly expected.)

* (Use case 2) The `RecentItem` is created. The name/title is a dummy placeholder.
