### PR TITLE
Personal Campaign Pages (PCP) incorrectly displays "Don't list my contribution in the honour roll"

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -182,29 +182,25 @@
     </fieldset>
   {/if}
 
-  {if $pcpBlock}
+  {if $pcpBlock && $pcp_display_in_roll}
     <div class="crm-group pcp_display-group">
       <div class="header-dark">
         {ts}Contribution Honor Roll{/ts}
       </div>
       <div class="display-block">
-        {if $pcp_display_in_roll}
-          {ts}List my contribution{/ts}
-          {if $pcp_is_anonymous}
-            <strong>{ts}anonymously{/ts}.</strong>
-          {else}
-            {ts}under the name{/ts}:
-            <strong>{$pcp_roll_nickname}</strong>
-            <br/>
-            {if $pcp_personal_note}
-              {ts}With the personal note{/ts}:
-              <strong>{$pcp_personal_note}</strong>
-            {else}
-              <strong>{ts}With no personal note{/ts}</strong>
-            {/if}
-          {/if}
+        {ts}List my contribution{/ts}
+        {if $pcp_is_anonymous}
+          <strong>{ts}anonymously{/ts}.</strong>
         {else}
-          {ts}Don't list my contribution in the honor roll.{/ts}
+          {ts}under the name{/ts}:
+          <strong>{$pcp_roll_nickname}</strong>
+          <br/>
+          {if $pcp_personal_note}
+            {ts}With the personal note{/ts}:
+            <strong>{$pcp_personal_note}</strong>
+          {else}
+            <strong>{ts}With no personal note{/ts}</strong>
+          {/if}
         {/if}
         <br/>
       </div>

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -215,26 +215,22 @@
     </fieldset>
   {/if}
 
-  {if $pcpBlock}
+  {if $pcpBlock && $pcp_display_in_roll}
     <div class="crm-group pcp_display-group">
       <div class="header-dark">
         {ts}Contribution Honor Roll{/ts}
       </div>
       <div class="display-block">
-        {if $pcp_display_in_roll}
-          {ts}List my contribution{/ts}
-          {if $pcp_is_anonymous}
-            <strong>{ts}anonymously{/ts}.</strong>
-          {else}
-            {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
-            {if $pcp_personal_note}
-              {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
-            {else}
-              <strong>{ts}With no personal note{/ts}</strong>
-            {/if}
-          {/if}
+        {ts}List my contribution{/ts}
+        {if $pcp_is_anonymous}
+          <strong>{ts}anonymously{/ts}.</strong>
         {else}
-          {ts}Don't list my contribution in the honor roll.{/ts}
+          {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
+          {if $pcp_personal_note}
+            {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
+          {else}
+            <strong>{ts}With no personal note{/ts}</strong>
+          {/if}
         {/if}
         <br />
       </div>

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -55,28 +55,24 @@
         </div>
     </div>
 
-    {if $pcpBlock}
+    {if $pcpBlock && $pcp_display_in_roll}
     <div class="crm-group pcp_display-group">
         <div class="header-dark">
            {ts}Contribution Honor Roll{/ts}
         </div>
         <div class="display-block">
-            {if $pcp_display_in_roll}
-                {ts}List my contribution{/ts}
-                {if $pcp_is_anonymous}
-                    <strong>{ts}anonymously{/ts}.</strong>
-                {else}
+          {ts}List my contribution{/ts}
+          {if $pcp_is_anonymous}
+              <strong>{ts}anonymously{/ts}.</strong>
+          {else}
             {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
-                    {if $pcp_personal_note}
-                        {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
-                    {else}
-                     <strong>{ts}With no personal note{/ts}</strong>
-                     {/if}
-                {/if}
+            {if $pcp_personal_note}
+                {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
             {else}
-                {ts}Don't list my contribution in the honor roll.{/ts}
-            {/if}
-            <br />
+             <strong>{ts}With no personal note{/ts}</strong>
+             {/if}
+          {/if}
+          <br />
         </div>
     </div>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Personal Campaign Pages (PCP), incorrectly displays "Don't list my contribution in the honor roll" even if the Contribution Honour Roll feature is not enabled or the user has opted out of the Honour Roll.

This confuses users who get to this step and then wonder "What honour roll?".

This PR was raised in response to a CiviCRM Support Request that Agileware received.

Before
----------------------------------------
On the PCP Confirmation and Thank You pages, the text: "Don't list my contribution in the honor roll" is displayed.
**Even if the Honour Roll feature is not enabled or the user has opted out of the Honour Roll.**

![honor roll](https://user-images.githubusercontent.com/58866555/175219631-d991d050-09cb-4501-b3d9-5c1f956bd631.png)

After
----------------------------------------
On the PCP Confirmation and Thank You pages, **no text is shown** if the Honour Roll feature is **not enabled** or the user has **opted out** of the Honour Roll.

![image](https://user-images.githubusercontent.com/58866555/175219720-815074c8-4467-4124-acfd-b226e5c27554.png)


Technical Details
----------------------------------------
Was unable to find a smarty variable to handle the situation where the Honour Roll is enabled and they opted out. So the lessor of two evils is just to not show the text.

Comments
----------------------------------------

Agileware Ref: CIVICRM-2004