### PR TITLE
[php8] E_WARNING on Find Contributions

### DIFF
--- a/templates/CRM/Contribute/Form/Search/Common.tpl
+++ b/templates/CRM/Contribute/Form/Search/Common.tpl
@@ -25,7 +25,7 @@
     <label>{ts}Currency{/ts}</label> <br />
     {$form.contribution_currency_type.html|crmAddClass:twenty}
   </td>
-  {if $form.contribution_batch_id.html}
+  {if $form.contribution_batch_id}
     <td>
       {$form.contribution_batch_id.label}<br />
       {$form.contribution_batch_id.html}

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -59,6 +59,9 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
       'Find Contacts' => [
         'civicrm/contact/search?reset=1',
       ],
+      'Find Contributions' => [
+        'civicrm/contribute/search?reset=1',
+      ],
       'Fulltext search' => [
         'civicrm/contact/search/custom?csid=15&reset=1',
       ],


### PR DESCRIPTION
Overview
----------------------------------------
E_WARNING about array access on null on Find Contributions

Before
----------------------------------------
`Warning: Trying to access array offset on value of type null in include() (line 34 of .../templates_c/en_US/%%90/90E/90E76DDD%%Common.tpl.php).`

Note it only comes up if you haven't created any batches in your system.

After
----------------------------------------


Technical Details
----------------------------------------
There's a line at https://github.com/civicrm/civicrm-core/blob/d7a8ffbdd8ee5cf98f712358f261f023f7ebf015/CRM/Contribute/BAO/Query.php#L1034 that is supposed to deal with this but that method only works if the value in the template being accessed is at the "top level", i.e. not an array element 2 levels deep in the array. In this case I think it's sufficient to change the template to only check the higher level element exists.

Comments
----------------------------------------
The test passes in php 7 but fails in php 8. The error is an E_NOTICE in php 7 and an E_WARNING in php 8, but smarty excludes notices from error_reporting. See also https://github.com/civicrm/civicrm-core/pull/24196 for a way to make it fail in php 7.
