### PR TITLE
Allow Smarty "$VARS". Fix warning on "Match Fields" step.

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -122,6 +122,7 @@ class CRM_Core_Smarty extends Smarty {
 
     $tsLocale = CRM_Core_I18n::getLocale();
     $this->assign('tsLocale', $tsLocale);
+    $this->assign('VARS', new CRM_Core_Smarty_ReflectStub($this));
 
     // CRM-7163 hack: we don’t display langSwitch on upgrades anyway
     if (!CRM_Core_Config::isUpgradeMode()) {

--- a/CRM/Core/Smarty/ReflectStub.php
+++ b/CRM/Core/Smarty/ReflectStub.php
@@ -1,0 +1,27 @@
+<?php
+
+class CRM_Core_Smarty_ReflectStub {
+
+  private $smarty;
+
+  /**
+   * @param \CRM_Core_Smarty $scope
+   */
+  public function __construct($scope) {
+    $this->smarty = $scope;
+  }
+
+  /**
+   * Lookup a Smarty variable.
+   *
+   * @param string $name
+   * @param mixed|null $default
+   * @return mixed|null
+   *   The value of the Smarty variable, or else the $default.
+   */
+  public function get($name, $default = NULL) {
+    $all = $this->smarty->get_template_vars();
+    return $all[$name] ?? $default;
+  }
+
+}

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -28,7 +28,7 @@ if ( document.getElementsByName("saveMapping")[0].checked ) {
     document.getElementsByName("saveMapping")[0].checked = false;
 }
 {/literal}
-{if $isCheked}
+{if $VARS->get('isCheked')}
     document.getElementsByName("saveMapping")[0].checked = true;
 {/if}
 </script>


### PR DESCRIPTION
Overview
----------------------------------------

Alternative to #23905

Before
----------------------------------------

If you set `CIVICRM_SMARTY_DEFAULT_ESCAPE` to `TRUE`, then basic conditions like this are unreliable:

```html
{if $foo}
...
{/if}
```

They are unreliable because `$foo` is pushed through the default filter, which mucks up detection of `$foo`. In this mode, there does not appear any notation that means "check for `$foo`, plain and simple".

After
----------------------------------------

There is a safe notation for testing a variable in either mode:

```html
{if $VARS->get('foo')}
...
{/if}
```

You can optionally pass a default

```html
{if $VARS->get('foo', TRUE)}
...
{/if}
```

Comment
----------------------------------------

(Updated note) I included one commit for the `MapField.tpl`, but that could be removed from the branch.