### PR TITLE
dev/core#3752 Fix issue with price set membership terms

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1849,7 +1849,8 @@ DESC limit 1");
     }
 
     foreach ($this->order->getMembershipLineItems() as $membershipLineItem) {
-      $memTypeNumTerms = $this->getSubmittedValue('num_terms') ?: $membershipLineItem['membership_num_terms'];
+      $memTypeNumTerms = $this->getSubmittedValue('num_terms') &&
+      !$this->getSubmittedValue('price_set_id') ? $this->getSubmittedValue('num_terms') : $membershipLineItem['membership_num_terms'];
       $calcDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType(
         $membershipLineItem['membership_type_id'],
         $this->getSubmittedValue('join_date'),


### PR DESCRIPTION
Overview
----------------------------------------
Number of Terms present in priceset not get used while signing up using offline form.


Reproduction steps
----------------------------------------
1. Crete Price and field of Select option.
1. Use Membership type `Student` which is 1 year duration.
1. Use the same membership type with different terms.
1. Now, go to the contact and sign up for membership using priceset.
1. Use Membership with 2 or 3 year terms.
1. Result : it extends by only 1 year.


Current behaviour
----------------------------------------
Irrespective of different terms of membership, membership only extends by only one year.



Expected behaviour
----------------------------------------
Membership should extend as per terms set in the price set field option.

----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/3752