### PR TITLE
[REF][PHP8.1] Fix issues in core extensions where passing in NULL val…

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -466,13 +466,13 @@ function _afform_angular_module_name($fileBaseName, $format = 'camel') {
   switch ($format) {
     case 'camel':
       $camelCase = '';
-      foreach (preg_split('/[-_ ]/', $fileBaseName, NULL, PREG_SPLIT_NO_EMPTY) as $shortNamePart) {
+      foreach (preg_split('/[-_ ]/', $fileBaseName, -1, PREG_SPLIT_NO_EMPTY) as $shortNamePart) {
         $camelCase .= ucfirst($shortNamePart);
       }
       return strtolower($camelCase[0]) . substr($camelCase, 1);
 
     case 'dash':
-      return strtolower(implode('-', preg_split('/[-_ ]|(?=[A-Z])/', $fileBaseName, NULL, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE)));
+      return strtolower(implode('-', preg_split('/[-_ ]|(?=[A-Z])/', $fileBaseName, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE)));
 
     default:
       throw new \Exception("Unrecognized format");

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -93,7 +93,7 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
     $formValues['table'] = $this->getFieldValue($formValues, 'table', 'String');
     $this->_table = $formValues['table'];
 
-    $formValues['text'] = trim($this->getFieldValue($formValues, 'text', 'String', ''));
+    $formValues['text'] = trim($this->getFieldValue($formValues, 'text', 'String', '') ?? '');
     $this->_text = $formValues['text'];
 
     if (!$this->_table) {

--- a/ext/oauth-client/Civi/Api4/Action/OAuthContactToken/Create.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthContactToken/Create.php
@@ -18,7 +18,7 @@ class Create extends \Civi\Api4\Generic\DAOCreateAction {
       return;
     }
 
-    $tag = $this->values['tag'] ?? NULL;
+    $tag = $this->values['tag'] ?? '';
 
     if ('linkContact:' === substr($tag, 0, 12)) {
       $this->values['contact_id'] = substr($tag, 12);

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -722,7 +722,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   private function replaceTokens($tokenExpr, $data, $format, $index = 0) {
-    if (strpos($tokenExpr, '[') !== FALSE) {
+    if (strpos(($tokenExpr ?? ''), '[') !== FALSE) {
       foreach ($this->getTokens($tokenExpr) as $token) {
         $val = $data[$token] ?? NULL;
         if (isset($val) && $format === 'view') {
@@ -733,7 +733,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         if ($format === 'url' && (!isset($replacement) || $replacement === '')) {
           return NULL;
         }
-        $tokenExpr = str_replace('[' . $token . ']', $replacement, $tokenExpr);
+        $tokenExpr = str_replace('[' . $token . ']', ($replacement ?? ''), ($tokenExpr ?? ''));
       }
     }
     return $tokenExpr;


### PR DESCRIPTION
…ues is no longer supported

Overview
----------------------------------------
Null values are passed into these parameters and in PHP8.1 this causes deprecation notices

Before
----------------------------------------
Null values passed in and deprecation notices triggered

After
----------------------------------------
Null values not used and deprecation notices are not triggered in this part of the code

ping @eileenmcnaughton @demeritcowboy @totten @colemanw 