### PR TITLE
Import fix - if there are no required fields validateRequiredFields should 'pass'

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1277,6 +1277,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @throws \CRM_Core_Exception Exception thrown if field requirements are not met.
    */
   protected function validateRequiredFields(array $requiredFields, array $params, $prefixString = ''): void {
+    if (empty($requiredFields)) {
+      return;
+    }
     $missingFields = [];
     foreach ($requiredFields as $key => $required) {
       if (!is_array($required)) {


### PR DESCRIPTION
Overview
----------------------------------------
Import fix - if there are no required fields validateRequiredFields should 'pass'

Before
----------------------------------------
`getRequiredFields` will return FALSE if there are NO required fields - because it is returning during the loop

After
----------------------------------------
Early exit

Technical Details
----------------------------------------

Comments
----------------------------------------
There is no real way to r-run this in core