### PR TITLE
Remove unused impossible function in upgrade page

### DIFF
--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -17,13 +17,6 @@
 class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
 
   /**
-   * Pre-process.
-   */
-  public function preProcess() {
-    parent::preProcess();
-  }
-
-  /**
    * Run upgrade.
    *
    * @throws \Exception


### PR DESCRIPTION
Overview
----------------------------------------
This function isn't called from anywhere, and can't possibly work if it was called, and even if it did the way OO works it doesn't add anything and would automatically call the parent.

Before
----------------------------------------
Unused function

After
----------------------------------------
Definitely unused

Technical Details
----------------------------------------
`Page`'s don't have pre/postProcess functions. You can easily see this would fail if it were called using e.g. `cv ev "$u = new CRM_Upgrade_Page_Upgrade('foo'); $u->preProcess();"` which gives `Error: Call to undefined method CRM_Core_Page::preProcess() `

Comments
----------------------------------------

