### PR TITLE
Unhide message_admin extension

### DIFF
--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -16,9 +16,6 @@
   </urls>
   <releaseDate>2021-06-12</releaseDate>
   <version>5.54.alpha1</version>
-  <tags>
-    <tag>mgmt:hidden</tag>
-  </tags>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.54</ver>


### PR DESCRIPTION
Overview
----------------------------------------
Unhide message_admin extension

Before
----------------------------------------
Extension is hidden

After
----------------------------------------
Unhidden

Technical Details
----------------------------------------
@totten I went to look at why https://github.com/civicrm/civicrm-core/pull/24174 is stalled again & it seems stuck on tests not running due to a conflict in the info.xml. As I commented there I think we should just unhide it separately & then we can commit to getting the rest sorted in the next two weeks rather than have it drag on for another release - I think we are almost there but we are in danger of back-sliding

Comments
----------------------------------------
