### PR TITLE
dev/core#3719 API4 - UserJob.get for job_type:label does not return a string

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1597,10 +1597,11 @@ WHERE  id = %1
    * @param array $options
    *   List of options, each as a record of id+name+label.
    *   Ex: [['id' => 123, 'name' => 'foo_bar', 'label' => 'Foo Bar']]
+   *   or: ['index' => ['id' => 123, 'name' => 'foo_bar', 'label' => 'Foo Bar']]
    */
   public static function formatArrayOptions($context, array &$options) {
     // Already flat; return keys/values according to context
-    if (!isset($options[0]) || !is_array($options[0])) {
+    if (!isset($options[array_key_first($options)]) || !is_array($options[array_key_first($options)])) {
       // For validate context, machine names are expected in place of labels.
       // A flat array has no names so use the ids for both key and value.
       return $context === 'validate' ?


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3719

Before
----------------------------------------
``` json
(1) [
      {
        "id": 1,
        "job_type:label": {
          "id": "contact_import",
          "name": "contact_import",
          "label": "Contact Import",
          "class": "CRM_Contact_Import_Parser_Contact"
        }
      }
    ]
```

After
----------------------------------------
``` json
(1) [
      {
        "id": 1,
        "job_type:label": "Contact Import"
      }
    ]
```

Technical Details
----------------------------------------
I dont see a technical need for the options to be an index array instead of an associative array, so I changed the conditions.

Comments
----------------------------------------
I assume this is related to the changes from https://github.com/civicrm/civicrm-core/pull/23888

I hope test coverage for pseudoconstants is reasonably good to verify that this change does not break stuff 🤞.

