### PR TITLE
dev/core#3680 - Currency incorrectly displayed for price set when default is not USD

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -70,16 +70,16 @@
                       {if ($option.tax_amount || $option.tax_amount == "0") && $displayOpt && $invoicing}
                         {assign var="amount" value=`$option.amount+$option.tax_amount`}
                         {if $displayOpt == 'Do_not_show'}
-                          {$amount|crmMoney}
+                          {$amount|crmMoney:$currency}
                         {elseif $displayOpt == 'Inclusive'}
-                          {$amount|crmMoney}
-                          <span class='crm-price-amount-label'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney}(includes %1 of %2){/ts}</span>
+                          {$amount|crmMoney:$currency}
+                          <span class='crm-price-amount-label'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney:$currency}(includes %1 of %2){/ts}</span>
                         {else}
-                          {$option.amount|crmMoney}
-                          <span class='crm-price-amount-label'> + {$option.tax_amount|crmMoney} {$taxTerm}</span>
+                          {$option.amount|crmMoney:$currency}
+                          <span class='crm-price-amount-label'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
                         {/if}
                       {else}
-                        {$option.amount|crmMoney} {$fieldHandle} {$form.$fieldHandle.frozen}
+                        {$option.amount|crmMoney:$currency} {$fieldHandle} {$form.$fieldHandle.frozen}
                       {/if}
                       {if $form.$element_name.frozen EQ 1} ({ts}Sold out{/ts}){/if}
                     {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3680

Before
----------------------------------------
1. Change the default currency to CAD.
1. Create a price set with a text/quantity field, say $100.
1. Create a contribution page and on the amounts tab make the currency USD and use the price set.
1. Visit the contribution page. It says CA$100 for the field.

Both before and after, transactions are charged using the correct currency, but people hesitate to make the transaction when it shows the wrong currency.

After
----------------------------------------
No currency displayed, which is better than the wrong currency.

Technical Details
----------------------------------------

Comments
----------------------------------------
It still works on backend contributions, but there it always uses the default currency, which is a bit bizarre because price sets generally aren't interchangable between currencies, but that's not a new issue. $currency is null here, so it's doing the same thing as before the patch.

There are 4 scenarios this patch covers. Without tax, and then also if you [enable tax and invoicing](https://docs.civicrm.org/user/en/latest/contributions/sales-tax-and-vat/), and then the 3 variations of how tax is displayed at the bottom of that config page.
<img width="352" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/175045127-fee9242a-b494-4ba4-8051-095804642397.png">
