### PR TITLE
(REF) Extract method `Array::single()`

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -543,7 +543,7 @@ class CRM_Core_DAO extends DB_DataObject {
   public function sequenceKey() {
     static $sequenceKeys;
     if (!isset($sequenceKeys)) {
-      $sequenceKeys = [$this->getPrimaryKey()[0], TRUE];
+      $sequenceKeys = [CRM_Utils_Array::single($this->getPrimaryKey()), TRUE];
     }
     return $sequenceKeys;
   }
@@ -644,7 +644,7 @@ class CRM_Core_DAO extends DB_DataObject {
     // In practice the 'Import' entities are probably the only ones with a single
     // primary key that is not import. Should we check all if more than one?
     // Can do that when it comes up...
-    $primaryField = $this->getPrimaryKey()[0];
+    $primaryField = CRM_Utils_Array::single($this->getPrimaryKey());
     if (!empty($this->$primaryField)) {
       if ($hook) {
         $preEvent = new \Civi\Core\DAO\Event\PreUpdate($this);

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1212,6 +1212,35 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Take one well-defined item out of a single-item list.
+   *
+   * Assert that the list genuinely contains *exactly* one item.
+   *
+   * @param iterable $items
+   * @param string $recordTypeLabel
+   * @return mixed
+   *   The first (and only) item from the $items list.
+   * @throws \CRM_Core_Exception
+   */
+  public static function single(iterable $items, string $recordTypeLabel = 'record') {
+    $result = NULL;
+    foreach ($items as $values) {
+      if ($result === NULL) {
+        $result = $values;
+      }
+      else {
+        throw new \CRM_Core_Exception("Expected to find one {$recordTypeLabel}, but there were multiple.");
+      }
+    }
+
+    if ($result === NULL) {
+      throw new \CRM_Core_Exception("Expected to find one {$recordTypeLabel}, but there were zero.");
+    }
+
+    return $result;
+  }
+
+  /**
    * Convert a simple dictionary into separate key+value records.
    *
    * @param array $array

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -87,21 +87,7 @@ class Result extends \ArrayObject implements \JsonSerializable {
    * @throws \API_Exception
    */
   public function single() {
-    $result = NULL;
-    foreach ($this as $values) {
-      if ($result === NULL) {
-        $result = $values;
-      }
-      else {
-        throw new \API_Exception("Expected to find one {$this->entity} record, but there were multiple.");
-      }
-    }
-
-    if ($result === NULL) {
-      throw new \API_Exception("Expected to find one {$this->entity} record, but there were zero.");
-    }
-
-    return $result;
+    return \CRM_Utils_Array::single($this, "{$this->entity} record");
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -458,4 +458,51 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals($flat, $expected);
   }
 
+  public function testSingle() {
+    $okExamples = [
+      ['abc'],
+      [123],
+      [TRUE],
+      [FALSE],
+      [''],
+      [[]],
+      [[1, 2, 3]],
+      ['a' => 'b'],
+      (function () {
+        yield 'abc';
+      })(),
+    ];
+    $badExamples = [
+      [],
+      [1, 2],
+      ['a' => 'b', 'c' => 'd'],
+      [[], []],
+      (function () {
+        yield from [];
+      })(),
+      (function () {
+        yield 1;
+        yield 2;
+      })(),
+    ];
+
+    $todoCount = count($okExamples) + count($badExamples);
+    foreach ($okExamples as $i => $okExample) {
+      $this->assertTrue(CRM_Utils_Array::single($okExample) !== NULL, "Expect to get a result from example ($i)");
+      $todoCount--;
+    }
+
+    foreach ($badExamples as $i => $badExample) {
+      try {
+        CRM_Utils_Array::single($badExample);
+        $this->fail("Expected exception for bad example ($i)");
+      }
+      catch (CRM_Core_Exception $e) {
+        $todoCount--;
+      }
+    }
+
+    $this->assertEquals(0, $todoCount);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Extract the `single()` method from API4's `Result` so that it can be used with other arrays.

Technical Details
----------------------------------------

You may notice that the exception-type looks different. `API_Exception` is just an alias of `CRM_Core_Exception`.
