### PR TITLE
Ensure apiv3 params are converted at the line item level

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -94,6 +94,10 @@ function civicrm_api3_order_create(array $params): array {
         $order->setEntityParameters($lineItems['params'], $index);
       }
       foreach ($lineItems['line_item'] as $innerIndex => $lineItem) {
+        // For historical reasons it might be name.
+        if (!empty($lineItem['membership_type_id']) && !is_numeric($lineItem['membership_type_id'])) {
+          $lineItem['membership_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'membership_type_id', $lineItems['params']['membership_type_id']);
+        }
         $lineIndex = $index . '+' . $innerIndex;
         $order->setLineItem($lineItem, $lineIndex);
         $order->addLineItemToEntityParameters($lineIndex, $index);


### PR DESCRIPTION
We switched to using apiv4 but at least one test seems to be passing in a string
at the line item level which is a bit weird but we should handle it

Minor split off from https://github.com/civicrm/civicrm-core/pull/23870 to help me simplify it down