### PR TITLE
dev/core#3702 - `<af-field>` tags are not valid html

### DIFF
--- a/ext/afform/core/Civi/Afform/Symbols.php
+++ b/ext/afform/core/Civi/Afform/Symbols.php
@@ -35,7 +35,7 @@ class Symbols {
    */
   public static function scan($html) {
     $symbols = new static();
-    $doc = new \DOMDocumentWrapper($html, 'text/html');
+    $doc = new \DOMDocumentWrapper($html, 'text/xml');
     $symbols->scanNode($doc->root);
     return $symbols;
   }

--- a/ext/afform/core/tests/phpunit/Civi/Afform/SymbolsTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/SymbolsTest.php
@@ -25,7 +25,7 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
     $exs[] = [
       '<div/>',
       [
-        'e' => ['div' => 1, 'body' => 1],
+        'e' => ['div' => 1, 'fake' => 1],
         'a' => [],
         'c' => [],
       ],
@@ -33,7 +33,7 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
     $exs[] = [
       '<my-tabset><my-tab id="1"/><my-tab id="2">foo</my-tab><my-tab id="3">bar</my-tab></my-tabset>',
       [
-        'e' => ['my-tabset' => 1, 'my-tab' => 3, 'body' => 1],
+        'e' => ['my-tabset' => 1, 'my-tab' => 3, 'fake' => 1],
         'a' => ['id' => 3],
         'c' => [],
       ],
@@ -41,7 +41,7 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
     $exs[] = [
       '<div class="my-parent"><div class="my-child"><img class="special" src="foo.png"/></div></div>',
       [
-        'e' => ['div' => 2, 'img' => 1, 'body' => 1],
+        'e' => ['div' => 2, 'img' => 1, 'fake' => 1],
         'a' => ['class' => 3, 'src' => 1],
         'c' => [
           'my-parent' => 1,
@@ -53,7 +53,7 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
     $exs[] = [
       '<div class="my-parent foo bar">a<div class="my-child whiz bang {{ghost + stuff}} last">b</div>c</div>',
       [
-        'e' => ['div' => 2, 'body' => 1],
+        'e' => ['div' => 2, 'fake' => 1],
         'a' => ['class' => 2],
         'c' => [
           'my-parent' => 1,
@@ -70,7 +70,7 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
     $exs[] = [
       '<div class="{{make[\'cheese\']}} {{ghost + stuff}} {{a}}_{{b}}"/>',
       [
-        'e' => ['div' => 1, 'body' => 1],
+        'e' => ['div' => 1, 'fake' => 1],
         'a' => ['class' => 1],
         'c' => [
           '{{ghost + stuff}}' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3702

Before
----------------------------------------
On dashboard, error `DOMDocument::loadHTML(): Tag af-field invalid in Entity`

After
----------------------------------------


Technical Details
----------------------------------------
I'm only getting this in php 8, so something must be different about how DOMDocument validates html. The afform blocks that get loaded during hook_civicrm_angularModules contain tags that are not part of the html spec. See lab ticket for more details.

Comments
----------------------------------------
It looks like this code in Symbols.php is only used for parsing out bits of the block, so whether it's html or xml doesn't seem too relevant.

Unit test is at https://github.com/civicrm/civicrm-core/pull/23918