### PR TITLE
Fix regex on windows

### DIFF
--- a/tools/scripts/composer/guzzle-mockhandler-fix.sh
+++ b/tools/scripts/composer/guzzle-mockhandler-fix.sh
@@ -15,7 +15,7 @@ function simple_replace() {
 }
 
 
-# add in class_exists test as per CRM-8921.
+# php 8.1 compatibility
 if ! grep -q ':int' vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php; then
-  simple_replace vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php '/public function count\(\)$/m' 'public function count() :int'
+  simple_replace vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php '#public function count\(\)$#m' 'public function count(): int'
 fi


### PR DESCRIPTION
Overview
----------------------------------------
Fix regex 

Before
----------------------------------------
$argv[2] has "C:/path/to/git" prepended to it. Resulting patched file is an empty file.

After
----------------------------------------
Better

Technical Details
----------------------------------------
I dunno I guess in this context as an argument to a script it does argument expansion and preprocesses the `/` and thinks it's a file path and so converts it to an absolute file path? It might even be doing that on unix but happens to work out because the absolute path would be the same?

Comments
----------------------------------------
@seamuslee001 

Since this is a vendor package, should it be one of those patches that only lives in cyberspace instead?
