### PR TITLE
(dev/core#3768) add filter for 'Activity type of the last activity' for case detail r…

### DIFF
--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -249,6 +249,12 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
           ],
         ],
         'filters' => [
+          'last_activity_activity_type' => [
+            'name' => 'activity_type_id',
+            'title' => ts('Activity type of the last activity'),
+            'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+            'options' => CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE),
+          ],
           'last_activity_date_time' => [
             'name' => 'activity_date_time',
             'title' => ts('Last Action Date'),


### PR DESCRIPTION
…eport

Overview
----------------------------------------
add filter for 'Activity type of the last activity' for case detail report

Before
----------------------------------------
no filter on 'Activity type of the last activity' 

After
----------------------------------------
 filter on 'Activity type of the last activity' is added