### PR TITLE
Move unshared code to unshared function

### DIFF
--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -21,6 +21,26 @@
   {* Table for mapping data to CRM fields *}
  {include file="CRM/Contact/Import/Form/MapTable.tpl" mapper=$form.mapper}
 
+ {* // Set default location type *}
+ {literal}
+   <script type="text/javascript">
+     CRM.$(function($) {
+       var defaultLocationType = "{/literal}{$defaultLocationType}{literal}";
+       if (defaultLocationType.length) {
+        $('#map-field').on('change', 'select[id^="mapper"][id$="_0"]', function() {
+          var select = $(this).next();
+          $('option', select).each(function() {
+            if ($(this).attr('value') == defaultLocationType  && $(this).text() == {/literal}{
+              $defaultLocationTypeLabel|@json_encode}{literal}) {
+              select.val(defaultLocationType);
+            }
+          });
+        });
+       }
+     });
+   </script>
+ {/literal}
+
 <script type="text/javascript" >
 {literal}
 if ( document.getElementsByName("saveMapping")[0].checked ) {

--- a/templates/CRM/Contact/Import/Form/MapTable.tpl
+++ b/templates/CRM/Contact/Import/Form/MapTable.tpl
@@ -8,25 +8,3 @@
  +--------------------------------------------------------------------+
 *}
 {include file="CRM/Import/Form/MapTableCommon.tpl"}
-
-{if $wizard.currentStepName != 'Preview'}
-  {* // Set default location type *}
-  {literal}
-    <script type="text/javascript">
-    CRM.$(function($) {
-      var defaultLocationType = "{/literal}{$defaultLocationType}{literal}";
-      if (defaultLocationType.length) {
-        $('#map-field').on('change', 'select[id^="mapper"][id$="_0"]', function() {
-          var select = $(this).next();
-          $('option', select).each(function() {
-            if ($(this).attr('value') == defaultLocationType  && $(this).text() == {/literal}{
-              $defaultLocationTypeLabel|@json_encode}{literal}) {
-              select.val(defaultLocationType);
-            }
-          });
-        });
-      }
-    });
-    </script>
-  {/literal}
-{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Move unshared code to unshared function

Before
----------------------------------------
Two forms share `MapTable.tpl` - Preview & MapField. The tpl has a shared one-liner and a chunk of code in an `{if $wizard.currentStepName != 'Preview'}` - ie code that only runs from `MapField`

![image](https://user-images.githubusercontent.com/336308/183839433-7967a73d-0f54-4504-bdfa-75df5b21f47d.png)


After
----------------------------------------
`MapField` only code relocated to `MapField` tpl file

Technical Details
----------------------------------------
Straight up code move - the `MapTable` class could go now but not in scope for this PR

Comments
----------------------------------------

