### PR TITLE
ClassScanner - Log a warning if a class-file doesn't have the expected clas

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -198,6 +198,10 @@ class ClassScanner {
             $classes[] = $class;
           }
         }
+        elseif (!interface_exists($class) && !trait_exists($class)) {
+          // ClassScanner runs during boot (before container is established). At this early stage, PHP's logger is more reliable.
+          error_log("Scanned file {$relFile} for class {$class}, but it was not found.");
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

This improves error reporting when working with scanned classes.

Suppose you create a class-file like this:

```php
<?php
// FILE: Civi/Foo/Bar.php
class Bar {
}
```

It's missing the `namespace`!  Similarly, you might make a typo in the `namespace` or `class`. So what happens with it?

(Note: This is one of two alternative PRs: #24347 does a warning, #24348 does an exception.)

Before
----------------------------------------

The class is silently ignored. Functionality doesn't work. 

Depending on the specific use-case, you may face the implacable silence of software ("Why doesn't my file load?") or you might get some random error (*that has to be traced back to the misnamed class*).

After
----------------------------------------

There is an error message in the PHP log.

Comments
----------------------------------------

I reflexively wrote this as a warning (since that's usually safer). But on second thought, there may be a good argument for throwing an exception:

1. The `scan-classes` stuff is fairly new and not widely used yet, so there's not much concern about breaking things that  (somehow/bizarrely) rely on mismatched names.
2. If you intentionally have weird/different class-file structure, then you're not supposed to enable `scan-classes`. (That's the point of making it toggleable....)
3. An exception is more apparent to the developer than a warning in a log.
4. It makes this kind of error tantamount to a syntax error.