### PR TITLE
APIv4 - Drop support for deprecated join syntax

### DIFF
--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -82,14 +82,6 @@ class SchemaMapBuilder {
     if ($fkClass) {
       $tableName = AllCoreTables::getTableForClass($fkClass);
       $fkKey = $data['FKKeyColumn'] ?? 'id';
-      // Backward-compatibility for older api calls using e.g. "contact" instead of "contact_id"
-      if (strpos($field, '_id')) {
-        $alias = str_replace('_id', '', $field);
-        $joinable = new Joinable($tableName, $fkKey, $alias);
-        $joinable->setJoinType($joinable::JOIN_TYPE_MANY_TO_ONE);
-        $joinable->setDeprecated();
-        $table->addTableLink($field, $joinable);
-      }
       $joinable = new Joinable($tableName, $fkKey, $field);
       $joinable->setJoinType($joinable::JOIN_TYPE_MANY_TO_ONE);
       $table->addTableLink($field, $joinable);

--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -445,24 +445,6 @@ class FkJoinTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('TesterCo', $emailGet['contact_id.employer_id.display_name']);
   }
 
-  public function testDeprecatedJoins() {
-    $message = '';
-    try {
-      \Civi\Api4\Email::get(FALSE)
-        ->addWhere('contact.first_name', '=', 'Peter')
-        ->addWhere('contact.last_name', '=', '')
-        ->addWhere('contact.is_deleted', '=', 0)
-        ->addWhere('contact.is_deceased', '=', 0)
-        ->addWhere('email', '=', '')
-        ->addWhere('is_primary', '=', TRUE)
-        ->setSelect(['contact_id'])->execute();
-    }
-    catch (\Exception $e) {
-      $message = $e->getMessage();
-    }
-    $this->assertStringContainsString("Deprecated join alias 'contact' used in APIv4 get. Should be changed to 'contact_id'", $message);
-  }
-
   public function testJoinWithExpression() {
 
     $contact1 = $this->createTestRecord('Contact');


### PR DESCRIPTION
Overview
----------------------------------------
Removes support for join syntax that has been noisily deprecated for over a year.

Technical Details
----------------------------------------
See #20130 and #20716
