### PR TITLE
Add upgrade for contribution offline receipt

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -342,6 +342,14 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'payment_or_refund_notification', 'type' => 'text'],
         ],
       ],
+      [
+        'version' => '5.53.alpha1',
+        'upgrade_descriptor' => ts('Update to new smarty variables for line items, tax'),
+        'templates' => [
+          ['name' => 'contribution_offline_receipt', 'type' => 'text'],
+          ['name' => 'contribution_offline_receipt', 'type' => 'html'],
+        ],
+      ],
     ];
   }
 
@@ -350,7 +358,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
    *
    * @return array
    */
-  public function getTemplatesToUpdate() {
+  public function getTemplatesToUpdate(): array {
     $templates = $this->getTemplateUpdates();
     $return = [];
     foreach ($templates as $templateArray) {


### PR DESCRIPTION
Overview
----------------------------------------
Add upgrade for contribution offline receipt

Before
----------------------------------------
There are a few updated in the receipts that we have not push-upgraded but the updates to the contribution offline receipts are now fairly material with new preferred smarty variables

`$lineItems`
`$taxRateBreakdown`
`$isShowTax`

After
----------------------------------------
Default message templates updates, users will see message to update their templates

Technical Details
----------------------------------------
I've added a little bit over at https://docs.civicrm.org/user/en/latest/email/message-templates/#variables-and-tokens-in-workflow-message-templates - I could add it to the upgrade message maybe

Comments
----------------------------------------
@demeritcowboy 