### PR TITLE
Scheduled Reminders - Missing metadata required by some tokens

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -645,6 +645,7 @@ FROM civicrm_action_schedule cas
       'actionSchedule' => $schedule,
       'actionMapping' => $mapping,
       'smarty' => TRUE,
+      'schema' => ['contactId'],
     ]);
     $tp->addMessage('body_text', $schedule->body_text, 'text/plain');
     $tp->addMessage('body_html', $schedule->body_html, 'text/html');


### PR DESCRIPTION
Overview
----------------------------------------

Backport #24115 from 5.52-rc to 5.51-stable (in re: https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/issues/52).

