### PR TITLE
Remove another instance of pledges using contribution option group

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -780,14 +780,15 @@ GROUP BY  currency
 
     $returnMessages = [];
 
-    $sendReminders = CRM_Utils_Array::value('send_reminders', $params, FALSE);
+    $sendReminders = $params['send_reminders'] ?? FALSE;
 
-    $allStatus = array_flip(CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name'));
-    $allPledgeStatus = CRM_Core_OptionGroup::values('pledge_status',
-      TRUE, FALSE, FALSE, NULL, 'name', TRUE
-    );
+    $allStatus = array_flip(CRM_Pledge_BAO_PledgePayment::buildOptions('status_id', 'validate'));
+    // We are left with 'Pending' & 'Overdue' - ie. payment required - should we just filter in the ones we want?
+    unset($allStatus['Completed'], $allStatus['Cancelled']);
+
+    $allPledgeStatus = array_flip(CRM_Pledge_BAO_Pledge::buildOptions('status_id', 'validate'));
+    // We are left with 'Pending' & 'Overdue', 'In Progress'
     unset($allPledgeStatus['Completed'], $allPledgeStatus['Cancelled']);
-    unset($allStatus['Completed'], $allStatus['Cancelled'], $allStatus['Failed']);
 
     $statusIds = implode(',', $allStatus);
     $pledgeStatusIds = implode(',', $allPledgeStatus);


### PR DESCRIPTION
Overview
----------------------------------------
Remove another instance of pledges using contribution option group

Before
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/23074 if we remove 'Overdue' from the Contribution Status option group we get a fail because pledge code is using that option group instead of the one for pledge statuses (they were separated long ago)


![image](https://user-images.githubusercontent.com/336308/177697844-82557e92-81e7-4e3f-9403-a45900df97cf.png)


After
----------------------------------------
Pledge option group accessed

Technical Details
----------------------------------------

Comments
----------------------------------------
