### PR TITLE
Remove legacy `apiquery` call from `isContactInGroup`

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -9,6 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contact;
 use Civi\Api4\SubscriptionHistory;
 use Civi\Core\Event\PostEvent;
 use Civi\Core\HookInterface;
@@ -502,28 +503,19 @@ SELECT    *
   }
 
   /**
+   * Function that doesn't do much.
+   *
    * @param int $contactID
    * @param int $groupID
    *
+   * @deprecated
    * @return bool
    */
-  public static function isContactInGroup($contactID, $groupID) {
-    if (!CRM_Utils_Rule::positiveInteger($contactID) ||
-      !CRM_Utils_Rule::positiveInteger($groupID)
-    ) {
-      return FALSE;
-    }
-
-    $params = [
-      ['group', 'IN', [$groupID], 0, 0],
-      ['contact_id', '=', $contactID, 0, 0],
-    ];
-    [$contacts] = CRM_Contact_BAO_Query::apiQuery($params, ['contact_id']);
-
-    if (!empty($contacts)) {
-      return TRUE;
-    }
-    return FALSE;
+  public static function isContactInGroup(int $contactID, int $groupID) {
+    return (bool) Contact::get(FALSE)
+      ->addWhere('id', '=', $contactID)
+      ->addWhere('groups', 'IN', [$groupID])
+      ->selectRowCount()->execute()->count();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -648,12 +648,12 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
   /**
    * Test case for createProfileContact.
    */
-  public function testCreateProfileContact() {
+  public function testCreateProfileContact(): void {
     //Create 3 groups.
     foreach (['group1', 'group2', 'group3'] as $key => $title) {
       $this->groups["id{$key}"] = $this->callAPISuccess('Group', 'create', [
         'title' => $title,
-        'visibility' => "Public Pages",
+        'visibility' => 'Public Pages',
       ])['id'];
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove legacy `apiquery` call from `isContactInGroup`

Before
----------------------------------------
Legacy function call to determine if contact is in a group

After
----------------------------------------
Api call

Technical Details
----------------------------------------
This is only called from one place in core & one test. I figured I'd clean it up while the test still calls if for reviewer friendliness. So, it's only soft-deprecated at the main function level

Comments
----------------------------------------
Getting rid of calls to `apiQuery` is a back-burner goal
