### PR TITLE
APIv4 - Fix mishandling of boolean custom values

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -514,6 +514,12 @@ abstract class AbstractAction implements \ArrayAccess {
       $options = FormattingUtil::getPseudoconstantList($info['field'], $info['expr'], $record, 'create');
       $record[$fieldName] = FormattingUtil::replacePseudoconstant($options, $info['val'], TRUE);
     }
+    // The DAO works better with ints than booleans. See https://github.com/civicrm/civicrm-core/pull/23970
+    foreach ($record as $key => $value) {
+      if (is_bool($value)) {
+        $record[$key] = (int) $value;
+      }
+    }
   }
 
   /**

--- a/tests/phpunit/api/v4/Custom/FalseNotEqualsZeroTest.php
+++ b/tests/phpunit/api/v4/Custom/FalseNotEqualsZeroTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Custom;
+
+use Civi\Api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
+
+/**
+ * @group headless
+ */
+class FalseNotEqualsZeroTest extends CustomTestBase {
+
+  public function testFalseNotEqualsZero() {
+
+    $customGroup = CustomGroup::create(FALSE)
+      ->addValue('title', 'MyContactFields')
+      ->addValue('extends', 'Contact')
+      ->execute()
+      ->first();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'Lightswitch')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Radio')
+      ->addValue('data_type', 'Boolean')
+      ->execute();
+
+    $contactId = $this->createTestRecord('Contact', [
+      'first_name' => 'Red',
+      'last_name' => 'Tester',
+      'contact_type' => 'Individual',
+      'MyContactFields.Lightswitch' => FALSE,
+    ])['id'];
+
+    $result = Contact::get($contactId, 'Contact')
+      ->addSelect('MyContactFields.Lightswitch')
+      ->addWhere('id', '=', $contactId)
+      ->execute()
+      ->first()['MyContactFields.Lightswitch'];
+
+    $this->assertNotNull($result);
+  }
+
+}


### PR DESCRIPTION
Overview
-----------

Fixes https://lab.civicrm.org/dev/core/-/issues/3497 to correctly save boolean custom field values.

Before
-------------
APIv4 would store FALSE as NULL.

After
---------------
Boolean fields correctly saved.