### PR TITLE
Simplify Domain edit form to not call complete `LocationBlock::buildQuickForm`

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -49,24 +49,16 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   protected $_locationDefaults = [];
 
   /**
-   * How many locationBlocks should we display?
-   *
-   * @var int
-   * @const
-   */
-  const LOCATION_BLOCKS = 1;
-
-  /**
    * Explicitly declare the entity api name.
    */
-  public function getDefaultEntity() {
+  public function getDefaultEntity(): string {
     return 'Domain';
   }
 
   /**
    * Explicitly declare the form context.
    */
-  public function getDefaultContext() {
+  public function getDefaultContext(): string {
     return 'create';
   }
 
@@ -121,13 +113,17 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
 
   /**
    * Build the form object.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->addField('name', ['label' => ts('Organization Name')], TRUE);
     $this->addField('description', ['label' => ts('Description'), 'size' => 30]);
 
     //build location blocks.
-    CRM_Contact_Form_Location::buildQuickForm($this);
+    CRM_Contact_Form_Edit_Address::buildQuickForm($this, 1);
+    CRM_Contact_Form_Edit_Email::buildQuickForm($this, 1);
+    CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);
 
     $this->addButtons([
       [

--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -31,15 +31,15 @@
 
     <h3>{ts}Default Organization Address{/ts}</h3>
         <div class="description">{ts 1=&#123;domain.address&#125;}CiviMail mailings must include the sending organization's address. This is done by putting the %1 token in either the body or footer of the mailing. This token may also be used in regular 'Email - send now' messages and in other Message Templates. The token is replaced by the address entered below when the message is sent.{/ts}</div>
-        {include file="CRM/Contact/Form/Edit/Address.tpl" masterAddress='' parseStreetAddress=''}
+        {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1 masterAddress='' parseStreetAddress=''}
     <h3>{ts}Organization Contact Information{/ts}</h3>
         <div class="description">{ts}You can also include general email and/or phone contact information in mailings.{/ts} {help id="additional-contact"}</div>
         <table class="form-layout-compressed">
             {* Display the email block *}
-            {include file="CRM/Contact/Form/Edit/Email.tpl"}
+            {include file="CRM/Contact/Form/Edit/Email.tpl" blockId=1}
 
             {* Display the phone block *}
-            {include file="CRM/Contact/Form/Edit/Phone.tpl"}
+            {include file="CRM/Contact/Form/Edit/Phone.tpl" blockId=1}
         </table>
 
     <div class="spacer"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Simplify Domain edit form to not call complete `LocationBlock::buildQuickForm`

Before
----------------------------------------
`CRM_Contact_Form_Location::buildQuickForm($this);` is calling a complex function of which not much is used

After
----------------------------------------
Just calls the required parts directly
```
 CRM_Contact_Form_Edit_Address::buildQuickForm($this, 1);
 CRM_Contact_Form_Edit_Email::buildQuickForm($this, 1);
 CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);
```

Technical Details
----------------------------------------
This will leave only the `Contact_Edit` form calling the method which holds it's complexity

Comments
----------------------------------------
