### PR TITLE
dev/drupal#176 - Make loadBootstrap work in drupal 10, e.g. to make `cv` work

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -430,11 +430,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $kernel->preHandle($request);
     $container = $kernel->rebuildContainer();
     // Add our request to the stack and route context.
-    $routeInterface = class_exists('\Drupal\Core\Routing\RouteObjectInterface')
-      ? '\Drupal\Core\Routing\RouteObjectInterface'
-      : '\Symfony\Cmf\Component\Routing\RouteObjectInterface';
-    $request->attributes->set($routeInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
-    $request->attributes->set($routeInterface::ROUTE_NAME, '<none>');
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME, '<none>');
     $container->get('request_stack')->push($request);
     $container->get('router.request_context')->fromRequest($request);
 


### PR DESCRIPTION
Overview
----------------------------------------
This is identical to https://github.com/civicrm/cv/pull/126, and is needed to make `cv` work in drupal 10 (for anything besides `cv core:install`).

`Error: Class "\Symfony\Cmf\Component\Routing\RouteObjectInterface" not found in CRM_Utils_System_Drupal8->loadBootStrap() (line 436 of ...\CRM\Utils\System\Drupal8.php)`