### PR TITLE
[REF][PHP8.1] Apply patch and a wrapper for Guzzle v6 to make it run in php8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
     },
     "psr-4": {
       "Civi\\": [".", "Civi/", "setup/src/"]
-    }
+    },
+    "files": [
+      "guzzle_php81_shim.php"
+    ]
   },
   "include-path": ["vendor/tecnickcom"],
   "config": {
@@ -107,7 +110,8 @@
       "bash tools/scripts/composer/pear-exception-fix.sh",
       "bash tools/scripts/composer/net-smtp-fix.sh",
       "bash tools/scripts/composer/pear-mail-fix.sh",
-      "bash tools/scripts/composer/phpword-jquery.sh"
+      "bash tools/scripts/composer/phpword-jquery.sh",
+      "bash tools/scripts/composer/guzzle-mockhandler-fix.sh"
     ],
     "post-update-cmd": [
       "bash tools/scripts/composer/dompdf-cleanup.sh",
@@ -115,7 +119,8 @@
       "bash tools/scripts/composer/pear-exception-fix.sh",
       "bash tools/scripts/composer/net-smtp-fix.sh",
       "bash tools/scripts/composer/pear-mail-fix.sh",
-      "bash tools/scripts/composer/phpword-jquery.sh"
+      "bash tools/scripts/composer/phpword-jquery.sh",
+      "bash tools/scripts/composer/guzzle-mockhandler-fix.sh"
     ]
   },
   "repositories": {

--- a/composer.json
+++ b/composer.json
@@ -294,6 +294,9 @@
         "Apply patch to ensure that MySQLI reporting remains the same in php8.1": "https://patch-diff.githubusercontent.com/raw/pear/DB/pull/13.patch",
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
+      "pear/log": {
+        "Apply patch for php8.1": "https://patch-diff.githubusercontent.com/raw/pear/Log/pull/23.patch"
+      },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://raw.githubusercontent.com/civicrm/civicrm-core/36319938a5bf26c1e7e2110a26a65db6a5979268/tools/scripts/composer/patches/pear-mail.patch"
       },
