### PR TITLE
[REF][PHP8.1] Apply patches from upstream to ensure league/csv can work on php8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -280,6 +280,13 @@
       "adrienrn/php-mimetyper": {
         "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch"
       },
+      "league/csv": {
+        "Adding in eol support to fputcsv for php8.1": "https://raw.githubusercontent.com/civicrm/civicrm-core/cacdbfaeaed8e04d504bf2fc604536137c03abeb/tools/scripts/composer/leage_csv_fputcsv.patch",
+        "Remove deprecated flag from php8.1": "https://github.com/thephpleague/csv/commit/380f884922a6cdaaaaab3ad4bfc7d1d710af736e.patch",
+        "Fix php8.1 deprecation errors part 1": "https://github.com/thephpleague/csv/commit/613db0b20157a1114cb1f9a801bd4c9c1f609cdf.patch",
+        "Fix php8.1 deprecation errors part 2": "https://github.com/thephpleague/csv/commit/49e2b08ca025ebaf87a904b5645f535c807b6f10.patch",
+        "Fix php8.1 notice issues part 3": "https://github.com/thephpleague/csv/commit/b83e972caea3cd22e7aaf65c5cffff1d49b46b69.patch"
+      },
       "html2text/html2text": {
         "Fix deprecation warning in php8.1 on html_entity_decode": "https://raw.githubusercontent.com/civicrm/civicrm-core/e758d20e9f613ca6c4cf652c23d2cd7e5d3af3ce/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch"
       },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b12312ec9937f1286f2fc9c89ab89e6",
+    "content-hash": "d3f9eac4e515b2362f8a91da1cef29f1",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/tools/scripts/composer/leage_csv_fputcsv.patch
+++ b/tools/scripts/composer/leage_csv_fputcsv.patch
@@ -1,0 +1,78 @@
+From ed92049ea509ab20392313a9158d07433eede7f4 Mon Sep 17 00:00:00 2001
+From: Ignace Nyamagana Butera <nyamsprod@gmail.com>
+Date: Sat, 3 Apr 2021 22:27:53 +0200
+Subject: [PATCH] Adding eol support to fputcsv for PHP8.1+
+
+---
+ .github/workflows/build.yml |  2 +-
+ src/Stream.php              |  5 ++++-
+ src/Writer.php              | 16 ++++++++++++----
+ 3 files changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/src/Stream.php b/src/Stream.php
+index f6e68a31..c0262cdb 100644
+--- a/src/Stream.php
++++ b/src/Stream.php
+@@ -304,9 +304,12 @@ public function setFlags(int $flags): void
+      *
+      * @return int|false
+      */
+-    public function fputcsv(array $fields, string $delimiter = ',', string $enclosure = '"', string $escape = '\\')
++    public function fputcsv(array $fields, string $delimiter = ',', string $enclosure = '"', string $escape = '\\', string $eol = "\n")
+     {
+         $controls = $this->filterControl($delimiter, $enclosure, $escape, __METHOD__);
++        if (80100 <= PHP_VERSION_ID) {
++            $controls[] = $eol;
++        }
+ 
+         return fputcsv($this->stream, $fields, ...$controls);
+     }
+diff --git a/src/Writer.php b/src/Writer.php
+index 5bb0d3c0..0b4a07e7 100644
+--- a/src/Writer.php
++++ b/src/Writer.php
+@@ -100,9 +100,8 @@ public function getNewline(): string
+     /**
+      * Get the flush threshold.
+      *
+-     * @return int|null
+      */
+-    public function getFlushThreshold()
++    public function getFlushThreshold(): ?int
+     {
+         return $this->flush_threshold;
+     }
+@@ -159,6 +158,10 @@ public function insertOne(array $record): int
+      */
+     protected function addRecord(array $record)
+     {
++        if (80100 <= PHP_VERSION_ID) {
++            return $this->document->fputcsv($record, $this->delimiter, $this->enclosure, $this->escape, $this->newline);
++        }
++
+         return $this->document->fputcsv($record, $this->delimiter, $this->enclosure, $this->escape);
+     }
+ 
+@@ -201,7 +204,12 @@ protected function addRFC4180CompliantRecord(array $record)
+         }
+         unset($field);
+ 
+-        return $this->document->fwrite(implode($this->delimiter, $record)."\n");
++        $newline = "\n";
++        if (80100 <= PHP_VERSION_ID) {
++            $newline = $this->newline;
++        }
++
++        return $this->document->fwrite(implode($this->delimiter, $record).$newline);
+     }
+ 
+     /**
+@@ -237,7 +245,7 @@ protected function validateRecord(array $record): void
+     protected function consolidate(): int
+     {
+         $bytes = 0;
+-        if ("\n" !== $this->newline) {
++        if (80100 > PHP_VERSION_ID && "\n" !== $this->newline) {
+             $this->document->fseek(-1, SEEK_CUR);
+             /** @var int $newlineBytes */
+             $newlineBytes = $this->document->fwrite($this->newline, strlen($this->newline));


### PR DESCRIPTION
Overview
----------------------------------------
Note that this incldues the PR #24045 

This applies the following patches (one minorly modified locally) to get league/csv to work with php8.1

[1](https://github.com/thephpleague/csv/commit/ed92049ea509ab20392313a9158d07433eede7f4)
[2](https://github.com/thephpleague/csv/commit/380f884922a6cdaaaaab3ad4bfc7d1d710af736e)
[3](https://github.com/thephpleague/csv/commit/613db0b20157a1114cb1f9a801bd4c9c1f609cdf)
[4](https://github.com/thephpleague/csv/commit/49e2b08ca025ebaf87a904b5645f535c807b6f10)
[5](https://github.com/thephpleague/csv/commit/b83e972caea3cd22e7aaf65c5cffff1d49b46b69)

Before
----------------------------------------
League/csv installed version won't work with php8.1

After
----------------------------------------
League/csv version does work with php8.1

If we just upgraded league/csv to the released version that contained these patches we would need to bump our minimum install version to php7.3 which might be a reasonable thing to do anyway but this at least allows us to get through without needing to do that

ping @demeritcowboy @totten @eileenmcnaughton @colemanw 