### PR TITLE
dev/core#3722 Stop infinite reconciliation

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -60,10 +60,10 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
     // function to format definition column
     if (isset($params['definition']) && is_array($params['definition'])) {
       $params['definition'] = self::convertDefinitionToXML($caseTypeName, $params['definition']);
-      // @see dev/core#3722 Only reconcile if it's an XML-based managed entity.
+      // @see dev/core#3722 Only reconcile if it's an API v3 entity.
       // @see CRM-14786 Reconcilation added to manage whenever a case-type XML definition changes,
       // in order to add/remove associated activity and relationship types.
-      if (self::hasXmlDefinition($caseTypeName)) {
+      if (isset($params['version']) && $params['version'] == 3) {
         CRM_Core_ManagedEntities::scheduleReconciliation();
       }
     }
@@ -496,21 +496,10 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
     $caseTypeName = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'name', 'id', TRUE);
     if ($caseTypeName) {
       $dbDefinition = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'definition', 'id', TRUE);
-      $fileDefinition = self::hasXmlDefinition($caseTypeName);
+      $fileDefinition = CRM_Case_XMLRepository::singleton()->retrieveFile($caseTypeName);
       return $fileDefinition && $dbDefinition;
     }
     return NULL;
-  }
-
-  /**
-   * Case Type has an xml file-based definition.
-   *
-   * @param string $caseTypeName
-   * @return bool
-   */
-  public static function hasXmlDefinition($caseTypeName) {
-    $fileDefinition = CRM_Case_XMLRepository::singleton()->retrieveFile($caseTypeName);
-    return (!empty($fileDefinition)) ? TRUE : FALSE;
   }
 
   /**

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -63,8 +63,8 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
       // @see dev/core#3722 Prevent reconciliation from being called infinitely.
       // @see CRM-14786 Reconcilation added to manage whenever a case-type XML definition changes,
       // in order to add/remove associated activity and relationship types.
-      if (!isset(\Civi::$statics[__CLASS__][$params['name']])) {
-        \Civi::$statics[__CLASS__][$params['name']] = 1;
+      if (!isset(\Civi::$statics[__CLASS__][$caseTypeName])) {
+        \Civi::$statics[__CLASS__][$caseTypeName] = 1;
         CRM_Core_ManagedEntities::scheduleReconciliation();
       }
     }

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -60,7 +60,9 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
     // function to format definition column
     if (isset($params['definition']) && is_array($params['definition'])) {
       $params['definition'] = self::convertDefinitionToXML($caseTypeName, $params['definition']);
-      CRM_Core_ManagedEntities::scheduleReconciliation();
+      if (self::isForked($params['id'])) {
+        CRM_Core_ManagedEntities::scheduleReconciliation();
+      }
     }
 
     $caseTypeDAO->copyValues($params);

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -63,8 +63,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
       // @see dev/core#3722 Prevent reconciliation from being called infinitely.
       // @see CRM-14786 Reconcilation added to manage whenever a case-type XML definition changes,
       // in order to add/remove associated activity and relationship types.
-      if (!isset(\Civi::$statics[__CLASS__][$caseTypeName])) {
-        \Civi::$statics[__CLASS__][$caseTypeName] = 1;
+      if (isset($params['version']) && $params['version'] == 3) {
         CRM_Core_ManagedEntities::scheduleReconciliation();
       }
     }

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -508,7 +508,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
    */
   public static function hasXmlDefinition($caseTypeName) {
     $fileDefinition = CRM_Case_XMLRepository::singleton()->retrieveFile($caseTypeName);
-    return (!empty($fileDefinition)) ? TRUE: FALSE;
+    return (!empty($fileDefinition)) ? TRUE : FALSE;
   }
 
   /**

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -60,10 +60,11 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
     // function to format definition column
     if (isset($params['definition']) && is_array($params['definition'])) {
       $params['definition'] = self::convertDefinitionToXML($caseTypeName, $params['definition']);
-      // @see dev/core#3722 Only reconcile if it's an API v3 entity.
+      // @see dev/core#3722 Prevent reconciliation from being called infinitely.
       // @see CRM-14786 Reconcilation added to manage whenever a case-type XML definition changes,
       // in order to add/remove associated activity and relationship types.
-      if (isset($params['version']) && $params['version'] == 3) {
+      if (!isset(\Civi::$statics[__CLASS__][$params['name']])) {
+        \Civi::$statics[__CLASS__][$params['name']] = 1;
         CRM_Core_ManagedEntities::scheduleReconciliation();
       }
     }

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -60,7 +60,9 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
     // function to format definition column
     if (isset($params['definition']) && is_array($params['definition'])) {
       $params['definition'] = self::convertDefinitionToXML($caseTypeName, $params['definition']);
-      // @see dev/core#3722 only reconcile if it's an XML-based managed entity.
+      // @see dev/core#3722 Only reconcile if it's an XML-based managed entity.
+      // @see CRM-14786 Reconcilation added to manage whenever a case-type XML definition changes,
+      // in order to add/remove associated activity and relationship types.
       if (self::hasXmlDefinition($caseTypeName)) {
         CRM_Core_ManagedEntities::scheduleReconciliation();
       }

--- a/mixin/mgd-php@1/example/CRM/BunnyDance.mgd.php
+++ b/mixin/mgd-php@1/example/CRM/BunnyDance.mgd.php
@@ -14,41 +14,40 @@ return [
         'is_active' => TRUE,
         'is_reserved' => TRUE,
         'weight' => 1,
-        // FIXME: At time of writing, if I create a full CaseType with a definition, then the system runs out of memory.
-        // 'definition' => [
-        //   'activityTypes' => [
-        //     ['name' => 'Open Case', 'max_instances' => '1'],
-        //     ['name' => 'Follow up'],
-        //     ['name' => 'Change Case Type'],
-        //     ['name' => 'Change Case Status'],
-        //     ['name' => 'Change Case Start Date'],
-        //     ['name' => 'Link Cases'],
-        //     ['name' => 'Email'],
-        //     ['name' => 'Meeting'],
-        //     ['name' => 'Phone Call'],
-        //     ['name' => 'Nibble'],
-        //   ],
-        //   'activitySets' => [
-        //     [
-        //       'name' => 'standard_timeline',
-        //       'label' => 'Standard Timeline',
-        //       'timeline' => 1,
-        //       'activityTypes' => [
-        //         ['name' => 'Open Case', 'status' => 'Completed'],
-        //         ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
-        //         ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
-        //       ],
-        //     ],
-        //   ],
-        //   'timelineActivityTypes' => [
-        //     ['name' => 'Open Case', 'status' => 'Completed'],
-        //     ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
-        //     ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
-        //   ],
-        //   'caseRoles' => [
-        //     ['name' => 'Case Coordinator', 'creator' => '1', 'manager' => '1'],
-        //   ],
-        // ],
+        'definition' => [
+          'activityTypes' => [
+            ['name' => 'Open Case', 'max_instances' => '1'],
+            ['name' => 'Follow up'],
+            ['name' => 'Change Case Type'],
+            ['name' => 'Change Case Status'],
+            ['name' => 'Change Case Start Date'],
+            ['name' => 'Link Cases'],
+            ['name' => 'Email'],
+            ['name' => 'Meeting'],
+            ['name' => 'Phone Call'],
+            ['name' => 'Nibble'],
+          ],
+          'activitySets' => [
+            [
+              'name' => 'standard_timeline',
+              'label' => 'Standard Timeline',
+              'timeline' => 1,
+              'activityTypes' => [
+                ['name' => 'Open Case', 'status' => 'Completed'],
+                ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
+                ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
+              ],
+            ],
+          ],
+          'timelineActivityTypes' => [
+            ['name' => 'Open Case', 'status' => 'Completed'],
+            ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
+            ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
+          ],
+          'caseRoles' => [
+            ['name' => 'Case Coordinator', 'creator' => '1', 'manager' => '1'],
+          ],
+        ],
       ],
     ],
   ],

--- a/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
+++ b/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
@@ -24,13 +24,11 @@ class ManagedCaseTypeTest extends \PHPUnit\Framework\Assert {
     $this->assertEquals(TRUE, $items[0]['is_active']);
     $this->assertEquals(1, count($items));
 
-    // FIXME: The example is partially disabled - because the full example causes a crash.
-    // Hence, these assertions don't yet pass.
-    // $actTypes = $cv->api4('OptionValue', 'get', [
-    //   'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
-    // ]);
-    // $this->assertEquals('Nibble', $actTypes[0]['name'], 'ActivityType "Nibble" should be auto enabled. It\'s missing.');
-    // $this->assertEquals(TRUE, $actTypes[0]['is_active'], 'ActivityType "Nibble" should be auto enabled. It\'s inactive.');
+    $actTypes = $cv->api4('OptionValue', 'get', [
+      'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
+    ]);
+    $this->assertEquals('Nibble', $actTypes[0]['name'], 'ActivityType "Nibble" should be auto enabled. It\'s missing.');
+    $this->assertEquals(TRUE, $actTypes[0]['is_active'], 'ActivityType "Nibble" should be auto enabled. It\'s inactive.');
   }
 
   public function testDisabled($cv) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3722

Before
----------------------------------------

It schedules managed entity reconciliation over and over and over and over and over again.

After
----------------------------------------

It only schedules reconciliation if the definition is from an xml file *and* it is in the db already.

Technical Details
----------------------------------------

New to 5.50.0 we can now export CaseTypes as managed entities from API4. This attempts to fix the assumptions in CaseType which thinks it's coming from an xml file alone.
