### PR TITLE
API - Standardize group ACL checks

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -317,6 +317,22 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function addSelectWhereClause() {
+    $clauses = [];
+    if (!CRM_Core_Permission::check([['edit all contacts', 'view all contacts']])) {
+      $allGroups = CRM_Core_PseudoConstant::allGroup(NULL, FALSE);
+      // FIXME: TableName 'civicrm_saved_search' seems wrong but is consistent with self::checkPermission
+      $allowedGroups = \CRM_ACL_API::group(CRM_ACL_API::VIEW, NULL, 'civicrm_saved_search', $allGroups);
+      $groupsIn = $allowedGroups ? implode(',', $allowedGroups) : '0';
+      $clauses['id'][] = "IN ($groupsIn)";
+    }
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+    return $clauses;
+  }
+
+  /**
    * Create a new group.
    *
    * @param array $params

--- a/api/v3/Group.php
+++ b/api/v3/Group.php
@@ -63,9 +63,6 @@ function civicrm_api3_group_get($params) {
 
   $groups = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, 'Group');
   foreach ($groups as $id => $group) {
-    if (!empty($params['check_permissions']) && !CRM_Contact_BAO_Group::checkPermission($group['id'])) {
-      unset($groups[$id]);
-    }
     if (!empty($options['return']) && in_array('member_count', $options['return'])) {
       $groups[$id]['member_count'] = CRM_Contact_BAO_Group::memberCount($id);
     }

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -336,9 +336,11 @@ class api_v3_GroupTest extends CiviUnitTestCase {
 
   /**
    * Test that ACLs are applied to group.get calls.
-   * FIXME: Api4
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGroupGetACLs() {
+  public function testGroupGetACLs($version) {
+    $this->_apiversion = $version;
     $this->createLoggedInUser();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $this->callAPISuccessGetCount('Group', ['check_permissions' => 1], 0);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes problems documented in [dev/core#2667](https://lab.civicrm.org/dev/core/-/issues/2667).

Technical Details
----------------------------------------
Implements a standard BAO::addSelectWhereClause() function for checking group ACLs.
This fixes setting a limit in APIv3, and fixes ACLs for v4 with test coverage.