### PR TITLE
dev/core#3766 Keep league/csv on 9.6 for D9 as well so patches can apply

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "pear/log": "1.13.3",
     "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^3.0",
-    "league/csv": "^9.6",
+    "league/csv": "~9.6.2",
     "league/oauth2-client": "^2.4",
     "league/oauth2-google": "^3.0",
     "tplaner/when": "~3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13a9932b926aa601a4f3ac3e39f9a7bf",
+    "content-hash": "8981b1591f0efc0eea2f42da02760495",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
@demeritcowboy as you suggested on the ticket I think this will do what we want 

Before
----------------------------------------
9.7.x installed on d9 and causes notices because patches are already applied upstream

After
----------------------------------------
9.6.x installed on d9 and patches apply cleanly

ping @demeritcowboy 