### PR TITLE
[REF] Fix for receiving blank invoice PDF of free event registration.

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1546,7 +1546,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment',
           $this->_id, 'contribution_id', 'participant_id'
         );
-        if (Civi::settings()->get('invoice_is_email_pdf')) {
+        if (Civi::settings()->get('invoice_is_email_pdf') && !empty($contributionId)) {
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $contributionId;
         }


### PR DESCRIPTION
Overview
----------------------------------------
If there's a free event and the admin user registers a participant through the `New Event Registration` option, then the registered user gets an `Event Confirmation` email with a blank `Invoice.pdf` attachment. And if we register the user with `Event's Registration Link` then the user gets email with no attachment.

Before
----------------------------------------
In the below screenshot, you can see the blank PDF attachment in the email.
![Screenshot 2022-07-20 at 10 56 12 AM](https://user-images.githubusercontent.com/89973450/179904838-540e0d6d-8935-4be8-a62b-71bf2e2166f2.png)


After
----------------------------------------
In this screenshot, you can see no attachment is added to the email after new changes.
![Screenshot 2022-07-20 at 10 59 31 AM](https://user-images.githubusercontent.com/89973450/179905014-50b8a50b-2236-4d18-adc8-de985466fd06.png)

Technical Details
----------------------------------------
After debugging both event registration processes, I found that while registering through `Event's Registration Link (CRM/Event/BAO/Event.php)` this `!empty($values['contributionId']` condition is also checked before sending an email to participants, which is not added in `New Event Registration (CRM/Event/Form/Participant.php)` registration process.
