### PR TITLE
Strict smarty notice fix on contact edit - `isSingleRecordEdit`

### DIFF
--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -78,7 +78,7 @@
 
     {foreach from = $editOptions item = "title" key="name"}
       {if $name eq 'CustomData' }
-        <div id='customData'>{include file="CRM/Contact/Form/Edit/CustomData.tpl"}</div>
+        <div id='customData'>{include file="CRM/Contact/Form/Edit/CustomData.tpl" isSingleRecordEdit=false}</div>
       {else}
         {include file="CRM/Contact/Form/Edit/$name.tpl"}
       {/if}

--- a/templates/CRM/Custom/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomData.tpl
@@ -1,4 +1,4 @@
-{if empty($isSingleRecordEdit) && $cd_edit.is_multiple eq 1 and $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
+{if !$isSingleRecordEdit && $cd_edit.is_multiple eq 1 and $cd_edit.table_id and $contactId and !$skipTitle and $cd_edit.style eq 'Inline'}
   {assign var=tableID value=$cd_edit.table_id}
   <a href="#" class="crm-hover-button crm-custom-value-del" title="{ts 1=$cd_edit.title}Delete %1{/ts}"
      data-post='{ldelim}"valueID": "{$tableID}", "groupID": "{$group_id}", "contactId": "{$contactId}", "key": "{crmKey name='civicrm/ajax/customvalue'}"{rdelim}'>
@@ -9,7 +9,7 @@
 {if $cd_edit.help_pre}
   <div class="messages help">{$cd_edit.help_pre}</div>
 {/if}
-<table {if empty($isSingleRecordEdit)}class="form-layout-compressed"{/if}>
+<table {if !$isSingleRecordEdit}class="form-layout-compressed"{/if}>
   {foreach from=$cd_edit.fields item=element key=field_id}
     {if $customDataEntity && $blockId}
       {* custom data entity combined with blockId tells us we have an entity with mutliple blocks
@@ -25,7 +25,7 @@
 </table>
 <div class="spacer"></div>
 {if $cd_edit.help_post}<div class="messages help">{$cd_edit.help_post}</div>{/if}
-{if empty($isSingleRecordEdit) && $cd_edit.is_multiple and ( ( $cd_edit.max_multiple eq '' )  or ( $cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount ) ) }
+{if !$isSingleRecordEdit && $cd_edit.is_multiple and ( ( $cd_edit.max_multiple eq '' )  or ( $cd_edit.max_multiple > 0 and $cd_edit.max_multiple > $cgCount ) ) }
   {if $skipTitle}
     {* We don't yet support adding new records in inline-edit forms *}
     <div class="messages help">


### PR DESCRIPTION
Overview
----------------------------------------
Strict smarty notice fix on contact edit - `isSingleRecordEdit`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/185812373-004c1311-f6e9-4718-9412-d07ae74a1032.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/185812380-331251df-4773-4f0a-a884-44723854db40.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
