### PR TITLE
New/Edit Contact: remove the Cancel button

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -857,10 +857,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         'subName' => 'new',
       ];
     }
-    $buttons[] = [
-      'type' => 'cancel',
-      'name' => ts('Cancel'),
-    ];
 
     if (!empty($this->_values['contact_sub_type'])) {
       $this->_oldSubtypes = explode(CRM_Core_DAO::VALUE_SEPARATOR,


### PR DESCRIPTION
Overview
----------------------------------------

When creating a new Contact, or editing a contact, do not display a Cancel button, as it is unlikely to be used for its intended purpose.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/178829900-6f443137-954e-4ac3-adc7-a20e1fab6ec8.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/178830005-7e60cfa3-4ecc-4b45-bb37-4b8535d0f25a.png)

Comments
----------------------------------------

- Using the Cancel button is rather unlikely. Users are more likely to hit back or use the navigation menu.
- If they do hit the Cancel button, it's probably by accident, which can be pretty frustrating.