### PR TITLE
dev/core#3514 Add interface to allow extensions that deal with imports to cope with 5.51

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -22,6 +22,26 @@
 class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
 
   /**
+   * Get information about the provided job.
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   *  e.g. ['activity_import' => ['id' => 'activity_import', 'label' => ts('Activity Import'), 'name' => 'activity_import']]
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'activity_import' => [
+        'id' => 'activity_import',
+        'name' => 'activity_import',
+        'label' => ts('Activity Import'),
+      ],
+    ];
+  }
+
+  /**
    * The initializer code, called before the processing.
    */
   public function init() {

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -86,6 +86,25 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
+   * Get information about the provided job.
+   *
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'contact_import' => [
+        'id' => 'contact_import',
+        'name' => 'contact_import',
+        'label' => ts('Contact Import'),
+      ],
+    ];
+  }
+
+  /**
    * Get the fields to track the import.
    *
    * @return array

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -43,6 +43,26 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   }
 
   /**
+   * Get information about the provided job.
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   *  e.g. ['activity_import' => ['id' => 'activity_import', 'label' => ts('Activity Import'), 'name' => 'activity_import']]
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'contribution_import' => [
+        'id' => 'contribution_import',
+        'name' => 'contribution_import',
+        'label' => ts('Contribution Import'),
+      ],
+    ];
+  }
+
+  /**
    * Contribution-specific result codes
    * @see CRM_Import_Parser result code constants
    */

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -15,6 +15,9 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Core\ClassScanner;
+use Civi\UserJob\UserJobInterface;
+
 /**
  * This class contains user jobs functionality.
  */
