### PR TITLE
membership tokens don't always work

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -641,6 +641,7 @@ FROM civicrm_action_schedule cas
       'actionSchedule' => $schedule,
       'actionMapping' => $mapping,
       'smarty' => TRUE,
+      'schema' => ['contactId'],
     ]);
     $tp->addMessage('body_text', $schedule->body_text, 'text/plain');
     $tp->addMessage('body_html', $schedule->body_html, 'text/html');


### PR DESCRIPTION


Overview
----------------------------------------
See Discussion at https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/issues/52

Before
----------------------------------------
Tokens will work when sending an email directly to a contact but not via scheduled reminders.

After
----------------------------------------
Tokens work as expected in scheduled reminders


Comments
----------------------------------------
See discussion at https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/issues/52  and specifically https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/issues/52#issuecomment-1198375913