### PR TITLE
Add missing country=>billingCountry to PropertyBag mapping

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -43,6 +43,7 @@ class PropertyBag implements \ArrayAccess {
     'billing_state_province'      => 'billingStateProvince',
     'state_province'              => 'billingStateProvince',
     'billingCountry'              => TRUE,
+    'country'                     => 'billingCountry',
     'contactID'                   => TRUE,
     'contact_id'                  => 'contactID',
     'contributionID'              => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
When address fields got added this mapping got missed

Before
----------------------------------------
`country` not mapped to `billingCountry` so country may not be saved.

After
----------------------------------------
`country` not mapped to `billingCountry` so country saved if using "standard" propertyBag fields

Technical Details
----------------------------------------


Comments
----------------------------------------

