### PR TITLE
dev/financial#201 Fix pledge payment not to refer to contribution status

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -472,12 +472,11 @@ GROUP BY  currency
    * @param array $params
    *   An assoc array of name/value pairs.
    */
-  public static function sendAcknowledgment(&$form, $params) {
+  public static function sendAcknowledgment($form, $params) {
     //handle Acknowledgment.
     $allPayments = $payments = [];
 
     // get All Payments status types.
-    $paymentStatusTypes = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
     $returnProperties = [
       'status_id',
       'scheduled_amount',
@@ -508,14 +507,6 @@ GROUP BY  currency
             'status' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
           ]
         );
-
-        // get the first valid payment id.
-        if (!isset($form->paymentId) && ($paymentStatusTypes[$values['status_id']] == 'Pending' ||
-            $paymentStatusTypes[$values['status_id']] == 'Overdue'
-          )
-        ) {
-          $form->paymentId = $values['id'];
-        }
       }
     }
 

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\PledgePayment;
+
 /**
  * This class generates form components for processing a pledge
  */
@@ -79,9 +81,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     $this->userDisplayName = $this->userEmail = NULL;
     if ($this->_contactID) {
-      list($this->userDisplayName,
-        $this->userEmail
-        ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
+      [$this->userDisplayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
     }
 
     $this->setPageTitle(ts('Pledge'));
@@ -416,8 +416,10 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
   /**
    * Process the form submission.
+   *
+   * @throws \API_Exception
    */
-  public function postProcess() {
+  public function postProcess(): void {
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Pledge_BAO_Pledge::deletePledge($this->_id);
       return;
@@ -457,13 +459,13 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $dates = ['create_date', 'start_date', 'acknowledge_date', 'cancel_date'];
     foreach ($dates as $d) {
       if ($this->_id && (!$this->_isPending) && !empty($this->_values[$d])) {
-        if ($d == 'start_date') {
+        if ($d === 'start_date') {
           $params['scheduled_date'] = CRM_Utils_Date::processDate($this->_values[$d]);
         }
         $params[$d] = CRM_Utils_Date::processDate($this->_values[$d]);
       }
       elseif (!empty($formValues[$d]) && !CRM_Utils_System::isNull($formValues[$d])) {
-        if ($d == 'start_date') {
+        if ($d === 'start_date') {
           $params['scheduled_date'] = CRM_Utils_Date::processDate($formValues[$d]);
         }
         $params[$d] = CRM_Utils_Date::processDate($formValues[$d]);
@@ -499,10 +501,11 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     // create pledge record.
     $pledge = CRM_Pledge_BAO_Pledge::create($params);
+    $pledgeID = $pledge->id;
 
     $statusMsg = NULL;
 
-    if ($pledge->id) {
+    if ($pledgeID) {
       // set the status msg.
       if ($this->_action & CRM_Core_Action::ADD) {
         $statusMsg = ts('Pledge has been recorded and the payment schedule has been created.<br />');
@@ -513,28 +516,31 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     }
 
     // handle Acknowledgment.
-    if (!empty($formValues['is_acknowledge']) && $pledge->id) {
+    if (!empty($formValues['is_acknowledge'])) {
 
       // calculate scheduled amount.
       $params['scheduled_amount'] = round($params['amount'] / $params['installments']);
       $params['total_pledge_amount'] = $params['amount'];
       // get some required pledge values in params.
-      $params['id'] = $pledge->id;
+      $params['id'] = $pledgeID;
       $params['acknowledge_date'] = $pledge->acknowledge_date;
       $params['is_test'] = $pledge->is_test;
       $params['currency'] = $pledge->currency;
       // retrieve 'from email id' for acknowledgement
       $params['from_email_id'] = $formValues['from_email_address'];
 
-      $this->paymentId = NULL;
       // send Acknowledgment mail.
       CRM_Pledge_BAO_Pledge::sendAcknowledgment($this, $params);
 
       $statusMsg .= ' ' . ts("An acknowledgment email has been sent to %1.<br />", [1 => $this->userEmail]);
-
+      // get the first valid payment id.
+      $nextPaymentID = PledgePayment::get()
+        ->addWhere('pledge_id', '=', $pledgeID)
+        ->addWhere('status_id:name', 'IN', ['Pending', 'Overdue'])
+        ->addOrderBy('scheduled_date')->setLimit(1)->execute()->first()['id'];
       // build the payment urls.
-      if ($this->paymentId) {
-        $urlParams = "reset=1&action=add&cid={$this->_contactID}&ppid={$this->paymentId}&context=pledge";
+      if ($nextPaymentID) {
+        $urlParams = "reset=1&action=add&cid={$this->_contactID}&ppid={$nextPaymentID}&context=pledge";
         $contribURL = CRM_Utils_System::url('civicrm/contact/view/contribution', $urlParams);
         $urlParams .= "&mode=live";
         $creditURL = CRM_Utils_System::url('civicrm/contact/view/contribution', $urlParams);


### PR DESCRIPTION
Overview
----------------------------------------
Fix pledge payment not to refer to contribution status



Before
----------------------------------------
When creating a pledge using the new pledge back office form the popup notification has links to submit a payment against the pledge IF you check send notification, have a valid processor (e.g the dummy) and have payments to pay. It looks like this and works as intended - but relies on using the wrong option group (contribution rather than pledge payment)

![image](https://user-images.githubusercontent.com/336308/181057651-5f5a40aa-5335-4cbf-a3f0-7f983160e75c.png)


After
----------------------------------------
Same - but code does not refer to the wrong option group

Technical Details
----------------------------------------
I refactored the use of the option group out. The `form` object is being passed to `sendNotification` and the `paymentId` was being set on it. `sendNotification` is called from the front end contribution form and the backoffice pledge form. Grepping for `->paymentId` shows only the back office form uses it - which is logical as the link is a back office link. I moved the determination of the next pledge payment to the form that actually uses it because sanity. I also refactored to an api look up to retrieve it

Comments
----------------------------------------
I think it's irrational that the link only had the payment links if `send_notification` is checked & will move it in a follow up PR if there is interest in reviewing / merging that PR. Obviously it's been like that for years....