### PR TITLE
APIv4 - Support updating activity.case_id

### DIFF
--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -65,16 +65,9 @@ class CRM_Case_Page_AJAX {
     $activityParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');
     $activityParams['case_id'] = $caseId;
     $activityParams['is_auto'] = 0;
-    $activityParams['subject'] = 'Change Case Tags';
+    $activityParams['subject'] = ts('Change Case Tags');
 
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
-
-    $caseParams = [
-      'activity_id' => $activity->id,
-      'case_id' => $caseId,
-    ];
-
-    CRM_Case_BAO_Case::processCaseActivity($caseParams);
 
     echo 'true';
     CRM_Utils_System::civiExit();
@@ -138,16 +131,9 @@ class CRM_Case_Page_AJAX {
     $activityParams['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');
     $activityParams['case_id'] = $caseId;
     $activityParams['is_auto'] = 0;
-    $activityParams['subject'] = 'Client Added To Case';
+    $activityParams['subject'] = ts('Client Added To Case');
 
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
-
-    $caseParams = [
-      'activity_id' => $activity->id,
-      'case_id' => $caseId,
-    ];
-
-    CRM_Case_BAO_Case::processCaseActivity($caseParams);
     CRM_Utils_JSON::output(TRUE);
   }
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -540,13 +540,6 @@ AND        a.is_deleted = 0
     if (!$activity) {
       throw new CRM_Core_Exception('Unable to create Activity');
     }
-
-    // create case activity record
-    $caseParams = [
-      'activity_id' => $activity->id,
-      'case_id' => $params['caseID'],
-    ];
-    CRM_Case_BAO_Case::processCaseActivity($caseParams);
     return TRUE;
   }
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -464,17 +464,10 @@ FROM civicrm_action_schedule cas
       'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
       'activity_type_id' => $activityTypeID,
       'source_record_id' => $entityID,
+      'case_id' => $caseID,
     ];
     // @todo use api, remove all the above wrangling
     $activity = CRM_Activity_BAO_Activity::create($activityParams);
-
-    //file reminder on case if source activity is a case activity
-    if (!empty($caseID)) {
-      $caseActivityParams = [];
-      $caseActivityParams['case_id'] = $caseID;
-      $caseActivityParams['activity_id'] = $activity->id;
-      CRM_Case_BAO_Case::processCaseActivity($caseActivityParams);
-    }
   }
 
   /**

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -63,6 +63,11 @@ function civicrm_api3_activity_create($params) {
   // needs testing
   $params['skipRecentView'] = TRUE;
 
+  // In APIv3, only new activities can be filed on a case.
+  if (!$isNew && isset($params['case_id'])) {
+    unset($params['case_id']);
+  }
+
   // create activity
   $activityBAO = CRM_Activity_BAO_Activity::create($params);
 

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -749,19 +749,13 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
     $case1 = $this->createCase($clientId1, $loggedInUser);
     $case2 = $this->createCase($clientId2, $loggedInUser);
     $linkActivity = $this->callAPISuccess('Activity', 'create', [
-      'case_id' => $case1->id,
+      'case_id' => [$case1->id, $case2->id],
       'source_contact_id' => $loggedInUser,
       'target_contact' => $clientId1,
       'activity_type_id' => 'Link Cases',
       'subject' => 'Test Link Cases',
       'status_id' => 'Completed',
     ]);
-
-    // Put it in the format needed for endPostProcess
-    $activity = new StdClass();
-    $activity->id = $linkActivity['id'];
-    $params = ['link_to_case_id' => $case2->id];
-    CRM_Case_Form_Activity_LinkCases::endPostProcess(NULL, $params, $activity);
 
     // Get the option_value.value for case status Closed
     $closedStatusResult = $this->callAPISuccess('OptionValue', 'get', [


### PR DESCRIPTION
Overview
----------------------------------------
Allows updating the case(s) associated with an activity. This allows e.g. a SearchKit display of activities to expose "File On Case" as an in-place-editable column.

Before
----------------------------------------
The API supported filing a brand new activity on a case (during create action).

After
----------------------------------------
Unchanged for APIv3.
APIv4 now supports changing the case associated with an activity; switching it to a different case or removing it altogether. 

Technical Details
----------------------------------------
Care was taken to support the edge case of multiple cases per activity while maintaining backward-compatibility.