### PR TITLE
Invoice template - switch from dataArray to taxBreakdown

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -105,20 +105,13 @@
                 <td style="text-align:right;"><font size="1">{ts}Sub Total{/ts}</font></td>
                 <td style="text-align:right;"><font size="1">{$subTotal|crmMoney:$currency}</font></td>
               </tr>
-              {if !empty($dataArray)}
-              {foreach from=$dataArray item=value key=priceset}
+              {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
                 <tr>
                   <td colspan="3"></td>
-                    {if $priceset}
-                      <td style="text-align:right;white-space: nowrap"><font size="1">{if $taxTerm}{ts 1=$taxTerm 2=$priceset}TOTAL %1 %2%{/ts}{/if}</font></td>
-                      <td style="text-align:right"><font size="1" align="right">{$value|crmMoney:$currency}</font> </td>
-                    {elseif $priceset == 0}
-                      <td style="text-align:right;white-space: nowrap"><font size="1">{if $taxTerm}{ts 1=$taxTerm}TOTAL %1{/ts}{/if}</font></td>
-                      <td style="text-align:right"><font size="1" align="right">{$value|crmMoney:$currency}</font> </td>
-                    {/if}
+                  <td style="text-align:right;white-space: nowrap"><font size="1">{if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if}</td>
+                  <td style="text-align:right"><font size="1" align="right">{$taxDetail.amount|crmMoney:'{contribution.currency}'}</td>
                 </tr>
               {/foreach}
-              {/if}
               <tr>
                 <td colspan="3"></td>
                 <td style="text-align:right;white-space: nowrap"><b><font size="1">{ts 1=$currency}TOTAL %1{/ts}</font></b></td>


### PR DESCRIPTION
Overview
----------------------------------------
This switches the template from using the weird `$dataArray` to the `$taxBreakdown` variable

![image](https://user-images.githubusercontent.com/336308/182046242-f2aa8785-add6-4844-96bd-92ab1d1e66a5.png)


Before
----------------------------------------
Does not show in preview, `$dataArray` makes no sense

After
----------------------------------------
The now-documented `$taxBreakdown` variable is used & the line about Sales Tax now shows in the preview (others not yet fixed for preview in this template)

https://docs.civicrm.org/user/en/latest/email/message-templates/#variables-and-tokens-in-workflow-message-templates

![image](https://user-images.githubusercontent.com/336308/182045866-dd49ecd3-d21f-40c7-a14e-dfd4f662eb2e.png)


Technical Details
----------------------------------------
No update to sql in this one yet - requires manual update - is conflicty

Comments
----------------------------------------
Looking to remove this specific array in the other templates too.