### PR TITLE
Fix import falling over when a note is included

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1177,35 +1177,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       return TRUE;
     }
 
-    // Cache the various object fields
-    // @todo - remove this after confirming this is just a compilation of other-wise-cached fields.
-    static $fields = [];
-
-    if (isset($values['note'])) {
-      // add a note field
-      if (!isset($params['note'])) {
-        $params['note'] = [];
-      }
-      $noteBlock = count($params['note']) + 1;
-
-      $params['note'][$noteBlock] = [];
-      if (!isset($fields['Note'])) {
-        $fields['Note'] = CRM_Core_DAO_Note::fields();
-      }
-
-      // get the current logged in civicrm user
-      $session = CRM_Core_Session::singleton();
-      $userID = $session->get('userID');
-
-      if ($userID) {
-        $values['contact_id'] = $userID;
-      }
-
-      _civicrm_api3_store_values($fields['Note'], $values, $params['note'][$noteBlock]);
-
-      return TRUE;
-    }
-
     // Check for custom field values
     $customFields = CRM_Core_BAO_CustomField::getFields(CRM_Utils_Array::value('contact_type', $values),
       FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_with_note.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_with_note.csv
@@ -1,0 +1,2 @@
+First Name,Last Name,Note
+Mr, Jones,Kinda dull


### PR DESCRIPTION
Overview
----------------------------------------
Fix import falling over when a note is included

Before
----------------------------------------
With an import like https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:import_note?expand=1#diff-e16a6dde5dc7845c64c4d653444853caf4d1fcbee91de419b94eae230e0215ce the queue fails to progress as it is trying to use a string as an array

After
----------------------------------------
Works, tested

Technical Details
----------------------------------------
It seems there **may** have been an intent in the code to allow importing several notes at once - I'm not sure if it worked & it is completely broken without this patch. If that is raised as a regression I will re-instate that behaviour in a better way

Comments
----------------------------------------
