### PR TITLE
dev/core#3778 Add a new "Registered by Contact ID/Created ID" field to Event Participants

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -548,6 +548,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         'participant_discount_name' => 1,
         'participant_fee_currency' => 1,
         'participant_registered_by_id' => 1,
+        'participant_created_id' => 1,
         'participant_campaign_id' => 1,
       ];
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -457,13 +457,22 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       // Get registered_by contact ID and display_name if participant was registered by someone else (CRM-4859)
       if (!empty($defaults[$this->_id]['participant_registered_by_id'])) {
-        $registered_by_contact_id = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant',
-          $defaults[$this->_id]['participant_registered_by_id'],
-          'contact_id', 'id'
+        // Prefer the newer, more accurate "created_id" and fallback to the participant_id stored in registered_by_id
+        $created_id = CRM_Core_DAO::getFieldValue(
+          'CRM_Event_DAO_Participant',
+          $defaults[$this->_id]['participant_id'],
+          'created_id', 'id'
         );
+        if (empty($created_id)) {
+          $created_id = CRM_Core_DAO::getFieldValue(
+            'CRM_Event_DAO_Participant',
+            $defaults[$this->_id]['participant_registered_by_id'],
+            'contact_id', 'id'
+          );
+        }
         $this->assign('participant_registered_by_id', $defaults[$this->_id]['participant_registered_by_id']);
-        $this->assign('registered_by_contact_id', $registered_by_contact_id);
-        $this->assign('registered_by_display_name', CRM_Contact_BAO_Contact::displayName($registered_by_contact_id));
+        $this->assign('created_id', $created_id);
+        $this->assign('registered_by_display_name', CRM_Contact_BAO_Contact::displayName($created_id));
       }
     }
     elseif ($this->_contactID) {
@@ -483,6 +492,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $defaults[$this->_id]['financial_type_id'] = $financialTypeID;
         }
       }
+
+      $defaults[$this->_id]['created_id'] = CRM_Core_Session::getLoggedInContactID();
 
       if ($this->_mode) {
         $fields["email-{$this->_bltID}"] = 1;
@@ -630,8 +641,10 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     if ($this->_single) {
       $contactField = $this->addEntityRef('contact_id', ts('Participant'), ['create' => TRUE, 'api' => ['extra' => ['email']]], TRUE);
+      $registeredByContactField = $this->addEntityRef('created_id', ts('Registered By'), ['create' => FALSE], TRUE);
       if ($this->_context != 'standalone') {
         $contactField->freeze();
+        $registeredByContactField->freeze();
       }
     }
 

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -117,11 +117,11 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
 
     // Get registered_by contact ID and display_name if participant was registered by someone else (CRM-4859)
     if (!empty($values[$participantID]['participant_registered_by_id'])) {
-      $values[$participantID]['registered_by_contact_id'] = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Participant",
+      $values[$participantID]['created_id'] = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Participant",
         $values[$participantID]['participant_registered_by_id'],
         'contact_id', 'id'
       );
-      $values[$participantID]['registered_by_display_name'] = CRM_Contact_BAO_Contact::displayName($values[$participantID]['registered_by_contact_id']);
+      $values[$participantID]['registered_by_display_name'] = CRM_Contact_BAO_Contact::displayName($values[$participantID]['created_id']);
     }
 
     // Check if this is a primaryParticipant (registered for others) and retrieve additional participants if true  (CRM-4859)

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -658,8 +658,13 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $participant = $this->addParticipant($this, $contactID);
     $this->_participantIDS[] = $participant->id;
 
