### PR TITLE
SearchKit - missing role contact id in tokens

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -365,6 +365,7 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
               'label' => 'Name',
               'type' => 'field',
               'editable' => TRUE,
+              'icons' => [['field' => 'activity_type_id:icon', 'side' => 'left']],
             ],
             [
               'key' => 'Contact_Email_contact_id_01.email',


### PR DESCRIPTION
In SearchKit, when you use "with Contact Case Role", you don't get contact id from person who have role in the case. You only get display name (near side or far side). There should be also his contact id.

This apply for all civicrm version.

![image](https://user-images.githubusercontent.com/36272679/185460769-1e2ff600-b785-4665-81d5-74c682de282e.png)


