### PR TITLE
Afform - Store all values in submission record

### DIFF
--- a/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
@@ -148,7 +148,8 @@ class AfformSubmitEvent extends AfformBaseEvent {
    * @return $this
    */
   public function setJoinIds($index, $joinEntity, $joinIds) {
-    $this->entityIds[$this->entityName][$index]['joins'][$joinEntity] = $joinIds;
+    $idField = CoreUtil::getIdFieldName($joinEntity);
+    $this->entityIds[$this->entityName][$index]['_joins'][$joinEntity] = \CRM_Utils_Array::filterColumns($joinIds, [$idField]);
     return $this;
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -154,9 +154,10 @@ class Submit extends AbstractProcessor {
         continue;
       }
       try {
+        $idField = CoreUtil::getIdFieldName($event->getEntityType());
         $saved = $api4($event->getEntityType(), 'save', ['records' => [$record['fields']]])->first();
-        $event->setEntityId($index, $saved['id']);
-        self::saveJoins($event, $index, $saved['id'], $record['joins'] ?? []);
+        $event->setEntityId($index, $saved[$idField]);
+        self::saveJoins($event, $index, $saved[$idField], $record['joins'] ?? []);
       }
       catch (\API_Exception $e) {
         // What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
@@ -244,7 +245,7 @@ class Submit extends AbstractProcessor {
           'checkPermissions' => FALSE,
           'where' => self::getJoinWhereClause($event->getFormDataModel(), $event->getEntityName(), $joinEntityName, $entityId),
           'records' => $values,
-        ], ['id']);
+        ]);
         $indexedResult = array_combine(array_keys($values), (array) $result);
         $event->setJoinIds($index, $joinEntityName, $indexedResult);
       }

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -68,11 +68,12 @@ class SubmitFile extends AbstractProcessor {
     $apiEntity = $this->joinEntity ?: $afformEntity['type'];
     $entityIndex = (int) $this->entityIndex;
     $joinIndex = (int) $this->joinIndex;
+    $idField = CoreUtil::getIdFieldName($apiEntity);
     if ($this->joinEntity) {
-      $entityId = $this->_entityIds[$this->modelName][$entityIndex]['joins'][$this->joinEntity][$joinIndex] ?? NULL;
+      $entityId = $this->_entityIds[$this->modelName][$entityIndex]['_joins'][$this->joinEntity][$joinIndex][$idField] ?? NULL;
     }
     else {
-      $entityId = $this->_entityIds[$this->modelName][$entityIndex]['id'] ?? NULL;
+      $entityId = $this->_entityIds[$this->modelName][$entityIndex][$idField] ?? NULL;
     }
 
     if (!$entityId) {
@@ -101,7 +102,7 @@ class SubmitFile extends AbstractProcessor {
     if (strpos($apiEntity, 'Custom_') === 0) {
       civicrm_api4($apiEntity, 'update', [
         'values' => [
-          'id' => $entityId,
+          $idField => $entityId,
           $this->fieldName => $file['id'],
         ],
       ]);

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformContactUsageTest.php
@@ -158,7 +158,11 @@ EOHTML;
 
     $this->assertEquals($this->formName, $submission['afform_name']);
     $this->assertIsInt($submission['data']['Activity1'][0]['id']);
+    $this->assertEquals('Individual1', $submission['data']['Activity1'][0]['subject']);
     $this->assertIsInt($submission['data']['Individual1'][0]['id']);
+    $this->assertEquals($firstName, $submission['data']['Individual1'][0]['first_name']);
+    $this->assertEquals('site', $submission['data']['Individual1'][0]['last_name']);
+    $this->assertEquals('This field is set in the data array', $submission['data']['Individual1'][0]['source']);
 
     // Check that Activity was submitted correctly.
     $activity = \Civi\Api4\Activity::get(FALSE)
@@ -170,7 +174,7 @@ EOHTML;
       ->execute()->first();
     $this->assertEquals($firstName, $contact['first_name']);
     $this->assertEquals('site', $contact['last_name']);
-    // Check that the data overrides form submsision
+    // Check that the data overrides form submission
     $this->assertEquals('Register A site', $contact['source']);
     // Check that the contact and the activity were correctly linked up as per the form.
     $this->callAPISuccessGetSingle('ActivityContact', ['contact_id' => $contact['id'], 'activity_id' => $activity['id']]);
@@ -342,7 +346,12 @@ EOHTML;
       ->execute()->single();
     $this->assertEquals($contact['id'], $submission['data']['Individual1'][0]['id']);
     $this->assertEquals($contact['org.id'], $submission['data']['Organization1'][0]['id']);
+    $this->assertEquals('Organization1', $submission['data']['Individual1'][0]['employer_id']);
     $this->assertEquals($contact['email_primary'], $submission['data']['Individual1'][0]['_joins']['Email'][0]['id']);
+    $this->assertEquals($individualEmail, $submission['data']['Individual1'][0]['_joins']['Email'][0]['email']);
+    $this->assertEquals($locationType, $submission['data']['Individual1'][0]['_joins']['Email'][0]['location_type_id']);
+    $this->assertEquals($orgEmail, $submission['data']['Organization1'][0]['_joins']['Email'][0]['email']);
+    $this->assertEquals($locationType, $submission['data']['Organization1'][0]['_joins']['Email'][0]['location_type_id']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Stores all submitted values in the submission record, including saved ids. This allows values to be retrieved from the submission for debugging or display purposes.
Builds on #24080

Technical Details
----------------------------------------
Required some refactoring of the structure of the ids/values arrays to make them more compatible with each other:
- Prefixed `['_joins']` with an underscore so it never conflicts with a field name
- Consistently use `CoreUtil::getIdFieldName()` helper so we are compatible with entities that don't use `'id'` as the unique identifier.
- Make join entities follow the same structure as primary entities.

