### PR TITLE
dev/core#3782 Remove rule that stops signing up for a membership if matched contact already has a cancelled on of that type

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -895,44 +895,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
       }
 
-      $currentMemberships = NULL;
-      if ($membershipIsActive) {
-        $is_test = $self->_mode != 'live' ? 1 : 0;
-        $memContactID = $self->_membershipContactID;
-
-        // For anonymous user check using dedupe rule
-        // if user has Cancelled Membership
-        if (!$memContactID) {
-          $memContactID = CRM_Contact_BAO_Contact::getFirstDuplicateContact($fields, 'Individual', 'Unsupervised', [], FALSE);
-        }
-        $currentMemberships = CRM_Member_BAO_Membership::getContactsCancelledMembership($memContactID,
-          $is_test
-        );
-
-        foreach ($self->_values['fee'] as $fieldKey => $fieldValue) {
-          if ($fieldValue['html_type'] != 'Text' && !empty($fields['price_' . $fieldKey])) {
-            if (!is_array($fields['price_' . $fieldKey]) && isset($fieldValue['options'][$fields['price_' . $fieldKey]])) {
-              if (array_key_exists('membership_type_id', $fieldValue['options'][$fields['price_' . $fieldKey]])
-                && in_array($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'], $currentMemberships)
-              ) {
-                $errors['price_' . $fieldKey] = ts('Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.', [1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$fields['price_' . $fieldKey]]['membership_type_id'])]);
-              }
-            }
-            else {
-              if (is_array($fields['price_' . $fieldKey])) {
-                foreach (array_keys($fields['price_' . $fieldKey]) as $key) {
-                  if (array_key_exists('membership_type_id', $fieldValue['options'][$key])
-                    && in_array($fieldValue['options'][$key]['membership_type_id'], $currentMemberships)
-                  ) {
-                    $errors['price_' . $fieldKey] = ts('Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.', [1 => CRM_Member_PseudoConstant::membershipType($fieldValue['options'][$key]['membership_type_id'])]);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
       // CRM-12233
       if ($membershipIsActive && empty($self->_membershipBlock['is_required'])
         && $self->isFormSupportsNonMembershipContributions()

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -499,7 +499,7 @@ abstract class CRM_Utils_Hook {
    *   The name of the form.
    * @param array &$fields the POST parameters as filtered by QF
    * @param array &$files the FILES parameters as sent in by POST
-   * @param array &$form the form object
+   * @param CRM_Core_Form &$form the form object
    * @param array &$errors the array of errors.
    *
    * @return mixed


### PR DESCRIPTION
Overview
----------------------------------------
A client had intermittent reports from people not being able to sign-up (for a membership) and being redirected to `civicrm%2Fcontribute%2Ftransact` instead of to the payment processor (though it turns out the same thing happens whatever payment processor you use).

After a lot of work troubleshooting and adding debug I finally tracked it down to the following error:
`Your %1 membership was previously cancelled and can not be renewed online. Please contact the site administrator for assistance.`
But that error was not being reported back to the client and I had to log the contents of `$this->_errors` in `CRM_Core_Form::validate()` to find out what was going on.

I don't really understand why https://github.com/civicrm/civicrm-core/pull/3531 ever got merged given that it seems no-one was in favour of restricting memberships in this way: https://issues.civicrm.org/jira/browse/CRM-14645

Proposal: Just remove the code. If anyone actually needs it they could easily add it via a validateForm hook.

Before
----------------------------------------
Cannot signup for a membership via contribution page if matched contact has a cancelled membership of that type.

After
----------------------------------------
Can signup for a membership via contribution page if matched contact has a cancelled membership of that type.

Technical Details
----------------------------------------


Comments
----------------------------------------