-    //setting register_by_id field and primaryContactId
-    if (!empty($this->_params['is_primary'])) {
+    // Set the registerByID and primaryContactId field if:
+    // - This is the primary participant
+    // - The participant has a contact ID
+    // - The primary contact_id field is not empty (this is the cid= param) on the form and will be set to 0/NULL if registering someone else.
+    // - The participant $contactID is equal to the contact_id used to make the registration (ie. they are registering themselves + others
+    //   and did not select the "Not X, or want to register a different person.
+    if (!empty($this->_params['is_primary']) && !empty($contactID) && !empty($this->_params['contact_id']) && ($contactID == $this->_params['contact_id'])) {
       $this->set('registerByID', $participant->id);
       $this->set('primaryContactId', $contactID);
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -696,6 +696,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     }
     //otherwise send mail Confirmation/Receipt
     $primaryContactId = $this->get('primaryContactId');
+    $primaryParticipantID = $primaryParticipant['participantID'];
 
     // for Transfer checkout.
     // The concept of contributeMode is deprecated.
@@ -707,7 +708,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     ) {
 
       //build an array of custom profile and assigning it to template
-      $customProfile = CRM_Event_BAO_Event::buildCustomProfile($registerByID, $this->_values, NULL, $isTest);
+      $customProfile = CRM_Event_BAO_Event::buildCustomProfile($primaryParticipantID, $this->_values, NULL, $isTest);
       if (count($customProfile)) {
         $this->assign('customProfile', $customProfile);
         $this->set('customProfile', $customProfile);
@@ -782,7 +783,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     else {
 
       //build an array of cId/pId of participants
-      $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($registerByID,
+      $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($primaryParticipantID,
         NULL, $primaryContactId, $isTest,
         TRUE
       );

--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -144,6 +144,13 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form {
             'title' => ts('Registered by Participant Name'),
             'name' => 'registered_by_id',
           ),
+          'created_id' => array(
+            'title' => ts('Registered by Contact ID'),
+          ),
+          'registered_by_contact_name' => array(
+            'title' => ts('Registered by Contact Name'),
+            'name' => 'created_id',
+          ),
           'source' => array(
             'title' => ts('Source'),
           ),
@@ -635,6 +642,16 @@ ORDER BY  cv.label
           $rows[$rowNum]['civicrm_participant_registered_by_name'] = CRM_Contact_BAO_Contact::displayName($registeredByContactId);
           $rows[$rowNum]['civicrm_participant_registered_by_name_link'] = CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $registeredByContactId, $this->_absoluteUrl);
           $rows[$rowNum]['civicrm_participant_registered_by_name_hover'] = ts('View Contact Summary for Contact that registered the participant.');
+        }
+      }
+
+      // Handle registered by contact name
+      if (array_key_exists('civicrm_participant_registered_by_contact_name', $row)) {
+        $registeredByContactId = $row['civicrm_participant_registered_by_contact_name'];
+        if ($registeredByContactId) {
+          $rows[$rowNum]['civicrm_participant_registered_by_contact_name'] = CRM_Contact_BAO_Contact::displayName($registeredByContactId);
+          $rows[$rowNum]['civicrm_participant_registered_by_contact_name_link'] = CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $registeredByContactId, $this->_absoluteUrl);
+          $rows[$rowNum]['civicrm_participant_registered_by_contact_name_hover'] = ts('View Contact Summary for Contact that registered the participant.');
         }
       }
 

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -62,6 +62,10 @@
             <td class="label">{$form.contact_id.label}</td>
             <td>{$form.contact_id.html}</td>
           </tr>
+          <tr class="crm-participant-form-registered-by-contact-id">
+            <td class="label">{$form.created_id.label}</td>
+            <td>{$form.created_id.html}</td>
+          </tr>
           {if $action EQ 2}
             {if $additionalParticipants} {* Display others registered by this participant *}
               <tr class="crm-participant-form-block-additionalParticipants">
@@ -73,11 +77,11 @@
                 </td>
               </tr>
             {/if}
-            {if $registered_by_contact_id}
+            {if $created_id}
               <tr class="crm-participant-form-block-registered-by">
                 <td class="label"><label>{ts}Registered By{/ts}</label></td>
                 <td class="view-value">
-                  <a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}"
+                  <a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$created_id&action=view"}"
                      title="{ts}view primary participant{/ts}">{$registered_by_display_name}</a>
                 </td>
               </tr>

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -41,7 +41,7 @@
   {if $participant_registered_by_id} {* Display primary participant *}
       <tr class="crm-event-participantview-form-block-registeredBy">
           <td class="label">{ts}Registered By{/ts}</td>
