### PR TITLE
Deprecate two single-use option-value functions `create-a-sock` and `delete-a-sock`

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -15,6 +15,9 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\OptionGroup;
+use Civi\Api4\OptionValue;
+
 /**
  * This class generates form components for Localization.
  */
@@ -231,29 +234,45 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
    *
    * @param string[] $currencies array of currencies ['USD', 'CAD']
    * @param string $default default currency
+   *
+   * @throws \CRM_Core_Exception
    */
-  public static function updateEnabledCurrencies($currencies, $default) {
+  public static function updateEnabledCurrencies(array $currencies, string $default): void {
 
     // sort so that when we display drop down, weights have right value
     sort($currencies);
-
     // get labels for all the currencies
     $options = [];
 
     $currencySymbols = CRM_Admin_Form_Setting_Localization::getCurrencySymbols();
-    for ($i = 0; $i < count($currencies); $i++) {
+    foreach ($currencies as $i => $currency) {
       $options[] = [
-        'label' => $currencySymbols[$currencies[$i]],
-        'value' => $currencies[$i],
+        'label' => $currencySymbols[$currency],
+        'value' => $currency,
         'weight' => $i + 1,
         'is_active' => 1,
-        'is_default' => $currencies[$i] == $default,
+        'is_default' => $currency === $default,
       ];
     }
+    $optionGroupID = OptionGroup::get(FALSE)->addSelect('id')
+      ->addWhere('name', '=', 'currencies_enabled')
+      ->execute()->first()['id'];
+    // @TODO: This causes a problem in multilingual
+    // (https://github.com/civicrm/civicrm-core/pull/17228), but is needed in
+    // order to be able to remove currencies once added.
+    if (!CRM_Core_I18n::isMultiLingual()) {
+      CRM_Core_DAO::executeQuery("
+        DELETE
+        FROM civicrm_option_value
+        WHERE option_group_id = $optionGroupID
+      ");
+    }
 
-    $dontCare = NULL;
-    CRM_Core_OptionGroup::createAssoc('currencies_enabled', $options, $dontCare);
-
+    OptionValue::save(FALSE)
+      ->setRecords($options)
+      ->setDefaults(['is_active' => 1, 'option_group_id' => $optionGroupID])
+      ->setMatch(['option_group_id', 'value'])
+      ->execute();
   }
 
   /**

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -476,6 +476,7 @@ WHERE  v.option_group_id = g.id
    *   the option group ID
    */
   public static function createAssoc($groupName, &$values, &$defaultID, $groupTitle = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('use the api');
     // @TODO: This causes a problem in multilingual
     // (https://github.com/civicrm/civicrm-core/pull/17228), but is needed in
     // order to be able to remove currencies once added.
@@ -568,8 +569,12 @@ ORDER BY v.weight
   /**
    * @param string $groupName
    * @param string $operator
+   *
+   * @deprecated
    */
   public static function deleteAssoc($groupName, $operator = "=") {
+    CRM_Core_Error::deprecatedFunctionWarning('use the api');
+
     $query = "
 DELETE g, v
   FROM civicrm_option_group g,

--- a/tests/phpunit/CRM/Admin/Form/Setting/LocalizationTest.php
+++ b/tests/phpunit/CRM/Admin/Form/Setting/LocalizationTest.php
@@ -7,22 +7,20 @@ class CRM_Admin_Form_Setting_LocalizationTest extends CiviUnitTestCase {
 
   /**
    * Test adding and removing a currency.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testUpdateCurrencies() {
+  public function testUpdateCurrencies(): void {
     CRM_Admin_Form_Setting_Localization::updateEnabledCurrencies(['USD', 'CAD'], 'USD');
-    CRM_Core_OptionGroup::flushAll();
+
     $currencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
     $this->assertEquals(['CAD', 'USD'], $currencies, 'Unable to add a currency.');
 
     // Now try to remove it.
     CRM_Admin_Form_Setting_Localization::updateEnabledCurrencies(['USD'], 'USD');
-    CRM_Core_OptionGroup::flushAll();
+
     $currencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
     $this->assertEquals(['USD'], $currencies, 'Unable to remove a currency.');
-
-    // Note in the form there's code to prevent removing the default. The
-    // function we're testing here isn't the full form so we're not testing
-    // that.
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate two single-use option-value functions `create-a-sock` and `delete-a-sock`

Before
----------------------------------------
`OptionGroup` has two weird functions `createAssoc` and `deleteAssoc` - it turns out they are only called from `updateEnabledCurrencies` 

After
----------------------------------------
The sock functions are deprecated & `updateEnabledCurrencies`  is simplified & calls the api

Technical Details
----------------------------------------
It's possible the api call will be a little slower than the DAO save - but this is a rarely called functin

Comments
----------------------------------------
@colemanw that is at least two down...
