### PR TITLE
Unused functions in CRM_Upgrade_Form

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -222,36 +222,6 @@ class CRM_Upgrade_Form extends CRM_Core_Form {
   }
 
   /**
-   * Use the form name to create the tpl file name.
-   *
-   * @return string
-   */
-
-  /**
-   * @return string
-   */
-  public function getTemplateFileName() {
-    $this->assign('title',
-      $this->getFieldsetTitle()
-    );
-    $this->assign('message',
-      $this->getTemplateMessage()
-    );
-    return 'CRM/Upgrade/Base.tpl';
-  }
-
-  public function postProcess() {
-    $this->upgrade();
-
-    if (!$this->verifyPostDBState($errorMessage)) {
-      if (!isset($errorMessage)) {
-        $errorMessage = 'post-condition failed for current upgrade step';
-      }
-      throw new CRM_Core_Exception($errorMessage);
-    }
-  }
-
-  /**
    * @param $version
    *
    * @return Object


### PR DESCRIPTION
Overview
----------------------------------------
They can't be used because they contain calls to nonexistent functions. It's easy to see:

`cv ev "(new CRM_Upgrade_Form())->getTemplateFileName();"`
Error: Call to undefined method CRM_Upgrade_Form::getTemplateMessage() in CRM_Upgrade_Form->getTemplateFileName() (line 238 of ...\CRM\Upgrade\Form.php).

`cv ev "(new CRM_Upgrade_Form())->postProcess();"`
Error: Call to undefined method CRM_Upgrade_Form::upgrade() in CRM_Upgrade_Form->postProcess() (line 244 of ...\CRM\Upgrade\Form.php).