### PR TITLE
(dev/core#3141) Membership should be listed chronologically by end da…

### DIFF
--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -55,6 +55,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $this->_contactId;
     $dao->whereAdd($addWhere);
+    $dao->orderBy('end_date DESC');
     $dao->find();
 
     //CRM--4418, check for view, edit, delete

--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -29,7 +29,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
     $dao = new CRM_Member_DAO_Membership();
     $dao->contact_id = $this->_contactId;
     $dao->is_test = 0;
-    $dao->orderBy('start_date DESC');
+    $dao->orderBy('end_date DESC');
     $dao->find();
 
     while ($dao->fetch()) {


### PR DESCRIPTION
…te DESC

Overview
----------------------------------------
All memberships (active and inactive memberships) should be listed chronologically by end date, the most recent member since first. The behavior should be consistent across Userdashboard and Member Tab.

Before
----------------------------------------
member tab doesn't have sorted membership records


After
----------------------------------------
member tab has sorted membership records with end date DESC
