### PR TITLE
Alternate to #24143 - Update all is_reserved message templates during upgrade and their corresponding is_default's if it hasn't been edited

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -582,6 +582,13 @@ SET    version = '$version'
     }
 
     $task = new CRM_Queue_Task(
+      ['CRM_Upgrade_Incremental_MessageTemplates', 'updateReservedAndMaybeDefaultTemplates'],
+      [],
+      "Update all reserved message templates"
+    );
+    $queue->createItem($task, ['weight' => 990]);
+
+    $task = new CRM_Queue_Task(
       ['CRM_Upgrade_Form', 'doCoreFinish'],
       [$rev, $latestVer, $latestVer, $postUpgradeMessageFile],
       "Finish core DB updates $latestVer"

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -528,4 +528,81 @@ class CRM_Upgrade_Incremental_MessageTemplates {
     }
   }
 
+  /**
+   * Make sure *all* reserved ones get updated. Might be inefficient because we either already updated or
+   * there were no changes to a given template, but there's only about 30.
+   * This runs near the final steps of the upgrade, otherwise the earlier checks that run during the
+   * individual revisions wouldn't accurately be checking against the right is_reserved version to see
+   * if it had changed.
+   * @todo - do we still need those earlier per-version runs? e.g. the token replacement functions should still work as-is?
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   * @return bool
+   */
+  public static function updateReservedAndMaybeDefaultTemplates(CRM_Queue_TaskContext $ctx): bool {
+    // This has to come first otherwise it would be checking against is_reserved we already updated.
+    $uneditedTemplates = self::getUneditedTemplates();
+
+    $dao = CRM_Core_DAO::executeQuery("SELECT id, workflow_id, workflow_name FROM civicrm_msg_template WHERE is_reserved=1");
+    while ($dao->fetch()) {
+      foreach (['html', 'text', 'subject'] as $type) {
+        $content = file_get_contents(\Civi::paths()->getPath('[civicrm.root]/xml/templates/message_templates/' . $dao->workflow_name . '_' . $type . '.tpl'));
+        if ($content) {
+          CRM_Core_DAO::executeQuery(
+            "UPDATE civicrm_msg_template SET msg_{$type} = %1 WHERE id = %2", [
+              1 => [$content, 'String'],
+              2 => [$dao->id, 'Integer'],
+            ]
+          );
+
+          // If the same workflow_id and type appears in our list of unedited templates, update it too.
+          // There's probably a more efficient way to look this up but simple for now.
+          foreach ($uneditedTemplates as $uneditedTemplate) {
+            if ($uneditedTemplate['workflow_id'] === $dao->workflow_id && $uneditedTemplate['type'] === $type) {
+              CRM_Core_DAO::executeQuery(
+                "UPDATE civicrm_msg_template SET msg_{$type} = %1 WHERE id = %2", [
+                  1 => [$content, 'String'],
+                  2 => [$uneditedTemplate['id'], 'Integer'],
+                ]
+              );
+              break;
+            }
+          }
+        }
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * Get all the is_default templates that are the unchanged from their is_reserved counterpart, which
+   * at the time this runs was the version shipped with core when it was last changed.
+   *
+   * @todo have pulled this out since want to re-use it to get the preUpgrade message right. Currently
+   * it always tells you all the ones in the hardcoded per-version list have been customized.
+   *
+   * @return array
+   */
+  public static function getUneditedTemplates(): array {
+    $templates = [];
+    foreach (['html', 'text', 'subject'] as $type) {
+      $dao = CRM_Core_DAO::executeQuery("
+        SELECT default_template.id, default_template.workflow_id FROM civicrm_msg_template reserved
+        LEFT JOIN civicrm_msg_template default_template
+          ON reserved.workflow_id = default_template.workflow_id
+        WHERE reserved.is_reserved = 1 AND default_template.is_default = 1 AND reserved.id <> default_template.id
+        AND reserved.msg_{$type} = default_template.msg_{$type}
+      ");
+      while ($dao->fetch()) {
+        // Note the same id can appear multiple times, e.g. you might change the html but not the subject.
+        $templates[] = [
+          'id' => $dao->id,
+          'type' => $type,
+          'workflow_id' => $dao->workflow_id,
+        ];
+      }
+    }
+    return $templates;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to #24143.

Before
----------------------------------------
The is_reserved templates (and their corresponding unedited is_default templates) are only updated during upgrade if they're listed in the hardcoded list of ones that have changed.

After
----------------------------------------
All the is_reserved templates (and their corresponding unedited is_default templates) are always updated during upgrade, near the very end.

Technical Details
----------------------------------------
is_reserved is the db copy of the template distributed with core (as opposed to is_default which is the tpl that's in-use currently on the site). If the corresponding is_default has not been edited (i.e. is the same as the existing is_reserved before we update that to the latest), then it's safe to update that is_default too.

It's very convoluted how the flow goes with several different functions with very similar names. I should post my trace somewhere. For now, this doesn't change what happens with the hardcoded list, so for ones listed in there it will still do what it does, and then the is_reserved ones will get updated twice but other than some extra disk access that's ok, and I'm looking to improve that later.

Comments
----------------------------------------
There's more I'd like to do here but this is the minimum to meet the original goal of #24143.

The main thing is this doesn't fix the always-wrong preupgrade message. The determination of the preupgrade message is very tangled. There is some sense in having it computed at the same time as it updates the templates like now, but I think it would be better separated out, i.e. Just determine the message during the [revisions loop](https://github.com/civicrm/civicrm-core/blob/71f0493a66a694331938cf2bb5e4e9667fc274c8/CRM/Upgrade/Form.php#L909), but then update the templates all at once after that.