### PR TITLE
[REF] Simplify error handling in contribution import

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1710,17 +1710,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       throw new CRM_Core_Exception(ts('External ID already exists in Database.'), CRM_Import_Parser::DUPLICATE);
     }
     if ($contactID) {
-      $existingContact = Contact::get(FALSE)
-        ->addWhere('id', '=', $contactID)
-        // Don't auto-filter deleted - people use import to undelete.
-        ->addWhere('is_deleted', 'IN', [0, 1])
-        ->addSelect('contact_type')->execute()->first();
-      if (empty($existingContact['id'])) {
-        throw new CRM_Core_Exception('No contact found for this contact ID:' . $params['id'], CRM_Import_Parser::NO_MATCH);
-      }
-      if ($existingContact['contact_type'] !== $params['contact_type']) {
-        throw new CRM_Core_Exception('Mismatched contact Types', CRM_Import_Parser::NO_MATCH);
-      }
+      $this->validateContactID($contactID, $params['contact_type']);
       return $contactID;
     }
     // Time to see if we can find an existing contact ID to make this an update


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Simplify error handling in contribution import

Before
----------------------------------------
`private function deprecatedFormatParams($params, &$values, $create = FALSE)`
returns an array which is converted into an exception & thrown

After
----------------------------------------
The exception is just thrown directly

Technical Details
----------------------------------------
Although there is handling for different types of error those were not being hit - so this doesn't change that (just throws the type of error it was winding up being.) I also removed a validate on the campaign as that is checked in the `validate` process as is the fact the contact_id is an integer (although I cast it to an int as good practice when using in a query)

Comments
----------------------------------------
