### PR TITLE
Move participant cancel tests to extension

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2434,13 +2434,14 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
   }
 
   /**
-   * Create array of message information - ie. return html version, txt version, to field
+   * Create array of message information - ie. return html version, txt
+   * version, to field
    *
    * @param array $input
    *   Incoming information.
-   *   - is_recur - should this be treated as recurring (not sure why you wouldn't
-   *    just check presence of recur object but maintaining legacy approach
-   *    to be careful)
+   *   - is_recur - should this be treated as recurring (not sure why you
+   *   wouldn't just check presence of recur object but maintaining legacy
+   *   approach to be careful)
    * @param array $ids
    *   IDs of related objects.
    * @param array $values
@@ -2448,12 +2449,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   This is augmented by values 'gathered' by gatherMessageValues
    * @param bool $returnMessageText
    *   Distinguishes between whether to send message or return.
-   *   message text. We are working towards this function ALWAYS returning message text & calling
-   *   function doing emails / pdfs with it
+   *   message text. We are working towards this function ALWAYS returning
+   *   message text & calling function doing emails / pdfs with it
    *
    * @return array
    *   messages
-   * @throws Exception
+   * @throws \CRM_Core_Exception
    */
   public function composeMessageArray(&$input, &$ids, &$values, $returnMessageText = TRUE) {
     $ids = array_merge(self::getComponentDetails($this->id), $ids);

--- a/ext/contributioncancelactions/contributioncancelactions.php
+++ b/ext/contributioncancelactions/contributioncancelactions.php
@@ -1,9 +1,7 @@
 <?php
 
 require_once 'contributioncancelactions.civix.php';
-// phpcs:disable
-use CRM_Contributioncancelactions_ExtensionUtil as E;
-// phpcs:enable
+
 use Civi\Api4\LineItem;
 use Civi\Api4\Participant;
 
@@ -23,13 +21,11 @@ use Civi\Api4\Participant;
  * @throws \API_Exception
  */
 function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $objectRef) {
-  if ($op === 'edit' && $objectName === 'Contribution') {
-    if (in_array(CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id),
-      ['Cancelled', 'Failed']
-    )) {
-      contributioncancelactions_cancel_related_pending_memberships((int) $objectId);
-      contributioncancelactions_cancel_related_pending_participant_records((int) $objectId);
-    }
+  if ($op === 'edit' && $objectName === 'Contribution'
+    && in_array(CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $objectRef->contribution_status_id), ['Cancelled', 'Failed'], TRUE)
+  ) {
+    contributioncancelactions_cancel_related_pending_memberships((int) $objectId);
+    contributioncancelactions_cancel_related_pending_participant_records((int) $objectId);
   }
 }
 
