### PR TITLE
APIv4 - Improve pseudoconstant support in getFields

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -22,6 +22,108 @@ namespace Civi\Api4;
 class Entity extends Generic\AbstractEntity {
 
   /**
+   * @var array[]
+   */
+  public static $entityFields = [
+    [
+      'name' => 'name',
+      'description' => 'Entity name',
+    ],
+    [
+      'name' => 'title',
+      'description' => 'Localized title (singular)',
+    ],
+    [
+      'name' => 'title_plural',
+      'description' => 'Localized title (plural)',
+    ],
+    [
+      'name' => 'type',
+      'data_type' => 'Array',
+      'description' => 'Base class for this entity',
+      'pseudoconstant' => ['callback' => ['Civi\Api4\Utils\CoreUtil', 'getEntityTypes']],
+    ],
+    [
+      'name' => 'description',
+      'description' => 'Description from docblock',
+    ],
+    [
+      'name' => 'comment',
+      'description' => 'Comments from docblock',
+    ],
+    [
+      'name' => 'icon',
+      'description' => 'crm-i icon class associated with this entity',
+    ],
+    [
+      'name' => 'dao',
+      'description' => 'Class name for dao-based entities',
+    ],
+    [
+      'name' => 'table_name',
+      'description' => 'Name of sql table, if applicable',
+    ],
+    [
+      'name' => 'primary_key',
+      'data_type' => 'Array',
+      'description' => 'Name of unique identifier field(s) (e.g. [id])',
+    ],
+    [
+      'name' => 'label_field',
+      'description' => 'Field to show when displaying a record',
+    ],
+    [
+      'name' => 'order_by',
+      'description' => 'Default column to sort results',
+    ],
+    [
+      'name' => 'searchable',
+      'description' => 'How should this entity be presented in search UIs',
+      'pseudoconstant' => ['callback' => ['Civi\Api4\Utils\CoreUtil', 'getSearchableOptions']],
+    ],
+    [
+      'name' => 'paths',
+      'data_type' => 'Array',
+      'description' => 'System paths for accessing this entity',
+    ],
+    [
+      'name' => 'see',
+      'data_type' => 'Array',
+      'description' => 'Any @see annotations from docblock',
+    ],
+    [
+      'name' => 'since',
+      'data_type' => 'String',
+      'description' => 'Version this API entity was added',
+    ],
+    [
+      'name' => 'class',
+      'data_type' => 'String',
+      'description' => 'PHP class name',
+    ],
+    [
+      'name' => 'class_args',
+      'data_type' => 'Array',
+      'description' => 'Arguments needed by php action factory functions (used when multiple entities share a class, e.g. CustomValue).',
+    ],
+    [
+      'name' => 'bridge',
+      'data_type' => 'Array',
+      'description' => 'Connecting fields for EntityBridge types',
+    ],
+    [
+      'name' => 'ui_join_filters',
+      'data_type' => 'Array',
+      'description' => 'When joining entities in the UI, which fields should be presented by default in the ON clause',
+    ],
+    [
+      'name' => 'group_weights_by',
+      'data_type' => 'Array',
+      'description' => 'For sortable entities, what field groupings are used to order by weight',
+    ],
+  ];
+
+  /**
    * @param bool $checkPermissions
    * @return Action\Entity\Get
    */
@@ -36,109 +138,7 @@ class Entity extends Generic\AbstractEntity {
    */
   public static function getFields($checkPermissions = TRUE) {
     return (new Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function(Generic\BasicGetFieldsAction $getFields) {
-      return [
-        [
-          'name' => 'name',
-          'description' => 'Entity name',
-        ],
-        [
-          'name' => 'title',
-          'description' => 'Localized title (singular)',
-        ],
-        [
-          'name' => 'title_plural',
-          'description' => 'Localized title (plural)',
-        ],
-        [
-          'name' => 'type',
-          'data_type' => 'Array',
-          'description' => 'Base class for this entity',
-          'options' => $getFields->getLoadOptions() ? self::getEntityTypes() : TRUE,
-        ],
-        [
-          'name' => 'description',
-          'description' => 'Description from docblock',
-        ],
-        [
-          'name' => 'comment',
-          'description' => 'Comments from docblock',
-        ],
-        [
-          'name' => 'icon',
-          'description' => 'crm-i icon class associated with this entity',
-        ],
-        [
-          'name' => 'dao',
-          'description' => 'Class name for dao-based entities',
-        ],
-        [
-          'name' => 'table_name',
-          'description' => 'Name of sql table, if applicable',
-        ],
-        [
-          'name' => 'primary_key',
-          'data_type' => 'Array',
-          'description' => 'Name of unique identifier field(s) (e.g. [id])',
-        ],
-        [
-          'name' => 'label_field',
-          'description' => 'Field to show when displaying a record',
-        ],
-        [
-          'name' => 'order_by',
-          'description' => 'Default column to sort results',
-        ],
-        [
-          'name' => 'searchable',
-          'description' => 'How should this entity be presented in search UIs',
-          'options' => [
-            'primary' => ts('Primary'),
-            'secondary' => ts('Secondary'),
-            'bridge' => ts('Bridge'),
-            'none' => ts('None'),
-          ],
-        ],
-        [
-          'name' => 'paths',
-          'data_type' => 'Array',
-          'description' => 'System paths for accessing this entity',
-        ],
-        [
-          'name' => 'see',
-          'data_type' => 'Array',
-          'description' => 'Any @see annotations from docblock',
-        ],
-        [
-          'name' => 'since',
-          'data_type' => 'String',
-          'description' => 'Version this API entity was added',
-        ],
-        [
-          'name' => 'class',
-          'data_type' => 'String',
-          'description' => 'PHP class name',
-        ],
-        [
-          'name' => 'class_args',
-          'data_type' => 'Array',
-          'description' => 'Arguments needed by php action factory functions (used when multiple entities share a class, e.g. CustomValue).',
-        ],
-        [
-          'name' => 'bridge',
-          'data_type' => 'Array',
-          'description' => 'Connecting fields for EntityBridge types',
-        ],
-        [
-          'name' => 'ui_join_filters',
-          'data_type' => 'Array',
-          'description' => 'When joining entities in the UI, which fields should be presented by default in the ON clause',
-        ],
-        [
-          'name' => 'group_weights_by',
-          'data_type' => 'Array',
-          'description' => 'For sortable entities, what field groupings are used to order by weight',
-        ],
-      ];
+      return Entity::$entityFields;
     }))->setCheckPermissions($checkPermissions);
   }
 
@@ -159,22 +159,6 @@ class Entity extends Generic\AbstractEntity {
     return [
       'default' => ['access CiviCRM'],
     ];
-  }
-
-  /**
-   * Collect the 'type' values from every entity.
-   *
-   * @return array
-   */
-  private static function getEntityTypes() {
-    $provider = \Civi::service('action_object_provider');
-    $entityTypes = [];
-    foreach ($provider->getEntities() as $entity) {
-      foreach ($entity['type'] ?? [] as $type) {
-        $entityTypes[$type] = $type;
-      }
-    }
-    return $entityTypes;
   }
 
 }

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -158,19 +158,30 @@ abstract class AbstractEntity {
     foreach (ReflectionUtils::getTraits(static::class) as $trait) {
       $info['type'][] = self::stripNamespace($trait);
     }
+    // Get DocBlock from APIv4 Entity class
     $reflection = new \ReflectionClass(static::class);
-    $info = array_merge($info, ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]));
+    $docBlock = ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]);
+    // Convert docblock keys to snake_case
+    foreach ($docBlock as $key => $val) {
+      $docBlock[\CRM_Utils_String::convertStringToSnakeCase($key)] = $val;
+    }
+    // Filter docblock to only declared entity fields
+    foreach (\Civi\Api4\Entity::$entityFields as $field) {
+      if (isset($docBlock[$field['name']])) {
+        $val = $docBlock[$field['name']];
+        // Convert to array if data_type == Array
+        if (isset($field['data_type']) && $field['data_type'] === 'Array' && is_string($val)) {
+          $val = \CRM_Core_DAO::unSerializeField($val, \CRM_Core_DAO::SERIALIZE_COMMA);
+        }
+        $info[$field['name']] = $val;
+      }
+    }
+
     if ($dao) {
       $info['description'] = $dao::getEntityDescription() ?? $info['description'] ?? NULL;
     }
