### PR TITLE
Dev/core#3803 - DB Error when Create User Record

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -247,7 +247,7 @@ AND    domain_id = %2
           else {
             $primary_email = $user->email;
           }
-          $params = ['email' => $primary_email];
+          $params['email'] = $primary_email;
         }
 
         if ($ctype === 'Organization') {


### PR DESCRIPTION
Keep the $params variable to allow later retrieval of the Civicrm contact
see https://lab.civicrm.org/dev/core/-/issues/3803

