### PR TITLE
Further caching fix - use metadata cache

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -219,6 +219,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
 
     $optionValue->id = $id;
     $optionValue->save();
+    Civi::cache('metadata')->flush();
     CRM_Core_PseudoConstant::flush();
 
     CRM_Utils_Hook::post($op, 'OptionValue', $id, $optionValue);
@@ -477,24 +478,24 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
    *   an array of array of values for this option group
    */
   public static function getOptionValuesArray($optionGroupID) {
+    global $tsLocale;
     // check if we can get the field values from the system cache
-    $cacheKey = "CRM_Core_BAO_OptionValue_OptionGroupID_{$optionGroupID}";
-    $cache = CRM_Utils_Cache::singleton();
-    $optionValues = $cache->get($cacheKey);
-    if (empty($optionValues)) {
-      $dao = new CRM_Core_DAO_OptionValue();
-      $dao->option_group_id = $optionGroupID;
-      $dao->orderBy('weight ASC, label ASC');
-      $dao->find();
-
-      $optionValues = [];
-      while ($dao->fetch()) {
-        $optionValues[$dao->id] = [];
-        CRM_Core_DAO::storeValues($dao, $optionValues[$dao->id]);
-      }
-
-      $cache->set($cacheKey, $optionValues);
+    $cacheKey = "CRM_Core_BAO_OptionValue_OptionGroupID_{$optionGroupID}_$tsLocale";
+    if (Civi::cache('metadata')->has($cacheKey)) {
+      return Civi::cache('metadata')->get($cacheKey);
     }
+    $dao = new CRM_Core_DAO_OptionValue();
+    $dao->option_group_id = $optionGroupID;
+    $dao->orderBy('weight ASC, label ASC');
+    $dao->find();
+
+    $optionValues = [];
+    while ($dao->fetch()) {
+      $optionValues[$dao->id] = [];
+      CRM_Core_DAO::storeValues($dao, $optionValues[$dao->id]);
+    }
+
+    Civi::cache('metadata')->set($cacheKey, $optionValues);
 
     return $optionValues;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Further caching fix - use metadata cache

Before
----------------------------------------
This cache access construct 
`$optionValues =  `CRM_Utils_Cache::singleton()->get($cacheKey);`

After
----------------------------------------
Uses
```
  if (Civi::cache('metadata')->has($cacheKey)) {
      return Civi::cache('metadata')->get($cacheKey);
    }

```

Technical Details
----------------------------------------
This is a performance fix - for `Redis` users the current method never uses the array cache whereas the latter does. In conjunction with https://github.com/civicrm/civicrm-core/pull/24156 I got about another 10% improvement on Contact updates in our staging environment.


The data is a bit murky in prod as I accidentally undeployed the [first patch](https://github.com/civicrm/civicrm-core/pull/24156 ) when I first deployed this (where it the U goes back up again) & then when I re-deployed (where it shoots back down again)  our high volume ended just as it was starting to look like this would show a clear-cut boost (those zig-zags at the end are when traffic slowed & we started working with a colder cache / less consistent run size)

![image](https://user-images.githubusercontent.com/336308/185269718-ef793a76-0649-4d21-851d-1c105c4eb1eb.png)


Comments
----------------------------------------