### PR TITLE
[NFC] Convert Payment Processor ID field to payment processor in even…

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1137,7 +1137,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'is_show_location' => 0,
       'is_email_confirm' => 1,
     ], $params);
-
+    if (!empty($params['payment_processor_id'])) {
+      $params['payment_processor'] = is_array($params['payment_processor_id']) ? $params['payment_processor_id'] : [$params['payment_processor_id']];
+    }
     $event = Event::create(FALSE)->setValues($params)->execute()->first();
     $this->ids['event'][] = $event['id'];
     return $event;


### PR DESCRIPTION
…t create in tests

Overview
----------------------------------------
@eileenmcnaughton what I found was that you were passing in the key of `payment_processor_id` https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php#L475 when the field name in this case is `payment_processor` and it expects an array to be passed in not a string so was figured this is the easiest place to handle it

Before
----------------------------------------
testOnlineRegNoPrice test fails on notice error in php8.1

After
----------------------------------------
Test passes in php8.1

ping @eileenmcnaughton @demeritcowboy 