### PR TITLE
Civi\Test - Fix leak in active module-list for headless test

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -755,7 +755,7 @@ class CRM_Core_I18n {
    *   Ex: $stringTable['enabled']['wildcardMatch']['foo'] = 'bar';
    */
   private function getWordReplacements() {
-    if (isset(Civi::$statics['testPreInstall'])) {
+    if (isset(Civi\Test::$statics['testPreInstall'])) {
       return [];
     }
 

--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -32,7 +32,7 @@ class Test {
     $conn = \Civi\Test::pdo();
 
     $oldEscaper = \CRM_Core_I18n::$SQL_ESCAPER;
-    \Civi::$statics['testPreInstall'] = (\Civi::$statics['testPreInstall'] ?? 0) + 1;
+    \Civi\Test::$statics['testPreInstall'] = (\Civi\Test::$statics['testPreInstall'] ?? 0) + 1;
     try {
       \CRM_Core_I18n::$SQL_ESCAPER = function ($text) use ($conn) {
         return substr($conn->quote($text), 1, -1);
@@ -40,9 +40,9 @@ class Test {
       return $callback();
     } finally {
       \CRM_Core_I18n::$SQL_ESCAPER = $oldEscaper;
-      \Civi::$statics['testPreInstall']--;
-      if (\Civi::$statics['testPreInstall'] <= 0) {
-        unset(\Civi::$statics['testPreInstall']);
+      \Civi\Test::$statics['testPreInstall']--;
+      if (\Civi\Test::$statics['testPreInstall'] <= 0) {
+        unset(\Civi\Test::$statics['testPreInstall']);
       }
     }
   }

--- a/Civi/Test/Data.php
+++ b/Civi/Test/Data.php
@@ -42,6 +42,7 @@ class Data {
       unset($query, $query2, $query3);
 
       \Civi\Test::schema()->setStrict(TRUE);
+      \Civi::reset();
     });
 
     civicrm_api('setting', 'create', ['installed' => 1, 'domain_id' => 'all', 'version' => 3]);

--- a/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
+++ b/setup/plugins/installDatabase/BootstrapCivi.civi-setup.php
@@ -22,7 +22,7 @@ if (!defined('CIVI_SETUP')) {
     \Civi\Setup::log()->info(sprintf('[%s] Bootstrap CiviCRM', basename(__FILE__)));
 
     \CRM_Core_I18n::$SQL_ESCAPER = NULL;
-    unset(\Civi::$statics['testPreInstall']);
+    unset(\Civi\Test::$statics['testPreInstall']);
 
     CRM_Core_Config::singleton(TRUE, TRUE);
 

--- a/setup/plugins/installDatabase/Preboot.civi-setup.php
+++ b/setup/plugins/installDatabase/Preboot.civi-setup.php
@@ -42,7 +42,7 @@ if (!defined('CIVI_SETUP')) {
       return $conn->escape_string($text);
     };
 
-    \Civi::$statics['testPreInstall'] = 1;
+    \Civi\Test::$statics['testPreInstall'] = 1;
 
     CRM_Core_Config::singleton(FALSE, TRUE);
 


### PR DESCRIPTION
Overview
-------------

Fixes a recent regression (circa 5.51) with running headless unit-tests from extensions.

Steps to reproduce
------------------

Observed on a `dmaster` build while running these steps:

* Run civix's [make-example.sh](https://github.com/totten/civix/blob/master/tests/make-example.sh#L35)
* Or just run some subset involving a headless test, eg
   * `civibuild restore $BUILDNAME`
   * `civix generate:module $EXMODULE --enable=no`
   * `civix generate:test --template=headless 'Civi\Civiexample\BarTest'`
   * `cv api extension.install key=$EXMODULE`
   * `phpunit8 ./tests/phpunit/Civi/Civiexample/BarTest.php`

Interestingly, if you are running tests manually, then the problem fades away - at least temporarily. Until you restore DB to the starting point.

```
civibuild restore $BUILDNAME
phpunit8 --group headless ## Fail, first test
phpunit8 --group headless ## Pass
phpunit8 --group headless ## Pass
civibuild restore $BUILDNAME
phpunit8 --group headless ## Fail, first test
phpunit8 --group headless ## Pass
```

Before
------

Test fails:

```
Fatal error: Uncaught Error: Class 'Civi\Api4\SearchSegment' not found in
/home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/search_kit
/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
on line 52
```

After
-----

Test succeeds

Technical Details
----------------------------------------

I discovered that a way to prevent the error was to manually delete a few things from the snapshot:

```
civibuild restore dmaster

cv sql --test
# delete from civicrm_extension where full_name ='org.civicrm.search_kit'; 
# drop table civicrm_search_segment;

cv flush

phpunit8 --group headless ## Pass
```

What's going on?

* The `headless` test suite first boots Civi with whatever content is in the headless DB (eg `CiviTestListenerPHPUnit7::autoboot()`). For example, it may initially boot with a copy of `search_kit` active.
* Then, it starts running headless tests. Each headless test has the opportunity to declare a different/preferred environment (which will cause it reset). For example, they may declare "We need extension XYZ but not extension ABC." The test will teardown/reset Civi generally.
* However, tit does not teardown/reset `Civi::$statics`  -- so some information is reset ("Only extension XYZ is active") while other information is leaked/stale (eg "search_kit is active").

The patch clears `Civi::$statics` (`Civi::reset()`). It also fixes a bit of test-infra that depended on `Civi::$statics`.