### PR TITLE
Move hook_civicrm_translateFields from message_admin to core

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -527,4 +527,17 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
     return $mailContent;
   }
 
+  /**
+   * Mark these fields as translatable.
+   *
+   * @todo move this definition to the metadata.
+   *
+   * @see CRM_Utils_Hook::translateFields
+   */
+  public static function hook_civicrm_translateFields(&$fields) {
+    $fields['civicrm_msg_template']['msg_subject'] = TRUE;
+    $fields['civicrm_msg_template']['msg_text'] = TRUE;
+    $fields['civicrm_msg_template']['msg_html'] = TRUE;
+  }
+
 }

--- a/ext/message_admin/message_admin.php
+++ b/ext/message_admin/message_admin.php
@@ -106,13 +106,3 @@ function message_admin_civicrm_entityTypes(&$entityTypes) {
 //  ));
 //  _message_admin_civix_navigationMenu($menu);
 //}
-
-/**
- * Mark these fields as translateable.
- * @see CRM_Utils_Hook::translateFields
- */
-function message_admin_civicrm_translateFields(&$fields) {
-  $fields['civicrm_msg_template']['msg_subject'] = TRUE;
-  $fields['civicrm_msg_template']['msg_text'] = TRUE;
-  $fields['civicrm_msg_template']['msg_html'] = TRUE;
-}

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -203,9 +203,9 @@ class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
         break;
 
       case 'Translation':
-        $extraValues['entity_table'] = 'civicrm_event';
-        $extraValues['entity_field'] = 'description';
-        $extraValues['entity_id'] = $this->getFkID('Event');
+        $extraValues['entity_table'] = 'civicrm_msg_template';
+        $extraValues['entity_field'] = 'msg_subject';
+        $extraValues['entity_id'] = $this->getFkID('MessageTemplate');
         break;
 
       case 'Case':

--- a/tests/phpunit/api/v4/Entity/TranslationTest.php
+++ b/tests/phpunit/api/v4/Entity/TranslationTest.php
@@ -20,16 +20,17 @@
 namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
+use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class TranslationTest extends Api4TestBase implements TransactionalInterface {
+class TranslationTest extends Api4TestBase implements TransactionalInterface, HookInterface {
 
   protected $ids = [];
 
-  public function getCreateOKExamples() {
+  public function getCreateOKExamples(): array {
     $es = [];
 
     $es['asDraft'] = [
@@ -132,7 +133,7 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface {
     return $es;
   }
 
-  public function getUpdateBadExamples() {
+  public function getUpdateBadExamples(): array {
     $createOk = $this->getCreateOKExamples()['asDraft'][0];
     $bads = $this->getCreateBadExamples();
 
@@ -150,10 +151,15 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface {
   }
 
   /**
+   * Test valid creation.
+   *
    * @dataProvider getCreateOKExamples
+   *
    * @param array $record
+   *
+   * @throws \API_Exception
    */
-  public function testCreateOK($record) {
+  public function testCreateOK(array $record): void {
     $record = $this->fillRecord($record);
     $createResults = \civicrm_api4('Translation', 'create', [
       'checkPermissions' => FALSE,
@@ -170,11 +176,12 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface {
 
   /**
    * @dataProvider getCreateBadExamples
+   *
    * @param array $record
    * @param string $errorRegex
    *   Regular expression to compare against the error message.
    */
-  public function testCreateBad($record, $errorRegex) {
+  public function testCreateBad(array $record, string $errorRegex): void {
     $record = $this->fillRecord($record);
     try {
       \civicrm_api4('Translation', 'create', [
@@ -197,7 +204,7 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface {
    * @throws \API_Exception
    * @throws \Civi\API\Exception\NotImplementedException
    */
-  public function testUpdateBad($createRecord, $badUpdate, $errorRegex) {
+  public function testUpdateBad($createRecord, $badUpdate, $errorRegex): void {
     $record = $this->fillRecord($createRecord);
     $createResults = \civicrm_api4('Translation', 'create', [
       'checkPermissions' => FALSE,
@@ -232,6 +239,16 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface {
       $record['entity_id'] = $this->ids['*EVENT*'] = $eventId;
     }
     return $record;
+  }
+
+  /**
+   * Mark these fields as translatable.
+   *
+   * @see CRM_Utils_Hook::translateFields
+   */
+  public static function hook_civicrm_translateFields(&$fields): void {
+    $fields['civicrm_event']['description'] = TRUE;
+    $fields['civicrm_event']['title'] = TRUE;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Move hook_civicrm_translateFields from message_admin to core

https://github.com/civicrm/civicrm-core/pull/23844

Before
----------------------------------------
The fact that message template fields are translatable is in the message admin UI extension. However, rendering translated is core functionality (well once the rest of https://github.com/civicrm/civicrm-core/pull/23844 is merged) it will be - so the right place to define it is in core where the functionality is

After
----------------------------------------
Moved

Technical Details
----------------------------------------
This is the part of https://github.com/civicrm/civicrm-core/pull/23844 that is causing test fails so I'm separating it out - also, it should be an easy merge when tests pass

Comments
----------------------------------------
