### PR TITLE
[REF][PHP8.1] Permit single quotes within html attributes

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -511,7 +511,7 @@ class CRM_Core_Page {
     $attribs = array_merge($standardAttribs, $attribs);
     foreach ($attribs as $attrib => $val) {
       if (strlen($val)) {
-        $val = htmlspecialchars($val);
+        $val = htmlspecialchars($val, ENT_COMPAT);
         $attribString .= " $attrib=\"$val\"";
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
In PHP8.1 the default flags for htmlentities changed 

```
8.1.0	flags changed from ENT_COMPAT to ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401.
```

This meant that now `'` was getting escaped in php8.1 when it wasn't before, this just restores that back for this specific thing

Before
----------------------------------------
Test fails because of the change in Flags

After
----------------------------------------
Tests pass on php8.1

ping @eileenmcnaughton @totten @colemanw @demeritcowboy 