### PR TITLE
CRM_Report_Form: set _from and _where as public for the alterReportVar hook

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -265,14 +265,16 @@ class CRM_Report_Form extends CRM_Core_Form {
   protected $_aliases = [];
 
   /**
+   * SQL where clause. May be altered by hook_civicrm_alterReportVar.
    * @var string
    */
-  protected $_where;
+  public $_where;
 
   /**
+   * SQL from clause. May be altered by hook_civicrm_alterReportVar.
    * @var string
    */
-  protected $_from;
+  public $_from;
 
   /**
    * SQL Limit clause


### PR DESCRIPTION
Overview
----------------------------------------

The [alterReportVar](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterReportVar/) hook documentation states:

> sql - this is called shortly before the query is executed. $var here is the same as $reportForm. You can alter $var->_select, $var->_from, etc.

which would mean that the hook should be able to alter the `$reportForm->_from` variable, but we can't because it's a protected variable.

Many other variables are public, so I don't see any harm in making these public?

Here is an example use-case:

```
/**
 * Implements hook_civicrm_alterReportVar().
 */
function foo_civicrm_alterReportVar($varType, &$var, $reportForm) {
  if ($varType == 'sql') {
    if ($reportForm->getID() == 45) {
      // Use the billing address, instead of the primary address
      $reportForm->_from = preg_replace('/address_civireport.is_primary = 1/', 'address_civireport.is_billing = 1', $reportForm->_from);
    }
  }
}
```