### PR TITLE
dev/core#3717 - Fix sorting by mapping type

### DIFF
--- a/CRM/Admin/Page/Mapping.php
+++ b/CRM/Admin/Page/Mapping.php
@@ -123,8 +123,8 @@ class CRM_Admin_Page_Mapping extends CRM_Core_Page_Basic {
    * Run the basic page.
    */
   public function run() {
-    $sort = 'mapping_type asc';
-    return parent::run($sort);
+    $sort = 'mapping_type_id ASC, name ASC';
+    return parent::run(NULL, NULL, $sort);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3717

Before
----------------------------------------
Sorted by name, although it is supposed to be sorted by mapping type

After
----------------------------------------
Sorted by mapping type id, followed by name

Comments
----------------------------------------
It might be even more usefull to sort it by mapping type name instead of the mapping type id, but that would probably way more effort.

The pretty old comment in the parent `run()` function suggest that we could drop the first 2 parameters altogether.
https://github.com/civicrm/civicrm-core/blob/3cf2f2b0a0c5b499a0064be725887ec5b2fdfe47/CRM/Core/Page/Basic.php#L119-L125