### PR TITLE
[REF][PHP8.1] Add in type hints to fix deprecations and add in #[\Ret…

### DIFF
--- a/CRM/Utils/LazyArray.php
+++ b/CRM/Utils/LazyArray.php
@@ -56,15 +56,16 @@ class CRM_Utils_LazyArray implements ArrayAccess, IteratorAggregate, Countable {
     return $this;
   }
 
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->load()->cache[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function &offsetGet($offset) {
     return $this->load()->cache[$offset];
   }
 
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     if ($offset === NULL) {
       $this->load()->cache[] = $value;
     }
@@ -73,10 +74,11 @@ class CRM_Utils_LazyArray implements ArrayAccess, IteratorAggregate, Countable {
     }
   }
 
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     unset($this->load()->cache[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function getIterator() {
     return new ArrayIterator($this->load()->cache);
   }
@@ -88,7 +90,7 @@ class CRM_Utils_LazyArray implements ArrayAccess, IteratorAggregate, Countable {
     return $this->load()->cache;
   }
 
-  public function count() {
+  public function count(): int {
     return count($this->load()->cache);
   }
 

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -327,13 +327,14 @@ abstract class AbstractAction implements \ArrayAccess {
   /**
    * @inheritDoc
    */
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return in_array($offset, ['entity', 'action', 'params', 'version', 'check_permissions', 'id']) || isset($this->_arrayStorage[$offset]);
   }
 
   /**
    * @inheritDoc
    */
+  #[\ReturnTypeWillChange]
   public function &offsetGet($offset) {
     $val = NULL;
     if (in_array($offset, ['entity', 'action'])) {
@@ -359,7 +360,7 @@ abstract class AbstractAction implements \ArrayAccess {
   /**
    * @inheritDoc
    */
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     if (in_array($offset, ['entity', 'action', 'entityName', 'actionName', 'params', 'version', 'id'])) {
       throw new \API_Exception('Cannot modify api4 state via array access');
     }
@@ -374,7 +375,7 @@ abstract class AbstractAction implements \ArrayAccess {
   /**
    * @inheritDoc
    */
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     if (in_array($offset, ['entity', 'action', 'entityName', 'actionName', 'params', 'check_permissions', 'version', 'id'])) {
       throw new \API_Exception('Cannot modify api4 state via array access');
     }

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -157,7 +157,7 @@ class Result extends \ArrayObject implements \JsonSerializable {
    *
    * @return int
    */
-  public function count() {
+  public function count(): int {
     return $this->rowCount ?? parent::count();
   }
 
@@ -211,6 +211,7 @@ class Result extends \ArrayObject implements \JsonSerializable {
   /**
    * @return array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getArrayCopy();
   }

--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -176,23 +176,26 @@ class RequestSpec implements \Iterator {
     return $this->action;
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     return reset($this->fields);
   }
 
+  #[\ReturnTypeWillChange]
   public function current() {
     return current($this->fields);
   }
 
+  #[\ReturnTypeWillChange]
   public function key() {
     return key($this->fields);
   }
 
-  public function next() {
-    return next($this->fields);
+  public function next(): void {
+    next($this->fields);
   }
 
-  public function valid() {
+  public function valid(): bool {
     return key($this->fields) !== NULL;
   }
 

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -528,6 +528,7 @@ class TokenRowIterator extends \IteratorIterator {
     $this->tokenProcessor = $tokenProcessor;
   }
 
+  #[\ReturnTypeWillChange]
   public function current() {
     return new TokenRow($this->tokenProcessor, parent::key());
   }

--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -355,7 +355,7 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
    *
    * @return bool
    */
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->tokenProcessor->rowContexts[$this->tokenRow][$offset])
       || isset($this->tokenProcessor->context[$offset]);
   }
@@ -367,6 +367,7 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
    *
    * @return string
    */
+  #[\ReturnTypeWillChange]
   public function &offsetGet($offset) {
     if (isset($this->tokenProcessor->rowContexts[$this->tokenRow][$offset])) {
       return $this->tokenProcessor->rowContexts[$this->tokenRow][$offset];
@@ -384,7 +385,7 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
    * @param string $offset
    * @param mixed $value
    */
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     $this->tokenProcessor->rowContexts[$this->tokenRow][$offset] = $value;
   }
 
@@ -393,7 +394,7 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
    *
    * @param mixed $offset
    */
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     unset($this->tokenProcessor->rowContexts[$this->tokenRow][$offset]);
   }
 
@@ -402,6 +403,7 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
    *
    * @return \ArrayIterator
    */
+  #[\ReturnTypeWillChange]
   public function getIterator() {
     return new \ArrayIterator($this->createMergedArray());
   }
@@ -411,7 +413,7 @@ class TokenRowContext implements \ArrayAccess, \IteratorAggregate, \Countable {
    *
    * @return int
    */
-  public function count() {
+  public function count(): int {
     return count($this->createMergedArray());
   }
 

--- a/ext/eventcart/CRM/Event/Cart/BAO/EventInCart.php
+++ b/ext/eventcart/CRM/Event/Cart/BAO/EventInCart.php
@@ -222,7 +222,7 @@ class CRM_Event_Cart_BAO_EventInCart extends CRM_Event_Cart_DAO_EventInCart impl
    *
    * @return bool
    */
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return array_key_exists(array_merge($this->fields(), ['main_conference_event_id']), $offset);
   }
 
@@ -231,6 +231,7 @@ class CRM_Event_Cart_BAO_EventInCart extends CRM_Event_Cart_DAO_EventInCart impl
    *
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset) {
     if ($offset == 'event') {
       return $this->event->toArray();
@@ -249,13 +250,13 @@ class CRM_Event_Cart_BAO_EventInCart extends CRM_Event_Cart_DAO_EventInCart impl
    * @param mixed $offset
    * @param mixed $value
    */
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
   }
 
   /**
    * @param mixed $offset
    */
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/QueryTestDataProvider.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTestDataProvider.php
@@ -210,6 +210,7 @@ class CRM_Contact_BAO_QueryTestDataProvider implements Iterator {
     $this->i = 0;
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->i = 0;
   }
@@ -217,6 +218,7 @@ class CRM_Contact_BAO_QueryTestDataProvider implements Iterator {
   /**
    * @return array
    */
+  #[\ReturnTypeWillChange]
   public function current() {
     $count = count($this->dataset[$this->i]['id']);
     $ids = $this->dataset[$this->i]['id'];
@@ -234,18 +236,19 @@ class CRM_Contact_BAO_QueryTestDataProvider implements Iterator {
   /**
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->i;
   }
 
-  public function next() {
+  public function next(): void {
     $this->i++;
   }
 
   /**
    * @return bool
    */
-  public function valid() {
+  public function valid(): bool {
     return isset($this->dataset[$this->i]);
   }
 

--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTestDataProvider.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/GroupTestDataProvider.php
@@ -323,6 +323,7 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
     ],
   ];
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->i = 0;
   }
@@ -330,6 +331,7 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
   /**
    * @return array
    */
+  #[\ReturnTypeWillChange]
   public function current() {
     $count = count($this->dataset[$this->i]['id']);
     $ids = $this->dataset[$this->i]['id'];
@@ -357,18 +359,19 @@ class CRM_Contact_Form_Search_Custom_GroupTestDataProvider implements Iterator {
   /**
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->i;
   }
 
-  public function next() {
+  public function next(): void {
     $this->i++;
   }
 
   /**
    * @return bool
    */
-  public function valid() {
+  public function valid(): bool {
     return isset($this->dataset[$this->i]);
   }
 

--- a/tests/phpunit/CRM/Mailing/BAO/QueryTestDataProvider.php
+++ b/tests/phpunit/CRM/Mailing/BAO/QueryTestDataProvider.php
@@ -113,6 +113,7 @@ class CRM_Mailing_BAO_QueryTestDataProvider implements Iterator {
     $this->i = 0;
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->i = 0;
   }
@@ -120,6 +121,7 @@ class CRM_Mailing_BAO_QueryTestDataProvider implements Iterator {
   /**
    * @return array
    */
+  #[\ReturnTypeWillChange]
   public function current() {
     $count = count($this->dataset[$this->i]['id']);
     $ids = $this->dataset[$this->i]['id'];
@@ -137,18 +139,19 @@ class CRM_Mailing_BAO_QueryTestDataProvider implements Iterator {
   /**
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->i;
   }
 
-  public function next() {
+  public function next(): void {
     $this->i++;
   }
 
   /**
    * @return bool
    */
-  public function valid() {
+  public function valid(): bool {
     return isset($this->dataset[$this->i]);
   }
 


### PR DESCRIPTION
…urnTypeWillChange] where type hint would be transversable or mixed for php7 compatability

Overview
----------------------------------------
Does what it says on the tin

Before
----------------------------------------
php8.1 triggers deprecations

After
----------------------------------------
less deprecations triggered in php8.1

ping @eileenmcnaughton @totten @demeritcowboy @monishdeb 