### PR TITLE
Move `isSkipDuplicates` to shared parent

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -441,17 +441,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   }
 
   /**
-   * Did the user specify duplicates should be skipped and not imported.
-   *
-   * @return bool
-   *
-   * @throws \CRM_Core_Exception
-   */
-  private function isSkipDuplicates(): bool {
-    return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_SKIP;
-  }
-
-  /**
    * Get the fields to be highlighted in the UI.
    *
    * The highlighted fields are those used to match

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -674,4 +674,13 @@ class CRM_Import_Forms extends CRM_Core_Form {
     return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_SKIP;
   }
 
+  /**
+   * Did the user specify duplicates should be skipped and not imported.
+   *
+   * @return bool
+   */
+  protected function isSkipDuplicates(): bool {
+    return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_SKIP;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Move `isSkipDuplicates` to shared parent

Before
----------------------------------------
Function private on child class

After
----------------------------------------
Function protected on parent class

Technical Details
----------------------------------------
This PR is prelminary to further change - just putting it up first to keep the noise levels low. However, even in the context of the current code this puts the function with it's 'sister' functions so makes more sense

Comments
----------------------------------------
