### PR TITLE
Angular - Support popping up an afform or other ang module via ajax modal

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -48,6 +48,13 @@ class AngularLoader {
   protected $region;
 
   /**
+   * @var array
+   * When adding supplimental modules via snippet,
+   * these modules are already loaded.
+   */
+  protected $modulesAlreadyLoaded = [];
+
+  /**
    * @var string
    *   Ex: 'civicrm/a'.
    */
@@ -73,6 +80,11 @@ class AngularLoader {
     $this->region = \CRM_Utils_Request::retrieve('snippet', 'String') ? 'ajax-snippet' : 'html-header';
     $this->pageName = \CRM_Utils_System::currentPath();
     $this->modules = [];
+    if ($this->region === 'ajax-snippet' && !empty($_GET['crmAngularModules'])) {
+      $this->modulesAlreadyLoaded = explode(',', $_GET['crmAngularModules']);
+    }
+    // Ensure region exists
+    \CRM_Core_Region::instance($this->region);
   }
 
   /**
@@ -115,7 +127,13 @@ class AngularLoader {
       ]);
     }
 
-    $moduleNames = $this->findActiveModules();
+    $allModules = $this->findActiveModules();
+    $moduleNames = array_values(array_diff($allModules, $this->modulesAlreadyLoaded));
+
+    if (!$moduleNames && $this->modulesAlreadyLoaded) {
+      // No modules to load
+      return $this;
+    }
     if (!$this->isAllModules($moduleNames)) {
       $assetParams = ['modules' => implode(',', $moduleNames)];
     }
@@ -124,7 +142,7 @@ class AngularLoader {
       $assetParams = ['nonce' => md5(implode(',', $moduleNames))];
     }
 
-    $res->addSettingsFactory(function () use (&$moduleNames, $angular, $res, $assetParams) {
+    $res->addSettingsFactory(function () use (&$moduleNames, $angular, $res, $assetParams, $allModules) {
       // Merge static settings with the results of settingsFactory functions
       $settingsByModule = $angular->getResources($moduleNames, 'settings', 'settings');
       foreach ($angular->getResources($moduleNames, 'settingsFactory', 'settingsFactory') as $moduleName => $factory) {
@@ -144,7 +162,7 @@ class AngularLoader {
       return array_merge($settingsByModule, ['permissions' => $permissions], [
         'resourceUrls' => \CRM_Extension_System::singleton()->getMapper()->getActiveModuleUrls(),
         'angular' => [
-          'modules' => $moduleNames,
+          'modules' => $allModules,
           'requires' => $angular->getResources($moduleNames, 'requires', 'requires'),
           'cacheCode' => $res->getCacheCode(),
           'bundleUrl' => \Civi::service('asset_builder')->getUrl('angular-modules.json', $assetParams),
@@ -152,13 +170,17 @@ class AngularLoader {
       ]);
     });
 
-    $res->addScriptFile('civicrm', 'bower_components/angular/angular.min.js', 100, $this->getRegion(), FALSE);
+    if (!$this->modulesAlreadyLoaded) {
+      $res->addScriptFile('civicrm', 'bower_components/angular/angular.min.js', 100, $this->getRegion(), FALSE);
+    }
 
     $headOffset = 0;
     $config = \CRM_Core_Config::singleton();
-    if ($config->debug) {
-      // FIXME: The `resetLocationProviderHashPrefix.js` has to stay in sync with `\Civi\Angular\Page\Modules::buildAngularModules()`.
-      $res->addScriptFile('civicrm', 'ang/resetLocationProviderHashPrefix.js', 101, $this->getRegion(), FALSE);
+    if ($config->debug || $this->modulesAlreadyLoaded) {
+      if (!$this->modulesAlreadyLoaded) {
+        // FIXME: The `resetLocationProviderHashPrefix.js` has to stay in sync with `\Civi\Angular\Page\Modules::buildAngularModules()`.
+        $res->addScriptFile('civicrm', 'ang/resetLocationProviderHashPrefix.js', 101, $this->getRegion(), FALSE);
+      }
       foreach ($moduleNames as $moduleName) {
         foreach ($this->angular->getResources($moduleName, 'css', 'cacheUrl') as $url) {
           $res->addStyleUrl($url, self::DEFAULT_MODULE_WEIGHT + (++$headOffset), $this->getRegion());
@@ -187,8 +209,10 @@ class AngularLoader {
       }
     }
     // Add bundles
-    foreach ($this->angular->getResources($moduleNames, 'bundles', 'bundles') as $bundles) {
-      $res->addBundle($bundles);
+    if (!$this->modulesAlreadyLoaded) {
+      foreach ($this->angular->getResources($moduleNames, 'bundles', 'bundles') as $bundles) {
+        $res->addBundle($bundles);
+      }
     }
 
     return $this;
@@ -366,7 +390,9 @@ class AngularLoader {
   public function onRegionRender($e) {
     if ($e->region->_name === $this->region && ($this->modules || $this->crmApp)) {
       $this->loadAngularResources();
-      $this->res->addScriptFile('civicrm', 'js/crm-angularjs-loader.js', 200, $this->getRegion(), FALSE);
+      if (!$this->modulesAlreadyLoaded) {
+        $this->res->addScriptFile('civicrm', 'js/crm-angularjs-loader.js', 200, $this->getRegion(), FALSE);
+      }
     }
   }
 

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -1097,21 +1097,27 @@
             $timeout(function() {
               var newPageTitle = _.trim($el.html()),
                 newDocumentTitle = scope.crmDocumentTitle || $el.text(),
-                h1Count = 0;
-              document.title = $('title').text().replace(documentTitle, newDocumentTitle);
-              // If the CMS has already added title markup to the page, use it
-              $('h1').not('.crm-container h1').each(function() {
-                if ($(this).hasClass('crm-page-title') || _.trim($(this).html()) === pageTitle) {
-                  $(this).addClass('crm-page-title').html(newPageTitle);
-                  $el.hide();
-                  ++h1Count;
+                h1Count = 0,
+                dialog = $el.closest('.ui-dialog-content');
+              if (dialog.length) {
+                dialog.dialog('option', 'title', newDocumentTitle);
+                $el.hide();
+              } else {
+                document.title = $('title').text().replace(documentTitle, newDocumentTitle);
+                // If the CMS has already added title markup to the page, use it
+                $('h1').not('.crm-container h1').each(function () {
+                  if ($(this).hasClass('crm-page-title') || _.trim($(this).html()) === pageTitle) {
+                    $(this).addClass('crm-page-title').html(newPageTitle);
+                    $el.hide();
+                    ++h1Count;
+                  }
+                });
+                if (!h1Count) {
+                  $el.show();
                 }
-              });
-              if (!h1Count) {
-                $el.show();
+                pageTitle = newPageTitle;
+                documentTitle = newDocumentTitle;
               }
-              pageTitle = newPageTitle;
-              documentTitle = newDocumentTitle;
             });
           }
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -68,14 +68,22 @@
 
       // Called after form is submitted and files are uploaded
       function postProcess() {
-        var metaData = ctrl.getFormMeta();
+        var metaData = ctrl.getFormMeta(),
+          dialog = $element.closest('.ui-dialog-content');
 
         $element.trigger('crmFormSuccess', {
           afform: metaData,
           data: data
         });
 
-        if (metaData.redirect) {
+        status.resolve();
+        $element.unblock();
+
+        if (dialog.length) {
+          dialog.dialog('close');
+        }
+
+        else if (metaData.redirect) {
           var url = metaData.redirect;
           if (url.indexOf('civicrm/') === 0) {
             url = CRM.url(url);
@@ -84,8 +92,6 @@
           }
           $window.location.href = url;
         }
-        status.resolve();
-        $element.unblock();
       }
 
       this.submit = function() {

--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -18,9 +18,22 @@
           $scope.crmUrl = CRM.url;
 
           // Afforms do not use routing, but some forms get input from search params
-          $scope.$watch(function() {return $location.search();}, function(params) {
-            $scope.routeParams = params;
-          });
+          var dialog = $el.closest('.ui-dialog-content');
+          if (!dialog.length) {
+            // Full-screen mode
+            $scope.$watch(function() {return $location.search();}, function(params) {
+              $scope.routeParams = params;
+            });
+          } else {
+            // Use urlHash embedded in popup dialog
+            $scope.routeParams = {};
+            if (dialog.data('urlHash')) {
+              var searchParams = new URLSearchParams(dialog.data('urlHash'));
+              searchParams.forEach(function(value, key) {
+                $scope.routeParams[key] = value;
+              });
+            }
+          }
 
           $scope.$parent.afformTitle = meta.title;
 

--- a/js/angular-crmResource/all.js
+++ b/js/angular-crmResource/all.js
@@ -5,14 +5,13 @@
 
   angular.module('crmResource').factory('crmResource', function($q, $http) {
     var deferreds = {}; // null|object; deferreds[url][idx] = Deferred;
-    var templates = null; // null|object; templates[url] = HTML;
 
     var notify = function notify() {
       var oldDfrds = deferreds;
       deferreds = null;
 
       angular.forEach(oldDfrds, function(dfrs, url) {
-        if (templates[url]) {
+        if (CRM.angular.templates[url]) {
           angular.forEach(dfrs, function(dfr) {
             dfr.resolve({
               status: 200,
@@ -20,7 +19,7 @@
                 var headers = {'Content-type': 'text/html'};
                 return name ? headers[name] : headers;
               },
-              data: templates[url]
+              data: CRM.angular.templates[url]
             });
           });
         }
@@ -35,10 +34,10 @@
     var moduleUrl = CRM.angular.bundleUrl;
     $http.get(moduleUrl)
       .then(function httpSuccess(response) {
-        templates = [];
-        angular.forEach(response.data, function(module) {
+        CRM.angular.templates = CRM.angular.templates || {};
+        angular.forEach(response.data, function (module) {
           if (module.partials) {
-            angular.extend(templates, module.partials);
+            angular.extend(CRM.angular.templates, module.partials);
           }
           if (module.strings) {
             CRM.addStrings(module.domain, module.strings);
@@ -46,15 +45,14 @@
         });
         notify();
       }, function httpError() {
-        templates = [];
         notify();
       });
 
     return {
       // @return string|Promise<string>
       getUrl: function getUrl(url) {
-        if (templates !== null) {
-          return templates[url];
+        if (CRM.angular.templates && CRM.angular.templates[url]) {
+          return CRM.angular.templates[url];
         }
         else {
           var deferred = $q.defer();

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -302,8 +302,10 @@
       });
     },
     refresh: function() {
-      var that = this;
-      var url = this._formatUrl(this.options.url, 'json');
+      var that = this,
+        hash = this.options.url.split('#')[1];
+        url = this._formatUrl(this.options.url, 'json');
+      $(this.element).data('urlHash', hash);
       if (this.options.crmForm) $('form', this.element).ajaxFormUnbind();
       if (this.options.block) this.element.block();
       this._ajax(url).then(function(data) {

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -273,6 +273,9 @@
         } else {
           url = url.replace(/snippet=[^&]*/, 'snippet=' + snippetType);
         }
+        if (snippetType === 'json' && CRM.angular) {
+          url += '&crmAngularModules=' + CRM.angular.modules.join();
+        }
       }
       return url;
     },


### PR DESCRIPTION
Overview
----------------------------------------
Allows Afforms to work as modal dialogs.

Before
----------------------------------------
Afform as popup not possible

After
----------------------------------------
Now they work.

Technical Details
----------------------------------------
- Fixes the AngularLoader to work with modal dialogs via ajax.
- Dedupes the already-loaded modules to only load what's needed.
- Passes args from the hash part of the url through to the afform (e.g. for pre-loading entities)
- Closes the dialog after submitting the afform (and refreshes search results if the popup originated from a search display)

Comments
-------------------
Also see https://lab.civicrm.org/extensions/certifications/-/issues/5