### PR TITLE
Fix email notices on email edit block

### DIFF
--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -33,6 +33,7 @@ class CRM_Contact_Form_Edit_Email {
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
     // passing this via the session is AWFUL. we need to fix this
     if (!$blockCount) {
+      CRM_Core_Error::deprecatedWarning('pass in blockCount');
       $blockId = ($form->get('Email_Block_Count')) ? $form->get('Email_Block_Count') : 1;
     }
     else {
@@ -83,21 +84,6 @@ class CRM_Contact_Form_Edit_Email {
       }
 
       $form->addElement('radio', "email[$blockId][is_primary]", '', '', '1', $js);
-      // Only display the signature fields if this contact has a CMS account
-      // because they can only send email if they have access to the CRM
-      $isAddSignatureFields = $form instanceof \CRM_Contact_Form_Contact && !empty($form->_contactId);
-      $form->assign('isAddSignatureFields', $isAddSignatureFields);
-      if ($isAddSignatureFields) {
-        $ufID = CRM_Core_BAO_UFMatch::getUFId($form->_contactId);
-        if ($ufID) {
-          $form->add('textarea', "email[$blockId][signature_text]", ts('Signature (Text)'),
-            ['rows' => 2, 'cols' => 40]
-          );
-          $form->add('wysiwyg', "email[$blockId][signature_html]", ts('Signature (HTML)'),
-            ['rows' => 2, 'cols' => 40]
-          );
-        }
-      }
     }
   }
 

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -85,10 +85,31 @@ class CRM_Contact_Form_Location {
           $generateAjaxRequest++;
           $ajaxRequestBlocks[$blockName][$instance] = TRUE;
         }
+        switch ($blockName) {
+          case 'Email':
+            CRM_Contact_Form_Edit_Email::buildQuickForm($form, $instance);
+            // Only display the signature fields if this contact has a CMS account
+            // because they can only send email if they have access to the CRM
+            $ufID = $form->_contactId && CRM_Core_BAO_UFMatch::getUFId($form->_contactId);
+            $form->assign('isAddSignatureFields', (bool) $ufID);
+            if ($ufID) {
+              $form->add('textarea', "email[$instance][signature_text]", ts('Signature (Text)'),
+                ['rows' => 2, 'cols' => 40]
+              );
+              $form->add('wysiwyg', "email[$instance][signature_html]", ts('Signature (HTML)'),
+                ['rows' => 2, 'cols' => 40]
+              );
+            }
+            break;
 
-        $form->set($blockName . '_Block_Count', $instance);
-        $formName = 'CRM_Contact_Form_Edit_' . $blockName;
-        $formName::buildQuickForm($form);
+          default:
+            // @todo This pattern actually adds complexity compared to filling out a switch statement
+            // for the limited number of blocks - as we also have to receive the block count
+            $form->set($blockName . '_Block_Count', $instance);
+            $formName = 'CRM_Contact_Form_Edit_' . $blockName;
+            $formName::buildQuickForm($form);
+        }
+
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix email notices on email edit block


Before
----------------------------------------
On a contact with no user ID 
![image](https://user-images.githubusercontent.com/336308/185813830-ab13ecfd-1ada-440a-86a0-95e54eb6f7a0.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/185813811-d53ab915-69c4-4bdd-9688-169fad0b9f2e.png)

Technical Details
----------------------------------------
This moves logic from ` CRM_Contact_Form_Edit_Email::buildQuickForm` that is only used by the `Contact_Edit` up one step to `CRM_Contact_Form_Location::buildQuickForm`. 

In a separate (merged) PR I fixed the other core place that calls it (the domain form) to ... not call `CRM_Contact_Form_Location::buildQuickForm` because it is unnecessarily complicate for it's use.

A universe search only finds one non-core call to this function & the form does not definte `contactId` so it might get an e-notice but nothing worse

![image](https://user-images.githubusercontent.com/336308/185813497-a5dc30ca-eb84-4e54-8cf7-37e713f39f7b.png)


Comments
----------------------------------------

