### PR TITLE
(NFC) mgd-php@1 - Add example+assertions for new case-type 

### DIFF
--- a/mixin/mgd-php@1/example/CRM/BunnyDance.mgd.php
+++ b/mixin/mgd-php@1/example/CRM/BunnyDance.mgd.php
@@ -1,0 +1,55 @@
+<?php
+return [
+  [
+    'name' => 'CaseType_BunnyDance',
+    'entity' => 'CaseType',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'BunnyDance',
+        'title' => 'Bunny Dance Case',
+        'description' => 'The mysterious case of the dancing bunny',
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+        'weight' => 1,
+        // FIXME: At time of writing, if I create a full CaseType with a definition, then the system runs out of memory.
+        // 'definition' => [
+        //   'activityTypes' => [
+        //     ['name' => 'Open Case', 'max_instances' => '1'],
+        //     ['name' => 'Follow up'],
+        //     ['name' => 'Change Case Type'],
+        //     ['name' => 'Change Case Status'],
+        //     ['name' => 'Change Case Start Date'],
+        //     ['name' => 'Link Cases'],
+        //     ['name' => 'Email'],
+        //     ['name' => 'Meeting'],
+        //     ['name' => 'Phone Call'],
+        //     ['name' => 'Nibble'],
+        //   ],
+        //   'activitySets' => [
+        //     [
+        //       'name' => 'standard_timeline',
+        //       'label' => 'Standard Timeline',
+        //       'timeline' => 1,
+        //       'activityTypes' => [
+        //         ['name' => 'Open Case', 'status' => 'Completed'],
+        //         ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
+        //         ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
+        //       ],
+        //     ],
+        //   ],
+        //   'timelineActivityTypes' => [
+        //     ['name' => 'Open Case', 'status' => 'Completed'],
+        //     ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
+        //     ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
+        //   ],
+        //   'caseRoles' => [
+        //     ['name' => 'Case Coordinator', 'creator' => '1', 'manager' => '1'],
+        //   ],
+        // ],
+      ],
+    ],
+  ],
+];

--- a/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
+++ b/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Civi\Shimmy\Mixins;
+
+/**
+ * Assert that the mgd-php mixin is picking the case-type and all its related data.
+ *
+ * This class defines the assertions to run when installing or uninstalling the extension.
+ * It use called as part of E2E_Shimmy_LifecycleTest.
+ *
+ * @see E2E_Shimmy_LifecycleTest
+ */
+class ManagedCaseTypeTest extends \PHPUnit\Framework\Assert {
+
+  public function testPreConditions($cv) {
+    $this->assertFileExists(static::getPath('/CRM/BunnyDance.mgd.php'), 'The shimmy extension must have a Case MGD file.');
+  }
+
+  public function testInstalled($cv) {
+    $items = $cv->api4('CaseType', 'get', ['where' => [['name', '=', 'BunnyDance']]]);
+    $this->assertEquals('The mysterious case of the dancing bunny', $items[0]['description']);
+    $this->assertEquals('BunnyDance', $items[0]['name']);
+    $this->assertEquals('Bunny Dance Case', $items[0]['title']);
+    $this->assertEquals(TRUE, $items[0]['is_active']);
+    $this->assertEquals(1, count($items));
+
+    // FIXME: The example is partially disabled - because the full example causes a crash.
+    // Hence, these assertions don't yet pass.
+    // $actTypes = $cv->api4('OptionValue', 'get', [
+    //   'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
+    // ]);
+    // $this->assertEquals('Nibble', $actTypes[0]['name'], 'ActivityType "Nibble" should be auto enabled. It\'s missing.');
+    // $this->assertEquals(TRUE, $actTypes[0]['is_active'], 'ActivityType "Nibble" should be auto enabled. It\'s inactive.');
+  }
+
+  public function testDisabled($cv) {
+    $items = $cv->api4('CaseType', 'get', ['where' => [['name', '=', 'BunnyDance']]]);
+    $this->assertEquals('The mysterious case of the dancing bunny', $items[0]['description']);
+    $this->assertEquals('BunnyDance', $items[0]['name']);
+    $this->assertEquals('Bunny Dance Case', $items[0]['title']);
+    $this->assertEquals(FALSE, $items[0]['is_active']);
+    $this->assertEquals(1, count($items));
+  }
+
+  public function testUninstalled($cv) {
+    $items = $cv->api4('CaseType', 'get', ['where' => [['name', '=', 'BunnyDance']]]);
+    $this->assertEquals(0, count($items));
+
+    $actTypes = $cv->api4('OptionValue', 'get', [
+      'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
+    ]);
+    $this->assertEmpty($actTypes);
+  }
+
+  protected static function getPath($suffix = ''): string {
+    return dirname(__DIR__, 2) . $suffix;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

This adds some E2E/lifecycle test-coverage for using `*.mgd.php` files to manage `CaseType`s.

Before
----------------------------------------

The test for `mgd-php` / `hook_managed` assert that `OptionGroup` is added+removed during installation+uninstallation.

After
----------------------------------------

The test for `mgd-php` / `hook_managed` *additionally* assert that `CaseType` is added+removed during installation+uninstallation.

(I'm not saying that we should add assertions for every entity that could go through mgd-php -- but `CaseType` is good to check because the entity has some special bits.)

Technical Details
----------------------------------------

You can run tests with a command along these lines:

```
civibuild restore dmaster
./tools/mixin/bin/mixer test -f --bare /PATH/TO/web/sites/default/files/civicrm/ext/example-mixin/ mgd-php@1
```

The test stops short on some assertions and data-points - because I discovered bug (probably some kind of regression) while using the full assertions. That bug is demonstrated more specifically by https://gist.github.com/totten/3ec8164c3f8ca9d3c51e768feab946da. Nevertheless, I think it's useful to add coverage for the parts that are currently working.
