### PR TITLE
Add afform blocks to print summary

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -207,7 +207,7 @@ function afform_civicrm_tabset($tabsetName, &$tabs, $context) {
  * Adds afforms as contact summary blocks.
  */
 function afform_civicrm_pageRun(&$page) {
-  if (get_class($page) !== 'CRM_Contact_Page_View_Summary') {
+  if (!in_array(get_class($page), ['CRM_Contact_Page_View_Summary', 'CRM_Contact_Page_View_Print'])) {
     return;
   }
   $scanner = \Civi::service('afform_scanner');


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3743
Contact summary blocks don't load on the Print Summary page.

Before
----------------------------------------
No summary blocks.

After
----------------------------------------
Summary blocks.

Comments
----------------------------------------
This is a partial fix, because `templates/CRM/common/print.tpl` fires `window.print()` before the AJAX completes, but if you cancel the print, you can press "Print" to get the blocks included.  Better in than out.
