### PR TITLE
[wip] dev/core#3701 Fix import notices

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -57,4 +57,13 @@ class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     return $this->parser;
   }
 
+  /**
+   * Get the mapping name per the civicrm_mapping_field.type_id option group.
+   *
+   * @return string
+   */
+  public function getMappingTypeName(): string {
+    return 'Import Activity';
+  }
+
 }

--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -99,7 +99,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
     $mappingArray = CRM_Core_BAO_Mapping::getMappings('Import Contact');
 
-    $this->assign('savedMapping', $mappingArray);
+    $this->buildSavedMapping();
     $this->addElement('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
     $js = ['onClick' => "buildSubTypes();buildDedupeRules();"];
@@ -227,6 +227,15 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    */
   public function getTitle(): string {
     return ts('Choose Data Source');
+  }
+
+  /**
+   * Get the mapping name per the civicrm_mapping_field.type_id option group.
+   *
+   * @return string
+   */
+  public function getMappingTypeName(): string {
+    return 'Import Contact';
   }
 
 }

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -78,8 +78,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    */
   public static function formRule($fields, $files, $self) {
     $errors = [];
-    $invalidTagName = $invalidGroupName = FALSE;
-
     if (!empty($fields['newTagName'])) {
       if (!CRM_Utils_Rule::objectExists(trim($fields['newTagName']),
         ['CRM_Core_DAO_Tag']
@@ -88,7 +86,6 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
         $errors['newTagName'] = ts('Tag \'%1\' already exists.',
           [1 => $fields['newTagName']]
         );
-        $invalidTagName = TRUE;
       }
     }
 
@@ -104,13 +101,9 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
         ]
       );
       if ($grpCnt) {
-        $invalidGroupName = TRUE;
         $errors['newGroupName'] = ts('Group \'%1\' already exists.', [1 => $fields['newGroupName']]);
       }
     }
-
-    $self->assign('invalidTagName', $invalidTagName);
-    $self->assign('invalidGroupName', $invalidGroupName);
 
     return empty($errors) ? TRUE : $errors;
   }

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -66,4 +66,13 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     return $this->parser;
   }
 
+  /**
+   * Get the mapping name per the civicrm_mapping_field.type_id option group.
+   *
+   * @return string
+   */
+  public function getMappingTypeName(): string {
+    return 'Import Contribution';
+  }
+
 }

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -138,4 +138,13 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     return $this->parser;
   }
 
+  /**
+   * Get the type of used for civicrm_mapping.mapping_type_id.
+   *
+   * @return string
+   */
+  public function getMappingTypeName(): string {
+    return 'Import Multi value custom data';
+  }
+
 }

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -63,4 +63,13 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     return $this->parser;
   }
 
+  /**
+   * Get the mapping name per the civicrm_mapping_field.type_id option group.
+   *
+   * @return string
+   */
+  public function getMappingTypeName(): string {
+    return 'Import Participant';
+  }
+
 }

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -84,14 +84,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
 
     $this->add('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2], TRUE);
     $this->setDefaults(['fieldSeparator' => $config->fieldSeparator]);
-    $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . static::IMPORT_ENTITY);
-
-    $this->assign('savedMapping', $mappingArray);
-    $this->add('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
-
-    if ($loadedMapping = $this->get('loadedMapping')) {
-      $this->setDefaults(['savedMapping' => $loadedMapping]);
-    }
+    $this->buildSavedMapping();
 
     //build date formats
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
@@ -197,6 +190,21 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    */
   private function instantiateDataSource(): void {
     $this->getDataSourceObject()->initialize();
+  }
+
+  /**
+   * Build the saved mapping widget.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function buildSavedMapping(): void {
+    $mappings = CRM_Core_BAO_Mapping::getCreateMappingValues($this->getMappingTypeName());
+    $this->add('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappings);
+
+    if ($this->getMappingID()) {
+      $this->_submitValues['savedMapping'] = $this->getMappingID();
+    }
   }
 
 }

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -73,14 +73,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     $this->assign('mapper', $this->getMappedFieldLabels());
     $this->assign('dataValues', $this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());
-    //get the mapping name displayed if the mappingId is set
-    $mappingId = $this->get('loadMappingId');
-    if ($mappingId) {
-      $mapDAO = new CRM_Core_DAO_Mapping();
-      $mapDAO->id = $mappingId;
-      $mapDAO->find(TRUE);
-    }
-    $this->assign('savedMappingName', $mappingId ? $mapDAO->name : NULL);
+    $this->assign('savedMappingName', $this->getMapping()['name'] ?? NULL);
     $this->assign('skipColumnHeader', $this->getSubmittedValue('skipColumnHeader'));
     $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader'));
     // rowDisplayCount is deprecated - it used to be used with {section} but we have nearly gotten rid of it.

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -778,9 +778,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function getMappingID(): ?int {
     if (!$this->getUserJobID() || empty($this->getUserJob()['metadata']['mapping'])) {
-      return $this->getSubmittedValue('savedMapping');
+      return $this->getSubmittedValue('savedMapping') ?: NULL;
     }
-    return $this->getUserJob()['metadata']['mapping']['id'];
+    return $this->getUserJob()['metadata']['mapping']['id'] ?? NULL;
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -18,6 +18,8 @@
 use Civi\Api4\UserJob;
 use League\Csv\Writer;
 
+use Civi\Api4\Mapping;
+
 /**
  * This class helps the forms within the import flow access submitted & parsed values.
  */
@@ -761,6 +763,40 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected function getBaseEntity(): string {
     $info = $this->getParser()->getUserJobInfo();
     return reset($info)['entity'];
+  }
+
+  /**
+   * Get the mapping ID.
+   *
+   * We use the one chosen in the DataSource form, unless
+   * we have progressed past that form, in which case we use the
+   * saved/updated/selected mapping.
+   *
+   * @return int|null
+   *
+   * @throws \API_Exception
+   */
+  protected function getMappingID(): ?int {
+    if (!$this->getUserJobID() || empty($this->getUserJob()['metadata']['mapping'])) {
+      return $this->getSubmittedValue('savedMapping');
+    }
+    return $this->getUserJob()['metadata']['mapping']['id'];
+  }
+
+  /**
+   * Get the mapping, if any.
+   *
+   * @return array
+   * @throws \API_Exception
+   */
+  protected function getMapping(): array {
+    //get the mapping name displayed if the mappingId is set
+    if ($this->getMappingID()) {
+      return (array) Mapping::get(FALSE)->addWhere('id', '=', $this->getMappingID())
+        ->addSelect('name', 'id', 'description')
+        ->execute()->first();
+    }
+    return [];
   }
 
 }

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -64,4 +64,13 @@ class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     return $this->parser;
   }
 
