### PR TITLE
Add initial Event Message Template previewability

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1189,12 +1189,15 @@ WHERE civicrm_event.is_active = 1
         }
 
         $sendTemplateParams = [
-          'groupName' => 'msg_tpl_workflow_event',
           'workflow' => 'event_online_receipt',
           'contactId' => $contactID,
           'isTest' => $isTest,
           'tplParams' => $tplParams,
           'PDFFilename' => ts('confirmation') . '.pdf',
+          'modelProps' => [
+            'participantID' => (int) $participantId,
+            'eventID' => (int) $values['event']['id'],
+          ],
         ];
 
         // address required during receipt processing (pdf and email receipt)

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -398,7 +398,6 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
       ];
 
       $sendTemplateParams = [
-        'groupName' => 'msg_tpl_workflow_event',
         'workflow' => 'event_online_receipt',
         'contactId' => $participantDetails[$participant->id]['contact_id'],
         'tplParams' => $tplParams,
@@ -407,6 +406,10 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
         'toEmail' => $toEmail,
         'cc' => $eventDetails['cc_confirm'] ?? NULL,
         'bcc' => $eventDetails['bcc_confirm'] ?? NULL,
+        'modelProps' => [
+          'participantID' => $participant->id,
+          'eventID' => $participant->event_id,
+        ],
       ];
       CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
     }

--- a/CRM/Event/WorkflowMessage/EventExamples.php
+++ b/CRM/Event/WorkflowMessage/EventExamples.php
@@ -1,0 +1,108 @@
+<?php
+
+use Civi\Api4\PriceSetEntity;
+use Civi\Api4\WorkflowMessage;
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+use Civi\WorkflowMessage\WorkflowMessageExample;
+
+/**
+ * Basic contribution example for contribution templates.
+ *
+ * @noinspection PhpUnused
+ */
+class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
+
+  /**
+   * Get the examples this class is able to deliver.
+   *
+   * @throws \API_Exception
+   */
+  public function getExamples(): iterable {
+    $workflows = ['event_online_receipt', 'event_offline_receipt'];
+    foreach ($workflows as $workflow) {
+      $priceSets = $this->getPriceSets();
+      foreach ($priceSets as $priceSet) {
+        yield [
+          'name' => 'workflow/' . $workflow . '/' . 'price_set_' . $priceSet['name'],
+          'title' => ts('Completed Registration') . ' : ' . $priceSet['title'],
+          'tags' => ['preview'],
+          'workflow' => $workflow,
+          'is_show_line_items' => !$priceSet['is_quick_config'],
+          'event_id' => $priceSet['event_id'],
+        ];
+      }
+    }
+  }
+
+  /**
+   * Build an example to use when rendering the workflow.
+   *
+   * @param array $example
+   *
+   * @throws \API_Exception
+   */
+  public function build(array &$example): void {
+    $workFlow = WorkflowMessage::get(TRUE)->addWhere('name', '=', $example['workflow'])->execute()->first();
+    $this->setWorkflowName($workFlow['name']);
+    $messageTemplate = new $workFlow['class']();
+    $this->addExampleData($messageTemplate, $example);
+    $example['data'] = $this->toArray($messageTemplate);
+  }
+
+  /**
+   * Add relevant example data.
+   *
+   * @param \CRM_Event_WorkflowMessage_EventOnlineReceipt|\CRM_Event_WorkflowMessage_EventOfflineReceipt $messageTemplate
+   * @param array $example
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function addExampleData(GenericWorkflowMessage $messageTemplate, $example): void {
+    $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
+    $messageTemplate->setEventID($example['event_id']);
+  }
+
+  /**
+   * Get prices sets from the site - ideally one quick config & one not.
+   *
+   * @return array
+   *
+   * @throws \API_Exception
+   */
+  private function getPriceSets(): ?array {
+    // Permission check defaults to true - likely implicitly OK but may need to be false.
+    $quickConfigPriceSet = $this->getPriceSet(TRUE);
+    $nonQuickConfigPriceSet = $this->getPriceSet(FALSE);
+
+    return array_filter([$quickConfigPriceSet, $nonQuickConfigPriceSet]);
+  }
+
+  /**
+   * Get a price set.
+   *
+   * @param bool $isQuickConfig
+   *
+   * @return array|null
+   * @throws \API_Exception
+   */
+  private function getPriceSet(bool $isQuickConfig): ?array {
+    $priceSetEntity = PriceSetEntity::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_event')
+      ->addSelect('price_set_id.id', 'entity_id', 'price_set_id.is_quick_config', 'price_set_id.name', 'price_set_id.title')
+      ->setLimit(1)
+      ->addWhere('price_set_id.is_quick_config', '=', $isQuickConfig)
+      ->execute()->first();
+
+    return empty($priceSetEntity) ? NULL : [
+      'id' => $priceSetEntity['price_set_id'],
+      'name' => $priceSetEntity['price_set_id.name'],
+      'title' => $priceSetEntity['price_set_id.title'],
+      'event_id' => $priceSetEntity['entity_id'],
+      'is_quick_config' => $priceSetEntity['price_set_id.is_quick_config'],
+    ];
+  }
+
+}

