### PR TITLE
Resolve existential crisis for customfield.is_active

### DIFF
--- a/xml/schema/Core/CustomField.xml
+++ b/xml/schema/Core/CustomField.xml
@@ -194,7 +194,6 @@
     <title>Custom Field Is Active?</title>
     <comment>Is this property active?</comment>
     <default>1</default>
-    <default>0</default>
     <add>1.1</add>
   </field>
   <field>


### PR DESCRIPTION
Overview
----------------------------------------

https://github.com/civicrm/civicrm-core/blob/f39fe198b5cd9f1e95c6a0c566d4e8d470a05f9f/xml/schema/Core/CustomField.xml#L196-L197


Before
----------------------------------------

![choose-wisely](https://user-images.githubusercontent.com/2967821/184495200-91b8bf47-0c50-4261-bb31-2f9bd65ce538.jpg)



After
----------------------------------------

![wisely](https://user-images.githubusercontent.com/2967821/184495203-4f072d26-21b9-41e3-99dd-b9b406280905.jpg)


Technical Details
----------------------------------------
The DAO doesn't need updating since it already has `1`. Ditto no upgrade script needed. Also why no backport needed.

Comments
----------------------------------------
