### PR TITLE
dev/core#3681 Add token for CiviCRM empowered by image

### DIFF
--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -58,6 +58,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       'now' => ts('Current time/date'),
       'base_url' => ts('Domain absolute base url'),
       'tax_term' => ts('Sales tax term (e.g VAT)'),
+      'empowered_by_civicrm_image_url' => ts('Empowered By CiviCRM Image'),
     ];
   }
 
@@ -127,6 +128,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
       $tokens['phone'] = $phone['phone'] ?? '';
       $tokens['email'] = $email['email'] ?? '';
       $tokens['base_url'] = Civi::paths()->getVariable('cms.root', 'url');
+      $tokens['empowered_by_civicrm_image_url'] = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'i/civi99.png';
       $tokens['tax_term'] = (string) Civi::settings()->get('tax_term');
       Civi::cache('metadata')->set($cacheKey, $tokens);
     }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -808,6 +808,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{domain.postal_code}' => 'Domain (Organization) Postal Code',
       '{domain.state_province_id:label}' => 'Domain (Organization) State',
       '{domain.country_id:label}' => 'Domain (Organization) Country',
+      '{domain.empowered_by_civicrm_image_url}' => 'Empowered By CiviCRM Image',
     ];
   }
 

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -9,7 +9,7 @@
     {if $config->empoweredBy}
       <table style="margin-top:5px;padding-bottom:50px;" cellpadding="5" cellspacing="0">
         <tr>
-          <td><img src="{$resourceBase}/i/civi99.png" height="34px" width="99px"></td>
+          <td><img src="{domain.empowered_by_civicrm_image_url}" height="34px" width="99px"></td>
         </tr>
       </table>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Add token for CiviCRM empowered by image

(Beware - may require cache clearing)

Before
----------------------------------------
The code used to add the empowered by CiviCRM image is broken in preview

![image](https://user-images.githubusercontent.com/336308/182045632-5cdbb2f5-a720-4cd7-bbf1-14a0e0ddf92a.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/182045114-7aed6707-ec3b-44b2-be2c-d29a2e9cd93c.png)


Technical Details
----------------------------------------
I have not included any template updates to update the sql on install or upgrade as I imagine this might require some finessing & test updates & that can be done once this is merged

Comments
----------------------------------------
I did propose removing the image from the template but I think there was soft support for keeping it so going with tokenising