### PR TITLE
(REF) Extract LocaleTestTrait. Tighten up multilingual testing.

### DIFF
--- a/Civi/Test/LocaleTestTrait.php
+++ b/Civi/Test/LocaleTestTrait.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Define helpers for testing multiple locales.
+ *
+ * Ex: Multilingual test with try/finally
+ *   try {
+ *     $this->enableMultilingual(['en_US' => 'fr_CA']);
+ *     $this->assert(...);
+ *   } finally {
+ *     $this->disbleMultilingual();
+ *   }
+ *
+ * Ex: Multilingual with auto-clean
+ *   $cleanup = $this->useMultilingual(['en_US' => 'fr_CA']);
+ */
+trait LocaleTestTrait {
+
+  /**
+   * @var string
+   */
+  private static $defaultSystemLocale = 'en_US';
+
+  /**
+   * Temporarily use multilingual.
+   *
+   * @param array $addLocales
+   *   A list of new locales to setup.
+   *   A locale is initialized by copying from an existing locale.
+   *
+   *   Ex: Copy from en_US to fr_CA
+   *       ['en_US' => 'fr_CA']
+   *   Ex: Copy from en_US to fr_CA and de_DE
+   *       ['en_US' => ['fr_CA', 'de_DE]]
+   * @return \CRM_Utils_AutoClean
+   *   A reference to the temporary configuration. Once removed, the system will revert to single language.
+   */
+  public function useMultilingual(array $addLocales): \CRM_Utils_AutoClean {
+    $this->enableMultilingual($addLocales);
+    return \CRM_Utils_AutoClean::with([$this, 'disableMultilingual']);
+  }
+
+  /**
+   * Enable multilingual.
+   *
+   * @param array|null $addLocales
+   *   A list of new locales to setup.
+   *   A locale is initialized by copying from an existing locale.
+   *
+   *   Ex: Copy from en_US to fr_CA
+   *       ['en_US' => 'fr_CA']
+   *   Ex: Copy from en_US to fr_CA and de_DE
+   *       ['en_US' => ['fr_CA', 'de_DE]]
+   */
+  public function enableMultilingual(?array $addLocales = NULL): void {
+    $this->callAPISuccess('Setting', 'create', [
+      'lcMessages' => static::$defaultSystemLocale,
+      'languageLimit' => [
+        static::$defaultSystemLocale => 1,
+      ],
+    ]);
+
+    \CRM_Core_I18n_Schema::makeMultilingual(static::$defaultSystemLocale);
+
+    global $dbLocale;
+    $dbLocale = '_' . static::$defaultSystemLocale;
+
+    if ($addLocales !== NULL) {
+      foreach ($addLocales as $fromLocale => $toLocales) {
+        foreach ((array) $toLocales as $toLocale) {
+          \CRM_Core_I18n_Schema::addLocale($toLocale, $fromLocale);
+        }
+        \Civi::settings()->set('languageLimit', \Civi::settings()->get('languageLimit') + [$toLocale => '1']);
+      }
+    }
+  }
+
+  public function disableMultilingual(): void {
+    \CRM_Core_I18n::singleton()->setLocale(static::$defaultSystemLocale);
+    \CRM_Core_I18n_Schema::makeSinglelingual(static::$defaultSystemLocale);
+    \Civi::settings()->revert('languageLimit');
+    \Civi::$statics['CRM_Core_I18n']['singleton'] = [];
+  }
+
+}

--- a/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
@@ -20,14 +20,13 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
   public function setUp(): void {
     parent::setUp();
     $this->_financialTypeID = 1;
-    $this->enableMultilingual();
-    CRM_Core_I18n_Schema::addLocale('fr_FR', 'en_US');
+    $this->enableMultilingual(['en_US' => 'fr_FR']);
   }
 
   public function tearDown(): void {
     global $dbLocale;
     if ($dbLocale) {
-      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+      $this->disableMultilingual();
     }
     parent::tearDown();
   }

