### PR TITLE
CrmUi - Fix tabSetOptions variable

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -759,7 +759,7 @@
         restrict: 'EA',
         scope: {
           crmUiTabSet: '@',
-          tabSetOptions: '@'
+          tabSetOptions: '<'
         },
         templateUrl: '~/crmUi/tabset.html',
         transclude: true,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes JS error caused by #23749 refactoring.

Before
----------------------------------------
JS Error when using the MapPins extension.

After
----------------------------------------
Core code is now correct. I'll submit a PR to MapPins because they are still treating the object as if it were a string.

Technical Details
----------------------------------------
Prior to #23749 this had been passing an object around as a string.
During the refactoring it was treated as an object but still left as a string param.
Now it's passed as an object.