### PR TITLE
dev/core#3050 - (Alternate) Fix crash removing an entry from a batch

### DIFF
--- a/CRM/Financial/Page/BatchTransaction.php
+++ b/CRM/Financial/Page/BatchTransaction.php
@@ -67,7 +67,7 @@ class CRM_Financial_Page_BatchTransaction extends CRM_Core_Page_Basic {
         'remove' => [
           'name' => ts('Remove'),
           'title' => ts('Remove Transaction'),
-          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'remove' . '\' );"',
+          'extra' => 'onclick = "removeFromBatch(%%id%%);"',
         ],
       ];
     }

--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -114,6 +114,23 @@ function assignRemove(recordID, op) {
   }
 }
 
+function removeFromBatch(financial_trxn_id) {
+  var entityID = "{/literal}{$entityID}{literal}";
+  if (financial_trxn_id && entityID) {
+    CRM.api4("EntityBatch", "delete", {where: [
+      ["entity_id", "=", financial_trxn_id],
+      ["entity_table", "=", "civicrm_financial_trxn"],
+      ["batch_id", "=", entityID]
+    ]}).then(function(batch) {
+      buildTransactionSelectorAssign(true);
+      buildTransactionSelectorRemove();
+      batchSummary(entityID);
+    }, function(failure) {
+      CRM.alert({/literal}'{ts escape="js"}Error removing from batch.{/ts}', '{ts escape="js"}Api Error{/ts}'{literal}, 'error');
+    });
+  }
+}
+
 function noServerResponse() {
   CRM.alert({/literal}'{ts escape="js"}No response from the server. Check your internet connection and try reloading the page.{/ts}', '{ts escape="js"}Network Error{/ts}'{literal}, 'error');
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3050

Alternate to https://github.com/civicrm/civicrm-core/pull/23957

Before
----------------------------------------
1. Contributions - Accounting Batches - New batch
2. Add one of the contributions to the batch.
3. Using the "Remove" link on the far right of the row, remove the entry you just added.
4. Crash

After
----------------------------------------
Ok

Technical Details
----------------------------------------
The backend was refactored in https://github.com/civicrm/civicrm-core/pull/21213 but it doesn't work here from the ajax call.

Comments
----------------------------------------
The test from the other PR won't work here. Not sure what to do for a test since it would mostly just be a test of calling api4.