### PR TITLE
[php 8.1 compat] Avoid CRM_Utils_System::url null for $query param

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -244,23 +244,27 @@ class CRM_Utils_System {
    *   An HTML string containing a link to the given path.
    */
   public static function url(
-    $path = NULL,
-    $query = NULL,
+    $path = '',
+    $query = '',
     $absolute = FALSE,
     $fragment = NULL,
     $htmlize = TRUE,
     $frontend = FALSE,
     $forceBackend = FALSE
   ) {
+    // handle legacy null params
+    $path = $path ?? '';
+    $query = $query ?? '';
+
     $query = self::makeQueryString($query);
 
     // Legacy handling for when the system passes around html escaped strings
-    if (strstr(($query ?? ''), '&amp;')) {
+    if (strstr($query, '&amp;')) {
       $query = html_entity_decode($query);
     }
 
     // Extract fragment from path or query if munged together
-    if ($query && strstr(($query ?? ''), '#')) {
+    if ($query && strstr($query, '#')) {
       list($path, $fragment) = explode('#', $query);
     }
     if ($path && strstr($path, '#')) {

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -103,8 +103,8 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     $separator = ($htmlize && $frontend) ? '&amp;' : '&';
 
     if (!$config->cleanURL) {
-      if (isset($path)) {
-        if (isset($query)) {
+      if ($path !== NULL && $path !== '' && $path !== FALSE) {
+        if ($query !== NULL && $query !== '' && $query !== FALSE) {
           return $base . $script . '?q=' . $path . $separator . $query . $fragment;
         }
         else {
@@ -112,7 +112,7 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
         }
       }
       else {
-        if (isset($query)) {
+        if ($query !== NULL && $query !== '' && $query !== FALSE) {
           return $base . $script . '?' . $query . $fragment;
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Passing null to strstr etc

Before
----------------------------------------
passing null

After
----------------------------------------
String

Technical Details
----------------------------------------
There are several places that explicitly pass null or omit the $query param. It seemed appropriate to handle it here.

Comments
----------------------------------------
A little surprised this didn't come up in any of the core tests. It comes up in some mink tests.
