### PR TITLE
(WIP) Smarty - Experiment with boxing+unboxing EscapedStrings to fix pipeline/opt-in behavior

### DIFF
--- a/tests/phpunit/CRM/Core/Smarty/EscapeTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/EscapeTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Class CRM_Core_Smarty_EscapeTest
+ * @group headless
+ * @group resources
+ */
+class CRM_Core_Smarty_EscapeTest extends CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+
+    // Templates injected into regions should normally be file names, but for unit-testing it's handy to use "string:" notation
+    require_once 'CRM/Core/Smarty/resources/String.php';
+    civicrm_smarty_register_string_resource();
+
+    $this->useTransaction();
+  }
+
+  protected function getCommonVariables(): array {
+    return [
+      'xInt' => 100,
+      'xFloat' => 55.44,
+      'xString' => 'Hello world',
+      'xMarkup' => '<b>Yo!</b>',
+      'xNULL' => NULL,
+      'xTRUE' => TRUE,
+      'xFALSE' => FALSE,
+    ];
+  }
+
+  /**
+   * List of examples which should always render the same way, regardless of processingmode.
+   *
+   * @return array
+   */
+  protected function getCommonExamples(): array {
+    return [
+      // Smarty template => Expected output
+      'string:{$xInt}' => '100',
+      'string:{$xFloat}' => '55.44',
+      'string:{$xString|crmEscape:"none"}' => 'Hello world',
+      'string:{$xString|crmEscape:"html"}' => 'Hello world',
+      'string:{$xMarkup|crmEscape:"none"}' => '<b>Yo!</b>',
+      'string:{$xMarkup|crmEscape:"html"}' => '&lt;b&gt;Yo!&lt;/b&gt;',
+      'string:{$xMarkup|crmEscape:"html"|crmEscape:"none"}' => '&lt;b&gt;Yo!&lt;/b&gt;',
+      'string:{$xMarkup|crmEscape:"html"|crmEscape:"html"}' => '&amp;lt;b&amp;gt;Yo!&amp;lt;/b&amp;gt;',
+      'string:{if $xInt eq 100}match{else}no match{/if}' => 'match',
+      'string:{if $xInt eq 88}match{else}no match{/if}' => 'no match',
+      'string:{if $xFloat > 6}yes{else}no{/if}' => 'yes',
+      'string:{if $xFloat > 40}yes{else}no{/if}' => 'yes',
+      'string:{if $xFloat > 60}yes{else}no{/if}' => 'no',
+    ];
+  }
+
+  protected function getDefaultUnescapedExamples(): array {
+    return [
+      // Smarty template => Expected output
+      'string:{$xInt}, {$xString}, {$xMarkup}' => '100, Hello world, <b>Yo!</b>',
+      'string:{$xString}' => 'Hello world',
+      'string:{$xMarkup}' => '<b>Yo!</b>',
+    ];
+  }
+
+  protected function getDefaultEscapedExamples(): array {
+    return [
+      // Smarty template => Expected output
+      'string:{$xInt}, {$xString}, {$xMarkup}' => '100, Hello world, &lt;b&gt;Yo!&lt;/b&gt;',
+      'string:{$xString}' => 'Hello world',
+      'string:{$xMarkup}' => '&lt;b&gt;Yo!&lt;/b&gt;',
+    ];
+  }
+
+  public function testDefaultOff() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assignAll($this->getCommonVariables());
+    $GLOBALS['_CIVICRM_SMARTY_DEFAULT_ESCAPE'] = FALSE;
+    $examples = $this->getCommonExamples() + $this->getDefaultUnescapedExamples();
+    $actual = $this->renderAll($smarty, $examples);
+    $this->assertEquals($examples, $actual);
+  }
+
+  public function testDefaultOn() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assignAll($this->getCommonVariables());
+    $GLOBALS['_CIVICRM_SMARTY_DEFAULT_ESCAPE'] = TRUE;
+    $examples = $this->getCommonExamples() + $this->getDefaultEscapedExamples();
+    // $examples = $this->getCommonExamples();
+    // $examples = $this->getDefaultEscapedExamples();
+    $actual = $this->renderAll($smarty, $examples);
+    $this->assertEquals($examples, $actual);
+  }
+
+  protected function renderAll(CRM_Core_Smarty $smarty, array $examples): array {
+    $result = [];
+    foreach ($examples as $template => $expected) {
+      $result[$template] = $smarty->fetch($template);
+    }
+    return $result;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

In Smarty v2, the baseline behavior is to output variables with no extra escaping (eg `{$x}` shows the literal/exact value of `$x` without any extra HTML-entities, etc). There has been some work on changing the default, and it relies on Smarty's `default_modifiers` option. However, I find Smarty's interpretation of `default_modifiers` confusing - eg if you specify an explicit escape rule, it doesn't disable/override the default escape rule. They stack on top of each other. (*Unless you add some extra quirky incantations, eg `{$x|smarty:nodefaults|escape:"html"}`*)

This branch is an experiment (from last week) to try a technique that might make the escape rule behave more intuitively (eg *the default escape-mode can be overriden with an explicit escape mode*). As an experiment, it may include some other bits are by-the-by/separate issues.  I'm posting it to Github (a) to see what passes/fails and (b) to have somewhere to refer back to for this experiment. 

Highlights
----------------------------------------

The key is to define how "default escape-mode" should behave. This is representative excerpt from the tests:

```php
// Example data
'xInt' => 100,
'xMarkup' => '<b>Yo!</b>',
```
```php
// Example expressions and what they should output

// Some examples should differ, depending on the default escape mode
'string:{$xMarkup}' => '<b>Yo!</b>',  // ... if the default escape mode is *none*.
'string:{$xMarkup}' => '&lt;b&gt;Yo!&lt;/b&gt;', // ... if the default escape mode is *html*.

// Other examples should behave the same, regardless of default escape mode
'string:{$xMarkup|crmEscape:"none"}' => '<b>Yo!</b>'
'string:{$xMarkup|crmEscape:"html"}' => '&lt;b&gt;Yo!&lt;/b&gt;',
'string:{$xMarkup|crmEscape:"html"|crmEscape:"html"}' => '&amp;lt;b&amp;gt;Yo!&amp;lt;/b&amp;gt;',
'string:{if $xInt eq 100}match{else}no match{/if}' => 'match',
```

Before
----------------------------------------

* In standard/backward-compatible configuration, it does not add any default modifiers.
* In the experimental/diagnostic/opt-in configuration (`CIVICRM_SMARTY_DEFAULT_ESCAPE`), it adds `|escape:"htmlall"` as a default modifier -- which means that applies some heuristics (eg "don't escape strings that start with `<input` but do escape strings that start with `<table`").
* If you want to explicitly specify the escaping (so that it works in both modes), then you must use `|smarty:nodefaults` plus the preferred escape rule, eg
    <table>
    <thead><tr><th>Description</th><th>Example</th></tr></thead>
    <tbody>
      <tr><td>Explicitly enable HTML escaping </td><td> `{$xMarkup|smarty:nodefaults|escape:"html"}` </td></tr>
      <tr><td> Explicitly enable URL escaping </td><td> `{$xMarkup|smarty:nodefaults|escape:"url"}` </td></tr>
      <tr><td> Explicitly enable URL+HTML escaping </td><td> `{$xMarkup|smarty:nodefaults|escape:"url"|escape:"html"}` </td></tr>
      <tr><td> Explicitly pass-through raw data </td><td> `{$xMarkup|smarty:nodefaults|escape:"none"}` </td></tr>
    </tbody></table>

After
----------------------------------------

* It always adds `|crmAutoescape` as a default modifier.
* The `|crmAutoescape` behaves differently depending on `CIVICRM_SMARTY_DEFAULT_ESCAPE` (ie enabling or disabling HTML as the default escape mode).
* If you want to explicitly specify the escaping (so that it works in both modes), then this is simpler:
    <table>
    <thead><tr><th>Description</th><th>Example</th></tr></thead>
    <tbody>
      <tr><td>Explicitly enable HTML escaping </td><td> `{$xMarkup|crmEscape:"html"}` </td></tr>
      <tr><td> Explicitly enable URL escaping </td><td> `{$xMarkup|crmEscape:"url"}` </td></tr>
      <tr><td> Explicitly enable URL+HTML escaping </td><td> `{$xMarkup|crmEscape:"url"|crmEscape:"html"}` </td></tr>
      <tr><td> Explicitly pass-through raw data </td><td> `{$xMarkup|crmEscape:"none"}` </td></tr>
    </tbody></table>

(Note: The data passed into `crmEscape:"xxx"` is actually any instance of `EscapedString`. This allows it to inspect the string more carefully and decide whether/how the new escape-rule should replace or stack with the autoescape rule.)

Comments
---------------------------------------

The branch was focused on making the explicit/implicit/chained escaping feel sensible. If we do this,then a couple more things to try:

* Override `|escape` instead of adding a new `|crmEscape`
* Better distinguish between these modes:
    * Do not use any autoescaping code.  (Be as close as possible to historical behavior.)
    * Use autoescaping and set default escape-mode to `none`. (New mechanisms - but same policy as before)
    * Use autoescaping and set default escape-mode to `html`. (New mechanisms - and new policy)
