### PR TITLE
Update references to 'workflow' (from old 'valueName' parameter)

### DIFF
--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -571,7 +571,7 @@ AND         tag_id = ( SELECT id FROM civicrm_tag WHERE name = %2 )";
           CRM_Core_BAO_MessageTemplate::sendTemplate(
             [
               'groupName' => 'msg_tpl_workflow_petition',
-              'valueName' => 'petition_sign',
+              'workflow' => 'petition_sign',
               'contactId' => $params['contactId'],
               'tplParams' => $tplParams,
               'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",
@@ -628,7 +628,7 @@ AND         tag_id = ( SELECT id FROM civicrm_tag WHERE name = %2 )";
           CRM_Core_BAO_MessageTemplate::sendTemplate(
             [
               'groupName' => 'msg_tpl_workflow_petition',
-              'valueName' => 'petition_confirmation_needed',
+              'workflow' => 'petition_confirmation_needed',
               'contactId' => $params['contactId'],
               'tplParams' => $tplParams,
               'from' => "\"{$domainEmailName}\" <{$domainEmailAddress}>",

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1340,7 +1340,7 @@ HERESQL;
       list($result[CRM_Utils_Array::value('contact_id', $info)], $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
           'groupName' => 'msg_tpl_workflow_case',
-          'valueName' => 'case_activity',
+          'workflow' => 'case_activity',
           'contactId' => $info['contact_id'] ?? NULL,
           'tplParams' => $tplParams,
           'from' => $receiptFrom,

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -454,7 +454,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       // send duplicate alert, if dupe match found during on-behalf-of processing.
       if (!empty($values['onbehalf_dupe_alert'])) {
         $sendTemplateParams['groupName'] = 'msg_tpl_workflow_contribution';
-        $sendTemplateParams['valueName'] = 'contribution_dupalert';
+        $sendTemplateParams['workflow'] = 'contribution_dupalert';
         $sendTemplateParams['from'] = ts('Automatically Generated') . " <{$values['receipt_from_email']}>";
         $sendTemplateParams['toName'] = $values['receipt_from_name'] ?? NULL;
         $sendTemplateParams['toEmail'] = $values['receipt_from_email'] ?? NULL;
@@ -554,7 +554,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       [$displayName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contribution['contact_id'], FALSE);
       $templatesParams = [
         'groupName' => 'msg_tpl_workflow_contribution',
-        'valueName' => 'contribution_recurring_notify',
+        'workflow' => 'contribution_recurring_notify',
         'contactId' => $contribution['contact_id'],
         'tplParams' => [
           'recur_frequency_interval' => $recur->frequency_interval,

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -666,7 +666,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $domainValues = CRM_Core_BAO_Domain::getNameAndEmail();
       $sendTemplateParams = [
         'groupName' => 'msg_tpl_workflow_contribution',
-        'valueName' => 'pcp_owner_notify',
+        'workflow' => 'pcp_owner_notify',
         'contactId' => $contributionSoft['contact_id'],
         'toEmail' => $ownerEmail,
         'toName' => $ownerName,

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -263,7 +263,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         $sendTemplateParams
           = [
             'groupName' => $this->_mode == 'auto_renew' ? 'msg_tpl_workflow_membership' : 'msg_tpl_workflow_contribution',
-            'valueName' => $this->_mode == 'auto_renew' ? 'membership_autorenew_cancelled' : 'contribution_recurring_cancelled',
+            'workflow' => $this->_mode == 'auto_renew' ? 'membership_autorenew_cancelled' : 'contribution_recurring_cancelled',
             'contactId' => $this->getSubscriptionDetails()->contact_id,
             'tplParams' => $tplParams,
             'tokenContext' => ['contribution_recurId' => $this->getContributionRecurID()],

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -323,7 +323,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
 
       $sendTemplateParams = array(
         'groupName' => $this->getSubscriptionDetails()->membership_id ? 'msg_tpl_workflow_membership' : 'msg_tpl_workflow_contribution',
-        'valueName' => $this->getSubscriptionDetails()->membership_id ? 'membership_autorenew_billing' : 'contribution_recurring_billing',
+        'workflow' => $this->getSubscriptionDetails()->membership_id ? 'membership_autorenew_billing' : 'contribution_recurring_billing',
         'contactId' => $this->getSubscriptionDetails()->contact_id,
         'tplParams' => $tplParams,
         'isTest' => $this->getSubscriptionDetails()->is_test,

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -303,7 +303,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
 
         $sendTemplateParams = [
           'groupName' => 'msg_tpl_workflow_contribution',
-          'valueName' => 'contribution_recurring_edit',
+          'workflow' => 'contribution_recurring_edit',
           'contactId' => $contactID,
           'tplParams' => ['receipt_from_email' => $receiptFrom],
           'isTest' => $this->_subscriptionDetails->is_test,

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -287,8 +287,8 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
     $modelDefaults = [
       // instance of WorkflowMessageInterface, containing a list of data to provide to the message-template
       'model' => NULL,
-      // Symbolic name of the workflow step. Matches the option-value-name of the template.
-      'valueName' => NULL,
+      // Symbolic name of the workflow step. Matches the value in civicrm_msg_template.workflow_name.
+      'workflow' => NULL,
       // additional template params (other than the ones already set in the template singleton)
       'tplParams' => [],
       // additional token params (passed to the TokenProcessor)
@@ -343,7 +343,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
     $params = array_merge($modelDefaults, $viewDefaults, $envelopeDefaults, $params);
 
     CRM_Utils_Hook::alterMailParams($params, 'messageTemplate');
-    $mailContent = self::loadTemplate((string) $params['valueName'], $params['isTest'], $params['messageTemplateID'] ?? NULL, $params['groupName'] ?? '', $params['messageTemplate'], $params['subject'] ?? NULL);
+    $mailContent = self::loadTemplate((string) $params['workflow'], $params['isTest'], $params['messageTemplateID'] ?? NULL, $params['groupName'] ?? '', $params['messageTemplate'], $params['subject'] ?? NULL);
 
     self::synchronizeLegacyParameters($params);
     $rendered = CRM_Core_TokenSmarty::render(CRM_Utils_Array::subset($mailContent, ['text', 'html', 'subject']), $params['tokenContext'], $params['tplParams']);
@@ -363,6 +363,9 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
    * @param array $params
    */
   private static function synchronizeLegacyParameters(&$params) {
+    // 'valueName' is deprecated, docs were updated some time back
+    // and people have been notified. Having it here means the
+    // hooks will still see it until we remove.
     CRM_Utils_Array::pathSync($params, ['workflow'], ['valueName']);
     CRM_Utils_Array::pathSync($params, ['tokenContext', 'contactId'], ['contactId']);
     CRM_Utils_Array::pathSync($params, ['tokenContext', 'smarty'], ['disableSmarty'], function ($v, bool $isCanon) {
@@ -505,7 +508,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
       // Group name & valueName are deprecated parameters. At some point it will not be passed out.
       // https://github.com/civicrm/civicrm-core/pull/17180
       'groupName' => $groupName,
-      'valueName' => $workflowName,
+      'workflow' => $workflowName,
     ];
 
     CRM_Utils_Hook::alterMailContent($mailContent);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2690,7 +2690,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
           'groupName' => 'msg_tpl_workflow_uf',
-          'valueName' => 'uf_notify',
+          'workflow' => 'uf_notify',
           'contactId' => $contactID,
           'tplParams' => [
             'displayName' => $displayName,

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1190,7 +1190,7 @@ WHERE civicrm_event.is_active = 1
 
         $sendTemplateParams = [
           'groupName' => 'msg_tpl_workflow_event',
-          'valueName' => 'event_online_receipt',
+          'workflow' => 'event_online_receipt',
           'contactId' => $contactID,
           'isTest' => $isTest,
           'tplParams' => $tplParams,

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -399,7 +399,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
 
       $sendTemplateParams = [
         'groupName' => 'msg_tpl_workflow_event',
-        'valueName' => 'event_online_receipt',
+        'workflow' => 'event_online_receipt',
         'contactId' => $participantDetails[$participant->id]['contact_id'],
         'tplParams' => $tplParams,
         'from' => $receiptFrom,

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -281,7 +281,7 @@ class CRM_Financial_BAO_Payment {
 
     $sendTemplateParams = [
       'groupName' => 'msg_tpl_workflow_contribution',
-      'valueName' => 'payment_or_refund_notification',
+      'workflow' => 'payment_or_refund_notification',
       'PDFFilename' => ts('notification') . '.pdf',
       'contactId' => $entities['contact']['id'],
       'toName' => $entities['contact']['display_name'],

--- a/CRM/Friend/BAO/Friend.php
+++ b/CRM/Friend/BAO/Friend.php
@@ -289,7 +289,7 @@ class CRM_Friend_BAO_Friend extends CRM_Friend_DAO_Friend {
 
     $templateParams = [
       'groupName' => 'msg_tpl_workflow_friend',
-      'valueName' => 'friend',
+      'workflow' => 'friend',
       'contactId' => $contactID,
       'tplParams' => [
         $values['module'] => $values['module'],

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -716,7 +716,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
     list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'groupName' => 'msg_tpl_workflow_contribution',
-        'valueName' => $tplName,
+        'workflow' => $tplName,
         'contactId' => $pcpInfo['contact_id'],
         'tplParams' => $tplParams,
         'from' => $receiptFrom,

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -315,7 +315,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
       list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
           'groupName' => 'msg_tpl_workflow_contribution',
-          'valueName' => 'pcp_notify',
+          'workflow' => 'pcp_notify',
           'contactId' => $contactID,
           'from' => "$domainEmailName <$domainEmailAddress>",
           'toEmail' => $to,

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -595,7 +595,7 @@ GROUP BY  currency
     [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'groupName' => 'msg_tpl_workflow_pledge',
-        'valueName' => 'pledge_acknowledge',
+        'workflow' => 'pledge_acknowledge',
         'contactId' => $params['contact_id'],
         'from' => $receiptFrom,
         'toName' => $pledgerDisplayName,
@@ -962,7 +962,7 @@ SELECT  pledge.contact_id              as contact_id,
             ] = CRM_Core_BAO_MessageTemplate::sendTemplate(
               [
                 'groupName' => 'msg_tpl_workflow_pledge',
-                'valueName' => 'pledge_reminder',
+                'workflow' => 'pledge_reminder',
                 'contactId' => $contactId,
                 'from' => $receiptFrom,
                 'toName' => $pledgerName,

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -341,7 +341,7 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
         'is_pay_later' => $this->is_pay_later,
         'pay_later_receipt' => $this->pay_later_receipt,
       ],
-      'valueName' => 'event_registration_receipt',
+      'workflow' => 'event_registration_receipt',
       'PDFFilename' => ts('confirmation') . '.pdf',
     ];
     $template_params_to_copy = [

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -30,7 +30,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
       'suffix_id' => NULL,
     ]);
     $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
-      'valueName' => 'case_activity',
+      'workflow' => 'case_activity',
       'tokenContext' => [
         'contactId' => $contactId,
       ],
@@ -58,7 +58,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     ]);
     [$sent, $subject, $messageText, $messageHtml] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
-        'valueName' => 'case_activity',
+        'workflow' => 'case_activity',
         'contactId' => $contactId,
         'from' => 'admin@example.com',
         // No 'toEmail'/'toName' address => not sendable, but still returns rendered value.
@@ -99,7 +99,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
 
       [$sent, $subject, $messageText, $messageHtml] = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
-          'valueName' => 'case_activity',
+          'workflow' => 'case_activity',
           'contactId' => $contactId,
           'from' => 'admin@example.com',
           // No 'toEmail'/'toName' address => not sendable, but still returns rendered value.
@@ -137,7 +137,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
 
       [$sent, $subject, $messageText, $messageHtml] = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
-          'valueName' => 'case_activity',
+          'workflow' => 'case_activity',
           'tokenContext' => [
             'contactId' => $contactId,
             'activityId' => $activityId,
@@ -188,7 +188,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertEquals([], \Civi\Test\Invasive::get([$msg, '_extras']));
 
     [, $subject, $message] = $msg->sendTemplate([
-      'valueName' => 'case_activity',
+      'workflow' => 'case_activity',
       'from' => 'admin@example.com',
       'toName' => 'Demo',
       'toEmail' => 'admin@example.com',
@@ -217,7 +217,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $tokenString = '{domain.' . implode('} ~ {domain.', array_keys($values)) . '}';
 
     $messageContent = CRM_Core_BAO_MessageTemplate::renderTemplate([
-      'valueName' => 'dummy',
+      'workflow' => 'dummy',
       'messageTemplate' => [
         'msg_html' => $tokenString,
         // Check the space is stripped.
@@ -241,7 +241,7 @@ London, 90210
    */
   public function testRenderTemplateSmarty(): void {
     $messageContent = CRM_Core_BAO_MessageTemplate::renderTemplate([
-      'valueName' => 'dummy',
+      'workflow' => 'dummy',
       'messageTemplate' => [
         'msg_html' => '{$tokenString}',
         // Check the space is stripped.
@@ -261,7 +261,7 @@ London, 90210
    */
   public function testRenderTemplateIgnoreSmarty(): void {
     $messageContent = CRM_Core_BAO_MessageTemplate::renderTemplate([
-      'valueName' => 'dummy',
+      'workflow' => 'dummy',
       'messageTemplate' => [
         'msg_html' => '{$tokenString}',
         // Check the space is stripped.
@@ -308,7 +308,7 @@ London, 90210
       $tokenString .= "{$key}:{contact.{$key}}\n";
     }
     $messageContent = CRM_Core_BAO_MessageTemplate::renderTemplate([
-      'valueName' => 'dummy',
+      'workflow' => 'dummy',
       'messageTemplate' => [
         'msg_html' => $tokenString,
         // Check the space is stripped.


### PR DESCRIPTION
Overview
----------------------------------------
Update references to 'workflow' (from old 'valueName' parameter)

Before
----------------------------------------
We have deprecated `valueName` and the docs are updated to use `workflow` instead. There is handling to ensure both are passed to `alterMailParams` and we have updated some places to pass `workflow`, safe in the knowledge that `alterMailParams` will get both - but confusingly lots of places still pass `valueName`

After
----------------------------------------
`valueName` is 'almost' gone. There is still the sync code and references in unit tests designed to check what `alterMailParams` gets. 

The api v3 code is a bit tricksy. Where we end up is that
- the new (`workflow`, the old `valueName` and the attempt to have a prettier variable for the api `option_value_name`) are all accepted
- `workflow` is the promoted param

Technical Details
----------------------------------------


Comments
----------------------------------------
