### PR TITLE
Fix 'Pledge Made Date' display to show date and not time

### DIFF
--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -109,6 +109,7 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
           ],
           'pledge_create_date' => [
             'title' => ts('Pledge Made Date'),
+            'type' => CRM_Utils_Type::T_DATE,
           ],
           'start_date' => [
             'title' => ts('Pledge Start Date'),


### PR DESCRIPTION
Overview
----------------------------------------
Fix 'Pledge Made Date' display to show date and not time

Before
----------------------------------------
![made_before](https://user-images.githubusercontent.com/3455173/180133604-ebcef5e6-7066-4c3e-8bc4-fbee299c87d7.png)


After
----------------------------------------
![made_after](https://user-images.githubusercontent.com/3455173/180133624-6a463715-f365-4f6f-806b-ffdf0232f9dc.png)

