### PR TITLE
dev/core#3771 - E-notice fix on manage groups

### DIFF
--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-group-search-form-block">
-  <div class="crm-accordion-wrapper crm-search_builder-accordion {if $rows and empty($showSearchForm)}collapsed{/if}">
+  <div class="crm-accordion-wrapper crm-search_builder-accordion">
     <div class="crm-accordion-header crm-master-accordion-header">
       {ts}Find Groups{/ts}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
E-notice fix

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/185591389-d10f1e91-6a62-4ac1-b3f0-0b5b612a760e.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
I couldn't find how this if could be triggered - so concluded that it was copy & paste from search builder... the only other place that refers to `$showSearchForm)`

![image](https://user-images.githubusercontent.com/336308/185592761-2551af50-1fd9-40c3-9035-720aea119729.png)


Comments
----------------------------------------
