### PR TITLE
APIv4 - Fix some hard-coded references to 'id' in DAO action classes

### DIFF
--- a/Civi/Api4/Generic/DAOCreateAction.php
+++ b/Civi/Api4/Generic/DAOCreateAction.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Create a new $ENTITY from supplied values.
  *
@@ -37,8 +39,9 @@ class DAOCreateAction extends AbstractCreateAction {
    * @throws \API_Exception
    */
   protected function validateValues() {
-    if (!empty($this->values['id'])) {
-      throw new \API_Exception('Cannot pass id to Create action. Use Update action instead.');
+    $idField = CoreUtil::getIdFieldName($this->getEntityName());
+    if (!empty($this->values[$idField])) {
+      throw new \API_Exception("Cannot pass $idField to Create action. Use Update action instead.");
     }
     parent::validateValues();
   }

--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -54,28 +54,29 @@ class DAODeleteAction extends AbstractBatchAction {
    * @throws \API_Exception
    */
   protected function deleteObjects($items) {
-    $ids = [];
+    $idField = CoreUtil::getIdFieldName($this->getEntityName());
+    $result = [];
     $baoName = $this->getBaoName();
 
     // Use BAO::del() method if it is not deprecated
     if (method_exists($baoName, 'del') && !ReflectionUtils::isMethodDeprecated($baoName, 'del')) {
       foreach ($items as $item) {
-        $args = [$item['id']];
+        $args = [$item[$idField]];
         $bao = call_user_func_array([$baoName, 'del'], $args);
         if ($bao !== FALSE) {
-          $ids[] = ['id' => $item['id']];
+          $result[] = [$idField => $item[$idField]];
         }
         else {
-          throw new \API_Exception("Could not delete {$this->getEntityName()} id {$item['id']}");
+          throw new \API_Exception("Could not delete {$this->getEntityName()} $idField {$item[$idField]}");
         }
       }
     }
     else {
       foreach ($baoName::deleteRecords($items) as $instance) {
-        $ids[] = ['id' => $instance->id];
+        $result[] = [$idField => $instance->$idField];
       }
     }
-    return $ids;
+    return $result;
   }
 
 }

--- a/Civi/Api4/Generic/DAOSaveAction.php
+++ b/Civi/Api4/Generic/DAOSaveAction.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * @inheritDoc
  */
@@ -22,11 +24,12 @@ class DAOSaveAction extends AbstractSaveAction {
    * @inheritDoc
    */
   public function _run(Result $result) {
+    $idField = CoreUtil::getIdFieldName($this->getEntityName());
     foreach ($this->records as &$record) {
       $record += $this->defaults;
       $this->formatWriteValues($record);
       $this->matchExisting($record);
-      if (empty($record['id'])) {
+      if (empty($record[$idField])) {
         $this->fillDefaults($record);
       }
     }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -121,9 +121,10 @@ trait DAOActionTrait {
     }
 
     $result = [];
+    $idField = CoreUtil::getIdFieldName($this->getEntityName());
 
     foreach ($items as &$item) {
-      $entityId = $item['id'] ?? NULL;
+      $entityId = $item[$idField] ?? NULL;
       FormattingUtil::formatWriteParams($item, $this->entityFields());
       $this->formatCustomParams($item, $entityId);
 


### PR DESCRIPTION
Overview
----------------------------------------
Makes APIv4 more flexible and able to handle tables with a primary key not named 'id'.

Technical Details
----------------------------------------
Helps with #24230