### PR TITLE
SearchKit - Allow aggreation by partial dates

### DIFF
--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -192,7 +192,7 @@ abstract class SqlExpression {
    * @return mixed|null
    */
   protected function captureKeyword($keywords, &$arg) {
-    foreach ($keywords as $key) {
+    foreach (array_filter($keywords, 'strlen') as $key) {
       // Match keyword followed by a space or eol
       if (strpos($arg, $key . ' ') === 0 || rtrim($arg) === $key) {
         $arg = ltrim(substr($arg, strlen($key)));

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -163,7 +163,7 @@ abstract class SqlFunction extends SqlExpression {
     $params = [];
     foreach (static::params() as $param) {
       // Merge in defaults to ensure each param has these properties
-      $params[] = $param + [
+      $param += [
         'name' => NULL,
         'label' => ts('Select'),
         'min_expr' => 1,
@@ -174,6 +174,10 @@ abstract class SqlFunction extends SqlExpression {
         'must_be' => ['SqlField', 'SqlFunction', 'SqlString', 'SqlNumber', 'SqlNull'],
         'api_default' => NULL,
       ];
+      if (!$param['max_expr']) {
+        $param['must_be'] = [];
+      }
+      $params[] = $param;
     }
     return $params;
   }

--- a/Civi/Api4/Query/SqlFunctionAVG.php
+++ b/Civi/Api4/Query/SqlFunctionAVG.php
@@ -23,7 +23,7 @@ class SqlFunctionAVG extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['DISTINCT' => ts('Distinct')],
+        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionCOUNT.php
+++ b/Civi/Api4/Query/SqlFunctionCOUNT.php
@@ -23,7 +23,7 @@ class SqlFunctionCOUNT extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['DISTINCT' => ts('Distinct')],
+        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct')],
         'max_expr' => 1,
         'must_be' => ['SqlField', 'SqlWild'],
       ],

--- a/Civi/Api4/Query/SqlFunctionEXTRACT.php
+++ b/Civi/Api4/Query/SqlFunctionEXTRACT.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionEXTRACT extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static function params(): array {
+    return [
+      [
+        'label' => ts('Unit'),
+        'flag_before' => [
+          'SECOND' => ts('Seconds'),
+          'MINUTE' => ts('Minutes'),
+          'HOUR' => ts('Hours'),
+          'DAY' => ts('Days'),
+          'WEEK' => ts('Weeks'),
+          'MONTH' => ts('Months'),
+          'QUARTER' => ts('Quarters'),
+          'YEAR' => ts('Years'),
+          'MINUTE_SECOND' => ts('Minutes:Seconds'),
+          'HOUR_SECOND' => ts('Hours:Minutes:Seconds'),
+          'HOUR_MINUTE' => ts('Hours:Minutes'),
+          'DAY_SECOND' => ts('Days Hours:Minutes:Seconds'),
+          'DAY_MINUTE' => ts('Days Hours:Minutes'),
+          'DAY_HOUR' => ts('Days Hours'),
+          'YEAR_MONTH' => ts('Years-Months'),
+        ],
+        'max_expr' => 0,
+        'optional' => FALSE,
+      ],
+      [
+        'name' => 'FROM',
+        'must_be' => ['SqlField'],
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Partial Date');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The numeric month (1-12) of a date.');
+  }
+
+}

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -23,7 +23,7 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['DISTINCT' => ts('Distinct')],
+        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct')],
         'max_expr' => 1,
         'must_be' => ['SqlField', 'SqlFunction'],
         'optional' => FALSE,

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -23,7 +23,7 @@ class SqlFunctionMAX extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['DISTINCT' => ts('Distinct')],
+        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -23,7 +23,7 @@ class SqlFunctionMIN extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['DISTINCT' => ts('Distinct')],
+        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -21,7 +21,7 @@ class SqlFunctionSUM extends SqlFunction {
   protected static function params(): array {
     return [
       [
-        'flag_before' => ['DISTINCT' => ts('Distinct')],
+        'flag_before' => ['' => NULL, 'DISTINCT' => ts('Distinct')],
         'must_be' => ['SqlField'],
       ],
     ];

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -184,8 +184,8 @@
 
         function getKeyword(whitelist) {
           var keyword;
-          _.each(whitelist, function(flag) {
-            if (argString.indexOf(flag) === 0) {
+          _.each(_.filter(whitelist), function(flag) {
+            if (argString.indexOf(flag + ' ') === 0) {
               keyword = flag;
               argString = _.trim(argString.substr(flag.length));
               return false;
@@ -216,16 +216,18 @@
           var exprCount = 0,
             expr, flagBefore;
           argString = _.trim(argString);
-          if (!argString.length || (param.name && !getKeyword(param.name))) {
+          if (!argString.length || (param.name && !_.startsWith(argString, param.name + ' '))) {
             return false;
           }
           if (param.max_expr) {
             while (++exprCount <= param.max_expr && argString.length) {
               flagBefore = getKeyword(_.keys(param.flag_before || {}));
+              var name = getKeyword(param.name ? [param.name] : []);
               expr = getExpr();
               if (expr) {
                 expr.param = param.name || index;
                 expr.flag_before = flagBefore;
+                expr.name = name;
                 info.args.push(expr);
               }
               // Only continue if an expression was found and followed by a comma
@@ -237,6 +239,12 @@
             if (expr && !_.isEmpty(expr.flag_after)) {
               _.last(info.args).flag_after = getKeyword(_.keys(param.flag_after));
             }
+          } else if (param.flag_before && !param.optional) {
+            flagBefore = getKeyword(_.keys(param.flag_before));
+            info.args.push({
+              value: '',
+              flag_before: flagBefore
+            });
           }
         });
         if (!info.data_type && info.args.length) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -36,7 +36,8 @@
       // Gets the first arg of type "field"
       function getFirstArgFromExpr(expr) {
         if (!(expr in meta)) {
-          meta[expr] = _.findWhere(searchMeta.parseExpr(expr).args, {type: 'field'});
+          var args = searchMeta.parseExpr(expr).args;
+          meta[expr] = _.findWhere(args, {type: 'field'});
         }
         return meta[expr] || {};
       }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -48,7 +48,8 @@
         var param = ctrl.getParam(ctrl.args.length);
         ctrl.args.push({
           type: ctrl.exprTypes[exprType].type,
-          flag_before: _.keys(param.flag_before)[0],
+          flag_before: _.filter(_.keys(param.flag_before))[0],
+          name: param.name,
           value: exprType === 'SqlNumber' ? 0 : ''
         });
       };
@@ -62,7 +63,7 @@
           while (
             (ctrl.args.length - index < param.min_expr) &&
             // TODO: Handle named params like "ORDER BY"
-            !param.name &&
+            !(param.name && param.optional) &&
             (!param.optional || param.must_be.length === 1)
           ) {
             ctrl.addArg(param.must_be[0]);
@@ -71,7 +72,9 @@
       }
 
       this.getParam = function(index) {
-        return ctrl.fn.params[index] || _.last(ctrl.fn.params);
+        if (ctrl.fn) {
+          return ctrl.fn.params[index] || _.last(ctrl.fn.params);
+        }
       };
 
       this.canAddArg = function() {
@@ -80,8 +83,8 @@
         }
         var param = ctrl.getParam(ctrl.args.length),
           index = ctrl.fn.params.indexOf(param);
-        // TODO: Handle named params like "ORDER BY"
-        if (param.name) {
+        // TODO: Handle optional named params like "ORDER BY"
+        if (param.name && param.optional) {
           return false;
         }
         return ctrl.args.length - index < param.max_expr;
@@ -123,20 +126,25 @@
 
       this.selectFunction = function() {
         ctrl.fn = _.find(CRM.crmSearchAdmin.functions, {name: ctrl.fnName});
-        delete ctrl.fieldArg.flag_before;
         ctrl.args = [ctrl.fieldArg];
         if (ctrl.fn) {
           var exprType,
             pos = 0;
           // Add non-field args to the beginning if needed
           while (!_.includes(ctrl.fn.params[pos].must_be, 'SqlField')) {
-            exprType = ctrl.fn.params[pos].must_be[0];
+            exprType = _.first(ctrl.fn.params[pos].must_be);
             ctrl.args.splice(pos, 0, {
-              type: ctrl.exprTypes[exprType].type,
+              type: exprType ? ctrl.exprTypes[exprType].type : null,
+              flag_before: _.filter(_.keys(ctrl.fn.params[pos].flag_before))[0],
+              name: ctrl.fn.params[pos].name,
               value: exprType === 'SqlNumber' ? 0 : ''
             });
             ++pos;
           }
+          // Update fieldArg
+          var fieldParam = ctrl.fn.params[pos];
+          ctrl.fieldArg.flag_before = _.keys(fieldParam.flag_before)[0];
+          ctrl.fieldArg.name = fieldParam.name;
           initFunction();
         }
         ctrl.writeExpr();
@@ -160,8 +168,8 @@
       this.writeExpr = function() {
         if (ctrl.fnName) {
           var args = _.transform(ctrl.args, function(args, arg, index) {
-            if (arg.value) {
-              var prefix = arg.flag_before ? (index ? ' ' : '') + arg.flag_before + ' ' : (index ? ', ' : '');
+            if (arg.value || arg.flag_before) {
+              var prefix = arg.flag_before || arg.name ? (index ? ' ' : '') + (arg.flag_before || arg.name) + (arg.value ? ' ' : '') : (index ? ', ' : '');
               args.push(prefix + (arg.type === 'string' ? JSON.stringify(arg.value) : arg.value));
             }
           });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -2,20 +2,13 @@
   <input class="form-control fa-crm-formula" style="min-width: 20px" ng-model="$ctrl.fnName" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ' ', width: 'off', dropdownCss: {width: '275px'}}" ng-change="$ctrl.selectFunction()">
 </span>
 <label ng-hide="$ctrl.mode !== 'select' && !$ctrl.fn">{{ $ctrl.fieldArg.field.label }}</label>
-<label ng-repeat="(val, label) in $ctrl.fn.params[0].flag_before">
-  <input type="checkbox" ng-checked="$ctrl.fieldArg.flag_before === val" ng-click="$ctrl.fieldArg.flag_before = ($ctrl.fieldArg.flag_before === val ? null : val); $ctrl.writeExpr();" >
-  {{ label }}
-</label>
-<div class="form-group" ng-repeat="arg in $ctrl.args" ng-if="arg !== $ctrl.fieldArg">
-  <select class="form-control" ng-if="$index && $ctrl.getParam($index).flag_before" ng-model="arg.flag_before" ng-change="$ctrl.writeExpr();">
-    <option ng-repeat="(val, label) in $ctrl.getParam($index).flag_before" value="{{ val }}">
-      {{ label }}
-    </option>
-  </select>
-  <span ng-switch="arg.type">
+
+<div class="form-group" ng-repeat="arg in $ctrl.args">
+  <crm-search-function-flag ng-if="$ctrl.fn" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
+  <span ng-switch="arg.type" ng-if="arg !== $ctrl.fieldArg">
     <input ng-switch-when="number" class="form-control" type="number" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.changeArg($index)" ng-model-options="{updateOn: 'blur'}">
     <input ng-switch-when="string" class="form-control" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.changeArg($index)" ng-trim="false" ng-model-options="{updateOn: 'blur'}">
-    <input ng-switch-default class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label}" ng-change="$ctrl.changeArg($index)">
+    <input ng-switch-when="field" class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label}" ng-change="$ctrl.changeArg($index)">
   </span>
 </div>
 <div class="btn-group" ng-if="$ctrl.canAddArg()">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
@@ -1,0 +1,27 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('crmSearchFunctionFlag', {
+    bindings: {
+      arg: '<',
+      param: '<',
+      writeExpr: '&'
+    },
+    templateUrl: '~/crmSearchAdmin/crmSearchFunctionFlag.html',
+    controller: function($scope) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.$onInit = function() {
+        if (!ctrl.param || !ctrl.param.flag_before) {
+          this.widget = null;
+        } else if (_.keys(ctrl.param.flag_before).length === 2 && '' in ctrl.param.flag_before) {
+          this.widget = 'checkbox';
+        } else {
+          this.widget = 'select';
+        }
+      };
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
@@ -1,0 +1,13 @@
+<span ng-switch="$ctrl.widget">
+  <span ng-switch-when="checkbox">
+    <label ng-repeat="(val, label) in $ctrl.param.flag_before" ng-if="val">
+      <input type="checkbox" ng-checked="$ctrl.arg.flag_before === val" ng-click="$ctrl.arg.flag_before = ($ctrl.arg.flag_before === val ? null : val); $ctrl.writeExpr();" >
+      {{ label }}
+    </label>
+  </span>
+  <select ng-switch-when="select" class="form-control" ng-model="$ctrl.arg.flag_before" ng-change="$ctrl.writeExpr();">
+    <option ng-repeat="(val, label) in $ctrl.param.flag_before" value="{{ val }}">
+      {{ label }}
+    </option>
+  </select>
+</span>

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -326,6 +326,14 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('birth_date')
       ->execute()->single();
     $this->assertEquals('2009-11-11', $result['birth_date']);
+
+    // Try in GROUP_BY
+    $result = Contact::get(FALSE)
+      ->addSelect('COUNT(id) AS counted')
+      ->addWhere('last_name', '=', $lastName)
+      ->addGroupBy('EXTRACT(YEAR FROM birth_date)')
+      ->execute();
+    $this->assertCount(2, $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Improves SearchKit so that you can e.g. Group by the month+year of a birth-date.
See [dev/core#3700](https://lab.civicrm.org/dev/core/-/issues/3700)

Before
----------------------------------------
Partial dates were limited to YEAR and MONTH

After
----------------------------------------
All SQL date parts are supported:

![image](https://user-images.githubusercontent.com/2874912/183522170-e6b5dcbf-b1d3-4a27-821f-4e45eeb2f795.png)


Technical Details
----------------------------------------
Supports the EXTRACT() sql function so that partial dates can be extracted.

Required heavy refactoring of the function selector (field transformations) because this function has a different signature and the UI needed to be able to handle keywords and arguments in a different order.