### PR TITLE
crm-l10n.js - don't assume GenericHookEvent has params

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -427,7 +427,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
       return;
     }
     $e->mimeType = 'application/javascript';
-    $params = $e->params;
+    $params = (array) $e->params;
     $params += [
       'contactSearch' => json_encode($params['includeEmailInName'] ? ts('Search by name/email or id...') : ts('Search by name or id...')),
       'otherSearch' => json_encode(ts('Enter search term or id...')),


### PR DESCRIPTION
Overview
----------------------------------------
I spotted this message in my logs:

```
Error: Unsupported operand types in CRM_Core_Resources::renderL10nJs() (line 434 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Resources.php).
```

These lines are the culprit:
```php
    $params = $e->params;
    $params += [
      'contactSearch' => json_encode($params['includeEmailInName'] ? ts('Search by name/email or id...') : ts('Search by name or id...')),
      'otherSearch' => json_encode(ts('Enter search term or id...')),
      'entityRef' => self::getEntityRefMetadata(),
    ];
```
When you visit certain URLs (in my case, `http://dmaster.localhost/civicrm/asset/builder?an=crm-l10n.js&ap=XczLCsIwEEDRX5HBZVHra9GdFAUFRRAXQkHGZNDIJKl5oEX8d+PCIm7vgfsEoSQUgwyUERwlzTUqXpoNaoIiuEgZ4BUfW1vH2s8NnphkC8z2PmNyYRaDlcpr5T3ylx15G52gEsWFSivTEFaH6c2QOe53kAFbgfypbRBrSocz+Z8oMdDS1DEsrNMYkmhd9aWs+k2TOCj9x3mq2hpq2tLt5NlwNO5NpvB6Aw==&ad=31c289033814bcd6479ed823f4c9c65b`), `$e->params` is null, and you can't use `+` to join an array to a null.

Before
----------------------------------------
Unsupported operand type error.

After
----------------------------------------
`crm-l10n.js` renders correctly.

Technical Details
----------------------------------------
Just type-casting `$e->params`.  The only other way I could get this code to run was by clearing cache, which showed `$e->params` as an array - but we can deduce it's always (supposed to be) an array because in no other scenario could we use `+=` to add an array to something.