### PR TITLE
Simplify custom data view markup for avoiding display issues with table-layout

### DIFF
--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -47,41 +47,40 @@
                   </a>
                 </div>
               {/if}
-              {foreach from=$cd_edit.fields item=element key=field_id}
+              {if !empty($cd_edit.fields)}
                 <table class="crm-info-panel">
-                  <tr>
-                    {if $element.options_per_line != 0}
+                  {foreach from=$cd_edit.fields item=element key=field_id}
+                    <tr>
                       <td class="label">{$element.field_title}</td>
                       <td class="html-adjust">
-                        {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                        {foreach from=$element.field_value item=val}
-                          {$val}
-                          <br/>
-                        {/foreach}
-                      </td>
-                    {else}
-                      <td class="label">{$element.field_title}</td>
-                      {if $element.field_data_type == 'Money'}
-                        {if $element.field_type == 'Text'}
-                          <td class="html-adjust">{$element.data|crmMoney}</td>
+                        {if $element.options_per_line != 0}
+                          {* sort by fails for option per line. Added a variable to iterate through the element array*}
+                          {foreach from=$element.field_value item=val}
+                            {$val}
+                            <br/>
+                          {/foreach}
                         {else}
-                          <td class="html-adjust">{$element.field_value}</td>
-                        {/if}
-                      {else}
-                        <td class="html-adjust">
-                          {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
-                            {', '|implode:$element.contact_ref_links}
-                          {elseif $element.field_data_type == 'Memo'}
-                            {$element.field_value|nl2br}
+                          {if $element.field_data_type == 'Money'}
+                            {if $element.field_type == 'Text'}
+                              {$element.data|crmMoney}
+                            {else}
+                              {$element.field_value}
+                            {/if}
                           {else}
-                            {$element.field_value}
+                            {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
+                              {', '|implode:$element.contact_ref_links}
+                            {elseif $element.field_data_type == 'Memo'}
+                              {$element.field_value|nl2br}
+                            {else}
+                              {$element.field_value}
+                            {/if}
                           {/if}
-                        </td>
-                      {/if}
-                    {/if}
-                  </tr>
+                        {/if}
+                      </td>
+                    </tr>
+                  {/foreach}
                 </table>
-              {/foreach}
+              {/if}
               {assign var="rowCount" value=$rowCount+1}
             </div>
             <!-- end of body -->


### PR DESCRIPTION
Overview
----------------------------------------
Custom fields on entities (e.g. memberships) might be displayed with random column widths, causing a weird chaos of custom field values. This effect increases for longer custom field values, or, in general, very different field value/label lengths across custom fields within a custom group accordion.

Before
----------------------------------------
Custom fields may be displayed with "randomly" computed column widths
![Bildschirmfoto vom 2022-07-19 12-29-53](https://user-images.githubusercontent.com/29565644/179730861-c12eb0be-fa3d-475c-a81e-5d19128e3b11.png)

![image](https://user-images.githubusercontent.com/29565644/179731916-48df752a-3fff-47b6-b7b0-2bdbcca4eb7f.png)

After
----------------------------------------
Custom fields are rendered within a single table per custom group accordion, being coherent with other stuff being displayed for such entities (e.g. memberships).
![Bildschirmfoto vom 2022-07-19 12-31-30](https://user-images.githubusercontent.com/29565644/179731114-5497afec-4720-4bbf-aa81-035e15a306c9.png)

![Bildschirmfoto vom 2022-07-19 12-31-58](https://user-images.githubusercontent.com/29565644/179731136-9280096f-5386-49aa-b0f6-0bd59239c16f.png)

Technical Details
----------------------------------------
Custom fields on entities are being displayed with markup containing one HTML table element for each custom field within a custom group accordion. This can cause display glitches when table layout is being computed differently for each custom field by the browser.

Comments
----------------------------------------
I took the chance for reducing duplicated markup in the several Smarty conditions around that code.