### PR TITLE
Reset smarty-security after an exception

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -176,15 +176,22 @@ class CRM_Core_Smarty extends Smarty {
    * @param bool $display
    *
    * @return bool|mixed|string
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
    */
   public function fetch($resource_name, $cache_id = NULL, $compile_id = NULL, $display = FALSE) {
     if (preg_match('/^(\s+)?string:/', $resource_name)) {
       $old_security = $this->security;
       $this->security = TRUE;
     }
-    $output = parent::fetch($resource_name, $cache_id, $compile_id, $display);
-    if (isset($old_security)) {
-      $this->security = $old_security;
+    try {
+      $output = parent::fetch($resource_name, $cache_id, $compile_id, $display);
+    }
+    finally {
+      if (isset($old_security)) {
+        $this->security = $old_security;
+      }
     }
     return $output;
   }


### PR DESCRIPTION
This stops tests from getting befuddled
