### PR TITLE
allow bounce threshold to be 0 for bounces that you want to ignore like vacation auto reply

### DIFF
--- a/CRM/Mailing/Event/BAO/Bounce.php
+++ b/CRM/Mailing/Event/BAO/Bounce.php
@@ -261,7 +261,7 @@ class CRM_Mailing_Event_BAO_Bounce extends CRM_Mailing_Event_DAO_Bounce {
     $dao = CRM_Core_DAO::executeQuery($query);
 
     while ($dao->fetch()) {
-      if ($dao->bounces >= $dao->threshold) {
+      if ($dao->threshold && $dao->bounces >= $dao->threshold) {
         $email = new CRM_Core_BAO_Email();
         $email->id = $email_id;
         $email->on_hold = TRUE;


### PR DESCRIPTION
We can set the bounce threshold = 0 when you want to record bounces but not mark the email on hold.


Related to: https://lab.civicrm.org/dev/core/-/issues/3552