### PR TITLE
Afform - Check is_public directly

### DIFF
--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -10,7 +10,7 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
     // The api will throw an exception if afform is not found (because of the index 0 param)
     $afform = civicrm_api4('Afform', 'get', [
       'where' => [['name', '=', $pageArgs['afform']]],
-      'select' => ['title', 'module_name', 'directive_name', 'type'],
+      'select' => ['title', 'module_name', 'directive_name', 'type', 'is_public'],
     ], 0);
 
     $this->assign('directive', $afform['directive_name']);
@@ -18,11 +18,10 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
     Civi::service('angularjs.loader')
       ->addModules([$afform['module_name'], 'afformStandalone']);
 
-    $config = \CRM_Core_Config::singleton();
-    $isFrontEndPage = $config->userSystem->isFrontEndPage();
+    $isFrontEndPage = !empty($afform['is_public']);
 
-    // If the user has "access civicrm" append home breadcrumb, if not being shown on the front-end website
-    if (CRM_Core_Permission::check('access CiviCRM') && !$isFrontEndPage) {
+    // If not being shown on the front-end website, append breadcrumb for CiviCRM users
+    if (!$isFrontEndPage && CRM_Core_Permission::check('access CiviCRM')) {
       CRM_Utils_System::appendBreadCrumb([['title' => E::ts('CiviCRM'), 'url' => CRM_Utils_System::url('civicrm')]]);
       // If the user has "admin civicrm" & the admin extension is enabled
       if (CRM_Core_Permission::check('administer CiviCRM')) {


### PR DESCRIPTION
Overview
----------------------------------------
[Fixes dev/core#3741](https://lab.civicrm.org/dev/core/-/issues/3741)

Technical Details
--------------------

Instead of relying on the menu system to tell if a form is frontend, just read that info directly from the afform definition.