### PR TITLE
[php 8.1 compat] Avoid CRM_Utils_System::url null for $query param

### DIFF
--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -171,8 +171,8 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     $separator = '&';
 
     if (!$config->cleanURL) {
-      if (isset($path)) {
-        if (isset($query)) {
+      if ($path !== NULL && $path !== '' && $path !== FALSE) {
+        if ($query !== NULL && $query !== '' && $query !== FALSE) {
           return $base . $script . '?q=' . $path . $separator . $query . $fragment;
         }
         else {
@@ -180,7 +180,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
         }
       }
       else {
-        if (isset($query)) {
+        if ($query !== NULL && $query !== '' && $query !== FALSE) {
           return $base . $script . '?' . $query . $fragment;
         }
         else {
@@ -189,8 +189,8 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
       }
     }
     else {
-      if (isset($path)) {
-        if (isset($query)) {
+      if ($path !== NULL && $path !== '' && $path !== FALSE) {
+        if ($query !== NULL && $query !== '' && $query !== FALSE) {
           return $base . $path . '?' . $query . $fragment;
         }
         else {
@@ -198,7 +198,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
         }
       }
       else {
-        if (isset($query)) {
+        if ($query !== NULL && $query !== '' && $query !== FALSE) {
           return $base . $script . '?' . $query . $fragment;
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Brings in line with https://github.com/civicrm/civicrm-core/pull/24176.

Before
----------------------------------------
Some inconsistency between null and '' on drupal 7, more so when not using clean urls.

After
----------------------------------------
More like before, but more php8.1 better.

Technical Details
----------------------------------------

Comments
----------------------------------------
It doesn't look like wordpress or joomla need a similar update since they don't use isset on $query.
