### PR TITLE
[Import-code-cleanup] Remove unused function

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -152,40 +152,6 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
   }
 
   /**
-   * Common form postProcess.
-   * @deprecated - just use postProcess.
-   *
-   * @param string $parserClassName
-   * @param string|null $entity
-   *   Entity to set for paraser currently only for custom import
-   */
-  protected function submitFileForMapping($parserClassName, $entity = NULL) {
-    CRM_Core_Session::singleton()->set('dateTypes', $this->getSubmittedValue('dateFormats'));
-    $this->processDatasource();
-
-    $mapper = [];
-
-    $parser = new $parserClassName($mapper);
-    if ($entity) {
-      $parser->setEntity($this->get($entity));
-    }
-    $parser->setMaxLinesToProcess(100);
-    $parser->setUserJobID($this->getUserJobID());
-    $parser->run(
-      $this->getSubmittedValue('uploadFile'),
-      $this->getSubmittedValue('fieldSeparator'),
-      [],
-      $this->getSubmittedValue('skipColumnHeader'),
-      CRM_Import_Parser::MODE_MAPFIELD,
-      $this->getSubmittedValue('contactType')
-    );
-
-    // add all the necessary variables to the form
-    $parser->set($this);
-    $this->controller->resetPage('MapField');
-  }
-
-  /**
    * Return a descriptive name for the page, used in wizard header.
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused function

Before
----------------------------------------
Function still exists, but is no longer called

After
----------------------------------------
poof

Technical Details
----------------------------------------
The only place in universe that calls this is `civihr` - I added a copy of this function to the existing unmerged pr which would need to be merged to support 5.51 - I suspect it is no longer maintained
https://github.com/compucorp/civihr/pull/2993

Comments
----------------------------------------
