### PR TITLE
Further fix on  `fastArrayCache` `has` 

### DIFF
--- a/CRM/Utils/Cache/FastArrayDecorator.php
+++ b/CRM/Utils/Cache/FastArrayDecorator.php
@@ -119,7 +119,17 @@ class CRM_Utils_Cache_FastArrayDecorator implements CRM_Utils_Cache_Interface {
     if (array_key_exists($key, $this->values)) {
       return TRUE;
     }
-    return $this->delegate->has($key);
+    // Doing a get here populates `$this->values`. If the calling
+    // code does a `has()` followed by a `get` we want only one
+    // look-up so do that lookup on the first request.
+    // (The only real reason to do `has` & then `get` is it is
+    // less ambiguous for false & empty values)
+    // `$this->delegate->has($key)` here then an extra
+    // lookup will be needed if we do `has` followed by `get`.
+    // Reducing `get` calls to the underlying cache has significant
+    // speed improvement (see https://github.com/civicrm/civicrm-core/pull/24156)
+    $this->get($key);
+    return array_key_exists($key, $this->values);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Further fix on  `fastArrayCache` `has` 

We recently got a good performance boost on accessing the `metadata` (and other `fastArray` caches) by improving our 'hit-rate' on intercepting requests at the fast array cache https://github.com/civicrm/civicrm-core/pull/24156

This adds a much smaller boost in intercepts such that the pattern of 
```
if (Civi::cache('metadata')->has($key)) {
  return Civi::cache('metadata')->get($key);
}
```
results in one lookup of the underlying cache rather than two.

Before
----------------------------------------
A call to `has` on a `fastArray` cache does not result in the value retrieved from the `get` request that it does being cached to the array so we wind up with two get requests when we do `has` followed by `get` - has seems to call `get` internally anyway - but not in a way the `fastArray` decorator can access

```
1660868589.692973 [0 127.0.0.1:44142] "GET" "crm/metadata_5_51_beta2/CRM_Core_BAO_OptionValue_OptionGroupID_2_en_US"
1660868589.693399 [0 127.0.0.1:44142] "GET" "crm/metadata_5_51_beta2/CRM_Core_BAO_OptionValue_OptionGroupID_2_en_US"
```

After
----------------------------------------
Using a `get` internally results in the value being cached & available for a second call

Technical Details
----------------------------------------
it's hard to think of when a `has` would be used without a subsequent `get`

Comments
----------------------------------------
This won't impact batch job performance except on the very first cache access - which suggests maybe a 120ms improvement on a single contact save on our infra - that's not a tonne & results may vary - but we have removed queries with far less impact & it's hard to see a downside