### PR TITLE
Message Templates - Allow rendering & previewing of translated messages

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -527,7 +527,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
       $mailContent['subject'] = $subjectOverride;
     }
 
-    return $mailContent;
+    return [$mailContent, $apiCall->getTranslationLanguage()];
   }
 
   /**

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -341,9 +341,18 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
 
     self::synchronizeLegacyParameters($params);
     $params = array_merge($modelDefaults, $viewDefaults, $envelopeDefaults, $params);
-
+    $language = $params['language'] ?? (!empty($params['contactId']) ? Civi\Api4\Contact::get(FALSE)->addWhere('id', '=', $params['contactId'])->addSelect('preferred_language')->execute()->first()['preferred_language'] : NULL);
     CRM_Utils_Hook::alterMailParams($params, 'messageTemplate');
-    $mailContent = self::loadTemplate((string) $params['workflow'], $params['isTest'], $params['messageTemplateID'] ?? NULL, $params['groupName'] ?? '', $params['messageTemplate'], $params['subject'] ?? NULL);
+    [$mailContent, $translatedLanguage] = self::loadTemplate((string) $params['workflow'], $params['isTest'], $params['messageTemplateID'] ?? NULL, $params['groupName'] ?? '', $params['messageTemplate'], $params['subject'] ?? NULL, $language);
+    global $moneyFormatLocale;
+    $originalValue = $moneyFormatLocale;
+    if ($translatedLanguage) {
+      // If the template has been translated then set the moneyFormatLocale to match the translation.
+      // Note that in future if we do the same for dates we are likely to want to set it to match
+      // the preferred_language rather than the translation language - a long discussion is on the
+      // property in AbstractAction
+      $moneyFormatLocale = $translatedLanguage;
+    }
 
     self::synchronizeLegacyParameters($params);
     $rendered = CRM_Core_TokenSmarty::render(CRM_Utils_Array::subset($mailContent, ['text', 'html', 'subject']), $params['tokenContext'], $params['tplParams']);
@@ -352,6 +361,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
     }
     $nullSet = ['subject' => NULL, 'text' => NULL, 'html' => NULL];
     $mailContent = array_merge($nullSet, $mailContent, $rendered);
+    $moneyFormatLocale = $originalValue;
     return [$mailContent, $params];
   }
 
@@ -459,18 +469,20 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
    *   If omitted, the record will be loaded from workflowName/messageTemplateID.
    * @param string|null $subjectOverride
    *   This option is the older, wonkier version of $messageTemplate['msg_subject']...
+   * @param string|null $language
    *
    * @return array
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
-  protected static function loadTemplate(string $workflowName, bool $isTest, int $messageTemplateID = NULL, $groupName = NULL, ?array $messageTemplateOverride = NULL, ?string $subjectOverride = NULL): array {
+  protected static function loadTemplate(string $workflowName, bool $isTest, int $messageTemplateID = NULL, $groupName = NULL, ?array $messageTemplateOverride = NULL, ?string $subjectOverride = NULL, ?string $language = NULL): array {
     $base = ['msg_subject' => NULL, 'msg_text' => NULL, 'msg_html' => NULL, 'pdf_format_id' => NULL];
     if (!$workflowName && !$messageTemplateID) {
       throw new CRM_Core_Exception(ts("Message template's option value or ID missing."));
     }
 
     $apiCall = MessageTemplate::get(FALSE)
+      ->setLanguage($language)
       ->addSelect('msg_subject', 'msg_text', 'msg_html', 'pdf_format_id', 'id')
       ->addWhere('is_default', '=', 1);
 
@@ -480,7 +492,8 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
     else {
       $apiCall->addWhere('workflow_name', '=', $workflowName);
     }
-    $messageTemplate = array_merge($base, $apiCall->execute()->first() ?: [], $messageTemplateOverride ?: []);
+    $result = $apiCall->execute();
+    $messageTemplate = array_merge($base, $result->first() ?: [], $messageTemplateOverride ?: []);
     if (empty($messageTemplate['id']) && empty($messageTemplateOverride)) {
       if ($messageTemplateID) {
         throw new CRM_Core_Exception(ts('No such message template: id=%1.', [1 => $messageTemplateID]));

--- a/CRM/Core/BAO/TranslateGetWrapper.php
+++ b/CRM/Core/BAO/TranslateGetWrapper.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Wrapper to swap in translated text.
+ */
+class CRM_Core_BAO_TranslateGetWrapper {
+
+  protected $fields;
+  protected $translatedLanguage;
+
+  /**
+   * CRM_Core_BAO_TranslateGetWrapper constructor.
+   *
+   * This wrapper replaces values with configured translated values, if any exist.
+   *
+   * @param array $translated
+   */
+  public function __construct($translated) {
+    $this->fields = $translated['fields'];
+    $this->translatedLanguage = $translated['language'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function fromApiInput($apiRequest) {
+    return $apiRequest;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function toApiOutput($apiRequest, $result) {
+    foreach ($result as &$value) {
+      if (!isset($value['id'], $this->fields[$value['id']])) {
+        continue;
+      }
+      $toSet = array_intersect_key($this->fields[$value['id']], $value);
+      $value = array_merge($value, $toSet);
+      $value['actual_language'] = $this->translatedLanguage;
+    }
+    return $result;
+  }
+
+}

--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -11,13 +11,14 @@
 
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Translation;
+use Civi\Core\HookInterface;
 
 /**
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi\Core\HookInterface {
+class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookInterface {
 
   use CRM_Core_DynamicFKAccessTrait;
 
@@ -26,7 +27,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi
    *
    * @return array[]
    */
-  public static function getStatuses() {
+  public static function getStatuses(): array {
     return [
       ['id' => 1, 'name' => 'active', 'label' => ts('Active')],
       ['id' => 2, 'name' => 'draft', 'label' => ts('Draft')],

--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Translation;
+
 /**
  *
  * @package CRM
@@ -142,6 +145,101 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements \Civi
         $e->addError($r, 'entity_id', 'nonexistent_id', ts('Entity does not exist'));
       }
     }
+  }
+
+  /**
+   * Callback for hook_civicrm_post().
+   *
+   * Flush out cached values.
+   *
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event): void {
+    unset(Civi::$statics[__CLASS__]);
+  }
+
+  /**
+   * Implements hook_civicrm_apiWrappers().
+   *
+   * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/
+   *
+   * @see \CRM_Utils_Hook::apiWrappers()
+   * @throws \CRM_Core_Exception
+   */
+  public static function hook_civicrm_apiWrappers(&$wrappers, $apiRequest): void {
+    if (!($apiRequest instanceof \Civi\Api4\Generic\DAOGetAction)) {
+      return;
+    }
+
+    $mode = $apiRequest->getTranslationMode();
+    if ($mode !== 'fuzzy') {
+      return;
+    }
+
+    $communicationLanguage = \Civi\Core\Locale::detect()->nominal;
+    if ($communicationLanguage === Civi::settings()->get('lcMessages')) {
+      return;
+    }
+
+    if ($apiRequest['action'] === 'get') {
+      if (!isset(\Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$communicationLanguage])) {
+        $translated = self::getTranslatedFieldsForRequest($apiRequest);
+        // @todo - once https://github.com/civicrm/civicrm-core/pull/24063 is merged
+        // this could set any defined translation fields that don't have a translation
+        // for one or more fields in the set to '' - ie 'if any are defined for
+        // an entity/language then all must be' - it seems like being strict on this
+        // now will make it easier later....
+        //n No, this doesn't work - 'fields' array doesn't look like that.
+        //n if (!empty($translated['fields']['msg_html']) && !isset($translated['fields']['msg_text'])) {
+        //n  $translated['fields']['msg_text'] = '';
+        //n }
+        foreach ($translated['fields'] ?? [] as $field) {
+          \Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$communicationLanguage]['fields'][$field['entity_id']][$field['entity_field']] = $field['string'];
+          \Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$communicationLanguage]['language'] = $translated['language'];
+        }
+      }
+      if (!empty(\Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$communicationLanguage])) {
+        $wrappers[] = new CRM_Core_BAO_TranslateGetWrapper(\Civi::$statics[__CLASS__]['translate_fields'][$apiRequest['entity']][$communicationLanguage]);
+      }
+    }
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\AbstractAction $apiRequest
+   * @return array translated fields.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected static function getTranslatedFieldsForRequest(AbstractAction $apiRequest): array {
+    $userLocale = \Civi\Core\Locale::detect();
+
+    $translations = Translation::get()
+      ->addWhere('entity_table', '=', CRM_Core_DAO_AllCoreTables::getTableForEntityName($apiRequest['entity']))
+      ->setCheckPermissions(FALSE)
+      ->setSelect(['entity_field', 'entity_id', 'string', 'language']);
+    if ((substr($userLocale->nominal, '-3', '3') !== '_NO')) {
+      // Generally we want to check for any translations of the base language
+      // and prefer, for example, French French over US English for French Canadians.
+      // Sites that genuinely want to cater to both will add translations for both
+      // and we work through preferences below.
+      $translations->addWhere('language', 'LIKE', substr($userLocale->nominal, 0, 2) . '%');
+    }
+    else {
+      // And here we have ... the Norwegians. They have three main variants which
+      // share the same country suffix but not language prefix. As with other languages
+      // any Norwegian is better than no Norwegian and sites that care will do multiple
+      $translations->addWhere('language', 'LIKE', '%_NO');
+    }
+    $fields = $translations->execute();
+    $languages = [];
+    foreach ($fields as $index => $field) {
+      $languages[$field['language']][$index] = $field;
+    }
+
+    $bizLocale = $userLocale->renegotiate(array_keys($languages));
+    return $bizLocale
+      ? ['fields' => $languages[$bizLocale->nominal], 'language' => $bizLocale->nominal]
+      : [];
   }
 
 }

--- a/Civi/Api4/Action/WorkflowMessage/Render.php
+++ b/Civi/Api4/Action/WorkflowMessage/Render.php
@@ -75,13 +75,24 @@ class Render extends \Civi\Api4\Generic\AbstractAction {
 
   public function _run(\Civi\Api4\Generic\Result $result) {
     $this->validateValues();
+    global $moneyFormatLocale;
+    $separatorConfig = \CRM_Utils_Constant::value('IGNORE_SEPARATOR_CONFIG');
+    $originalValue = $moneyFormatLocale;
 
+    if ($this->getTranslationLanguage()) {
+      // Passing in translation language forces money formatting, useful when the
+      // template is previewed before being saved.
+      $moneyFormatLocale = $this->getTranslationLanguage();
+      putenv('IGNORE_SEPARATOR_CONFIG=' . 1);
+    }
     $r = \CRM_Core_BAO_MessageTemplate::renderTemplate([
       'model' => $this->_model,
       'messageTemplate' => $this->getMessageTemplate(),
       'messageTemplateId' => $this->getMessageTemplateId(),
+      'language' => $this->getPreferredLanguage(),
     ]);
-
+    $moneyFormatLocale = $originalValue;
+    putenv('IGNORE_SEPARATOR_CONFIG=' . $separatorConfig);
     $result[] = \CRM_Utils_Array::subset($r, ['subject', 'html', 'text']);
   }
 

--- a/Civi/Api4/Action/WorkflowMessage/Render.php
+++ b/Civi/Api4/Action/WorkflowMessage/Render.php
@@ -75,24 +75,12 @@ class Render extends \Civi\Api4\Generic\AbstractAction {
 
   public function _run(\Civi\Api4\Generic\Result $result) {
     $this->validateValues();
-    global $moneyFormatLocale;
-    $separatorConfig = \CRM_Utils_Constant::value('IGNORE_SEPARATOR_CONFIG');
-    $originalValue = $moneyFormatLocale;
-
-    if ($this->getTranslationLanguage()) {
-      // Passing in translation language forces money formatting, useful when the
-      // template is previewed before being saved.
-      $moneyFormatLocale = $this->getTranslationLanguage();
-      putenv('IGNORE_SEPARATOR_CONFIG=' . 1);
-    }
     $r = \CRM_Core_BAO_MessageTemplate::renderTemplate([
       'model' => $this->_model,
       'messageTemplate' => $this->getMessageTemplate(),
       'messageTemplateId' => $this->getMessageTemplateId(),
-      'language' => $this->getPreferredLanguage(),
+      'language' => $this->getLanguage(),
     ]);
-    $moneyFormatLocale = $originalValue;
-    putenv('IGNORE_SEPARATOR_CONFIG=' . $separatorConfig);
     $result[] = \CRM_Utils_Array::subset($r, ['subject', 'html', 'text']);
   }
 

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -24,6 +24,8 @@ use Civi\Api4\Utils\CoreUtil;
  *
  * @method $this setHaving(array $clauses)
  * @method array getHaving()
+ * @method $this setTranslationMode(string|null $mode)
+ * @method string|null getTranslationMode()
  */
 class DAOGetAction extends AbstractGetAction {
   use Traits\DAOActionTrait;
@@ -79,6 +81,15 @@ class DAOGetAction extends AbstractGetAction {
    * @var array
    */
   protected $having = [];
+
+  /**
+   * Should we automatically overload the result with translated data?
+   * How do we pick the suitable translation?
+   *
+   * @var string|null
+   * @options fuzzy,strict
+   */
+  protected $translationMode;
 
   /**
    * @throws \API_Exception

--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -271,6 +271,7 @@
       crmApi4({
         examples: ['ExampleData', 'get', {
           // FIXME: workflow name
+          language: $ctrl.lang,
           where: [["tags", "CONTAINS", "preview"], ["name", "LIKE", "workflow/" + $ctrl.records.main.workflow_name + "/%"]],
           select: ['name', 'title', 'data']
         }],
@@ -279,7 +280,6 @@
           format: 'example'
         }]
       }).then(function(resp) {
-        console.log('resp',resp);
         if ((!resp.examples || resp.examples.length === 0) && resp.adhoc) {
           // In the future, if Preview dialog allows editing adhoc examples, then we can show the dialog. But for now, it won't work without explicit examples.
           crmUiAlert({

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -1,10 +1,14 @@
 (function(angular, $, _) {
 
-  angular.module('crmMsgadm').controller('MsgtpluiPreviewCtrl', function($scope, crmUiHelp, crmStatus, crmApi4, crmUiAlert, $timeout, $q, dialogService) {
+  angular.module('crmMsgadm').controller('MsgtpluiPreviewCtrl', function($scope, crmUiHelp, crmStatus, crmApi4, crmUiAlert, $timeout, $q, dialogService, $location) {
     var ts = $scope.ts = CRM.ts('crmMsgadm');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/MessageAdmin/crmMsgadm'}); // See: templates/CRM/MessageAdmin/crmMsgadm.hlp
 
     var $ctrl = this, model = $scope.model;
+    var args = $location.search();
+    if (args.lang) {
+      $ctrl.lang = args.lang;
+    }
 
     $ctrl.exampleId = parseInt(_.findKey(model.examples, {name: model.exampleName}));
     $ctrl.revisionId = parseInt(_.findKey(model.revisions, {name: model.revisionName}));
@@ -35,6 +39,7 @@
       dlgModel.refresh = function(){
         return crmApi4('ExampleData', 'get', {
           where: [["name", "=", model.examples[$ctrl.exampleId].name]],
+          language: $ctrl.lang,
           select: ['name', 'file', 'title', 'data']
         }).then(function(response){
           dlgModel.title = ts('Example: %1', {1: response[0].title || response[0].name});
@@ -64,6 +69,7 @@
     function requestStoredExample() {
       return crmApi4('ExampleData', 'get', {
         where: [["name", "=", model.examples[$ctrl.exampleId].name]],
+        language: $ctrl.lang,
         select: ['data']
       }).then(function(response) {
         return response[0].data;
@@ -82,6 +88,8 @@
       rendering.then(function(exampleData) {
         var filteredData = model.filterData ? model.filterData(exampleData) : exampleData;
         return crmApi4('WorkflowMessage', 'render', {
+          language: $ctrl.lang,
+          translationLanguage: $ctrl.lang,
           workflow: filteredData.workflow,
           values: filteredData.modelProps,
           messageTemplate: model.revisions[$ctrl.revisionId].rec

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -89,7 +89,6 @@
         var filteredData = model.filterData ? model.filterData(exampleData) : exampleData;
         return crmApi4('WorkflowMessage', 'render', {
           language: $ctrl.lang,
-          translationLanguage: $ctrl.lang,
           workflow: filteredData.workflow,
           values: filteredData.modelProps,
           messageTemplate: model.revisions[$ctrl.revisionId].rec

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -40,6 +40,9 @@ return new class() extends EventCheck implements HookInterface {
     'Precedence' => ['type' => 'string|NULL', 'for' => ['civimail', 'flexmailer'], 'regex' => '/(bulk|first-class|list)/'],
     'job_id' => ['type' => 'int|NULL', 'for' => ['civimail', 'flexmailer']],
 
+    // ## Language
+    'language' => ['type' => 'string|NULL', 'for' => ['messageTemplate']],
+
     // ## Content
 
     'subject' => ['for' => ['messageTemplate', 'singleEmail'], 'type' => 'string'],

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -47,6 +47,94 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that translated strings are rendered for templates where they exist.
+   *
+   * @throws \API_Exception|\CRM_Core_Exception
+   */
+  public function testRenderTranslatedTemplate(): void {
+    $this->individualCreate(['preferred_language' => 'fr_FR']);
+    $contributionID = $this->contributionCreate(['contact_id' => $this->ids['Contact']['individual_0']]);
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila!'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_FR',
+    ])->execute();
+
+    $messageTemplateFrench = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id', 'msg_subject', 'msg_html')
+      ->setLanguage('fr_FR')
+      ->execute()->first();
+
+    $this->assertEquals('Bonjour', $messageTemplateFrench['msg_subject']);
+    $this->assertEquals('Voila!', $messageTemplateFrench['msg_html']);
+
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'workflow' => 'contribution_online_receipt',
+      'tokenContext' => [
+        'contactId' => $this->ids['Contact']['individual_0'],
+        'contributionId' => $contributionID,
+      ],
+    ]);
+    $this->assertEquals('Bonjour', $rendered['subject']);
+    $this->assertEquals('Voila!', $rendered['html']);
+    $this->assertEquals('100,00 $US', $rendered['text']);
+
+    // French Canadian should ALSO pick up French if there
+    //is no specific French Canadian.
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'workflow' => 'contribution_online_receipt',
+      'tokenContext' => [
+        'contactId' => $this->ids['Contact']['individual_0'],
+        'contributionId' => $contributionID,
+      ],
+      'language' => 'fr_CA',
+    ]);
+    $this->assertEquals('Bonjour', $rendered['subject']);
+    $this->assertEquals('Voila!', $rendered['html']);
+    // Money is formatted per fr_FR locale as that is the found-template-locale.
+    $this->assertEquals('100,00 $US', $rendered['text']);
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour Canada'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila! Canada'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_CA',
+    ])->execute();
+
+    // But, prefer French Canadian where both exist.
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'workflow' => 'contribution_online_receipt',
+      'tokenContext' => [
+        'contactId' => $this->ids['Contact']['individual_0'],
+        'contributionId' => $contributionID,
+      ],
+      'language' => 'fr_CA',
+    ]);
+    $this->assertEquals('Bonjour Canada', $rendered['subject']);
+    $this->assertEquals('Voila! Canada', $rendered['html']);
+    // Note that as there was a native-Canada format the money-formatting is
+    // also subtly different.
+    $this->assertEquals('100,00 $ US', $rendered['text']);
+  }
+
+  /**
    * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -3,6 +3,7 @@
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\MessageTemplate;
+use Civi\Api4\Translation;
 use Civi\Token\TokenProcessor;
 
 /**
@@ -199,6 +200,56 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertEquals('[case #' . $msg->getIdHash() . '] Test 123', $subject);
     $this->assertStringContainsString('Your Case Role(s) : Sand grain counter', $message);
     $this->assertStringContainsString('Case ID : 1234', $message);
+  }
+
+  public function getTranslationSettings(): array {
+    $es = [];
+    $es['fr_FR-full'] = [
+      ['partial_locales' => FALSE, 'uiLanguages' => ['en_US', 'fr_FR', 'fr_CA']],
+    ];
+    $es['fr_FR-partial'] = [
+      ['partial_locales' => TRUE, 'uiLanguages' => ['en_US']],
+    ];
+    return $es;
+  }
+
+  /**
+   * Test that translated strings are rendered for templates where they exist.
+   *
+   * @dataProvider getTranslationSettings
+   * @throws \API_Exception|\CRM_Core_Exception
+   */
+  public function testGetTranslatedTemplate($translationSettings): void {
+    $cleanup = \CRM_Utils_AutoClean::swapSettings($translationSettings);
+
+    $this->individualCreate(['preferred_language' => 'fr_FR']);
+    $this->contributionCreate(['contact_id' => $this->ids['Contact']['individual_0']]);
+    $this->addTranslation();
+
+    $messageTemplate = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
+      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
+      ->setLanguage('fr_FR')
+      ->setTranslationMode('fuzzy')
+      ->execute()->indexBy('workflow_name');
+
+    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+
+    $this->assertStringContainsString('{ts}Contribution Receipt{/ts}', $messageTemplate['contribution_offline_receipt']['msg_subject']);
+    $this->assertStringContainsString('Below you will find a receipt', $messageTemplate['contribution_offline_receipt']['msg_html']);
+    $this->assertArrayNotHasKey('actual_language', $messageTemplate['contribution_offline_receipt']);
+
+    $messageTemplate = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
+      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
+      ->setLanguage('fr_CA')
+      ->setTranslationMode('fuzzy')
+      ->execute()->indexBy('workflow_name');
+
+    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+
   }
 
   /**
@@ -918,6 +969,40 @@ id |' . $tokenData['contact_id'] . '
 t_stuff.favourite_emoticon |
 ';
     return $expected;
+  }
+
+  /**
+   * @return mixed
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function addTranslation() {
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila!'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_FR',
+    ])->execute();
+    return $messageTemplateID;
+  }
+
+  /**
+   * @param $contribution_online_receipt
+   */
+  private function assertFrenchTranslationRetrieved($contribution_online_receipt): void {
+    $this->assertEquals('Bonjour', $contribution_online_receipt['msg_subject']);
+    $this->assertEquals('Voila!', $contribution_online_receipt['msg_html']);
+    $this->assertEquals('fr_FR', $contribution_online_receipt['actual_language']);
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -3,7 +3,6 @@
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\MessageTemplate;
-use Civi\Api4\Translation;
 use Civi\Token\TokenProcessor;
 
 /**
@@ -200,56 +199,6 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
     $this->assertEquals('[case #' . $msg->getIdHash() . '] Test 123', $subject);
     $this->assertStringContainsString('Your Case Role(s) : Sand grain counter', $message);
     $this->assertStringContainsString('Case ID : 1234', $message);
-  }
-
-  public function getTranslationSettings(): array {
-    $es = [];
-    $es['fr_FR-full'] = [
-      ['partial_locales' => FALSE, 'uiLanguages' => ['en_US', 'fr_FR', 'fr_CA']],
-    ];
-    $es['fr_FR-partial'] = [
-      ['partial_locales' => TRUE, 'uiLanguages' => ['en_US']],
-    ];
-    return $es;
-  }
-
-  /**
-   * Test that translated strings are rendered for templates where they exist.
-   *
-   * @dataProvider getTranslationSettings
-   * @throws \API_Exception|\CRM_Core_Exception
-   */
-  public function testGetTranslatedTemplate($translationSettings): void {
-    $cleanup = \CRM_Utils_AutoClean::swapSettings($translationSettings);
-
-    $this->individualCreate(['preferred_language' => 'fr_FR']);
-    $this->contributionCreate(['contact_id' => $this->ids['Contact']['individual_0']]);
-    $this->addTranslation();
-
-    $messageTemplate = MessageTemplate::get()
-      ->addWhere('is_default', '=', 1)
-      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
-      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
-      ->setLanguage('fr_FR')
-      ->setTranslationMode('fuzzy')
-      ->execute()->indexBy('workflow_name');
-
-    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
-
-    $this->assertStringContainsString('{ts}Contribution Receipt{/ts}', $messageTemplate['contribution_offline_receipt']['msg_subject']);
-    $this->assertStringContainsString('Below you will find a receipt', $messageTemplate['contribution_offline_receipt']['msg_html']);
-    $this->assertArrayNotHasKey('actual_language', $messageTemplate['contribution_offline_receipt']);
-
-    $messageTemplate = MessageTemplate::get()
-      ->addWhere('is_default', '=', 1)
-      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
-      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
-      ->setLanguage('fr_CA')
-      ->setTranslationMode('fuzzy')
-      ->execute()->indexBy('workflow_name');
-
-    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
-
   }
 
   /**
@@ -969,40 +918,6 @@ id |' . $tokenData['contact_id'] . '
 t_stuff.favourite_emoticon |
 ';
     return $expected;
-  }
-
-  /**
-   * @return mixed
-   * @throws \API_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  private function addTranslation() {
-    $messageTemplateID = MessageTemplate::get()
-      ->addWhere('is_default', '=', 1)
-      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
-      ->addSelect('id')
-      ->execute()->first()['id'];
-
-    Translation::save()->setRecords([
-      ['entity_field' => 'msg_subject', 'string' => 'Bonjour'],
-      ['entity_field' => 'msg_html', 'string' => 'Voila!'],
-      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
-    ])->setDefaults([
-      'entity_table' => 'civicrm_msg_template',
-      'entity_id' => $messageTemplateID,
-      'status_id:name' => 'active',
-      'language' => 'fr_FR',
-    ])->execute();
-    return $messageTemplateID;
-  }
-
-  /**
-   * @param $contribution_online_receipt
-   */
-  private function assertFrenchTranslationRetrieved($contribution_online_receipt): void {
-    $this->assertEquals('Bonjour', $contribution_online_receipt['msg_subject']);
-    $this->assertEquals('Voila!', $contribution_online_receipt['msg_html']);
-    $this->assertEquals('fr_FR', $contribution_online_receipt['actual_language']);
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -67,6 +67,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
       'civicrm_participant',
       'civicrm_batch',
       'civicrm_product',
+      'civicrm_translation',
     ];
     $this->cleanup(['tablesToTruncate' => $tablesToTruncate]);
     parent::tearDown();

--- a/tests/phpunit/api/v4/Options/TranslationModeTest.php
+++ b/tests/phpunit/api/v4/Options/TranslationModeTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Options;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\MessageTemplate;
+use Civi\Api4\Translation;
+
+/**
+ * Tests for the option `$apiRequest->setTranslationMode(...)`.
+ *
+ * Broadly, these tests need to:
+ *   - Make some example business records
+ *   - Add translations for them
+ *   - Read back the translations, with variations on the translation-mode.
+ *
+ * @group headless
+ */
+class TranslationModeTest extends Api4TestBase {
+
+  public function getTranslationSettings(): array {
+    $es = [];
+    $es['fr_FR-full'] = [
+      ['partial_locales' => FALSE, 'uiLanguages' => ['en_US', 'fr_FR', 'fr_CA']],
+    ];
+    $es['fr_FR-partial'] = [
+      ['partial_locales' => TRUE, 'uiLanguages' => ['en_US']],
+    ];
+    return $es;
+  }
+
+  /**
+   * Test that translated strings are rendered for templates where they exist.
+   *
+   * @dataProvider getTranslationSettings
+   * @throws \API_Exception|\CRM_Core_Exception
+   * @group locale
+   */
+  public function testGetTranslatedTemplate($translationSettings): void {
+    $cleanup = \CRM_Utils_AutoClean::swapSettings($translationSettings);
+
+    $cid = $this->createTestRecord('Contact', ['preferred_language' => 'fr_FR'])['id'];
+    $this->createTestRecord('Contribution', ['contact_id' => $cid]);
+    $this->addTranslation();
+
+    $messageTemplate = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
+      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
+      ->setLanguage('fr_FR')
+      ->setTranslationMode('fuzzy')
+      ->execute()->indexBy('workflow_name');
+
+    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+
+    $this->assertStringContainsString('{ts}Contribution Receipt{/ts}', $messageTemplate['contribution_offline_receipt']['msg_subject']);
+    $this->assertStringContainsString('Below you will find a receipt', $messageTemplate['contribution_offline_receipt']['msg_html']);
+    $this->assertArrayNotHasKey('actual_language', $messageTemplate['contribution_offline_receipt']);
+
+    $messageTemplate = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', 'IN', ['contribution_online_receipt', 'contribution_offline_receipt'])
+      ->addSelect('id', 'msg_subject', 'msg_html', 'workflow_name')
+      ->setLanguage('fr_CA')
+      ->setTranslationMode('fuzzy')
+      ->execute()->indexBy('workflow_name');
+
+    $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+  }
+
+  /**
+   * @return mixed
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function addTranslation() {
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['entity_field' => 'msg_subject', 'string' => 'Bonjour'],
+      ['entity_field' => 'msg_html', 'string' => 'Voila!'],
+      ['entity_field' => 'msg_text', 'string' => '{contribution.total_amount}'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'status_id:name' => 'active',
+      'language' => 'fr_FR',
+    ])->execute();
+    return $messageTemplateID;
+  }
+
+  /**
+   * @param $contribution_online_receipt
+   */
+  private function assertFrenchTranslationRetrieved($contribution_online_receipt): void {
+    $this->assertEquals('Bonjour', $contribution_online_receipt['msg_subject']);
+    $this->assertEquals('Voila!', $contribution_online_receipt['msg_html']);
+    $this->assertEquals('fr_FR', $contribution_online_receipt['actual_language']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Allow `MessageTemplates` to be translated. This PR builds on prior work (`ext/message_admin`) which allowed the administrator to create+edit translations, but this update is needed to *render*, *preview*, or *deliver* the translated templates in fully localized form. There are a few major sections in this branch.

(1) APIv4 Translation Mode
----------------------------------------

Suppose you read a record (such as a `MessageTemplate`):

```php
$m = MessageTemplate::get()
  ->addWhere('workflow_name', '=', 'xxx')
  ->execute();
```

This returns the *canonical* record. However, there may exist `Translation` records for this `MessageTemplate`. If you actually want to *use* those translations, then you must lookup the `Translation`s and synthesize an effective/de-facto template.

The PR adds an option `$translationMode` which will automatically lookup the best available translation. It currently supports two modes, *fuzzy* (opt-in) or *off* (default/status-quo). For example:

```php
$m = MessageTemplate::get()
  ->addWhere('workflow_name', '=', 'xxx')
  ->setLanguage('fr_CA')
  ->setTranslationMode('fuzzy')
  ->execute();
```

This first loads the canonical version of the `xxx` template, and then it attempts to translate (*replacing `msg_subject`, `msg_html`, `msg_text` with localized variants*). It will use the active language (`fr_CA`) and look for the closest matching template. The choice of "closest" is based in `Civi\Core\Locale::renegotiate()`:

* If there is an exact translation (`fr_CA`), use that.
* If there is a similar translation (`fr_FR`), use that.
* If there is no translation, it continue with the original/canonical template.

Note that the translation-mode is emphatically superficial. It modifies the output of a basic `get` request. It does not support other operations, such as writing-back translated data or filtering/grouping translated data. It is difficult to define an automatic/one-size-fits-all behavior for those operations. (You can use the `Translation` API instead.)

However, for basic application-usage (*fetch and display record X*), it is much easier to read data this way.

Recap:

* _Before_: Load individual field-translations via `Translation` API.
* _After_: Load a translated record, based on the closest-available locale.

(2) Message Template Runtime
----------------------------------------

There are various APIs for using `MessageTemplate`s. These are slight permutations on the same basic mechanism:

* `CRM_Core_BAO_MessageTemplate::sendTemplate()`
* `CRM_Core_BAO_MessageTemplate::renderTemplate()`
* `Civi\Api4\WorkflowMessage::render()`

In each case, it is possible to either (a) pass in a specific template or (b) autoload a template by name. The PR changes the autoloading rule:

* _Before_: Always load the canonical message-template.
* _After_: If available, load a translated message-template. Pick a template based on fuzzy match to the recipient's `preferred_language`. Otherwise, continue with the canonical message-template.

(3) Message Admin UI
----------------------------------------

The `message_admin` UI allows you to create and preview translated templates. However, it needed a fix to render the tokens in the intended locale:

* _Before_: When previewing a message, tokens are rendered in the language of the web-user. Tokens that rely on formatting or translation may appear inconsistent (e.g. French prose with American currency formatting).
* _After_: When previewing a message, tokens are rendered in the assigned locale of the template.

Comments
----------------------------------------

There is a long list of locales supported for *communication purposes* (ie `preferred_language`; ie `languages`) - it is longer than the list of locales supported by the CIviCRM application. This is not necessarily a problem - but it can be. (Some mail-tokens may require l10n resources. But tokens are discretionary, and there are often similar/close-enough resources available.) To get the best support for many languages, enable the "Partial/Mixed Locales" option from #24403.

Development History
----------------------------------------

This PR builds on #24116 and #23844. Major differences relate to:

* Splitting `setPreferredLanguage()` in two:
    * `setLanguage()` is basically as before, but promoted
    * `setTranslationMode()` is the new mechanism that autoloads translations, and it only applies to DAO `get`
* Move the proposed `$moneyFormatLocale` into an object (along with `$tsLocale` and `$dbLocale`).
    * Don't sprinkle so many globals+envvars for l10n into random methods.
    * Do define the major locale-based flags as a `Locale` object and make fallbacks more general

This PR was used as an exploratory branch for patches in inter-related areas, so the history is quite long. Several elements were subsequently re-split. This includes smaller cleanups (#24281, #24284, #24369, and #24400) and more visible functionality (#24269, #24430 and [dev/tranlsation#78](https://lab.civicrm.org/dev/translation/-/issues/78)'s #24403).

