### PR TITLE
Fix Contact token prefetch to avoid db retrievals for pseudoconstants

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1261,7 +1261,13 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         break;
 
       case 'Link':
-        $display = $display ? "<a href=\"$display\" target=\"_blank\">$display</a>" : $display;
+        if (empty($display)) {
+          return '';
+        }
+        // The (tested) token code might pass it in twice. A better fix might eventuate when
+        // we switch that code to use v4 token fields (ie set to a PSR7 object & resolve in
+        // the parent - but this is quick & dirty & safe for now.
+        $display = strpos($display, '<a href') !== 0 ? "<a href=\"$display\" target=\"_blank\">$display</a>" : $display;
         break;
 
       case 'TextArea':


### PR DESCRIPTION
Overview
----------------------------------------
Fix Contact token prefetch to avoid db retrievals for pseudoconstants

Before
----------------------------------------
- The value passed to the parent as `prefetch` is not in the correct format
![image](https://user-images.githubusercontent.com/336308/185270870-13f45fa6-1860-41a2-8388-d03798e7091f.png)

- The parent class will do a `contact.get` lookup to evaluate `{contact.prefix_id:label}` even when it has `prefix_id`

After
----------------------------------------
The data is passed in the correct format & it checks for relevant pseudoconstant info before doing a db lookup

Technical Details
----------------------------------------
I also switched to getting data from ` $row->context` less repetitively - during  php profiling that came up as a slower code path as it does some recursive array stuff - although in the end I wasn't sure how significant it was in the overall speed improvement I got (fixing the `redis` cache miss on `has` more than doubled throughput on contact update processing & all the other fixes I tried combined only gave me another 20%)

Comments
----------------------------------------

