### PR TITLE
(dev/core#3732) Show billing address on Edit contribution screen as well

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -465,6 +465,14 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['campaign_id'] = $this->_pledgeValues['campaign_id'];
     }
 
+    $billing_address = '';
+    if (!empty($defaults['address_id'])) {
+      $addressDetails = CRM_Core_BAO_Address::getValues(['id' => $defaults['address_id']], FALSE, 'id');
+      $addressDetails = array_values($addressDetails);
+      $billing_address = $addressDetails[0]['display'];
+    }
+    $this->assign('billing_address', $billing_address);
+
     $this->_defaults = $defaults;
     return $defaults;
   }

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -413,6 +413,14 @@
         {/foreach}
       </div>
     {/if}
+    {if $billing_address}
+      <fieldset>
+        <legend>{ts}Billing Address{/ts}</legend>
+        <div class="form-item">
+          {$billing_address|nl2br}
+        </div>
+      </fieldset>
+    {/if}
     <br />
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
We currently show billing address on _View Contribution_ screen. We should show billing address on _Edit Contribution_ screen as well for consistency.

Before
----------------------------------------
Billing address is shown only on _View contribution_ screen
![cf_pre](https://user-images.githubusercontent.com/3455173/179513499-12ce58fd-6044-4006-91f2-46ae7cbcb0b0.png)



After
----------------------------------------
Billing address is shown on both _View contribution_ and _Edit contribution_ screens
![cf_post](https://user-images.githubusercontent.com/3455173/179513530-e2243ba6-e534-481d-a7b5-faa0805cb438.png)

