### PR TITLE
dev/core#3701 - Prevent e-notice on map fields form

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -328,6 +328,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $js .= "</script>\n";
     $this->assign('initHideBoxes', $js);
 
+    $this->assign('saveMappingIsChecked', FALSE);
+
     $this->setDefaults($defaults);
 
     $this->addFormButtons();
@@ -357,9 +359,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
     }
     $template = CRM_Core_Smarty::singleton();
-    if (!empty($fields['saveMapping'])) {
-      $template->assign('isCheked', TRUE);
-    }
+    $template->assign('saveMappingIsChecked', !empty($fields['saveMapping']));
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -28,7 +28,7 @@ if ( document.getElementsByName("saveMapping")[0].checked ) {
     document.getElementsByName("saveMapping")[0].checked = false;
 }
 {/literal}
-{if $isCheked}
+{if $saveMappingIsChecked}
     document.getElementsByName("saveMapping")[0].checked = true;
 {/if}
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3701

Before
----------------------------------------
e-notice appears

After
----------------------------------------
e-notice disappears

Technical Details
----------------------------------------
I chose 5.51 as target branch since this was a review based on the rc testing. Feel free to recommend otherwise.

Comments
----------------------------------------
I can't wrap my head around, what the javascript in https://github.com/civicrm/civicrm-core/blob/4a01628cfa19ac305b5734e8ea36713f363b8d91/templates/CRM/Contact/Import/Form/MapField.tpl#L24-L34 is actually supposed to achieve.
