### PR TITLE
Unassigned variable in invoice message template

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -288,8 +288,8 @@
 
       <table style="margin-top:75px;font-family: Arial, Verdana, sans-serif" width="100%" border="0" cellpadding="5" cellspacing="5" id="desc">
         <tr>
-          <td colspan="2" {$valueStyle}>
-            <table> {* FIXME: style this table so that it looks like the text version (justification, etc.) *}
+          <td colspan="2">
+            <table>
               <tr>
                 <th style="padding-right:28px;text-align:left;font-weight:bold;width:200px;"><font size="1">{ts}Description{/ts}</font></th>
                 <th style="padding-left:28px;text-align:right;font-weight:bold;"><font size="1">{ts}Quantity{/ts}</font></th>


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/23829

This unassigned variable was giving me an error while testing the above PR. It appears to be copy/paste from another template, added at https://github.com/civicrm/civicrm-core/commit/b8df2a8051da700883575bb47ff07ed32889e957.

Similarly the comment is copy/paste and meaningless here because there is no text version of this template.