### PR TITLE
[php 8 compat] Make sure variables are assigned in civireport

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -21,7 +21,7 @@ class CRM_Report_Form extends CRM_Core_Form {
    *
    * @var string[]
    */
-  public $expectedSmartyVariables = ['pager', 'skip', 'sections', 'grandStat', 'chartEnabled'];
+  public $expectedSmartyVariables = ['pager', 'skip', 'sections', 'grandStat', 'chartEnabled', 'uniqueId', 'rows'];
 
   /**
    * Deprecated constant, Reports should be updated to use the getRowCount function.


### PR DESCRIPTION
Overview
----------------------------------------
These two vars only get assigned during postProcess, but the template references them.

Before
----------------------------------------
On php 7 you can see these if you turn on debugging at administer - system settings - debugging.
Visit a report like Contribution Summary (without force=1).

`Warning: Undefined array key "uniqueId" in include() (line 20 of .../templates_c/en_US/%%2F/2F5/2F52D1C6%%Graph.tpl.php).`

`Warning: Undefined array key "rows" in include() (line 5 of .../templates_c/en_US/%%F5/F54/F5478576%%Table.tpl.php).`

After
----------------------------------------
Other errors, but not those.

Technical Details
----------------------------------------


Comments
----------------------------------------

