### PR TITLE
[Import] [Ref] Extract shared form rule code

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -333,28 +333,14 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param array $fields
    *   Posted values of the form.
    *
-   * @return array|true
+   * @return array|bool
    *   list of errors to be posted back to the form
    */
-  public static function formRule($fields) {
-    $errors = [];
+  public static function formRule(array $fields) {
     if (!empty($fields['saveMapping'])) {
-      $nameField = $fields['saveMappingName'] ?? NULL;
-      if (empty($nameField)) {
-        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
-      }
-      else {
-        $mappingTypeId = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Contact');
-        if (CRM_Core_BAO_Mapping::checkMapping($nameField, $mappingTypeId)) {
-          $errors['saveMappingName'] = ts('Duplicate Import Mapping Name');
-        }
-      }
+      CRM_Core_Smarty::singleton()->assign('isCheked', TRUE);
     }
-    $template = CRM_Core_Smarty::singleton();
-    if (!empty($fields['saveMapping'])) {
-      $template->assign('isCheked', TRUE);
-    }
-    return empty($errors) ? TRUE : $errors;
+    return parent::mappingRule($fields);
   }
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -186,6 +186,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    *
    * @param int|null $savedMappingID
    *
+   * @deprecated - working to remove this in favour of `addSavedMappingFields`
    * @throws \CiviCRM_API3_Exception
    */
   protected function buildSavedMappingFields($savedMappingID) {
@@ -299,8 +300,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     //Updating Mapping Records
     if ($this->getSubmittedValue('updateMapping')) {
       foreach (array_keys($this->getColumnHeaders()) as $i) {
-        $this->saveMappingField($this->getSubmittedValue('mappingId'), $i, TRUE);
+        $this->saveMappingField((int) $this->getSubmittedValue('mappingId'), $i, TRUE);
       }
+      $this->updateUserJobMetadata('mapping', ['id' => (int) $this->getSubmittedValue('mappingId')]);
     }
     //Saving Mapping Details and Records
     if ($this->getSubmittedValue('saveMapping')) {
@@ -314,6 +316,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
         $this->saveMappingField($savedMappingID, $i, FALSE);
       }
       $this->set('savedMapping', $savedMappingID);
+      $this->updateUserJobMetadata('mapping', ['id' => $savedMappingID]);
     }
   }
 
@@ -408,6 +411,49 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $this->assign('initHideBoxes', $js);
     $this->setDefaults($defaults);
     return [$sel, $headerPatterns];
+  }
+
+  /**
+   * Add the saved mapping fields to the form.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function addSavedMappingFields(): void {
+    $savedMappingID = (int) $this->getSubmittedValue('savedMapping');
+    $this->buildSavedMappingFields($savedMappingID);
+    $this->addFormRule(['CRM_Import_Form_MapField', 'mappingRule']);
+  }
+
+  /**
+   * Global validation rules for the form.
+   *
+   * @param array $fields
+   *   Posted values of the form.
+   *
+   * @return array|true
+   *   list of errors to be posted back to the form
+   */
+  public static function mappingRule($fields) {
+    $errors = [];
+    if (!empty($fields['saveMapping'])) {
+      $nameField = $fields['saveMappingName'] ?? NULL;
+      if (empty($nameField)) {
+        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
+      }
+      else {
+        $mappingTypeId = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Contact');
+        if (CRM_Core_BAO_Mapping::checkMapping($nameField, $mappingTypeId)) {
+          $errors['saveMappingName'] = ts('Duplicate Import Mapping Name');
+        }
+      }
+    }
+    // This is horrible & should be removed once gone from tpl
+    if (!empty($errors['saveMappingName'])) {
+      $_flag = 1;
+      $assignError = new CRM_Core_Page();
+      $assignError->assign('mappingDetailsError', $_flag);
+    }
+    return empty($errors) ? TRUE : $errors;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
[Import] [Ref] Extract shared form rule code

Before
----------------------------------------
`formRule` code is repetitively duplicated

After
----------------------------------------
Code is shared

Technical Details
----------------------------------------
This is a partial from https://github.com/civicrm/civicrm-core/pull/23950 - at the time that was written we have a lot of user testing so we were pushing in bigger code changes to hit 5.51 - however, it is a lot to go back to after this time - so I've peeled off a small part that consolidates the relevant form rule code between contact & Activity imports - it winds up being mostly moving code around - but I have ensured `mappingId` is cast to an int as that seems to be the issue we stalled on last time 

Comments
----------------------------------------
