### PR TITLE
[REF][PHP8.1] Apply patches to pear/log and zetacomponents/mail packa…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -294,6 +294,9 @@
         "Apply patch to ensure that MySQLI reporting remains the same in php8.1": "https://patch-diff.githubusercontent.com/raw/pear/DB/pull/13.patch",
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
+      "pear/log": {
+        "Apply patch for php8.1": "https://patch-diff.githubusercontent.com/raw/pear/Log/pull/23.patch"
+      },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"
       },
@@ -304,8 +307,10 @@
         "Add in CiviCRM custom error message for CRM-8744": "https://raw.githubusercontent.com/civicrm/civicrm-core/a6a0ff13d2a155ad962529595dceaef728116f96/tools/scripts/composer/patches/net-smtp-patch.patch"
       },
       "zetacomponents/mail": {
+        "PHP 8.1 Compatability fixes": "https://patch-diff.githubusercontent.com/raw/zetacomponents/Mail/pull/88.patch",
         "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch",
-        "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch"
+        "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch",
+        "CiviCRM Custom patch to fix a php8.1 issue found in CiviCRM unit tests": "https://raw.githubusercontent.com/civicrm/civicrm-core/5506f4ce5d46799857b4f4ddf34069e7541e9cc5/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch"
       }
     },
     "compile-includes": ["ext/greenwich/composer.compile.json"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3f9eac4e515b2362f8a91da1cef29f1",
+    "content-hash": "07b7e8a8fdf410a6f7f16582e5d8ad95",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch
+++ b/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch
@@ -1,0 +1,13 @@
+--- src/parser/interfaces/part_parser.php    2022-07-26 20:42:22.585924146 +0000
++++ src/parser/interfaces/part_parser.php    2022-07-26 20:41:55.801553916 +0000
+@@ -171,8 +171,8 @@
+                 // dev/core#940 Ensure that emails are not processed as .unknown attachments by checking
+                 // for Filename or name in the content-disposition and content-type headers.
+                 if ( (ezcMailPartParser::$parseTextAttachmentsAsFiles === true)                   &&
+-                     (preg_match('/\s*filename="?([^;"]*);?/i', $headers['Content-Disposition']) ||
+-                      preg_match( '/\s*name="?([^;"]*);?/i'   , $headers['Content-Type'])        )  )
++                     (preg_match('/\s*filename="?([^;"]*);?/i', $headers['Content-Disposition'] ?? '') ||
++                      preg_match( '/\s*name="?([^;"]*);?/i'   , $headers['Content-Type'] ?? '')        )  )
+                 {
+                     $bodyParser = new ezcMailFileParser( $mainType, $subType, $headers );
+                 }


### PR DESCRIPTION
…ges to support php8.1

Overview
----------------------------------------
This applies the following PRs from upstream repos to support php8.1
[Pear/Log](https://github.com/pear/log/pull/23)
[zetacomponents/mail](https://github.com/zetacomponents/Mail/pull/88)

Before
----------------------------------------
Packages are not php8.1 compliant

After
----------------------------------------
Packages are patched to be compliant with php8.1

ping @eileenmcnaughton @totten @colemanw @demeritcowboy 