### PR TITLE
[REF]dev/core#2517 Remove tests from core test suites relating to mem…

### DIFF
--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -285,6 +285,14 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
     $this->assertEquals('Cancelled', $contribution['contribution_status_id:name']);
     $membership = $this->callAPISuccessGetSingle('Membership', []);
     $this->assertEquals('Cancelled', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']));
+    $this->assertEquals(TRUE, $membership['is_override']);
+    $membershipSignupActivity = Activity::get()
+      ->addSelect('subject', 'source_record_id', 'status_id')
+      ->addWhere('activity_type_id:name', '=', 'Membership Signup')
+      ->execute();
+    $this->assertCount(1, $membershipSignupActivity);
+    $this->assertEquals($membership['id'], $membershipSignupActivity->first()['source_record_id']);
+    $this->assertEquals('General - Payment - Status: Pending', $membershipSignupActivity->first()['subject']);
     $activity = Activity::get()
       ->addSelect('subject', 'source_record_id', 'status_id')
       ->addWhere('activity_type_id:name', '=', 'Change Membership Status')

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1420,38 +1420,6 @@ Expires: ',
   }
 
   /**
-   * Test membership status overrides when contribution is cancelled.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function testContributionFormStatusUpdate(): void {
-    // @todo figure out why financial validation fails with this test.
-    $this->isValidateFinancialsOnPostAssert = FALSE;
-    $this->_contactID = $this->ids['Contact']['order'] = $this->createLoggedInUser();
-    $this->createContributionAndMembershipOrder();
-
-    $params = [
-      'total_amount' => 50,
-      'financial_type_id' => 2,
-      'contact_id' => $this->_contactID,
-      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
-      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled'),
-    ];
-    $_REQUEST['action'] = 'update';
-    $_REQUEST['id'] = $this->ids['Contribution'][0];
-    $form = $this->getContributionForm($params);
-    $form->postProcess();
-    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_contactID]);
-
-    //Assert membership status overrides when the contribution cancelled.
-    $this->assertEquals(TRUE, $membership['is_override']);
-    $this->assertEquals($membership['status_id'], $this->callAPISuccessGetValue('MembershipStatus', [
-      'return' => 'id',
-      'name' => 'Cancelled',
-    ]));
-  }
-
-  /**
    * Get the contribution form object.
    *
    * @param array $formValues

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -148,44 +148,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test Activity creation on cancellation of membership contribution.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function testActivityForCancelledContribution(): void {
-    // @todo figure out why financial validation fails with this test.
-    $this->isValidateFinancialsOnPostAssert = FALSE;
-    $contactId = $this->ids['Contact']['order'] = $this->createLoggedInUser();
-
-    $this->createContributionAndMembershipOrder();
-    $membershipID = $this->callAPISuccessGetValue('MembershipPayment', ['return' => 'id']);
-
-    $_REQUEST['id'] = $this->ids['Contribution'][0];
-    $_REQUEST['action'] = 'update';
-    // change pending contribution to completed
-    /* @var CRM_Contribute_Form_Contribution $form */
-    $form = $this->getFormObject('CRM_Contribute_Form_Contribution', [
-      'total_amount' => 100,
-      'financial_type_id' => 1,
-      'contact_id' => $contactId,
-      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
-      'contribution_status_id' => 3,
-    ]);
-    $form->buildForm();
-    $form->postProcess();
-
-    $this->callAPISuccessGetSingle('Activity', [
-      'activity_type_id' => 'Membership Signup',
-      'source_record_id' => $membershipID,
-      'subject' => 'General - Payment - Status: Pending',
-    ]);
-    $this->callAPISuccessGetSingle('Activity', [
-      'activity_type_id' => 'Change Membership Status',
-      'source_record_id' => $membershipID,
-    ]);
-  }
-
-  /**
    * Test Multiple Membership Status for same contribution id.
    */
   public function testMultipleMembershipsContribution(): void {


### PR DESCRIPTION
…bership cancellation process and update extension unit tests to cover for gaps in testing

Overview
----------------------------------------
@eileenmcnaughton this should get rid of the other two found in https://github.com/civicrm/civicrm-core/pull/22686

Before
----------------------------------------
Core test suites have tests that depend on having the contributecancelactions extension installed

After
----------------------------------------
Core test suite doesn't rely on it anymore