### PR TITLE
APIv4 - Add generic `setLanguage`, to all APIs

### DIFF
--- a/CRM/Core/BAO/TranslateGetWrapper.php
+++ b/CRM/Core/BAO/TranslateGetWrapper.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Wrapper to swap in translated text.
+ */
+class CRM_Core_BAO_TranslateGetWrapper {
+
+  protected $fields;
+  protected $translatedLanguage;
+
+  /**
+   * CRM_Core_BAO_TranslateGetWrapper constructor.
+   *
+   * This wrapper replaces values with configured translated values, if any exist.
+   *
+   * @param array $translated
+   */
+  public function __construct($translated) {
+    $this->fields = $translated['fields'];
+    $this->translatedLanguage = $translated['language'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function fromApiInput($apiRequest) {
+    return $apiRequest;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function toApiOutput($apiRequest, $result) {
+    foreach ($result as &$value) {
+      if (!isset($value['id'], $this->fields[$value['id']])) {
+        continue;
+      }
+      $toSet = array_intersect_key($this->fields[$value['id']], $value);
+      $value = array_merge($value, $toSet);
+      $value['actual_language'] = $this->translatedLanguage;
+    }
+    return $result;
+  }
+
+}

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -32,6 +32,8 @@ use Civi\Api4\Utils\ReflectionUtils;
  * @method bool getDebug()
  * @method $this setChain(array $chain)
  * @method array getChain()
+ * @method $this setLanguage(string|null $language)
+ * @method string|null getLanguage()
  */
 abstract class AbstractAction implements \ArrayAccess {
 
@@ -43,6 +45,18 @@ abstract class AbstractAction implements \ArrayAccess {
    * @var int
    */
   protected $version = 4;
+
+  /**
+   * Language (optional).
+   *
+   * If set then listeners such as the Translation subsystem may alter
+   * the output.
+   *
+   * @var string
+   *
+   * @optionsCallback getPreferredLanguageOptions
+   */
+  protected $language;
 
   /**
    * Additional api requests - will be called once per result.
@@ -562,6 +576,17 @@ abstract class AbstractAction implements \ArrayAccess {
         $this->_debugOutput['callback'] = get_class($callable);
       }
     }
+  }
+
+  /**
+   * Get available preferred languages.
+   *
+   * @return array
+   */
+  protected function getPreferredLanguageOptions(): array {
+    $languages = \CRM_Contact_BAO_Contact::buildOptions('preferred_language');
+    ksort($languages);
+    return array_keys($languages);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This updates the api contract to support `setLanguage` eg.

```
    $messageTemplate = MessageTemplate::get()
      ->addWhere('is_default', '=', 1)
      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
      ->setLanguage('ca_FR')
      ->execute()->indexBy('workflow_name');
```

At a generic level this provides a way for an api consumer to specify where there is a language preference. A language preference does not mean that something usable by that language will be available - but it allows listeners, including the core `Translation` BAO to provide them.

If the language preference alters the api behaviour then the record should have `actual_language` set on it.

The language preferrence can be implemented by any hook - however, core core will implement the translation model for any entity/field combos which have been marked as `translatedFields`. For these fields (only MessageTemplate fields in core) the `Translation` BAO will add in the message template fields for `msg_subject,  msg_html and msg_text` if translations exist.

This results in a return like the image below, where the first template has no translation and the second has one

![image](https://user-images.githubusercontent.com/336308/182257154-883c43b7-1dac-42e9-af36-5bb67ea7d0a5.png)

Split off from https://github.com/civicrm/civicrm-core/pull/23844

Before
----------------------------------------
No way to invoke the `Translation` retrieval from core

After
----------------------------------------
`setPreferredLanguage` can be set on any api action This indicates that where possible that language should be used, allowing for both custom hooks and for core code to retrieve any existing translations.


In the core `BAO_Translation` code any translated fields will be swapped out with one in the preferred language, or a variant (eg. French will returned if French Canadian is preferred but only a French translation is available). If a substitution is retrieved then the `actual_language` property will be added to the return result


Technical Details
----------------------------------------
Note that the `BAO_Translation` code only kicks in when a field is defined as translatable using the `translateFields` hook - per 
https://github.com/civicrm/civicrm-core/pull/24063 - this hook will be defined in core for ONLY the message template fields (as core will render these for sending languages) - any other fields would need to be defined in an extension, or a new discussion started

Comments
----------------------------------------
Coleman's input was
![image](https://user-images.githubusercontent.com/336308/182256629-66a258ca-7357-4b58-8e13-50c794c9a192.png)

However - I used `actual_language` rather than just `language` which is already used in at least one table (erm the translation table)