-    unset($info['package'], $info['method']);
 
-    // Ensure all keys are snake_case
-    $keys = array_keys($info);
-    foreach ($keys as &$key) {
-      $key = \CRM_Utils_String::convertStringToSnakeCase($key);
-    }
-    return array_combine($keys, array_values($info));
+    return $info;
   }
 
   /**

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -336,7 +336,6 @@ trait DAOActionTrait {
     if (!isset($record[$weightField]) && !empty($record[$idField])) {
       return;
     }
-    $daoFields = $daoName::getSupportedFields();
     $newWeight = $record[$weightField] ?? NULL;
     $oldWeight = empty($record[$idField]) ? NULL : \CRM_Core_DAO::getFieldValue($daoName, $record[$idField], $weightField);
 

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -49,7 +49,7 @@ class SpecFormatter {
         $field->setOptionsCallback([__CLASS__, 'getOptions']);
         $suffixes = ['label'];
         if (!empty($data['option_group_id'])) {
-          $suffixes = self::getOptionValueFields($data['option_group_id'], 'id');
+          $suffixes = CoreUtil::getOptionValueFields($data['option_group_id'], 'id');
         }
         $field->setSuffixes($suffixes);
       }
@@ -78,7 +78,7 @@ class SpecFormatter {
           }
         }
         if (!empty($data['pseudoconstant']['optionGroupName'])) {
-          $suffixes = self::getOptionValueFields($data['pseudoconstant']['optionGroupName'], 'name');
+          $suffixes = CoreUtil::getOptionValueFields($data['pseudoconstant']['optionGroupName'], 'name');
         }
         $field->setSuffixes($suffixes);
       }
@@ -97,26 +97,6 @@ class SpecFormatter {
     }
 
     return $field;
-  }
-
-  /**
-   * Get the suffixes supported by this option group
-   *
-   * @param string|int $optionGroup
-   *   OptionGroup id or name
-   * @param string $key
-   *   Is $optionGroup being passed as "id" or "name"
-   * @return array
-   */
-  private static function getOptionValueFields($optionGroup, $key) {
-    // Prevent crash during upgrade
-    if (array_key_exists('option_value_fields', \CRM_Core_DAO_OptionGroup::getSupportedFields())) {
-      $fields = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionGroup, 'option_value_fields', $key);
-    }
-    if (!isset($fields)) {
-      return ['name', 'label', 'description'];
-    }
-    return explode(',', $fields);
   }
 
   /**

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -259,4 +259,52 @@ class CoreUtil {
     return $dao->getReferenceCounts();
   }
 
+  /**
+   * @return array
+   */
+  public static function getSearchableOptions(): array {
+    return [
+      'primary' => ts('Primary'),
+      'secondary' => ts('Secondary'),
+      'bridge' => ts('Bridge'),
+      'none' => ts('None'),
+    ];
+  }
+
+  /**
+   * Collect the 'type' values from every entity.
+   *
+   * @return array
+   */
+  public static function getEntityTypes(): array {
+    $provider = \Civi::service('action_object_provider');
+    $entityTypes = [];
+    foreach ($provider->getEntities() as $entity) {
+      foreach ($entity['type'] ?? [] as $type) {
+        $entityTypes[$type] = $type;
+      }
+    }
+    return $entityTypes;
+  }
+
+  /**
+   * Get the suffixes supported by a given option group
+   *
+   * @param string|int $optionGroup
+   *   OptionGroup id or name
+   * @param string $key
+   *   Is $optionGroup being passed as "id" or "name"
+   * @return array
+   */
+  public static function getOptionValueFields($optionGroup, $key = 'name'): array {
+    // Prevent crash during upgrade
+    if (array_key_exists('option_value_fields', \CRM_Core_DAO_OptionGroup::getSupportedFields())) {
+      $fields = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionGroup, 'option_value_fields', $key);
+    }
+    if (!isset($fields)) {
+      return ['name', 'label', 'description'];
+    }
+    return explode(',', $fields);
+  }
+
 }

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -88,7 +88,7 @@ class ReflectionUtils {
         elseif ($key == 'return') {
           $info['return'] = explode('|', $words[0]);
         }
-        elseif ($key == 'options' || $key == 'ui_join_filters' || $key == 'groupWeightsBy') {
+        elseif ($key == 'options') {
           $val = str_replace(', ', ',', implode(' ', $words));
           $info[$key] = explode(',', $val);
         }

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -123,8 +123,7 @@ class Afform extends Generic\AbstractEntity {
         ],
         [
           'name' => 'type',
-          'options' => $self->pseudoconstantOptions('afform_type'),
-          'suffixes' => ['id', 'name', 'label', 'icon'],
+          'pseudoconstant' => ['optionGroupName' => 'afform_type'],
         ],
         [
           'name' => 'requires',
@@ -225,7 +224,7 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'String',
           'description' => 'Name of extension which provides this form',
           'readonly' => TRUE,
-          'options' => $self->getLoadOptions() ? \CRM_Core_PseudoConstant::getExtensions() : TRUE,
+          'pseudoconstant' => ['callback' => ['CRM_Core_PseudoConstant', 'getExtensions']],
         ];
         $fields[] = [
           'name' => 'search_displays',

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetFieldsTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetFieldsTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Civi\Afform;
+
+use Civi\Api4\Afform;
+use Civi\Test\HeadlessInterface;
+
+/**
+ * @group headless
+ */
+class AfformGetFieldsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+  }
+
+  public function testGetFields() {
+    $fields = Afform::getFields(FALSE)
+      ->setAction('get')
+      ->execute()->indexBy('name');
+    $this->assertTrue($fields['type']['options']);
+    $this->assertEquals(['name', 'label', 'icon', 'description'], $fields['type']['suffixes']);
+
+    $this->assertTrue($fields['base_module']['options']);
+    $this->assertTrue($fields['contact_summary']['options']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Makes APIv4 smarter about automatically loading option lists for `getFields`

Before
----------------------------------------
A custom getFields function always had to deal with loading its own options.

After
----------------------------------------
This allows APIv4 getFields arrays to specify a pseudoconstant key which is automatically transformed into an array of options in the right format.