@@ -140,44 +143,20 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
    * @return array
    */
   public static function getTypes(): array {
-    return [
-      [
-        'id' => 'contact_import',
-        'name' => 'contact_import',
-        'label' => ts('Contact Import'),
-        'class' => 'CRM_Contact_Import_Parser_Contact',
-      ],
-      [
-        'id' => 'contribution_import',
-        'name' => 'contribution_import',
-        'label' => ts('Contribution Import'),
-        'class' => 'CRM_Contribute_Import_Parser_Contribution',
-      ],
-      [
-        'id' => 'membership_import',
-        'name' => 'membership_import',
-        'label' => ts('Membership Import'),
-        'class' => 'CRM_Member_Import_Parser_Membership',
-      ],
-      [
-        'id' => 'activity_import',
-        'name' => 'activity_import',
-        'label' => ts('Activity Import'),
-        'class' => 'CRM_Activity_Import_Parser_Activity',
-      ],
-      [
-        'id' => 'participant_import',
-        'name' => 'participant_import',
-        'label' => ts('Participant Import'),
-        'class' => 'CRM_Event_Import_Parser_Participant',
-      ],
-      [
-        'id' => 'custom_field_import',
-        'name' => 'custom_field_import',
-        'label' => ts('Multiple Value Custom Field Import'),
-        'class' => 'CRM_Custom_Import_Parser_Api',
-      ],
-    ];
+    $types = Civi::cache()->get('UserJobTypes');
+    if ($types === NULL) {
+      $types = [];
+      $classes = ClassScanner::get(['interface' => UserJobInterface::class]);
+      foreach ($classes as $class) {
+        $declaredTypes = $class::getUserJobInfo();
+        foreach ($declaredTypes as $index => $declaredType) {
+          $declaredTypes[$index]['class'] = $class;
+        }
+        $types = array_merge($types, $declaredTypes);
+      }
+      Civi::cache()->set('UserJobTypes', $types);
+    }
+    return $types;
   }
 
 }

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -11,6 +11,25 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
   protected $_multipleCustomData = '';
 
   /**
+   * Get information about the provided job.
+   *
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'custom_field_import' => [
+        'id' => 'custom_field_import',
+        'name' => 'custom_field_import',
+        'label' => ts('Multiple Value Custom Field Import'),
+      ],
+    ];
+  }
+
+  /**
    * The initializer code, called before the processing
    *
    * @return void

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -72,6 +72,25 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
   }
 
   /**
+   * Get information about the provided job.
+   *
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'participant_import' => [
+        'id' => 'participant_import',
+        'name' => 'participant_import',
+        'label' => ts('Participant Import'),
+      ],
+    ];
+  }
+
+  /**
    * The initializer code, called before the processing.
    */
   public function init() {

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -562,6 +562,7 @@ abstract class CRM_Import_DataSource {
     foreach (CRM_Core_BAO_UserJob::getTypes() as $type) {
       if ($this->getUserJob()['job_type'] === $type['id']) {
         $parserClass = $type['class'];
+        break;
       }
     }
     /* @var \CRM_Import_Parser */

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -55,6 +55,26 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
   protected $_lineCount;
 
   /**
+   * Get information about the provided job.
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   *  e.g. ['activity_import' => ['id' => 'activity_import', 'label' => ts('Activity Import'), 'name' => 'activity_import']]
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'membership_import' => [
+        'id' => 'membership_import',
+        'name' => 'membership_import',
+        'label' => ts('Membership Import'),
+      ],
+    ];
+  }
+
+  /**
    * @param string $name
    * @param $title
    * @param int $type

--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -135,6 +135,7 @@ class ClassScanner {
     static::scanFolders($classes, $civicrmRoot, 'CRM/*/WorkflowMessage', '_');
     static::scanFolders($classes, $civicrmRoot, 'Civi/*/WorkflowMessage', '\\');
     static::scanFolders($classes, $civicrmRoot, 'Civi/WorkflowMessage', '\\');
+    static::scanFolders($classes, $civicrmRoot, 'CRM/*/Import', '_');
     if (\CRM_Utils_Constant::value('CIVICRM_UF') === 'UnitTests') {
       static::scanFolders($classes, $civicrmRoot . 'tests/phpunit', 'CRM/*/WorkflowMessage', '_');
       static::scanFolders($classes, $civicrmRoot . 'tests/phpunit', 'Civi/*/WorkflowMessage', '\\');

--- a/Civi/UserJob/UserJobInterface.php
+++ b/Civi/UserJob/UserJobInterface.php
@@ -1,1 +1,42 @@
 <?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\UserJob;
+
+interface UserJobInterface {
+
+  /**
+   * Get information about the provided job.
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   *  e.g. ['activity_import' => ['id' => 'activity_import', 'label' => ts('Activity Import'), 'name' => 'activity_import']]
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array;
+
+  /**
+   * Run import.
+   *
+   * @param \CRM_Queue_TaskContext $taskContext
+   * @param int $userJobID
+   *   The id in the civicrm_user_job table.
+   * @param int $limit
+   *   A value of zero means no limit
+   * @param int $offset
+   *
+   * @return bool
+   */
+  public static function runJob(\CRM_Queue_TaskContext $taskContext, int $userJobID, int $limit, int $offset): bool;
+
+}

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -381,7 +381,7 @@ class QueueTest extends Api4TestBase {
     $this->assertEquals(0, $queue->numberOfItems());
 
     $userJob = \Civi\Api4\UserJob::create(FALSE)->setValues([
-      'job_type:label' => 'Contact Import',
+      'job_type:name' => 'contact_import',
       'status_id:name' => 'in_progress',
       'queue_id.name' => $queue->getName(),
     ])->execute()->single();


### PR DESCRIPTION
Overview
----------------------------------------
I have to update `csvImporter` for 5.51 & there is also AdvImport & they need to be able to use the userJob table - this allows them to define interfaces

(Depends: #23888)

Before
----------------------------------------
Core UserJob table has a hard-coded list of job-types

After
----------------------------------------
Extensions can declare UserJob interfaces


Technical Details
----------------------------------------
The required functions are
```  public static function getUserJobInfo(): array;```
```  public static function runJob(\CRM_Queue_TaskContext $taskContext, int $userJobID, int $limit, int $offset): bool;```



Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3514