### PR TITLE
dev/core#3774 Ensure that if we are in live credit card mode that the…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -703,8 +703,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
     }
 
-    // If contribution is a template receive date is not required
-    $receiveDateRequired = !$this->_values['is_template'];
+    // If contribution is a template receive date is not required and if we are in a live credit card mode
+    $receiveDateRequired = !$this->_values['is_template'] && !$this->_mode;
     // add various dates
     $this->addField('receive_date', ['entity' => 'contribution'], $receiveDateRequired, FALSE);
     $this->addField('receipt_date', ['entity' => 'contribution'], FALSE, FALSE);


### PR DESCRIPTION
… receive date field is a non required field

Overview
----------------------------------------
This looks to be a regression from https://github.com/civicrm/civicrm-core/commit/b01d99886f46694e3eb82666b804ded5d0386500 which was added in 5.51

Before
----------------------------------------
Back office credit card contributions cannot be submitted

After
----------------------------------------
Back office credit card contributions can be submitted

ping @eileenmcnaughton @totten @MegaphoneJon 