### PR TITLE
Clean up another cache usage to use metadata

### DIFF
--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -266,6 +266,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue {
     $hookParams = ['id' => $optionValueId];
     CRM_Utils_Hook::pre('delete', 'OptionValue', $optionValueId, $hookParams);
     if (self::updateRecords($optionValueId, CRM_Core_Action::DELETE)) {
+      Civi::cache('metadata')->flush();
       CRM_Core_PseudoConstant::flush();
       $optionValue->delete();
       CRM_Utils_Hook::post('delete', 'OptionValue', $optionValueId, $optionValue);

--- a/CRM/Extension/Manager/Report.php
+++ b/CRM/Extension/Manager/Report.php
@@ -37,7 +37,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
    *
    * @throws CRM_Core_Exception
    */
-  public function onPreInstall(CRM_Extension_Info $info) {
+  public function onPreInstall(CRM_Extension_Info $info): void {
     $customReports = $this->getCustomReportsByName();
     if (array_key_exists($info->key, $customReports)) {
       throw new CRM_Core_Exception(ts('This report is already registered.'));
@@ -67,7 +67,7 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
       'is_active' => 1,
     ];
 
-    $optionValue = CRM_Core_BAO_OptionValue::add($params);
+    CRM_Core_BAO_OptionValue::add($params);
   }
 
   /**
@@ -108,14 +108,14 @@ class CRM_Extension_Manager_Report extends CRM_Extension_Manager_Base {
    * @return array
    */
   public function getCustomReportsByName() {
-    return CRM_Core_OptionGroup::values(self::REPORT_GROUP_NAME, TRUE, FALSE, FALSE, NULL, 'name', FALSE, TRUE);
+    return CRM_Core_OptionGroup::values(self::REPORT_GROUP_NAME, TRUE, FALSE, FALSE, NULL, 'name', FALSE);
   }
 
   /**
    * @return array
    */
   public function getCustomReportsById() {
-    return CRM_Core_OptionGroup::values(self::REPORT_GROUP_NAME, FALSE, FALSE, FALSE, NULL, 'id', FALSE, TRUE);
+    return CRM_Core_OptionGroup::values(self::REPORT_GROUP_NAME, FALSE, FALSE, FALSE, NULL, 'id', FALSE);
   }
 
 }

--- a/CRM/Extension/Manager/Search.php
+++ b/CRM/Extension/Manager/Search.php
@@ -105,15 +105,15 @@ class CRM_Extension_Manager_Search extends CRM_Extension_Manager_Base {
   /**
    * @return array
    */
-  protected function getCustomSearchesByName() {
-    return CRM_Core_OptionGroup::values(self::CUSTOM_SEARCH_GROUP_NAME, TRUE, FALSE, FALSE, NULL, 'name', FALSE, TRUE);
+  protected function getCustomSearchesByName(): array {
+    return CRM_Core_OptionGroup::values(self::CUSTOM_SEARCH_GROUP_NAME, TRUE, FALSE, FALSE, NULL, 'name', FALSE);
   }
 
   /**
    * @return array
    */
-  protected function getCustomSearchesById() {
-    return CRM_Core_OptionGroup::values(self::CUSTOM_SEARCH_GROUP_NAME, FALSE, FALSE, FALSE, NULL, 'id', FALSE, TRUE);
+  protected function getCustomSearchesById(): array {
+    return CRM_Core_OptionGroup::values(self::CUSTOM_SEARCH_GROUP_NAME, FALSE, FALSE, FALSE, NULL, 'id', FALSE);
   }
 
 }

--- a/tests/phpunit/api/v3/OptionValueTest.php
+++ b/tests/phpunit/api/v3/OptionValueTest.php
@@ -293,7 +293,7 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
   /**
    * Check that pseudoconstant reflects new value added.
    */
-  public function testCRM11876CreateOptionPseudoConstantUpdated() {
+  public function testCRM11876CreateOptionPseudoConstantUpdated(): void {
     $optionGroupID = $this->callAPISuccess('option_group', 'getvalue', [
       'name' => 'payment_instrument',
       'return' => 'id',
@@ -304,13 +304,13 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
       'label' => $newOption,
     ]);
 
-    $fields = $this->callAPISuccess('contribution', 'getoptions', ['field' => 'payment_instrument_id']);
-    $this->assertTrue(in_array($newOption, $fields['values']));
+    $fields = $this->callAPISuccess('Contribution', 'getoptions', ['field' => 'payment_instrument_id']);
+    $this->assertContains($newOption, $fields['values']);
 
-    $this->callAPISuccess('option_value', 'delete', ['id' => $apiResult['id']]);
+    $this->callAPISuccess('OptionValue', 'delete', ['id' => $apiResult['id']]);
 
-    $fields = $this->callAPISuccess('contribution', 'getoptions', ['field' => 'payment_instrument_id']);
-    $this->assertFalse(in_array($newOption, $fields['values']));
+    $fields = $this->callAPISuccess('Contribution', 'getoptions', ['field' => 'payment_instrument_id']);
+    $this->assertNotContains($newOption, $fields['values']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Clean up another cache usage to use metadata

Before
----------------------------------------
Function uses its own special version of a cache with a php static front end

After
----------------------------------------
Cache uses 'metadata' cache which has the same config & it otherwise used for option values

Technical Details
----------------------------------------
This is just standardisation - I didn't identify it during performance testing - but ideally we would have a consistent pattern. I think I might hit some of those `fresh` param calls in the first test run though 

Comments
----------------------------------------
