### PR TITLE
APIv4 - Return ID field from getFields when action is create

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -87,7 +87,7 @@ class SpecGatherer {
 
     foreach ($DAOFields as $DAOField) {
       if ($DAOField['name'] == 'id' && $action == 'create') {
-        continue;
+        $DAOField['required'] = FALSE;
       }
       if (array_key_exists('contactType', $DAOField) && $spec->getValue('contact_type') && $DAOField['contactType'] != $spec->getValue('contact_type')) {
         continue;

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -105,6 +105,7 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
       ->setAction('create')
       ->execute()->indexBy('name');
 
+    $this->assertFalse($actFields['id']['required']);
     $this->assertTrue($actFields['activity_type_id']['required']);
     $this->assertFalse($actFields['activity_type_id']['nullable']);
     $this->assertFalse($actFields['subject']['required']);


### PR DESCRIPTION
Overview
----------------------------------------
Improves APIv4 getFields output by not unnecessarily hiding the ID field.

Technical Details
----------------------------------------
Early on in APIv4 development, it seemed like a clever idea to hide the 'id' field from getFields when the action was 'create'. After all, it's not possible to change that field value.
However, it is valid to use it to identify a record in the 'save' action, which uses the same getFields data.
Also, we now have the new "readonly" designation, which is more precise than entirely hiding the field.