### PR TITLE
dev/core#3664 Remove dataColumnGuessing

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -64,9 +64,9 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
   /**
    * Build the form object.
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $savedMappingID = (int) $this->getSubmittedValue('savedMapping');
     $this->buildSavedMappingFields($savedMappingID);
     $this->addFormRule(['CRM_Activity_Import_Form_MapField', 'formRule']);
@@ -75,7 +75,6 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $defaults = [];
     $headerPatterns = $this->getHeaderPatterns();
-    $dataPatterns = $this->getDataPatterns();
     $fieldMappings = $this->getFieldMappings();
     $columnHeaders = $this->getColumnHeaders();
     $hasHeaders = $this->getSubmittedValue('skipColumnHeader');
@@ -112,9 +111,6 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
           if ($hasHeaders) {
             $defaults["mapper[$i]"] = [$this->defaultFromHeader($columnHeader, $headerPatterns)];
           }
-          else {
-            $defaults["mapper[$i]"] = [$this->defaultFromData($dataPatterns, $i)];
-          }
         }
         // End of load mapping.
       }
@@ -126,10 +122,6 @@ class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
             $this->defaultFromHeader($columnHeader, $headerPatterns),
             0,
           ];
-        }
-        else {
-          // Otherwise guess the default from the form of the data
-          $defaults["mapper[$i]"] = [$this->defaultFromData($dataPatterns, $i), 0];
         }
       }
 

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -309,12 +309,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
             ];
           }
         }
-        else {
-          // Otherwise guess the default from the form of the data
-          $defaults["mapper[$i]"] = [
-            $this->defaultFromData($this->getDataPatterns(), $i),
-          ];
-        }
         $last_key = array_key_last($defaults["mapper[$i]"]) ?? 0;
       }
       // Call swapOptions on the deepest select element to hide the empty select lists above it.

--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -90,15 +90,6 @@ trait CRM_Contact_Import_MetadataTrait {
    *
    * @return array
    */
-  public function getDataPatterns(): array {
-    return CRM_Utils_Array::collect('dataPattern', $this->getContactImportMetadata());
-  }
-
-  /**
-   * Get an array of header patterns for importable keys.
-   *
-   * @return array
-   */
   public function getFieldTitles() {
     return CRM_Utils_Array::collect('title', $this->getContactImportMetadata());
   }

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -140,7 +140,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     $mapperKeys = array_keys($this->_mapperFields);
     $hasHeaders = $this->getSubmittedValue('skipColumnHeader');
     $headerPatterns = $this->getHeaderPatterns();
-    $dataPatterns = $this->getDataPatterns();
     $mapperKeysValues = $this->getSubmittedValue('mapper');
     $columnHeaders = $this->getColumnHeaders();
     $fieldMappings = $this->getFieldMappings();
@@ -214,9 +213,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
           if ($hasHeaders) {
             $defaults["mapper[$i]"] = [$this->defaultFromHeader($columnHeader, $headerPatterns)];
           }
-          else {
-            $defaults["mapper[$i]"] = [$this->defaultFromData($dataPatterns, $i)];
-          }
         }
         //end of load mapping
       }
@@ -236,13 +232,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
               0,
             ];
           }
-        }
-        else {
-          // Otherwise guess the default from the form of the data
-          $defaults["mapper[$i]"] = [
-            $this->defaultFromData($dataPatterns, $i),
-            0,
-          ];
         }
         if (!empty($mapperKeysValues) && ($mapperKeysValues[$i][0] ?? NULL) === 'soft_credit') {
           $softCreditField = $mapperKeysValues[$i][1];

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -348,7 +348,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $mapperKeys = array_keys($this->_mapperFields);
     $hasHeaders = $this->getSubmittedValue('skipColumnHeader');
     $headerPatterns = $this->getHeaderPatterns();
-    $dataPatterns = $this->getDataPatterns();
     $fieldMappings = $this->getFieldMappings();
     /* Initialize all field usages to false */
 
@@ -387,9 +386,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
           if ($hasHeaders) {
             $defaults["mapper[$i]"] = [$this->defaultFromHeader($columnHeader, $headerPatterns)];
           }
-          else {
-            $defaults["mapper[$i]"] = [$this->defaultFromData($dataPatterns, $i)];
-          }
         }
         //end of load mapping
       }
@@ -401,14 +397,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
             $this->defaultFromHeader($columnHeader,
               $headerPatterns
             ),
-            //                     $defaultLocationType->id
-            0,
-          ];
-        }
-        else {
-          // Otherwise guess the default from the form of the data
-          $defaults["mapper[$i]"] = [
-            $this->defaultFromData($dataPatterns, $i),
             //                     $defaultLocationType->id
             0,
           ];

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -654,15 +654,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
    *
    * @return array
    */
-  public function getDataPatterns(): array {
-    return $this->getParser()->getDataPatterns();
-  }
-
-  /**
-   * Get the data patterns to pattern match the incoming data.
-   *
-   * @return array
-   */
   public function getHeaderPatterns(): array {
     return $this->getParser()->getHeaderPatterns();
   }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -584,19 +584,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * @deprecated
-   *
-   * @return array
-   */
-  public function getDataPatterns():array {
-    $values = [];
-    foreach ($this->_fields as $name => $field) {
-      $values[$name] = $field->_dataPattern;
-    }
-    return $values;
-  }
-
-  /**
    * Remove single-quote enclosures from a value array (row).
    *
    * @param array $values

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -23,9 +23,9 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
   /**
    * Build the form object.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->buildSavedMappingFields($this->getSubmittedValue('savedMapping'));
     $this->addFormRule(array('CRM_Member_Import_Form_MapField', 'formRule'), $this);
 
@@ -35,7 +35,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $columnHeaders = $this->getColumnHeaders();
     $hasHeaders = $this->getSubmittedValue('skipColumnHeader');
     $headerPatterns = $this->getHeaderPatterns();
-    $dataPatterns = $this->getDataPatterns();
     // For most fields using the html label is a good thing
     // but for contact ID we really want to specify ID.
     $this->_mapperFields['membership_contact_id'] = ts('Contact ID');
@@ -84,9 +83,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
           if ($hasHeaders) {
             $defaults["mapper[$i]"] = array($this->defaultFromHeader($columnHeader, $headerPatterns));
           }
-          else {
-            $defaults["mapper[$i]"] = array($this->defaultFromData($dataPatterns, $i));
-          }
         }
         //end of load mapping
       }
@@ -98,14 +94,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
             $this->defaultFromHeader($columnHeader,
               $headerPatterns
             ),
-            //                     $defaultLocationType->id
-            0,
-          );
-        }
-        else {
-          // Otherwise guess the default from the form of the data
-          $defaults["mapper[$i]"] = array(
-            $this->defaultFromData($dataPatterns, $i),
             //                     $defaultLocationType->id
             0,
           );


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3664 Remove dataColumnGuessing

Before
----------------------------------------
When importing a file without column headers CiviCRM will attempt to guess the field the data matches to based on the content. In practice this means 'match field to prefix is the value in the first row is `mr`, `mrs` or `dr`, otherwise map to city'


After
----------------------------------------
The attempt at dataColumn matching is removed

Technical Details
----------------------------------------
This was discussed & agreed over at https://lab.civicrm.org/dev/core/-/issues/3664 & is a pre-requisite to some further code consolidation with a view to switching to Select 2 - unless @colemanw has a  Select 2 alternative ...

Note replacing the content with an angular widget is also possible.

Comments
----------------------------------------
