### PR TITLE
dev/core#3713 Use front-end urls for event url tokens

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -136,8 +136,8 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'postal_code' => $event['loc_block_id.address_id.postal_code'],
 
       ]);
-      $tokens['info_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE);
-      $tokens['registration_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/register', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE);
+      $tokens['info_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
+      $tokens['registration_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/register', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
       $tokens['start_date']['text/html'] = !empty($event['start_date']) ? new DateTime($event['start_date']) : '';
       $tokens['end_date']['text/html'] = !empty($event['end_date']) ? new DateTime($event['end_date']) : '';
       $tokens['event_type_id:label']['text/html'] = CRM_Core_PseudoConstant::getLabel('CRM_Event_BAO_Event', 'event_type_id', $event['event_type_id']);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3713 Use front-end urls for event url tokens

Before
----------------------------------------
Event info & registration tokens do not specify `frontend= TRUE`

After
----------------------------------------
They DO specify frontend true

Technical Details
----------------------------------------
I haven't done the work to determine if this is a regression - but it seems clear cut that this change should be made.

There HAS been change in this area which is experienced as a regression in dev/core#3713 Use front-end urls for event url tokens and I think there is a moderate chance the broken code only existed to fix the url to frontend in Joomla 

Comments
----------------------------------------
