### PR TITLE
Remove `loadAll` parameter from loadRelatedObjects

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2311,13 +2311,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   Input as delivered from Payment Processor.
    * @param array $ids
    *   Ids as Loaded by Payment Processor.
-   * @param bool $loadAll
-   *   Load all related objects - even where id not passed in? (allows API to call this).
    *
    * @return bool
    * @throws CRM_Core_Exception
    */
-  public function loadRelatedObjects($input, &$ids, $loadAll = FALSE) {
+  public function loadRelatedObjects($input, &$ids) {
     // @todo deprecate this function - the steps should be
     // 1) add additional functions like 'getRelatedMemberships'
     // 2) switch all calls that refer to ->_relatedObjects to
@@ -2326,12 +2324,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // 4) make ->_relatedObjects protected
     // 5) hone up the individual functions to not use rely on this having been called
     // 6) deprecate like mad
-    if ($loadAll) {
-      $ids = array_merge(self::getComponentDetails($this->id), $ids);
-      if (empty($ids['contact']) && isset($this->contact_id)) {
-        $ids['contact'] = $this->contact_id;
-      }
-    }
     if (empty($this->_component)) {
       if (!empty($ids['event'])) {
         $this->_component = 'event';
@@ -2467,7 +2459,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws Exception
    */
   public function composeMessageArray(&$input, &$ids, &$values, $returnMessageText = TRUE) {
-    $this->loadRelatedObjects($input, $ids, TRUE);
+    $ids = array_merge(self::getComponentDetails($this->id), $ids);
+    if (empty($ids['contact']) && isset($this->contact_id)) {
+      $ids['contact'] = $this->contact_id;
+    }
+    $this->loadRelatedObjects($input, $ids);
 
     if (empty($this->_component)) {
       $this->_component = $input['component'] ?? NULL;

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -114,11 +114,11 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
     $contribution->find(TRUE);
-    $contribution->loadRelatedObjects($this->input, $this->ids, TRUE);
+    $ids = array_merge(CRM_Contribute_BAO_Contribution::getComponentDetails($this->_contributionId), $this->ids);
+    $contribution->loadRelatedObjects($this->input, $ids);
     $this->assertNotEmpty($contribution->_relatedObjects['membership']);
     $this->assertArrayHasKey($this->_membershipId . '_' . $this->_membershipTypeID, $contribution->_relatedObjects['membership']);
     $this->assertTrue(is_a($contribution->_relatedObjects['membership'][$this->_membershipId . '_' . $this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
-    $this->assertTrue(is_a($contribution->_relatedObjects['financialType'], 'CRM_Financial_BAO_FinancialType'));
     $this->assertNotEmpty($contribution->_relatedObjects['contributionRecur']);
     $this->assertNotEmpty($contribution->_relatedObjects['paymentProcessor']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove `loadAll ` parameter from legacy function `loadRelatedObjects`

Before
----------------------------------------
 `loadAll` parameter causes a couple of extra lines of code to run

After
----------------------------------------
The lines are moved to the caling functions

Technical Details
----------------------------------------
- I removed the setting of `contact` where we can see it is already set & the test check for `financialType` which is never otherwise used

Comments
----------------------------------------
test cover is good. The goal is to remove this function entirely...