### PR TITLE
🎁 CiviEvent, Event Dashboard, iCal links are inside the h3 styling move out and add spacing

### DIFF
--- a/templates/CRM/Event/Page/DashBoard.tpl
+++ b/templates/CRM/Event/Page/DashBoard.tpl
@@ -17,8 +17,10 @@
     <div class="clear">&nbsp;</div>
     <h3 id="crm-event-dashboard-heading">{ts}Event Summary{/ts}
       {help id="id-event-intro"}
-      {include file="CRM/Event/Page/iCalLinks.tpl"}
     </h3>
+    <div class="crm-clearfix">
+      {include file="CRM/Event/Page/iCalLinks.tpl"}
+    </div>
     {include file="CRM/common/jsortable.tpl"}
     <table id="options" class="display">
     <thead>


### PR DESCRIPTION
Overview
----------------------------------------
CiviEvent, Event Dashboard, iCal links are inside the h3 styling move out and add spacing

Before
----------------------------------------
On the Event Dashboard the iCal links are inside the h3.

![image](https://user-images.githubusercontent.com/58866555/182760638-2a25e4df-e10f-41da-867a-a3912085912c.png)


After
----------------------------------------
On the Event Dashboard the iCal links are outside the h3 with additional spacing.

PR with feedback.

![image](https://user-images.githubusercontent.com/58866555/189553400-fab23f9a-b823-4b1a-b7aa-960befc54fa3.png)

Original PR prior to feedback.

![image](https://user-images.githubusercontent.com/58866555/182760702-4341eb71-fdf9-49e3-ad0a-4eaf3b9d2234.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
We probably introduced this bug, sorry about that!

Agileware Ref: CIVICRM-2024