### PR TITLE
[REF] dev/core#3676 Add in html2text/html2text to replace usage of roundcube's version we have in packages

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -437,10 +437,9 @@ class CRM_Utils_String {
    *   the converted string
    */
   public static function htmlToText($html) {
-    require_once 'html2text/rcube_html2text.php';
     $token_html = preg_replace('!\{([a-z_.]+)\}!i', 'token:{$1}', $html);
-    $converter = new rcube_html2text($token_html);
-    $token_text = $converter->get_text();
+    $converter = new \Html2Text\Html2Text($token_html, ['do_links' => 'table', 'width' => 75]);
+    $token_text = $converter->getText();
     $text = preg_replace('!token\:\{([a-z_.]+)\}!i', '{$1}', $token_text);
     return $text;
   }

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
     "ext-json": "*",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18",
-    "symfony/polyfill-php73": "^1.23"
+    "symfony/polyfill-php73": "^1.23",
+    "html2text/html2text": "^4.3.1"
   },
   "scripts": {
     "post-install-cmd": [
@@ -274,6 +275,9 @@
     "patches": {
       "adrienrn/php-mimetyper": {
         "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch"
+      },
+      "html2text/html2text": {
+        "Fix deprecation warning in php8.1 on html_entity_decode": "https://raw.githubusercontent.com/civicrm/civicrm-core/e758d20e9f613ca6c4cf652c23d2cd7e5d3af3ce/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch"
       },
       "pear/db": {
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "619a88e88f80e415abfc58a76082e9f5",
+    "content-hash": "6f116bb2d3eca13dde70ec793930d91f",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1093,6 +1093,47 @@
                 }
             ],
             "time": "2022-06-20T21:43:03+00:00"
+        },
+        {
+            "name": "html2text/html2text",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mtibben/html2text.git",
+                "reference": "61ad68e934066a6f8df29a3d23a6460536d0855c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mtibben/html2text/zipball/61ad68e934066a6f8df29a3d23a6460536d0855c",
+                "reference": "61ad68e934066a6f8df29a3d23a6460536d0855c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "symfony/polyfill-mbstring": "If you can't install ext-mbstring"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Html2Text\\": [
+                        "src/",
+                        "test/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Converts HTML to formatted plain text",
+            "support": {
+                "issues": "https://github.com/mtibben/html2text/issues",
+                "source": "https://github.com/mtibben/html2text/tree/4.3.1"
+            },
+            "time": "2020-04-16T23:44:31+00:00"
         },
         {
             "name": "laminas/laminas-escaper",

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -164,6 +164,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         //  body_html, filtered
         "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
         "\n" .
+        "\n" .
         "Links:\n" .
         "------\n" .
         "\\[1\\] http://example.net/first\\?cs=[0-9a-f_]+\n" .
@@ -216,6 +217,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
         ";" .
         //  body_html, filtered
         "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
+        "\n" .
         "\n" .
         "Links:\n" .
         "------\n" .

--- a/tests/phpunit/CRM/Utils/HtmlToTextTest.php
+++ b/tests/phpunit/CRM/Utils/HtmlToTextTest.php
@@ -56,8 +56,8 @@ class CRM_Utils_HtmlToTextTest extends CiviUnitTestCase {
   public function testHtmlToText($html, $text) {
     $output = CRM_Utils_String::htmlToText($html);
     $this->assertEquals(
-      trim($output),
       trim($text),
+      trim($output),
       "Text Output did not match for $html"
     );
   }

--- a/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch
+++ b/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch
@@ -1,0 +1,40 @@
+From c4d3df97f95c74cea45b452fa8bc8e153658f3f8 Mon Sep 17 00:00:00 2001
+From: Ade Attwood <ade@practically.io>
+Date: Fri, 14 Jan 2022 10:31:09 +0000
+Subject: [PATCH] Fix `html_entity_decode` deprecation warning in PHP 8.1
+
+Passing null as the second parameter is deprecated in PHP 8.1. When using the
+`legacyConstruct` function the `htmlFuncFlags` are never set and passing null
+into `html_entity_decode`.
+
+This move setting `htmlFuncFlags` above the legacy check to ensure they are
+always set to prevent passing null into `html_entity_decode`.
+---
+ src/Html2Text.php | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/Html2Text.php b/src/Html2Text.php
+index 16a6572..c3e0109 100644
+--- a/src/Html2Text.php
++++ b/src/Html2Text.php
+@@ -236,6 +236,10 @@ private function legacyConstruct($html = '', $fromFile = false, array $options =
+      */
+     public function __construct($html = '', $options = array())
+     {
++        $this->htmlFuncFlags = (PHP_VERSION_ID < 50400)
++            ? ENT_QUOTES
++            : ENT_QUOTES | ENT_HTML5;
++
+         // for backwards compatibility
+         if (!is_array($options)) {
+             return call_user_func_array(array($this, 'legacyConstruct'), func_get_args());
+@@ -247,9 +247,6 @@ public function __construct($html = '', $options = array())
+ 
+         $this->html = $html;
+         $this->options = array_merge($this->options, $options);
+-        $this->htmlFuncFlags = (PHP_VERSION_ID < 50400)
+-            ? ENT_COMPAT
+-            : ENT_COMPAT | ENT_HTML5;
+     }
+ 
+     /**


### PR DESCRIPTION
Overview
----------------------------------------
This replaces the usage of roundcube's html2text with the html2text/html2text package as suggested by @MegaphoneJon on the lab ticket

Before
----------------------------------------
Roundcube's html2text used and an old version at that

After
----------------------------------------
html2text/html2text package used with a patch to support php8.1

ping @eileenmcnaughton @demeritcowboy @MegaphoneJon 