### PR TITLE
dev/core#3716 - Fix smarty e-notice on mapping page

### DIFF
--- a/templates/CRM/Admin/Page/Mapping.tpl
+++ b/templates/CRM/Admin/Page/Mapping.tpl
@@ -23,13 +23,13 @@
             <tr class="columnheader">
               <th>{ts}Name{/ts}</th>
               <th>{ts}Description{/ts}</th>
-                    <th>{ts}Mapping Type{/ts}</th>
+              <th>{ts}Mapping Type{/ts}</th>
               <th></th>
             </tr>
             {foreach from=$rows item=row}
             <tr class="{cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if} crm-mapping">
                 <td class="crm-mapping-name">{$row.name}</td>
-                <td class="crm-mapping-description">{$row.description}</td>
+                <td class="crm-mapping-description">{if !empty($row.description)} {$row.description}{/if}</td>
                 <td class="crm-mapping-mapping_type">{$row.mapping_type}</td>
                 <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
             </tr>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3716

Before
----------------------------------------
e-notice appears

After
----------------------------------------
e-notice disappears

Comments
----------------------------------------
The sorting on the page does not work as it was originally intended: https://github.com/civicrm/civicrm-core/blob/3cf2f2b0a0c5b499a0064be725887ec5b2fdfe47/CRM/Admin/Page/Mapping.php#L126
I will create a separate PR to make it work.