### PR TITLE
Cleanup repeattransaction

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2184,6 +2184,12 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
    * Gaps in the above (
    *
    * @param array $input
+   *    Keys are all optional, if not supplied the template contribution's values are used.
+   *    The template contribution is either the actual template or the latest added contribution
+   *    for the ContributionRecur specified in $contributionParams['contribution_recur_id'].
+   *    - total_amount
+   *    - financial_type_id
+   *    - campaign_id
    *
    * @param array $contributionParams
    *

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4448,7 +4448,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $contribution1 = $this->callAPISuccess('contribution', 'create', array_merge(
         $this->_params,
         ['contribution_recur_id' => $contributionRecur['id'], 'payment_instrument_id' => 2])
-    );
+    )['id'];
     $contribution2 = $this->callAPISuccess('contribution', 'repeattransaction', [
       'contribution_status_id' => 'Completed',
       'trxn_id' => 'blah',
@@ -4549,7 +4549,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('contribution', 'repeattransaction', [
       'contribution_status_id' => 'Completed',
       'trxn_id' => 7890,
-      'original_contribution_id' => $contribution,
+      'original_contribution_id' => $contribution['id'],
     ]);
     $domain = $this->callAPISuccess('domain', 'getsingle', ['id' => 1]);
     $mut->checkMailLog([
@@ -4592,7 +4592,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('Contribution', 'repeattransaction', [
       'contribution_status_id' => 'Completed',
       'trxn_id' => 5678,
-      'original_contribution_id' => $originalContribution,
+      'original_contribution_id' => $originalContribution['id'],
     ]
     );
     $mut->checkMailLog([
@@ -4620,7 +4620,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->callAPISuccess('contribution', 'repeattransaction', [
       'contribution_status_id' => 'Completed',
       'trxn_id' => 4567,
-      'original_contribution_id' => $originalContribution,
+      'original_contribution_id' => $originalContribution['id'],
     ]);
     $mut->checkMailLog([
       'From: ' . $domain['name'] . ' <' . $domain['domain_email'] . '>',


### PR DESCRIPTION
Overview
----------------------------------------

The code in api3 complete transaction was recently merged with an overloaded _ipn_complete_transaction() method's code. A note in the code said: We need to clean this up.

This is my attempt, though it still raised lots of questions!


Before
----------------------------------------

All sorts of weird stuff (understandable for historical reasons, but a mess). e.g. load a BAO Contribution object, set properties on it and then do nothing with it!



After
----------------------------------------

It's a bit tidier. More work could be done, see comments left in code (I'm happy to update the PR with input from y'all). Of note:

- the function mostly deals with setting up an $input array based on data from the passed in $params.
- I decided to leave the $params input array as-is, rather than update it as the old code did; I think this is best practise, as it means anytime we reference $params, we're referencing passed in data, not data we made up in the mean time.
- There's stuff that doesn't look right, now it's tidier and these things can be seen: Like
   - supplying amount and total_amount keys - surely we should just use total_amount?
   - we check for contribution_page_id and set some email from details if missing, but if it is set, we don't pass that on?
- I took a *few* liberties, wrt did people *actually* mean isset but empty() where I was fairly confident. But there's more that could be tidied up.
- I don't think we need to set 'component' on the $input. Which saved a bunch of code that instantiated a BAO Contribution object.


Technical Details
----------------------------------------

I'll wait the full test set but I ran `phpunit8 $(ag -Gphp -l  contribution tests/phpunit)` to run all tests whose code includes the word 'contribution' and they all passed.


tagging: @mattwire @eileenmcnaughton 