### PR TITLE
[REF] [Upgrade] Remove the entry point that called the unused entry point

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -186,17 +186,6 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
     }
   }
 
-  public function preProcess() {
-    $this->setTitle($this->getTitle());
-    if (!$this->verifyPreDBState($errorMessage)) {
-      if (!isset($errorMessage)) {
-        $errorMessage = 'pre-condition failed for current upgrade step';
-      }
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $this->assign('recentlyViewed', FALSE);
-  }
-
   public function buildQuickForm() {
     $this->addDefaultButtons($this->getButtonTitle(),
       'next',


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [Upgrade] Remove the entry point that called the unused entry point

the function `verifyPreDBState` was (removed)[https://github.com/civicrm/civicrm-core/pull/22237] in 5.46 so this code would fatal if ever called - ergo it isn't....

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/185013609-081ecd88-dbf9-47ef-abb7-a960c7367b82.png)

After
----------------------------------------

Technical Details
----------------------------------------

hard to see the matching `verifyPostDBState`

Comments
----------------------------------------
