### PR TITLE
Fix contribution online receipt to be, somewhat, previewable

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -10,7 +10,7 @@
 {capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
-  <table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
+<table id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
   <!-- BEGIN HEADER -->
   <!-- You can add table row(s) here with logo or other header elements -->
@@ -31,123 +31,99 @@
 
    </td>
   </tr>
-  </table>
-  <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
-
-     {if $amount}
-
-
-      <tr>
-       <th {$headerStyle}>
+</table>
+<table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
+  {if '{contribution.total_amount|raw}' !== '0.00'}
+    <tr>
+      <th {$headerStyle}>
         {ts}Contribution Information{/ts}
-       </th>
+      </th>
+    </tr>
+
+    {if $isShowLineItems}
+      <tr>
+        <td colspan="2" {$valueStyle}>
+          <table>
+            <tr>
+              <th>{ts}Item{/ts}</th>
+              <th>{ts}Qty{/ts}</th>
+              <th>{ts}Each{/ts}</th>
+              {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+                <th>{ts}Subtotal{/ts}</th>
+                <th>{ts}Tax Rate{/ts}</th>
+                <th>{ts}Tax Amount{/ts}</th>
+              {/if}
+              <th>{ts}Total{/ts}</th>
+            </tr>
+            {foreach from=$lineItems item=line}
+              <tr>
+                <td>{$line.title}</td>
+                <td>{$line.qty}</td>
+                <td>{$line.unit_price|crmMoney:$currency}</td>
+                {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+                  <td>{$line.unit_price*$line.qty|crmMoney:$currency}</td>
+                  {if $line.tax_rate || $line.tax_amount != ""}
+                    <td>{$line.tax_rate|string_format:"%.2f"}%</td>
+                    <td>{$line.tax_amount|crmMoney:$currency}</td>
+                  {else}
+                    <td></td>
+                    <td></td>
+                  {/if}
+                {/if}
+                <td>
+                  {$line.line_total+$line.tax_amount|crmMoney:$currency}
+                </td>
+              </tr>
+            {/foreach}
+          </table>
+        </td>
       </tr>
 
-      {if $isShowLineItems}
-
-       {foreach from=$lineItem item=value key=priceset}
+      {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
         <tr>
-         <td colspan="2" {$valueStyle}>
-          <table>
-           <tr>
-            <th>{ts}Item{/ts}</th>
-            <th>{ts}Qty{/ts}</th>
-            <th>{ts}Each{/ts}</th>
-            {if !empty($dataArray)}
-             <th>{ts}Subtotal{/ts}</th>
-             <th>{ts}Tax Rate{/ts}</th>
-             <th>{ts}Tax Amount{/ts}</th>
-            {/if}
-            <th>{ts}Total{/ts}</th>
-           </tr>
-           {foreach from=$value item=line}
-            <tr>
-             <td>
-             {if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description}<div>{$line.description|truncate:30:"..."}</div>{/if}
-             </td>
-             <td>
-              {$line.qty}
-             </td>
-             <td>
-              {$line.unit_price|crmMoney:$currency}
-             </td>
-             {if !empty($getTaxDetails)}
-              <td>
-               {$line.unit_price*$line.qty|crmMoney:$currency}
-              </td>
-              {if $line.tax_rate || $line.tax_amount != ""}
-               <td>
-                {$line.tax_rate|string_format:"%.2f"}%
-               </td>
-               <td>
-                {$line.tax_amount|crmMoney:$currency}
-               </td>
-              {else}
-               <td></td>
-               <td></td>
-              {/if}
-             {/if}
-             <td>
-              {$line.line_total+$line.tax_amount|crmMoney:$currency}
-             </td>
-            </tr>
-           {/foreach}
-          </table>
-         </td>
-        </tr>
-       {/foreach}
-       {if !empty($dataArray)}
-        <tr>
-         <td {$labelStyle}>
-          {ts} Amount before Tax : {/ts}
-         </td>
-         <td {$valueStyle}>
-          {$amount-$totalTaxAmount|crmMoney:$currency}
-         </td>
+          <td {$labelStyle}>
+            {ts} Amount before Tax : {/ts}
+          </td>
+          <td {$valueStyle}>
+            {$amount-$totalTaxAmount|crmMoney:$currency}
+          </td>
         </tr>
 
-        {foreach from=$dataArray item=value key=priceset}
-         <tr>
-          {if $priceset || $priceset == 0}
-           <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
-           <td>&nbsp;{$value|crmMoney:$currency}</td>
-          {else}
-           <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
-           <td>&nbsp;{$value|crmMoney:$currency}</td>
-          {/if}
-         </tr>
+        {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
+          <tr>
+            <td>{if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if}</td>
+            <td>{$taxDetail.amount|crmMoney:'{contribution.currency}'}</td>
+          </tr>
         {/foreach}
 
-       {/if}
-       {if $isShowTax}
+      {/if}
+      {if $isShowTax}
         <tr>
-         <td {$labelStyle}>
-          {ts}Total Tax{/ts}
-         </td>
-         <td {$valueStyle}>
-          {$totalTaxAmount|crmMoney:$currency}
-         </td>
+          <td {$labelStyle}>
+            {ts}Total Tax{/ts}
+          </td>
+          <td {$valueStyle}>
+            {contribution.tax_amount}
+          </td>
         </tr>
-       {/if}
-       <tr>
+      {/if}
+      <tr>
         <td {$labelStyle}>
-         {ts}Total Amount{/ts}
+          {ts}Total Amount{/ts}
         </td>
         <td {$valueStyle}>
-         {$amount|crmMoney:$currency}
+          {contribution.total_amount}
         </td>
-       </tr>
-
-      {else}
-
-      {if !empty($totalTaxAmount)}
-         <tr>
-           <td {$labelStyle}>
-             {ts}Total Tax Amount{/ts}
-           </td>
-           <td {$valueStyle}>
-             {contribution.tax_amount|crmMoney}
-           </td>
+      </tr>
+    {else}
+      {if '{contribution.tax_amount|raw}' !== '0.00'}
+        <tr>
+          <td {$labelStyle}>
+            {ts}Total Tax Amount{/ts}
+          </td>
+          <td {$valueStyle}>
+            {contribution.tax_amount}
+          </td>
          </tr>
        {/if}
        <tr>
@@ -155,13 +131,13 @@
          {ts}Amount{/ts}
         </td>
         <td {$valueStyle}>
-         {$amount|crmMoney:$currency} {if '{contribution.amount_level}'} - {contribution.amount_level}{/if}
+         {contribution.total_amount} {if '{contribution.amount_level}'} - {contribution.amount_level}{/if}
         </td>
        </tr>
 
       {/if}
 
-     {/if}
+  {/if}
 
 
      {if !empty($receive_date)}

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -9,49 +9,43 @@
 ===========================================================
 {/if}
 
-{if $amount}
+{if '{contribution.total_amount|raw}' !== '0.00'}
 ===========================================================
 {ts}Contribution Information{/ts}
 
 ===========================================================
 {if $isShowLineItems}
-{foreach from=$lineItem item=value key=priceset}
+
 ---------------------------------------------------------
 {capture assign=ts_item}{ts}Item{/ts}{/capture}
 {capture assign=ts_qty}{ts}Qty{/ts}{/capture}
 {capture assign=ts_each}{ts}Each{/ts}{/capture}
-{if !empty($dataArray)}
+{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
 {capture assign=ts_subtotal}{ts}Subtotal{/ts}{/capture}
 {capture assign=ts_taxRate}{ts}Tax Rate{/ts}{/capture}
 {capture assign=ts_taxAmount}{ts}Tax Amount{/ts}{/capture}
 {/if}
 {capture assign=ts_total}{ts}Total{/ts}{/capture}
-{$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if !empty($dataArray)} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
+{$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
 ----------------------------------------------------------
-{foreach from=$value item=line}
-{capture assign=ts_item}{if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if} {if $line.description} {$line.description}{/if}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if !empty($dataArray)}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
-{/foreach}
+{foreach from=$lineItems item=line}
+{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if !empty($dataArray)}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
 {/foreach}
 
-{if !empty($dataArray)}
+{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
 {ts}Amount before Tax{/ts}: {$amount-$totalTaxAmount|crmMoney:$currency}
-
-{foreach from=$dataArray item=value key=priceset}
-{if $priceset || $priceset == 0}
-{$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
-{else}
-{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
-{/if}
-{/foreach}
+  {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
+    {if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if} : {$taxDetail.amount|crmMoney:'{contribution.currency}'}
+  {/foreach}
 {/if}
 
 {if $isShowTax}
 {ts}Total Tax Amount{/ts}: {contribution.tax_amount|crmMoney}
 {/if}
 
-{ts}Total Amount{/ts}: {$amount|crmMoney:$currency}
+{ts}Total Amount{/ts}: {contribution.total_amount}
 {else}
-{ts}Amount{/ts}: {$amount|crmMoney:$currency} {if '{contribution.amount_level}'} - {contribution.amount_level}{/if}
+{ts}Amount{/ts}: {contribution.total_amount} {if '{contribution.amount_level}'} - {contribution.amount_level}{/if}
 {/if}
 {/if}
 {if !empty($receive_date)}


### PR DESCRIPTION
Overview
----------------------------------------
Fix contribution online receipt to be, somewhat, previewable

Before
----------------------------------------
Trying to preview online contribution templates draws a blank

After
----------------------------------------
The line item & tax fields I fixed up for offline & invoice are showing up well now....

![image](https://user-images.githubusercontent.com/336308/185672408-5afded1b-0e0e-4cbd-9f8d-536e33b99f33.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
