### PR TITLE
returns weight 0 when weight column name is empty

### DIFF
--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -233,6 +233,11 @@ class CRM_Utils_Weight {
    * @return int
    */
   public static function getMax($daoName, $fieldValues = NULL, $weightField = 'weight') {
+    if (empty($weightField)) {
+      Civi::log()->warning('Missing weight field name for ' . $daoName);
+      return 0;
+    }
+
     $selectField = "MAX(ROUND($weightField)) AS max_weight";
     $weightDAO = CRM_Utils_Weight::query('SELECT', $daoName, $fieldValues, $selectField);
     $weightDAO->fetch();


### PR DESCRIPTION
Overview
----------------------------------------
During upgrades, some columns may not exist yet, causing CRM_Utils_Weight::getMax() to occasionally fail.

Before
----------------------------------------
Sometimes $weightField is empty which triggers a DB Error.

After
----------------------------------------
When $weightField is empty, a weight of zero is returned by CRM_Utils_Weight::getMax() and a warning is logged.


