### PR TITLE
composer.json - Update scssphp and related libraries (for PHP 8.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
     "ext-intl": "*",
     "pear/mail_mime": "~1.10",
     "pear/db": "1.11",
-    "civicrm/composer-compile-lib": "~0.3 || ~1.0",
+    "civicrm/composer-compile-lib": "~0.6 || ~1.0",
     "ext-json": "*",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c03452159c5e34628225b66163e000e8",
+    "content-hash": "2b12312ec9937f1286f2fc9c89ab89e6",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -335,22 +335,22 @@
         },
         {
             "name": "civicrm/composer-compile-lib",
-            "version": "v0.3",
+            "version": "v0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-compile-lib.git",
-                "reference": "980b26dcc3d51ecf47aa45c43564ab9b6dbac244"
+                "reference": "8bd52f0d2ba97eaa83853c3cfc37841376f5b903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-compile-lib/zipball/980b26dcc3d51ecf47aa45c43564ab9b6dbac244",
-                "reference": "980b26dcc3d51ecf47aa45c43564ab9b6dbac244",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-lib/zipball/8bd52f0d2ba97eaa83853c3cfc37841376f5b903",
+                "reference": "8bd52f0d2ba97eaa83853c3cfc37841376f5b903",
                 "shasum": ""
             },
             "require": {
-                "civicrm/composer-compile-plugin": "~0.9 || ~1.0",
+                "civicrm/composer-compile-plugin": "~0.19 || ~1.0",
                 "padaliyajay/php-autoprefixer": "~1.2",
-                "scssphp/scssphp": "~1.2",
+                "scssphp/scssphp": "^1.8.1",
                 "symfony/filesystem": "~2.8 || ~3.4 || ~4.0 || ~5.0",
                 "tubalmartin/cssmin": "^4.1"
             },
@@ -396,22 +396,22 @@
             "description": "Small library of compilation helpers",
             "support": {
                 "issues": "https://github.com/civicrm/composer-compile-lib/issues",
-                "source": "https://github.com/civicrm/composer-compile-lib/tree/v0.3"
+                "source": "https://github.com/civicrm/composer-compile-lib/tree/v0.6"
             },
-            "time": "2020-10-03T00:11:18+00:00"
+            "time": "2022-07-22T09:41:59+00:00"
         },
         {
             "name": "civicrm/composer-compile-plugin",
-            "version": "v0.18",
+            "version": "v0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-compile-plugin.git",
-                "reference": "158be6061320c2f481e1aa8f821be5c7e0eea220"
+                "reference": "496d266d42fddb3d7cdec2d7c46bad3e9495801c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/158be6061320c2f481e1aa8f821be5c7e0eea220",
-                "reference": "158be6061320c2f481e1aa8f821be5c7e0eea220",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/496d266d42fddb3d7cdec2d7c46bad3e9495801c",
+                "reference": "496d266d42fddb3d7cdec2d7c46bad3e9495801c",
                 "shasum": ""
             },
             "require": {
@@ -445,9 +445,9 @@
             "description": "Define a 'compile' event for all packages in the dependency-graph",
             "support": {
                 "issues": "https://github.com/civicrm/composer-compile-plugin/issues",
-                "source": "https://github.com/civicrm/composer-compile-plugin/tree/v0.18"
+                "source": "https://github.com/civicrm/composer-compile-plugin/tree/v0.19"
             },
-            "time": "2022-04-01T08:01:29+00:00"
+            "time": "2022-07-22T09:22:20+00:00"
         },
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -3505,16 +3505,16 @@
         },
         {
             "name": "scssphp/scssphp",
-            "version": "1.2.1",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "a05ea68160b7286ebbfd6e5fd7ae9e1a946ad6e1"
+                "reference": "0f1e1516ed2412ad43e42a6a319e77624ba1f713"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/a05ea68160b7286ebbfd6e5fd7ae9e1a946ad6e1",
-                "reference": "a05ea68160b7286ebbfd6e5fd7ae9e1a946ad6e1",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/0f1e1516ed2412ad43e42a6a319e77624ba1f713",
+                "reference": "0f1e1516ed2412ad43e42a6a319e77624ba1f713",
                 "shasum": ""
             },
             "require": {
@@ -3523,11 +3523,19 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3",
-                "sass/sass-spec": "2020.08.10",
+                "bamarni/composer-bin-plugin": "^1.4",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
+                "sass/sass-spec": "*",
                 "squizlabs/php_codesniffer": "~3.5",
-                "twbs/bootstrap": "~4.3",
+                "symfony/phpunit-bridge": "^5.1",
+                "thoughtbot/bourbon": "^7.0",
+                "twbs/bootstrap": "~5.0",
+                "twbs/bootstrap4": "4.6.1",
                 "zurb/foundation": "~6.5"
+            },
+            "suggest": {
+                "ext-iconv": "Can be used as fallback when ext-mbstring is not available",
+                "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv"
             },
             "bin": [
                 "bin/pscss"
@@ -3565,9 +3573,9 @@
             ],
             "support": {
                 "issues": "https://github.com/scssphp/scssphp/issues",
-                "source": "https://github.com/scssphp/scssphp/tree/1.2.1"
+                "source": "https://github.com/scssphp/scssphp/tree/v1.10.3"
             },
-            "time": "2020-09-07T21:15:42+00:00"
+            "time": "2022-05-16T07:22:18+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
Overview
--------

Update scssphp/scssphp, civicrm/composer-compile-plugin, and civicrm/composer-compile-lib.

Before
-------

Large number of warnings are generated in scssphp / php81, leading to an overflow

```
Compiling additional files (For full details, use verbose "-v" mode.)
Compile: Generate CCL wrapper functions
Compile: Greenwich CSS (dist/bootstrap3.css)

Fatal error: Allowed memory size of 1610612736 bytes exhausted (tried to allocate 36864 bytes) in phar:///Users/totten/bknix/bin/composer/vendor/symfony/process/Pipes/UnixPipes.php on line 132

Check https://getcomposer.org/doc/articles/troubleshooting.md#memory-limit-errors for more info on how to handle out of memory errors.Subcommand @composer compile  returned with error code 255

In ComposerPassthru.php line 72:

  Subcommand @composer compile  returned with error code 255

install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
```

After
-----

Compilation works

Comments
--------

Generated via: `composer update civicrm/composer-compile-lib scssphp/scssphp civicrm/composer-compile-plugin`
