### PR TITLE
dev/core#3784 fix contribution/membership/participant import matching on external id or contact id

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -417,7 +417,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         $error = $this->checkContactDuplicate($paramValues);
 
         if (CRM_Core_Error::isAPIError($error, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
-          $matchedIDs = explode(',', $error['error_message']['params'][0]);
+          $matchedIDs = (array) $error['error_message']['params'];
           if (count($matchedIDs) > 1) {
             throw new CRM_Core_Exception('Multiple matching contact records detected for this row. The contribution was not imported', CRM_Import_Parser::ERROR);
           }
@@ -776,7 +776,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
               $error = $this->checkContactDuplicate($params);
 
               if (isset($error['error_message']['params'][0])) {
-                $matchedIDs = explode(',', $error['error_message']['params'][0]);
+                $matchedIDs = (array) $error['error_message']['params'];
 
                 // check if only one contact is found
                 if (count($matchedIDs) > 1) {

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -236,7 +236,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         $error = $this->checkContactDuplicate($formatValues);
 
         if (CRM_Core_Error::isAPIError($error, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
-          $matchedIDs = explode(',', $error['error_message']['params'][0]);
+          $matchedIDs = (array) $error['error_message']['params'];
           if (count($matchedIDs) >= 1) {
             foreach ($matchedIDs as $contactId) {
               $formatted['contact_id'] = $contactId;

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -215,7 +215,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         $error = $this->checkContactDuplicate($formatValues);
 
         if (CRM_Core_Error::isAPIError($error, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
-          $matchedIDs = explode(',', $error['error_message']['params'][0]);
+          $matchedIDs = (array) $error['error_message']['params'];
           if (count($matchedIDs) > 1) {
             throw new CRM_Core_Exception('Multiple matching contact records detected for this row. The membership was not imported', CRM_Import_Parser::ERROR);
           }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -277,6 +277,49 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals('No matching Contact found for (mum@example.com )', $row['_status_message']);
   }
 
+  public function testImportWithMatchByExternalIdentifier() :void {
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_contact AUTO_INCREMENT = 1000000");
+
+    $contactRubyParams = [
+      'first_name' => 'Ruby',
+      'external_identifier' => 'ruby',
+      'contact_type' => 'Individual',
+    ];
+    $contactSapphireParams = [
+      'first_name' => 'Sapphire',
+      'external_identifier' => 'sapphire',
+      'contact_type' => 'Individual',
+    ];
+    $contactRubyId = $this->individualCreate($contactRubyParams);
+    $contactSapphireId = $this->individualCreate($contactSapphireParams);
+
+    // make sure we're testing dev/core#3784
+    self::assertEquals(1, substr($contactRubyId, 0, 1));
+    self::assertEquals(1, substr($contactSapphireId, 0, 1));
+
+    $mapping = [
+      ['name' => 'external_identifier'],
+      ['name' => 'total_amount'],
+      ['name' => 'receive_date'],
+      ['name' => 'financial_type_id'],
+    ];
+    $this->importCSV('contributions_match_external_id.csv', $mapping);
+
+    $contributionsOfRuby = Contribution::get()
+      ->addWhere('contact_id', '=', $contactRubyId)->execute();
+    $contributionsOfSapphire = Contribution::get()
+      ->addWhere('contact_id', '=', $contactSapphireId)->execute();
+
+    $this->assertCount(1, $contributionsOfRuby, 'Wrong number of contributions imported');
+    $this->assertCount(1, $contributionsOfSapphire, 'Wrong number of contributions imported');
+    $this->assertEquals(22222, $contributionsOfRuby->first()['total_amount']);
+    $this->assertEquals(5, $contributionsOfSapphire->first()['total_amount']);
+
+    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
+    $this->assertEquals(0, $dataSource->getRowCount([CRM_Import_Parser::ERROR]));
+    $this->assertEquals(2, $dataSource->getRowCount([CRM_Import_Parser::VALID]));
+  }
+
   /**
    * Run the import parser.
    *

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_match_external_id.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_match_external_id.csv
@@ -1,0 +1,3 @@
+External Identifier,Total Amount,Receive Date,Financial Type
+sapphire,5,2005-05-05,Donation
+ruby,22222,2022-02-22,Donation


### PR DESCRIPTION
Overview
----------------------------------------
Fixes 5.51 regression https://lab.civicrm.org/dev/core/-/issues/3784 and adds a test for it.

Before
----------------------------------------
When importing contributions, supposedly matching on external identifier or contact id, imported contributions are instead attached to contact ids 1-9.

After
----------------------------------------
Imported contributions are attached to the contacts specified by external id/contact id in the input CSV.

Comments
----------------------------------------
Thank you @eileenmcnaughton for the fabulous work on refactoring nightmarish import code. The code was relatively easy to read/trace through, so finding this bug wasn't too hard!