### PR TITLE
dev/core#3707 Fix wordpress issue of page not refreshing after import

### DIFF
--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -81,7 +81,8 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-
+    // Perhaps never used, but permits url passing of the group.
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
     $multipleCustomData = CRM_Core_BAO_CustomGroup::getMultipleFieldGroup();
     $this->assign('fieldGroups', $multipleCustomData);
     $this->add('select', 'multipleCustomData', ts('Multi-value Custom Data'), ['' => ts('- select -')] + $multipleCustomData, TRUE);

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -23,13 +23,6 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE);
-    $params = "reset=1";
-    if ($this->_id) {
-      $params .= "&id={$this->_id}";
-    }
-    CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url(static::PATH, $params));
-
     // check for post max size
     CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     $this->assign('importEntity', $this->getTranslatedEntity());

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -141,7 +141,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
       'onEndUrl' => CRM_Utils_System::url('civicrm/import/contact/summary', [
         'user_job_id' => $this->getUserJobID(),
         'reset' => 1,
-      ]),
+      ], FALSE, NULL, FALSE),
     ]);
     $runner->runAllViaWeb();
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3707 Fix wordpress issue of page not refreshing after import

https://lab.civicrm.org/dev/core/-/issues/3707

Before
----------------------------------------
After importing on wordpress the browser is redirect to what looks like the right url - but doesn't load up the right page unless you refresh it

After
----------------------------------------
It loads correctly, 

Technical Details
----------------------------------------
The url was html-ised hence it looked right & loaded right on refresh

The other removed lines are a red herring - I originally thought they were the issue but they are actually now meaningless in the latest code. It used to be the case that the import eventually (& inconsistently) redirected back to the start page -but now it doesn't. (Apparent from confusing me when diagnosing this those lines also cause (more) issues with csv importer because they require a constant to be set that is not used in any meaningful way)

Comments
----------------------------------------

