### PR TITLE
dev/financial#201 Fix PaypalPro IPN to refer to correct option group

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -267,20 +267,18 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
     //set transaction type
     $txnType = $this->retrieve('txn_type', 'String');
     //Changes for paypal pro recurring payment
-    $contributionStatuses = array_flip(CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate'));
     switch ($txnType) {
       case 'recurring_payment_profile_created':
-        if (in_array($recur->contribution_status_id, [
-          $contributionStatuses['Pending'],
-          $contributionStatuses['In Progress'],
-        ])
+        if (in_array(CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', $recur->contribution_status_id), [
+          'Pending', 'In Progress',
+        ], TRUE)
           && !empty($recur->processor_id)
         ) {
-          echo "already handled";
+          echo 'already handled';
           return;
         }
         $recur->create_date = $now;
-        $recur->contribution_status_id = $contributionStatuses['Pending'];
+        $recur->contribution_status_id = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Pending');
         $recur->processor_id = $this->retrieve('recurring_payment_id', 'String');
         $recur->trxn_id = $recur->processor_id;
         $subscriptionPaymentStatus = CRM_Core_Payment::RECURRING_PAYMENT_START;
@@ -290,12 +288,12 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       case 'recurring_payment':
         if (!$first) {
           if ($input['paymentStatus'] !== 'Completed') {
-            throw new CRM_Core_Exception("Ignore all IPN payments that are not completed");
+            throw new CRM_Core_Exception('Ignore all IPN payments that are not completed');
           }
 
           // In future moving to create pending & then complete, but this OK for now.
           // Also consider accepting 'Failed' like other processors.
-          $input['contribution_status_id'] = $contributionStatuses['Completed'];
+          $input['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Completed');
           $input['invoice_id'] = md5(uniqid(rand(), TRUE));
           $input['original_contribution_id'] = $this->getContributionID();
           $input['contribution_recur_id'] = $this->getContributionRecurID();
@@ -305,12 +303,12 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
         }
 
         //contribution installment is completed
-        if ($this->retrieve('profile_status', 'String') == 'Expired') {
+        if ($this->retrieve('profile_status', 'String') === 'Expired') {
           if (!empty($recur->end_date)) {
-            echo "already handled";
+            echo 'already handled';
             return;
           }
-          $recur->contribution_status_id = $contributionStatuses['Completed'];
+          $recur->contribution_status_id = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Completed');
           $recur->end_date = $now;
           $sendNotification = TRUE;
           $subscriptionPaymentStatus = CRM_Core_Payment::RECURRING_PAYMENT_END;


### PR DESCRIPTION
Overview
----------------------------------------
Fix PaypalPro IPN to refer to correct option group

Before
----------------------------------------
Paypal pro is looking up the options in the Contribution.contribution_status_id option group when it wants the valid statuses for recurrings. This works OK at the moment but when we remove 'In Progress from the Contribution status option group it won't work anymore.

After
----------------------------------------
It correctly gets statuses from the contribution recur. contribution_status_id option group

Technical Details
----------------------------------------
This has test cover - notably in CRM_Core_Payment_PayPalProIPNTest::testIPNPaymentExpressRecurSuccess - which was the test that highlighted it as having the dependency in PR https://github.com/civicrm/civicrm-core/pull/23074

Comments
----------------------------------------
