### PR TITLE
Add whitespace to exception message

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -225,7 +225,7 @@ class SpecGatherer {
   private function getDAOFields(string $entityName): array {
     $bao = CoreUtil::getBAOFromApiName($entityName);
     if (!$bao) {
-      throw new \API_Exception('Entity not loaded' . $entityName);
+      throw new \API_Exception('Entity not loaded: ' . $entityName);
     }
     return $bao::getSupportedFields();
   }


### PR DESCRIPTION
"Entity not loadedGrant" -> "Entity not loaded: Grant"