### PR TITLE
(REF) Extract compiler passes from CRM_Api4_Services

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -16,7 +16,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Core\Event\EventScanner;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
@@ -37,15 +36,6 @@ class CRM_Api4_Services {
       'registerApiProvider',
       [new Reference('action_object_provider')]
     );
-
-    // add event subscribers$container->get(
-    $dispatcher = $container->getDefinition('dispatcher');
-    $subscribers = $container->findTaggedServiceIds('event_subscriber');
-
-    foreach (array_keys($subscribers) as $subscriber) {
-      $listenerMap = EventScanner::findListeners($container->findDefinition($subscriber)->getClass());
-      $dispatcher->addMethodCall('addSubscriberServiceMap', [$subscriber, $listenerMap]);
-    }
 
     // add spec providers
     $providers = $container->findTaggedServiceIds('spec_provider');

--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -36,17 +36,6 @@ class CRM_Api4_Services {
       'registerApiProvider',
       [new Reference('action_object_provider')]
     );
-
-    // add spec providers
-    $providers = $container->findTaggedServiceIds('spec_provider');
-    $gatherer = $container->getDefinition('spec_gatherer');
-
-    foreach (array_keys($providers) as $provider) {
-      $gatherer->addMethodCall(
-        'addSpecProvider',
-        [new Reference($provider)]
-      );
-    }
   }
 
   /**

--- a/Civi/Core/Compiler/EventScannerPass.php
+++ b/Civi/Core/Compiler/EventScannerPass.php
@@ -1,0 +1,35 @@
+<?php
+namespace Civi\Core\Compiler;
+
+use Civi\Core\Event\EventScanner;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Scan for services that have the tag 'event_subscriber'.
+ *
+ * Specifically, any class tagged as `event_subscriber` will be scanned for event listeners.
+ * The subscriber should implement a relevant interface, such as:
+ *
+ * - HookInterface: The class uses `hook_*()` methods.
+ * - EventSubscriberInterface: the class provides a `getSubscribedEvents()` method.
+ *
+ * The list of listeners will be extracted stored as part of the container-cache.
+ *
+ * NOTE: This is similar to Symfony's `RegisterListenersPass()` but differs in a few ways:
+ *   - Works with both HookInterface and EventSubscriberInterface
+ *   - Watches tag 'event_subscriber' (not 'kernel.event_listener' or 'kernel.event_subscriber')
+ */
+class EventScannerPass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container) {
+    $dispatcher = $container->getDefinition('dispatcher');
+    $subscribers = $container->findTaggedServiceIds('event_subscriber');
+
+    foreach (array_keys($subscribers) as $subscriber) {
+      $listenerMap = EventScanner::findListeners($container->findDefinition($subscriber)->getClass());
+      $dispatcher->addMethodCall('addSubscriberServiceMap', [$subscriber, $listenerMap]);
+    }
+  }
+
+}

--- a/Civi/Core/Compiler/SpecProviderPass.php
+++ b/Civi/Core/Compiler/SpecProviderPass.php
@@ -1,0 +1,26 @@
+<?php
+namespace Civi\Core\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Scan the container for services tagged as 'spec_provider'.
+ * Register each with the `spec_gatherer`.
+ */
+class SpecProviderPass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container) {
+    $providers = $container->findTaggedServiceIds('spec_provider');
+    $gatherer = $container->getDefinition('spec_gatherer');
+
+    foreach (array_keys($providers) as $provider) {
+      $gatherer->addMethodCall(
+        'addSpecProvider',
+        [new Reference($provider)]
+      );
+    }
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Core;
 
+use Civi\Core\Compiler\EventScannerPass;
 use Civi\Core\Event\EventScanner;
 use Civi\Core\Lock\LockManager;
 use Symfony\Component\Config\ConfigCache;
@@ -90,6 +91,7 @@ class Container {
   public function createContainer() {
     $civicrm_base_path = dirname(dirname(__DIR__));
     $container = new ContainerBuilder();
+    $container->addCompilerPass(new EventScannerPass());
     $container->addCompilerPass(new RegisterListenersPass());
     $container->addObjectResource($this);
     $container->setParameter('civicrm_base_path', $civicrm_base_path);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -2,6 +2,7 @@
 namespace Civi\Core;
 
 use Civi\Core\Compiler\EventScannerPass;
+use Civi\Core\Compiler\SpecProviderPass;
 use Civi\Core\Event\EventScanner;
 use Civi\Core\Lock\LockManager;
 use Symfony\Component\Config\ConfigCache;
@@ -92,6 +93,7 @@ class Container {
     $civicrm_base_path = dirname(dirname(__DIR__));
     $container = new ContainerBuilder();
     $container->addCompilerPass(new EventScannerPass());
+    $container->addCompilerPass(new SpecProviderPass());
     $container->addCompilerPass(new RegisterListenersPass());
     $container->addObjectResource($this);
     $container->setParameter('civicrm_base_path', $civicrm_base_path);


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Api4_Services` has interesting behavior that (*sort of*) applies to all container-based services -- it detects services with the tags `event_subscriber` and `spec_provider`, and it registers them with the necessary provider (ie the event-dispatcher or the spec-gatherer).

This patch preserves support for these tags, but it moves the code to a more conventional spot, fixes a bug, and adds explanatory docblocks.

Before
----------------------------------------

It scans for tagged services (`findTaggedServiceIds()`) during the *definition phase*. This is too early. The tags will work for some services -- but they'll be quietly ignored on other services.

For example, if you define a tagged-service in `Civi\Core\Container::createContainer()`, then it will be recongized. But if you define the same tagged-service in `hook_civicrm_container`, then it won't be recognized.

After
----------------------------------------

It scans for tagged services  (`findTaggedServiceIds()`) during the *compilation process*. This is slightly later -- after all service definitions have been defined.

Consequently, the tags will work the same way (regardless of who defines the service).

Technical Details
----------------------------------------

The key thing is to distinguish these use-cases:

* You may wish to *define a service*. This is generally done by calling `$container->setDefinition()` (et al).
* You may wish to *define a generic handler to enhance other services*. This is generally done by calling `$container->addCompilerPass()`

The prior code conflates these two things. The PR splits them apart (running as separate phases - in keeping with the general design of Symfony's `ContainerBuilder`).


Comments
----------------------------------------

The specific folders / interfaces / tags for `CRM_Api4_Services` may seem a bit alien. I submit that doesn't matter -- because there's a bunch of test-coverage that relies on `CRM_Api4_Services`(*if it breaks, you'll see a lot of failures*) and because it's a step toward #24276, which will allow a more consistent model.