--- a/CRM/Event/WorkflowMessage/EventOnlineReceipt.php
+++ b/CRM/Event/WorkflowMessage/EventOnlineReceipt.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Receipt sent when confirming a back office participation record.
+ *
+ * @support template-only
+ *
+ * @see \CRM_Event_BAO_Event::sendMail()
+ * @see \CRM_Event_Form_SelfSvcTransfer::participantTransfer
+ */
+class CRM_Event_WorkflowMessage_EventOnlineReceipt extends GenericWorkflowMessage {
+  use CRM_Event_WorkflowMessage_ParticipantTrait;
+  public const WORKFLOW = 'event_online_receipt';
+
+}

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -19,4 +19,14 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    */
   public $eventID;
 
+  /**
+   * @param int $eventID
+   *
+   * @return CRM_Event_WorkflowMessage_ParticipantTrait
+   */
+  public function setEventID(int $eventID) {
+    $this->eventID = $eventID;
+    return $this;
+  }
+
 }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -82,7 +82,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    *
    * @dataProvider getThousandSeparators
    */
-  public function testPaidSubmit($thousandSeparator) {
+  public function testPaidSubmit(string $thousandSeparator): void {
     // @todo - figure out why this doesn't pass validate financials
     $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->setCurrencySeparators($thousandSeparator);

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -52,8 +52,8 @@
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
-       {$event.event_title}<br />
-       {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+       {event.title}<br />
+       {event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
       </td>
      </tr>
 

--- a/xml/templates/message_templates/event_offline_receipt_subject.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{ts}Event Confirmation{/ts} - {$event.title} - {contact.display_name}
+{ts}Event Confirmation{/ts} - {event.title} - {contact.display_name}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -41,8 +41,8 @@
 
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 
-{$event.event_title}
-{$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+{event.title}
+{event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
 
 {if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and empty($defaultRole)}
 {ts}Participant Role{/ts}: {$event.participant_role}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -63,8 +63,8 @@
      </tr>
      <tr>
       <td colspan="2" {$valueStyle}>
-       {$event.event_title}<br />
-       {$event.event_start_date|crmDate:"%A"} {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
+       {event.title}<br />
+       {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
       </td>
      </tr>
 

--- a/xml/templates/message_templates/event_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/event_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if !empty($isOnWaitlist)}{ts}Wait List Confirmation{/ts}{elseif !empty($isRequireApproval)}{ts}Registration Request Confirmation{/ts}{else}{ts}Registration Confirmation{/ts}{/if} - {$event.event_title} - {contact.display_name}
+{if !empty($isOnWaitlist)}{ts}Wait List Confirmation{/ts}{elseif !empty($isRequireApproval)}{ts}Registration Request Confirmation{/ts}{else}{ts}Registration Confirmation{/ts}{/if} - {event.title} - {contact.display_name}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -46,8 +46,8 @@
 
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
-{$event.event_title}
-{$event.event_start_date|crmDate:"%A"} {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
+{event.title}
+{event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
 {if !empty($conference_sessions)}
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Add initial Event Message Template previewability.

Note this PR also makes `participant` and `event` tokens work in the `event_online` template - they were only working in the offline before this

Before
----------------------------------------
No event template preview possible

After
----------------------------------------
Initial functionality added - event tokens are an easy add here to I fixed some very simple variables to be tokens to get this far

![image](https://user-images.githubusercontent.com/336308/185721812-9831bb70-b828-4f9f-8424-08d1f6c4b002.png)

Technical Details
----------------------------------------
This adds if for online & offline receipt. The other participant templates will be a follow on once this is merged

Comments
----------------------------------------
Pre-existing test cover in https://github.com/civicrm/civicrm-core/pull/24323/files#diff-c4ddaa8aa71ca49d31466c04cefbb2f1d608a04e3836791a756859d73ef560c2

@demeritcowboy hopefully this is an easy-ish merge as it is similar to other recent ones 
