### PR TITLE
WorkflowMessageTest - Re-enable skipped test

### DIFF
--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -66,11 +66,16 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
     $this->assertRegExp('/The role is myrole./', $result['text']);
   }
 
+  public function testRenderExamplesBaseline() {
+    $examples = $this->getRenderExamples();
+    $this->assertTrue(isset($examples['workflow/contribution_recurring_edit/AlexCancelled']));
+  }
+
   public function getRenderExamples(): array {
     $metas = \Civi\Test::examples()->getMetas();
     $results = [];
     foreach ($metas as $name => $meta) {
-      if (empty($meta['workflow'])) {
+      if (!empty($meta['data']['workflow'])) {
         continue;
       }
       if (empty($meta['tags']) || !in_array('phpunit', $meta['tags'])) {


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #23811 (409b1e0c30d28179f6244c1f180838a473d7582c). The prior commit changed the way it found examples - and caused it to skip some examples.

This re-enables the example and adds an assertion to ensure that it actually finds some examples.

Before
----------------------------------------

* Test may be skipped -- because data-provider may return empty.

After
----------------------------------------

* Test runs -- because data-provider returns real data.
* If data-provider somehow returns empty, then it would raise a different error.

