### PR TITLE
Fix broken js on Contribution Import

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -125,9 +125,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CiviCRM_API3_Exception
    */
   public function buildQuickForm() {
-    $savedMappingID = $this->getSubmittedValue('savedMapping');
-
-    $this->buildSavedMappingFields($savedMappingID);
+    $this->addSavedMappingFields();
 
     $this->addFormRule([
       'CRM_Contribute_Import_Form_MapField',
@@ -256,7 +254,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param $files
    * @param self $self
    *
-   * @return array
+   * @return array|true
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields, $files, $self) {
@@ -316,24 +314,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
     }
 
-    if (!empty($fields['saveMapping'])) {
-      $nameField = $fields['saveMappingName'] ?? NULL;
-      if (empty($nameField)) {
-        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
-      }
-      else {
-        if (CRM_Core_BAO_Mapping::checkMapping($nameField, CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Contribution'))) {
-          $errors['saveMappingName'] = ts('Duplicate Import Contribution Mapping Name');
-        }
-      }
-    }
-
     if (!empty($errors)) {
-      if (!empty($errors['saveMappingName'])) {
-        $_flag = 1;
-        $assignError = new CRM_Core_Page();
-        $assignError->assign('mappingDetailsError', $_flag);
-      }
       if (!empty($errors['_qf_default'])) {
         CRM_Core_Session::setStatus($errors['_qf_default'], ts("Error"), "error");
         return $errors;

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -154,11 +154,10 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     $this->setDefaults($defaults);
 
     $js = "<script type='text/javascript'>\n";
-    $formName = 'document.forms.' . $this->_name;
-    foreach ($defaults as  $index => $default) {
+    foreach ($defaults as $index => $default) {
       //  e.g swapOptions(document.forms.MapField, 'mapper[0]', 0, 3, 'hs_mapper_0_');
       // where 0 is the highest populated field number in the array and 3 is the maximum.
-      $js .= "swapOptions($formName, '$index', " . (array_key_last(array_filter($default)) ?: 0) . ", 3, 'hs_mapper_0_');\n";
+      $js .= "swapOptions(document.forms.MapField, '$index', " . (array_key_last(array_filter($default)) ?: 0) . ", 3, 'hs_mapper_0_');\n";
     }
     $js .= "</script>\n";
     $this->assign('initHideBoxes', $js);

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -501,4 +501,23 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return array_values($categories);
   }
 
+  /**
+   * Get the 'best' mapping default from the column headers.
+   *
+   * @param string $columnHeader
+   *
+   * @return string
+   */
+  protected function guessMappingBasedOnColumns(string $columnHeader): string {
+    $headerPatterns = $this->getHeaderPatterns();
+    // do array search first to see if has mapped key
+    $columnKey = array_search($columnHeader, $this->_mapperFields, TRUE);
+    if ($columnKey && empty($this->_fieldUsed[$columnKey])) {
+      $this->_fieldUsed[$columnKey] = TRUE;
+      return $columnKey;
+    }
+    // Infer the default from the column names if we have them
+    return $this->defaultFromHeader($columnHeader, $headerPatterns);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix broken js on Contribution Import

Before
----------------------------------------
If you do a contribution import and proceed past the `MapField` screen (without saving the mapping) and then go back AND you have a soft credit field mapped you get  a js error

![image](https://user-images.githubusercontent.com/336308/186342088-b50c2caa-22ec-4e9e-a74b-316b16777051.png)

After
----------------------------------------
Fixed - also code is much cleaner

Technical Details
----------------------------------------
I wasn't going to fix the js as I'm hoping to move away from the `hierselect` - but once I saw how @darrick  fixed in on the contact MapField (https://github.com/civicrm/civicrm-core/pull/23619) it was just soooo much cleaner (and not broken) I figured it made sense to get rid of the old js code so we would never have to look at it again

Comments
----------------------------------------
