### PR TITLE
Fix Smarty notice `groupID`

### DIFF
--- a/templates/CRM/Contact/Form/Edit/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Edit/CustomData.tpl
@@ -30,8 +30,6 @@
   </div>
   <!-- crm-accordion-wrapper -->
   <div id="custom_group_{$group_id}_{$cgCount}"></div>
-  {/foreach}
+{/foreach}
 
-  {include file="CRM/common/customData.tpl"}
-
-  {include file="CRM/Form/attachmentjs.tpl"}
+{include file="CRM/Form/attachmentjs.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------
Fix Smarty notice `groupID`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/185812842-7cbacee9-7107-4b72-90b9-206f357508d9.png)

After
----------------------------------------
`groupID` fixed...

![image](https://user-images.githubusercontent.com/336308/185812812-1d1f3edb-2c71-46a0-a25e-0165bedf7969.png)


Technical Details
----------------------------------------
This doesn't really feel right - but I also couldn't see any difference in the network tab or the ui when I removed it. If it IS right then the next line likely should go too

Comments
----------------------------------------
