### PR TITLE
Add 'Entity' to the information import parser classes provide

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -37,6 +37,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         'id' => 'activity_import',
         'name' => 'activity_import',
         'label' => ts('Activity Import'),
+        'entity' => 'Activity',
       ],
     ];
   }

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -100,6 +100,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         'id' => 'contact_import',
         'name' => 'contact_import',
         'label' => ts('Contact Import'),
+        'entity' => 'Contact',
       ],
     ];
   }

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -58,6 +58,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         'id' => 'contribution_import',
         'name' => 'contribution_import',
         'label' => ts('Contribution Import'),
+        'entity' => 'Contribution',
       ],
     ];
   }

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -135,10 +135,12 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
   /**
    * Get the types Import Jobs.
    *
-   * This is largely a placeholder at this stage. It will likely wind
-   * up as an option value so extensions can add different types.
-   *
-   * However, for now it just holds the one type being worked on.
+   * Each type is keyed by it's id and has
+   *   -id
+   *   -name
+   *   -label
+   *   -class
+   *   -entity
    *
    * @return array
    */
@@ -148,6 +150,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
       $types = [];
       $classes = ClassScanner::get(['interface' => UserJobInterface::class]);
       foreach ($classes as $class) {
+        /* @var UserJobInterface $class */
         $declaredTypes = $class::getUserJobInfo();
         foreach ($declaredTypes as $index => $declaredType) {
           $declaredTypes[$index]['class'] = $class;

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -25,6 +25,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
         'id' => 'custom_field_import',
         'name' => 'custom_field_import',
         'label' => ts('Multiple Value Custom Field Import'),
+        'entity' => 'Contact',
       ],
     ];
   }

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -84,6 +84,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         'id' => 'participant_import',
         'name' => 'participant_import',
         'label' => ts('Participant Import'),
+        'entity' => 'Participant',
       ],
     ];
   }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -70,6 +70,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         'id' => 'membership_import',
         'name' => 'membership_import',
         'label' => ts('Membership Import'),
+        'entity' => 'Membership',
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Add 'Entity' to the information import parser classes provide

Before
----------------------------------------
Imports (some) store an `entity_id` to the import table - but we can't build off this without knowing the entity

After
----------------------------------------
Entity is added to the declaration

Technical Details
----------------------------------------
Trying to de-noise https://github.com/civicrm/civicrm-core/pull/24230

Comments
----------------------------------------