### PR TITLE
dev/core#3432 UI Dialog - Fix transparent background caused by certain other plugins

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3141,6 +3141,7 @@ span.crm-select-item-color {
 }
 
 .crm-container.ui-dialog {
+  background-color: #fff;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
 }
 .crm-container.ui-dialog.ui-resizable:before {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3432](https://lab.civicrm.org/dev/core/-/issues/3432)
It was reported that certain Drupal modules that include a copy of jQuery UI cause the background to become transparent. This should prevent that.

