### PR TITLE
Do not escape error message

### DIFF
--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -8,10 +8,10 @@
  +--------------------------------------------------------------------+
 *}
 {* Handles display of passed $infoMessage. *}
-{if $infoMessage || $infoTitle}
-  <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions}'{/if}>
+{if $infoMessage|smarty:nodefaults || $infoTitle|smarty:nodefaults}
+  <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions|smarty:nodefaults}'{/if}>
     {icon icon="fa-info-circle"}{/icon}
     <span class="msg-title">{$infoTitle}</span>
-    <span class="msg-text">{$infoMessage}</span>
+    <span class="msg-text">{$infoMessage|smarty:nodefaults}</span>
   </div>
 {/if}

--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -12,6 +12,6 @@
   <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions|smarty:nodefaults}'{/if}>
     {icon icon="fa-info-circle"}{/icon}
     <span class="msg-title">{$infoTitle}</span>
-    <span class="msg-text">{$infoMessage|smarty:nodefaults}</span>
+    <span class="msg-text">{$infoMessage|smarty:nodefaults|purify}</span>
   </div>
 {/if}

--- a/templates/CRM/common/info.tpl
+++ b/templates/CRM/common/info.tpl
@@ -9,7 +9,7 @@
 *}
 {* Handles display of passed $infoMessage. *}
 {if $infoMessage|smarty:nodefaults || $infoTitle|smarty:nodefaults}
-  <div class="messages status {$infoType}"{if $infoOptions} data-options='{$infoOptions|smarty:nodefaults}'{/if}>
+  <div class="messages status {$infoType}"{if $infoOptions|smarty:nodefaults} data-options='{$infoOptions|smarty:nodefaults}'{/if}>
     {icon icon="fa-info-circle"}{/icon}
     <span class="msg-title">{$infoTitle}</span>
     <span class="msg-text">{$infoMessage|smarty:nodefaults|purify}</span>

--- a/templates/CRM/common/status.tpl
+++ b/templates/CRM/common/status.tpl
@@ -17,6 +17,6 @@
     {else}
       {assign var="infoType" value=$statItem.type}
     {/if}
-    {include file="CRM/common/info.tpl" infoTitle=$statItem.title infoMessage=$statItem.text infoOptions=$statItem.options|@json_encode}
+    {include file="CRM/common/info.tpl" infoTitle=$statItem.title|smarty:nodefaults infoMessage=$statItem.text|smarty:nodefaults infoOptions=$statItem.options|smarty:nodefaults|@json_encode}
   {/foreach}
 {/if}

--- a/templates/CRM/common/status.tpl
+++ b/templates/CRM/common/status.tpl
@@ -17,6 +17,6 @@
     {else}
       {assign var="infoType" value=$statItem.type}
     {/if}
-    {include file="CRM/common/info.tpl" infoTitle=$statItem.title|smarty:nodefaults infoMessage=$statItem.text|smarty:nodefaults infoOptions=$statItem.options|smarty:nodefaults|@json_encode}
+    {include file="CRM/common/info.tpl" infoTitle=$statItem.title infoMessage=$statItem.text|smarty:nodefaults|purify infoOptions=$statItem.options|smarty:nodefaults|@json_encode}
   {/foreach}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Do not escape error message when smarty default security is enabled

![image](https://user-images.githubusercontent.com/336308/177734612-31f3c10c-84be-4954-ad08-992f1ad6d285.png)

Before
----------------------------------------
This popup gets called from multiple places & has munged html - in this case  I've been doing 'save and test email'

![image](https://user-images.githubusercontent.com/336308/177732282-c15f73f6-bbb0-4848-9ad5-13a5da9ff0e3.png)

![image](https://user-images.githubusercontent.com/336308/177732457-646a8e52-563d-40ab-9ef2-c1b5b7143a50.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/177733990-3ffe2a09-d493-4b55-8c01-7ff565394055.png)

Technical Details
----------------------------------------
I added `purify` since adding `smarty:nodefaults` is kinda like saying 'I've check this & it's secure' - but actually I've checked it & it strikes me it would be easy to make a mistake such that it isn't I think that's not a risk for the json bits

Comments
----------------------------------------
