### PR TITLE
remove start/end date as mandatory in Demographics report

### DIFF
--- a/CRM/Report/Form/Case/Demographics.php
+++ b/CRM/Report/Form/Case/Demographics.php
@@ -150,11 +150,11 @@ class CRM_Report_Form_Case_Demographics extends CRM_Report_Form {
           ],
           'start_date' => [
             'title' => ts('Case Start'),
-            'required' => TRUE,
+            'default' => TRUE,
           ],
           'end_date' => [
             'title' => ts('Case End'),
-            'required' => TRUE,
+            'default' => TRUE,
           ],
         ],
         'filters' => [


### PR DESCRIPTION
Overview
----------------------------------------
remove start/end date as mandatory in _Demographics_ report. No reason why we can't uncheck the column.

Before
----------------------------------------
start/end date are mandatory in _Demographics_ report
![case_demographics_before](https://user-images.githubusercontent.com/3455173/180951178-c509036e-1c07-4fdf-a818-a0d8602a72f2.png)


After
----------------------------------------
start/end date are optional in _Demographics_ report

![case_demographics_after](https://user-images.githubusercontent.com/3455173/180951211-3fdba44f-ee68-41b8-8adc-6dce64a10a40.png)
