### PR TITLE
[REF] Upgrade DOMPDF to 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   "require": {
     "php": "~7.2.5 || ~7.3 || ~8",
     "cache/integration-tests": "~0.17.0",
-    "dompdf/dompdf" : "~1.2.1",
+    "dompdf/dompdf" : "~2",
     "firebase/php-jwt": ">=3 <6",
     "rubobaquero/phpquery": "^0.9.15",
     "symfony/config": "~4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f116bb2d3eca13dde70ec793930d91f",
+    "content-hash": "9808720dbc97471b1d5cc71fdc6b6897",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -612,26 +612,29 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v1.2.1",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "c6dfd9bb8b0040609f04754f729d4cb3016e0575"
+                "reference": "79573d8b8a141ec8a17312515de8740eed014fa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/c6dfd9bb8b0040609f04754f729d4cb3016e0575",
-                "reference": "c6dfd9bb8b0040609f04754f729d4cb3016e0575",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/79573d8b8a141ec8a17312515de8740eed014fa9",
+                "reference": "79573d8b8a141ec8a17312515de8740eed014fa9",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
                 "phenx/php-font-lib": "^0.5.4",
                 "phenx/php-svg-lib": "^0.3.3 || ^0.4.0",
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
+                "ext-json": "*",
+                "ext-zip": "*",
                 "mockery/mockery": "^1.3",
                 "phpunit/phpunit": "^7.5 || ^8 || ^9",
                 "squizlabs/php_codesniffer": "^3.5"
@@ -673,9 +676,9 @@
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v1.2.1"
+                "source": "https://github.com/dompdf/dompdf/tree/v2.0.0"
             },
-            "time": "2022-03-24T12:57:42+00:00"
+            "time": "2022-06-21T21:14:57+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -1751,6 +1754,75 @@
                 "source": "https://github.com/MarkBaker/PHPMatrix/tree/2.1.3"
             },
             "time": "2021-05-25T15:42:17+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "f640ac1bdddff06ea333a920c95bbad8872429ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f640ac1bdddff06ea333a920c95bbad8872429ab",
+                "reference": "f640ac1bdddff06ea333a920c95bbad8872429ab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.7.5"
+            },
+            "time": "2021-07-01T14:25:37+00:00"
         },
         {
             "name": "myclabs/php-enum",

--- a/tools/scripts/composer/dompdf-cleanup.sh
+++ b/tools/scripts/composer/dompdf-cleanup.sh
@@ -23,80 +23,78 @@ function safe_delete() {
 ##############################################################################
 ## usage: make_font_cache > font-cache.php
 function make_font_cache() {
-cat <<EOFONT
-<?php return array (
-  'sans-serif' =>
+php -r "echo json_encode(array (
+  'sans-serif' => 
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Helvetica',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Helvetica-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Helvetica-Oblique',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Helvetica-BoldOblique',
+    'normal' => 'Helvetica',
+    'bold' => 'Helvetica-Bold',
+    'italic' => 'Helvetica-Oblique',
+    'bold_italic' => 'Helvetica-BoldOblique',
   ),
-  'times' =>
+  'times' => 
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Times-Roman',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Times-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Times-Italic',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Times-BoldItalic',
+    'normal' => 'Times-Roman',
+    'bold' => 'Times-Bold',
+    'italic' => 'Times-Italic',
+    'bold_italic' => 'Times-BoldItalic',
   ),
-  'times-roman' =>
+  'times-roman' => 
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Times-Roman',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Times-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Times-Italic',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Times-BoldItalic',
+    'normal' => 'Times-Roman',
+    'bold' => 'Times-Bold',
+    'italic' => 'Times-Italic',
+    'bold_italic' => 'Times-BoldItalic',
   ),
   'courier' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Courier',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Courier-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Courier-Oblique',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Courier-BoldOblique',
+    'normal' => 'Courier',
+    'bold' => 'Courier-Bold',
+    'italic' => 'Courier-Oblique',
+    'bold_italic' => 'Courier-BoldOblique',
   ),
   'helvetica' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Helvetica',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Helvetica-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Helvetica-Oblique',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Helvetica-BoldOblique',
