### PR TITLE
[php 8.1 compat] Avoid passing null to explode()

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -657,7 +657,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    * @return bool
    */
   public function isFrontEndPage() {
-    $path = CRM_Utils_System::currentPath();
+    $path = CRM_Utils_System::currentPath() ?? '';
 
     // Get the menu for above URL.
     $item = CRM_Core_Menu::get($path);


### PR DESCRIPTION
Overview
----------------------------------------
Avoid passing null to explode() in Menu::get()

Before
----------------------------------------
Passing null

After
----------------------------------------
String

Technical Details
----------------------------------------


Comments
----------------------------------------
Comes up in drupal when on the front page.
