### PR TITLE
dev/core#3027 - require add contacts to see widget

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3547,9 +3547,9 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
    * @return array|false
    */
   public static function getEntityRefCreateLinks($appendProfiles = []) {
-    // You'd think that "create contacts" would be the permission to check,
+    // You'd think that "add contacts" would be a sufficient permission to check,
     // But new contact popups are profile forms and those use their own permissions.
-    if (!CRM_Core_Permission::check([['profile create', 'profile listings and forms']])) {
+    if (!CRM_Core_Permission::check([['profile create', 'profile listings and forms, 'add contacts']])) {
       return FALSE;
     }
     $profiles = [];

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3549,7 +3549,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
   public static function getEntityRefCreateLinks($appendProfiles = []) {
     // You'd think that "add contacts" would be a sufficient permission to check,
     // But new contact popups are profile forms and those use their own permissions.
-    if (!CRM_Core_Permission::check([['profile create', 'profile listings and forms, 'add contacts']])) {
+    if (!CRM_Core_Permission::check([['profile create', 'profile listings and forms', 'add contacts']])) {
       return FALSE;
     }
     $profiles = [];


### PR DESCRIPTION
Overview
----------------------------------------
See: https://lab.civicrm.org/dev/core/-/issues/3027

Before
----------------------------------------
Add contact widget shows for everyone regardless of permission

After
----------------------------------------
Add contact widget only shows for those with the "add contacts" permission