### PR TITLE
[REF] Decouple CiviGrant from core permission function

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -476,7 +476,6 @@ class CRM_Core_Permission {
         'CiviMember' => 'edit memberships',
         'CiviPledge' => 'edit pledges',
         'CiviContribute' => 'edit contributions',
-        'CiviGrant' => 'edit grants',
         'CiviMail' => 'access CiviMail',
         'CiviAuction' => 'add auction items',
       ];

--- a/ext/civigrant/CRM/Grant/BAO/Grant.php
+++ b/ext/civigrant/CRM/Grant/BAO/Grant.php
@@ -114,12 +114,12 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
       $title = CRM_Contact_BAO_Contact::displayName($grant->contact_id) . ' - ' . ts('Grant') . ': ' . $grantTypes[$grant->grant_type_id];
 
       $recentOther = [];
-      if (CRM_Core_Permission::checkActionPermission('CiviGrant', CRM_Core_Action::UPDATE)) {
+      if (CRM_Core_Permission::check('edit grants')) {
         $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/contact/view/grant',
           "action=update&reset=1&id={$grant->id}&cid={$grant->contact_id}&context=home"
         );
       }
-      if (CRM_Core_Permission::checkActionPermission('CiviGrant', CRM_Core_Action::DELETE)) {
+      if (CRM_Core_Permission::check('delete in CiviGrant')) {
         $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/contact/view/grant',
           "action=delete&reset=1&id={$grant->id}&cid={$grant->contact_id}&context=home"
         );

--- a/ext/civigrant/CRM/Grant/Form/Grant.php
+++ b/ext/civigrant/CRM/Grant/Form/Grant.php
@@ -54,8 +54,9 @@ class CRM_Grant_Form_Grant extends CRM_Core_Form {
     $this->assign('action', $this->_action);
     $this->assign('context', $this->_context);
 
-    //check permission for action.
-    if (!CRM_Core_Permission::checkActionPermission('CiviGrant', $this->_action)) {
+    // check permission for action.
+    $perm = $this->_action & CRM_Core_Action::DELETE ? 'delete in CiviGrant' : 'edit grants';
+    if (!CRM_Core_Permission::check($perm)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
 

--- a/ext/civigrant/CRM/Grant/Form/GrantView.php
+++ b/ext/civigrant/CRM/Grant/Form/GrantView.php
@@ -76,12 +76,12 @@ class CRM_Grant_Form_GrantView extends CRM_Core_Form {
     $title = CRM_Contact_BAO_Contact::displayName($values['contact_id']) . ' - ' . ts('Grant') . ': ' . CRM_Utils_Money::format($values['amount_total']) . ' (' . $grantType[$values['grant_type_id']] . ')';
 
     $recentOther = [];
-    if (CRM_Core_Permission::checkActionPermission('CiviGrant', CRM_Core_Action::UPDATE)) {
+    if (CRM_Core_Permission::check('edit grants')) {
       $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/contact/view/grant',
         "action=update&reset=1&id={$values['id']}&cid={$values['contact_id']}&context=home"
       );
     }
-    if (CRM_Core_Permission::checkActionPermission('CiviGrant', CRM_Core_Action::DELETE)) {
+    if (CRM_Core_Permission::check('delete in CiviGrant')) {
       $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/contact/view/grant',
         "action=delete&reset=1&id={$values['id']}&cid={$values['contact_id']}&context=home"
       );

--- a/ext/civigrant/CRM/Grant/Form/Task/Delete.php
+++ b/ext/civigrant/CRM/Grant/Form/Task/Delete.php
@@ -39,7 +39,7 @@ class CRM_Grant_Form_Task_Delete extends CRM_Grant_Form_Task {
     parent::preProcess();
 
     //check permission for delete.
-    if (!CRM_Core_Permission::checkActionPermission('CiviGrant', CRM_Core_Action::DELETE)) {
+    if (!CRM_Core_Permission::check('delete in CiviGrant')) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
   }

--- a/ext/civigrant/CRM/Grant/Form/Task/Update.php
+++ b/ext/civigrant/CRM/Grant/Form/Task/Update.php
@@ -31,7 +31,7 @@ class CRM_Grant_Form_Task_Update extends CRM_Grant_Form_Task {
     parent::preProcess();
 
     //check permission for update.
-    if (!CRM_Core_Permission::checkActionPermission('CiviGrant', CRM_Core_Action::UPDATE)) {
+    if (!CRM_Core_Permission::check('edit grants')) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Code simplification.

Before
----------------------------------------
Unnecessary coupling between CiviGrant and core.

After
----------------------------------------
Less coupling

Comments
------------------------------------
This function seems pretty pointless. Not using it is actually less code than using it, and it adds unnecessary coupling between core and components/extensions.