### PR TITLE
dev/core#1532 - Add upgrade message about civicase activity revisions

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyFour.php
@@ -21,6 +21,15 @@
  */
 class CRM_Upgrade_Incremental_php_FiveFiftyFour extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    parent::setPreUpgradeMessage($preUpgradeMessage, $rev, $currentVer);
+    if ($rev === '5.54.alpha1') {
+      if (\Civi::settings()->get('civicaseActivityRevisions')) {
+        $preUpgradeMessage .= '<p>' . ts('The setting that used to be at <em>Administer &gt; CiviCase &gt; CiviCase Settings</em> for <strong>Enable deprecated Embedded Activity Revisions</strong> is enabled, but is no longer functional.<ul><li>For more information see this <a %1>Lab Snippet</a>.</li></ul>', [1 => 'target="_blank" href="https://lab.civicrm.org/-/snippets/85"']) . '</p>';
+      }
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
Warningless

After
----------------------------------------
If the setting is currently turned on, you will see a message:

<img width="515" alt="Untitled2" src="https://user-images.githubusercontent.com/2967821/184710706-566104e2-cf20-4446-9b77-fa08cc069047.png">


Technical Details
----------------------------------------


Comments
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/24249#issuecomment-1214473282
