### PR TITLE
Move a little code from legacy function `loadRelatedObjects` to the calling functions

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1830,6 +1830,15 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
     $contribution->id = $ids['contribution'];
     $contribution->find();
 
+    if (empty($contribution->_component)) {
+      if (!empty($ids['event'])) {
+        $contribution->_component = 'event';
+      }
+      else {
+        $contribution->_component = strtolower(CRM_Utils_Array::value('component', $input, 'contribute'));
+      }
+    }
+
     $contribution->loadRelatedObjects($input, $ids);
 
     $memberships = $contribution->_relatedObjects['membership'] ?? [];
@@ -2324,20 +2333,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // 4) make ->_relatedObjects protected
     // 5) hone up the individual functions to not use rely on this having been called
     // 6) deprecate like mad
-    if (empty($this->_component)) {
-      if (!empty($ids['event'])) {
-        $this->_component = 'event';
-      }
-      else {
-        $this->_component = strtolower(CRM_Utils_Array::value('component', $input, 'contribute'));
-      }
-    }
-
-    // If the object is not fully populated then make sure it is - this is a more about legacy paths & cautious
-    // refactoring than anything else, and has unit test coverage.
-    if (empty($this->financial_type_id)) {
-      $this->find(TRUE);
-    }
 
     $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $input, CRM_Utils_Array::value(
       'paymentProcessor',
@@ -2462,6 +2457,21 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $ids = array_merge(self::getComponentDetails($this->id), $ids);
     if (empty($ids['contact']) && isset($this->contact_id)) {
       $ids['contact'] = $this->contact_id;
+    }
+
+    if (empty($this->_component)) {
+      if (!empty($ids['event'])) {
+        $this->_component = 'event';
+      }
+      else {
+        $this->_component = strtolower(CRM_Utils_Array::value('component', $input, 'contribute'));
+      }
+    }
+
+    // If the object is not fully populated then make sure it is - this is a more about legacy paths & cautious
+    // refactoring than anything else, and has unit test coverage.
+    if (empty($this->financial_type_id)) {
+      $this->find(TRUE);
     }
     $this->loadRelatedObjects($input, $ids);
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1828,7 +1828,7 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
 
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $ids['contribution'];
-    $contribution->find();
+    $contribution->find(TRUE);
 
     if (empty($contribution->_component)) {
       if (!empty($ids['event'])) {

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -244,6 +244,16 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       // and calls deprecated code. If we decide a contribution title is a
       // 'real thing' then we should create a token.
       $ids = array_merge(CRM_Contribute_BAO_Contribution::getComponentDetails($contributionID), $ids);
+
+      if (empty($contribution->_component)) {
+        if (!empty($ids['event'])) {
+          $contribution->_component = 'event';
+        }
+        else {
+          $contribution->_component = strtolower(CRM_Utils_Array::value('component', $input, 'contribute'));
+        }
+      }
+
       $contribution->loadRelatedObjects($input, $ids);
 
       $input['amount'] = $contribution->total_amount;

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -239,7 +239,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
 
       $contribution = new CRM_Contribute_BAO_Contribution();
       $contribution->id = $contributionID;
-      $contribution->fetch();
+      $contribution->find(TRUE);
       // @todo this is only used now to load the event title, it causes an enotice
       // and calls deprecated code. If we decide a contribution title is a
       // 'real thing' then we should create a token.

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -114,6 +114,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
     $contribution->find(TRUE);
+    $contribution->_component = 'contribute';
     $ids = array_merge(CRM_Contribute_BAO_Contribution::getComponentDetails($this->_contributionId), $this->ids);
     $contribution->loadRelatedObjects($this->input, $ids);
     $this->assertNotEmpty($contribution->_relatedObjects['membership']);


### PR DESCRIPTION
Overview
----------------------------------------
 `loadRelatedObjects` is a function we have been trying to decommission since the GFC. I'm pretty close to removing the call from the invoice task (which would leave two) but it interacts with `_component` in weird ways - moving that interaction out of `loadRelatedObjects` & into the three places that call it creates opportunities for futher code cleanup

Before
----------------------------------------
The chunk of code that sets `_component` based on the `input` is in `loadRelatedObjects`

After
----------------------------------------
It is moved to the three calling functions. Two out of the three already call `find()` so I moved that line to the one that doesn't (or at least on a quick skim didn't appear to - I can look at the functions separately in more depth as we remove their shared dependencies

Technical Details
----------------------------------------
@mattwire - another baby step - once we get rid of `loadRelatedObjects` out of the `Invoice` task it will just remain in `transitioncomponents` (itself on the hit list) and `sendConfirmation`

Comments
----------------------------------------

