### PR TITLE
Remove call to `loadRelatedObjects` from `completetransaction`

### DIFF
--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -495,18 +495,6 @@ function civicrm_api3_contribution_completetransaction($params) {
   ];
   $input = array_intersect_key($params, array_fill_keys($passThroughParams, NULL));
 
-  $ids = [];
-  if (!$contribution->loadRelatedObjects(['payment_processor_id' => $input['payment_processor_id'] ?? NULL], $ids, TRUE)) {
-    throw new API_Exception('failed to load related objects');
-  }
-
-  // @todo Copied from _ipn_process_transaction - needs cleanup/refactor
-  $objects = $contribution->_relatedObjects;
-  $objects['contribution'] = &$contribution;
-  $input['component'] = $contribution->_component;
-  $input['is_test'] = $contribution->is_test;
-  $input['amount'] = empty($input['total_amount']) ? $contribution->total_amount : $input['total_amount'];
-
   if (isset($params['is_email_receipt'])) {
     $input['is_email_receipt'] = $params['is_email_receipt'];
   }
@@ -529,8 +517,8 @@ function civicrm_api3_contribution_completetransaction($params) {
     $input['payment_instrument_id'] = $params['payment_instrument_id'];
   }
   return CRM_Contribute_BAO_Contribution::completeOrder($input,
-    !empty($objects['contributionRecur']) ? $objects['contributionRecur']->id : NULL,
-    $objects['contribution']->id ?? NULL,
+    $contribution->contribution_recur_id,
+    $params['id'],
     $params['is_post_payment_create'] ?? NULL);
 }
 

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -476,7 +476,7 @@ function _civicrm_api3_contribution_sendconfirmation_spec(&$params) {
  * @throws \CRM_Core_Exception
  * @throws \Exception
  */
-function civicrm_api3_contribution_completetransaction($params) {
+function civicrm_api3_contribution_completetransaction($params): array {
   $contribution = new CRM_Contribute_BAO_Contribution();
   $contribution->id = $params['id'];
   if (!$contribution->find(TRUE)) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3282,7 +3282,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    *
    * @throws \Exception
    */
-  public function testCompleteTransactionSetStatusToInProgress($dataSet) {
+  public function testCompleteTransactionSetStatusToInProgress(array $dataSet): void {
     $paymentProcessorID = $this->paymentProcessorCreate();
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
       'contact_id' => $this->_individualId,
@@ -3304,7 +3304,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       ])
     );
     $this->callAPISuccess('Contribution', 'completetransaction', [
-      'id' => $contribution,
+      'id' => $contribution['id'],
       'receive_date' => $dataSet['receive_date'],
     ]);
     $contributionRecur = $this->callAPISuccessGetSingle('ContributionRecur', [


### PR DESCRIPTION
Overview
----------------------------------------
Remove call to `loadRelatedObjects` from `completetransaction`

Before
----------------------------------------
Legacy cruft call `loadRelatedObjects`  sometimes causes notices

After
----------------------------------------
poof

Technical Details
----------------------------------------
This call is has been removed from the other places (Paypal & Authorize.net) that call `completeOrder`. The values it loads are no longer passed in/ used

The only one that is a bit confusing is `amount` - this is actually a copy & paste legacy from when the coede was shared with `repeattransaction` which DOES accept `amount` as an input. `completeOrder`, however, does not allow amount to be changed.

Comments
----------------------------------------
@mattwire - I fixed up some tests to have better data but now they are hitting the e-notice so it feels like a good time to finally rip out this bit of code - the last round (or the one before) of cleanup in `completeOrder` made it obsolete