### PR TITLE
SearchKit - Add contacts to mailing group in batches

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -48,7 +48,7 @@
         if (ctrl.action === 'save') {
           // For the save action, take each record from params and copy it with each supplied id
           params.records = _.transform(ctrl.ids.slice(ctrl.first, ctrl.last), function(records, id) {
-            _.each(_.cloneDeep(ctrl.params.records), function(record) {
+            _.each(_.cloneDeep(ctrl.params.records || [{}]), function(record) {
               record[ctrl.idField || 'id'] = id;
               records.push(record);
             });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.html
@@ -24,9 +24,13 @@
         {{:: ts('All of the selected contacts have active email addresses.') }}
       </div>
     </div>
-    <div ng-if="$ctrl.run" class="crm-search-task-progress">
+    <div ng-if="$ctrl.run && !$ctrl.addContacts" class="crm-search-task-progress">
       <h5>{{:: ts('Creating mailing...') }}</h5>
-      <crm-search-batch-runner entity="'Group'" action="create" params="$ctrl.run" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'Group'" action="create" params="$ctrl.run" success="$ctrl.afterGroupCreate(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+    </div>
+    <div ng-if="$ctrl.addContacts" class="crm-search-task-progress">
+      <h5>{{:: ts('Adding contacts...') }}</h5>
+      <crm-search-batch-runner entity="'GroupContact'" action="save" params="$ctrl.addContacts" ids="$ctrl.ids" id-field="contact_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
     </div>
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
     <crm-dialog-button text="ts('Create Mailing')" icons="{primary: 'fa-paper-plane'}" on-click="$ctrl.submit()" disabled="!$ctrl.recipientCount || $ctrl.run || !crmSearchTaskMailingForm.$valid" />


### PR DESCRIPTION
Overview
----------------------------------------
Fixes potential problems when creating large CiviMail mailing groups via SearchKit (for the "Email - schedule/send via CiviMail" action).

Before
----------------------------------------
No batching.

After
----------------------------------------
Uses the batch runner for adding contacts to the mailing group instead of doing it all at once via chaining.

Technical Details
----------------------------------------
This prevents timeouts when creating very large mailings > 500 contacts.

Comments
----------------------------------------
This may fix the problems noted in #24186
