### PR TITLE
Add preliminary previewability to case-activity

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1369,7 +1369,6 @@ HERESQL;
 
       list($result[CRM_Utils_Array::value('contact_id', $info)], $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
-          'groupName' => 'msg_tpl_workflow_case',
           'workflow' => 'case_activity',
           'contactId' => $info['contact_id'] ?? NULL,
           'tplParams' => $tplParams,
@@ -1377,6 +1376,9 @@ HERESQL;
           'toName' => $displayName,
           'toEmail' => $mail,
           'attachments' => $attachments,
+          'modelProps' => [
+            'activityID' => $activityId,
+          ],
         ]
       );
 

--- a/CRM/Case/WorkflowMessage/ActivityExamples.php
+++ b/CRM/Case/WorkflowMessage/ActivityExamples.php
@@ -1,0 +1,67 @@
+<?php
+
+use Civi\Api4\WorkflowMessage;
+use Civi\WorkflowMessage\WorkflowMessageExample;
+
+/**
+ * Basic contribution example for contribution templates.
+ *
+ * @noinspection PhpUnused
+ */
+class CRM_Case_WorkflowMessage_ActivityExamples extends WorkflowMessageExample {
+
+  /**
+   * Get the examples this class is able to deliver.
+   */
+  public function getExamples(): iterable {
+    $workflows = ['case_activity'];
+    foreach ($workflows as $workflow) {
+      foreach ([TRUE, FALSE] as $caseID) {
+        yield [
+          'name' => 'workflow/' . $workflow . '/activity' . (bool) $caseID,
+          'title' => $caseID ? ts('Case Activity') : ts('Activity'),
+          'tags' => ['preview'],
+          'workflow' => $workflow,
+          'case_id' => $caseID,
+        ];
+      }
+    }
+  }
+
+  /**
+   * Build an example to use when rendering the workflow.
+   *
+   * @param array $example
+   *
+   * @throws \API_Exception
+   */
+  public function build(array &$example): void {
+    $workFlow = WorkflowMessage::get(TRUE)->addWhere('name', '=', $example['workflow'])->execute()->first();
+    $this->setWorkflowName($workFlow['name']);
+    $messageTemplate = new $workFlow['class']();
+    $this->addExampleData($messageTemplate, $example);
+    $example['data'] = $this->toArray($messageTemplate);
+  }
+
+  /**
+   * Add relevant example data.
+   *
+   * @param \CRM_Case_WorkflowMessage_CaseActivity $messageTemplate
+   * @param array $example
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function addExampleData(CRM_Case_WorkflowMessage_CaseActivity $messageTemplate, array $example): void {
+    $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
+    $messageTemplate->setActivity([
+      'activity_type_id:label' => ts('Follow up'),
+      // Ideally something better but let's not add more strings until we hae a good one.
+      'subject' => ('Follow up'),
+      'case_id' => $example['case_id'] ? 1 : NULL,
+    ]);
+  }
+
+}

--- a/CRM/Case/WorkflowMessage/CaseActivity.php
+++ b/CRM/Case/WorkflowMessage/CaseActivity.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * When an activity is created in a case, the "case_activity" email is sent.
+ * Generally, the email is sent to the assignee, although (depending on
+ * the configuration/add-ons) additional copies may be sent.
+ *
+ * @see CRM_Case_BAO_Case::sendActivityCopy
+ *
+ * @support template-only
+ */
+class CRM_Case_WorkflowMessage_CaseActivity extends GenericWorkflowMessage {
+
+  public const WORKFLOW = 'case_activity';
+
+  /**
+   * The activity.
+   *
+   * @var array|null
+   *
+   * @scope tokenContext as activity
+   */
+  public $activity;
+
+  /**
+   * @var int
+   *
+   * @scope tokenContext as activityId
+   */
+  public $activityID;
+
+  /**
+   * @param array $activity
+   *
+   * @return CRM_Case_WorkflowMessage_CaseActivity
+   */
+  public function setActivity(array $activity): CRM_Case_WorkflowMessage_CaseActivity {
+    $this->activity = $activity;
+    if (!empty($activity['id'])) {
+      $this->activityID = $activity['id'];
+    }
+    return $this;
+  }
+
+}

--- a/xml/templates/message_templates/case_activity_html.tpl
+++ b/xml/templates/message_templates/case_activity_html.tpl
@@ -23,10 +23,10 @@
           <table style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse; width:100%;">
             <tr>
               <th {$headerStyle}>
-                {ts}Activity Summary{/ts} - {$activityTypeName}
+                {ts}Activity Summary{/ts} - {activity.activity_type_id:label}
               </th>
             </tr>
-            {if !empty($isCaseActivity)}
+            {if 'activity_case_id'}
               <tr>
                 <td {$labelStyle}>
                   {ts}Your Case Role(s){/ts}

--- a/xml/templates/message_templates/case_activity_subject.tpl
+++ b/xml/templates/message_templates/case_activity_subject.tpl
@@ -1,1 +1,1 @@
-{if !empty($idHash)}[case #{$idHash}]{/if} {$activitySubject}
+{if !empty($idHash)}[case #{$idHash}]{/if} {activity.subject}

--- a/xml/templates/message_templates/case_activity_text.tpl
+++ b/xml/templates/message_templates/case_activity_text.tpl
@@ -1,7 +1,7 @@
 ===========================================================
-{ts}Activity Summary{/ts} - {$activityTypeName}
+{ts}Activity Summary{/ts} - {activity.activity_type_id:label}
 ===========================================================
-{if !empty($isCaseActivity)}
+{if '{activity.case_id}'}
 {ts}Your Case Role(s){/ts} : {$contact.role|default:''}
 {if !empty($manageCaseURL)}
 {ts}Manage Case{/ts} : {$manageCaseURL}


### PR DESCRIPTION
Overview
----------------------------------------
Add preliminary previewability to case-activity


Before
----------------------------------------
Activity tokens not available in case-activity workflow template,, not preview

After
----------------------------------------
The tokens work - but very limited preview as not many tokens in there. I'm on a push to get just the token part working for the template preview 

![image](https://user-images.githubusercontent.com/336308/185723552-0829d2ea-9712-49f5-bcc6-5040879c6405.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
I suspect things like `manageCaseURL` could be case tokens but not dug in