+    'normal' => 'Helvetica',
+    'bold' => 'Helvetica-Bold',
+    'italic' => 'Helvetica-Oblique',
+    'bold_italic' => 'Helvetica-BoldOblique',
   ),
   'zapfdingbats' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/ZapfDingbats',
-    'bold' => DOMPDF_DIR . '/lib/fonts/ZapfDingbats',
-    'italic' => DOMPDF_DIR . '/lib/fonts/ZapfDingbats',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/ZapfDingbats',
+    'normal' => 'ZapfDingbats',
+    'bold' => 'ZapfDingbats',
+    'italic' => 'ZapfDingbats',
+    'bold_italic' => 'ZapfDingbats',
   ),
   'symbol' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Symbol',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Symbol',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Symbol',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Symbol',
+    'normal' => 'Symbol',
+    'bold' => 'Symbol',
+    'italic' => 'Symbol',
+    'bold_italic' => 'Symbol',
   ),
   'serif' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Times-Roman',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Times-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Times-Italic',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Times-BoldItalic',
+    'normal' => 'Times-Roman',
+    'bold' => 'Times-Bold',
+    'italic' => 'Times-Italic',
+    'bold_italic' => 'Times-BoldItalic',
   ),
   'monospace' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Courier',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Courier-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Courier-Oblique',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Courier-BoldOblique',
+    'normal' => 'Courier',
+    'bold' => 'Courier-Bold',
+    'italic' => 'Courier-Oblique',
+    'bold_italic' => 'Courier-BoldOblique',
   ),
   'fixed' =>
   array (
-    'normal' => DOMPDF_DIR . '/lib/fonts/Courier',
-    'bold' => DOMPDF_DIR . '/lib/fonts/Courier-Bold',
-    'italic' => DOMPDF_DIR . '/lib/fonts/Courier-Oblique',
-    'bold_italic' => DOMPDF_DIR . '/lib/fonts/Courier-BoldOblique',
+    'normal' => 'Courier',
+    'bold' => 'Courier-Bold',
+    'italic' => 'Courier-Oblique',
+    'bold_italic' => 'Courier-BoldOblique',
   ),
-) ?>
-EOFONT
+), JSON_PRETTY_PRINT);"
 }
 
 function make_font_readme() {
@@ -124,5 +122,5 @@ safe_delete vendor/phenx/php-font-lib/www
 
 # Remove DejaVu fonts. They add 12mb.
 safe_delete vendor/dompdf/dompdf/lib/fonts/DejaVu*
-make_font_cache > vendor/dompdf/dompdf/lib/fonts/dompdf_font_family_cache.dist.php
+make_font_cache > vendor/dompdf/dompdf/lib/fonts/installed-fonts.dist.json
 make_font_readme > vendor/dompdf/dompdf/lib/fonts/README.DejaVuFonts.txt

--- a/tools/scripts/composer/dompdf-cleanup.sh
+++ b/tools/scripts/composer/dompdf-cleanup.sh
@@ -126,6 +126,3 @@ safe_delete vendor/phenx/php-font-lib/www
 safe_delete vendor/dompdf/dompdf/lib/fonts/DejaVu*
 make_font_cache > vendor/dompdf/dompdf/lib/fonts/dompdf_font_family_cache.dist.php
 make_font_readme > vendor/dompdf/dompdf/lib/fonts/README.DejaVuFonts.txt
-
-# Remove debug_print_backtrace(), which can leak system details. Put backtrace in log.
-simple_replace vendor/dompdf/dompdf/lib/html5lib/TreeBuilder.php 'debug_print_backtrace();' 'CRM_Core_Error::backtrace("backTrace", TRUE);'


### PR DESCRIPTION
Overview
----------------------------------------
This Upgrades DOMPDF to be on the 2.x branch which is the next version up and updates the cleanup script appropriately

Before
----------------------------------------
DOMPDF version 1.2.1 used

After
----------------------------------------
DOMPDF version 2.0.0 used

Technical Details
----------------------------------------
There is nothing that immediately stands out as issues for us on the release notes https://github.com/dompdf/dompdf/releases

ping @demeritcowboy @eileenmcnaughton @totten @kcristiano 