### PR TITLE
Fix PHP notice and hide/show 'including yourself' depending on if contact_id is set

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -368,8 +368,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
 
     $contactID = $this->getContactID();
+    $this->assign('contact_id', $contactID);
     if ($contactID) {
-      $this->assign('contact_id', $contactID);
       $this->assign('display_name', CRM_Contact_BAO_Contact::displayName($contactID));
     }
 

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -60,7 +60,7 @@
       <div class="crm-public-form-item crm-section additional_participants-section" id="noOfparticipants">
         <div class="label">{$form.additional_participants.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></div>
         <div class="content">
-          {$form.additional_participants.html}{if $contact_id || $contact_id == NULL}&nbsp;{ts}(including yourself){/ts}{/if}
+          {$form.additional_participants.html}{if $contact_id}&nbsp;{ts}(including yourself){/ts}{/if}
           <br/>
           <div class="description" id="additionalParticipantsDescription" style="display: none;">{ts}Fill in your registration information on this page. You will be able to enter the registration information for additional people after you complete this page and click &quot;Continue&quot;.{/ts}</div>
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix PHP notice and hide/show 'including yourself' depending on if contact_id is set

Before
----------------------------------------
`(including yourself)` always shown.

After
----------------------------------------
`(including yourself)` only shown if contact id is set - if you select not you or want to register another participant contact_id=0 and it should not say "including yourself".

Technical Details
----------------------------------------

Comments
----------------------------------------

