### PR TITLE
Sync all messge templates during upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -182,8 +182,12 @@ class CRM_Upgrade_Incremental_General {
       1 => 'https://docs.civicrm.org/user/en/latest/email/message-templates/#modifying-system-workflow-message-templates',
       2 => '<ul>' . implode('', $messagesHtml) . '</ul>',
     ]);
-
-    $messageObj->updateTemplates();
+    if (version_compare($version, 5.26, '>')) {
+      // updateTemplates requires workflow_name which has been around
+      // for a couple of years at this point. As user hit later versions
+      // they will be get the update anyway.
+      $messageObj->updateTemplates();
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Sync all messge templates during upgrade

Currently we sync a hard-coded list of templates which is also the basis for telling users to update their customisations. Because we don't want to hassle the user for every minor tweak we don't add to this list very often. However, ideally we would always update the default template to the latest on upgrade and update any non-customised templates, leaving only customised ones for less frequent attention.

This PR breaks the link between syncing default & uncustomised & asking the user to do updates.


Before
----------------------------------------
We either do nothing about message template updates OR update them to the extent we can and notify the user to the extent we can't

After
----------------------------------------
We always sync to the extent we can, we notify the user less often...

Technical Details
----------------------------------------
The test cover I used for this is `testMessageTemplateUpgrade`

Comments
----------------------------------------
@seamuslee001 @demeritcowboy - this works stepping through the test - but I'm not quite sure when it gets called during upgrades - ideally not every version they iterate through....
