### PR TITLE
dev/core#3796 include subtypes where filter > 0

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2347,7 +2347,7 @@ SELECT  civicrm_custom_group.id as groupID, civicrm_custom_group.title as groupT
    */
   public static function getSubTypes(): array {
     $sel2 = [];
-    $activityType = CRM_Core_PseudoConstant::activityType(FALSE, TRUE, FALSE, 'label', TRUE);
+    $activityType = CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'search');
 
     $eventType = CRM_Core_OptionGroup::values('event_type');
     $campaignTypes = CRM_Campaign_PseudoConstant::campaignType();


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/3796

This removes this one tiny deprecated function call and replaces it with one that will not exclude activity types where filter > 0. As far as I can see, we should be allowed to have managed entities where filter > 0 and have custom groups on them.

Somehow this needs to work both for the UI and the API (including managed entities). So fingers crossed.