### PR TITLE
[NFC] Resolve phpunit warning about using assertContains on strings

### DIFF
--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -188,7 +188,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       $this->fail('validation error expected.');
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertContains('Required parameter missing: Status', $e->getMessage());
+      $this->assertStringContainsString('Required parameter missing: Status', $e->getMessage());
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This resolves the following warning in phpunit runs

``` 
Warning Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
```

Before
----------------------------------------
Warning is shown in phpunit runs

After
----------------------------------------
No warning

ping @eileenmcnaughton @colemanw @totten @demeritcowboy 