### PR TITLE
dev/core#3779 add an ability to set a field as display only in formbuilder

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -167,6 +167,9 @@
           case 'Number':
             return !(defn.options || defn.data_type === 'Boolean');
 
+          case 'DisplayOnly':
+            return true;
+
           default:
             return false;
         }

--- a/ext/afform/admin/ang/afGuiEditor/inputType/DisplayOnly.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/DisplayOnly.html
@@ -1,0 +1,3 @@
+<div class="form-inline">
+  <input class="form-control" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Field value will be shown on the form') }}" disabled/>
+</div>

--- a/ext/afform/core/ang/af/fields/DisplayOnly.html
+++ b/ext/afform/core/ang/af/fields/DisplayOnly.html
@@ -1,0 +1,1 @@
+{{dataProvider.getFieldData()[$ctrl.fieldName]}}


### PR DESCRIPTION
Overview
----------------------------------------
We should be able to set a field as display only. 


After
----------------------------------------
Admin Configuration
![Screenshot from 2022-08-05 12-26-41](https://user-images.githubusercontent.com/151481/183068153-51b2e114-9b97-4684-94ba-936d95d06c8d.png)


Display on the form
![Screenshot from 2022-08-05 12-26-22](https://user-images.githubusercontent.com/151481/183068173-661ab150-2fc4-4a70-92a5-6035d0f1d04e.png)


