### PR TITLE
[REF][PHP8.1] Ensure that NULL is not passed to substr in CRM_Utils_F…

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -729,7 +729,7 @@ abstract class CRM_Utils_System_Base {
       }
     }
     else {
-      $userFrameworkResourceURL = NULL;
+      $userFrameworkResourceURL = '';
     }
 
     return [


### PR DESCRIPTION
…ile::addTrailingSlash

Overview
----------------------------------------
This aims to fix the following deprecation `Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Utils/File.php on line 267` which is triggered when trying to run CRM API etc unit tests on php8.1

Before
----------------------------------------
Deprecation triggered

After
----------------------------------------
No Deprecation triggered

ping @eileenmcnaughton @totten @demeritcowboy 