### PR TITLE
[WIP]

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -144,7 +144,7 @@ class CRM_Core_Smarty extends Smarty {
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
 
-    if ($config->debug) {
+    if ($config->debug || (defined('CIVICRM_TEST') && CIVICRM_TEST)) {
       $this->error_reporting = E_ALL;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
I was confused about something passing on 7.4 but failing on 8.0 when the only difference was E_NOTICE upgraded to E_WARNING. Smarty has a thing where it ignores E_NOTICES unless you tell it not to. Civi does tell it, but only if you have debugging enabled. I tried setting that in CiviUnitTestCase but it's getting overridden somewhere so trying a different way.

Anyway just want to see what this breaks.