### PR TITLE
APIv4 export action: find DAO by ID instead of just calling the constructor and setting the ID

### DIFF
--- a/Civi/Api4/Generic/ExportAction.php
+++ b/Civi/Api4/Generic/ExportAction.php
@@ -159,8 +159,7 @@ class ExportAction extends AbstractAction {
     $daoName = CoreUtil::getInfoItem($entityType, 'dao');
     if ($daoName) {
       /** @var \CRM_Core_DAO $dao */
-      $dao = new $daoName();
-      $dao->id = $entityId;
+      $dao = $daoName::findById($entityId);
       // Collect references into arrays keyed by entity type
       $references = [];
       foreach ($dao->findReferences() as $reference) {


### PR DESCRIPTION
Overview
----------------------------------------
Find DAO by ID instead of just calling the constructor and setting the ID. Otherwise, finding references might fail because of missing entity values when comparing, e.g. `option_group_id` for OptionVaue BAOs.

Before
----------------------------------------
Running e.g. `OptionGroup.export` might not work when finding references to option values, because comparing `option_group_id` will evaluate to `null == null` here:
https://github.com/civicrm/civicrm-core/blob/c75c0f2e7fcf06b5eb47664e75641121e361a6cf/CRM/Core/Reference/OptionValue.php#L43-L45

After
----------------------------------------
Comparison with BAO properties will be correct with the BAO being loaded via `\CRM_Core_DAO::findById()` instead of just calling the constructor and setting the BAO ID.

Technical Details
----------------------------------------
I'm not sure what might cause that `null == null` comparison in the first place, in my case it was comparing two unrelated option values that had both `option_group_id` not set.