### PR TITLE
For Contribution pages with a recurring payment option. Change the label from "Regular amount"  to "Regular Amount"

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -348,7 +348,7 @@
         frequencyUnit.prop('disabled', false).addClass('required');
         frequencyInerval.prop('disabled', false).addClass('required');
         installments.prop('disabled', false);
-        cj('#amount_sum_label').text('{/literal}{ts escape='js'}Regular amount{/ts}{literal}');
+        cj('#amount_sum_label').text('{/literal}{ts escape='js'}Regular Amount{/ts}{literal}');
       }
       else {
         cj('#recurHelp').hide();


### PR DESCRIPTION
Overview
----------------------------------------
For Contribution pages with a recurring payment option. Change the label from "Regular amount"  to "Regular Amount" which is the defacto CiviCRM standard of first letter case.

Before
----------------------------------------
Current Contribution pages display, "Regular amount"

![image](https://user-images.githubusercontent.com/58866555/185516355-c93ee0df-066d-49fd-9112-2b0efd2e2f98.png)


After
----------------------------------------
Contribution pages will now display, "Regular Amount"

![image](https://user-images.githubusercontent.com/58866555/185516363-b0134b77-91e9-40ac-9f6b-b1543b4abf68.png)


Technical Details
----------------------------------------
None.

Comments
----------------------------------------
 Consistent UIs look better.


Agileware Ref: CIVICRM-2033 