-          <td><a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$registered_by_contact_id&action=view"}" title="{ts}view primary participant{/ts}">{$registered_by_display_name}</a></td>
+          <td><a href="{crmURL p='civicrm/contact/view/participant' q="reset=1&id=$participant_registered_by_id&cid=$created_id&action=view"}" title="{ts}view primary participant{/ts}">{$registered_by_display_name}</a></td>
       </tr>
   {/if}
   {if $additionalParticipants} {* Display others registered by this participant *}

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -96,6 +96,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
       '{participant.fee_level}' => 'low',
       '{participant.fee_amount}' => '$ 0.00',
       '{participant.registered_by_id}' => NULL,
+      '{participant.created_id}' => NULL,
       '{participant.transferred_to_contact_id}' => NULL,
       '{participant.role_id:label}' => 'Attendee',
       '{participant.fee_label}' => NULL,

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1722,6 +1722,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'participant_discount_name' => 1,
       'participant_fee_currency' => 1,
       'participant_registered_by_id' => 1,
+      'participant_created_id' => 1,
       'participant_campaign_id' => 1,
     ];
   }
@@ -1968,6 +1969,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'participant_status' => '`participant_status` varchar(255)',
       'participant_register_date' => '`participant_register_date` varchar(32)',
       'participant_registered_by_id' => '`participant_registered_by_id` varchar(64)',
+      'participant_created_id' => '`participant_created_id` varchar(64)',
       'participant_is_test' => '`participant_is_test` varchar(64)',
       'componentpaymentfield_total_amount' => '`componentpaymentfield_total_amount` varchar(32)',
       'componentpaymentfield_transaction_id' => '`componentpaymentfield_transaction_id` varchar(255)',
@@ -2139,6 +2141,11 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
         [
           0 => 'Participant',
           'name' => 'transferred_to_contact_id',
+        ],
+      32 =>
+        [
+          0 => 'Participant',
+          'name' => 'created_id',
         ],
     ];
   }
@@ -2685,6 +2692,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       'participant_discount_name' => '`participant_discount_name` varchar(64)',
       'participant_fee_currency' => '`participant_fee_currency` varchar(3)',
       'participant_registered_by_id' => '`participant_registered_by_id` varchar(64)',
+      'participant_created_id' => '`participant_created_id` varchar(255)',
       'participant_campaign_id' => '`participant_campaign_id` varchar(64)',
     ];
   }

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -53,6 +53,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
       'contact_id' => $this->_contactID2,
       'event_id' => $this->_eventID,
       'registered_by_id' => $this->_participantID,
+      'created_id' => $this->_contactID,
     ]);
     $this->_participantID3 = $this->participantCreate([
       'contact_id' => $this->_contactID2,
@@ -818,6 +819,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
       'event_id' => $this->_eventID,
       'status_id' => 5,
       'registered_by_id' => $participantID,
+      'created_id' => $this->_contactID,
     ]);
 
     $this->hookClass->setHook('civicrm_post', [$this, 'onPost']);


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3778

The existing field "registered_by_id" has a number of problems:
- It does not get set if you add a registration via the backend forms.
- It *always* gets set to the primary participant even when the user selects "Not X, or want to register a different person" (ie. URL has the parameter cid=0).
- The "registered_by_id" field requires a participant ID and not a contact ID. This means that you cannot record that you registered one or more participants unless you are also a participant of that event.

* Why not change registered_by_id to a contact ID? That's likely to have all sorts of unexpected impacts as the existing field is used in various wonderful ways (eg. registration emails behave a bit differently if there is a registered_by_id).

* Does this fix everything?
No, not yet. That will require more work on the UI / mailing side of things to use the new field. But it's accessible as part of the Participant entity which means it can be used via the API and with searchkit.
This PR includes a little bit of UI work on the backend event participant form to allow you to set the new "registered by contact" field and this form will prefer that field.

* What about setting the primary participant ID when they weren't the one registering?
Yes, this PR fixes that. It checks if the contact ID on the form is the same as the primary participant contact ID. If it's not it won't set the `registered_by_id` field.

Before
----------------------------------------
`registered_by_id` doesn't allow you to record a contact that doesn't also have a participant record.

After
----------------------------------------
A new field allows you to record the contact ID that registered the participant, without them having to be a participant too.

Technical Details
----------------------------------------
Described above (I think).

Comments
----------------------------------------

