### PR TITLE
Fix array-cache-bypass - in FastArrays on `has()`

### DIFF
--- a/CRM/Utils/Cache/FastArrayDecorator.php
+++ b/CRM/Utils/Cache/FastArrayDecorator.php
@@ -115,6 +115,10 @@ class CRM_Utils_Cache_FastArrayDecorator implements CRM_Utils_Cache_Interface {
   }
 
   public function has($key) {
+    CRM_Utils_Cache::assertValidKey($key);
+    if (array_key_exists($key, $this->values)) {
+      return TRUE;
+    }
     return $this->delegate->has($key);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix array-cache-bypass in FastArrays on `has()`

When running the `tokenProcessor` (notably in `processGreetings` when creating a contact) it uses the `metadata` cache. This cache stores .. erm ... `metadata` using the preferred cache method for the site aided by an in-process cache on the `CRM_Utils_Cache_FastArrayDecorator` class. If the cache key has already been hit in the current php process it is loaded from this php array cache, otherwise it falls back the the preferred cache method (in our case `Redis`).

However, when the method `has` is being called it was by-passing the `php array cache` and going straight to `Redis` - which was causing a significant performance hit for us. 

Before
----------------------------------------
Calling `Civi::cache('metadata')->get()` accesses the array cache & only falls back to (eg.) Redis if no key exists. However, `Civi::cache('metadata')->has()` always by-passed the array cache & hits (eg) `Redis`

After
----------------------------------------
Calling `Civi::cache('metadata')->has()` also accesses the array cache, where possible.


Technical Details
----------------------------------------
This appears to just be a coding over-sight as the `CRM_Utils_Cache_ArrayDecorator` class was not impacted.

Comments
----------------------------------------
I feel like the performance hit I was seeing on our staging server sing `Redis` was surprisingly high (higher than using the `sqlCache` would have been) so I think there is also an investigation at our end to see if it was higher than it should be