### PR TITLE
Consolidate error handling on Custom data import tpl

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2251,6 +2251,7 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
    * @return array
    */
   public static function getMultipleFieldGroup() {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     $multipleGroup = [];
     $dao = new CRM_Core_DAO_CustomGroup();
     $dao->is_multiple = 1;

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -55,6 +55,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    * Common form elements.
    */
   public function buildQuickForm() {
+    $this->assign('errorMessage', $this->getErrorMessage());
     $config = CRM_Core_Config::singleton();
     // When we switch to using the DataSource.tpl used by Contact we can remove this in
     // favour of the one used by Contact - I was trying to consolidate
@@ -107,6 +108,15 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
           'name' => ts('Cancel'),
         ],
     ]);
+  }
+
+  /**
+   * Get an error message to assign to the template.
+   *
+   * @return string
+   */
+  protected function getErrorMessage(): string {
+    return '';
   }
 
   /**

--- a/templates/CRM/Custom/Import/Form/DataSource.tpl
+++ b/templates/CRM/Custom/Import/Form/DataSource.tpl
@@ -9,69 +9,70 @@
 *}
 
 {* Import Wizard - Step 1 (choose data source) *}
+{* Import Wizard - Step 1 (choose data source) *}
 <div class="crm-block crm-form-block crm-import-datasource-form-block">
 
   {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
   {include file="CRM/common/WizardHeader.tpl"}
- {if !$fieldGroups}
-  <div class="messages warning no-popup">
-    {ts}This import screen cannot be used because there are no Multi-value custom data groups.{/ts}
-  </div>
- {/if}
+  {if $errorMessage}
+    <div class="messages warning no-popup">
+      {$errorMessage}
+    </div>
+  {/if}
   <div class="help">
     {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
     {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}
   </div>
- <div id="upload-file" class="form-item">
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-   <table class="form-layout">
-    <tr class="crm-import-uploadfile-form-block-uploadFile">
+  <div id="upload-file" class="form-item">
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+    <table class="form-layout">
+      <tr class="crm-import-uploadfile-form-block-uploadFile">
       <td class="label">{$form.uploadFile.label}</td>
       <td>{$form.uploadFile.html}<br />
       <span class="description">
         {ts}File format must be comma-separated-values (CSV).{/ts}
       </span>
-    </td>
-  </tr>
-  <tr>
-    <td>&nbsp;</td>
-      <td>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</td>
-        </tr>
-  <tr class="crm-import-form-block-skipColumnHeader">
-            <td>&nbsp;</td>
-            <td>{$form.skipColumnHeader.html} {$form.skipColumnHeader.label}<br />
-                <span class="description">
-                    {ts}Check this box if the first row of your file consists of field names (Example: "Contact ID", "Participant Role").{/ts}
-                </span>
-            </td>
-  </tr>
-  <tr class="crm-import-uploadfile-form-block-multipleCustomData">
-              <td class="label">{$form.multipleCustomData.label}</td>
-              <td><span>{$form.multipleCustomData.html}</span> </td>
-  </tr>
-  <tr class="crm-import-uploadfile-from-block-contactType">
-              <td class="label">{$form.contactType.label}</td>
-             <td>{$form.contactType.html}</td>
-  </tr>
+      </td>
+    </tr>
+      <tr>
+        <td>&nbsp;</td>
+        <td>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</td>
+      </tr>
+      <tr class="crm-import-form-block-skipColumnHeader">
+        <td>&nbsp;</td>
+        <td>{$form.skipColumnHeader.html} {$form.skipColumnHeader.label}<br />
+          <span class="description">
+            {ts}Check this box if the first row of your file consists of field names (Example: "Contact ID", "Participant Role").{/ts}
+          </span>
+        </td>
+      </tr>
+     <tr class="crm-import-uploadfile-form-block-multipleCustomData">
+       <td class="label">{$form.multipleCustomData.label}</td>
+       <td><span>{$form.multipleCustomData.html}</span> </td>
+     </tr>
+     <tr class="crm-import-uploadfile-from-block-contactType">
+       <td class="label">{$form.contactType.label}</td>
+       <td>{$form.contactType.html}</td>
+     </tr>
 
-   <tr class="crm-import-datasource-form-block-fieldSeparator">
-     <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
-     <td>{$form.fieldSeparator.html}</td>
-   </tr>
-  <tr class="crm-import-uploadfile-form-block-date_format">
-            {include file="CRM/Core/Date.tpl"}
-  </tr>
-  {if $savedMapping}
-  <tr class="crm-import-uploadfile-form-block-savedMapping">
-              <td class="label">{$form.savedMapping.label}</td>
-              <td><span>{$form.savedMapping.html}</span> </td>
-  </tr>
-  <tr>
-            <td>&nbsp;</td>
-            <td class="description">{ts}Select Saved Mapping, or leave blank to create a new mapping.{/ts}</td>
-        {/if}
-        </tr>
-    </table>
-    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+     <tr class="crm-import-datasource-form-block-fieldSeparator">
+       <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
+       <td>{$form.fieldSeparator.html}</td>
+     </tr>
+     <tr class="crm-import-uploadfile-form-block-date_format">
+       {include file="CRM/Core/Date.tpl"}
+     </tr>
+     {if $savedMapping}
+       <tr class="crm-import-uploadfile-form-block-savedMapping">
+         <td class="label">{$form.savedMapping.label}</td>
+         <td><span>{$form.savedMapping.html}</span> </td>
+       </tr>
+       <tr>
+         <td>&nbsp;</td>
+         <td class="description">{ts}Select Saved Mapping, or leave blank to create a new mapping.{/ts}</td>
+       </tr>
+     {/if}
+  </table>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   </div>
- </div>
+</div>

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -13,6 +13,11 @@
 
   {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
   {include file="CRM/common/WizardHeader.tpl"}
+  {if $errorMessage}
+    <div class="messages warning no-popup">
+      {$errorMessage}
+    </div>
+  {/if}
   <div class="help">
     {ts 1=$importEntity 2= $importEntities}The %1 Import Wizard allows you to easily upload %2 from other applications into CiviCRM.{/ts}
     {ts}Files to be imported must be in the 'comma-separated-values' format (CSV) and must contain data needed to match an existing contact in your CiviCRM database.{/ts} {help id='upload'}


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate error handling on Custom data import tpl

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/183827282-50d9e371-f0a7-4dac-b9e6-ece4a56a29b2.png)

![image](https://user-images.githubusercontent.com/336308/183828798-37f3b388-2dc3-470c-a70b-bc2b7576f5e4.png)


After
----------------------------------------

UI is the same - but the tpl code is generic

Technical Details
----------------------------------------
During the last round I consolidated all the other non-contact files - but I got stuck on the error handling. I thought there was a less stupid approach but in the end stupid is no worse that how it was & it gets us past it.

Once consolidated at the tpl layer I can change it in one place to consolidate with Contact - which has the extra `sql import` and lack of consolidation there is the reason I can't fix the default / positioning on column headers

Comments
----------------------------------------
