### PR TITLE
Add `paid_amount `, `balance_amount`, `tax_exclusive_amount` available to apiv4

### DIFF
--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -401,6 +401,8 @@ WHERE ceft.entity_id = %1";
    * @param int $contributionID
    * @param bool $includeRefund
    *
+   * @deprecated use Apiv4.
+   *
    * @return float
    */
   public static function getTotalPayments($contributionID, $includeRefund = FALSE): float {

--- a/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+class ContributionGetSpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    // Amount paid field
+    if (!$spec->getValue('paid_amount')) {
+      $field = new FieldSpec('paid_amount', 'Contribution', 'Float');
+      $field->setLabel(ts('Amount Paid'))
+        ->setTitle(ts('Amount Paid'))
+        ->setDescription(ts('Amount paid'))
+        ->setType('Extra')
+        ->setDataType('Money')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'calculateAmountPaid']);
+      $spec->addFieldSpec($field);
+    }
+    if (!$spec->getValue('balance_amount')) {
+      $field = new FieldSpec('balance_amount', 'Contribution', 'Float');
+      $field->setLabel(ts('Balance'))
+        ->setTitle(ts('Balance'))
+        ->setDescription(ts('Balance'))
+        ->setType('Extra')
+        ->setDataType('Money')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'calculateBalance']);
+      $spec->addFieldSpec($field);
+    }
+    if (!$spec->getValue('tax_exclusive_amount')) {
+      $field = new FieldSpec('tax_exclusive_amount', 'Contribution', 'Float');
+      $field->setLabel(ts('Tax Exclusive Amount'))
+        ->setTitle(ts('Tax Exclusive Amount'))
+        ->setDescription(ts('Tax Exclusive Amount'))
+        ->setType('Extra')
+        ->setDataType('Money')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'calculateTaxExclusiveAmount']);
+      $spec->addFieldSpec($field);
+    }
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'Contribution' && $action === 'get';
+  }
+
+  /**
+   * Generate SQL for amount_paid field
+   *
+   * @return string
+   */
+  public static function calculateTaxExclusiveAmount(): string {
+    return 'COALESCE(a.total_amount, 0) - COALESCE(a.tax_amount, 0)';
+  }
+
+  /**
+   * Generate SQL for amount_paid field
+   *
+   * @return string
+   */
+  public static function calculateAmountPaid(): string {
+    $statusIDs = [
+      \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded'),
+    ];
+
+    return "COALESCE((SELECT SUM(ft.total_amount) FROM civicrm_financial_trxn ft
+      INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
+      WHERE eft.entity_id = a.id AND ft.is_payment = 1 AND ft.status_id IN (" . implode(',', $statusIDs) . ')), 0)';
+  }
+
+  /**
+   * Generate SQL for age field
+   *
+   * @return string
+   */
+  public static function calculateBalance(): string {
+    $statusIDs = [
+      \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded'),
+    ];
+
+    return "a.total_amount - COALESCE((SELECT SUM(ft.total_amount) FROM civicrm_financial_trxn ft
+      INNER JOIN civicrm_entity_financial_trxn eft ON (eft.financial_trxn_id = ft.id AND eft.entity_table = 'civicrm_contribution')
+      WHERE eft.entity_id = a.id AND ft.is_payment = 1 AND ft.status_id IN (" . implode(',', $statusIDs) . ')), 0)';
+  }
+
+}

--- a/Civi/Schema/Traits/DataTypeSpecTrait.php
+++ b/Civi/Schema/Traits/DataTypeSpecTrait.php
@@ -63,7 +63,7 @@ trait DataTypeSpecTrait {
    * @param $dataType
    *
    * @return $this
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function setDataType($dataType) {
     if (array_key_exists($dataType, self::$typeAliases)) {
@@ -71,7 +71,7 @@ trait DataTypeSpecTrait {
     }
 
     if (!in_array($dataType, $this->getValidDataTypes())) {
-      throw new \Exception(sprintf('Invalid data type "%s', $dataType));
+      throw new \CRM_Core_Exception(sprintf('Invalid data type "%s', $dataType));
     }
 
     $this->dataType = $dataType;

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -315,6 +315,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       total_amount = {contribution.total_amount}
       net_amount = {contribution.net_amount}
       fee_amount = {contribution.fee_amount}
+      paid_amount = {contribution.paid_amount}
+      balance_amount = {contribution.balance_amount}
       campaign_id = {contribution.campaign_id}
       campaign name = {contribution.campaign_id:name}
       campaign label = {contribution.campaign_id:label}';
@@ -341,6 +343,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       'total_amount = €100.00',
       'net_amount = €95.00',
       'fee_amount = €5.00',
+      'paid_amount = €100.00',
+      'balance_amount = €0.00',
       'campaign_id = 1',
       'campaign name = big_campaign',
       'campaign label = Campaign',

--- a/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FinancialTrxnTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
+
 /**
  * Class CRM_Core_BAO_FinancialTrxnTest
  * @group headless
@@ -53,7 +55,7 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testGetTotalPayments() {
+  public function testGetTotalPayments(): void {
     $contactId = $this->individualCreate();
 
     $params = [
@@ -81,13 +83,19 @@ class CRM_Core_BAO_FinancialTrxnTest extends CiviUnitTestCase {
     $totalPaymentAmount = CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id']);
     $this->assertEquals(0, $totalPaymentAmount, 'Amount not matching.');
 
+    $this->assertEquals(0, Contribution::get()->addWhere('id', '=', $contribution['id'])
+      ->addSelect('paid_amount')->execute()->first()['paid_amount']);
     $params['id'] = $contribution['id'];
     $params['contribution_status_id'] = 1;
 
     $contribution = $this->callAPISuccess('Contribution', 'create', $params);
 
     $totalPaymentAmount = CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id']);
+    $this->assertEquals('200.00', Contribution::get()->addWhere('id', '=', $contribution['id'])
+      ->addSelect('paid_amount')->execute()->first()['paid_amount']);
+
     $this->assertEquals('200.00', $totalPaymentAmount, 'Amount not matching.');
+
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add paid_amount , balance_amount, tax_exclusive_amount available to apiv4

This makes these three fields available as tokens and as fields for apiv4

Re-instatement of https://github.com/civicrm/civicrm-core/pull/23802 (plus one more field)

Before
----------------------------------------
now you don't see it

After
----------------------------------------
now you do

![image](https://user-images.githubusercontent.com/336308/182301495-fcb5c492-3f66-417f-878c-5d3592845ae2.png)


Technical Details
----------------------------------------
This PR was open before but with two issues
- there was an initial question about performance. This was resolved in discussion on https://github.com/civicrm/civicrm-core/pull/23802 in that @colemanw  clarified that  these pseudo fields are not fetched unless specifically requested
- the second issue was that https://github.com/civicrm/civicrm-core/pull/23802 had cleanup in the invoice template that went way beyond just these fields. I opted to do that cleanup first & closed the PR until that was merged so this PR could narrowly target the fields I am focussed on

Comments
----------------------------------------
