### PR TITLE
AllCoreTables - Dismbiguate `init `and `flush`

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -271,7 +271,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     self::clearDBCache();
     Civi::cache('session')->clear();
     Civi::cache('metadata')->clear();
-    CRM_Core_DAO_AllCoreTables::reinitializeCache();
+    CRM_Core_DAO_AllCoreTables::flush();
     CRM_Utils_System::flushCache();
 
     if ($sessionReset) {

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -33,7 +33,7 @@ class CRM_Core_DAO_AllCoreTables {
     if ($fresh) {
       CRM_Core_Error::deprecatedWarning('Use CRM_Core_DAO_AllCoreTables::flush()');
     }
-    Civi::$statics[__CLASS__]['initialised'] = TRUE;
+
     Civi::$statics[__CLASS__] = [];
 
     $file = preg_replace('/\.php$/', '.data.php', __FILE__);
@@ -385,9 +385,11 @@ class CRM_Core_DAO_AllCoreTables {
 
   /**
    * Reinitialise cache.
+   *
+   * @deprecated
    */
-  public static function reinitializeCache() {
-    self::init(TRUE);
+  public static function reinitializeCache(): void {
+    self::flush();
   }
 
   /**

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -24,13 +24,16 @@ class CRM_Core_DAO_AllCoreTables {
   /**
    * Initialise.
    *
-   * @param bool $fresh
+   * @param bool $fresh Deprecated parameter, use flush() to flush.
    */
-  public static function init($fresh = FALSE) {
-    static $init = FALSE;
-    if ($init && !$fresh) {
+  public static function init(bool $fresh = FALSE): void {
+    if (!empty(Civi::$statics[__CLASS__]['initialised']) && !$fresh) {
       return;
     }
+    if ($fresh) {
+      CRM_Core_Error::deprecatedWarning('Use CRM_Core_DAO_AllCoreTables::flush()');
+    }
+    Civi::$statics[__CLASS__]['initialised'] = TRUE;
     Civi::$statics[__CLASS__] = [];
 
     $file = preg_replace('/\.php$/', '.data.php', __FILE__);
@@ -50,7 +53,14 @@ class CRM_Core_DAO_AllCoreTables {
       );
     }
 
-    $init = TRUE;
+    Civi::$statics[__CLASS__]['initialised'] = TRUE;
+  }
+
+  /**
+   * Flush class cache.
+   */
+  public static function flush(): void {
+    Civi::$statics[__CLASS__]['initialised'] = FALSE;
   }
 
   /**

--- a/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
+++ b/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
@@ -26,7 +26,7 @@ class CRM_Core_DAO_AllCoreTablesTest extends CiviUnitTestCase {
     // 2. Now, let's hook into it...
     $this->hookClass->setHook('civicrm_entityTypes', [$this, '_hook_civicrm_entityTypes']);
     unset(Civi::$statics['CRM_Core_DAO_Email']);
-    CRM_Core_DAO_AllCoreTables::init(1);
+    CRM_Core_DAO_AllCoreTables::flush();
 
     // 3. And see if the data has changed...
     $fields = CRM_Core_DAO_Email::fields();
@@ -50,7 +50,7 @@ class CRM_Core_DAO_AllCoreTablesTest extends CiviUnitTestCase {
 
   protected function tearDown(): void {
     CRM_Utils_Hook::singleton()->reset();
-    CRM_Core_DAO_AllCoreTables::init(1);
+    CRM_Core_DAO_AllCoreTables::flush();
     parent::tearDown();
   }
 

--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -257,9 +257,6 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
    */
   public function testHookDupeQueryMatch(): void {
     $this->hookClass->setHook('civicrm_dupeQuery', [$this, 'hook_civicrm_dupeQuery']);
-
-    \CRM_Core_DAO_AllCoreTables::flush();
-
     \CRM_Core_DAO_AllCoreTables::registerEntityType('TestEntity', 'CRM_Dedupe_DAO_TestEntity', 'civicrm_dedupe_test_table');
     $this->apiKernel = \Civi::service('civi_api_kernel');
     $this->adhocProvider = new \Civi\API\Provider\AdhocProvider(3, 'TestEntity');
@@ -380,7 +377,6 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
     $this->assertCount(0, $foundDupes);
 
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_dedupe_test_table');
-    \CRM_Core_DAO_AllCoreTables::flush();
   }
 
   /**

--- a/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
+++ b/tests/phpunit/CRM/Dedupe/BAO/RuleGroupTest.php
@@ -255,10 +255,10 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testHookDupeQueryMatch() {
+  public function testHookDupeQueryMatch(): void {
     $this->hookClass->setHook('civicrm_dupeQuery', [$this, 'hook_civicrm_dupeQuery']);
 
-    \CRM_Core_DAO_AllCoreTables::init(TRUE);
+    \CRM_Core_DAO_AllCoreTables::flush();
 
     \CRM_Core_DAO_AllCoreTables::registerEntityType('TestEntity', 'CRM_Dedupe_DAO_TestEntity', 'civicrm_dedupe_test_table');
     $this->apiKernel = \Civi::service('civi_api_kernel');
@@ -380,7 +380,7 @@ class CRM_Dedupe_BAO_RuleGroupTest extends CiviUnitTestCase {
     $this->assertCount(0, $foundDupes);
 
     CRM_Core_DAO::executeQuery('DROP TABLE civicrm_dedupe_test_table');
-    \CRM_Core_DAO_AllCoreTables::init(TRUE);
+    \CRM_Core_DAO_AllCoreTables::flush();
   }
 
   /**

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -39,7 +39,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       // it might be a bit expensive to add to every single test
       // so a bit selectively.
       $this->hookClass->reset();
-      CRM_Core_DAO_AllCoreTables::reinitializeCache(TRUE);
+      CRM_Core_DAO_AllCoreTables::flush();
     }
     parent::tearDown();
   }
@@ -1466,7 +1466,7 @@ WHERE
       $this,
       'hookEntityTypes',
     ]);
-    CRM_Core_DAO_AllCoreTables::reinitializeCache(TRUE);
+    CRM_Core_DAO_AllCoreTables::flush();
     $contact1 = $this->individualCreate();
     $contact2 = $this->individualCreate(['api.Im.create' => ['name' => 'chat_handle']]);
     $this->callAPISuccess('Contact', 'merge', ['to_keep_id' => $contact1, 'to_remove_id' => $contact2]);

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -30,7 +30,6 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    \CRM_Core_DAO_AllCoreTables::flush();
 
     \CRM_Core_DAO_AllCoreTables::registerEntityType('FakeFile', 'CRM_Fake_DAO_FakeFile', 'fake_file');
     $fileProvider = new StaticProvider(
@@ -100,11 +99,6 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
       'select',
       ['fake_widget', 'fake_forbidden']
     ));
-  }
-
-  protected function tearDown(): void {
-    parent::tearDown();
-    \CRM_Core_DAO_AllCoreTables::flush();
   }
 
   /**
@@ -184,7 +178,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
    *
    * @dataProvider okDataProvider
    */
-  public function testOk(string $entity, string $action, array $params): array {
+  public function testOk(string $entity, string $action, array $params): void {
     $params['version'] = 3;
     $params['debug'] = 1;
     $params['check_permissions'] = 1;

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -178,12 +178,13 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
   }
 
   /**
-   * @param $entity
-   * @param $action
+   * @param string $entity
+   * @param string $action
    * @param array $params
+   *
    * @dataProvider okDataProvider
    */
-  public function testOk($entity, $action, $params) {
+  public function testOk(string $entity, string $action, array $params): array {
     $params['version'] = 3;
     $params['debug'] = 1;
     $params['check_permissions'] = 1;

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -30,7 +30,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    \CRM_Core_DAO_AllCoreTables::init(TRUE);
+    \CRM_Core_DAO_AllCoreTables::flush();
 
     \CRM_Core_DAO_AllCoreTables::registerEntityType('FakeFile', 'CRM_Fake_DAO_FakeFile', 'fake_file');
     $fileProvider = new StaticProvider(
@@ -104,7 +104,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
 
   protected function tearDown(): void {
     parent::tearDown();
-    \CRM_Core_DAO_AllCoreTables::init(TRUE);
+    \CRM_Core_DAO_AllCoreTables::flush();
   }
 
   /**

--- a/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
@@ -349,7 +349,7 @@ class WhitelistSubscriberTest extends \CiviUnitTestCase {
    * @dataProvider restrictionCases
    */
   public function testEach($apiRequest, $rules, $expectSuccess) {
-    \CRM_Core_DAO_AllCoreTables::init(TRUE);
+    \CRM_Core_DAO_AllCoreTables::flush();
 
     $recs = $this->getFixtures();
 

--- a/tests/phpunit/api/v3/CustomApiTest.php
+++ b/tests/phpunit/api/v3/CustomApiTest.php
@@ -69,10 +69,10 @@ class api_v3_CustomApiTest extends CiviUnitTestCase {
   /**
    * Install the custom api.
    */
-  public function installApi() {
+  public function installApi(): void {
     require_once __DIR__ . '/custom_api/MailingProviderData.php';
     $this->hookClass->setHook('civicrm_entityTypes', [$this, 'hookEntityTypes']);
-    CRM_Core_DAO_AllCoreTables::init(TRUE);
+    CRM_Core_DAO_AllCoreTables::flush();
     CRM_Core_DAO::executeQuery(
       "CREATE TABLE IF NOT EXISTS `civicrm_mailing_provider_data` (
     `contact_identifier` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',


### PR DESCRIPTION
Overview
----------------------------------------
Dismbiguate `init `and `flush`

Before
----------------------------------------
To flush the static cache in `AllCoreTables` you need to call `init` with the `flush` parameter set to TRUE

After
----------------------------------------
call `flush()`

Technical Details
----------------------------------------
I fixed the test places that call this - perhaps some of them are also obsolete now but I didn't want to go down that rabbit hole

Comments
----------------------------------------
It might be worth puting up separate PRs removing some of the test places (esp in tearDown) once this is merged - to avoid whackamole


UPDATE - it turns out there was already a `reinitializeCache` that still used the nasty method internally. I stuck with switching to `flush()` as it seemed more consistent with our functions elsewhere - although an argument could be made to phase in `clear` based on PSR16