### PR TITLE
dev/core/-/issues/3786 💩 Matching by External / Contact ID always matches contacts with ID < 10 for Participant importer and possibly others because return params is not an array

### DIFF
--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -48,7 +48,7 @@ function _civicrm_api3_deprecated_duplicate_formatted_contact($params) {
         'is_error' => 1,
         'error_message' => [
           'code' => CRM_Core_Error::DUPLICATE_CONTACT,
-          'params' => $contact->id,
+          'params' => [$contact->id],
           'level' => 'Fatal',
           'message' => "Found matching contacts: $contact->id",
         ],


### PR DESCRIPTION
Overview
----------------------------------------
Matching by External / Contact ID always matches contacts with ID < 10 for Participant importer and possibly others

This is due do an incorrectly replaced Error generation function in core commit [972906b](https://github.com/civicrm/civicrm-core/commit/972906b33960dd2126bcb5629faec188f6d1a8f9) (Merged for 5.51.0)

**Steps to reproduce**

1. Create a CSV with a Contact External ID or Contact ID, Event Title, Registration Status
2. Set up the import to match on Contact External ID or Contact ID
3. Map the other fields
4. Execute import

**Error**: Import will execute and create Participant records associated all with Contact ID: 1 or Contact ID: 2 (or another ID < ID:10). Not matching against the correct Contact ID.

Before
----------------------------------------
Cannot import Event Participants correctly. Participants are created but associated with the wrong Contact.

After
----------------------------------------
Can import Event Participants correctly. Participants are created and associated with the correct Contact.

Technical Details
----------------------------------------
Bug introduced due to recent refactor of import code,see core commit [972906b](https://github.com/civicrm/civicrm-core/commit/972906b33960dd2126bcb5629faec188f6d1a8f9)

Comments
----------------------------------------
This bug gets the :hankey: icon because it took a very long time to track down and caused imports to fail, making a customer very unhappy 😬

Gitlab, https://lab.civicrm.org/dev/core/-/issues/3786

Agileware Ref: CIVICRM-2025