### PR TITLE
[Import-code-cleanup] Mark a few functions deprecated for clarity & mark parser class internal

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -19,6 +19,9 @@ use Civi\UserJob\UserJobInterface;
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ * @internal - this class is likely to change and extending it in extensions is not
+ * supported.
  */
 abstract class CRM_Import_Parser implements UserJobInterface {
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -581,6 +581,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
+   * @deprecated
+   *
    * @return array
    */
   public function getDataPatterns():array {
@@ -597,6 +599,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @param array $values
    * @param string $enclosure
    *
+   * @deprecated
+   *
    * @return void
    */
   public static function encloseScrub(&$values, $enclosure = "'") {
@@ -611,6 +615,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
   /**
    * Setter function.
+   *
+   * @deprecated
    *
    * @param int $max
    *
@@ -762,6 +768,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   /**
    * Determines the file extension based on error code.
    *
+   * @deprecated
+   *
    * @var int $type error code constant
    * @return string
    */
@@ -797,6 +805,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   /**
    * Determines the file name based on error code.
    *
+   * @deprecated
+   *
    * @var int $type code constant
    * @return string
    */
@@ -830,6 +840,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * Check if contact is a duplicate .
    *
    * @param array $formatValues
+   *
+   * @deprecated
    *
    * @return array
    */
@@ -917,6 +929,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    *   The structured parameter list.
    *
    * @return bool|CRM_Utils_Error
+   *
+   * @deprecated
    */
   private function _civicrm_api3_deprecated_add_formatted_param(&$values, &$params) {
     // @todo - like most functions in import ... most of this is cruft....
@@ -1197,6 +1211,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * We will try to match name first or (per https://lab.civicrm.org/dev/core/issues/1285 if we have an id.
    *
    * but if not available then see if we have a label that can be converted to a name.
+   *
+   * @deprecated
    *
    * @param string|int|null $submittedValue
    * @param array $fieldSpec
@@ -2030,6 +2046,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    *   Type of date.
    * @param string $dateParam
    *   Index of params.
+   *
+   * @deprecated
    */
   public static function formatCustomDate(&$params, &$formatted, $dateType, $dateParam) {
     //fix for CRM-2687

--- a/CRM/Utils/DeprecatedUtils.php
+++ b/CRM/Utils/DeprecatedUtils.php
@@ -26,6 +26,8 @@ require_once 'api/v3/utils.php';
 
 /**
  *
+ * @deprecated
+ *
  * @param array $params
  *
  * @return array


### PR DESCRIPTION
Overview
----------------------------------------
Mark a few functions deprecated for clarity & mark parser class internal

Before
----------------------------------------
There was a suggestion that extensions might be using some of these functions - it's not supported as they are not a supported / defined interface, but it seems adding `deprecated` would make that clearer

After
----------------------------------------
Marked deprecated, class marked internal

Technical Details
----------------------------------------
I do think it is reasonable to develop a supported interface for imports - but one has not been defined as yet

Comments
----------------------------------------