### PR TITLE
Afform - Update correct existing email,phone,address & prevent deletion of others

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -242,7 +242,7 @@ class Submit extends AbstractProcessor {
         $result = civicrm_api4($joinEntityName, 'replace', [
           // Disable permission checks because the main entity has already been vetted
           'checkPermissions' => FALSE,
-          'where' => self::getJoinWhereClause($event->getEntityType(), $joinEntityName, $entityId),
+          'where' => self::getJoinWhereClause($event->getFormDataModel(), $event->getEntityName(), $joinEntityName, $entityId),
           'records' => $values,
         ], ['id']);
         $indexedResult = array_combine(array_keys($values), (array) $result);
@@ -254,7 +254,7 @@ class Submit extends AbstractProcessor {
           civicrm_api4($joinEntityName, 'delete', [
             // Disable permission checks because the main entity has already been vetted
             'checkPermissions' => FALSE,
-            'where' => self::getJoinWhereClause($event->getEntityType(), $joinEntityName, $entityId),
+            'where' => self::getJoinWhereClause($event->getFormDataModel(), $event->getEntityName(), $joinEntityName, $entityId),
           ]);
         }
         catch (\API_Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug introduced in #21254 which caused existing contacts' email, address, phone, im to be updated incorrectly.

(*The bug applies to Phone / Email / Address blocks with a singular location-type. Multi-address blocks are not affected.*)

Before
----------------------------------------
**To reproduce:**
1. Log in and update your own contact record with > 1 email address
2. Set up an afform which pre-populates the current user
3. Add an email to the form. Set it to update "Primary" instead of "Multiple"
      ![image](https://user-images.githubusercontent.com/2874912/183312629-07e10f61-6817-4443-87bf-5dad546a8969.png)
4. Use the form - your primary email will be updated but other emails will be deleted!


After
----------------------------------------
Fixed.
