### PR TITLE
dev/core#3181 - Resolver - Compatibility fix for GLOBALS in PHP 8.1

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1077,6 +1077,9 @@ class CRM_Utils_Array {
    * @return bool
    */
   public static function pathIsset($values, $path) {
+    if ($path === []) {
+      return ($values !== NULL);
+    }
     foreach ($path as $key) {
       if (!is_array($values) || !isset($values[$key])) {
         return FALSE;
@@ -1100,6 +1103,11 @@ class CRM_Utils_Array {
    *   TRUE if anything has been removed. FALSE if no changes were required.
    */
   public static function pathUnset(&$values, $path, $cleanup = FALSE) {
+    if (count($path) === 0) {
+      $values = NULL;
+      return TRUE;
+    }
+
     if (count($path) === 1) {
       if (isset($values[$path[0]])) {
         unset($values[$path[0]]);
@@ -1131,6 +1139,10 @@ class CRM_Utils_Array {
    *   Ex: 456.
    */
   public static function pathSet(&$values, $pathParts, $value) {
+    if ($pathParts === []) {
+      $values = $value;
+      return;
+    }
     $r = &$values;
     $last = array_pop($pathParts);
     foreach ($pathParts as $part) {

--- a/Civi/Core/Resolver.php
+++ b/Civi/Core/Resolver.php
@@ -251,7 +251,8 @@ class ResolverApi {
 
 class ResolverGlobalCallback {
   private $mode;
-  private $path;
+  private $basePath;
+  private $subPath;
 
   /**
    * Class constructor.
@@ -259,10 +260,13 @@ class ResolverGlobalCallback {
    * @param string $mode
    *   'getter' or 'setter'.
    * @param string $path
+   *   Ex: 'dbLocale' <=> $GLOBALS['dbLocale']
+   *   Ex: 'civicrm_setting/domain/debug_enabled' <=> $GLOBALS['civicrm_setting']['domain']['debug_enabled']
    */
   public function __construct($mode, $path) {
     $this->mode = $mode;
-    $this->path = $path;
+    $this->subPath = explode('/', $path);
+    $this->basePath = array_shift($this->subPath);
   }
 
   /**
@@ -273,11 +277,12 @@ class ResolverGlobalCallback {
    * @return mixed
    */
   public function __invoke($arg1 = NULL) {
+    // For PHP 8.1+ compatibility, we resolve the first path-item before doing any array operations.
     if ($this->mode === 'getter') {
-      return \CRM_Utils_Array::pathGet($GLOBALS, explode('/', $this->path));
+      return \CRM_Utils_Array::pathGet($GLOBALS[$this->basePath], $this->subPath);
     }
     elseif ($this->mode === 'setter') {
-      \CRM_Utils_Array::pathSet($GLOBALS, explode('/', $this->path), $arg1);
+      \CRM_Utils_Array::pathSet($GLOBALS[$this->basePath], $this->subPath, $arg1);
       return NULL;
     }
     else {

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -207,6 +207,30 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
 
   }
 
+  public function testGetSet_EmptyPath() {
+    $emptyPath = [];
+
+    $x = 'hello';
+    $this->assertEquals(TRUE, CRM_Utils_Array::pathIsset($x, $emptyPath));
+    $this->assertEquals('hello', CRM_Utils_Array::pathGet($x, $emptyPath));
+    $this->assertEquals('hello', $x);
+
+    CRM_Utils_Array::pathSet($x, $emptyPath, 'bon jour');
+    $this->assertEquals(TRUE, CRM_Utils_Array::pathIsset($x, $emptyPath));
+    $this->assertEquals('bon jour', CRM_Utils_Array::pathGet($x, $emptyPath));
+    $this->assertEquals('bon jour', $x);
+
+    CRM_Utils_Array::pathUnset($x, $emptyPath);
+    $this->assertEquals(FALSE, CRM_Utils_Array::pathIsset($x, $emptyPath));
+    $this->assertEquals(NULL, CRM_Utils_Array::pathGet($x, $emptyPath));
+    $this->assertEquals(NULL, $x);
+
+    CRM_Utils_Array::pathSet($x, $emptyPath, 'buenos dias');
+    $this->assertEquals(TRUE, CRM_Utils_Array::pathIsset($x, $emptyPath));
+    $this->assertEquals('buenos dias', CRM_Utils_Array::pathGet($x, $emptyPath));
+    $this->assertEquals('buenos dias', $x);
+  }
+
   public function getSortExamples() {
     $red = ['label' => 'Red', 'id' => 1, 'weight' => '90'];
     $orange = ['label' => 'Orange', 'id' => 2, 'weight' => '70'];


### PR DESCRIPTION
Overview
----------------------------------------

This patch aims to fix a reported  PHP 8.1 compatibility issue. It refines the way in which `global://FOO` expressions are translated to `$GLOBALS['FOO']`.

See also: https://lab.civicrm.org/dev/core/-/issues/3181

ping @seamuslee001 

Before
----------------------------------------

It relies on walking `$GLOBALS` as if it were an array, eg

```php
return \CRM_Utils_Array::pathGet($GLOBALS, explode('/', $path));
```

But in php81, it's more like a magic object with `ArrayAccess::offsetGet` (ie it just supports `[]` but not loops/iterators/merges).

After
----------------------------------------

It does not need `$GLOBALS` to be a full array - it is manifest that it does not need loops/iterators/merges.

```php
[$basePath, ...$subPaths] = explode('/', $path);
return \CRM_Utils_Array::pathGet($GLOBALS[$basePath], $subPaths);
```

