### PR TITLE
Fix #3756 hook_civicrm_geocoderFormat does not alter address components

### DIFF
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -106,6 +106,8 @@ class CRM_Utils_Geocode_Google {
       $values['geo_code_error'] = $coord['geo_code_error'];
     }
 
+    CRM_Utils_Hook::geocoderFormat('Google', $values, $coord['request_xml']);
+
     return isset($coord['geo_code_1'], $coord['geo_code_2']);
   }
 
@@ -122,11 +124,18 @@ class CRM_Utils_Geocode_Google {
   /**
    * @param string $add
    *   Url-encoded address
+   *
    * @return array
+   *   An array of values with the following possible keys:
+   *     geo_code_error: String error message
+   *     geo_code_1: Float latitude
+   *     geo_code_2: Float longitude
+   *     request_xml: SimpleXMLElement parsed xml from geocoding API
+   *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private static function makeRequest($add) {
-
+    $coords = [];
     $config = CRM_Core_Config::singleton();
     if (!empty($config->geoAPIKey)) {
       $add .= '&key=' . urlencode($config->geoAPIKey);
@@ -140,11 +149,11 @@ class CRM_Utils_Geocode_Google {
 
     libxml_use_internal_errors(TRUE);
     $xml = @simplexml_load_string($string);
-    CRM_Utils_Hook::geocoderFormat('Google', $values, $xml);
+    $coords['request_xml'] = $xml;
     if ($xml === FALSE) {
       // account blocked maybe?
       CRM_Core_Error::debug_var('Geocoding failed.  Message from Google:', $string);
-      return ['geo_code_error' => $string];
+      $coords['geo_code_error'] = $string;
     }
 
     if (isset($xml->status)) {
@@ -155,22 +164,18 @@ class CRM_Utils_Geocode_Google {
       ) {
         $ret = $xml->result->geometry->location->children();
         if ($ret->lat && $ret->lng) {
-          return [
-            'geo_code_1' => (float) $ret->lat,
-            'geo_code_2' => (float) $ret->lng,
-          ];
+          $coords['geo_code_1'] = (float) $ret->lat;
+          $coords['geo_code_2'] = (float) $ret->lng;
         }
       }
-      elseif ($xml->status == 'ZERO_RESULTS') {
-        // reset the geo code values if we did not get any good values
-        return [];
-      }
-      else {
+      elseif ($xml->status != 'ZERO_RESULTS') {
+        // 'ZERO_RESULTS' is a valid status, in which case we'll change nothing in $ret;
+        // but if the status is anything else, we need to note the error.
         CRM_Core_Error::debug_var("Geocoding failed. Message from Google: ({$xml->status})", (string ) $xml->error_message);
-        return ['geo_code_error' => $xml->status];
+        $coords['geo_code_error'] = $xml->status;
       }
     }
-    return [];
+    return $coords;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Per the description in https://lab.civicrm.org/dev/core/-/issues/3756 , versions 5.51.0 and later have a regression in which hook_civicrm_geocoderFormat does not alter address components. This PR aims to fix that regression.

Before
----------------------------------------
As described in the linked issue, implementations of `hook_civicrm_geocoderFormat` fail to have an effect on the saved address.

After
----------------------------------------
Implementations of `hook_civicrm_geocoderFormat` will now alter the address values as designed.

Comments
----------------------------------------
In the linked issue, I suggested that "The `CRM_Utils_Geocode_Google::makeRequest()` method should receive `$values` as a parameter-by-reference." Such a change would look like this:

```
diff --git a/CRM/Utils/Geocode/Google.php b/CRM/Utils/Geocode/Google.php
index 0885a3d3ae..259df8a552 100644
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -97,7 +97,7 @@ class CRM_Utils_Geocode_Google {
       $add .= '+' . urlencode(str_replace('', '+', $values['country']));
     }
 
-    $coord = self::makeRequest($add);
+    $coord = self::makeRequest($add, $values);
 
     $values['geo_code_1'] = $coord['geo_code_1'] ?? 'null';
     $values['geo_code_2'] = $coord['geo_code_2'] ?? 'null';
@@ -125,7 +125,7 @@ class CRM_Utils_Geocode_Google {
    * @return array
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  private static function makeRequest($add) {
+  private static function makeRequest($add, &$values) {
 
     $config = CRM_Core_Config::singleton();
     if (!empty($config->geoAPIKey)) {
```

However, I'm uncomfortable adding `$values` to a method named `makeRequest()`, which sounds as though it should just be making a request and returning information about that request. 

Therefore, this PR is a few lines longer, and it solves the problem by adding the request XML to the array returned by `makeRequest()`, leaving it up to the `format()` method to do what it wants with that info. "What it wants" in this PR is to alter the address values by passing them (along with the request XML) to the relevant hook.

I'm happy to re-submit this PR to use the more concise change copied above, if that's preferable. Let me know.