### PR TITLE
Convert membership Import to use select2

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -125,7 +125,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    *
    * @return string
    */
-  public function defaultFromHeader($header, &$patterns) {
+  public function defaultFromHeader($header, $patterns) {
     foreach ($patterns as $key => $re) {
       // Skip empty key/patterns
       if (!$key || !$re || strlen("$re") < 5) {

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -456,4 +456,49 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return empty($errors) ? TRUE : $errors;
   }
 
+  /**
+   * This transforms the lists of fields for each contact type & component
+   * into a single unified list suitable for select2.
+   *
+   * @return array
+   */
+  public function getFieldOptions(): array {
+    $fields = $this->getFields();
+    $entity = $this->getBaseEntity();
+    $categories = $this->getImportEntities();
+    $highlightedFields = $this->getHighlightedFields();
+    foreach ($fields as $fieldName => $field) {
+      if ($fieldName === '') {
+        // @todo stop setting 'do not import' in the first place.
+        continue;
+      }
+      if ($field['name'] === 'id' && $entity === $field['entity'] && !$this->isUpdateExisting()) {
+        continue;
+      }
+      $childField = [
+        'text' => $field['title'],
+        'id' => $fieldName,
+        'has_location' => !empty($field['hasLocationType']),
+      ];
+      if (in_array($fieldName, $highlightedFields, TRUE)) {
+        $childField['text'] .= '*';
+      }
+      $category = ($childField['has_location'] || $field['name'] === 'contact_id') ? 'Contact' : ($field['entity'] ?? $entity);
+      if (empty($categories[$category])) {
+        $category = $entity;
+      }
+      $categories[$category]['children'][$fieldName] = $childField;
+    }
+
+    foreach ($categories as $index => $category) {
+      if (empty($category['children'])) {
+        unset($categories[$index]);
+      }
+      else {
+        $categories[$index]['children'] = array_values($category['children']);
+      }
+    }
+    return array_values($categories);
+  }
+
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -602,6 +602,17 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
+   * Get the fields available for import selection.
+   *
+   * @return array
+   *   e.g ['first_name' => 'First Name', 'last_name' => 'Last Name'....
+   *
+   */
+  protected function getImportEntities(): array {
+    return $this->getParser()->getImportEntities();
+  }
+
+  /**
    * Get an instance of the parser class.
    *
    * @return \CRM_Contact_Import_Parser_Contact|\CRM_Contribute_Import_Parser_Contribution
@@ -631,7 +642,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $mapper = [];
     $parser = $this->getParser();
     foreach ($this->getSubmittedValue('mapper') as $columnNumber => $mappedField) {
-      $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput($mappedField, 0, $columnNumber));
+      $mapper[$columnNumber] = $parser->getMappedFieldLabel($parser->getMappingFieldFromMapperInput((array) $mappedField, 0, $columnNumber));
     }
     return $mapper;
   }
@@ -711,6 +722,16 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function hasImportableRows(): bool {
     return (bool) $this->getRowCount(['new']);
+  }
+
+  /**
+   * Get the base entity for the import.
+   *
+   * @return string
+   */
+  protected function getBaseEntity(): string {
+    $info = $this->getParser()->getUserJobInfo();
+    return reset($info)['entity'];
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -579,7 +579,26 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \API_Exception
    */
   protected function getAvailableFields(): array {
-    return $this->getParser()->getAvailableFields();
+    $return = [];
+    foreach ($this->getFields() as $name => $field) {
+      if ($name === 'id' && $this->isSkipDuplicates()) {
+        // Duplicates are being skipped so id matching is not available.
+        continue;
+      }
+      $return[$name] = $field['html']['label'] ?? $field['title'];
+    }
+    return $return;
+  }
+
+  /**
+   * Get the fields available for import selection.
+   *
+   * @return array
+   *   e.g ['first_name' => 'First Name', 'last_name' => 'Last Name'....
+   *
+   */
+  protected function getFields(): array {
+    return $this->getParser()->getFieldsMetadata();
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -654,7 +654,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   protected function assignMapFieldVariables(): void {
-    $this->addExpectedSmartyVariable('highlightedRelFields');
+    $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
     $this->_columnCount = $this->getNumberOfColumns();
     $this->_columnNames = $this->getColumnHeaders();
     $this->_dataValues = array_values($this->getDataRows([], 2));

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -319,6 +319,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * Once we have cleaned up the way the mapper is handled
    * we can ditch all the existing _construct parameters in favour
    * of just the userJobID - there are current open PRs towards this end.
+   *
+   * @deprecated
    */
   public function getAvailableFields(): array {
     $this->setFieldMetadata();
@@ -1733,7 +1735,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    *
    * @return array
    */
-  protected function getFieldsMetadata() : array {
+  public function getFieldsMetadata() : array {
     if (empty($this->importableFieldsMetadata)) {
       unset($this->userJob);
       $this->setFieldMetadata();

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1744,6 +1744,17 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
+   * Get a list of entities this import supports.
+   *
+   * @return array
+   */
+  public function getImportEntities() : array {
+    return [
+      'Contact' => ['text' => ts('Contact Fields'), 'is_contact' => TRUE],
+    ];
+  }
+
+  /**
    * @param array $mappedField
    *   Field detail as would be saved in field_mapping table
    *   or as returned from getMappingFieldFromMapperInput
@@ -1796,7 +1807,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $mappedFields = [];
     $mapper = $this->getSubmittedValue('mapper');
     foreach ($mapper as $i => $mapperRow) {
-      $mappedField = $this->getMappingFieldFromMapperInput($mapperRow, 0, $i);
+      // Cast to an array as it will be a string for membership
+      // and any others we simplify away from using hierselect for a single option.
+      $mappedField = $this->getMappingFieldFromMapperInput((array) $mapperRow, 0, $i);
       // Just for clarity since 0 is a pseudo-value
       unset($mappedField['mapping_id']);
       $mappedFields[] = $mappedField;

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -33,7 +33,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
       $this->add('select2', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), $options, FALSE, ['class' => 'big', 'placeholder' => ts('- do not import -')]);
     }
-    $this->assign('initHideBoxes');
 
     $this->setDefaults($this->getDefaults());
 

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -26,8 +26,8 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm(): void {
-    $this->buildSavedMappingFields($this->getSubmittedValue('savedMapping'));
-    $this->addFormRule(array('CRM_Member_Import_Form_MapField', 'formRule'), $this);
+    $this->addSavedMappingFields();
+    $this->addFormRule(['CRM_Member_Import_Form_MapField', 'formRule'], $this);
 
     $options = $this->getFieldOptions();
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
@@ -108,29 +108,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
         }
       }
     }
-
-    if (!empty($fields['saveMapping'])) {
-      $nameField = $fields['saveMappingName'] ?? NULL;
-      if (empty($nameField)) {
-        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
-      }
-      else {
-        if (CRM_Core_BAO_Mapping::checkMapping($nameField, CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Membership'))) {
-          $errors['saveMappingName'] = ts('Duplicate Import Membership Mapping Name');
-        }
-      }
-    }
-
-    if (!empty($errors)) {
-      if (!empty($errors['saveMappingName'])) {
-        $_flag = 1;
-        $assignError = new CRM_Core_Page();
-        $assignError->assign('mappingDetailsError', $_flag);
-      }
-      return $errors;
-    }
-
-    return TRUE;
+    return $errors ?: TRUE;
   }
 
   /**

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -44,42 +44,22 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
       unset($sel1['membership_id']);
     }
 
-    $js = "<script type='text/javascript'>\n";
-    $formName = 'document.forms.' . $this->_name;
-
     $fieldMappings = $this->getFieldMappings();
 
     foreach ($columnHeaders as $i => $columnHeader) {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', array(1 => $i)), NULL);
-      $jsSet = FALSE;
+      $sel->setOptions([$sel1]);
       if ($this->getSubmittedValue('savedMapping')) {
         $fieldMapping = $fieldMappings[$i] ?? NULL;
         if (isset($fieldMappings[$i])) {
           if ($fieldMapping['name'] != ts('do_not_import')) {
-            //When locationType is not set
-            $js .= "{$formName}['mapper[$i][1]'].style.display = 'none';\n";
-
-            //When phoneType is not set
-            $js .= "{$formName}['mapper[$i][2]'].style.display = 'none';\n";
-
-            $js .= "{$formName}['mapper[$i][3]'].style.display = 'none';\n";
-
             $defaults["mapper[$i]"] = [$fieldMapping['name']];
-            $jsSet = TRUE;
           }
           else {
             $defaults["mapper[$i]"] = [];
           }
-          if (!$jsSet) {
-            for ($k = 1; $k < 4; $k++) {
-              $js .= "{$formName}['mapper[$i][$k]'].style.display = 'none';\n";
-            }
-          }
         }
         else {
-          // this load section to help mapping if we ran out of saved columns when doing Load Mapping
-          $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_" . $i . "_');\n";
-
           if ($hasHeaders) {
             $defaults["mapper[$i]"] = array($this->defaultFromHeader($columnHeader, $headerPatterns));
           }
@@ -87,7 +67,6 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
         //end of load mapping
       }
       else {
-        $js .= "swapOptions($formName, 'mapper[$i]', 0, 3, 'hs_mapper_" . $i . "_');\n";
         if ($this->getSubmittedValue('skipColumnHeader')) {
           // Infer the default from the skipped headers if we have them
           $defaults["mapper[$i]"] = array(
@@ -99,10 +78,8 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
           );
         }
       }
-      $sel->setOptions([$sel1]);
     }
-    $js .= "</script>\n";
-    $this->assign('initHideBoxes', $js);
+    $this->assign('initHideBoxes');
 
     $this->setDefaults($defaults);
 

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -29,20 +29,9 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->buildSavedMappingFields($this->getSubmittedValue('savedMapping'));
     $this->addFormRule(array('CRM_Member_Import_Form_MapField', 'formRule'), $this);
 
-    //-------- end of saved mapping stuff ---------
-
-    // For most fields using the html label is a good thing
-    // but for contact ID we really want to specify ID.
-    $this->_mapperFields['membership_contact_id'] = ts('Contact ID');
-    $sel1 = $this->_mapperFields;
-    if (!$this->getSubmittedValue('onDuplicate')) {
-      // If not updating then do not allow membership id.
-      unset($sel1['membership_id']);
-    }
-
+    $options = $this->getFieldOptions();
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {
-      $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
-      $sel->setOptions([$sel1]);
+      $this->add('select2', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), $options, FALSE, ['class' => 'big', 'placeholder' => ts('- do not import -')]);
     }
     $this->assign('initHideBoxes');
 
@@ -68,7 +57,7 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $importKeys = [];
     foreach ($fields['mapper'] as $mapperPart) {
-      $importKeys[] = $mapperPart[0];
+      $importKeys[] = $mapperPart;
     }
     // FIXME: should use the schema titles, not redeclare them
     $requiredFields = array(
@@ -226,11 +215,11 @@ class CRM_Member_Import_Form_MapField extends CRM_Import_Form_MapField {
       if ($this->getSubmittedValue('savedMapping')) {
         $fieldMapping = $fieldMappings[$i] ?? NULL;
         if (isset($fieldMappings[$i])) {
-          $defaults["mapper[$i]"] = ($fieldMapping['name'] !== 'do_not_import') ? [$fieldMapping['name']] : [];
+          $defaults["mapper[$i]"] = ($fieldMapping['name'] !== 'do_not_import') ? $fieldMapping['name'] : NULL;
         }
       }
       if (!isset($defaults["mapper[$i]"]) && $this->getSubmittedValue('skipColumnHeader')) {
-        $defaults["mapper[$i]"] = [$this->defaultFromHeader($columnHeader, $headerPatterns)];
+        $defaults["mapper[$i]"] = $this->defaultFromHeader($columnHeader, $headerPatterns);
       }
     }
     return $defaults;

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -76,6 +76,18 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
   }
 
   /**
+   * Get a list of entities this import supports.
+   *
+   * @return array
+   */
+  public function getImportEntities() : array {
+    return [
+      'Membership' => ['text' => ts('Membership Fields'), 'is_contact' => FALSE],
+      'Contact' => ['text' => ts('Contact Fields'), 'is_contact' => TRUE],
+    ];
+  }
+
+  /**
    * Validate the values.
    *
    * @param array $values


### PR DESCRIPTION
Overview
----------------------------------------
Convert membership Import to use select2 when selecting mapping fields

Before
----------------------------------------
Membership import uses a `hierselect` element but it it's actually hierarchical - it only collects the field name & the code to support the `hierselect` is just copy & paste

After
----------------------------------------
It's switched to using `select two`

Technical Details
----------------------------------------
@colemanw I am working towards an export-ui type approach on the Contribution import, which has some complexity. But I wanted to get the array right for select 2 and doing it for a simple import seemed like a good way to develop the code that delivers the array while also getting a code cleanup & a UI improvement on the membership import.

![image](https://user-images.githubusercontent.com/336308/186310040-cc0d85b3-88a4-46be-bbcd-b67fa50d9ae6.png)

![image](https://user-images.githubusercontent.com/336308/186309897-5459e576-756c-4b09-97d6-daedc95f219a.png)


Old version - - I tried out the 'color' for the highligted fields & Coleman & I agreed to ditch it & the above is more consistent with other screens

![image](https://user-images.githubusercontent.com/336308/186075050-cadf27ea-d6e8-4828-9d75-8b2f21ff30b9.png)


Comments
----------------------------------------