### PR TITLE
(WIP) Auto-activate classes that support HookInterface (et al)

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -225,6 +225,9 @@ class CRM_Extension_Manager {
     }
 
     $this->refresh();
+    // It might be useful to reset the container, but (given dev/core#3686) that's not likely to do much.
+    // \Civi::reset();
+    // \CRM_Core_Config::singleton(TRUE, TRUE);
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
   }
 
@@ -311,6 +314,8 @@ class CRM_Extension_Manager {
     $this->statuses = NULL;
     $this->mapper->refresh();
     if (!CRM_Core_Config::isUpgradeMode()) {
+      \Civi::reset();
+      \CRM_Core_Config::singleton(TRUE, TRUE);
       CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 
       $schema = new CRM_Logging_Schema();
@@ -422,6 +427,8 @@ class CRM_Extension_Manager {
 
     $this->statuses = NULL;
     $this->mapper->refresh();
+    \Civi::reset();
+    \CRM_Core_Config::singleton(TRUE, TRUE);
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 
     $this->popProcess($keys);
@@ -480,6 +487,8 @@ class CRM_Extension_Manager {
 
     $this->statuses = NULL;
     $this->mapper->refresh();
+    // At the analogous step of `install()` or `disable()`, it would reset the container.
+    // But here, the extension goes from "disabled=>uninstall". All we really need is to reconcile mgd's.
     CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
     $this->popProcess($keys);
   }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -63,21 +63,25 @@ class Container {
       return $containerBuilder;
     }
 
-    $envId = \CRM_Core_Config_Runtime::getId();
+    $envId = md5(implode(',', array_merge(
+      [\CRM_Core_Config_Runtime::getId()],
+      array_column(\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'prefix')
+    )));
     $file = \Civi::paths()->getPath("[civicrm.compile]/CachedCiviContainer.{$envId}.php");
+    $containerCacheClass = "CachedCiviContainer_{$envId}";
     $containerConfigCache = new ConfigCache($file, $cacheMode === 'auto');
     if (!$containerConfigCache->isFresh()) {
       $containerBuilder = $this->createContainer();
       $containerBuilder->compile();
       $dumper = new PhpDumper($containerBuilder);
       $containerConfigCache->write(
-        $dumper->dump(['class' => 'CachedCiviContainer']),
+        $dumper->dump(['class' => $containerCacheClass]),
         $containerBuilder->getResources()
       );
     }
 
     require_once $file;
-    $c = new \CachedCiviContainer();
+    $c = new $containerCacheClass();
     return $c;
   }
 

--- a/mixin/scan-classes@1/example/CRM/Shimmy/ShimmyHooks.php
+++ b/mixin/scan-classes@1/example/CRM/Shimmy/ShimmyHooks.php
@@ -1,0 +1,9 @@
+<?php
+
+class CRM_Shimmy_ShimmyHooks implements \Civi\Core\HookInterface {
+
+  public static function hook_civicrm_shimmyFooBar(array &$data, string $name): void {
+    $data[] = "hello $name";
+  }
+
+}

--- a/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
+++ b/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
@@ -109,6 +109,11 @@ class E2E_Shimmy_LifecycleTest extends \PHPUnit\Framework\TestCase implements \C
         return (array) civicrm_api4($entity, $action, $params);
       }
 
+      public function phpEval(string $expr): array {
+        // phpcs:ignore
+        return eval($expr);
+      }
+
     };
   }
 
@@ -122,6 +127,10 @@ class E2E_Shimmy_LifecycleTest extends \PHPUnit\Framework\TestCase implements \C
       public function api4($entity, $action, $params): array {
         $params = array_merge(['checkPermissions' => FALSE], $params);
         return $this->cv('api4 --in=json ' . escapeshellarg("$entity.$action"), json_encode($params));
+      }
+
+      public function phpEval(string $expr): array {
+        return $this->cv('php:eval ' . escapeshellarg($expr));
       }
 
       /**


### PR DESCRIPTION
Overview
----------------------------------------

`HookInterface` and `EventSubscriberInterface` provide a way for classes to listen for events. 

```php
class Foo implements \Civi\Core\HookInterface {
  public static function hook_civicrm_foobar($foo, $bar) { ... }
}

class Foo implements EventSubscriberInterface {
  public static function getSubscribedEvents() {
    return ['hook_civicrm_foobar' => 'onFoobar'];
  }

  public static function onFoobar($event) { ... }
}
```

This update makes it easier for extensions to use these interfaces. It also has to fix a related issue with extensions are activated/deactivated during testing.

(Note: This is an off-shoot of #23854 and depends upon it.)

Before
----------------------------------------

Classes like `Foo` are autoloaded in some limited scenarios - eg BAOs and headless tests.

It's maybe possible to manually register using some mix of `dispatcher()`, `hook_container`, `EventScanner`.

After
----------------------------------------

Classes like `Foo` are autoloaded from extensions, if they enable class scanning (#23854).

```xml
<!-- FILE: myextension/info.xml -->
<mixins>
  <mixin>scan-classes@1.0.0</mixin>
</mixins>
```

Comments
----------------------------------------

There is test coverage in `mixin/scan-classes@1/example`.

This is WIP because:

* Need a new test-run to see if the drafted fix for the phpunit-harness issue works.
* Need to add EventSubscriberInterface
* Need to test/consider what (if anything) is needed for the previous integration between headless-tests and HookInterface. (Don't want them to register at runtime...)
