### PR TITLE
Upgrader - Add snapshots for 5.52's data modifications

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyTwo.php
@@ -28,6 +28,14 @@ class CRM_Upgrade_Incremental_php_FiveFiftyTwo extends CRM_Upgrade_Incremental_B
    *   The version number matching this function name
    */
   public function upgrade_5_52_alpha1($rev): void {
+    $this->addSnapshotTask('contribution', CRM_Utils_SQL_Select::from('civicrm_contribution')
+      ->where('(contribution_recur_id IS NOT NULL) or (is_template = 1)')
+      ->select(['id', 'contribution_recur_id', 'is_template', 'total_amount'])
+    );
+    $this->addSnapshotTask('contribution_recur', CRM_Utils_SQL_Select::from('civicrm_contribution_recur')
+      ->select(['id', 'amount', 'modified_date'])
+    );
+
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Update 5.52-rc to take snapshots before applying modifications.

There is only one data change in the 5.52 upgrade (#23929; cc @eileenmcnaughton @artfulrobot).

Before
----------------------------------------

The `5.52.alpha1` upgrader modifies `civicrm_contribution` based on data in `civicrm_contribution{,_recur}`.

After
----------------------------------------

The `5.52.alpha1` upgrader additionally makes a snapshot of various rows/columns from `civicrm_contribution{,_recur}`.

Comments
----------------------------------------

Recall that snapshotting is automatic -- but with a threshold. The default behavior:

* If there are <200k contributions, then it automatically runs the snapshot. (*So it might copy ~1mb of data.*)
* If there are >200k contributions, then it shows a message and encourages the admin to opt-in to snapshots. (*It won't automatically copy 1gb of data.*)