### PR TITLE
composer.json - Declare requirement for `composer-runtime-api`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
   },
   "require": {
     "php": "~7.2.5 || ~7.3 || ~8",
+    "composer-runtime-api": "~2.0",
     "cache/integration-tests": "~0.17.0",
     "dompdf/dompdf" : "~2",
     "firebase/php-jwt": ">=3 <6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "597a6f0ac1c692fa35162842ebdf6112",
+    "content-hash": "1e50023d9d896bfc1a6782c9685052c5",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5717,6 +5717,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~7.2.5 || ~7.3 || ~8",
+        "composer-runtime-api": "~2.0",
         "ext-intl": "*",
         "ext-json": "*"
     },


### PR DESCRIPTION
Overview
----------------------------------------

This requirement was introduced to `5.53.alpha` via 9584d5d567eee10cacef55bad2cdff28c8013f8c + df54c6407797fa0ab807923f096289f5a5a91e89. It should be declared so that incompatible environments raise a sensible error.

Before
----------------------------------------

If you run `composer install` on composer 1.10.26, then it starts downloading+replacing files, it does a lot of work, and it ultimately fails with error `Class 'Composer\InstalledVersions' not found` in `guzzle_php81_shim.php` (*which is rather mysterious to anyone who doesn't know that class + file*).

<img width="949" alt="Screen Shot 2022-08-09 at 3 38 39 PM" src="https://user-images.githubusercontent.com/1336047/183773908-d99b5a71-9f81-4fb8-a2fd-90240813debc.png">

After
----------------------------------------

If you run `composer install` on composer 1.10.26, then it fails quickly, and the error suggests that the problem is your composer version:

<img width="1012" alt="Screen Shot 2022-08-09 at 3 40 12 PM" src="https://user-images.githubusercontent.com/1336047/183774002-1387e970-a889-4cf7-8734-de7413b17c99.png">

Technical Details
----------------------------------------

See also: https://getcomposer.org/doc/07-runtime.md#runtime-composer-utilities
