### PR TITLE
[REF][PHP8.1] Fix default values which triggeres deprecation notices …

### DIFF
--- a/CRM/Utils/GeocodeProvider.php
+++ b/CRM/Utils/GeocodeProvider.php
@@ -50,7 +50,7 @@ class CRM_Utils_GeocodeProvider {
    */
   public static function getUsableClassName() {
     if (self::$providerClassName === NULL) {
-      $provider = Civi::settings()->get('geoProvider');
+      $provider = Civi::settings()->get('geoProvider') ?? '';
       if (!class_exists($provider)) {
         if (class_exists('CRM_Utils_Geocode_' . $provider)) {
           $provider = 'CRM_Utils_Geocode_' . $provider;

--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -120,7 +120,7 @@ class SqlTriggers {
           );
           $variables = str_replace($template_params,
             $template_values,
-            \CRM_Utils_Array::value('variables', $value)
+            $value['variables'] ?? ''
           );
 
           if (!isset($triggers[$tableName][$eventName])) {


### PR DESCRIPTION
…in php8.1

Overview
----------------------------------------
This aims to fix deprecation notices on passing NULL as the 3rd param to str_replace or passing null into class_exists is deprecated in php8.1

Before
----------------------------------------
Deprecation notices triggered

After
----------------------------------------
Less deprecation notices triggered

ping @eileenmcnaughton @totten @monishdeb @demeritcowboy 