### PR TITLE
APIv4 - Expand Group.create permissions to include CiviMail

### DIFF
--- a/Civi/Api4/Group.php
+++ b/Civi/Api4/Group.php
@@ -22,4 +22,19 @@ namespace Civi\Api4;
 class Group extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
 
+  /**
+   * Provides more-open permissions that will be further restricted by checkAccess
+   *
+   * @see \CRM_Contact_BAO_Group::_checkAccess()
+   * @return array
+   */
+  public static function permissions():array {
+    $permissions = parent::permissions();
+
+    return [
+      // Create permission depends on the group type (see CRM_Contact_BAO_Group::_checkAccess).
+      'create' => ['access CiviCRM', ['edit groups', 'access CiviMail', 'create mailings']],
+    ] + $permissions;
+  }
+
 }

--- a/tests/phpunit/api/v4/Entity/GroupTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Group;
+
+/**
+ * @group headless
+ */
+class GroupTest extends Api4TestBase {
+
+  public function testCreate() {
+    $this->createLoggedInUser();
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'edit groups',
+    ];
+
+    $types = array_flip(\CRM_Contact_BAO_Group::buildOptions('group_type'));
+
+    Group::create(TRUE)
+      ->addValue('title', uniqid())
+      ->addValue('group_type:name', 'Access Control')
+      ->execute();
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'create mailings',
+    ];
+
+    // Cannot create any group other than ['Mailing List'] without 'edit groups'
+    try {
+      Group::create(TRUE)
+        ->addValue('title', uniqid())
+        ->addValue('group_type:name', 'Access Control')
+        ->execute();
+      $this->fail();
+    }
+    catch (UnauthorizedException $e) {
+    }
+    try {
+      Group::create(TRUE)
+        ->addValue('title', uniqid())
+        ->execute();
+      $this->fail();
+    }
+    catch (UnauthorizedException $e) {
+    }
+
+    // Can create a mailing group without 'edit groups'
+    Group::create(TRUE)
+      ->addValue('title', uniqid())
+      ->addValue('group_type', [$types['Mailing List']])
+      ->execute();
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'access CiviMail',
+    ];
+
+    // Also works with pseudoconstant notation
+    Group::create(TRUE)
+      ->addValue('title', uniqid())
+      ->addValue('group_type:name', 'Mailing List')
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This allows users without `'edit groups'` permission to still create a mailing from SearchKit.
See [dev/core#3755](https://lab.civicrm.org/dev/core/-/issues/3755)

Before
----------------------------------------
Creating a new group required `'edit groups'` permission.

After
----------------------------------------
When creating a 'Mailing List' group, either `'edit groups'` OR `'access CiviMail'` OR `'create mailings'` will work.
Creating other types of groups still requires `'edit groups'` as does, you know, editing groups.