--- a/tests/phpunit/CRM/Core/CopyTest.php
+++ b/tests/phpunit/CRM/Core/CopyTest.php
@@ -67,10 +67,7 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
 
     $locales = ['en_US', 'fr_CA', 'nl_NL'];
 
-    $this->enableMultilingual();
-    CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
-    CRM_Core_I18n_Schema::addLocale('nl_NL', 'en_US');
-
+    $cleanup = $this->useMultilingual(['en_US' => ['fr_CA', 'nl_NL']]);
     CRM_Core_I18n::singleton()->setLocale('en_US');
 
     $event = $this->eventCreate();
@@ -150,11 +147,6 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
       // other fields
       $this->compareLocalizedCopy($eventData, $eventCopy, $locParams, $identicalParams, $locSuffix);
     }
-
-    // reset to en_US only
-    CRM_Core_I18n::singleton()->setLocale('en_US');
-    CRM_Core_I18n_Schema::makeSinglelingual('en_US');
-
   }
 
   protected function compareLocalizedCopy($source, $dest, $locParams, $identicalParams, $locSuffix) {

--- a/tests/phpunit/CRM/Core/I18n/LocaleTest.php
+++ b/tests/phpunit/CRM/Core/I18n/LocaleTest.php
@@ -19,17 +19,11 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
    *
    */
   public function testI18nLocaleChange() {
-    $this->enableMultilingual();
-    CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
+    $cleanup = $this->useMultilingual(['en_US' => 'fr_CA']);
 
     CRM_Core_I18n::singleton()->setLocale('fr_CA');
     $locale = CRM_Core_I18n::getLocale();
-
-    $this->assertEquals($locale, 'fr_CA');
-
-    CRM_Core_I18n::singleton()->setLocale('en_US');
-    CRM_Core_I18n_Schema::makeSinglelingual('en_US');
-    Civi::$statics['CRM_Core_I18n']['singleton'] = [];
+    $this->assertEquals('fr_CA', $locale);
   }
 
   public function testUiLanguages() {
@@ -58,11 +52,7 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
     $result = CRM_Core_I18n::uiLanguages();
     $this->assertTreeEquals($languages, $result);
 
-    $this->enableMultilingual();
-    // Add fr_CA in db
-    CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
-    // Make fr_CA 'available'
-    Civi::settings()->set('languageLimit', ['en_US' => 1, 'fr_CA' => 1]);
+    $cleanup = $this->useMultilingual(['en_US' => 'fr_CA']);
 
     // Multilingual, codes
     $result = CRM_Core_I18n::uiLanguages(TRUE);
@@ -94,10 +84,6 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
       \CRM_Core_I18n::singleton()->setLocale('fr_CA');
       $this->assertEquals('Planifié', \CRM_Core_PseudoConstant::getLabel("CRM_Activity_BAO_Activity", "status_id", 1));
     }
-
-    CRM_Core_I18n::singleton()->setLocale('en_US');
-    CRM_Core_I18n_Schema::makeSinglelingual('en_US');
-    Civi::$statics['CRM_Core_I18n']['singleton'] = [];
   }
 
   /**

--- a/tests/phpunit/CRM/Core/I18n/SchemaTest.php
+++ b/tests/phpunit/CRM/Core/I18n/SchemaTest.php
@@ -32,7 +32,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
   }
 
   public function tearDown(): void {
-    CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+    $this->disableMultilingual();
     parent::tearDown();
   }
 
@@ -44,7 +44,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testI18nSchemaRewrite($table, $expectedRewrite) {
-    CRM_Core_I18n_Schema::makeMultilingual('en_US');
+    $this->enableMultilingual();
     $domains = $this->callAPISuccess('Domain', 'get')['values'];
     $this->assertGreaterThan(1, count($domains));
     foreach ($domains as $domain) {
@@ -106,7 +106,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
   }
 
   public function testSchemaBuild() {
-    CRM_Core_I18n_Schema::makeMultilingual('en_US');
+    $this->enableMultilingual();
     $inUseCollation = CRM_Core_BAO_SchemaHandler::getInUseCollation();
     $testCreateTable = CRM_Core_DAO::executeQuery("show create table civicrm_price_set", [], TRUE, NULL, FALSE, FALSE);
     while ($testCreateTable->fetch()) {
@@ -116,8 +116,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
   }
 
   public function testMultilingualCustomFieldCreation() {
-    $this->enableMultilingual();
-    CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
+    $this->enableMultilingual(['en_US' => 'fr_CA']);
     $id = $this->customGroupCreate()['id'];
     $this->customFieldCreate(['custom_group_id' => $id]);
   }

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -25,7 +25,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
   public function tearDown(): void {
     global $dbLocale;
     if ($dbLocale) {
-      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+      $this->disableMultilingual();
     }
     $this->financialAccountDelete('Donations');
     parent::tearDown();
@@ -112,11 +112,11 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
    * Check method del()
    *
    * @dataProvider multiLingual
+   * @group locale
    */
   public function testDel($isMultiLingual) {
     if ($isMultiLingual) {
-      $this->enableMultilingual();
-      CRM_Core_I18n_Schema::addLocale('fr_FR', 'en_US');
+      $this->enableMultilingual(['en_US' => 'fr_FR']);
     }
     $params = [
       'name' => 'Donations',

--- a/tests/phpunit/CRM/Logging/LoggingTest.php
+++ b/tests/phpunit/CRM/Logging/LoggingTest.php
@@ -3,22 +3,17 @@
 /**
  * Class CRM_Core_DAOTest
  * @group headless
+ * @group locale
  */
 class CRM_Logging_LoggingTest extends CiviUnitTestCase {
 
   use CRMTraits_Custom_CustomDataTrait;
 
-  /**
-   * Has the db been set to multilingual.
-   *
-   * @var bool
-   */
-  protected $isDBMultilingual = FALSE;
-
   public function tearDown(): void {
     Civi::settings()->set('logging', FALSE);
-    if ($this->isDBMultilingual) {
-      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+    global $dbLocale;
+    if ($dbLocale) {
+      $this->disableMultilingual();
     }
     $logging = new CRM_Logging_Schema();
     $logging->dropAllLogTables();
@@ -64,7 +59,7 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
    * Test creating logging schema when database is in multilingual mode.
    */
   public function testMultilingualLogging(): void {
-    $this->makeMultilingual();
+    $this->enableMultilingual();
     Civi::settings()->set('logging', TRUE);
     $value = CRM_Core_DAO::singleValueQuery('SELECT id FROM log_civicrm_contact LIMIT 1', [], FALSE, FALSE);
     $this->assertNotNull($value, 'Logging not enabled successfully');
@@ -75,7 +70,7 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
    * Also test altering a multilingual table.
    */
   public function testMultilingualAlterSchemaLogging(): void {
-    $this->makeMultilingual();
+    $this->enableMultilingual();
     Civi::settings()->set('logging', TRUE);
     $logging = new CRM_Logging_Schema();
     $value = CRM_Core_DAO::singleValueQuery('SELECT id FROM log_civicrm_contact LIMIT 1', [], FALSE, FALSE);
@@ -111,14 +106,6 @@ class CRM_Logging_LoggingTest extends CiviUnitTestCase {
       || in_array("  `logging_test` int DEFAULT '0'", $create, TRUE)
       || in_array('  `logging_test` int DEFAULT 0', $create, TRUE)
     );
-  }
-
-  /**
-   * Convert the database to multilingual mode.
-   */
-  protected function makeMultilingual(): void {
-    CRM_Core_I18n_Schema::makeMultilingual('en_US');
-    $this->isDBMultilingual = TRUE;
   }
 
 }

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -19,7 +19,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
   public function tearDown(): void {
     global $dbLocale;
     if ($dbLocale) {
-      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+      $this->disableMultilingual();
     }
     parent::tearDown();
   }

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -70,7 +70,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
   public function tearDown(): void {
     global $dbLocale;
     if ($dbLocale) {
-      CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+      $this->disableMultilingual();
     }
     parent::tearDown();
     $this->assertNotEmpty($this->counts['hook_alterMailParams']);

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -195,8 +195,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
     // transaction still increments the AUTO_INCREMENT counter for the table.
     // (If this behaviour ever changes we throw an exception.)
     if ($isMultiLingual) {
-      $this->enableMultilingual();
-      CRM_Core_I18n_Schema::addLocale('fr_FR', 'en_US');
+      $cleanup = $this->useMultilingual(['en_US' => 'fr_FR']);
     }
     $max_group_id = CRM_Core_DAO::singleValueQuery("SELECT MAX(id) FROM civicrm_group");
     $max_mailing_id = 0;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -74,6 +74,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   use \Civi\Test\DbTestTrait;
   use \Civi\Test\ContactTestTrait;
   use \Civi\Test\MailingTestTrait;
+  use \Civi\Test\LocaleTestTrait;
 
   /**
    *  Database has been initialized.
@@ -3423,23 +3424,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $contributionObj->id = $contributionID;
     $contributionObj->find(TRUE);
     return $contributionObj;
-  }
-
-  /**
-   * Enable multilingual.
-   */
-  public function enableMultilingual() {
-    $this->callAPISuccess('Setting', 'create', [
-      'lcMessages' => 'en_US',
-      'languageLimit' => [
-        'en_US' => 1,
-      ],
-    ]);
-
-    CRM_Core_I18n_Schema::makeMultilingual('en_US');
-
-    global $dbLocale;
-    $dbLocale = '_en_US';
   }
 
   /**

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -31,7 +31,7 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
   }
 
   public function tearDown(): void {
-    CRM_Core_I18n_Schema::makeSinglelingual('en_US');
+    $this->disableMultilingual();
     parent::tearDown();
   }
 
@@ -39,17 +39,8 @@ class api_v3_MultilingualTest extends CiviUnitTestCase {
    * @dataProvider versionThreeAndFour
    */
   public function testOptionLanguage($version) {
-    $this->enableMultilingual();
     $this->_apiversion = $version;
-
-    CRM_Core_I18n_Schema::addLocale('fr_CA', 'en_US');
-
-    $this->callAPISuccess('Setting', 'create', [
-      'languageLimit' => [
-        'en_US' => 1,
-        'fr_CA' => 1,
-      ],
-    ]);
+    $this->enableMultilingual(['en_US' => 'fr_CA']);
 
     // Take a semi-random OptionGroup and test manually changing its label
     // in one language, while making sure it stays the same in English.


### PR DESCRIPTION
Overview
----------------------------------------

This is a test-only change. Generally, it tightens up the way in which multilingual mode is enabled/disabled -- with an aim to (a) improving realism, (b) reducing duplication, (c) recovering better from test-errors.

Technical Details
----------------------------------------

There are multiple steps to setting up a valid multilingual environment, such as:

* Marking ML as enabled
* Rearranging DB columns for the original locale
* Adding DB columns for 1-2 additional locales
* Setting the list of active ML locales

Additionally, it is important to reverse these steps at the end. If there are scenarios where it doesn't cleanup (eg due to a failed test-assertion) or where it only partially cleans up

Before
----------------------------------------

Tests use some mix of:

* `$this->enableMultilingual()` or `\CRM_Core_I18n_Schema::makeMultilingual()`
* Maybe `\CRM_Core_I18n_Schema::makeSinglelingua()l`
* Maybe update Civi settings for ML
* Maybe add languages to ML

Some tests also don't do cleanup in a safe way (eg a failed assertion will cascade to break other tests)

If you try to run the entire `phpunit --group locale`, it doesn't work.

After
----------------------------------------

More consistent code-style. Either:

* Use the pair `$this->enableMultilingual(['srcLocale' => 'newLocale'])` and `$this->disableMultilingual()` (with try/finally or setup/teardown)
* Use the autoclean `$cleanup = $this->useMultilingual(['srcLocale' => 'newLocale'])`

If you try to run the entire `phpunit --group locale`, it does work.