### PR TITLE
Issue #3772: Fix undefined index notice.

### DIFF
--- a/CRM/Member/Form/Task/Batch.php
+++ b/CRM/Member/Form/Task/Batch.php
@@ -141,7 +141,7 @@ class CRM_Member_Form_Task_Batch extends CRM_Member_Form_Task {
             );
           }
           if ((CRM_Utils_Array::value($typeId, $entityColumnValue)) ||
-            CRM_Utils_System::isNull($entityColumnValue[$typeId])
+            CRM_Utils_System::isNull($entityColumnValue[$typeId] ?? NULL)
           ) {
             CRM_Core_BAO_UFGroup::buildProfile($this, $field, NULL, $memberId);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3772. Eliminates an "undefined index" notice that was filling up the logs.

Before
----------------------------------------
Lots of "Notice: Undefined offset: 18 in `CRM_Member_Form_Task_Batch->buildQuickForm()` (line 144 of /.../civicrm/CRM/Member/Form/Task/Batch.php)." in the logs.

After
----------------------------------------
No more notices.

Technical Details
----------------------------------------
N/A
