### PR TITLE
dev/core#3050 Api permissions for entity_batch - use edit manual batches

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1187,6 +1187,14 @@ class CRM_Core_Permission {
     ];
     $permissions['contribution_recur'] = $permissions['payment'];
 
+    $permissions['entity_batch']['create'] = $permissions['entity_batch']['delete'] = [
+      // This means that they can call create or delete if they have one of the
+      // below permissions. If they only have 'edit own' then the code *should* enforce
+      // that but the difference between the two seems to have
+      // been more of an intention to write code then something that
+      // was implemented....
+      ['edit own manual batches', 'edit all manual batches'],
+    ];
     // Custom field permissions
     $permissions['custom_field'] = [
       'default' => [


### PR DESCRIPTION
Overview
----------------------------------------
Api permissions for entity_batch - use edit manual batches

The goal of this PR is to support adding an api ajax call per https://github.com/civicrm/civicrm-core/pull/24025 and ensuring it uses the same permissioning of the form layer

Before
----------------------------------------
Required permission for adding to or deleting from manual batches is 'Administer CiviCRM"

After
----------------------------------------
Required permission is 'edit own manual batches' or 'edit all manual batches'

Technical Details
----------------------------------------
My take on the code is that a lot more work was done into speccing out permissions than in implementing them and that currently despite the difference in names the two permissions above are indistinguishable. 

Ideally an extra check would be added to check batch ownership  - - I'm not totally sure how we do that on create but I feel like it can also be pushed out of the scope of this PR since it would be a new 'feature' for it to actually work. 



Comments
----------------------------------------
@demeritcowboy  @seamuslee001   @JoeMurray 

Also I think @pradpnayak uses entity batches in Gift Aid with a different entity - although I doube this would be problematic
