### PR TITLE
Remove no-longer-used function

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -546,17 +546,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   /**
    * @return array
    */
-  public function getSelectValues(): array {
-    $values = [];
-    foreach ($this->_fields as $name => $field) {
-      $values[$name] = $field->_title;
-    }
-    return $values;
-  }
-
-  /**
-   * @return array
-   */
   public function getSelectTypes() {
     $values = [];
     // This is only called from the MapField form in isolation now,


### PR DESCRIPTION
Overview
----------------------------------------
Remove no-longer-used function

This function was refactored out of use during the import cleanup - but not yet removed

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/184727910-4ffa6f3b-dc9e-438a-ab8d-83a009a8422a.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
