### PR TITLE
Fix grep in guzzle mock patch

### DIFF
--- a/tools/scripts/composer/guzzle-mockhandler-fix.sh
+++ b/tools/scripts/composer/guzzle-mockhandler-fix.sh
@@ -16,6 +16,6 @@ function simple_replace() {
 
 
 # php 8.1 compatibility
-if ! grep -q ':int' vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php; then
+if ! grep -q ': int' vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php; then
   simple_replace vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php '#public function count\(\)$#m' 'public function count(): int'
 fi


### PR DESCRIPTION
Overview
----------------------------------------
I fixed one thing in https://github.com/civicrm/civicrm-core/pull/24094 but then inadvertently broke the grep.