### PR TITLE
API - Consistently save custom data for v3 & v4

### DIFF
--- a/CRM/ACL/BAO/ACLEntityRole.php
+++ b/CRM/ACL/BAO/ACLEntityRole.php
@@ -35,6 +35,7 @@ class CRM_ACL_BAO_ACLEntityRole extends CRM_ACL_DAO_ACLEntityRole {
   /**
    * @param array $params
    *
+   * @deprecated
    * @return CRM_ACL_BAO_ACLEntityRole
    */
   public static function create(&$params) {

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -174,6 +174,7 @@ FROM civicrm_action_schedule cas
    * @param array $params
    *   An assoc array of name/value pairs.
    *
+   * @deprecated
    * @return CRM_Core_DAO_ActionSchedule
    * @throws \CRM_Core_Exception
    */

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -149,6 +149,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * @param array $params
    * @param int $id
    *
+   * @deprecated
    * @return CRM_Core_DAO_Domain
    * @throws \CRM_Core_Exception
    */
@@ -160,6 +161,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
   /**
    * Create or update domain.
    *
+   * @deprecated
    * @param array $params
    * @return CRM_Core_DAO_Domain
    */

--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -144,6 +144,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity implemen
   /**
    * Create or update a RecurringEntity.
    *
+   * @deprecated
    * @param array $params
    * @return CRM_Core_DAO_RecurringEntity
    */

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -26,6 +26,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
    *
    * @param array $params
    *
+   * @deprecated
    * @return CRM_Core_DAO_Website
    * @throws \CRM_Core_Exception
    */
@@ -36,8 +37,6 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
   /**
    * Create website.
    *
-   * If called in a legacy manner this, temporarily, fails back to calling the legacy function.
-   *
    * @param array $params
    *
    * @return CRM_Core_DAO_Website
@@ -46,7 +45,7 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
    */
   public static function add($params) {
     CRM_Core_Error::deprecatedFunctionWarning('use apiv4');
-    return self::create($params);
+    return self::writeRecord($params);
   }
 
   /**

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1442,52 +1442,32 @@ ORDER BY   civicrm_email.is_bulkmail DESC
    * Add the mailings.
    *
    * @param array $params
-   *   Reference array contains the values submitted by the form.
-   * @param array $ids
-   *   Reference array contains the id.
-   *
    *
    * @return CRM_Mailing_DAO_Mailing
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function add(&$params, $ids = []) {
-    $id = $params['id'] ?? $ids['mailing_id'] ?? NULL;
+  public static function add($params) {
+    $id = $params['id'] ?? NULL;
 
-    if (empty($params['id']) && !empty($ids)) {
-      CRM_Core_Error::deprecatedWarning('Parameter $ids is no longer used by Mailing::add. Use the api or just pass $params');
-    }
     if (!empty($params['check_permissions']) && CRM_Mailing_Info::workflowEnabled()) {
       $params = self::processWorkflowPermissions($params);
     }
-    $action = $id ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($action, 'Mailing', $id, $params);
-
-    $mailing = new static();
-    if ($id) {
-      $mailing->id = $id;
-      $mailing->find(TRUE);
+    if (!$id) {
+      $params['domain_id'] = $params['domain_id'] ?? CRM_Core_Config::domainID();
     }
-    $mailing->domain_id = CRM_Utils_Array::value('domain_id', $params, CRM_Core_Config::domainID());
-
-    if (((!$id && empty($params['replyto_email'])) || !isset($params['replyto_email'])) &&
+    if (
+      ((!$id && empty($params['replyto_email'])) || !isset($params['replyto_email'])) &&
       isset($params['from_email'])
     ) {
       $params['replyto_email'] = $params['from_email'];
     }
-    $mailing->copyValues($params);
-
     // CRM-20892 Unset Modifed Date here so that MySQL can correctly set an updated modfied date.
-    unset($mailing->modified_date);
-    $result = $mailing->save();
+    unset($params['modified_date']);
+
+    $result = static::writeRecord($params);
 
     // CRM-20892 Re find record after saing so we can set the updated modified date in the result.
-    $mailing->find(TRUE);
-
-    if (isset($mailing->modified_date)) {
-      $result->modified_date = $mailing->modified_date;
-    }
-
-    CRM_Utils_Hook::post($action, 'Mailing', $mailing->id, $mailing);
+    $result->find(TRUE);
 
     return $result;
   }

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -19,6 +19,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
   /**
    * Create or update a MembershipBlock.
    *
+   * @deprecated
    * @param array $params
    * @return CRM_Member_DAO_MembershipBlock
    */

--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -38,8 +38,8 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
-   *
-   * @return CRM_Pledge_BAO_PledgeBlock
+   * @deprecated
+   * @return CRM_Pledge_DAO_PledgeBlock
    */
   public static function &create(&$params) {
     $transaction = new CRM_Core_Transaction();
@@ -61,8 +61,8 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
    * Add or update pledgeBlock.
    *
    * @param array $params
-   *
-   * @return object
+   * @deprecated
+   * @return CRM_Pledge_DAO_PledgeBlock
    */
   public static function add($params) {
     // FIXME: This is assuming checkbox input like ['foo' => 1, 'bar' => 0, 'baz' => 1]. Not API friendly.

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1334,9 +1334,28 @@ function _civicrm_api3_basic_create($bao_name, &$params, $entity = NULL) {
   else {
     // If we have custom fields the BAO may have taken care of it or we may have to.
     // DAO::writeRecord always handles custom data.
-    // Otherwise guess based on the $extendsMap hard-coded list of BAOs that take care of custom data.
-    if (isset($params['custom']) && $fct !== 'writeRecord' && empty(CRM_Core_BAO_CustomQuery::$extendsMap[$entity])) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($entity)), $bao->id);
+    if (isset($params['custom']) && $fct !== 'writeRecord') {
+      // List of BAOs that write custom data in their create or add function.
+      $alreadyHandled = array_keys(CRM_Core_BAO_CustomQuery::$extendsMap);
+      $alreadyHandled[] = 'ActivityContact';
+      $alreadyHandled[] = 'Batch';
+      $alreadyHandled[] = 'CustomField';
+      $alreadyHandled[] = 'EntityBatch';
+      $alreadyHandled[] = 'IM';
+      $alreadyHandled[] = 'Mailing';
+      $alreadyHandled[] = 'MailingAB';
+      $alreadyHandled[] = 'OpenID';
+      $alreadyHandled[] = 'Phone';
+      $alreadyHandled[] = 'PledgePayment';
+      $alreadyHandled[] = 'PriceField';
+      $alreadyHandled[] = 'PriceFieldValue';
+      $alreadyHandled[] = 'RelationshipType';
+      $alreadyHandled[] = 'SavedSearch';
+      $alreadyHandled[] = 'Tag';
+      $alreadyHandled[] = 'Website';
+      if (!in_array($entity, $alreadyHandled)) {
+        CRM_Core_BAO_CustomValueTable::store($params['custom'], CRM_Core_DAO_AllCoreTables::getTableForClass(CRM_Core_DAO_AllCoreTables::getFullName($entity)), $bao->id);
+      }
     }
     $values = [];
     _civicrm_api3_object_to_array($bao, $values[$bao->id]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3747](https://lab.civicrm.org/dev/core/-/issues/3747)

Before
----------------------------------------
Mailing custom fields saved for v3 but not v4.

After
----------------------------------------
Works for both, plus more cleanup.

Technical Details
----------------------------------------
APIv3 has a fallback for saving custom data in the API layer if the BAO doesn't handle it.  APIv4 does not, and relies on the BAO to always work. So we really need to get our BAOs consistently saving custom data. The best way to do that is for them to use `writeRecord` instead of ad-hoc `create` and `add` functions. I've been making an effort to mark `create` and `add` functions `@deprecated` which triggers the API to ignore them.

Comments
---------------
Ideally we should remove custom data handling from v3 but this PR doesn't go quite that far.