### PR TITLE
Remove extraneous closing tags

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -157,9 +157,6 @@
                 </tr>
               {/if}
             </table>
-          </td>
-        </tr>
-      </table>
 
       {if '{contribution.contribution_status_id:name}' == 'Pending' && '{contribution.is_pay_later}' == 1}
         <table style="margin-top:5px;" width="100%" border="0" cellpadding="0" cellspacing="0">


### PR DESCRIPTION
Overview
----------------------------------------
Remove extraneous closing tags

Before
----------------------------------------
The invoice message template has some extra closing tags

![image](https://user-images.githubusercontent.com/336308/182084686-601173a6-256d-49b1-8093-0346cf5a3b2e.png)

I output the full html of the invoice and confirmed the tags are extraneous in the generated content


After
----------------------------------------
poof

Technical Details
----------------------------------------
I was going to fix the indentation but then found there were extra tags....

Comments
----------------------------------------
