### PR TITLE
SettingsStyleTest - Stop the madness

### DIFF
--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -311,6 +311,7 @@ return [
     'is_contact' => 0,
     'description' => ts('The number of emails sendable via simple mail. Make sure you understand the implications for your spam reputation and legal requirements for bulk emails before editing. As there is some risk both to your spam reputation and the products if this is misused it is a hidden setting.'),
     'help_text' => 'CiviCRM forces users sending more than this number of mails to use CiviMails. CiviMails have additional precautions: not sending to contacts who do not want bulk mail, adding domain name and opt out links. You should familiarise yourself with the law relevant to you on bulk mailings if changing this setting. For the US https://en.wikipedia.org/wiki/CAN-SPAM_Act_of_2003 is a good place to start.',
+    'add' => '4.7.25',
   ],
   'auto_recipient_rebuild' => [
     'group_name' => 'Mailing Preferences',
@@ -325,6 +326,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Enable this setting to rebuild recipient list automatically during composing mail. Disable will allow you to rebuild recipient manually.'),
     'help_text' => ts('CiviMail automatically fetches recipient list and count whenever mailing groups are included or excluded while composing bulk mail. This phenomena may degrade performance for large sites, so disable this setting to build and fetch recipients for selected groups, manually.'),
+    'add' => '4.7.30',
   ],
   'allow_mail_from_logged_in_contact' => [
     'group_name' => 'Mailing Preferences',
@@ -338,6 +340,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Allow sending email from the logged in contact\'s email address.'),
     'help_text' => 'CiviCRM allows you to send email from the domain from email addresses and the logged in contact id addresses by default. Disable this if you only want to allow the domain from addresses to be used.',
+    'add' => '4.7.31',
   ],
   'url_tracking_default' => [
     'group_name' => 'Mailing Preferences',
@@ -352,6 +355,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If checked, mailings will have click-through tracking enabled by default.'),
     'help_text' => NULL,
+    'add' => '5.27.0',
   ],
   'open_tracking_default' => [
     'group_name' => 'Mailing Preferences',
@@ -366,6 +370,7 @@ return [
     'is_contact' => 0,
     'description' => ts('If checked, mailings will have open tracking enabled by default.'),
     'help_text' => NULL,
+    'add' => '5.27.0',
   ],
   // dev/cor#1768 Allow mailer sync interval to be configured by the
   // adminstrator.

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -213,7 +213,7 @@ return [
     'group_name' => 'Search Preferences',
     'group' => 'Search Preferences',
     'name' => 'quicksearch_options',
-    'type' => 'string',
+    'type' => 'String',
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
     'html_type' => 'checkboxes',
     'sortable' => TRUE,

--- a/tests/phpunit/Civi/Core/SettingsStyleTest.php
+++ b/tests/phpunit/Civi/Core/SettingsStyleTest.php
@@ -34,6 +34,12 @@ class SettingsStyleTest extends \CiviUnitTestCase {
       $assert($key, $key === $spec['name'], 'Should have matching name');
       $type = $spec['type'] ?? 'UNKNOWN';
       $assert($key, in_array($type, $validTypes), 'Should have known type. Found: ' . $type);
+      if (version_compare($spec['add'], '5.53', '>=')) {
+        $assert($key, preg_match(';^[a-z0-9]+(_[a-z0-9]+)+$;', $key), 'In 5.53+, names should use snake_case with a group/subsystem prefix.');
+      }
+      else {
+        $assert($key, preg_match(';^[a-z][a-zA-Z0-9_]+$;', $key), 'In 4.1-5.52, names should snake_case or lowerCamelCase.');
+      }
     }
     $this->assertEquals([], $errors);
   }


### PR DESCRIPTION
Overview
----------------------------------------

This adds a unit-test to ensure that `*.setting.php` files are more consistent (*going forward*).

Most notably, it ensures that new settings have names in `lower_snake` case. New `lowerCamel` names will raise test-errors. This is a step to reducing the conflicted naming of settings.

Before
----------------------------------------

No enforcement of a convention.

Setting names follow many different styles (regarding capitalization and grammar). A sample:

```
  'resCacheCode' => [
  'searchPrimaryDetailsOnly' => [
  'search_autocomplete_count' => [
  'secondDegRelPermissions' => [
  'secure_cache_timeout_minutes' => [
  'securityAlert' => [
  'show_events' => [
  'simple_mail_limit' => [
  'site_id' => [
  'smartGroupCacheTimeout' => [
  'smart_group_cache_refresh_mode' => [
```

After
----------------------------------------

The `SettingsStyleTest` ensures that core's `*.setting.php` files meet some criteria regarding properties:

* `name` (existing names may be `lower_snake` or `lowerCamel`; new/future names should be `lower_snake`)
* `type` (should be a valid type)
* `add` (should be a version number)

Comments
----------------------------------------

This does cleanup a few basic/obvious things. 

But the most notable change regards `name`. Names have followed mixed styles since the beginning of `Settings` circa v4.1.  (*This is probably because of the incremental way that other configuration-management layers were merged into the `Settings` layer? But that's by-the-by.*) Today, `civicrm-core` has >100 settings in `lower_snake` and >100 settings in `lowerCamel`.

Why does this draft land on the side of `lower_snake`? I'd be fine with either. They both have precedent+reasons. However, there is a major difference if you look to `universe`. It's been common+recommended for extensions to put a unique prefix in front of all their settings (eg `myprefix_mysetting`), and so `lower_snake` has become much more common in `universe`. When a developers moves between work in different folders/repos, I think it'll feel more natural if core emphasizes a similar `myprefix_mysetting`.