### PR TITLE
Lower minimum polyfill version since conflicts with drupal/core-recommended

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,10 +94,10 @@
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18",
     "symfony/polyfill-php73": "^1.23",
-    "symfony/polyfill-php74": "^1.26",
-    "symfony/polyfill-php80": "^1.26",
-    "symfony/polyfill-php81": "^1.26",
-    "symfony/polyfill-php82": "^1.26",
+    "symfony/polyfill-php74": "^1.0",
+    "symfony/polyfill-php80": "^1.0",
+    "symfony/polyfill-php81": "^1.0",
+    "symfony/polyfill-php82": "^1.0",
     "html2text/html2text": "^4.3.1"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85fe2247e48442ca8427938514785be8",
+    "content-hash": "c03452159c5e34628225b66163e000e8",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/drupal/core-recommended/blob/9.4.x/composer.json#L53

Before
----------------------------------------
Can't update civi in a drupal 9 install because 1.26 is too high a minimum.

After
----------------------------------------


Technical Details
----------------------------------------
I debated what to put. The lock file version isn't changing so this doesn't change anything for non-composer cmses/installs.

Technically we're still supporting drupal 9.0, which is 1.17.

Comments
----------------------------------------
