### PR TITLE
fixes #3706 URL validation regression

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -221,7 +221,11 @@ class CRM_Utils_Rule {
       // allow relative URL's (CRM-15598)
       $url = 'http://' . $_SERVER['HTTP_HOST'] . $url;
     }
-    return (bool) filter_var(self::idnToAsci($url), FILTER_VALIDATE_URL);
+    // Convert URLs with Unicode to ASCII
+    if (strlen($url) != strlen(utf8_decode($url))) {
+      $url = self::idnToAsci($url);
+    }
+    return (bool) filter_var($url, FILTER_VALIDATE_URL);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -345,7 +345,7 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test CVV rule
+   * Test Email rule
    *
    * @param string $email
    * @param bool $expected expected outcome of the rule validation
@@ -368,6 +368,27 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
     $cases['test@localhost'] = ['test@localhost', TRUE];
     $cases['test@ēxāmplē.co'] = ['test@exāmple', FALSE];
     return $cases;
+  }
+
+  public static function urls(): array {
+    $urls = [];
+    $urls[] = ['https://mysite.org/index.php/apps/files/?dir=/Talk/Test%20Folder1/Test%20Folder%202&fileid=597195', TRUE];
+    $urls[] = ['http://täst.de', TRUE];
+    $urls[] = ['https://الاردن.jo', TRUE];
+    $urls[] = ['I didn\'t say Simon Says', FALSE];
+    return $urls;
+  }
+
+  /**
+   * Test URL rule
+   *
+   * @param string $url
+   * @param bool $expected expected outcome of the rule validation
+   *
+   * @dataProvider urls
+   */
+  public function testUrlRule(string $url, bool $expected): void {
+    $this->assertEquals($expected, CRM_Utils_Rule::url($url));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3706 - Some valid non-Unicode URLs are now failing validation

Before
----------------------------------------
This URL fails: `https://mysite.org/index.php/apps/files/?dir=/Talk/Test%20Folder1/Test%20Folder%202&fileid=597195`.
No tests.

After
----------------------------------------
That URL passes.
Tests.

Technical Details
----------------------------------------
We don't pass non-Unicode URLs to `idn_to_ascii`.  We compare the number of bytes in the URL compared to the number of bytes after decoding to ASCII to determine if there are code points outside the first 255.