### PR TITLE
APIv4 - Allow values to start with a dollar sign in chaining

### DIFF
--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -118,7 +118,7 @@ class ActionObjectProvider implements EventSubscriberInterface, ProviderInterfac
     }
     elseif (is_string($val) && strlen($val) > 1 && substr($val, 0, 1) === '$') {
       $key = substr($val, 1);
-      $val = $result[$key] ?? \CRM_Utils_Array::pathGet($result, explode('.', $key));
+      $val = $result[$key] ?? \CRM_Utils_Array::pathGet($result, explode('.', $key)) ?? $val;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3754](https://lab.civicrm.org/dev/core/-/issues/3754)

Before
----------------------------------------
Cannot create search display starting with a dollar sign.

After
----------------------------------------
Fixed