### PR TITLE
Add Event online receipt to upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -350,6 +350,14 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'contribution_offline_receipt', 'type' => 'html'],
         ],
       ],
+      [
+        'version' => '5.53.alpha1',
+        'upgrade_descriptor' => ts('Fix non-php compliant dates'),
+        'templates' => [
+          ['name' => 'event_online_receipt', 'type' => 'subject'],
+          ['name' => 'event_online_receipt', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add Event online receipt to upgrade

Before
----------------------------------------
We are putting up a message to the user to update their dates in the template, but NOT doing it for them where we can

After
----------------------------------------
Where the template is not customised we update it, otherwise we tell the user to
- we update the detault template

Technical Details
----------------------------------------
While we do try not to tell the user to uprade their templates for every minor change  - however in this case we ARE currently asking them to upgrade this template - in a LESS USEFUL way than our normal message  - so I'm adding this to the update default+ uncustomised & tell them if they need to

Comments
----------------------------------------
@demeritcowboy @seamuslee001 I did a test upgrade for something else & hit the 'fix your date' on a non-customised event online template. I might try to see if anything else can be fixed in that template this round since we are now telling them to fix .... 