### PR TITLE
dev/core#3802 - Compatibility with symfony 6 for drupal 10 for listeners added via getSubscribedEvents

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -90,7 +90,7 @@ class Container {
   public function createContainer() {
     $civicrm_base_path = dirname(dirname(__DIR__));
     $container = new ContainerBuilder();
-    $container->addCompilerPass(new RegisterListenersPass('dispatcher'));
+    $container->addCompilerPass(new RegisterListenersPass());
     $container->addObjectResource($this);
     $container->setParameter('civicrm_base_path', $civicrm_base_path);
     //$container->set(self::SELF, $this);
@@ -132,6 +132,9 @@ class Container {
       []
     ))
       ->setFactory([new Reference(self::SELF), 'createEventDispatcher'])->setPublic(TRUE);
+    // In symfony 6 it only accepts event_dispatcher as the id, but there are
+    // several places in civi and extensions that reference dispatcher.
+    $container->setAlias('event_dispatcher', 'dispatcher')->setPublic(TRUE);
 
     $container->setDefinition('magic_function_provider', new Definition(
       'Civi\API\Provider\MagicFunctionProvider',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3802

Before
----------------------------------------
In symfony 6, [calling RegisterListenersPass()](https://github.com/symfony/event-dispatcher/commit/0bc2e0d8ba8a6eb353a42d19890f57a3dee410a5#diff-f3f413e17bbd20e345b3721f9c4556ed5e319d133c32bf7492dffd55a024d0efR57) with a constructor argument to set an id for the dispatcher Definition doesn't do anything and it's expecting it to now be called `event_dispatcher`, so then later when the process that registers listeners in classes that define getSubscribedEvents() runs it doesn't think there is a dispatcher to add them to.

An example of where this happens in civi is in drupal 10 if you create a drupal user in the backend, it calls civi's implementation of hook_user_insert, which then does the UFSync to create the contact. This then tries to evaluate greeting tokens, but never ends up calling the CRM_Contact_Tokens listener for civi.token.eval.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
I didn't just change the definition to event_dispatcher because there are places that use the form `Civi::service('dispatcher')`, which expect `dispatcher`.

I think this should be safe in all versions of symfony in use. We never saw the deprecation notice in symfony 5 because as far as I know nobody has been using symfony 5 with civi - drupal went straight from 4.4 to 6.

Comments
----------------------------------------

