### PR TITLE
Add  (pixels) to available label & pdf layout units

### DIFF
--- a/CRM/Core/BAO/LabelFormat.php
+++ b/CRM/Core/BAO/LabelFormat.php
@@ -203,13 +203,8 @@ class CRM_Core_BAO_LabelFormat extends CRM_Core_DAO_OptionValue {
    * @return array
    *   array of measurement units
    */
-  public static function getUnits() {
-    return [
-      'in' => ts('Inches'),
-      'cm' => ts('Centimeters'),
-      'mm' => ts('Millimeters'),
-      'pt' => ts('Points'),
-    ];
+  public static function getUnits(): array {
+    return CRM_Core_SelectValues::getLayoutUnits();
   }
 
   /**

--- a/CRM/Core/BAO/PdfFormat.php
+++ b/CRM/Core/BAO/PdfFormat.php
@@ -113,13 +113,8 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
    * @return array
    *   array of measurement units
    */
-  public static function getUnits() {
-    return [
-      'in' => ts('Inches'),
-      'cm' => ts('Centimeters'),
-      'mm' => ts('Millimeters'),
-      'pt' => ts('Points'),
-    ];
+  public static function getUnits(): array {
+    return CRM_Core_SelectValues::getLayoutUnits();
   }
 
   /**

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -770,6 +770,22 @@ class CRM_Core_SelectValues {
   }
 
   /**
+   * Get measurement units recognized by the TCPDF package used to create PDF labels.
+   *
+   * @return array
+   *   array of measurement units
+   */
+  public static function getLayoutUnits(): array {
+    return [
+      'in' => ts('Inches'),
+      'cm' => ts('Centimeters'),
+      'mm' => ts('Millimeters'),
+      'pt' => ts('Points'),
+      'px' => ts('Pixels'),
+    ];
+  }
+
+  /**
    * Extension types.
    *
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
Add  (pixels) to available label & pdf layout units

Before
----------------------------------------
`px` (pixels) not available as a layout unit

After
----------------------------------------
It has been added

Technical Details
----------------------------------------
This is an alternative to https://github.com/civicrm/civicrm-core/pull/24090 - we need to merge one for the 5.53 rc to go with the fix already merged - I'm not convinced that we need an option group as opposed to a hard-coded list (although I could be convinced) - so this feels like a smaller fix that doesn't commit us to a new option group but still adds the new option and consolidates the two functions

Comments
----------------------------------------
