### PR TITLE
(NFC) SoapTest - Skip this test on Drupal8+ and Backdrop

### DIFF
--- a/tests/phpunit/E2E/Extern/SoapTest.php
+++ b/tests/phpunit/E2E/Extern/SoapTest.php
@@ -34,6 +34,10 @@ class E2E_Extern_SoapTest extends CiviEndToEndTestCase {
     parent::setUp();
     CRM_Core_Config::singleton(1, 1);
 
+    if (CIVICRM_UF === 'Drupal8' || CIVICRM_UF === 'Backdrop') {
+      $this->markTestSkipped('Unsupported environment');
+    }
+
     global $_CV;
     $this->adminUser = $_CV['ADMIN_USER'];
     $this->adminPass = $_CV['ADMIN_PASS'];


### PR DESCRIPTION
Overview
----------------------------------------

Never passed on D8+.  Has been failing for a while on Backdrop.  There's a
work-a-like extension.  No need to monitor results on these configurations.

