### PR TITLE
dev/core#3050 - Fix crash removing an entry from a batch

### DIFF
--- a/CRM/Batch/BAO/EntityBatch.php
+++ b/CRM/Batch/BAO/EntityBatch.php
@@ -66,6 +66,19 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
     if (!is_array($params)) {
       $params = ['id' => $params];
     }
+    // This was refactored in 99f762 to call deleteRecord but crashes if there
+    // is no id in params. This function is marked deprecated but it seemed
+    // messier to try to fix the call from
+    // CRM_Financial_Page_AJAX::assignRemove because the entity there is
+    // variable and is expecting a function called del() to exist on the
+    // entity.
+    if (!isset($params['id'])) {
+      $dao = new CRM_Batch_DAO_EntityBatch();
+      $dao->copyValues($params);
+      if ($dao->find(TRUE)) {
+        $params['id'] = $dao->id;
+      }
+    }
     return self::deleteRecord($params);
   }
 

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -199,7 +199,7 @@ class CRM_Financial_Page_AJAX {
             break;
         }
 
-        if (method_exists($recordBAO, $methods[$op]) & !empty($params)) {
+        if (method_exists($recordBAO, $methods[$op]) && !empty($params)) {
           try {
             $updated = call_user_func_array(array($recordBAO, $methods[$op]), array(&$params));
           }

--- a/CRM/Financial/Page/AJAX.php
+++ b/CRM/Financial/Page/AJAX.php
@@ -167,6 +167,7 @@ class CRM_Financial_Page_AJAX {
     // make sure recordClass is in the CRM namespace and
     // at least 3 levels deep
     if ($recordClass[0] == 'CRM' && count($recordClass) >= 3) {
+      $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
       foreach ($records as $recordID) {
         $params = [];
         switch ($op) {
@@ -186,7 +187,6 @@ class CRM_Financial_Page_AJAX {
             $params = $totals[$recordID];
           case 'reopen':
             $status = $op == 'close' ? 'Closed' : 'Reopened';
-            $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
             $params['status_id'] = CRM_Utils_Array::key($status, $batchStatus);
             $session = CRM_Core_Session::singleton();
             $params['modified_date'] = date('YmdHis');
@@ -207,8 +207,8 @@ class CRM_Financial_Page_AJAX {
             $errorMessage = $e->getMessage();
           }
           if ($updated) {
-            $redirectStatus = $updated->status_id;
-            if ($batchStatus[$updated->status_id] == "Reopened") {
+            $redirectStatus = $updated->status_id ?? NULL;
+            if ($redirectStatus && $batchStatus[$redirectStatus] == "Reopened") {
               $redirectStatus = array_search("Open", $batchStatus);
             }
             $response = [

--- a/tests/phpunit/CRM/Batch/BAO/BatchTest.php
+++ b/tests/phpunit/CRM/Batch/BAO/BatchTest.php
@@ -128,4 +128,40 @@ class CRM_Batch_BAO_BatchTest extends CiviUnitTestCase {
     CRM_Batch_BAO_Batch::exportFinancialBatch([$batch['id']], 'CSV', NULL);
   }
 
+  /**
+   * Test removing from the batch via ajax
+   * (as in clicking the remove link at the far right of the row)
+   */
+  public function testRemoveFromBatch(): void {
+    $contact_id = $this->individualCreate([], 0, TRUE);
+    $batch_id = $this->callAPISuccess('Batch', 'create', [
+      'title' => 'Test Remove Batch',
+      'status_id' => 'Open',
+    ])['id'];
+    $contribution_id = $this->contributionCreate(['contact_id' => $contact_id]);
+    $_POST['op'] = 'assign';
+    $_POST['recordBAO'] = 'CRM_Batch_BAO_EntityBatch';
+    $_POST['records'] = [$contribution_id];
+    $_POST['entityID'] = $batch_id;
+    try {
+      CRM_Financial_Page_AJAX::assignRemove();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $this->assertEquals('record-updated-success', $e->errorData['status']);
+    }
+    // now remove it
+    $_POST['op'] = 'remove';
+    try {
+      CRM_Financial_Page_AJAX::assignRemove();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $this->assertEquals('record-updated-success', $e->errorData['status']);
+    }
+
+    unset($_POST['op']);
+    unset($_POST['recordBAO']);
+    unset($_POST['records']);
+    unset($_POST['entityID']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3050

Before
----------------------------------------
1. Contributions - Accounting Batches - New batch
2. Add one of the contributions to the batch.
3. Using the "Remove" link on the far right of the row, remove the entry you just added.
4. Crash

After
----------------------------------------
Ok

Technical Details
----------------------------------------
Was refactored in https://github.com/civicrm/civicrm-core/pull/21213 but it doesn't work here from the ajax call.

Comments
----------------------------------------
There's some extra fiddling in AJAX.php in the second commit because otherwise the test hits several undefined variables.