### PR TITLE
Add Saved searches to view import jobs

### DIFF
--- a/ext/civiimport/Civi/Api4/Service/Spec/Provider/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Service/Spec/Provider/ImportSpecProvider.php
@@ -32,17 +32,15 @@ class ImportSpecProvider implements Generic\SpecProviderInterface {
     $userJobID = substr($spec->getEntity(), (strpos($spec->getEntity(), '_') + 1));
     $userJob = UserJob::get(FALSE)->addWhere('id', '=', $userJobID)->addSelect('metadata', 'job_type', 'created_id')->execute()->first();
 
-    $headers = $userJob['metadata']['DataSource']['column_headers'] ?? [];
     foreach ($columns as $column) {
       $isInternalField = strpos($column['name'], '_') === 0;
       $exists = $isInternalField && $spec->getFieldByName($column['name']);
       if ($exists) {
         continue;
       }
-      $header = $isInternalField ? $column['name'] : array_shift($headers);
       $field = new FieldSpec($column['name'], $spec->getEntity(), 'String');
-      $field->setTitle(ts('Import field') . ':' . $header);
-      $field->setLabel($header);
+      $field->setTitle(ts('Import field') . ':' . $column['label']);
+      $field->setLabel($column['label']);
       $field->setReadonly($isInternalField);
       $field->setDescription(ts('Data being imported into the field.'));
       $field->setColumnName($column['name']);

--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -1,0 +1,182 @@
+<?php
+
+use Civi\Api4\Entity;
+use Civi\BAO\Import;
+use CRM_Civiimport_ExtensionUtil as E;
+
+// Check if SearchKit is enabled before adding SavedSearches.
+try {
+  if (!Entity::get(FALSE)
+    ->addWhere('name', '=', 'SearchDisplay')
+    ->selectRowCount()
+    ->execute()->count()) {
+    return [];
+  }
+}
+catch (CRM_Core_Exception $e) {
+  return [];
+}
+
+$managedEntities = [];
+$importEntities = Import::getImportTables();
+foreach ($importEntities as $importEntity) {
+  try {
+    $fields = array_merge(['_id' => TRUE, '_status' => TRUE, '_status_message' => TRUE], Import::getFieldsForUserJobID($importEntity['user_job_id'], FALSE));
+  }
+  catch (CRM_Core_Exception $e) {
+    continue;
+  }
+  $createdBy = empty($importEntity['created_by']) ? '' : ' (' . E::ts('Created by %1', [$importEntity['created_by'], 'String']) . ')';
+  $managedEntities[] = [
+    'name' => 'SavedSearch_Import' . $importEntity['user_job_id'],
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Import' . '_' . $importEntity['user_job_id'],
+        'label' => $importEntity['title'] . ' ' . $importEntity['description'],
+        'api_entity' => 'Import' . '_' . $importEntity['user_job_id'],
+        'api_params' => [
+          'version' => 4,
+          'select' => array_keys($fields),
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+        'expires_date' => $importEntity['expires_date'],
+        'created_date' => $importEntity['created_date'],
+        'created_id' => $importEntity['created_id'],
+        'description' => ts('Temporary import data'),
+        'mapping_id' => NULL,
+      ],
+    ],
+  ];
+  $managedEntities[] = [
+    'name' => 'SavedSearch_Import_Summary' . $importEntity['user_job_id'],
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Import_Summary' . '_' . $importEntity['user_job_id'],
+        'label' => E::ts('Import Summary') . ' ' . $importEntity['description'],
+        'api_entity' => 'Import' . '_' . $importEntity['user_job_id'],
+        'api_params' => [
+          'version' => 4,
+          'select' => ['_status', 'COUNT(_id) AS COUNT__id'],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => ['_status'],
+          'join' => [],
+          'having' => [],
+        ],
+        'expires_date' => $importEntity['expires_date'],
+        'created_date' => $importEntity['created_date'],
+        'created_id' => $importEntity['created_id'],
+        'description' => ts('Temporary import data'),
+        'mapping_id' => NULL,
+      ],
+    ],
+  ];
+  $columns = [];
+  foreach ($fields as $field) {
+    $columns[] = [
+      'type' => 'field',
+      'key' => $field['name'],
+      'dataType' => $field['data_type'] ?? 'String',
+      'label' => $field['title'] ?? $field['label'],
+      'sortable' => TRUE,
+      'editable' => strpos($field['name'], '_') !== 0,
+    ];
+  }
+  $managedEntities[] = [
+    'name' => 'SavedSearchDisplay_Import' . $importEntity['user_job_id'],
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Import' . '_' . $importEntity['user_job_id'],
+        'label' => E::ts('Import') . ' ' . $importEntity['user_job_id'] . $createdBy,
+        'saved_search_id.name' => 'Import' . '_' . $importEntity['user_job_id'],
+        'type' => 'table',
+        'settings' => [
+          'actions' => TRUE,
+          'limit' => 25,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'pager' => [
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+          ],
+          'sort' => [],
+          'columns' => $columns,
+        ],
+        'acl_bypass' => FALSE,
+      ],
+    ],
+  ];
+
+  $managedEntities[] = [
+    'name' => 'SavedSearchDisplay_Import_Summary' . $importEntity['user_job_id'],
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Import_Summary' . '_' . $importEntity['user_job_id'],
+        'label' => E::ts('Import Summary') . ' ' . $importEntity['user_job_id'] . $createdBy,
+        'saved_search_id.name' => 'Import_Summary' . '_' . $importEntity['user_job_id'],
+        'type' => 'table',
+        'settings' => [
+          'actions' => FALSE,
+          'limit' => 40,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'pager' => [
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+          ],
+          'sort' => [],
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => '_status',
+              'dataType' => 'String',
+              'label' => 'Row status',
+              'sortable' => TRUE,
+              'link' => [
+                'path' => 'civicrm/search#/display/Import_' . $importEntity['user_job_id'] . '/Import_' . $importEntity['user_job_id'] . '?_status=[_status]',
+                'entity' => '',
+                'action' => '',
+                'join' => '',
+                'target' => '',
+              ],
+              'rewrite' => '[_status]',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'COUNT__id',
+              'dataType' => 'Integer',
+              'label' => '',
+              'sortable' => TRUE,
+            ],
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ],
+    ],
+  ];
+}
+return $managedEntities;


### PR DESCRIPTION
Overview
----------------------------------------
Add Saved searches to view import jobs

Before
----------------------------------------
Although it is possible now to build your own search kit view on an import job it is not automatically available

After
----------------------------------------
The searches are now added - they will expire after the user job expires_date (both by having the value set in the saved search and by the expires date being used when coming up with the managed entities)

![image](https://user-images.githubusercontent.com/336308/185834182-cd8a6d79-ef22-489b-9fb8-43109994d282.png)

Summary - note there is a problem with the row count (pre-existing I thik) & with just one row with one status this looks a bit off

![image](https://user-images.githubusercontent.com/336308/185834212-3b65e348-27c9-4b4f-9a77-18fdf3245907.png)

Editable import job search display (the intent is that if a row is edited status will be updated it can be re-queued)

![image](https://user-images.githubusercontent.com/336308/185834285-95b6bc93-084c-43a6-af88-82abc9933a37.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
