### PR TITLE
APIv4 - Add `case_id` field to Activity entity

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -521,6 +521,15 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
 
+    // Add to case
+    if (!empty($params['case_id']) && $action === 'create') {
+      // If this is a brand new case activity, add to case(s)
+      foreach ((array) $params['case_id'] as $singleCaseId) {
+        $caseActivityParams = ['activity_id' => $activity->id, 'case_id' => $singleCaseId];
+        CRM_Case_BAO_Case::processCaseActivity($caseActivityParams);
+      }
+    }
+
     CRM_Utils_Hook::post($action, 'Activity', $activity->id, $activity);
     return $result;
   }

--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -81,36 +81,9 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
       parent::evaluateToken($row, $entity, $realField, $prefetch);
       $row->format('text/plain')->tokens($entity, $field, $row->tokens['activity'][$realField]);
     }
-    elseif ($field === 'case_id') {
-      // An activity can be linked to multiple cases so case_id is always an array.
-      // We just return the first case ID for the token.
-      // this weird hack might exist because apiv3 is weird &
-      $caseID = CRM_Core_DAO::singleValueQuery('SELECT case_id FROM civicrm_case_activity WHERE activity_id = %1 LIMIT 1', [1 => [$activityId, 'Integer']]);
-      $row->tokens($entity, $field, $caseID ?? '');
-    }
     else {
       parent::evaluateToken($row, $entity, $field, $prefetch);
     }
-  }
-
-  /**
-   * Get tokens that are special or calculated for this entity.
-   *
-   * @return array|array[]
-   */
-  protected function getBespokeTokens(): array {
-    $tokens = [];
-    if (CRM_Core_Component::isEnabled('CiviCase')) {
-      $tokens['case_id'] = [
-        'title' => ts('Activity Case ID'),
-        'name' => 'case_id',
-        'type' => 'calculated',
-        'options' => NULL,
-        'data_type' => 'Integer',
-        'audience' => 'user',
-      ];
-    }
-    return $tokens;
   }
 
   /**

--- a/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Api4\Event\Events;
+use Civi\Api4\Event\SchemaMapBuildEvent;
+use Civi\Api4\Service\Schema\Joinable\ExtraJoinable;
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ActivitySchemaMapSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      Events::SCHEMA_MAP_BUILD => 'onSchemaBuild',
+    ];
+  }
+
+  /**
+   * @param \Civi\Api4\Event\SchemaMapBuildEvent $event
+   */
+  public function onSchemaBuild(SchemaMapBuildEvent $event): void {
+    $schema = $event->getSchemaMap();
+    $table = $schema->getTableByName('civicrm_activity');
+
+    $link = (new ExtraJoinable('civicrm_case', 'id', 'case_id'))
+      ->setBaseTable('civicrm_activity')
+      ->setJoinType(Joinable::JOIN_TYPE_MANY_TO_ONE)
+      ->addCondition('`{target_table}`.`id` = (SELECT `civicrm_case_activity`.`case_id` FROM `civicrm_case_activity` WHERE `civicrm_case_activity`.`activity_id` = `{base_table}`.`id` LIMIT 1)');
+    $table->addTableLink('id', $link);
+
+  }
+
+}

