### PR TITLE
Fix another cache usage to use metadata cache

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2244,33 +2244,34 @@ WHERE  id IN ( %1, %2 )
    *
    * @param int $fieldID
    *   The fieldID of the custom field.
-   * @param bool $force
-   *   Force the sql to be run again (primarily used for tests).
    *
    * @return array
    *   fatal is fieldID does not exists, else array of tableName, columnName
    * @throws \CRM_Core_Exception
    */
-  public static function getTableColumnGroup($fieldID, $force = FALSE) {
-    $cacheKey = "CRM_Core_DAO_CustomField_CustomGroup_TableColumn_{$fieldID}";
-    $cache = CRM_Utils_Cache::singleton();
-    $fieldValues = $cache->get($cacheKey);
-    if (empty($fieldValues) || $force) {
-      $query = "
+  public static function getTableColumnGroup($fieldID): array {
+    global $tsLocale;
+    // check if we can get the field values from the system cache
+    $cacheKey = "CRM_Core_DAO_CustomField_CustomGroup_TableColumn_{$fieldID}_$tsLocale";
+    if (Civi::cache('metadata')->has($cacheKey)) {
+      return Civi::cache('metadata')->get($cacheKey);
+    }
+
+    $query = '
 SELECT cg.table_name, cf.column_name, cg.id
 FROM   civicrm_custom_group cg,
-       civicrm_custom_field cf
+     civicrm_custom_field cf
 WHERE  cf.custom_group_id = cg.id
-AND    cf.id = %1";
-      $params = [1 => [$fieldID, 'Integer']];
-      $dao = CRM_Core_DAO::executeQuery($query, $params);
+AND    cf.id = %1';
+    $params = [1 => [$fieldID, 'Integer']];
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
 
-      if (!$dao->fetch()) {
-        throw new CRM_Core_Exception("Cannot find table and column information for Custom Field " . $fieldID);
-      }
-      $fieldValues = [$dao->table_name, $dao->column_name, $dao->id];
-      $cache->set($cacheKey, $fieldValues);
+    if (!$dao->fetch()) {
+      throw new CRM_Core_Exception('Cannot find table and column information for Custom Field ' . $fieldID);
     }
+    $fieldValues = [$dao->table_name, $dao->column_name, $dao->id];
+    Civi::cache('metadata')->set($cacheKey, $fieldValues);
+
     return $fieldValues;
   }
 

--- a/tests/phpunit/api/v3/CustomValueContactTypeTest.php
+++ b/tests/phpunit/api/v3/CustomValueContactTypeTest.php
@@ -86,8 +86,8 @@ class api_v3_CustomValueContactTypeTest extends CiviUnitTestCase {
     $this->organizationSponsor = $this->organizationCreate($params);
     //refresh php cached variables
     CRM_Core_PseudoConstant::flush();
-    CRM_Core_BAO_CustomField::getTableColumnGroup($this->IndividualField['id'], TRUE);
-    CRM_Core_BAO_CustomField::getTableColumnGroup($this->IndiStudentField['id'], TRUE);
+    CRM_Core_BAO_CustomField::getTableColumnGroup($this->IndividualField['id']);
+    CRM_Core_BAO_CustomField::getTableColumnGroup($this->IndiStudentField['id']);
   }
 
   public function tearDown(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fix another cache usage to use metadata cache


Before
----------------------------------------
`CRM_Core_BAO_CustomField::getTableColumnGroup` uses `CRM_Utils_Cache::singleton()->get($cacheKey);` which does not use the `FastArray` cache to speed up repeated calls

After
----------------------------------------
```
 if (Civi::cache('metadata')->has($cacheKey)) {
      return Civi::cache('metadata')->get($cacheKey);
 }
```

Technical Details
----------------------------------------
We haven't deployed this yet but on staging I got a performance boost in the 5-10% range with this (simlar to https://github.com/civicrm/civicrm-core/pull/24294)  

Comments
----------------------------------------
