### PR TITLE
Upgrade script for contribution_recur amount, fix loading

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2162,12 +2162,11 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
   protected static function repeatTransaction(array $input, array $contributionParams) {
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution(
       (int) $contributionParams['contribution_recur_id'],
-      array_filter([
+      [
         'total_amount' => $input['total_amount'] ?? NULL,
         'financial_type_id' => $input['financial_type_id'] ?? NULL,
         'campaign_id' => $input['campaign_id'] ?? NULL,
-        // array_filter with strlen filters out NULL, '' and FALSE but not 0.
-      ], 'strlen')
+      ]
     );
     $contributionParams['line_item'] = $templateContribution['line_item'];
     $contributionParams['status_id'] = 'Pending';

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -509,7 +509,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $overrides = array_filter([
       'is_test' => $inputOverrides['is_test'] ?? $recurringContribution['is_test'],
       'financial_type_id' => $inputOverrides['financial_type_id'] ?? $recurringContribution['financial_type_id'],
-      'campaign_id' => $inputOverrides['campaign_id'] ?? $recurringContribution['campaign_id'],
+      'campaign_id' => $inputOverrides['campaign_id'] ?? ($recurringContribution['campaign_id'] ?? NULL),
       'total_amount' => $inputOverrides['total_amount'] ?? $recurringContribution['amount'],
     ], 'strlen');
 

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -496,10 +496,9 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
    * @throws \API_Exception
    */
   public static function getTemplateContribution(int $id, array $inputOverrides = []): array {
-    $recurFields = ['is_test', 'financial_type_id', 'amount', 'campaign_id'];
     $recurringContribution = ContributionRecur::get(FALSE)
       ->addWhere('id', '=', $id)
-      ->setSelect($recurFields)
+      ->setSelect(['is_test', 'financial_type_id', 'amount', 'campaign_id'])
       ->execute()
       ->first();
 

--- a/CRM/Upgrade/Incremental/sql/5.52.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.52.alpha1.mysql.tpl
@@ -1,1 +1,9 @@
 {* file to handle db changes in 5.52.alpha1 during upgrade *}
+--  Update any recurring contributions to have the same amount
+-- as the recurring template contribution if it exists.
+-- Some of these got out of sync over recent changes.
+UPDATE civicrm_contribution_recur r
+INNER JOIN civicrm_contribution c ON contribution_recur_id = r.id
+AND c.is_template = 1
+SET amount = total_amount
+WHERE total_amount IS NOT NULL;

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -813,6 +813,14 @@ function _civicrm_api3_contribution_repeattransaction_spec(&$params) {
     'name' => 'payment_processor_id',
     'type' => CRM_Utils_Type::T_INT,
   ];
+  $params['total_amount'] = [
+    'description' => ts('Optional override amount, will be ignored if more than one line item exists'),
+    'title' => ts('Total amount of the contribution'),
+    'name' => 'total_amount',
+    'type' => CRM_Utils_Type::T_MONEY,
+    // Map 'amount' to total_amount - historically both have been used at times.
+    'api.aliases' => ['amount'],
+  ];
 }
 
 /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -98,8 +98,6 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
 
   /**
    * Test checking if contribution recur object can allow for changes to financial types.
-   *
-   * @throws \CRM_Core_Exception|\CiviCRM_API3_Exception
    */
   public function testSupportFinancialTypeChange(): void {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $this->_params);

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2769,6 +2769,16 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     unset($expectedLineItem['id'], $expectedLineItem['entity_id'], $lineItem2['values'][0]['id'], $lineItem2['values'][0]['entity_id']);
     $this->assertEquals($expectedLineItem, $lineItem2['values'][0]);
+
+    $this->callAPISuccess('contribution', 'repeattransaction', [
+      'original_contribution_id' => $originalContribution['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 789,
+    ]);
+    $this->callAPISuccessGetSingle('contribution', [
+      'total_amount' => 400,
+      'trxn_id' => 789,
+    ]);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2702,8 +2702,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * CRM-16397 test appropriate action if total amount has changed for single
    * line items.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testRepeatTransactionAlteredAmount(): void {
     $paymentProcessorID = $this->paymentProcessorCreate();


### PR DESCRIPTION


Overview
----------------------------------------
Upgrade script for contribution_recur amount, fix loading

Before
----------------------------------------
Per the code comments - the expectation has long been that single line recurring contributions would prioritize the amount from the civicrm_contribution_recur record. This got broken at some point & the test wasn't correctly testing this (it may have at some point).

SInce then the template contribution screens were added and in some cases the template contributions have had their amount updated but the `civicrm_contribution_recur.total_amount` was not. This should not now happen or at least not with https://github.com/civicrm/civicrm-core/pull/23809 merged.  However, for us to be able to use `contribution_recur.total_amount` reliably it needs to be fixed for those instances where it was not updated - we can do this simply based off whether or not an attached contribution with `is_template` exists - as they should only exist if relevant


After
----------------------------------------
`civicrm_contribution_recur.amount` updated to match the template contribution's total amount, if it exists. This value is used for single line contributions & should be reliably in sync with the template contribution, if exists


Technical Details
----------------------------------------
 `testRepeatTransactionAlteredAmount()`  gave the appearance of covering the expected behaviour (that the `contribution_recur.total_amount` would be 'heeded' but it was actually passing it in so it wasn't ensuring it.

Comments
----------------------------------------
At this point sites who only use single line contributions and do not otherwise edit details on template contributions would ideally be able to disable the form (ie remove links to it) - I'm not a fan of settings but in this case I think one would make sense as 
- from a maintenance POV it is not maintaining a complex behaviour and
- I never really envisaged that we would be expecting users to edit recurrings via a template contribution form - only that it would be an option -  and it is quite confusing for users IMHO compared to the edit form