### PR TITLE
dev/core#3490 - Apply extension updates after core updates 

### DIFF
--- a/CRM/Extension/Upgrades.php
+++ b/CRM/Extension/Upgrades.php
@@ -61,7 +61,15 @@ class CRM_Extension_Upgrades {
       'name' => self::QUEUE_NAME,
       'reset' => TRUE,
     ]);
+    return static::fillQueue($queue);
+  }
 
+  /**
+   * @param \CRM_Queue_Queue $queue
+   *
+   * @return \CRM_Queue_Queue
+   */
+  public static function fillQueue(CRM_Queue_Queue $queue): CRM_Queue_Queue {
     foreach (self::getActiveUpgraders() as $upgrader) {
       /** @var \CRM_Extension_Upgrader_Interface $upgrader */
       $upgrader->notify('upgrade', ['enqueue', $queue]);

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -38,6 +38,29 @@ class CRM_Upgrade_DispatchPolicy {
   /**
    * Determine the dispatch policy
    *
+   * @return array
+   * @see \Civi\Core\CiviEventDispatcher::setDispatchPolicy()
+   */
+  public static function pick(): ?array {
+    if (!\CRM_Core_Config::isUpgradeMode()) {
+      return NULL;
+    }
+
+    // Have we run CRM_Upgrade_Form::doCoreFinish() for this version?
+    $codeVer = CRM_Utils_System::version();
+    $isCoreCurrent = CRM_Core_DAO::singleValueQuery('
+        SELECT count(*) as count
+        FROM civicrm_log
+        WHERE entity_table = "civicrm_domain"
+        AND data LIKE %1
+        ', [1 => ['upgrade:%->' . $codeVer, 'String']]);
+
+    return CRM_Upgrade_DispatchPolicy::get($isCoreCurrent < 1 ? 'upgrade.main' : 'upgrade.finish');
+  }
+
+  /**
+   * Read the dispatch policy.
+   *
    * @param string $phase
    *   Ex: 'upgrade.main' or 'upgrade.finish'.
    * @return array

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -17,6 +17,25 @@
 class CRM_Upgrade_DispatchPolicy {
 
   /**
+   * Create an auto-clean object which temporarily applies the preferred policy.
+   *
+   * @code
+   * $cleanup = CRM_Upgrade_DispatchPolicy::useTemporarily('upgrade.finish');
+   * doStuff();
+   * unset($cleanup);
+   * @endCode
+   *
+   * @param string $name
+   * @return \CRM_Utils_AutoClean
+   */
+  public static function useTemporarily(string $name): CRM_Utils_AutoClean {
+    Civi::dispatcher()->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get($name));
+    return \CRM_Utils_AutoClean::with(function() {
+      Civi::dispatcher()->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.main'));
+    });
+  }
+
+  /**
    * Determine the dispatch policy
    *
    * @param string $phase

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -150,4 +150,30 @@ class CRM_Upgrade_DispatchPolicy {
     return $policies[$phase];
   }
 
+  /**
+   * Assert that a specific policy is currently active.
+   *
+   * @param string $name
+   *   Ex: 'upgrade.main' or 'upgrade.finish'
+   * @throws \RuntimeException
+   */
+  public static function assertActive(string $name) {
+    $expected = static::get($name);
+    $actual = Civi::dispatcher()->getDispatchPolicy();
+    if ($expected != $actual) {
+      throw new \RuntimeException("Task can not execute correctly. The wrong dispatch policy is active. Expected to find \"$name\".");
+    }
+  }
+
+  /**
+   * Before running upgrade tasks, ensure that we apply the current dispatch-policy.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public static function onRunTask(\Civi\Core\Event\GenericHookEvent $event) {
+    if ($event->taskCtx->queue->getName() === \CRM_Upgrade_Form::QUEUE_NAME) {
+      Civi::dispatcher()->setDispatchPolicy(static::pick());
+    }
+  }
+
 }

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -809,6 +809,8 @@ SET    version = '$version'
     list($ignore, $latestVer) = $upgrade->getUpgradeVersions();
     // Seems extraneous in context, but we'll preserve old behavior
     $upgrade->setVersion($latestVer);
+    // Going forward, any new tasks will run in `upgrade.finish` mode.
+    // @see \CRM_Upgrade_DispatchPolicy::pick()
 
     $config = CRM_Core_Config::singleton();
     $config->userSystem->flush();

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -803,10 +803,7 @@ SET    version = '$version'
    * @throws \CRM_Core_Exception
    */
   public static function doCoreFinish(): bool {
-    Civi::dispatcher()->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.finish'));
-    $restore = \CRM_Utils_AutoClean::with(function() {
-      Civi::dispatcher()->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.main'));
-    });
+    $restore = \CRM_Upgrade_DispatchPolicy::useTemporarily('upgrade.finish');
 
     $upgrade = new CRM_Upgrade_Form();
     list($ignore, $latestVer) = $upgrade->getUpgradeVersions();

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -213,10 +213,7 @@ class CRM_Upgrade_Incremental_Base {
     // The `enableExtension` has a very high value of `weight`, so this runs after all
     // core DB schema updates have been resolved. We can use high-level services.
 
-    Civi::dispatcher()->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.finish'));
-    $restore = \CRM_Utils_AutoClean::with(function() {
-      Civi::dispatcher()->setDispatchPolicy(\CRM_Upgrade_DispatchPolicy::get('upgrade.main'));
-    });
+    CRM_Upgrade_DispatchPolicy::assertActive('upgrade.finish');
 
     $manager = CRM_Extension_System::singleton()->getManager();
     $manager->enable($manager->findInstallRequirements($keys));

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -334,12 +334,12 @@ class CiviEventDispatcher extends EventDispatcher {
     return $this;
   }
 
-  //  /**
-  //   * @return array|NULL
-  //   */
-  //  public function getDispatchPolicy() {
-  //    return  $this->dispatchPolicyRegex === NULL ? NULL : array_merge($this->dispatchPolicyExact, $this->dispatchPolicyRegex);
-  //  }
+  /**
+   * @return array|NULL
+   */
+  public function getDispatchPolicy() {
+    return $this->dispatchPolicyRegex === NULL ? NULL : array_merge($this->dispatchPolicyExact, $this->dispatchPolicyRegex);
+  }
 
   /**
    * Determine whether the dispatch policy applies to a given event.

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -597,6 +597,7 @@ class Container {
     $bootServices['paths'] = new \Civi\Core\Paths();
 
     $bootServices['dispatcher.boot'] = new CiviEventDispatcher();
+    $bootServices['dispatcher.boot']->addListener('civi.queue.runTask.start', ['CRM_Upgrade_DispatchPolicy', 'onRunTask']);
 
     // Quality control: There should be no pre-boot hooks because they make it harder to understand/support/refactor.
     // If a pre-boot hook sneaks in, we'll raise an error.

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -604,7 +604,6 @@ class Container {
       '/^hook_/' => 'not-ready',
       '/^civi\./' => 'run',
     ];
-    $mainDispatchPolicy = \CRM_Core_Config::isUpgradeMode() ? \CRM_Upgrade_DispatchPolicy::get('upgrade.main') : NULL;
     $bootServices['dispatcher.boot']->setDispatchPolicy($bootDispatchPolicy);
 
     $class = $runtime->userFrameworkClass;
@@ -630,7 +629,7 @@ class Container {
       \CRM_Extension_System::singleton()->getClassLoader()->register();
       \CRM_Extension_System::singleton()->getMixinLoader()->run();
       \CRM_Utils_Hook::singleton()->commonBuildModuleList('civicrm_boot');
-      $bootServices['dispatcher.boot']->setDispatchPolicy($mainDispatchPolicy);
+      $bootServices['dispatcher.boot']->setDispatchPolicy(\CRM_Core_Config::isUpgradeMode() ? \CRM_Upgrade_DispatchPolicy::pick() : NULL);
 
       $runtime->includeCustomPath();
 
@@ -646,7 +645,7 @@ class Container {
 
     }
     else {
-      $bootServices['dispatcher.boot']->setDispatchPolicy($mainDispatchPolicy);
+      $bootServices['dispatcher.boot']->setDispatchPolicy(\CRM_Core_Config::isUpgradeMode() ? \CRM_Upgrade_DispatchPolicy::pick() : NULL);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

In the past few months, we've been seeing support issues where a site has run core DB upgrades (eg `civicrm/upgrade` or `cv upgrade:db`) -- but has not yet run core *extension* DB upgrades (eg `civicrm/admin/extensions` or `cv ext:upgrade-db`). The omission can lead to arbitrary errors. This PR expands the core upgrader to also run extension upgrades.

See also: https://lab.civicrm.org/dev/core/-/issues/3490

Steps to reproduce
----------------------------------------


For my test/dev loop, I've used this process:

1. Setup
    1. Install Civi 5.45
    2. Login as web admin
    3. Save DB snapshot (`civibuild snapshot dmaster`)
    4. Checkout newer codebase (eg `master` or `master-run-ext-upgrades`)
    5. Run `composer install`
2. Trial run
    1. Reload DB snapshot (`civibuild restore dmaster`)
    2. Run core/main upgrade (either `civicrm/upgrade?reset=1` or `cv upgrade:db`)
    3. Open the system-status page (`civicrm/a/#/status`)

Before
----------------------------------------

After core/main upgrade, the system-status page cannot be viewed. The underlying REST request fails with an error like this:

```
{
   "code" : -18,
   "debug_info" : "SELECT `a`.`id` AS `id`, `a`.`name` AS `name`, `a`.`label` AS `label`, `a`.`description` AS `description`, `a`.`entity_name` AS `entity_name`, `a`.`items` AS `items`
FROM civicrm_search_segment a
ORDER BY `label` ASC
 [nativecode=1146 ** Table 'dmastercivi_pa1rx.civicrm_search_segment' doesn't exist]",
   "error_message" : "DB Error: no such table",
   "is_error" : 1,
   "mode" : 16,
   "to_string" : "[db_error: message=\"DB Error: no such table\" code=-18 mode=callback callback=CRM_Utils_REST::fatal prefix=\"\" info=\"SELECT `a`.`id` AS `id`, `a`.`name` AS `name`, `a`.`label` AS `label`, `a`.`description` AS `description`, `a`.`entity_name` AS `entity_name`, `a`.`items` AS `items`
FROM civicrm_search_segment a
ORDER BY `label` ASC
 [nativecode=1146 ** Table 'dmastercivi_pa1rx.civicrm_search_segment' doesn't exist]\"]",
   "type" : "DB_Error",
   "user_info" : "SELECT `a`.`id` AS `id`, `a`.`name` AS `name`, `a`.`label` AS `label`, `a`.`description` AS `description`, `a`.`entity_name` AS `entity_name`, `a`.`items` AS `items`
FROM civicrm_search_segment a
ORDER BY `label` ASC
 [nativecode=1146 ** Table 'dmastercivi_pa1rx.civicrm_search_segment' doesn't exist]"
}
```

(Note: This is very similar to other errors reported in Stackexchange/Mattermost, such as https://civicrm.stackexchange.com/questions/42094/civimail-issue-db-error-no-such-table-when-sending-mailing.)

After
----------------------------------------

After core/main upgrade, the system-status page works. There is no underlying error about `civicrm_search_segment`.

Technical Details
----------------------------------------

In [dev/core#3490](https://lab.civicrm.org/dev/core/-/issues/3490), I noted a challenge -- the hook dispatch-policy needs to switch as the upgrade progresses (*by the time you run extension-upgrades, you need to be firing most hooks*). I speculated that one could store some runner-state with the current upgrade-phase. Figuring how to record that runner-state is tricky (*because there are different runners like AJAX/cv/drush; because runners can get interrupted+retried; etc*). This PR is based on the idea that we already have enough runner-state -- stored in `civicrm_log`. To wit:

* In the initial/core-upgrade phase (`upgrade.main`), the `doCoreFinish()` has not yet run. The `civicrm_log` does not yet have a final version entry. (eg "We have not yet applied the upgrades for 5.52.0.") We fire very few/limited hooks/events.
* In the final/ext-upgrade phase (`upgrade.finish`), the `doCoreFinish()` has already run. The `civicrm_log` has the final version entry. (eg "We have applied the upgrades for 5.52.0.") We fire most/all hooks/events.

I've done some light testing as described in "Steps to reproduce", but we probably need a bigger set of scenarios.