### PR TITLE
[REF][PHP8.1] Stop Passing NULL values into mb_strlen in DAO nad strp…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -780,7 +780,7 @@ class CRM_Core_DAO extends DB_DataObject {
         }
         else {
           $maxLength = $field['maxlength'] ?? NULL;
-          if (!is_array($value) && $maxLength && mb_strlen($value) > $maxLength && empty($field['pseudoconstant'])) {
+          if (!is_array($value) && $maxLength && mb_strlen($value ?? '') > $maxLength && empty($field['pseudoconstant'])) {
             // No ts() since this is a sysadmin-y string not seen by general users.
             Civi::log()->warning('A string for field {dbName} has been truncated. The original string was {value}.', ['dbName' => $dbName, 'value' => $value]);
             // The string is too long - what to do what to do? Well losing data is generally bad so let's truncate

--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -145,7 +145,7 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
   }
 
   public function encodeValue($value) {
-    return str_replace(['<', '>'], ['&lt;', '&gt;'], $value);
+    return str_replace(['<', '>'], ['&lt;', '&gt;'], ($value ?? ''));
   }
 
   /**
@@ -192,7 +192,7 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
   }
 
   public function decodeValue($value) {
-    return str_replace(['&lt;', '&gt;'], ['<', '>'], $value);
+    return str_replace(['&lt;', '&gt;'], ['<', '>'], ($value ?? ''));
   }
 
   /**

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -694,7 +694,7 @@ function _civicrm_api3_activity_check_params(&$params) {
   // needs testing
   $activityTypes = CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'validate');
   $activityName = $params['activity_name'] ?? NULL;
-  $activityName = ucfirst($activityName);
+  $activityName = ucfirst($activityName ?? '');
   $activityLabel = $params['activity_label'] ?? NULL;
   if ($activityLabel) {
     $activityTypes = CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'create');

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -493,7 +493,7 @@ function civicrm_api3_contact_delete($params) {
  */
 function _civicrm_api3_contact_check_params(&$params) {
 
-  switch (strtolower(CRM_Utils_Array::value('contact_type', $params))) {
+  switch (strtolower($params['contact_type'] ?? '')) {
     case 'household':
       civicrm_api3_verify_mandatory($params, NULL, ['household_name']);
       break;

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -563,7 +563,7 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
     $returnProperties = NULL;
   }
 
-  if (substr($sort, 0, 2) == 'id') {
+  if (substr(($sort ?? ''), 0, 2) == 'id') {
     $sort = $lowercase_entity . "_" . $sort;
   }
 
@@ -1677,7 +1677,7 @@ function _civicrm_api3_validate_foreign_keys($entity, $action, &$params, $fields
  */
 function _civicrm_api3_validate_date(&$params, &$fieldName, &$fieldInfo) {
   [$fieldValue, $op] = _civicrm_api3_field_value_check($params, $fieldName);
-  if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
+  if (strpos(($op ?? ''), 'NULL') !== FALSE || strpos(($op ?? ''), 'EMPTY') !== FALSE) {
     return;
   }
 
@@ -2061,7 +2061,7 @@ function _civicrm_api3_validate_integer(&$params, $fieldName, &$fieldInfo, $enti
     // https://lab.civicrm.org/dev/rc/-/issues/14
     $fieldValue = 1;
   }
-  if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE) {
+  if (strpos(($op ?? ''), 'NULL') !== FALSE || strpos(($op ?? ''), 'EMPTY') !== FALSE) {
     return;
   }
 
@@ -2230,7 +2230,7 @@ function _civicrm_api3_validate_html(&$params, &$fieldName, $fieldInfo) {
 function _civicrm_api3_validate_string(&$params, &$fieldName, &$fieldInfo, $entity, $action) {
   $isGet = substr($action, 0, 3) === 'get';
   [$fieldValue, $op] = _civicrm_api3_field_value_check($params, $fieldName, 'String');
-  if (strpos($op, 'NULL') !== FALSE || strpos($op, 'EMPTY') !== FALSE || CRM_Utils_System::isNull($fieldValue)) {
+  if (strpos(($op ?? ''), 'NULL') !== FALSE || strpos(($op ?? ''), 'EMPTY') !== FALSE || CRM_Utils_System::isNull($fieldValue)) {
     return;
   }
 


### PR DESCRIPTION
…os in API validate string function

Overview
----------------------------------------
This resolves deprecation notices such as 

```
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /home/seamus/buildkit/build/dtest/web/sites/all/modules/civicrm/api/v3/utils.php on line 1680
PHP Deprecated:  ucfirst(): Passing null to parameter #1 ($string) of type string is deprecated in /home/seamus/buildkit/build/dtest/web/sites/all/modules/civicrm/api/v3/Activity.php on line 69
```
Before
----------------------------------------
Deprecation notices issued on php8.1

After
----------------------------------------
Less Deprecation notices issued on php8.1

ping @eileenmcnaughton @demeritcowboy @totten 