--- a/Civi/Api4/Service/Schema/Joinable/ExtraJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/ExtraJoinable.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Schema\Joinable;
+
+/**
+ * Like Joinable but without any default conditions so it can be fully customized.
+ */
+class ExtraJoinable extends Joinable {
+
+  /**
+   * This type of join relies entirely on the extra join conditions.
+   *
+   * @param string $baseTableAlias
+   * @param string $targetTableAlias
+   *
+   * @return array
+   */
+  public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias) {
+    $conditions = [];
+    $this->addExtraJoinConditions($conditions, $baseTableAlias, $targetTableAlias);
+    return $conditions;
+  }
+
+}

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -98,23 +98,32 @@ class Joinable {
    * Gets conditions required when joining to a base table
    *
    * @param string $baseTableAlias
-   * @param string $tableAlias
+   * @param string $targetTableAlias
    *
    * @return array
    */
-  public function getConditionsForJoin(string $baseTableAlias, string $tableAlias) {
+  public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias) {
     $conditions = [];
     $conditions[] = sprintf(
       '`%s`.`%s` =  `%s`.`%s`',
       $baseTableAlias,
       $this->baseColumn,
-      $tableAlias,
+      $targetTableAlias,
       $this->targetColumn
     );
-    foreach ($this->conditions as $condition) {
-      $conditions[] = str_replace(['{base_table}', '{target_table}'], [$baseTableAlias, $tableAlias], $condition);
-    }
+    $this->addExtraJoinConditions($conditions, $baseTableAlias, $targetTableAlias);
     return $conditions;
+  }
+
+  /**
+   * @param $conditions
+   * @param string $baseTableAlias
+   * @param string $targetTableAlias
+   */
+  protected function addExtraJoinConditions(&$conditions, string $baseTableAlias, string $targetTableAlias):void {
+    foreach ($this->conditions as $condition) {
+      $conditions[] = str_replace(['{base_table}', '{target_table}'], [$baseTableAlias, $targetTableAlias], $condition);
+    }
   }
 
   /**
@@ -201,13 +210,6 @@ class Joinable {
     $this->conditions[] = $condition;
 
     return $this;
-  }
-
-  /**
-   * @return array
-   */
-  public function getExtraJoinConditions() {
-    return $this->conditions;
   }
 
   /**

--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Service\Schema;
 
+use Civi\Api4\Query\Api4SelectQuery;
+
 class Joiner {
   /**
    * @var SchemaMap
@@ -60,6 +62,24 @@ class Joiner {
     }
 
     return $this->cache[$cacheKey];
+  }
+
+  /**
+   * SpecProvider callback for joins added via a SchemaMapSubscriber.
+   *
+   * This works for extra joins declared via SchemaMapSubscriber.
+   * It allows implicit joins through custom sql, by virtue of the fact
+   * that `$query->getField` will create the join not just to the `id` field
+   * but to every field on the joined entity, allowing e.g. joins to `address_primary.country_id:label`.
+   *
+   * @param array $field
+   * @param \Civi\Api4\Query\Api4SelectQuery $query
+   * @return string
+   */
+  public static function getExtraJoinSql(array $field, Api4SelectQuery $query): string {
+    $prefix = empty($field['explicit_join']) ? '' : $field['explicit_join'] . '.';
+    $idField = $query->getField($prefix . $field['name'] . '.id');
+    return $idField['sql_name'];
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -23,45 +23,59 @@ class ActivitySpecProvider implements Generic\SpecProviderInterface {
   public function modifySpec(RequestSpec $spec) {
     $action = $spec->getAction();
 
-    // The database default '1' is problematic as the option list is user-configurable,
-    // so activity type '1' doesn't necessarily exist. Best make the field required.
-    $spec->getFieldByName('activity_type_id')
-      ->setDefaultValue(NULL)
-      ->setRequired($action === 'create');
+    if (\CRM_Core_Component::isEnabled('CiviCase')) {
+      $field = new FieldSpec('case_id', 'Activity', 'Integer');
+      $field->setTitle(ts('Case ID'));
+      $field->setLabel($action === 'get' ? ts('Filed on Case') : ts('File on Case'));
+      $field->setDescription(ts('CiviCase this activity belongs to.'));
+      $field->setFkEntity('Case');
+      $field->setInputType('EntityRef');
+      $field->setColumnName('id');
+      $field->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
+      $spec->addFieldSpec($field);
+    }
 
-    $field = new FieldSpec('source_contact_id', 'Activity', 'Integer');
-    $field->setTitle(ts('Source Contact'));
-    $field->setLabel(ts('Added by'));
-    $field->setDescription(ts('Contact who created this activity.'));
-    $field->setRequired($action === 'create');
-    $field->setFkEntity('Contact');
-    $field->setInputType('EntityRef');
-    $spec->addFieldSpec($field);
+    if (in_array($action, ['create', 'update'], TRUE)) {
+      // The database default '1' is problematic as the option list is user-configurable,
+      // so activity type '1' doesn't necessarily exist. Best make the field required.
+      $spec->getFieldByName('activity_type_id')
+        ->setDefaultValue(NULL)
+        ->setRequired($action === 'create');
 
-    $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
-    $field->setTitle(ts('Target Contacts'));
-    $field->setLabel(ts('With Contact(s)'));
-    $field->setDescription(ts('Contact(s) involved in this activity.'));
-    $field->setFkEntity('Contact');
-    $field->setInputType('EntityRef');
-    $field->setInputAttrs(['multiple' => TRUE]);
-    $spec->addFieldSpec($field);
+      $field = new FieldSpec('source_contact_id', 'Activity', 'Integer');
+      $field->setTitle(ts('Source Contact'));
+      $field->setLabel(ts('Added by'));
+      $field->setDescription(ts('Contact who created this activity.'));
+      $field->setRequired($action === 'create');
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $spec->addFieldSpec($field);
 
-    $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
-    $field->setTitle(ts('Assignee Contacts'));
-    $field->setLabel(ts('Assigned to'));
-    $field->setDescription(ts('Contact(s) assigned to this activity.'));
-    $field->setFkEntity('Contact');
-    $field->setInputType('EntityRef');
-    $field->setInputAttrs(['multiple' => TRUE]);
-    $spec->addFieldSpec($field);
+      $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
+      $field->setTitle(ts('Target Contacts'));
+      $field->setLabel(ts('With Contact(s)'));
+      $field->setDescription(ts('Contact(s) involved in this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setInputAttrs(['multiple' => TRUE]);
+      $spec->addFieldSpec($field);
+
+      $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
+      $field->setTitle(ts('Assignee Contacts'));
+      $field->setLabel(ts('Assigned to'));
+      $field->setDescription(ts('Contact(s) assigned to this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setInputAttrs(['multiple' => TRUE]);
+      $spec->addFieldSpec($field);
+    }
   }
 
   /**
    * @inheritDoc
    */
   public function applies($entity, $action) {
-    return $entity === 'Activity' && in_array($action, ['create', 'update'], TRUE);
+    return $entity === 'Activity';
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
@@ -104,7 +104,7 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
           ->setColumnName('id')
           ->setType('Extra')
           ->setFkEntity($entity)
-          ->setSqlRenderer([__CLASS__, 'getLocationFieldSql']);
+          ->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
         $spec->addFieldSpec($field);
       }
     }
@@ -177,25 +177,6 @@ class ContactGetSpecProvider implements Generic\SpecProviderInterface {
    */
   public static function calculateAge(array $field): string {
     return "TIMESTAMPDIFF(YEAR, {$field['sql_name']}, CURDATE())";
-  }
-
-  /**
-   * Generate SQL for address/email/phone/im id field
-   *
-   * This works because the join was declared in ContactSchemaMapSubscriber
-   * and that also magically allows implicit joins through this one, by virtue
-   * of the fact that `$query->getField` will create the join not just to the `id` field
-   * but to every field on the joined entity, allowing e.g. joins to `address_primary.country_id:label`.
-   *
-   * @see \Civi\Api4\Event\Subscriber\ContactSchemaMapSubscriber::onSchemaBuild()
-   * @param array $field
-   * @param \Civi\Api4\Query\Api4SelectQuery $query
-   * @return string
-   */
-  public static function getLocationFieldSql(array $field, Api4SelectQuery $query): string {
-    $prefix = empty($field['explicit_join']) ? '' : $field['explicit_join'] . '.';
-    $idField = $query->getField($prefix . $field['name'] . '.id');
-    return $idField['sql_name'];
   }
 
 }

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -67,15 +67,6 @@ function civicrm_api3_activity_create($params) {
   $activityBAO = CRM_Activity_BAO_Activity::create($params);
 
   if (isset($activityBAO->id)) {
-    // Fixme - Move business logic out of API
-    if (!empty($params['case_id']) && $isNew) {
-      // If this is a brand new case activity, add to case(s)
-      foreach ((array) $params['case_id'] as $singleCaseId) {
-        $caseActivityParams = ['activity_id' => $activityBAO->id, 'case_id' => $singleCaseId];
-        CRM_Case_BAO_Case::processCaseActivity($caseActivityParams);
-      }
-    }
-
     _civicrm_api3_object_to_array($activityBAO, $activityArray[$activityBAO->id]);
     return civicrm_api3_create_success($activityArray, $params, 'Activity', 'get', $activityBAO);
   }

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -78,7 +78,7 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       '{activity.activity_type_id:label}' => 'Activity Type',
       '{activity.status_id:label}' => 'Activity Status',
       '{activity.campaign_id:label}' => 'Campaign',
-      '{activity.case_id}' => 'Activity Case ID',
+      '{activity.case_id}' => 'Case ID',
     ];
   }
 

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFLetterCommonTest.php
@@ -25,8 +25,12 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   public function testCreateDocumentBasicTokens(): void {
     CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $this->enableCiviCampaign();
+    $case = $this->createCase($this->individualCreate());
 
-    $activity = $this->activityCreate(['campaign_id' => $this->campaignCreate()]);
+    $activity = $this->activityCreate([
+      'campaign_id' => $this->campaignCreate(),
+      'case_id' => $case->id,
+    ]);
     $data = [
       ['Subject: {activity.subject}', 'Subject: Discussion on warm beer'],
       ['Date: {activity.activity_date_time}', 'Date: ' . CRM_Utils_Date::customFormat(date('Ymd'))],
@@ -41,7 +45,7 @@ class CRM_Activity_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ['Activity Type: {activity.activity_type_id:label}', 'Activity Type: Meeting'],
       ['(legacy) Activity ID: {activity.activity_id}', '(legacy) Activity ID: ' . $activity['id']],
       ['Activity ID: {activity.id}', 'Activity ID: ' . $activity['id']],
-      ['(just weird) Case ID: {activity.case_id}', '(just weird) Case ID: ' . ''],
+      ['(APIv4 virtual field) Case ID: {activity.case_id}', '(APIv4 virtual field) Case ID: ' . $case->id],
     ];
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['activityId']]);
 

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Activity;
 use Civi\Api4\Relationship;
 
 /**
@@ -65,6 +66,27 @@ class CaseTest extends Api4TestBase {
       ->first();
 
     $this->assertContains('Test Case Type', $field['options']);
+  }
+
+  public function testCaseActivity(): void {
+    $case1 = $this->createTestRecord('Case');
+    $case2 = $this->createTestRecord('Case');
+
+    $activity1 = $this->createTestRecord('Activity', [
+      'case_id' => $case1['id'],
+    ]);
+
+    $activity2 = $this->createTestRecord('Activity', [
+      'case_id' => $case2['id'],
+    ]);
+
+    $get1 = Activity::get(FALSE)
+      ->addWhere('case_id', '=', $case1['id'])
+      ->execute()
+      ->column('id');
+
+    $this->assertContains($activity1['id'], $get1);
+    $this->assertNotContains($activity2['id'], $get1);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This virtual field allows an activity to be easily filed on a case, and for cases to be looked up in SearchKit activity searches.

Before
--------------------------
The Activity entity does not have a `case_id` column, which would be really handy.

After
-----------------
Thanks to some APIv4 virtual field sql magic, now it does.

Technical Details
---------------------
The links between activities and cases goes through an intermediary bridge table (`civicrm_case_activity`). This kind of bridge join allows N-N relationships, so in theory one activity could be filed on multiple cases. But in practice, that never happens except for one specific activity type (Link Cases).

This PR adds `case_id` to the Activity entity which looks and acts like a real column as far as the API consumer is concerned. For the extremely rare Link Cases activity with more than one case, the field just returns the first one, and if you want the full picture just use the bridge join method, which is also available in APIv4 & SearchKit.
