### PR TITLE
SearchKit - Fix viewing search display for anonymous user

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -58,8 +58,9 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       CRM_Utils_System::civiExit();
     }
     try {
-      // Call multiple
+      // Two call formats. Which one was used? Note: CRM_Api4_Permission::check() and CRM_Api4_Page_AJAX::run() should have matching conditionals.
       if (empty($this->urlPath[3])) {
+        // Received multi-call format
         $calls = CRM_Utils_Request::retrieve('calls', 'String', CRM_Core_DAO::$_nullObject, TRUE, NULL, 'POST');
         $calls = json_decode($calls, TRUE);
         $response = [];
@@ -67,8 +68,8 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
           $response[$index] = call_user_func_array([$this, 'execute'], $call);
         }
       }
-      // Call single
       else {
+        // Received single-call format
         $entity = $this->urlPath[3];
         $action = $this->urlPath[4];
         $params = CRM_Utils_Request::retrieve('params', 'String');

--- a/CRM/Api4/Permission.php
+++ b/CRM/Api4/Permission.php
@@ -26,7 +26,9 @@ class CRM_Api4_Permission {
     $defaultPermissions = [
       ['access CiviCRM', 'access AJAX API'],
     ];
+    // Two call formats. Which one was used? Note: CRM_Api4_Permission::check() and CRM_Api4_Page_AJAX::run() should have matching conditionals.
     if (!empty($urlPath[3])) {
+      // Received single-call format
       $entity = $urlPath[3];
       $action = $urlPath[4];
       $permissions = $defaultPermissions;
@@ -34,6 +36,7 @@ class CRM_Api4_Permission {
       return CRM_Core_Permission::check($permissions);
     }
     else {
+      // Received multi-call format
       $calls = CRM_Utils_Request::retrieve('calls', 'String', CRM_Core_DAO::$_nullObject, TRUE, NULL, 'POST');
       $calls = json_decode($calls, TRUE);
       foreach ($calls as $call) {

--- a/CRM/Api4/Permission.php
+++ b/CRM/Api4/Permission.php
@@ -22,17 +22,29 @@
 class CRM_Api4_Permission {
 
   public static function check() {
-    $config = CRM_Core_Config::singleton();
-    $urlPath = explode('/', $_GET[$config->userFrameworkURLVar]);
-    $permissions = [
+    $urlPath = explode('/', CRM_Utils_System::currentPath());
+    $defaultPermissions = [
       ['access CiviCRM', 'access AJAX API'],
     ];
     if (!empty($urlPath[3])) {
       $entity = $urlPath[3];
       $action = $urlPath[4];
+      $permissions = $defaultPermissions;
       CRM_Utils_Hook::alterApiRoutePermissions($permissions, $entity, $action);
+      return CRM_Core_Permission::check($permissions);
     }
-    return CRM_Core_Permission::check($permissions);
+    else {
+      $calls = CRM_Utils_Request::retrieve('calls', 'String', CRM_Core_DAO::$_nullObject, TRUE, NULL, 'POST');
+      $calls = json_decode($calls, TRUE);
+      foreach ($calls as $call) {
+        $permissions = $defaultPermissions;
+        CRM_Utils_Hook::alterApiRoutePermissions($permissions, $call[0], $call[1]);
+        if (!CRM_Core_Permission::check($permissions)) {
+          return FALSE;
+        }
+      }
+      return TRUE;
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes anonymous access to SearchKit displays.

Before
----------------------------------------
Anonymous user cannot view SearchKit display, even if it is set to bypass permission checks.

After
----------------------------------------
It works again.

Technical Details
----------------------------------------
This regressed in aa5d068b84f7ccd6370dd94339ecdc82c052a2c1 when the single SearchDisplay::run api call was replaced with an array of calls. The gatekeeper `CRM_Api4_Permission` was only able to handle single calls.
This updates it so that it can handle an array of calls - it will call `hook_civicrm_alterApiRoutePermissions` for each one and reject the request if any of them lack permission.