### PR TITLE
Unused function getOptionalSmartyElements

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -127,19 +127,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   }
 
   /**
-   * Get any smarty elements that may not be present in the form.
-   *
-   * To make life simpler for smarty we ensure they are set to null
-   * rather than unset. This is done at the last minute when $this
-   * is converted to an array to be assigned to the form.
-   *
-   * @return array
-   */
-  public function getOptionalSmartyElements(): array {
-    return ['group'];
-  }
-
-  /**
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
I can't see where this is used, and I don't see any error about the missing var, even if I turn on smarty default escaping in civicrm.settings.php

Before
----------------------------------------
Quiet

After
----------------------------------------
Quiet

Technical Details
----------------------------------------
This may have been intended as $expectedSmartyVariables, but I can't see the error anywhere. In any case I can't see where this function is called.

Comments
----------------------------------------