@@ -304,8 +307,10 @@
         "Add in CiviCRM custom error message for CRM-8744": "https://raw.githubusercontent.com/civicrm/civicrm-core/a6a0ff13d2a155ad962529595dceaef728116f96/tools/scripts/composer/patches/net-smtp-patch.patch"
       },
       "zetacomponents/mail": {
+        "PHP 8.1 Compatability fixes": "https://patch-diff.githubusercontent.com/raw/zetacomponents/Mail/pull/88.patch",
         "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch",
-        "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch"
+        "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch",
+        "CiviCRM Custom patch to fix a php8.1 issue found in CiviCRM unit tests": "https://raw.githubusercontent.com/civicrm/civicrm-core/5506f4ce5d46799857b4f4ddf34069e7541e9cc5/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch"
       }
     },
     "compile-includes": ["ext/greenwich/composer.compile.json"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3f9eac4e515b2362f8a91da1cef29f1",
+    "content-hash": "07b7e8a8fdf410a6f7f16582e5d8ad95",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -82,7 +82,7 @@ function dm_install_core() {
   done
 
   dm_install_files "$repo" "$to" {agpl-3.0,agpl-3.0.exception,gpl,CONTRIBUTORS}.txt
-  dm_install_files "$repo" "$to" composer.json composer.lock package.json Civi.php README.md release-notes.md extension-compatibility.json
+  dm_install_files "$repo" "$to" composer.json composer.lock package.json Civi.php README.md release-notes.md extension-compatibility.json guzzle_php81_shim.php
 
   mkdir -p "$to/sql"
   pushd "$repo" >> /dev/null

--- a/guzzle_php81_shim.php
+++ b/guzzle_php81_shim.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GuzzleHttp;
+
+if (!function_exists('\GuzzleHttp\http_build_query')) {
+
+  /**
+   * Generates URL-encoded query string.
+   *
+   * This shim exists to make Guzzle 6 PHP 8.1 compatible.
+   *
+   * @link https://php.net/manual/en/function.http-build-query.php
+   *
+   * @param object|array $data
+   *   May be an array or object containing properties.
+   * @param string|null $numeric_prefix
+   *   (optional) If numeric indices are used in the base array and this parameter
+   *   is provided, it will be prepended to the numeric index for elements in
+   *   the base array only.
+   * @param string|null $arg_separator [optional] <p>
+   *   (optional) arg_separator.output is used to separate arguments, unless this
+   *   parameter is specified, and is then used.
+   * @param int $encoding_type
+   *   (optional) By default, PHP_QUERY_RFC1738.
+   *
+   * @return string
+   *   A URL-encoded string.
+   */
+  function http_build_query($data, $numeric_prefix = '', $arg_separator = '&', $encoding_type = \PHP_QUERY_RFC1738) {
+    return \http_build_query($data, is_null($numeric_prefix) ? '' : $numeric_prefix, $arg_separator, $encoding_type);
+  }
+
+}

--- a/tools/scripts/composer/guzzle-mockhandler-fix.sh
+++ b/tools/scripts/composer/guzzle-mockhandler-fix.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## Cleanup the vendor tree. The main issue here is that civi Civi is
+## deployed as a module inside a CMS, so all its source-code gets published.
+## Some libraries distribute admin tools and sample files which should not
+## be published.
+##
+## This script should be idempotent -- if you rerun it several times, it
+## should always produce the same post-condition.
+
+## Replace a line in a file
+## This is a bit like 'sed -i', but dumber and more cross-platform.
+function simple_replace() {
+  php -r 'file_put_contents($argv[1], preg_replace($argv[2], $argv[3], file_get_contents($argv[1])));' "$@"
+}
+
+
+# add in class_exists test as per CRM-8921.
+if ! grep -q ':int' vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php; then
+  simple_replace vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php '/public function count\(\)$/m' 'public function count() :int'
+fi

--- a/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch
+++ b/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch
@@ -1,0 +1,13 @@
+--- src/parser/interfaces/part_parser.php    2022-07-26 20:42:22.585924146 +0000
++++ src/parser/interfaces/part_parser.php    2022-07-26 20:41:55.801553916 +0000
+@@ -171,8 +171,8 @@
+                 // dev/core#940 Ensure that emails are not processed as .unknown attachments by checking
+                 // for Filename or name in the content-disposition and content-type headers.
+                 if ( (ezcMailPartParser::$parseTextAttachmentsAsFiles === true)                   &&
+-                     (preg_match('/\s*filename="?([^;"]*);?/i', $headers['Content-Disposition']) ||
+-                      preg_match( '/\s*name="?([^;"]*);?/i'   , $headers['Content-Type'])        )  )
++                     (preg_match('/\s*filename="?([^;"]*);?/i', $headers['Content-Disposition'] ?? '') ||
++                      preg_match( '/\s*name="?([^;"]*);?/i'   , $headers['Content-Type'] ?? '')        )  )
+                 {
+                     $bodyParser = new ezcMailFileParser( $mainType, $subType, $headers );
+                 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds in 2 things

1. A guzzle shim similar to what Drupal 9 added https://www.drupal.org/project/drupal/issues/3224421 with appropriate safeguarding for D9 installs
2. Adds a fix for 6.x Guzzle in the MockHandler which would only be needed in Guzzle 6.x as it has already been fixed in Guzzle 7.x which is why I am not using the standard composer-patches as we now permit installing of guzzle 7 

Before
----------------------------------------
Guzzle 6 bundled in CiviCRM not compatible with php8.1

After
----------------------------------------
Guzzle 6 bundled in tar balls in CiviCRM compatible with php8.1 at least in what unit tests need

ping @demeritcowboy @eileenmcnaughton @totten @colemanw 

(just a note this PR also include #24019 to help with testing on test boxes)