+  /**
+   * Get the mapping name per the civicrm_mapping_field.type_id option group.
+   *
+   * @return string
+   */
+  public function getMappingTypeName(): string {
+    return 'Import Membership';
+  }
+
 }

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -68,7 +68,7 @@
         </tr>
       {/if}
 
-      {if $savedMapping}
+      {if array_key_exists('savedMapping', $form)}
         <tr class="crm-import-datasource-form-block-savedMapping">
           <td class="label"><label for="savedMapping">{$form.savedMapping.label}</label></td>
           <td>{$form.savedMapping.html}<br />
@@ -87,7 +87,6 @@
       {/if}
     </table>
   </div>
-
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"} </div>
   {literal}
     <script type="text/javascript">

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -41,18 +41,6 @@
    </script>
  {/literal}
 
-<script type="text/javascript" >
-{literal}
-if ( document.getElementsByName("saveMapping")[0].checked ) {
-    document.getElementsByName("updateMapping")[0].checked = true;
-    document.getElementsByName("saveMapping")[0].checked = false;
-}
-{/literal}
-{if $isCheked}
-    document.getElementsByName("saveMapping")[0].checked = true;
-{/if}
-</script>
-
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
  {$initHideBoxes|smarty:nodefaults}
 

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -142,14 +142,6 @@
 
 {literal}
 <script type="text/javascript">
-
-{/literal}{if $invalidGroupName}{literal}
-cj("#new-group.collapsed").crmAccordionToggle();
-{/literal}{/if}{literal}
-
-{/literal}{if $invalidTagName}{literal}
-cj("#new-tag.collapsed").crmAccordionToggle();
-{/literal}{/if}{literal}
-
+cj('span.crm-error').closest('div.crm-accordion-wrapper').crmAccordionToggle();
 </script>
 {/literal}

--- a/templates/CRM/Import/Form/MapTableCommon.tpl
+++ b/templates/CRM/Import/Form/MapTableCommon.tpl
@@ -68,18 +68,21 @@
             } else {
               cj('#saveDetails').hide();
             }
-
-            function showSaveDetails(chkbox) {
-              if (chkbox.checked) {
-                document.getElementById("saveDetails").style.display = "block";
-                document.getElementById("saveMappingName").disabled = false;
-                document.getElementById("saveMappingDesc").disabled = false;
+            cj('#updateMapping').change(function() {
+              cj('#saveMapping').prop("checked", !this.checked).change();
+            });
+            cj('#saveMapping').change(function() {
+              if (this.checked) {
+                cj('#saveDetails').show();
+                cj('#updateMapping').prop('checked', false);
+                cj('#saveMappingName').removeAttr('disabled')
+                cj('#saveMappingDesc').removeAttr('disabled')
               } else {
-                document.getElementById("saveDetails").style.display = "none";
-                document.getElementById("saveMappingName").disabled = true;
-                document.getElementById("saveMappingDesc").disabled = true;
+                cj('#saveDetails').hide();
+                cj('#saveMappingName').attr('disabled','disabled');
+                cj('#saveMappingDesc').attr('disabled','disabled');
               }
-            }
+            });
             cj('select[id^="mapper"][id$="[0]"]').addClass('huge');
             {/literal}
             {include file="CRM/common/highLightImport.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
E-notice on the match fields forms: Notice: Undefined index: isCheked in include() (line 35 of /srv/buildkit/build/dmaster/web/sites/default/files/civicrm/templates_c/en_US/%%72/72E/72E39105%%MapField.tpl.php)

Before
----------------------------------------
The above notice affects all imports

After
----------------------------------------
Notice fixed - see https://lab.civicrm.org/dev/core/-/issues/3701#note_77844 for discussion of the behaviour

Technical Details
----------------------------------------
This is a regression to the extent that it used to only affect one import and now affects many - I had thought to leave it out of scope for the current re-write but two people put up PRs to try to fix it so I figured I should do a more complete fix. This fix also consolidates duplicated code into these two functions - https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:import_notice?expand=1#diff-f664874b9e78184d0a62439b5c070c7d2195ff19a5da2ce5c340483205aca00aR401 and most of the code changes are to that end.

This is a piece of string - I wound up questioning why we use js to make two checkboxes work like a radio button, should we re-organize the js, should we use an entity reference field, is the sky really blue - but at the end of the day this does include a good chunk of cleanup & addresses the issue


Comments
----------------------------------------
Review would be primarily UI testing