### PR TITLE
[REF][PHP8.1] Do not set auto_detect_line_endings to true on php vers…

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -597,7 +597,9 @@ if (!defined('CIVICRM_CLEANURL')) {
 }
 
 // force PHP to auto-detect Mac line endings
-ini_set('auto_detect_line_endings', '1');
+if (version_compare(PHP_VERSION, '8.1') < 0) {
+  ini_set('auto_detect_line_endings', '1');
+}
 
 // make sure the memory_limit is at least 64 MB
 $memLimitString = trim(ini_get('memory_limit'));


### PR DESCRIPTION
…ions 8.1 and later as it is deprecated

Overview
----------------------------------------
title says it all see also https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated

Before
----------------------------------------
Deprecation triggered

After
----------------------------------------
Deprecation not triggered for this item

ping @demeritcowboy @eileenmcnaughton @totten @colemanw 