### PR TITLE
Log a bit more deprecation info

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1091,7 +1091,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     foreach ($backtrace as $backtraceLine) {
       $miniBacktrace[] = ($backtraceLine['class'] ?? '') . '::' . ($backtraceLine['function'] ?? '');
     }
-    Civi::log()->warning($message . ' ' . implode("\n", $miniBacktrace), ['civi.tag' => 'deprecated']);
+    Civi::log()->warning($message . "\n" . implode("\n", $miniBacktrace), ['civi.tag' => 'deprecated']);
     trigger_error($message, E_USER_DEPRECATED);
   }
 

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1089,7 +1089,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // saying they can't track down where the deprecated calls are coming from.
     $miniBacktrace = [];
     foreach ($backtrace as $backtraceLine) {
-      $miniBacktrace[] = ($backtraceLine['function'] ?? NULL) . '::' . ($backtraceLine['class']);
+      $miniBacktrace[] = ($backtraceLine['class'] ?? '') . '::' . ($backtraceLine['function'] ?? '');
     }
     Civi::log()->warning($message . ' ' . implode("\n", $miniBacktrace), ['civi.tag' => 'deprecated']);
     trigger_error($message, E_USER_DEPRECATED);

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -1068,22 +1068,30 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   }
 
   /**
-   * Output a deprecated function warning to log file.  Deprecated class:function is automatically generated from calling function.
+   * Output a deprecated function warning to log file.
+   *
+   * Deprecated class:function is automatically generated from calling function.
    *
    * @param string $newMethod
    *   description of new method (eg. "buildOptions() method in the appropriate BAO object").
-   * @param string $oldMethod
+   * @param string|null $oldMethod
    *   optional description of old method (if not the calling method). eg. CRM_MyClass::myOldMethodToGetTheOptions()
    */
-  public static function deprecatedFunctionWarning($newMethod, $oldMethod = NULL) {
+  public static function deprecatedFunctionWarning(string $newMethod, ?string $oldMethod = NULL): void {
+    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
     if (!$oldMethod) {
-      $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-      $callerFunction = $dbt[1]['function'] ?? NULL;
-      $callerClass = $dbt[1]['class'] ?? NULL;
+      $callerFunction = $backtrace[1]['function'] ?? NULL;
+      $callerClass = $backtrace[1]['class'] ?? NULL;
       $oldMethod = "{$callerClass}::{$callerFunction}";
     }
     $message = "Deprecated function $oldMethod, use $newMethod.";
-    Civi::log()->warning($message, ['civi.tag' => 'deprecated']);
+    // Add a mini backtrace. Just the function is too little to be meaningful but people are
+    // saying they can't track down where the deprecated calls are coming from.
+    $miniBacktrace = [];
+    foreach ($backtrace as $backtraceLine) {
+      $miniBacktrace[] = ($backtraceLine['function'] ?? NULL) . '::' . ($backtraceLine['class']);
+    }
+    Civi::log()->warning($message . ' ' . implode("\n", $miniBacktrace), ['civi.tag' => 'deprecated']);
     trigger_error($message, E_USER_DEPRECATED);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Log a bit more deprecation info

Before
----------------------------------------
People (notably @aydun) commented that they can't track down where deprecation warnings are coming from when they see them in the ConfigAndLog

After
----------------------------------------
Hopefully this will add enough more to help find them without adding too much more

Technical Details
----------------------------------------
I realise we'd probably need to do similar to `deprecationWarning` - but just trying to see if we can do a small improvement

Comments
----------------------------------------
