### PR TITLE
dev/core#3780 add hidden field type support for formbuilder

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -177,6 +177,7 @@
             return !(defn.options || defn.data_type === 'Boolean');
 
           case 'DisplayOnly':
+          case 'Hidden':
             return true;
 
           default:

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Hidden.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Hidden.html
@@ -1,0 +1,3 @@
+<div class="form-inline">
+  <input class="form-control" ng-model="getSet('afform_default')" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Click to add default value') }}"/>
+</div>

--- a/ext/afform/core/ang/af/fields/Hidden.html
+++ b/ext/afform/core/ang/af/fields/Hidden.html
@@ -1,0 +1,1 @@
+<input class="form-control" type="hidden" id="{{:: fieldId }}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]">


### PR DESCRIPTION
Overview
----------------------------------------
Now you can set a field as hidden on the form. Also can set it's value via url.

Fixes https://lab.civicrm.org/dev/core/-/issues/3780


After
----------------------------------------
![Screenshot from 2022-08-05 17-51-08](https://user-images.githubusercontent.com/151481/183125473-e526436f-6f3a-436c-b2f0-8ef7d4e12ffd.png)
