### PR TITLE
Afform - Fix js error when checking to refresh menuBar

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -580,7 +580,7 @@
               snapshot.afform.name = data[0].name;
             });
             if (!angular.equals(afform.navigation, lastSaved.navigation) ||
-              (afform.server_route !== lastSaved.server_route && afform.navigation)
+              (afform.server_route !== lastSaved.server_route && afform.navigation) ||
               (afform.icon !== lastSaved.icon && afform.navigation)
             ) {
               refreshMenubar();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a js syntax error recently introduced to Afform-Admin

Before
----------------------------------------
Console errors visible when editing an Afform:
![image](https://user-images.githubusercontent.com/2874912/183139849-91376b01-6db6-44bf-8e2f-dcd3e00cb759.png)


After
----------------------------------------
Fixed