### PR TITLE
dev/core#3675 Fix Permissioned Relationship pseudoconstant

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1321,7 +1321,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         \Civi\Api4\Relationship::create(FALSE)
           ->addValue('contact_id_a', $contactID)
           ->addValue('contact_id_b', $orgID)
-          ->addValue('relationship_type_id', $relTypeId = CRM_Contact_BAO_RelationshipType::getEmployeeRelationshipTypeID())
+          ->addValue('relationship_type_id', CRM_Contact_BAO_RelationshipType::getEmployeeRelationshipTypeID())
           ->addValue('is_permission_a_b:name', 'View and update')
           ->execute();
       }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1041,9 +1041,21 @@ class CRM_Core_SelectValues {
    */
   public static function getPermissionedRelationshipOptions() {
     return [
-      CRM_Contact_BAO_Relationship::NONE => ts('None'),
-      CRM_Contact_BAO_Relationship::VIEW => ts('View only'),
-      CRM_Contact_BAO_Relationship::EDIT => ts('View and update'),
+      [
+        'id' => CRM_Contact_BAO_Relationship::NONE,
+        'name' => 'None',
+        'label' => ts('None'),
+      ],
+      [
+        'id' => CRM_Contact_BAO_Relationship::VIEW,
+        'name' => 'View only',
+        'label' => ts('View only'),
+      ],
+      [
+        'id' => CRM_Contact_BAO_Relationship::EDIT,
+        'name' => 'View and update',
+        'label' => ts('View and update'),
+      ],
     ];
   }
 

--- a/tests/phpunit/api/v4/Entity/RelationshipTest.php
+++ b/tests/phpunit/api/v4/Entity/RelationshipTest.php
@@ -47,7 +47,7 @@ class RelationshipTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount(2, $cacheRecords);
   }
 
-  public function testRelCacheCalcFields() {
+  public function testRelationshipCacheCalcFields(): void {
     $c1 = Contact::create(FALSE)->addValue('first_name', '1')->execute()->first()['id'];
     $c2 = Contact::create(FALSE)->addValue('first_name', '2')->execute()->first()['id'];
     $relationship = Relationship::create(FALSE)
@@ -57,7 +57,7 @@ class RelationshipTest extends Api4TestBase implements TransactionalInterface {
         'relationship_type_id' => 1,
         'description' => "Wow, we're related!",
         'is_permission_a_b' => 1,
-        'is_permission_b_a' => 2,
+        'is_permission_b_a:name' => 'View only',
       ])->execute()->first();
     $relationship = Relationship::get(FALSE)
       ->addWhere('id', '=', $relationship['id'])


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#3675 Permissioned Relationship no longer set up for "On Behalf of Organization" Membership Contribution Form submissions.

Replaces #23863

Before
----------------------------------------
Pseudoconstant callback used ambiguous flat array which caused several problems.

After
----------------------------------------
Unambiguous, works in every context.

Technical Details
----------------------------------------
See notes in #22730 for why this change is needed.