### PR TITLE
Remove last usage of `_fields` from `Import_Parser`

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -491,7 +491,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   private function isLocationTypeRequired($name): bool {
     if (!isset(Civi::$statics[__CLASS__]['location_fields'])) {
-      Civi::$statics[__CLASS__]['location_fields'] = (new CRM_Contact_Import_Parser_Contact())->setUserJobID($this->getUserJobID())->getSelectTypes();
+      Civi::$statics[__CLASS__]['location_fields'] = (new CRM_Contact_Import_Parser_Contact())->setUserJobID($this->getUserJobID())->getFieldsWhichSupportLocationTypes();
     }
     return (bool) (Civi::$statics[__CLASS__]['location_fields'][$name] ?? FALSE);
   }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -493,9 +493,11 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
+   * Get an array of available fields that support location types (e.g phone, street_address etc).
+   *
    * @return array
    */
-  public function getSelectTypes() {
+  public function getFieldsWhichSupportLocationTypes(): array {
     $values = [];
     // This is only called from the MapField form in isolation now,
     foreach ($this->getFieldsMetadata() as $name => $field) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -496,11 +496,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   public function getSelectTypes() {
     $values = [];
     // This is only called from the MapField form in isolation now,
-    // so we need to set the metadata.
-    $this->init();
-    foreach ($this->_fields as $name => $field) {
-      if (isset($field->_hasLocationType)) {
-        $values[$name] = $field->_hasLocationType;
+    foreach ($this->getFieldsMetadata() as $name => $field) {
+      if (isset($field['hasLocationType'])) {
+        $values[$name] = TRUE;
       }
     }
     return $values;
@@ -1799,6 +1797,19 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     // Force re-load of user job.
     unset($this->userJob);
     $this->setFieldMetadata();
+  }
+
+  /**
+   * Get metadata for all importable fields.
+   *
+   * @return array
+   */
+  protected function getFieldsMetadata() : array {
+    if (empty($this->importableFieldsMetadata)) {
+      unset($this->userJob);
+      $this->setFieldMetadata();
+    }
+    return $this->importableFieldsMetadata;
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -269,11 +269,13 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected $_warnings;
 
   /**
+   * TO BE REMOVED.
+   *
    * Array of all the fields that could potentially be part
    * of this import process
    * @var array
    */
-  protected $_fields;
+  private $_fields;
 
   /**
    * Metadata for all available fields, keyed by unique name.


### PR DESCRIPTION
Overview
----------------------------------------
Remove last usage of _fields

Before
----------------------------------------
In just this one place we still use the old metadata

After
----------------------------------------
Functionality is unchanged - location field loads for these fields
![image](https://user-images.githubusercontent.com/336308/184733029-69889ce0-9900-427a-bba6-342163760e39.png)

and the function returns the same array - which is a collection of the fields with `hasLocation` = true 
![image](https://user-images.githubusercontent.com/336308/184732580-a07752bc-5a67-4b0a-b2f7-b87a7eac72a2.png)

Technical Details
----------------------------------------
Over the course of the code tidy up we stopped using the complicated `_fields` construct which entails a whole lot of `Field` objects & switched to using the metadata array - however we are still building if for this one place

Comments
----------------------------------------

In fact the motivation for clearing this up is that there are some incorrect pseudoconstant refs in the contribution code & I was trying to purge incorrect refs to `contributionStatus` - however, the code in question can be removed rather than fixed & this change plus a couple of other removal PRs will allow that semi-sub-system to be ripped out so we can stop maintaining it