### PR TITLE
Set target="_blank" on external footer links

### DIFF
--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -15,15 +15,15 @@
 
   <div class="crm-footer" id="civicrm-footer">
     {crmVersion assign=version}
-    {ts}Powered by CiviCRM{/ts} <a href="https://download.civicrm.org/about/{$version}">{$version}</a>.
+    {ts}Powered by CiviCRM{/ts} <a href="https://download.civicrm.org/about/{$version}" rel="external" target="_blank">{$version}</a>.
     {if $footer_status_severity}
       <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>
     </span>
     {/if}
-    {ts 1='http://www.gnu.org/licenses/agpl-3.0.html'}CiviCRM is openly available under the <a href='%1'>GNU AGPL License</a>.{/ts}<br/>
-    <a href="https://civicrm.org/download">{ts}Download CiviCRM.{/ts}</a> &nbsp; &nbsp;
-    <a href="https://lab.civicrm.org/groups/dev/-/issues">{ts}View issues and report bugs.{/ts}</a> &nbsp; &nbsp;
+    {ts 1='href="http://www.gnu.org/licenses/agpl-3.0.html" rel="external" target="_blank"'}CiviCRM is openly available under the <a %1>GNU AGPL License</a>.{/ts}<br/>
+    <a href="https://civicrm.org/download" rel="external" target="_blank">{ts}Download CiviCRM.{/ts}</a> &nbsp; &nbsp;
+    <a href="https://lab.civicrm.org/groups/dev/-/issues" rel="external" target="_blank">{ts}View issues and report bugs.{/ts}</a> &nbsp; &nbsp;
     {capture assign=docUrlText}{ts}Online documentation.{/ts}{/capture}
     {docURL page="" text=$docUrlText}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Adds `rel="external"` and `target="_blank"` attributes to external links in the footer.

Before
----------------------------------------
Links in the footer use the same window context, which can potentially cause data loss when opened.

After
----------------------------------------
Links in the footer open in a new window/tab.

Technical Details
----------------------------------------
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-external
