### PR TITLE
(NFC) Mark various tests with `@group locale`

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
@@ -13,6 +13,7 @@
  * Test ContributionPage translation features.
  *
  * @group headless
+ * @group locale
  */
 class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Core/I18n/LocaleTest.php
+++ b/tests/phpunit/CRM/Core/I18n/LocaleTest.php
@@ -11,6 +11,7 @@
 /**
  * Class CRM_Core_I18n_LocaleTest
  * @group headless
+ * @group locale
  */
 class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Core/I18n/SchemaTest.php
+++ b/tests/phpunit/CRM/Core/I18n/SchemaTest.php
@@ -11,6 +11,7 @@
 /**
  * Class CRM_Core_I18n_SchemaTest
  * @group headless
+ * @group locale
  */
 class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmMoneyTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmMoneyTest.php
@@ -3,6 +3,7 @@
 /**
  * Class CRM_Core_Smarty_plugins_CrmMoneyTest
  * @group headless
+ * @group locale
  */
 class CRM_Core_Smarty_plugins_CrmMoneyTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -276,6 +276,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    * @throws \CRM_Core_Exception
    * @throws \API_Exception
+   * @group locale
    */
   public function testGetRecipientsEmailGroupIncludeExclude(): void {
     // Create contacts

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -3,6 +3,7 @@
 /**
  * Class CRM_Utils_RuleTest
  * @group headless
+ * @group locale
  */
 class CRM_Utils_MoneyTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/Civi/Core/FormatTest.php
+++ b/tests/phpunit/Civi/Core/FormatTest.php
@@ -20,6 +20,7 @@ use CiviUnitTestCase;
  *
  * @package Civi\Core
  * @group headless
+ * @group locale
  */
 class FormatTest extends CiviUnitTestCase {
 

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -177,6 +177,9 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     }
   }
 
+  /**
+   * @group locale
+   */
   public function testRenderLocalizedSmarty() {
     \CRM_Utils_Time::setTime('2022-04-08 16:32:04');
     $resetTime = \CRM_Utils_AutoClean::with(['CRM_Utils_Time', 'resetTime']);

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -14,6 +14,7 @@
  *
  * @package CiviCRM
  * @group headless
+ * @group locale
  */
 class api_v3_MultilingualTest extends CiviUnitTestCase {
   protected $_apiversion = 3;


### PR DESCRIPTION
Overview
----------------------------------------

Make  it a bit easier to run various internationalization tests.

Extracted from #24174

Technical Details
----------------------------------------

Example command:

```
civibuild restore dmaster --no-cms
CIVICRM_UF=UnitTests phpunit8 tests/phpunit/CRM/ --debug --group locale --stop-on-failure
```
