### PR TITLE
dev/core#3736 - Fix uploaded file on message template form

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -128,7 +128,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Core_Form {
       ];
       if (!($this->_action & CRM_Core_Action::DELETE)) {
         $buttons[] = [
-          'type' => 'submit',
+          'type' => 'upload',
           'name' => ts('Save and Done'),
           'subName' => 'done',
         ];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3736

Before
----------------------------------------
1. Admin - CiviMail - Message Templates
1. Add message template
1. Choose upload document for the Source.
1. Upload a document - just a simple Word doc is fine - the file itself doesn't seem to be the issue.
1. When you click "Save and Done" it doesn't get uploaded. It does work if you click "Save".

After
----------------------------------------
Good.

Technical Details
----------------------------------------
The button type needs to be `upload`.

Comments
----------------------------------------
See also https://github.com/civicrm/civicrm-core/blob/b04fd956f6d03d3adeaaa925d02fe8bbdfdeef4b/CRM/Event/Form/ManageEvent.php#L282-L290, so this is the same except there's no attachment over there but the point is you can have two upload buttons. I've refrained though from copying over the `'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',`, which as far as I can see doesn't do anything.
