### PR TITLE
CrmUi - Fix crmSelect2 to work with ngOptions

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -600,7 +600,7 @@
           // In cases where UI initiates update, there may be an extra
           // call to refreshUI, but it doesn't create a cycle.
 
-          if (ngModel) {
+          if (ngModel && !attrs.ngOptions) {
             ngModel.$render = function () {
               $timeout(function () {
                 // ex: msg_template_id adds new item then selects it; use $timeout to ensure that
@@ -631,9 +631,16 @@
             }
           }
 
-          // If using ngOptions, wait for them to load
+          // If using ngOptions, the above methods do not work because option values get rewritten.
+          // Skip init and do something simpler.
           if (attrs.ngOptions) {
-            $timeout(init);
+            $timeout(function() {
+              element.crmSelect2(scope.crmUiSelect || {});
+              // Ensure widget is updated when model changes
+              ngModel.$render = function () {
+                element.val(ngModel.$viewValue || '').change();
+              };
+            });
           } else {
             init();
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug reported in [dev/core#3797](https://lab.civicrm.org/dev/core/-/issues/3797)

Before
----------------------------------------
Select elements using `ngOptions` broken, such as those in CiviMail.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
As part of https://github.com/civicrm/civicrm-core/pull/23749 select elements using `ui-jq` were switched to `crm-ui-select`, which should have been a drop-in replacement, but it turned out to be incompatible with `ngOptions`. This fixes it.