### PR TITLE
[REF][PHP8.1] Fix deprecations where by calling trait static function…

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -167,7 +167,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
    * @see CRM_Core_Resources_CollectionTrait::findCreateSettingSnippet()
    */
   public function &findCreateSettingSnippet($options = []): array {
-    $options = CRM_Core_Resources_CollectionAdderTrait::mergeSettingOptions($options, [
+    $options = self::mergeSettingOptions($options, [
       'region' => NULL,
     ]);
     return $this->getSettingRegion($options['region'])->findCreateSettingSnippet($options);

--- a/CRM/Core/Resources/CollectionTrait.php
+++ b/CRM/Core/Resources/CollectionTrait.php
@@ -386,7 +386,7 @@ trait CRM_Core_Resources_CollectionTrait {
     $s = &$this->findCreateSettingSnippet();
     $result = $s['settings'];
     foreach ($s['settingsFactories'] as $callable) {
-      $result = CRM_Core_Resources_CollectionAdderTrait::mergeSettings($result, $callable());
+      $result = self::mergeSettings($result, $callable());
     }
     CRM_Utils_Hook::alterResourceSettings($result);
     return $result;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -27,6 +27,7 @@ use Civi\Api4\Utils\FormattingUtil;
 abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
   use SavedSearchInspectorTrait;
+  use ArrayQueryActionTrait;
 
   /**
    * Either the name of the display or an array containing the display definition (for preview mode)
@@ -303,7 +304,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $cssClass = $clause[0] ?? '';
       if ($cssClass) {
         $condition = $this->getRuleCondition(array_slice($clause, 1));
-        if (is_null($condition[0]) || (ArrayQueryActionTrait::filterCompare($data, $condition))) {
+        if (is_null($condition[0]) || (self::filterCompare($data, $condition))) {
           $classes[] = $cssClass;
         }
       }
@@ -327,7 +328,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       }
       if ($iconClass) {
         $condition = $this->getRuleCondition($icon['if'] ?? []);
-        if (!is_null($condition[0]) && !(ArrayQueryActionTrait::filterCompare($data, $condition))) {
+        if (!is_null($condition[0]) && !(self::filterCompare($data, $condition))) {
           continue;
         }
         $result[] = ['class' => $iconClass, 'side' => $icon['side'] ?? 'left'];
@@ -471,7 +472,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       }
       return TRUE;
     }
-    return ArrayQueryActionTrait::filterCompare($data, $item['condition']);
+    return self::filterCompare($data, $item['condition']);
   }
 
   /**


### PR DESCRIPTION
…s when not from a class that implements the trait is deprecated

Overview
----------------------------------------
This aims to fix deprecations like the following

```
PHP Deprecated:  Calling static trait method Civi\Api4\Generic\Traits\ArrayQueryActionTrait::filterCompare is deprecated, it should only be called on a class using the trait in /home/seamus/buildkit/build/dtest/web/sites/all/modules/civi                                                                                crm/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php on line 306
``` 

Before
----------------------------------------
Deprecations generated running unit tests locally

After
----------------------------------------
Less deprecations generated 

ping @totten @eileenmcnaughton @demeritcowboy 