### PR TITLE
Add hint to create membership "You do not have all the permissions needed for this page" message

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -474,7 +474,7 @@ DESC limit 1");
     // Throw status bounce when no Membership type or priceset is present
     if (empty($this->allMembershipTypeDetails) && empty($priceSets)
     ) {
-      CRM_Core_Error::statusBounce(ts('You do not have all the permissions needed for this page.'));
+      CRM_Core_Error::statusBounce(ts("You either do not have all the permissions needed for this page, or the membership types haven't been fully configured."));
     }
     // retrieve all memberships
     $allMembershipInfo = [];


### PR DESCRIPTION
Overview
----------------------------------------
This exception is *also* raised, when no membership types have been configured yet, which can be very confusing. It cost me a two hours to figure out the real reason, and I have the nagging suspicion that this had happened to me before. I'm not too happy about the phrasing, but it would be good to have a reference to a potentially incomplete configuration. Thanks.

Before
----------------------------------------
You get a "You do not have all the permissions needed for this page." message when clicking the "new membership" menu item without having configured a membership type.

After
----------------------------------------
You get a ""You either do not have all the permissions needed for this page, or the membership types haven't been fully configured." message when clicking the "new membership" menu item without having configured a membership type.

Comments
----------------------------------------
I think this might have cost a lot of people (including me) a lot of time to figure out.
