### PR TITLE
Enable the 'notify' parameter for WordPress user creation

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -881,6 +881,12 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       'role' => get_option('default_role'),
     ];
 
+    // The notify parameter was ignored on WordPress and default behaviour was to always notify.
+    // Preserve that behaviour but allow the "notify" parameter to be used.
+    if (!isset($params['notify'])) {
+      $params['notify'] = TRUE;
+    }
+
     // If there's a password add it, otherwise generate one.
     if (!empty($params['cms_pass'])) {
       $user_data['user_pass'] = $params['cms_pass'];
@@ -939,8 +945,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       wp_signon($creds, FALSE);
     }
 
-    // Fire the new user action. Sends notification email by default.
-    do_action('register_new_user', $uid);
+    if ($params['notify']) {
+      // Fire the new user action. Sends notification email by default.
+      do_action('register_new_user', $uid);
+    }
 
     // Restore the CiviCRM-WordPress listeners.
     $this->hooks_core_add();


### PR DESCRIPTION
Overview
----------------------------------------
The Drupal/Backdrop `createUser()` function supports a parameter "notify" which controls whether a CMS new account notification email is sent. This parameter is ignored in WordPress but easy to implement per this PR.

Before
----------------------------------------
"notify" parameter for `createUser()` is ignored on WordPress - user is always notified.

After
----------------------------------------
"notify" parameter for `createUser()` is respected on WordPress if set - if not set default behaviour to notify user is maintained.

Technical Details
----------------------------------------
This can be achieved in CMS specific ways too but adding this will make it much easier for extensions like cmsuser and for the CiviCRM core "add user" form to control whether the user should be notified of a new user account.

Comments
----------------------------------------

