### PR TITLE
Fixes core#3725 'Access CiviContribute' can't view a single contribution

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -32,7 +32,13 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     $id = $this->getID();
 
     // Check permission for action.
-    if (!CRM_Core_Permission::checkActionPermission('CiviContribute', $this->_action)) {
+    $actionMapping = [
+      CRM_Core_Action::VIEW => 'get',
+      CRM_Core_Action::ADD => 'create',
+      CRM_Core_Action::UPDATE => 'update',
+      CRM_Core_Action::DELETE => 'delete',
+    ];
+    if (!$this->isHasAccess($actionMapping[$this->_action])) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
     $params = ['id' => $id];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3725
Contacts with "Access CiviContribute" but not "edit contributions" can no longer view individual contributions. 

To replicate, give a contact the "Access CiviContribute" permission but not "edit contributions", go to a contact that has contributions, and click **View** next to one of the contributions.

Before
----------------------------------------
"You do not have permission to access this page." 

After
----------------------------------------
Contribution appears.

Technical Details
----------------------------------------
That calls CRM_Core_Permission::checkActionPermission() which says in its description, "Check permissions for delete and edit actions", but it's called even when viewing a contribution.

I updated to use the new-ish `isHasAccess()` which handles all permission checks, and also presumably closes the security hole when Financial ACLs are in use.

Comments
----------------------------------------
This is a regression from #22961 (security#112).
