### PR TITLE
APIv4 - Fix GroupContact permission to use standard ACLs

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -20,6 +20,7 @@ use Civi\Core\HookInterface;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implements HookInterface {
+  use CRM_Contact_AccessTrait;
 
   /**
    * Deprecated add function

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1279,7 +1279,9 @@ class CRM_Core_Permission {
     $permissions['group_nesting'] = $permissions['group'];
     $permissions['group_organization'] = $permissions['group'];
 
-    //Group Contact permission
+    // Note: The v3 GroupContact API is nonstandard and not easy to fix, so these permissions
+    // are unnecessarily strict for v3. The v4 API overrides them.
+    // @see Civi\Api4\GroupContact::permissions
     $permissions['group_contact'] = [
       'get' => [
         'access CiviCRM',

--- a/Civi/Api4/GroupContact.php
+++ b/Civi/Api4/GroupContact.php
@@ -71,4 +71,16 @@ class GroupContact extends Generic\DAOEntity {
     return $info;
   }
 
+  /**
+   * Returns a list of permissions needed to access the various actions in this api.
+   *
+   * @return array
+   */
+  public static function permissions() {
+    // Override CRM_Core_Permission::getEntityActionPermissions() because the v3 API is nonstandard
+    return [
+      'default' => ['access CiviCRM'],
+    ];
+  }
+
 }

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -210,6 +210,10 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
         'location_type_id' => 1,
       ],
     ];
+    // v3 GroupContact API is nonstandard
+    if ($version === 4) {
+      $testEntities['GroupContact'] = ['group_id' => $this->groupCreate()];
+    }
     foreach ($testEntities as $entity => $params) {
       $params += [
         'contact_id' => $disallowedContact,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes GroupContact API to use standard ACLs so that any user with permission to edit a given contact can also add/remove that contact from a group.

Fixes issue raised in https://lab.civicrm.org/dev/core/-/issues/3755#note_80161

Before
----------------------------------------
Adding/ removing a contact from a group required `'edit all contacts'` permission.

After
----------------------------------------
The APIv3 for this entity is nonstandard and not easy to fix, so I left it alone and it still requires `'edit all contacts'`. But the restriction is lifted for APIv4.

Technical Details
----------------------------------------
This is the new standard for applying ACLs to contact-related entities. Also see #20533