### PR TITLE
Fix line item 'title' determination

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\PriceField;
+
 /**
  * Business objects for managing price fields.
  *
@@ -164,6 +166,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     }
 
     $transaction->commit();
+    Civi::cache('metadata')->flush();
     return $priceField;
   }
 
@@ -870,6 +873,24 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
     }
 
     return 0;
+  }
+
+  /**
+   * Get a specific price field (leveraging the cache).
+   *
+   * @param int $id
+   *
+   * @return array
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  public static function getPriceField(int $id): array {
+    $cacheString = __CLASS__ . __FUNCTION__ . $id . CRM_Core_Config::domainID() . '_' . CRM_Core_I18n::getLocale();
+    if (!Civi::cache('metadata')->has($cacheString)) {
+      $field = PriceField::get(FALSE)->addWhere('id', '=', $id)->execute()->first();
+      Civi::cache('metadata')->set($cacheString, $field);
+    }
+    return Civi::cache('metadata')->get($cacheString);
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -712,7 +712,7 @@ Financial Type: Donation
 ---------------------------------------------------------
 Item                             Qty       Each    Subtotal Tax Rate Tax Amount       Total
 ----------------------------------------------------------
-Price Field 1                      1    $100.00    $100.00  10.00 %       $10.00        $110.00
+Price Field - Price Field 1        1    $100.00    $100.00  10.00 %       $10.00        $110.00
 
 
 Amount before Tax : $100.00
@@ -737,7 +737,7 @@ Financial Type: Donation
 ---------------------------------------------------------
 Item                             Qty       Each       Total
 ----------------------------------------------------------
-Price Field 1                      1    $100.00       $100.00
+Price Field - Price Field 1        1    $100.00       $100.00
 
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix line item 'title' determination

Before
----------------------------------------
The `contribution_offline_receipt` is switched to the new flatter `lineItems` array but I realised that the price field label is not being consistently added for Radio options (which should be `Price field label - Option label`)

After
----------------------------------------
Consistently added

Technical Details
----------------------------------------
In fixing I hit a situation where the test is creating an order with line items in different price sets - which caused an e-notice. I decided to lean into this and load the price field in the `BAO_Order` class - as there is some future intent to provide mix & match price fields with form builder rather than price sets being the configuration container (this was also why I felt ok flattening `lineItems` to not have to iterate through a price set layer

Comments
----------------------------------------
@demeritcowboy this is the minor regression I found affecting the offline receipt when digging into invoice - in https://github.com/civicrm/civicrm-core/pull/24122