### PR TITLE
Enable civiimport on install

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1788,6 +1788,7 @@ INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_act
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'ckeditor4', 'CKEditor4', 'CKEditor4', 'ckeditor4', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'legacycustomsearches', 'Custom search framework', 'Custom search framework', 'legacycustomsearches', 1);
 INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'org.civicrm.flexmailer', 'FlexMailer', 'FlexMailer', 'flexmailer', 1);
+INSERT IGNORE INTO civicrm_extension (type, full_name, name, label, file, is_active) VALUES ('module', 'civiimport', 'CiviCRM core import code', 'CiviCRM core import code', 'civiimport', 1);
 
 -- dev/core#3783 Recent Items providers
 INSERT INTO civicrm_option_group (`name`, `title`, `is_reserved`, `is_active`) VALUES ('recent_items_providers', {localize}'{ts escape="sql"}Recent Items Providers{/ts}'{/localize}, 1, 1);


### PR DESCRIPTION
Overview
----------------------------------------
Enable civiimport on install

Before
----------------------------------------
`civiimport` Not enabled on new install

After
----------------------------------------
`civiimport` enabled on new install

Technical Details
----------------------------------------
`civiimport` is intended to be required (although it is not yet functionally required)

Still to do
- add to upgrade - I have a PR that will conflict so waiting for that to merge first
- add to tests (should be possible with this merged)
- hide the extension (after added to upgrade)

Comments
----------------------------------------

