### PR TITLE
Fix test. Don't hide errors. (Followup to 23999)

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -505,7 +505,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
       ],
     ];
 
-    $htmlMsg = preg_split($newLineOperators['p']['pattern'], ($message ?? ''));
+    $htmlMsg = preg_split($newLineOperators['p']['pattern'], $message);
     foreach ($htmlMsg as $k => & $m) {
       $messages = preg_split($newLineOperators['br']['pattern'], $m);
       foreach ($messages as $key => & $msg) {

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -52,6 +52,7 @@ class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     $form = $this->getPDFForm([
       'pdf_file_name' => $pdfFileName,
       'subject' => $activitySubject,
+      'html_message' => '<p></p>',
     ], [$this->contactId], $isLiveMode);
     $fileNameAssigned = $this->submitForm($form)['fileName'];
     $this->assertEquals($expectedFilename, $fileNameAssigned);


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/23999#discussion_r922688821

Before
----------------------------------------
Recent change hides errors, but the only time there would be an error is when it really is an error.

After
----------------------------------------
Errors when there are errors.

Technical Details
----------------------------------------
When calling this function, there's never a time $message should be null. It's either coming from:
* The form values, in which case it's never null.
* Some other backend code, in which case if it's null it's a coding error since then what is the resulting pdf supposed to contain? (This is the situation with the test.)
* The converted uploaded doc/odt file for the message template, in which case if it's null there's a problem with the file, which is also an error.

So the error is helpful to tell you there's a problem.

Comments
----------------------------------------
To truly see the test pass/fail you would need php 8.1, since that's what the original PR was about.