### PR TITLE
remove pledge status as mandatory in Pledge report

### DIFF
--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -120,7 +120,7 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
           ],
           'status_id' => [
             'title' => ts('Pledge Status'),
-            'required' => TRUE,
+            'default' => TRUE,
           ],
         ],
         'filters' => [


### PR DESCRIPTION
Overview
----------------------------------------
remove pledge status as mandatory in _Pledge_ report. No reason why we can't uncheck the column.

Before
----------------------------------------
![beforee](https://user-images.githubusercontent.com/3455173/179900480-5de47534-aeeb-427a-9d48-a16f08c31519.png)



After
----------------------------------------
![afterrr](https://user-images.githubusercontent.com/3455173/179900502-0643d283-2ef0-41da-91db-e001aa5ef3f7.png)
