### PR TITLE
Fix ActionLog BAO to not overwrite existing data

### DIFF
--- a/CRM/Core/BAO/ActionLog.php
+++ b/CRM/Core/BAO/ActionLog.php
@@ -25,10 +25,12 @@ class CRM_Core_BAO_ActionLog extends CRM_Core_DAO_ActionLog {
    *
    * @param array $params
    *
-   * @return array
+   * @return CRM_Core_DAO_ActionLog
    */
   public static function create($params) {
-    $params['action_date_time'] = $params['action_date_time'] ?? date('YmdHis');
+    if (empty($params['id'])) {
+      $params['action_date_time'] = $params['action_date_time'] ?? date('YmdHis');
+    }
 
     return self::writeRecord($params);
   }


### PR DESCRIPTION
Overview
----------------------------------------
I spotted what looks like a bug in this BAO code. `create` functions in the BAO serve a double-duty, they are also used for `update`. So when setting defaults, one must be careful to check which operation is happening before possibly overwriting existing data.

Before
----------------------------------------
Default set unconditionally, existing data overwritten.

After
----------------------------------------
Default only set for `create` action.