### PR TITLE
Update zetacomponents/mail to 1.9.3 so can remove patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -318,9 +318,7 @@
         "PHP8.1 fix for passing null value into strlen": "https://patch-diff.githubusercontent.com/raw/PHPOffice/PHPWord/pull/2272.patch"
       },
       "zetacomponents/mail": {
-        "PHP 8.1 Compatability fixes": "https://patch-diff.githubusercontent.com/raw/zetacomponents/Mail/pull/88.patch",
         "CiviCRM Custom Patches for ZetaCompoents mail": "https://raw.githubusercontent.com/civicrm/civicrm-core/9d93748a36c7c5d44422911db1c98fb2f7067b34/tools/scripts/composer/patches/civicrm-custom-patches-zetacompoents-mail.patch",
-        "Allow single quotes to be used in return path": "https://github.com/zetacomponents/Mail/pull/86.patch",
         "CiviCRM Custom patch to fix a php8.1 issue found in CiviCRM unit tests": "https://raw.githubusercontent.com/civicrm/civicrm-core/5506f4ce5d46799857b4f4ddf34069e7541e9cc5/tools/scripts/composer/zetacomponents-php-81-civicrm-custom.patch"
       }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e50023d9d896bfc1a6782c9685052c5",
+    "content-hash": "0d26ff1d3cf6aacd77e3b92a91b15be5",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5630,23 +5630,23 @@
         },
         {
             "name": "zetacomponents/mail",
-            "version": "1.9.2",
+            "version": "1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Mail.git",
-                "reference": "c55267564d78724d4c25188fc653fef0da4c920a"
+                "reference": "7f7cf8135320fabf27f6530381da4977a31e1c78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/c55267564d78724d4c25188fc653fef0da4c920a",
-                "reference": "c55267564d78724d4c25188fc653fef0da4c920a",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/7f7cf8135320fabf27f6530381da4977a31e1c78",
+                "reference": "7f7cf8135320fabf27f6530381da4977a31e1c78",
                 "shasum": ""
             },
             "require": {
                 "zetacomponents/base": "~1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "~7.5",
+                "phpunit/phpunit": "~9.0",
                 "zetacomponents/unit-test": "*"
             },
             "type": "library",
@@ -5704,9 +5704,9 @@
             "homepage": "https://github.com/zetacomponents",
             "support": {
                 "issues": "https://github.com/zetacomponents/Mail/issues",
-                "source": "https://github.com/zetacomponents/Mail/tree/1.9.2"
+                "source": "https://github.com/zetacomponents/Mail/tree/1.9.3"
             },
-            "time": "2020-06-13T12:38:26+00:00"
+            "time": "2022-08-09T09:42:33+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Overview
----------------------------------------
The patches that were being applied started failing today on drupal 9 since zeta just included them in 1.9.3.

The only other included change seems to be https://github.com/zetacomponents/Mail/commit/606a075005d82c6fc07bc65e228701465214d96c but I don't think it changes anything.

require-dev has changed to require phpunit9, but I don't think that changes how it gets installed on the test nodes. Let's find out.