### PR TITLE
dev/core#3778 Add code hook to set civicrm_participant.created_id

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -102,7 +102,7 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'cart_id' => NULL,
       'must_wait' => NULL,
       'transferred_to_contact_id' => NULL,
-      'created_id' => NULL,
+      'created_id' => $this->_contactId,
     ];
 
     foreach ($compareValues as $key => $value) {

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -575,8 +575,8 @@ contribution_recur.payment_instrument_id:name :Check
    *
    * @return string
    */
-  protected function getExpectedParticipantTokenOutput(): string {
-    return 'participant.status_id :2
+  protected function getExpectedParticipantTokenOutput(int $participantCreatedID = NULL): string {
+    return "participant.status_id :2
 participant.role_id :1
 participant.register_date :February 19th, 2007
 participant.source :Wimbeldon
@@ -584,7 +584,7 @@ participant.fee_level :steep
 participant.fee_amount :$50.00
 participant.registered_by_id :
 participant.transferred_to_contact_id :
-participant.created_id :
+participant.created_id :{$participantCreatedID}
 participant.role_id:label :Attendee
 participant.balance :
 participant.custom_2 :99999
@@ -596,7 +596,7 @@ participant.status_id:name :Attended
 participant.role_id:name :Attendee
 participant.is_test:label :No
 participant.must_wait :
-';
+";
   }
 
   /**
@@ -664,7 +664,7 @@ December 21st, 2007
     $this->assertEquals(array_merge($tokens, $this->getEventTokens(), $this->getDomainTokens()), $tokenProcessor->listTokens());
 
     $this->callAPISuccess('job', 'send_reminder', []);
-    $expected = $this->getExpectedParticipantTokenOutput();
+    $expected = $this->getExpectedParticipantTokenOutput(3);
     $mut->checkMailLog([$expected]);
 
     $tokenProcessor->addMessage('html', $this->getTokenString(array_keys($this->getParticipantTokens())), 'text/plain');
@@ -834,7 +834,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
 
     $expectedEventString = $this->getExpectedEventTokenOutput();
     $this->callAPISuccess('job', 'send_reminder', []);
-    $expectedParticipantString = $this->getExpectedParticipantTokenOutput();
+    $expectedParticipantString = $this->getExpectedParticipantTokenOutput(5);
     $toCheck = array_merge(explode("\n", $expectedEventString), explode("\n", $expectedParticipantString));
     $toCheck[] = $expectedEventString;
     $toCheck[] = $expectedParticipantString;


### PR DESCRIPTION
Overview
----------------------------------------
This extracts the part of #23936 that populates the `created_id` field.

Before
----------------------------------------
`civicrm_participant.created_id` not populated.

After
----------------------------------------
`civicrm_participant.created_id` populated.

Technical Details
----------------------------------------
Set the "created_id" field.
The created_id should always be the person that actually did the registration.
That might be the first participant, but it might be someone registering someone without registering themselves.

1. Prefer logged in contact id
2. Fall back to 'registered_by_id' param.
3. Fall back to participant contact_id (for anonymous person registering themselves)

Comments
----------------------------------------