@@ -37,9 +33,10 @@ function contributioncancelactions_civicrm_post($op, $objectName, $objectId, $ob
  * Find and cancel any pending participant records.
  *
  * @param int $contributionID
+ *
  * @throws CiviCRM_API3_Exception
  */
-function contributioncancelactions_cancel_related_pending_participant_records($contributionID): void {
+function contributioncancelactions_cancel_related_pending_participant_records(int $contributionID): void {
   $pendingStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Pending'");
   $waitingStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Waiting'");
   $cancellableParticipantRecords = civicrm_api3('ParticipantPayment', 'get', [
@@ -59,10 +56,11 @@ function contributioncancelactions_cancel_related_pending_participant_records($c
  * Find and cancel any pending memberships.
  *
  * @param int $contributionID
+ *
  * @throws API_Exception
  * @throws CiviCRM_API3_Exception
  */
-function contributioncancelactions_cancel_related_pending_memberships($contributionID): void {
+function contributioncancelactions_cancel_related_pending_memberships(int $contributionID): void {
   $connectedMemberships = (array) LineItem::get(FALSE)->setWhere([
     ['contribution_id', '=', $contributionID],
     ['entity_table', '=', 'civicrm_membership'],

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -257,87 +257,11 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   }
 
   /**
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function testThatCancellingEventPaymentWillCancelAllAdditionalPendingParticipantsAndCreateCancellationActivities(): void {
-    // Test fails - reason not yet investigated.
-    $this->isValidateFinancialsOnPostAssert = FALSE;
-    $this->_setUpParticipantObjects('Pending from incomplete transaction');
-    $additionalParticipantId = $this->participantCreate([
-      'event_id' => $this->_eventId,
-      'registered_by_id' => $this->_participantId,
-      'status_id' => 'Pending from incomplete transaction',
-    ]);
-
-    Contribution::update(FALSE)->setValues([
-      'cancel_date' => 'now',
-      'contribution_status_id:name' => 'Cancelled',
-    ])->addWhere('id', '=', $this->_contributionId)->execute();
-
-    $cancelledParticipantsCount = $this->callAPISuccess('Participant', 'get', [
-      'sequential' => 1,
-      'id' => ['IN' => [$this->_participantId, $additionalParticipantId]],
-      'status_id' => 'Cancelled',
-    ])['count'];
-    $this->assertEquals(2, $cancelledParticipantsCount);
-
-    $cancelledActivatesCount = civicrm_api3('Activity', 'get', [
-      'sequential' => 1,
-      'activity_type_id' => 'Event Registration',
-      'subject' => ['LIKE' => '%Cancelled%'],
-      'source_record_id' => ['IN' => [$this->_participantId, $additionalParticipantId]],
-    ]);
-
-    $this->assertEquals(2, $cancelledActivatesCount['count']);
-  }
-
-  /**
-   * Test that related pending participant records are cancelled.
-   *
-   * @throws \API_Exception
-   * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  public function testThatFailedEventPaymentWillCancelAllAdditionalPendingParticipantsAndCreateCancellationActivities(): void {
-    $this->_setUpParticipantObjects('Pending from incomplete transaction');
-    $additionalParticipantId = $this->participantCreate([
-      'event_id' => $this->_eventId,
-      'registered_by_id' => $this->_participantId,
-      'status_id' => 'Pending from incomplete transaction',
-    ]);
-
-    Contribution::update(FALSE)->setValues([
-      'cancel_date' => 'now',
-      'contribution_status_id:name' => 'Failed',
-    ])->addWhere('id', '=', $this->ids['contribution'])->execute();
-
-    $cancelledParticipantsCount = civicrm_api3('Participant', 'get', [
-      'sequential' => 1,
-      'id' => ['IN' => [$this->_participantId, $additionalParticipantId]],
-      'status_id' => 'Cancelled',
-    ])['count'];
-    $this->assertEquals(2, $cancelledParticipantsCount);
-
-    $cancelledActivatesCount = civicrm_api3('Activity', 'get', [
-      'sequential' => 1,
-      'activity_type_id' => 'Event Registration',
-      'subject' => ['LIKE' => '%Cancelled%'],
-      'source_record_id' => ['IN' => [$this->_participantId, $additionalParticipantId]],
-    ]);
-
-    $this->assertEquals(2, $cancelledActivatesCount['count']);
-  }
-
-  /**
    * Prepare for contribution Test - involving only contribution objects
    *
    * @param bool $contributionPage
    */
-  public function _setUpContributionObjects($contributionPage = FALSE) {
+  public function _setUpContributionObjects($contributionPage = FALSE): void {
 
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -9,23 +9,11 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Api4\Contribution;
-
 /**
  * Class CRM_Core_Payment_BaseIPNTest
  * @group headless
  */
 class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
-
-  /**
-   * Should financials be checked after the test but before tear down.
-   *
-   * Ideally all tests (or at least all that call any financial api calls ) should do this but there
-   * are some test data issues and some real bugs currently blocking.
-   *
-   * @var bool
-   */
-  protected $isValidateFinancialsOnPostAssert = TRUE;
 
   protected $_financialTypeId;
   protected $_contributionParams;
@@ -105,8 +93,10 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
 
   /**
    * Test the LoadObjects function with recurring membership data.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testLoadMembershipObjectsLoadAll() {
+  public function testLoadMembershipObjectsLoadAll(): void {
     $this->_setUpMembershipObjects();
     $this->_setUpRecurringContribution();
     $this->_membershipId = $this->ids['membership'];
@@ -126,8 +116,10 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
 
   /**
    * Test the LoadObjects function with recurring membership data.
+   *
+   * @throws \Exception
    */
-  public function testSendMailMembershipObjects() {
+  public function testSendMailMembershipObjects(): void {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
@@ -142,8 +134,10 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    * Test the LoadObjects function data does not leak.
    *
    * If more than one iteration takes place the variables should not leak.
+   *
+   * @throws \Exception
    */
-  public function testSendMailMembershipObjectsNoLeakage() {
+  public function testSendMailMembershipObjectsNoLeakage(): void {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $values = [];
@@ -168,8 +162,10 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
 
   /**
    * Test the LoadObjects function with recurring membership data.
+   *
+   * @throws \Exception
    */
-  public function testSendMailMembershipWithoutLoadObjects() {
+  public function testSendMailMembershipWithoutLoadObjects(): void {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
@@ -181,8 +177,11 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
 
   /**
    * Test the LoadObjects function with a participant.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Exception
    */
-  public function testComposeMailParticipant() {
+  public function testComposeMailParticipant(): void {
     $this->_setUpParticipantObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
@@ -193,8 +192,9 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   }
 
   /**
+   * @throws \CRM_Core_Exception
    */
-  public function testComposeMailParticipantObjects() {
+  public function testComposeMailParticipantObjects(): void {
     $this->_setUpParticipantObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
@@ -224,9 +224,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    * Test the LoadObjects function with recurring membership data.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Exception
    */
-  public function testsendMailParticipantObjectsNoMail(): void {
+  public function testSendMailParticipantObjectsNoMail(): void {
     $this->_setUpParticipantObjects();
     $event = new CRM_Event_BAO_Event();
     $event->id = $this->_eventId;
@@ -247,6 +246,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
 
   /**
    * Test the LoadObjects function with a pledge.
+   *
+   * @throws \Exception
    */
   public function testSendMailPledge(): void {
     $this->_setUpPledgeObjects();
@@ -261,7 +262,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    *
    * @param bool $contributionPage
    */
-  public function _setUpContributionObjects($contributionPage = FALSE): void {
+  public function _setUpContributionObjects(bool $contributionPage): void {
 
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
@@ -339,7 +340,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     ];
   }
 
-  public function _setUpRecurringContribution() {
+  public function _setUpRecurringContribution(): void {
     $this->_contributionRecurParams = [
       'contact_id' => $this->_contactId,
       'amount' => 150.00,
@@ -367,9 +368,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    * @param string $participantStatus
    *   The participant to create status
    *
-   * @throws \CRM_Core_Exception
    */
-  public function _setUpParticipantObjects($participantStatus = 'Attended'): void {
+  public function _setUpParticipantObjects(string $participantStatus = 'Attended'): void {
     $event = $this->eventCreate(['is_email_confirm' => 1]);
     $this->setupContribution();
 
@@ -393,7 +393,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->input = [
       'component' => 'event',
       'total_amount' => 150.00,
-      'invoiceID' => "c8acb91e080ad7bd8a2adc119c192885",
+      'invoiceID' => 'c8acb91e080ad7bd8a2adc119c192885',
       'contactID' => $this->_contactId,
       'contributionID' => $contribution->id,
       'participantID' => $this->_participantId,
@@ -406,7 +406,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   /**
    * Set up participant requirements for test.
    */
-  public function _setUpPledgeObjects() {
+  public function _setUpPledgeObjects(): void {
     $this->setupContribution();
     $this->_pledgeId = $this->pledgeCreate(['contact_id' => $this->_contactId]);
     //we'll create membership payment here because to make setup more re-usable
@@ -421,7 +421,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->input = [
       'component' => 'contribute',
       'total_amount' => 150.00,
-      'invoiceID' => "c8acb91e080ad7bd8a2adc119c192885",
+      'invoiceID' => 'c8acb91e080ad7bd8a2adc119c192885',
       'contactID' => $this->_contactId,
       'contributionID' => $this->_contributionId,
       'pledgeID' => $this->_pledgeId,


### PR DESCRIPTION
Overview
----------------------------------------
Move participant cancel tests to extension

Before
----------------------------------------
Tests fail if extension is disabled

After
----------------------------------------
They are in the extension

Technical Details
----------------------------------------

Comments
----------------------------------------
