### PR TITLE
[php 8.1 compat] Avoid passing null to strlen

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -860,7 +860,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
     $key = Civi::service('settings_manager')
       ->getBagByContact(NULL, $cid)
       ->get('navigation');
-    if (strlen($key) !== self::CACHE_KEY_STRLEN) {
+    if (strlen($key ?? '') !== self::CACHE_KEY_STRLEN) {
       $key = self::resetNavigation($cid);
     }
     return $key;


### PR DESCRIPTION
Overview
----------------------------------------
Avoid passing null to strlen

Before
----------------------------------------
null

After
----------------------------------------
string

Technical Details
----------------------------------------


Comments
----------------------------------------

