### PR TITLE
[WIP] Use tokens instead of notice-y assign for participant isPrimary

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1189,11 +1189,10 @@ WHERE civicrm_event.is_active = 1
         }
 
         $sendTemplateParams = [
-          'groupName' => 'msg_tpl_workflow_event',
           'workflow' => 'event_online_receipt',
-          'contactId' => $contactID,
           'isTest' => $isTest,
           'tplParams' => $tplParams,
+          'tokenContext' => ['contactId' => $contactID, 'participantId' => $participantId],
           'PDFFilename' => ts('confirmation') . '.pdf',
         ];
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1419,6 +1419,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         }
 
         $this->assign('totalAmount', $params['total_amount'] ?? $contributionParams['total_amount']);
+        // @todo - phase this assign out - removed from shipped template 5.54
         $this->assign('isPrimary', 1);
         $this->assign('checkNumber', CRM_Utils_Array::value('check_number', $params));
       }

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -398,13 +398,13 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
       ];
 
       $sendTemplateParams = [
-        'groupName' => 'msg_tpl_workflow_event',
         'workflow' => 'event_online_receipt',
         'contactId' => $participantDetails[$participant->id]['contact_id'],
         'tplParams' => $tplParams,
         'from' => $receiptFrom,
         'toName' => $participantName,
         'toEmail' => $toEmail,
+        'tokenContext' => ['contactId' => $participantDetails[$participant->id]['contact_id'], 'participantId' => $participant->id],
         'cc' => $eventDetails['cc_confirm'] ?? NULL,
         'bcc' => $eventDetails['bcc_confirm'] ?? NULL,
       ];

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -28,12 +28,12 @@
 
     {if !empty($isOnWaitlist)}
      <p>{ts}You have been added to the WAIT LIST for this event.{/ts}</p>
-     {if !empty($isPrimary)}
+     {if '{participant.id}' === '{participant.registered_by_id}'}
        <p>{ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}</p>
      {/if}
     {elseif !empty($isRequireApproval)}
      <p>{ts}Your registration has been submitted.{/ts}</p>
-     {if !empty($isPrimary)}
+     {if '{participant.id}' === '{participant.registered_by_id}'}
       <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
      {/if}
     {elseif $is_pay_later}
@@ -152,7 +152,7 @@
       {if !empty($lineItem)}
        {foreach from=$lineItem item=value key=priceset}
         {if $value neq 'skip'}
-         {if !empty($isPrimary)}
+         {if '{participant.id}' === '{participant.registered_by_id}'}
           {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
            <tr>
             <td colspan="2" {$labelStyle}>
@@ -262,7 +262,7 @@
         </td>
        </tr>
       {/if}
-      {if !empty($isPrimary)}
+      {if '{participant.id}' === '{participant.registered_by_id}'}
        <tr>
         <td {$labelStyle}>
         {if isset($balanceAmount)}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -8,7 +8,7 @@
 
 {ts}You have been added to the WAIT LIST for this event.{/ts}
 
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 {ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
 
 {/if}
@@ -19,7 +19,7 @@
 
 {ts}Your registration has been submitted.{/ts}
 
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}
 
 {/if}
@@ -93,7 +93,7 @@
 {if !empty($lineItem)}{foreach from=$lineItem item=value key=priceset}
 
 {if $value neq 'skip'}
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
 {ts 1=$priceset+1}Participant %1{/ts}
 {/if}
@@ -143,7 +143,7 @@
 {if $totalTaxAmount}
 {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
 {/if}
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 
 {if !empty($balanceAmount)}{ts}Total Paid{/ts}{else}{ts}Total Amount{/ts}{/if}: {if !empty($totalAmount)}{$totalAmount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -39,12 +39,12 @@
     <p>
     {if !empty($isOnWaitlist)}
      <p>{ts}You have been added to the WAIT LIST for this event.{/ts}</p>
-     {if !empty($isPrimary)}
+     {if '{participant.id}' === '{participant.registered_by_id}'}
        <p>{ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}</p>
      {/if}
     {elseif !empty($isRequireApproval)}
      <p>{ts}Your registration has been submitted.{/ts}</p>
-     {if !empty($isPrimary)}
+     {if '{participant.id}' === '{participant.registered_by_id}'}
       <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
      {/if}
     {elseif !empty($is_pay_later) && empty($isAmountzero) && empty($isAdditionalParticipant)}
@@ -191,7 +191,7 @@
       {if !empty($lineItem)}
        {foreach from=$lineItem item=value key=priceset}
         {if $value neq 'skip'}
-         {if !empty($isPrimary)}
+         {if '{participant.id}' === '{participant.registered_by_id}'}
           {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
            <tr>
             <td colspan="2" {$labelStyle}>
@@ -306,7 +306,7 @@
         </td>
        </tr>
       {/if}
-      {if !empty($isPrimary)}
+      {if '{participant.id}' === '{participant.registered_by_id}'}
        <tr>
         <td {$labelStyle}>
          {ts}Total Amount{/ts}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -14,7 +14,7 @@
 
 {ts}You have been added to the WAIT LIST for this event.{/ts}
 
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 {ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
 {/if}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
@@ -24,7 +24,7 @@
 
 {ts}Your registration has been submitted.{/ts}
 
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}
 
 {/if}
@@ -108,7 +108,7 @@ You were registered by: {$payer.name}
 {if !empty($lineItem)}{foreach from=$lineItem item=value key=priceset}
 
 {if $value neq 'skip'}
-{if !empty($isPrimary)}
+{if '{participant.id}' === '{participant.registered_by_id}'}
 {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
 {ts 1=$priceset+1}Participant %1{/ts} {if !empty($part.$priceset)}{$part.$priceset.info}{/if}
 
@@ -163,7 +163,7 @@ You were registered by: {$payer.name}
 {if isset($totalTaxAmount)}
 {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
 {/if}
-{if !empty($isPrimary) }
+{if '{participant.id}' === '{participant.registered_by_id}'}
 
 {ts}Total Amount{/ts}: {if !empty($totalAmount)}{$totalAmount|crmMoney:$currency}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Use tokens instead of notice-y assign for participant isPrimary

Before
----------------------------------------
event templates rely on the form layer to assign `$isPrimary`

After
----------------------------------------
Always-available tokens used.

Technical Details
----------------------------------------
This is part of the generalised push to get away from smarty variables that are
 - e-noticey (in this case when secure smarty mode on)
 - reliant on the form layer
 - not following a predictable pattern
 - not functional in message admin preview mode

with tokens - which are consistent, standardised, not reliant on the form.

In this case I rather wonder we shouldn't instead create a api pseudofield (with token) for `participant.is_primary` which would do this in sql


Comments
----------------------------------------
