### PR TITLE
dev/core#3781 Downgrade Symfony Service Contracts to 2.2.0 to fix php fatal error i…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "symfony/filesystem": "~4.4",
     "symfony/process": "~4.4",
     "symfony/var-dumper": "~3.0 || ~4.4 || ~5.1",
-    "symfony/service-contracts": "~2.2.0",
+    "symfony/service-contracts": "~2.2",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
     "symfony/finder": "~4.4",
     "tecnickcom/tcpdf" : "6.4.*",
@@ -96,7 +96,7 @@
     "phpoffice/phpspreadsheet": "^1.18",
     "symfony/polyfill-php73": "^1.23",
     "html2text/html2text": "^4.3.1",
-    "psr/container": "~1.0.0"
+    "psr/container": "~1.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,8 @@
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18",
     "symfony/polyfill-php73": "^1.23",
-    "html2text/html2text": "^4.3.1"
+    "html2text/html2text": "^4.3.1",
+    "psr/container": "~1.0.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "symfony/filesystem": "~4.4",
     "symfony/process": "~4.4",
     "symfony/var-dumper": "~3.0 || ~4.4 || ~5.1",
+    "symfony/service-contracts": "~2.2.0",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
     "symfony/finder": "~4.4",
     "tecnickcom/tcpdf" : "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b55f08e5d00556eba400c19d2ed6ece",
+    "content-hash": "0fc116de60e32605258ea574d897653b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5dcb5ab67a0fcecb641846afdbbdc111",
+    "content-hash": "7b55f08e5d00556eba400c19d2ed6ece",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3055,22 +3055,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -3083,7 +3088,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -3097,9 +3102,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/master"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9808720dbc97471b1d5cc71fdc6b6897",
+    "content-hash": "5dcb5ab67a0fcecb641846afdbbdc111",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3737,73 +3737,6 @@
             "time": "2022-06-22T15:01:38+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:53:40+00:00"
-        },
-        {
             "name": "symfony/event-dispatcher",
             "version": "v4.4.42",
             "source": {
@@ -4884,25 +4817,21 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.2",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
-                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
+                "psr/container": "^1.0"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -4910,7 +4839,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4947,7 +4876,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/service-contracts/tree/master"
             },
             "funding": [
                 {
@@ -4963,7 +4892,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:17:29+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/var-dumper",


### PR DESCRIPTION
…n wordpress

Overview
----------------------------------------
This downgrades the version of symfony/service-contracts from 2.5.2 to 2.2.0 to fix a php fatal error when using wordpress and iThemes Security plguin

Before
----------------------------------------
Fatal error when using CiviCRM 5.52.0 and iThemes Security due to function declaration issue

After
----------------------------------------
No fatal error hopefully

Technical Details
----------------------------------------
The important change here is this https://github.com/symfony/service-contracts/compare/v2.2.0...v2.5.2#diff-9651ec0079b8028b20179b76c3b685511ca54d4e64f1948dfebaad06de0a303dR46 which is why a downgrade is needed

ping @demeritcowboy @kcristiano @eileenmcnaughton @totten 

