### PR TITLE
Remove another three no-longer-used functions

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -184,7 +184,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           'importID' => $currentImportID,
           'importTempTable' => $this->_tableName,
           'fieldHeaders' => $this->_mapperKeys,
-          'fields' => $this->_activeFields,
         ];
         CRM_Utils_Hook::import('Contact', 'process', $this, $hookParams);
       }

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -537,26 +537,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
   }
 
   /**
-   * Given a list of the importable field keys that the user has selected
-   * set the active fields array to this list
-   *
-   * @param array $fieldKeys mapped array of values
-   *
-   * @return void
-   */
-  public function setActiveFields($fieldKeys) {
-    $this->_activeFieldCount = count($fieldKeys);
-    foreach ($fieldKeys as $key) {
-      if (empty($this->_fields[$key])) {
-        $this->_activeFields[] = new CRM_Event_Import_Field('', ts('- do not import -'));
-      }
-      else {
-        $this->_activeFields[] = clone($this->_fields[$key]);
-      }
-    }
-  }
-
-  /**
    * @param string $name
    * @param $title
    * @param int $type

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -376,21 +376,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * Array of the fields that are actually part of the import process
-   * the position in the array also dictates their position in the import
-   * file
-   * @var array
-   */
-  protected $_activeFields = [];
-
-  /**
-   * Cache the count of active fields
-   *
-   * @var int
-   */
-  protected $_activeFieldCount;
-
-  /**
    * Cache of preview rows
    *
    * @var array
@@ -450,26 +435,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   public function __construct() {
     $this->_maxLinesToProcess = 0;
-  }
-
-  /**
-   * Format the field values for input to the api.
-   *
-   * @return array
-   *   (reference) associative array of name/value pairs
-   */
-  public function &getActiveFieldParams() {
-    $params = [];
-    for ($i = 0; $i < $this->_activeFieldCount; $i++) {
-      if (isset($this->_activeFields[$i]->_value)
-        && !isset($params[$this->_activeFields[$i]->_name])
-        && !isset($this->_activeFields[$i]->_related)
-      ) {
-
-        $params[$this->_activeFields[$i]->_name] = $this->_activeFields[$i]->_value;
-      }
-    }
-    return $params;
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -453,24 +453,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * Set and validate field values.
-   *
-   * @param array $elements
-   *   array.
-   */
-  public function setActiveFieldValues($elements): void {
-    $maxCount = count($elements) < $this->_activeFieldCount ? count($elements) : $this->_activeFieldCount;
-    for ($i = 0; $i < $maxCount; $i++) {
-      $this->_activeFields[$i]->setValue($elements[$i]);
-    }
-
-    // reset all the values that we did not have an equivalent import element
-    for (; $i < $this->_activeFieldCount; $i++) {
-      $this->_activeFields[$i]->resetValue();
-    }
-  }
-
-  /**
    * Format the field values for input to the api.
    *
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
Remove another three no-longer-used functions & associated class properties

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/184729821-9e9de774-ef9a-4e94-bd98-a90b3c90c64f.png)

![image](https://user-images.githubusercontent.com/336308/184730872-1d4a9ebb-8609-4144-860b-7482ef7d9db4.png)

![image](https://user-images.githubusercontent.com/336308/184731470-41773a4c-b86e-4a4c-9034-1151e4d03fa1.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
These are no longer called due to a deliberate effort to stop using `_fields` for metadata & just use the array on the class - `_fields` is close to final removal

Comments
----------------------------------------
