### PR TITLE
Deprecate `BAO_Contribution::importableFields` 

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -693,11 +693,12 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
    *
    * @param string $contactType
    * @param bool $status
-   *
+   * @deprecated
    * @return array
    *   array of importable Fields
    */
   public static function &importableFields($contactType = 'Individual', $status = TRUE) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     if (!self::$_importableFields) {
       if (!self::$_importableFields) {
         self::$_importableFields = [];

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -234,7 +234,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   protected function setFieldMetadata() {
     if (empty($this->importableFieldsMetadata)) {
-      $fields = $this->importableFields($this->getContactType(), FALSE);
+      $fields = $this->importableFields($this->getContactType());
 
       $fields = array_merge($fields,
         [
@@ -277,24 +277,15 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   /**
    * Combine all the importable fields from the lower levels object.
    *
-   * The ordering is important, since currently we do not have a weight
-   * scheme. Adding weight is super important and should be done in the
-   * next week or so, before this can be called complete.
+   * This function should be decommissioned into setFieldMetadata.
    *
    * @param string $contactType
-   * @param bool $status
    *
    * @return array
    *   array of importable Fields
    */
-  private function importableFields($contactType = 'Individual', $status = TRUE) {
-
-    if (!$status) {
-      $fields = ['' => ['title' => ts('- do not import -')]];
-    }
-    else {
-      $fields = ['' => ['title' => ts('- Contribution Fields -')]];
-    }
+  private function importableFields($contactType = 'Individual') {
+    $fields = ['' => ['title' => ts('- do not import -')]];
 
     $note = CRM_Core_DAO_Note::import();
     $tmpFields = CRM_Contribute_DAO_Contribution::import();
@@ -321,12 +312,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         );
         $value = $customFieldId ? 'custom_' . $customFieldId : $value;
         $tmpContactField[trim($value)] = $contactFields[trim($value)];
-        if (!$status) {
-          $title = $tmpContactField[trim($value)]['title'] . ' ' . ts('(match to contact)');
-        }
-        else {
-          $title = $tmpContactField[trim($value)]['title'];
-        }
+        $title = $tmpContactField[trim($value)]['title'] . ' ' . ts('(match to contact)');
         $tmpContactField[trim($value)]['title'] = $title;
       }
     }

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -234,7 +234,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   protected function setFieldMetadata() {
     if (empty($this->importableFieldsMetadata)) {
-      $fields = CRM_Contribute_BAO_Contribution::importableFields($this->getContactType(), FALSE);
+      $fields = $this->importableFields($this->getContactType(), FALSE);
 
       $fields = array_merge($fields,
         [
@@ -272,6 +272,73 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       }
       $this->importableFieldsMetadata = $fields;
     }
+  }
+
+  /**
+   * Combine all the importable fields from the lower levels object.
+   *
+   * The ordering is important, since currently we do not have a weight
+   * scheme. Adding weight is super important and should be done in the
+   * next week or so, before this can be called complete.
+   *
+   * @param string $contactType
+   * @param bool $status
+   *
+   * @return array
+   *   array of importable Fields
+   */
+  private function importableFields($contactType = 'Individual', $status = TRUE) {
+
+    if (!$status) {
+      $fields = ['' => ['title' => ts('- do not import -')]];
+    }
+    else {
+      $fields = ['' => ['title' => ts('- Contribution Fields -')]];
+    }
+
+    $note = CRM_Core_DAO_Note::import();
+    $tmpFields = CRM_Contribute_DAO_Contribution::import();
+    unset($tmpFields['option_value']);
+    $contactFields = CRM_Contact_BAO_Contact::importableFields($contactType, NULL);
+
+    // Using new Dedupe rule.
+    $ruleParams = [
+      'contact_type' => $contactType,
+      'used' => 'Unsupervised',
+    ];
+    $fieldsArray = CRM_Dedupe_BAO_DedupeRule::dedupeRuleFields($ruleParams);
+    $tmpContactField = [];
+    if (is_array($fieldsArray)) {
+      foreach ($fieldsArray as $value) {
+        //skip if there is no dupe rule
+        if ($value === 'none') {
+          continue;
+        }
+        $customFieldId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField',
+          $value,
+          'id',
+          'column_name'
+        );
+        $value = $customFieldId ? 'custom_' . $customFieldId : $value;
+        $tmpContactField[trim($value)] = $contactFields[trim($value)];
+        if (!$status) {
+          $title = $tmpContactField[trim($value)]['title'] . ' ' . ts('(match to contact)');
+        }
+        else {
+          $title = $tmpContactField[trim($value)]['title'];
+        }
+        $tmpContactField[trim($value)]['title'] = $title;
+      }
+    }
+
+    $tmpContactField['external_identifier'] = $contactFields['external_identifier'];
+    $tmpContactField['external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' ' . ts('(match to contact)');
+    $tmpFields['contribution_contact_id']['title'] = $tmpFields['contribution_contact_id']['html']['label'] = $tmpFields['contribution_contact_id']['title'] . ' ' . ts('(match to contact)');
+    $fields = array_merge($fields, $tmpContactField);
+    $fields = array_merge($fields, $tmpFields);
+    $fields = array_merge($fields, $note);
+    $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Contribution'));
+    return $fields;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -226,7 +226,10 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'rule_weight' => 10,
       'rule_field' => 'phone_numeric',
     ]);
-    $fields = CRM_Contribute_BAO_Contribution::importableFields();
+    $userJobID = UserJob::create()->setValues(['job_type:name' => 'Import Contributions', 'status_id:name' => 'Draft', 'metadata' => ['contactType' => 'Individual']])->execute()->first()['id'];
+    $parser = new CRM_Contribute_Import_Parser_Contribution();
+    $parser ->setUserJobID($userJobID);
+    $fields = $parser->getAvailableFields();
     $this->assertArrayHasKey('phone', $fields);
     $this->callApiSuccess('RuleGroup', 'create', [
       'id' => $unsupervisedRuleGroup['id'],

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -226,9 +226,8 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'rule_weight' => 10,
       'rule_field' => 'phone_numeric',
     ]);
-    $userJobID = UserJob::create()->setValues(['job_type:name' => 'Import Contributions', 'status_id:name' => 'Draft', 'metadata' => ['contactType' => 'Individual']])->execute()->first()['id'];
     $parser = new CRM_Contribute_Import_Parser_Contribution();
-    $parser ->setUserJobID($userJobID);
+    $parser ->setUserJobID($this->getUserJobID());
     $fields = $parser->getAvailableFields();
     $this->assertArrayHasKey('phone', $fields);
     $this->callApiSuccess('RuleGroup', 'create', [

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -227,7 +227,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'rule_field' => 'phone_numeric',
     ]);
     $parser = new CRM_Contribute_Import_Parser_Contribution();
-    $parser ->setUserJobID($this->getUserJobID());
+    $parser->setUserJobID($this->getUserJobID());
     $fields = $parser->getAvailableFields();
     $this->assertArrayHasKey('phone', $fields);
     $this->callApiSuccess('RuleGroup', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate `BAO_Contribution::importableFields` 

One of my code cleanup pushes is to return not-really-shared code to the class that uses them (& where possibly make them private or at least protected) - this gets us away from always having to endlessly grep before altering a function & less scared to do the actual cleanup.

In this case only the contact `importableFields` function is used by non-import classes. The only uses for the Contribution `importableFields` function are 
- an upgrade routine - this should be frozen in time so the upgrade class gets a ~car~ copy
- a test - this should really test the importer itself
- the import class

Before
----------------------------------------
The three uses above share the `BAO` function

After
----------------------------------------
A copy is 'frozen' for the upgrade class, the test tests the upgrader itself and the import class has it's own private copy of the function - the original is deprecated for eventual removal

Technical Details
----------------------------------------
Getting rid of code takes time....

Comments
----------------------------------------
