### PR TITLE
Importer - Increase size of queue batches

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -694,7 +694,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $totalRowCount = $totalRows = $dataSource->getRowCount(['new']);
     $queue = Civi::queue('user_job_' . $this->getUserJobID(), ['type' => 'Sql', 'error' => 'abort']);
     $offset = 0;
-    $batchSize = 5;
+    $batchSize = 50;
     while ($totalRows > 0) {
       if ($totalRows < $batchSize) {
         $batchSize = $totalRows;

--- a/release-notes/5.51.3.md
+++ b/release-notes/5.51.3.md
@@ -21,13 +21,14 @@ Released August 3, 2022
 ## <a name="bugs"></a>Bugs resolved
 
 * **_CiviContribute_: Cannot submit credit cards via backend form (on certain configurations) ([dev/core#3774](https://lab.civicrm.org/dev/core/-/issues/3774): [#24144](https://github.com/civicrm/civicrm-core/pull/24144))**
+* **_Importer_: Increase size of queue batches ([#24152](https://github.com/civicrm/civicrm-core/pull/24152))**
 
 ## <a name="credits"></a>Credits
 
 This release was developed by the following authors and reviewers:
 
 Wikimedia Foundation - Eileen McNaughton; Megaphone Technology Consulting - Jon Goldberg;
-JMA Consulting - Seamus Lee; CiviCRM - Tim Otten
+JMA Consulting - Seamus Lee; CiviCRM - Tim Otten; Andy Burns
 
 ## <a name="feedback"></a>Feedback
 


### PR DESCRIPTION
Overview
----------------------------------------

Addresses a simple, recent, and significant change in performance.

See https://github.com/civicrm/civicrm-core/pull/23669#discussion_r889758336

Comments
----------------------------------------

Compared to the 5.52 batch (#24151), this patch for 5.51 uses a slightly more conservative limit (100 vs 50). Either should be fine, but it'll harder to change 5.51 going forward, so it's more conservative.