### PR TITLE
[REF][PHP8.1] Apply PR patch to fix issue in php8.1 where mysqli erro…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -280,6 +280,7 @@
         "Fix deprecation warning in php8.1 on html_entity_decode": "https://raw.githubusercontent.com/civicrm/civicrm-core/e758d20e9f613ca6c4cf652c23d2cd7e5d3af3ce/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch"
       },
       "pear/db": {
+        "Apply patch to ensure that MySQLI reporting remains the same in php8.1": "https://patch-diff.githubusercontent.com/raw/pear/DB/pull/13.patch",
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
       "pear/mail": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5f3f8d4145a124b502eb526eb91a80e",
+    "content-hash": "af485ffc8ca2516c075da3632f6f7f42",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5623,5 +5623,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
…r reporting changed

Overview
----------------------------------------
This applies the following PR https://github.com/pear/DB/pull/13 to ensure that mysqli reporting when run via this package is the same in php8.1 as in php8.0

Before
----------------------------------------
Mysqli reporting had changed in php8.1 which meant that the package was not working the same as before

After
----------------------------------------
Package change to ensure that it works the same by altering mysqli php error report level back to the original default

ping @eileenmcnaughton @totten @demeritcowboy