### PR TITLE
New autocomplete widget based on APIv4 & Select2v4

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -40,7 +40,8 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       CRM_Utils_System::civiExit();
     }
     if ($_SERVER['REQUEST_METHOD'] == 'GET' &&
-      strtolower(substr($this->urlPath[4], 0, 3)) != 'get') {
+      ($this->urlPath[4] !== 'autocomplete' && strtolower(substr($this->urlPath[4], 0, 3)) !== 'get')
+    ) {
       $response = [
         'error_code' => 400,
         'error_message' => "SECURITY: All requests that modify the database must be http POST, not GET.",

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -189,6 +189,8 @@ class CRM_Core_Resources_Common {
       "packages/jquery/plugins/jquery.mousewheel.min.js",
       "bower_components/select2/select2.min.js",
       "bower_components/select2/select2.min.css",
+      "bower_components/select2-4.x/dist/js/select2.min.js",
+      "bower_components/select2-4.x/dist/css/select4.min.css",
       "bower_components/font-awesome/css/font-awesome.min.css",
       "packages/jquery/plugins/jquery.form.min.js",
       "packages/jquery/plugins/jquery.timeentry.min.js",

--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic;
+
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Retrieve $ENTITIES for an autocomplete form field.
+ */
+class AutocompleteAction extends AbstractAction {
+  use Traits\SavedSearchInspectorTrait;
+
+  /**
+   * Autocomplete search input
+   *
+   * @var string
+   */
+  protected $input = '';
+
+  /**
+   * @var int
+   */
+  protected $page = 1;
+
+  /**
+   * Name of SavedSearch to use for filtering.
+   * @var string
+   */
+  protected $savedSearch;
+
+  /**
+   * @var string
+   */
+  protected $formName;
+
+  /**
+   * @var string
+   */
+  protected $fieldName;
+
+  /**
+   * Fetch results.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $entityName = $this->getEntityName();
+    $fields = CoreUtil::getApiClass($entityName)::get()->entityFields();
+    $idField = CoreUtil::getIdFieldName($entityName);
+    $labelField = CoreUtil::getInfoItem($entityName, 'label_field');
+    $map = [
+      'id' => $idField,
+      'text' => $labelField,
+    ];
+    // FIXME: Use metadata
+    if (isset($fields['description'])) {
+      $map['description'] = 'description';
+    }
+    if (isset($fields['color'])) {
+      $map['color'] = 'color';
+    }
+    if (isset($fields['icon'])) {
+      $map['icon'] = 'icon';
+    }
+
+    if (!$this->savedSearch) {
+      $this->savedSearch = ['api_entity' => $entityName];
+    }
+    $this->loadSavedSearch();
+    $resultsPerPage = \Civi::settings()->get('search_autocomplete_count');
+    // Adding one extra result allows us to see if there are any more
+    $this->_apiParams['limit'] = $resultsPerPage + 1;
+    $this->_apiParams['offset'] = ($this->page - 1) * $resultsPerPage;
+    if (strlen($this->input)) {
+      $prefix = \Civi::settings()->get('includeWildCardInName') ? '%' : '';
+      $this->_apiParams['where'][] = [$labelField, 'LIKE', $prefix . $this->input . '%'];
+    }
+    if (empty($this->_apiParams['having'])) {
+      $this->_apiParams['select'] = array_values($map);
+    }
+    else {
+      $this->_apiParams['select'] = array_merge($this->_apiParams['select'], array_values($map));
+    }
+    $this->_apiParams['checkPermissions'] = $this->getCheckPermissions();
+    $apiResult = civicrm_api4($entityName, 'get', $this->_apiParams);
+    $rawResults = array_slice((array) $apiResult, 0, $resultsPerPage);
+    foreach ($rawResults as $row) {
+      $mapped = [];
+      foreach ($map as $key => $fieldName) {
+        $mapped[$key] = $row[$fieldName];
+      }
+      $result[] = $mapped;
+    }
+    $result->setCountMatched($apiResult->countFetched());
+  }
+
+}

--- a/Civi/Api4/Generic/BasicEntity.php
+++ b/Civi/Api4/Generic/BasicEntity.php
@@ -137,6 +137,15 @@ abstract class BasicEntity extends AbstractEntity {
   }
 
   /**
+   * @param bool $checkPermissions
+   * @return AutocompleteAction
+   */
+  public static function autocomplete($checkPermissions = TRUE) {
+    return (new AutocompleteAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * @inheritDoc
    */
   public static function getInfo() {

--- a/Civi/Api4/Generic/DAOEntity.php
+++ b/Civi/Api4/Generic/DAOEntity.php
@@ -90,4 +90,13 @@ abstract class DAOEntity extends AbstractEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return AutocompleteAction
+   */
+  public static function autocomplete($checkPermissions = TRUE) {
+    return (new AutocompleteAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Civi\Api4\Action\SearchDisplay;
+namespace Civi\Api4\Generic\Traits;
 
 use Civi\API\Request;
 use Civi\Api4\Query\SqlExpression;
@@ -174,6 +174,104 @@ trait SavedSearchInspectorTrait {
     // If the entity this column belongs to is being grouped by id, then also no
     $idField = substr($fieldPath, 0, 0 - strlen($field['name'])) . CoreUtil::getIdFieldName($field['entity']);
     return !in_array($idField, $apiParams['groupBy']);
+  }
+
+  /**
+   * @param array $fieldNames
+   *   If multiple field names are given they will be combined in an OR clause
+   * @param mixed $value
+   */
+  protected function applyFilter(array $fieldNames, $value) {
+    // Global setting determines if % wildcard should be added to both sides (default) or only the end of a search string
+    $prefixWithWildcard = \Civi::settings()->get('includeWildCardInName');
+
+    // Based on the first field, decide which clause to add this condition to
+    $fieldName = $fieldNames[0];
+    $field = $this->getField($fieldName);
+    // If field is not found it must be an aggregated column & belongs in the HAVING clause.
+    if (!$field) {
+      $this->_apiParams += ['having' => []];
+      $clause =& $this->_apiParams['having'];
+    }
+    // If field belongs to an EXCLUDE join, it should be added as a join condition
+    else {
+      $prefix = strpos($fieldName, '.') ? explode('.', $fieldName)[0] : NULL;
+      foreach ($this->_apiParams['join'] ?? [] as $idx => $join) {
+        if (($join[1] ?? 'LEFT') === 'EXCLUDE' && (explode(' AS ', $join[0])[1] ?? '') === $prefix) {
+          $clause =& $this->_apiParams['join'][$idx];
+        }
+      }
+    }
+    // Default: add filter to WHERE clause
+    if (!isset($clause)) {
+      $clause =& $this->_apiParams['where'];
+    }
+
+    $filterClauses = [];
+
+    foreach ($fieldNames as $fieldName) {
+      $field = $this->getField($fieldName);
+      $dataType = $field['data_type'] ?? NULL;
+      // Array is either associative `OP => VAL` or sequential `IN (...)`
+      if (is_array($value)) {
+        $value = array_filter($value, [$this, 'hasValue']);
+        // If array does not contain operators as keys, assume array of values
+        if (array_diff_key($value, array_flip(CoreUtil::getOperators()))) {
+          // Use IN for regular fields
+          if (empty($field['serialize'])) {
+            $filterClauses[] = [$fieldName, 'IN', $value];
+          }
+          // Use an OR group of CONTAINS for array fields
+          else {
+            $orGroup = [];
+            foreach ($value as $val) {
+              $orGroup[] = [$fieldName, 'CONTAINS', $val];
+            }
+            $filterClauses[] = ['OR', $orGroup];
+          }
+        }
+        // Operator => Value array
+        else {
+          $andGroup = [];
+          foreach ($value as $operator => $val) {
+            $andGroup[] = [$fieldName, $operator, $val];
+          }
+          $filterClauses[] = ['AND', $andGroup];
+        }
+      }
+      elseif (!empty($field['serialize'])) {
+        $filterClauses[] = [$fieldName, 'CONTAINS', $value];
+      }
+      elseif (!empty($field['options']) || in_array($dataType, ['Integer', 'Boolean', 'Date', 'Timestamp'])) {
+        $filterClauses[] = [$fieldName, '=', $value];
+      }
+      elseif ($prefixWithWildcard) {
+        $filterClauses[] = [$fieldName, 'CONTAINS', $value];
+      }
+      else {
+        $filterClauses[] = [$fieldName, 'LIKE', $value . '%'];
+      }
+    }
+    // Single field
+    if (count($filterClauses) === 1) {
+      $clause[] = $filterClauses[0];
+    }
+    else {
+      $clause[] = ['OR', $filterClauses];
+    }
+  }
+
+  /**
+   * Checks if a filter contains a non-empty value
+   *
+   * "Empty" search values are [], '', and NULL.
+   * Also recursively checks arrays to ensure they contain at least one non-empty value.
+   *
+   * @param $value
+   * @return bool
+   */
+  protected function hasValue($value) {
+    return $value !== '' && $value !== NULL && (!is_array($value) || array_filter($value, [$this, 'hasValue']));
   }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,7 @@
       "bash tools/scripts/composer/net-smtp-fix.sh",
       "bash tools/scripts/composer/pear-mail-fix.sh",
       "bash tools/scripts/composer/phpword-jquery.sh",
+      "bash tools/scripts/composer/select4.sh",
       "bash tools/scripts/composer/guzzle-mockhandler-fix.sh"
     ],
     "post-update-cmd": [
@@ -120,6 +121,7 @@
       "bash tools/scripts/composer/net-smtp-fix.sh",
       "bash tools/scripts/composer/pear-mail-fix.sh",
       "bash tools/scripts/composer/phpword-jquery.sh",
+      "bash tools/scripts/composer/select4.sh",
       "bash tools/scripts/composer/guzzle-mockhandler-fix.sh"
     ]
   },
@@ -267,6 +269,10 @@
       },
       "select2": {
         "url": "https://github.com/colemanw/select2/archive/v3.5-civicrm-1.0.zip"
+      },
+      "select2-4.x": {
+        "url": "https://github.com/select2/select2/archive/4.0.13.zip",
+        "ignore": [".*", "*.log", "*.md", "package.json", "docs", "src", "tests"]
       },
       "js-yaml": {
         "url": "https://github.com/nodeca/js-yaml/archive/3.13.1.zip",

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\SearchDisplay;
 
+use Civi\Api4\Generic\Traits\SavedSearchInspectorTrait;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\Utils\FormattingUtil;
 use Civi\Search\Display;

--- a/js/Common.js
+++ b/js/Common.js
@@ -523,6 +523,30 @@ if (!CRM.vars) CRM.vars = {};
     });
   };
 
+  // Autocomplete based on APIv4 and Select2 v4.
+  $.fn.crmAutocomplete = function(entityName, apiParams, select2Options) {
+    return $(this).each(function() {
+      $(this).select4({
+        ajax: {
+          delay: 250,
+          url: CRM.url('civicrm/ajax/api4/' + entityName + '/autocomplete'),
+          data: function (params) {
+            return {params: JSON.stringify(_.assign({
+              input: params.term,
+              page: params.page || 1
+            }, apiParams))};
+          },
+          processResults: function(data) {
+            return {
+              results: data.values,
+              pagination: {more: data.count > data.countFetched}
+            };
+          }
+        }
+      });
+    });
+  };
+
   /**
    * @see CRM_Core_Form::addEntityRef for docs
    * @param options object

--- a/tools/scripts/composer/select4.sh
+++ b/tools/scripts/composer/select4.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## This renames the 4.x version of Select2 to "select4"
+
+## str_replace in a file
+function str_replace() {
+  php -r 'file_put_contents($argv[1], str_replace($argv[2], $argv[3], file_get_contents($argv[1])));' "$@"
+}
+
+# For some reason CRM_Core_Resources won't add css files with the same name, even from different directories,
+# so rename to avoid conflicts with the v3 select2.css files.
+mv bower_components/select2-4.x/dist/css/select2.css bower_components/select2-4.x/dist/css/select4.css
+mv bower_components/select2-4.x/dist/css/select2.min.css bower_components/select2-4.x/dist/css/select4.min.css
+
+for file in bower_components/select2-4.x/dist/css/*.css ; do
+  str_replace "$file" 'select2' 'select4'
+done
+for file in bower_components/select2-4.x/dist/js/*.js ; do
+  str_replace "$file" 'select2' 'select4'
+done


### PR DESCRIPTION
Overview
----------------------------------------
New Autocomplete widget for selecting APIv4 entities. See https://lab.civicrm.org/dev/core/-/issues/3721

Before
----------------------------------------
Select2 javascript library is v3 (old unsupported version)

After
----------------------------------------
Select2 v3 AND v4 co-exist and can both be used.

Technical Details
----------------------------------------
This adds Select2 v4, allowing us to transition to that version from v3. It's a bit heavy-handed, but we need a transitional path from v3 to v4 of the Select2 library, and as-written the two versions cannot co-exist, due to a naming conflict in javascript as well as numerous naming conflicts with css classes.

This solution renames the library to select4 by replacing every string in the js and the css.

Why you might ask is this necessary? Why can't we just upgrade? The main issue is with the change made in v4 which drops support for `<input>` elements. Most of our markup using Select2 used an `<input>`, and this also affects how the values are stored. v4 multiselects return an array, but v3 `<input>` elements using multiselect return a comma-separated string. This is going to take time to sort out, thus the need for both versions.