### PR TITLE
Allow custom fields to have custom fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -226,7 +226,12 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     Civi::cache('metadata')->clear();
 
     foreach ($customFields as $index => $customField) {
-      CRM_Utils_Hook::post(empty($records[$index]['id']) ? 'create' : 'edit', 'CustomField', $customField->id, $customField);
+      $op = empty($records[$index]['id']) ? 'create' : 'edit';
+      // Theoretically a custom field could have custom fields! Trippy...
+      if (!empty($records[$index]['custom']) && is_array($records[$index]['custom'])) {
+        CRM_Core_BAO_CustomValueTable::store($records[$index]['custom'], static::$_tableName, $customField->id, $op);
+      }
+      CRM_Utils_Hook::post($op, 'CustomField', $customField->id, $customField);
     }
     return $customFields;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Theoretically a custom field could have custom fields! Trippy...
Fixes [dev/core#3731](https://lab.civicrm.org/dev/core/-/issues/3731)

Before
----------------------------------------
An extension like https://github.com/eileenmcnaughton/custom_custom won't work, because no one ever imagined we'd need to save custom data for custom fields.

After
----------------------------------------
Now it works. I still don't understand why anyone would need it, but it works.