### PR TITLE
Import - remove import button if it will not work

### DIFF
--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -43,38 +43,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
    * Build the form object.
    */
   public function buildQuickForm() {
-
-    // FIXME: This is a hack...
-    // The tpl contains javascript that starts the import on form submit
-    // Since our back/cancel buttons are of html type "submit" we have to prevent a form submit event when they are clicked
-    // Hacking in some onclick js to make them act more like links instead of buttons
-    $path = CRM_Utils_System::currentPath();
-    $query = ['_qf_MapField_display' => 'true'];
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
-    if (CRM_Utils_Rule::qfKey($qfKey)) {
-      $query['qfKey'] = $qfKey;
-    }
-    $previousURL = CRM_Utils_System::url($path, $query, FALSE, NULL, FALSE);
-    $cancelURL = CRM_Utils_System::url($path, 'reset=1', FALSE, NULL, FALSE);
-
-    $this->addButtons([
-      [
-        'type' => 'back',
-        'name' => ts('Previous'),
-        'js' => ['onclick' => "location.href='{$previousURL}'; return false;"],
-      ],
-      [
-        'type' => 'next',
-        'name' => ts('Import Now'),
-        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-        'js' => ['onclick' => "location.href='{$cancelURL}'; return false;"],
-      ],
-    ]);
+    $this->addButtons($this->getButtons());
   }
 
   /**
@@ -144,6 +113,49 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
       ], FALSE, NULL, FALSE),
     ]);
     $runner->runAllViaWeb();
+  }
+
+  /**
+   * Get the buttons for the form.
+   *
+   * @return array|array[]
+   * @throws \CRM_Core_Exception
+   */
+  private function getButtons(): array {
+    // FIXME: This is a hack...
+    // The tpl contains javascript that starts the import on form submit
+    // Since our back/cancel buttons are of html type "submit" we have to prevent a form submit event when they are clicked
+    // Hacking in some onclick js to make them act more like links instead of buttons
+    $path = CRM_Utils_System::currentPath();
+    $query = ['_qf_MapField_display' => 'true'];
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
+    if (CRM_Utils_Rule::qfKey($qfKey)) {
+      $query['qfKey'] = $qfKey;
+    }
+    $previousURL = CRM_Utils_System::url($path, $query, FALSE, NULL, FALSE);
+    $cancelURL = CRM_Utils_System::url($path, 'reset=1', FALSE, NULL, FALSE);
+    $buttons = [
+      [
+        'type' => 'back',
+        'name' => ts('Previous'),
+        'js' => ['onclick' => "location.href='{$previousURL}'; return false;"],
+      ],
+    ];
+    if ($this->hasImportableRows()) {
+      $buttons[] = [
+        'type' => 'next',
+        'name' => ts('Import Now'),
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+      ];
+    }
+    $buttons[] = [
+      'type' => 'cancel',
+      'name' => ts('Cancel'),
+      'js' => ['onclick' => "location.href='{$cancelURL}'; return false;"],
+    ];
+
+    return $buttons;
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -683,4 +683,15 @@ class CRM_Import_Forms extends CRM_Core_Form {
     return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_SKIP;
   }
 
+  /**
+   * Are there valid rows to import.
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function hasImportableRows(): bool {
+    return (bool) $this->getRowCount(['new']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Import - remove import button if it will not work

Before
----------------------------------------
When an import has no valid rows the 'import now' button still appears. Clicking on it gives a queue error because there is nothing to import

![image](https://user-images.githubusercontent.com/336308/186017122-57c9d9b2-f3b0-4394-9704-c04ac2600712.png)


After
----------------------------------------
The button is missing - which hopefully drives people to notice the 'no valid rows'
![image](https://user-images.githubusercontent.com/336308/186017007-0bcfeede-7b6f-42e0-b36f-a9d75522df07.png)

Technical Details
----------------------------------------
Probably we could do more here but this seems like an acceptable minimum to reduce confusion

Comments
----------------------------------------
