### PR TITLE
[REF][PHP8.1][INTL] Remove dependency on strftime function by using t…

### DIFF
--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -94,9 +94,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
 
     $chartData = $abbrMonthNames = [];
     if (is_array($chartInfoMonthly)) {
-      for ($i = 1; $i <= 12; $i++) {
-        $abbrMonthNames[$i] = strftime('%b', mktime(0, 0, 0, $i, 10, 1970));
-      }
+      $abbrMonthNames = CRM_Utils_Date::getAbbrMonthNames();
 
       foreach ($abbrMonthNames as $monthKey => $monthName) {
         $val = CRM_Utils_Array::value($monthKey, $chartInfoMonthly['By Month'], 0);

--- a/CRM/Core/Payment/Realex.php
+++ b/CRM/Core/Payment/Realex.php
@@ -363,7 +363,7 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
     }
 
     // Create timestamp
-    $timestamp = strftime('%Y%m%d%H%M%S');
+    $timestamp = date('YmdHis');
     $this->_setParam('timestamp', $timestamp);
   }
 

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -161,20 +161,25 @@ class CRM_Utils_Date {
    */
   public static function getAbbrWeekdayNames() {
     $key = 'abbrDays_' . \CRM_Core_I18n::getLocale();
-    $days = &\Civi::$statics[__CLASS__][$key];
-    if (!$days) {
-      $days = [];
+    if (empty(\Civi::$statics[__CLASS__][$key])) {
+      $days = [
+        0 => ts('Sun'),
+        1 => ts('Mon'),
+        2 => ts('Tue'),
+        3 => ts('Wed'),
+        4 => ts('Thu'),
+        5 => ts('Fri'),
+        6 => ts('Sat'),
+      ];
       // First day of the week
       $firstDay = Civi::settings()->get('weekBegins');
 
-      // set LC_TIME and build the arrays from locale-provided names
-      // June 1st, 1970 was a Monday
-      CRM_Core_I18n::setLcTime();
-      for ($i = $firstDay; count($days) < 7; $i = $i > 5 ? 0 : $i + 1) {
-        $days[$i] = strftime('%a', mktime(0, 0, 0, 6, $i, 1970));
+      \Civi::$statics[__CLASS__][$key] = [];
+      for ($i = $firstDay; count(\Civi::$statics[__CLASS__][$key]) < 7; $i = $i > 5 ? 0 : $i + 1) {
+        \Civi::$statics[__CLASS__][$key][$i] = $days[$i];
       }
     }
-    return $days;
+    return \Civi::$statics[__CLASS__][$key];
   }
 
   /**
@@ -192,20 +197,25 @@ class CRM_Utils_Date {
    */
   public static function getFullWeekdayNames() {
     $key = 'fullDays_' . \CRM_Core_I18n::getLocale();
-    $days = &\Civi::$statics[__CLASS__][$key];
-    if (!$days) {
-      $days = [];
+    if (empty(\Civi::$statics[__CLASS__][$key])) {
+      $days = [
+        0 => ts('Sunday'),
+        1 => ts('Monday'),
+        2 => ts('Tuesday'),
+        3 => ts('Wednesday'),
+        4 => ts('Thursday'),
+        5 => ts('Friday'),
+        6 => ts('Saturday'),
+      ];
       // First day of the week
       $firstDay = Civi::settings()->get('weekBegins');
 
-      // set LC_TIME and build the arrays from locale-provided names
-      // June 1st, 1970 was a Monday
-      CRM_Core_I18n::setLcTime();
-      for ($i = $firstDay; count($days) < 7; $i = $i > 5 ? 0 : $i + 1) {
-        $days[$i] = strftime('%A', mktime(0, 0, 0, 6, $i, 1970));
+      \Civi::$statics[__CLASS__][$key] = [];
+      for ($i = $firstDay; count(\Civi::$statics[__CLASS__][$key]) < 7; $i = $i > 5 ? 0 : $i + 1) {
+        \Civi::$statics[__CLASS__][$key][$i] = $days[$i];
       }
     }
-    return $days;
+    return \Civi::$statics[__CLASS__][$key];
   }
 
   /**
@@ -219,19 +229,26 @@ class CRM_Utils_Date {
    */
   public static function &getAbbrMonthNames($month = FALSE) {
     $key = 'abbrMonthNames_' . \CRM_Core_I18n::getLocale();
-    $abbrMonthNames = &\Civi::$statics[__CLASS__][$key];
-    if (!isset($abbrMonthNames)) {
-
-      // set LC_TIME and build the arrays from locale-provided names
-      CRM_Core_I18n::setLcTime();
-      for ($i = 1; $i <= 12; $i++) {
-        $abbrMonthNames[$i] = strftime('%b', mktime(0, 0, 0, $i, 10, 1970));
-      }
+    if (empty(\Civi::$statics[__CLASS__][$key])) {
+      \Civi::$statics[__CLASS__][$key] = [
+        1 => ts('Jan'),
+        2 => ts('Feb'),
+        3 => ts('Mar'),
+        4 => ts('Apr'),
+        5 => ts('May'),
+        6 => ts('Jun'),
+        7 => ts('Jul'),
+        8 => ts('Aug'),
+        9 => ts('Sep'),
+        10 => ts('Oct'),
+        11 => ts('Nov'),
+        12 => ts('Dec'),
+      ];
     }
     if ($month) {
-      return $abbrMonthNames[$month];
+      return \Civi::$statics[__CLASS__][$key][$month];
     }
-    return $abbrMonthNames;
+    return \Civi::$statics[__CLASS__][$key];
   }
 
   /**
@@ -287,7 +304,8 @@ class CRM_Utils_Date {
 
   /**
    * Create a date and time string in a provided format.
-   *
+   * %A - Full day name ('Saturday'..'Sunday')
+   * %a - abbreviated day name ('Sat'..'Sun')
    * %b - abbreviated month name ('Jan'..'Dec')
    * %B - full month name ('January'..'December')
    * %d - day of the month as a decimal number, 0-padded ('01'..'31')
@@ -318,6 +336,8 @@ class CRM_Utils_Date {
     // 1-based (January) month names arrays
     $abbrMonths = self::getAbbrMonthNames();
     $fullMonths = self::getFullMonthNames();
+    $fullWeekdayNames = self::getFullWeekdayNames();
+    $abbrWeekdayNames = self::getAbbrWeekdayNames();
 
     if (!$format) {
       $config = CRM_Core_Config::singleton();
@@ -381,6 +401,8 @@ class CRM_Utils_Date {
         $second = (int) substr($dateString, 12, 2);
       }
 
+      $dayInt = date('w', strtotime($dateString));
+
       if ($day % 10 == 1 and $day != 11) {
         $suffix = 'st';
       }
@@ -414,6 +436,8 @@ class CRM_Utils_Date {
       }
 
       $date = [
+        '%A' => $fullWeekdayNames[$dayInt] ?? NULL,
+        '%a' => $abbrWeekdayNames[$dayInt] ?? NULL,
         '%b' => $abbrMonths[$month] ?? NULL,
         '%B' => $fullMonths[$month] ?? NULL,
         '%d' => $day > 9 ? $day : '0' . $day,
@@ -430,7 +454,6 @@ class CRM_Utils_Date {
         '%i' => $minute > 9 ? $minute : '0' . $minute,
         '%p' => strtolower($type),
         '%P' => $type,
-        '%A' => $type,
         '%Y' => $year,
         '%s' => str_pad($second, 2, 0, STR_PAD_LEFT),
         '%S' => str_pad($second, 2, 0, STR_PAD_LEFT),

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -162,14 +162,15 @@ class CRM_Utils_Date {
   public static function getAbbrWeekdayNames() {
     $key = 'abbrDays_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
+      $intl_formatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, NULL, IntlDateFormatter::GREGORIAN, 'E');
       $days = [
-        0 => ts('Sun'),
-        1 => ts('Mon'),
-        2 => ts('Tue'),
-        3 => ts('Wed'),
-        4 => ts('Thu'),
-        5 => ts('Fri'),
-        6 => ts('Sat'),
+        0 => $intl_formatter->format(strtotime('Sunday')),
+        1 => $intl_formatter->format(strtotime('Monday')),
+        2 => $intl_formatter->format(strtotime('Tuesday')),
+        3 => $intl_formatter->format(strtotime('Wednesday')),
+        4 => $intl_formatter->format(strtotime('Thursday')),
+        5 => $intl_formatter->format(strtotime('Friday')),
+        6 => $intl_formatter->format(strtotime('Saturday')),
       ];
       // First day of the week
       $firstDay = Civi::settings()->get('weekBegins');
@@ -198,14 +199,15 @@ class CRM_Utils_Date {
   public static function getFullWeekdayNames() {
     $key = 'fullDays_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
+      $intl_formatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, NULL, IntlDateFormatter::GREGORIAN, 'EEEE');
       $days = [
-        0 => ts('Sunday'),
-        1 => ts('Monday'),
-        2 => ts('Tuesday'),
-        3 => ts('Wednesday'),
-        4 => ts('Thursday'),
-        5 => ts('Friday'),
-        6 => ts('Saturday'),
+        0 => $intl_formatter->format(strtotime('Sunday')),
+        1 => $intl_formatter->format(strtotime('Monday')),
+        2 => $intl_formatter->format(strtotime('Tuesday')),
+        3 => $intl_formatter->format(strtotime('Wednesday')),
+        4 => $intl_formatter->format(strtotime('Thursday')),
+        5 => $intl_formatter->format(strtotime('Friday')),
+        6 => $intl_formatter->format(strtotime('Saturday')),
       ];
       // First day of the week
       $firstDay = Civi::settings()->get('weekBegins');
@@ -230,19 +232,20 @@ class CRM_Utils_Date {
   public static function &getAbbrMonthNames($month = FALSE) {
     $key = 'abbrMonthNames_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
+      $intl_formatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, NULL, IntlDateFormatter::GREGORIAN, 'MMM');
       \Civi::$statics[__CLASS__][$key] = [
-        1 => ts('Jan'),
-        2 => ts('Feb'),
-        3 => ts('Mar'),
-        4 => ts('Apr'),
-        5 => ts('May'),
-        6 => ts('Jun'),
-        7 => ts('Jul'),
-        8 => ts('Aug'),
-        9 => ts('Sep'),
-        10 => ts('Oct'),
-        11 => ts('Nov'),
-        12 => ts('Dec'),
+        1 => $intl_formatter->format(strtotime('January')),
+        2 => $intl_formatter->format(strtotime('February')),
+        3 => $intl_formatter->format(strtotime('March')),
+        4 => $intl_formatter->format(strtotime('April')),
+        5 => $intl_formatter->format(strtotime('May')),
+        6 => $intl_formatter->format(strtotime('June')),
+        7 => $intl_formatter->format(strtotime('July')),
+        8 => $intl_formatter->format(strtotime('August')),
+        9 => $intl_formatter->format(strtotime('September')),
+        10 => $intl_formatter->format(strtotime('October')),
+        11 => $intl_formatter->format(strtotime('November')),
+        12 => $intl_formatter->format(strtotime('December')),
       ];
     }
     if ($month) {

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -271,6 +271,8 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%P"), "PM");
     $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%Y"), "2018");
     $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%s"), "44");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%A"), "Thursday");
+    $this->assertEquals(CRM_Utils_Date::customFormat($dateTime, "%a"), "Thu");
   }
 
   /**
@@ -293,6 +295,8 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
     $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%p"), "pm");
     $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%P"), "PM");
     $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%Y"), "2018");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%A"), "Thursday");
+    $this->assertEquals(CRM_Utils_Date::customFormatTs($ts, "%a"), "Thu");
   }
 
   /**
@@ -323,6 +327,19 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       $this->assertEquals($expectNames, $actualNames, "Check temporal names in $lang");
       unset($useLocale);
     }
+  }
+
+  public function testWeekDayArrayOrder() {
+    $this->callAPISuccess('Setting', 'create', ['weekBegins' => 1]);
+    $this->assertEquals([
+      1 => 'Monday',
+      2 => 'Tuesday',
+      3 => 'Wednesday',
+      4 => 'Thursday',
+      5 => 'Friday',
+      6 => 'Saturday',
+      0 => 'Sunday',
+    ], CRM_Utils_Date::getFullWeekdayNames());
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -314,7 +314,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
   public function testLocalizeConsts() {
     $expect['en_US'] = ['Jan', 'Tue', 'March', 'Thursday'];
     $expect['fr_FR'] = ['janv.', 'mar.', 'mars', 'jeudi'];
-    $expect['es_MX'] = ['ene', 'mar', 'Marzo', 'jueves'];
+    $expect['es_MX'] = ['ene.', 'mar.', 'Marzo', 'jueves'];
 
     foreach ($expect as $lang => $expectNames) {
       $useLocale = CRM_Utils_AutoClean::swapLocale($lang);


### PR DESCRIPTION
…s to generate day full names and abbreviations and month abbreviations

Overview
----------------------------------------
This aims to reduce dependency on the strftime function which is deprecated in php8.1 by replacing usage of it in CRM_Utils_Date and a couple of other places with ts() similar to #21157 

Before
----------------------------------------
strftime used to generate translated strings

After
----------------------------------------
ts used to generate same translated strings

ping @demeritcowboy @mlutfy @eileenmcnaughton @totten @colemanw 
