### PR TITLE
Deprecate `BAO_Membership::importableFields`

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -915,8 +915,11 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    * @return array
    *   array of importable Fields
    * @throws \CRM_Core_Exception
+   *
+   * @deprecated
    */
   public static function importableFields($contactType = 'Individual', $status = TRUE) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     $fields = Civi::cache('fields')->get('membership_importable_fields' . $contactType . $status);
     if (!$fields) {
       if (!$status) {


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate `BAO_Membership::importableFields`

Before
----------------------------------------
`BAO_Membership::importableFields` is called from two places - the import code and the upgrade script. We need to lock the version used by the upgrade script in but also it's time to start fixing up the one used by the import parser - which is easier if it 'owns' the function. Overall the `importableFields` functions didn't work out very well so this is the second one I'm starting the process of deprecating out of existance on.

After
----------------------------------------
Each of the places that use the function have their own copy. The original is deprecated

Technical Details
----------------------------------------
This increases code duplication short term but the copy in the import parser will be able to be refactored into nothing once it is clearly not shared & the deprecated function won't last forever. The one in the import... might outlive the others

Comments
----------------------------------------
