### PR TITLE
Fix regression causing custom groups to reset to 'Contact' when updated

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -29,9 +29,8 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
   }
 
   /**
-   * Takes an associative array and creates a custom group object.
-   *
-   * This function is invoked from within the web form layer and also from the api layer
+   * FIXME: This function is too complex because it's trying to handle both api-style inputs and
+   * quickform inputs. Needs to be deprecated and broken up.
    *
    * @param array $params
    *   (reference) an assoc array of name/value pairs.
@@ -40,8 +39,10 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @throws \Exception
    */
   public static function create(&$params) {
-    // This is the database default
-    $params += ['extends' => 'Contact'];
+    // FIXME: This is needed by the form parsing code below
+    if (empty($params['id'])) {
+      $params += ['extends' => 'Contact'];
+    }
     // create custom group dao, populate fields and then save.
     $group = new CRM_Core_DAO_CustomGroup();
     if (isset($params['title'])) {

--- a/tests/phpunit/api/v4/Custom/CustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomGroupTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Custom;
+
+use Civi\Api4\CustomGroup;
+
+/**
+ * @group headless
+ */
+class CustomGroupTest extends CustomTestBase {
+
+  public function testUpdateCustomGroup() {
+    $customGroup1 = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Contribution',
+      'weight' => 1,
+    ]);
+    $customGroup2 = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Contribution',
+    ]);
+
+    CustomGroup::update(FALSE)
+      ->addValue('weight', 1)
+      ->addWhere('id', '=', $customGroup2['id'])
+      ->execute();
+
+    $groups = CustomGroup::get(FALSE)
+      ->addWhere('id', 'IN', [$customGroup1['id'], $customGroup2['id']])
+      ->addOrderBy('id')
+      ->execute();
+
+    $this->assertEquals(1, $groups[1]['weight']);
+    $this->assertEquals(2, $groups[0]['weight']);
+    $this->assertEquals('Contribution', $groups[0]['extends']);
+    $this->assertEquals('Contribution', $groups[1]['extends']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression reported in [dev/core#3794](https://lab.civicrm.org/dev/core/-/issues/3794)