### PR TITLE
Add GroupTokens to replace WelcomeTokens

### DIFF
--- a/CRM/Core/GroupTokens.php
+++ b/CRM/Core/GroupTokens.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Core_GroupTokens
+ *
+ * Generate "member.*" tokens.
+ */
+class CRM_Core_GroupTokens extends CRM_Core_EntityTokens {
+
+  /**
+   * Get the entity name for api v4 calls.
+   *
+   * @return string
+   */
+  protected function getApiEntityName(): string {
+    return 'Group';
+  }
+
+  /**
+   * List out the fields that are exposed.
+   *
+   * @return string[]
+   */
+  protected function getExposedFields(): array {
+    return [
+      'id',
+      'name',
+      'title',
+      'frontend_title',
+      'frontend_description',
+    ];
+  }
+
+}

--- a/CRM/Mailing/Event/BAO/Subscribe.php
+++ b/CRM/Mailing/Event/BAO/Subscribe.php
@@ -151,7 +151,7 @@ SELECT     civicrm_email.id as email_id
    * @return object|null
    *   The subscribe event object, or null on failure
    */
-  public static function &verify($contact_id, $subscribe_id, $hash) {
+  public static function verify(int $contact_id, int $subscribe_id, $hash) {
     $success = NULL;
     $se = new CRM_Mailing_Event_BAO_Subscribe();
     $se->contact_id = $contact_id;
@@ -175,7 +175,7 @@ SELECT     civicrm_email.id as email_id
     $domain = CRM_Core_BAO_Domain::getDomain();
 
     //get the default domain email address.
-    list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
+    [$domainEmailName, $domainEmailAddress] = CRM_Core_BAO_Domain::getNameAndEmail();
 
     $localpart = CRM_Core_BAO_MailSettings::defaultLocalpart();
     $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -363,6 +363,10 @@ class Container {
       'CRM_Contribute_RecurTokens',
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
+    $container->setDefinition('crm_group_tokens', new Definition(
+      'CRM_Core_GroupTokens',
+      []
+    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     $container->setDefinition('crm_domain_tokens', new Definition(
       'CRM_Core_DomainTokens',
       []

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -191,7 +191,7 @@ trait ContactTestTrait {
    * @return int
    *   groupId of created group
    */
-  public function groupCreate($params = []) {
+  public function groupCreate(array $params = []): int {
     $params = array_merge([
       'name' => 'Test Group 1',
       'domain_id' => 1,

--- a/tests/phpunit/CRM/Mailing/BAO/ConfirmTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/ConfirmTest.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Group;
+use Civi\Api4\GroupContact;
+use Civi\Api4\Mailing;
+use Civi\Api4\MailingGroup;
+use Civi\Api4\SubscriptionHistory;
+
+/**
+ * Class CRM_Mailing_BAO_MailingTest
+ */
+class CRM_Mailing_BAO_ConfirmTest extends CiviUnitTestCase {
+
+  /**
+   * Cleanup after test.
+   */
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_group', 'civicrm_group_contact', 'civicrm_mailing', 'civicrm_mailing_group', 'civicrm_mailing_event_subscribe']);
+    parent::tearDown();
+  }
+
+  /**
+   * Test confirm function, with group token.
+   *
+   * @throws CRM_Core_Exception
+   */
+  public function testConfirm(): void {
+    $mailUtil = new CiviMailUtils($this);
+    $contactID = $this->individualCreate();
+    $groupID = Group::create()->setValues([
+      'name' => 'Test Group',
+      'title' => 'Test Group',
+      'frontend_title' => 'Test Group',
+    ])->execute()->first()['id'];
+    GroupContact::create()->setValues(['contact_id' => $contactID, 'status' => 'Added', 'group_id' => $groupID])->execute();
+    SubscriptionHistory::create()->setValues([
+      'contact_id' => $contactID,
+      'group_id' => $groupID,
+      'method' => 'Email',
+    ])->execute();
+    $mailingID = Mailing::create()->execute()->first()['id'];
+    MailingGroup::create()->setValues([
+      'mailing_id' => $mailingID,
+      'group_type' => 'Include',
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $groupID,
+    ])->execute()->first()['id'];
+
+    $mailingComponentID = $this->callAPISuccess('MailingComponent', 'get', ['component_type' => 'Welcome'])['id'];
+    $this->callAPISuccess('MailingComponent', 'create', [
+      // Swap {welcome.group} to {group.frontend_title} which is the standardised token.
+      // The intent is to make this version the default, but need to ensure it is required.
+      'body_html' => 'Welcome. Your subscription to the {group.frontend_title} mailing list has been activated.',
+      'body_text' => 'Welcome. Your subscription to the {group.frontend_title} mailing list has been activated.',
+      'id' => $mailingComponentID,
+    ]);
+    $hash = 4;
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_mailing_event_subscribe (group_id, contact_id, hash) VALUES ($groupID, $contactID, $hash)
+    ");
+
+    CRM_Mailing_Event_BAO_Confirm::confirm($contactID, 1, $hash);
+    $mailUtil->checkAllMailLog([
+      'From: "FIXME" <info@EXAMPLE.ORG>',
+      'To: "Mr. Anthony Anderson II" <anthony_anderson@civicrm.org>',
+      'Subject: Your Subscription has been Activated',
+      'Welcome. Your subscription to the Test Group mailing list has been activated.',
+    ]);
+  }
+
+}

--- a/tests/phpunit/CRM/Mailing/BAO/MailingJobTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingJobTest.php
@@ -20,7 +20,7 @@ class CRM_Mailing_BAO_MailingJobTest extends CiviUnitTestCase {
   /**
    * Tests CRM_Mailing_BAO_MailingJob::isTemporaryError() method.
    */
-  public function testIsTemporaryError() {
+  public function testIsTemporaryError(): void {
     $testcases[] = ['return' => TRUE, 'message' => 'Failed to set sender: test@example.org [SMTP: Invalid response code received from SMTP server while sending email. This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 421, response: Timeout waiting for data from client.)]'];
     $testcases[] = ['return' => TRUE, 'message' => 'Failed to send data [SMTP: Invalid response code received from SMTP server while sending email. This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 454, response: Throttling failure: Maximum sending rate exceeded.)]'];
     $testcases[] = ['return' => TRUE, 'message' => 'Failed to set sender: test@example.org [SMTP: Failed to write to socket: not connected (code: -1, response: )]'];

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -55,9 +55,10 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
    * @param $mailingID
    * @param $groupID
    * @param string $type
+   *
    * @return array|int
    */
-  private function createMailingGroup($mailingID, $groupID, $type = 'Include') {
+  private function createMailingGroup($mailingID, $groupID, string $type = 'Include') {
     return $this->callAPISuccess('MailingGroup', 'create', [
       'mailing_id' => $mailingID,
       'group_type' => $type,
@@ -69,7 +70,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
   /**
    * Test to ensure that using ACL permitted contacts are correctly fetched for bulk mailing
    */
-  public function testgetRecipientsUsingACL() {
+  public function testgetRecipientsUsingACL(): void {
     $this->prepareForACLs();
     $this->createLoggedInUser();
     // create hook to build ACL where clause which choses $this->allowedContactId as the only contact to be considered as mail recipient
@@ -77,7 +78,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'view my contact'];
 
     // Create dummy group and assign 2 contacts
-    $name = 'Test static group ' . substr(sha1(rand()), 0, 7);
+    $name = 'Test static group 1';
     $groupID = $this->groupCreate([
       'name' => $name,
       'title' => $name,
@@ -111,20 +112,16 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test mailing receipients when using previous mailing as include and contact is in exclude as well
+   * Test mailing recipients when using previous mailing as include and contact is in exclude as well
    */
-  public function testMailingIncludePreviousMailingExcludeGroup() {
-    $groupName = 'Test static group ' . substr(sha1(rand()), 0, 7);
-    $groupName2 = 'Test static group 2' . substr(sha1(rand()), 0, 7);
+  public function testMailingIncludePreviousMailingExcludeGroup(): void {
     $groupID = $this->groupCreate([
-      'name' => $groupName,
-      'title' => $groupName,
-      'is_active' => 1,
+      'name' => 'Test static group 1',
+      'title' => 'Test static group 1',
     ]);
     $groupID2 = $this->groupCreate([
-      'name' => $groupName2,
-      'title' => $groupName2,
-      'is_active' => 1,
+      'name' => 'Test static group 2',
+      'title' => 'Test static group 2',
     ]);
     $contactID = $this->individualCreate([], 0);
     $contactID2 = $this->individualCreate([], 2);


### PR DESCRIPTION
Overview
----------------------------------------
In conjunction with https://github.com/civicrm/civicrm-core/pull/24235

Hmm - this would make `{group.title}` work - but I see `replaceResubscribeTokens` actually concatentates several group titles together - not quite sure how we could do this to support that too ....

```
  public static function &replaceResubscribeTokens(
    $str, &$domain, &$groups, $html,
    $contact_id, $hash
  ) {
    if (self::token_match('resubscribe', 'group', $str)) {
      if (!empty($groups)) {
        $value = implode(', ', $groups);
        self::token_replace('resubscribe', 'group', $value, $str);
      }
    }
    return $str;
  }
```