### PR TITLE
APIv4 - Read & write contact primary and billing locations as implicit joins

### DIFF
--- a/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Api4\Event\Events;
+use Civi\Api4\Event\SchemaMapBuildEvent;
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ContactSchemaMapSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      Events::SCHEMA_MAP_BUILD => 'onSchemaBuild',
+    ];
+  }
+
+  /**
+   * @param \Civi\Api4\Event\SchemaMapBuildEvent $event
+   */
+  public function onSchemaBuild(SchemaMapBuildEvent $event) {
+    $schema = $event->getSchemaMap();
+    $table = $schema->getTableByName('civicrm_contact');
+
+    // Add links to primary & billing email, address, phone & im
+    foreach (['email', 'address', 'phone', 'im'] as $ent) {
+      foreach (['primary', 'billing'] as $type) {
+        $link = new Joinable("civicrm_$ent", 'contact_id', "{$ent}_$type");
+        $link->setBaseTable('civicrm_contact');
+        $link->setJoinType(Joinable::JOIN_TYPE_ONE_TO_ONE);
+        $link->addCondition("`{target_table}`.`is_$type` = 1");
+        $table->addTableLink('id', $link);
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -52,13 +52,15 @@ trait DAOActionTrait {
    * @return array
    */
   public function baoToArray($bao, $input) {
-    $allFields = array_column($bao->fields(), 'name');
+    $entityFields = array_column($bao->fields(), 'name');
+    $inputFields = array_map(function($key) {
+      return explode(':', $key)[0];
+    }, array_keys($input));
+    $combinedFields = array_unique(array_merge($entityFields, $inputFields));
     if (!empty($this->reload)) {
-      $inputFields = $allFields;
       $bao->find(TRUE);
     }
     else {
-      $inputFields = array_keys($input);
       // Convert 'null' input to true null
       foreach ($inputFields as $key) {
         if (($bao->$key ?? NULL) === 'null') {
@@ -67,8 +69,8 @@ trait DAOActionTrait {
       }
     }
     $values = [];
-    foreach ($allFields as $field) {
-      if (isset($bao->$field) || in_array($field, $inputFields)) {
+    foreach ($combinedFields as $field) {
+      if (isset($bao->$field) || in_array($field, $inputFields) || (!empty($this->reload) && in_array($field, $entityFields))) {
         $values[$field] = $bao->$field ?? NULL;
       }
     }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -799,7 +799,10 @@ class Api4SelectQuery {
     // If we're not explicitly referencing the ID (or some other FK field) of the joinEntity, search for a default
     if (!$explicitFK) {
       foreach ($this->apiFieldSpec as $name => $field) {
-        if (is_array($field) && $field['entity'] !== $joinEntity && $field['fk_entity'] === $joinEntity) {
+        if (!is_array($field) || $field['type'] !== 'Field') {
+          continue;
+        }
+        if ($field['entity'] !== $joinEntity && $field['fk_entity'] === $joinEntity) {
           $conditions[] = $this->treeWalkClauses([$name, '=', "$alias.id"], 'ON');
         }
         elseif (strpos($name, "$alias.") === 0 && substr_count($name, '.') === 1 && $field['fk_entity'] === $this->getEntity()) {

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -51,7 +51,7 @@ class Joinable {
   protected $alias;
 
   /**
-   * @var array
+   * @var string[]
    */
   protected $conditions = [];
 
@@ -103,15 +103,18 @@ class Joinable {
    * @return array
    */
   public function getConditionsForJoin(string $baseTableAlias, string $tableAlias) {
-    $baseCondition = sprintf(
+    $conditions = [];
+    $conditions[] = sprintf(
       '`%s`.`%s` =  `%s`.`%s`',
       $baseTableAlias,
       $this->baseColumn,
       $tableAlias,
       $this->targetColumn
     );
-
-    return array_merge([$baseCondition], $this->conditions);
+    foreach ($this->conditions as $condition) {
+      $conditions[] = str_replace(['{base_table}', '{target_table}'], [$baseTableAlias, $tableAlias], $condition);
+    }
+    return $conditions;
   }
 
   /**
@@ -190,11 +193,11 @@ class Joinable {
   }
 
   /**
-   * @param $condition
+   * @param string $condition
    *
    * @return $this
    */
-  public function addCondition($condition) {
+  public function addCondition(string $condition) {
     $this->conditions[] = $condition;
 
     return $this;
@@ -208,7 +211,7 @@ class Joinable {
   }
 
   /**
-   * @param array $conditions
+   * @param string[] $conditions
    *
    * @return $this
    */

--- a/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
@@ -49,6 +49,64 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
         ->setSqlRenderer([__CLASS__, 'calculateAge']);
       $spec->addFieldSpec($field);
     }
+
+    // Address, Email, Phone, IM
+    $entities = [
+      'Address' => [
+        'primary' => [
+          'title' => ts('Primary Address ID'),
+          'label' => ts('Primary Address'),
+        ],
+        'billing' => [
+          'title' => ts('Billing Address ID'),
+          'label' => ts('Billing Address'),
+        ],
+      ],
+      'Email' => [
+        'primary' => [
+          'title' => ts('Primary Email ID'),
+          'label' => ts('Primary Email'),
+        ],
+        'billing' => [
+          'title' => ts('Billing Email ID'),
+          'label' => ts('Billing Email'),
+        ],
+      ],
+      'Phone' => [
+        'primary' => [
+          'title' => ts('Primary Phone ID'),
+          'label' => ts('Primary Phone'),
+        ],
+        'billing' => [
+          'title' => ts('Billing Phone ID'),
+          'label' => ts('Billing Phone'),
+        ],
+      ],
+      'IM' => [
+        'primary' => [
+          'title' => ts('Primary IM ID'),
+          'label' => ts('Primary IM'),
+        ],
+        'billing' => [
+          'title' => ts('Billing IM ID'),
+          'label' => ts('Billing IM'),
+        ],
+      ],
+    ];
+    foreach ($entities as $entity => $types) {
+      foreach ($types as $type => $info) {
+        $name = strtolower($entity) . '_' . $type;
+        $field = new FieldSpec($name, 'Contact', 'String');
+        $field->setLabel($info['label'])
+          ->setTitle($info['title'])
+          ->setColumnName('id')
+          ->setType('Extra')
+          ->setFkEntity($entity)
+          ->setSqlRenderer([__CLASS__, 'getLocationFieldSql']);
+        $spec->addFieldSpec($field);
+      }
+    }
+
   }
 
   /**
@@ -117,6 +175,18 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
    */
   public static function calculateAge(array $field) {
     return "TIMESTAMPDIFF(YEAR, {$field['sql_name']}, CURDATE())";
+  }
+
+  /**
+   * Generate SQL for address/email/phone/im id field
+   * @param array $field
+   * @param \Civi\Api4\Query\Api4SelectQuery $query
+   * @return string
+   */
+  public static function getLocationFieldSql(array $field, Api4SelectQuery $query) {
+    $prefix = empty($field['explicit_join']) ? '' : $field['explicit_join'] . '.';
+    $idField = $query->getField($prefix . $field['name'] . '.id');
+    return $idField['sql_name'];
   }
 
 }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -192,6 +192,19 @@ class Admin {
             array_splice($entity['fields'], $index, 0, [$newField]);
           }
         }
+        // Useful address fields (see ContactSchemaMapSubscriber)
+        if ($entity['name'] === 'Contact') {
+          $addressFields = ['city', 'state_province_id', 'country_id'];
+          foreach ($addressFields as $fieldName) {
+            foreach (['primary', 'billing'] as $type) {
+              $newField = \CRM_Utils_Array::findAll($schema['Address']['fields'], ['name' => $fieldName])[0];
+              $newField['name'] = "address_$type.$fieldName";
+              $arg = [1 => $newField['label']];
+              $newField['label'] = $type === 'primary' ? ts('Address (primary) %1', $arg) : ts('Address (billing) %1', $arg);
+              $entity['fields'][] = $newField;
+            }
+          }
+        }
       }
     }
     return array_values($schema);

--- a/tests/phpunit/api/v4/Action/NullValueTest.php
+++ b/tests/phpunit/api/v4/Action/NullValueTest.php
@@ -29,10 +29,10 @@ use Civi\Test\TransactionalInterface;
  */
 class NullValueTest extends Api4TestBase implements TransactionalInterface {
 
-  public function setUpHeadless() {
+  public function setUp(): void {
     $format = '{contact.first_name}{ }{contact.last_name}';
     \Civi::settings()->set('display_name_format', $format);
-    return parent::setUpHeadless();
+    parent::setUp();
   }
 
   public function testStringNull() {

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -19,9 +19,12 @@
 
 namespace api\v4\Entity;
 
+use Civi\Api4\Address;
 use Civi\Api4\Contact;
+use Civi\Api4\Email;
 use Civi\Api4\OptionValue;
 use api\v4\Api4TestBase;
+use Civi\Api4\Phone;
 
 /**
  * @group headless
@@ -99,6 +102,58 @@ class ContactJoinTest extends Api4TestBase {
       ->first();
 
     $this->assertEquals($labels, $fetchedContact['preferred_communication_method:label']);
+  }
+
+  public function testCreateWithPrimaryAndBilling() {
+    $contact = $this->createTestRecord('Contact', [
+      'email_primary.email' => 'a@test.com',
+      'email_billing.email' => 'b@test.com',
+      'address_billing.city' => 'Hello',
+      'address_billing.state_province_id:abbr' => 'AK',
+      'address_billing.country_id:abbr' => 'USA',
+    ]);
+    $addr = Address::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(1, $addr);
+    $this->assertEquals('Hello', $contact['address_billing.city']);
+    $this->assertEquals(1228, $contact['address_billing.country_id']);
+    $emails = Email::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(2, $emails);
+    $this->assertEquals('a@test.com', $contact['email_primary.email']);
+    $this->assertEquals('b@test.com', $contact['email_billing.email']);
+  }
+
+  public function testUpdateDeletePrimaryAndBilling() {
+    $contact = $this->createTestRecord('Contact', [
+      'phone_primary.phone' => '12345',
+      'phone_billing.phone' => '54321',
+    ]);
+    Contact::update(FALSE)
+      ->addValue('id', $contact['id'])
+      // Delete primary phone, update billing phone
+      ->addValue('phone_primary.phone', NULL)
+      ->addValue('phone_billing.phone', 99999)
+      ->execute();
+    $phone = Phone::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute()
+      ->single();
+    $this->assertEquals('99999', $phone['phone']);
+    $this->assertTrue($phone['is_billing']);
+    // Contact only has one phone now, so it should be auto-set to primary
+    $this->assertTrue($phone['is_primary']);
+
+    $get = Contact::get(FALSE)
+      ->addWhere('id', '=', $contact['id'])
+      ->addSelect('phone_primary.*')
+      ->addSelect('phone_billing.*')
+      ->execute()->single();
+    $this->assertEquals('99999', $get['phone_primary.phone']);
+    $this->assertEquals('99999', $get['phone_billing.phone']);
+    $this->assertEquals($get['phone_primary.id'], $get['phone_billing.id']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Makes it easier to search and display contact primary email, phone, im without using any joins in SearchKit.
Both read & write are supported.
See [dev/core#3659](https://lab.civicrm.org/dev/core/-/issues/3659)

![image](https://user-images.githubusercontent.com/2874912/174116655-4e5954db-ee0c-41ad-b144-569daa8e76db.png)


Before
----------------------------------------
In SearchKit, you must add an explicit join if you want to view a contact's address, phone, email, etc.

After
----------------------------------------
Declares an implicit join between the contact record and primary/billing email, phone, address & im records, making it easier to retrieve those directly from the Contact API.
Read and write both supported. Also you can pass `NULL` to delete them.
