### PR TITLE
dev/core#3749 Fix process pledges to throw exception when civiPledge disabled

### DIFF
--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -772,11 +772,10 @@ GROUP BY  currency
    * @param array $params
    *
    * @return array
-   * @throws \API_Exception
+   *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
-  public static function updatePledgeStatus($params): array {
+  public static function updatePledgeStatus(array $params): array {
 
     $returnMessages = [];
 
@@ -875,7 +874,7 @@ SELECT  pledge.contact_id              as contact_id,
       );
       if ($newStatus != $pledgeStatus[$pledgeId]) {
         $returnMessages[] = "- status updated to: {$allPledgeStatus[$newStatus]}";
-        $updateCnt += 1;
+        ++$updateCnt;
       }
     }
 
@@ -992,8 +991,7 @@ SELECT  pledge.contact_id              as contact_id,
                 civicrm_api3('activity', 'create', $activityParams);
               }
               catch (CiviCRM_API3_Exception $e) {
-                $returnMessages[] = "Failed creating Activity for Pledge Reminder: " . $e->getMessage();
-                return ['is_error' => 1, 'message' => $returnMessages];
+                throw new CRM_Core_Exception('Failed creating Activity for Pledge Reminder: ' . $e->getMessage());
               }
               $returnMessages[] = "Payment reminder sent to: {$pledgerName} - {$toEmail}";
             }
@@ -1005,7 +1003,7 @@ SELECT  pledge.contact_id              as contact_id,
     // end if ( $sendReminders )
     $returnMessages[] = "{$updateCnt} records updated.";
 
-    return ['is_error' => 0, 'messages' => implode("\n\r", $returnMessages)];
+    return $returnMessages;
   }
 
   /**

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -306,19 +306,14 @@ function _civicrm_api3_job_update_greeting_spec(&$params) {
  * @param array $params
  *
  * @return array
+ *
+ * @throws \CRM_Core_Exception
  */
-function civicrm_api3_job_process_pledge($params) {
-  // *** Uncomment the next line if you want automated reminders to be sent
-  // $params['send_reminders'] = true;
-  $result = CRM_Pledge_BAO_Pledge::updatePledgeStatus($params);
-
-  if ($result['is_error'] == 0) {
-    // experiment: detailed execution log is a result here
-    return civicrm_api3_create_success($result['messages']);
+function civicrm_api3_job_process_pledge(array $params): array {
+  if (!CRM_Core_Component::isEnabled('CiviPledge')) {
+    throw new CRM_Core_Exception(ts('%1 is not enabled'), [1 => ['CiviPledge']]);
   }
-  else {
-    return civicrm_api3_create_error($result['error_message']);
-  }
+  return civicrm_api3_create_success(implode("\n\r", CRM_Pledge_BAO_Pledge::updatePledgeStatus($params)));
 }
 
 /**


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3749
…

Per the issue - it's fine for the job to not work if disabled,
but the error should be logical.

updatePledgeStatus is only called from one place so made the return
handling flatter for success, and exception on error

