### PR TITLE
[Ref] Import cleanup code that looks up contribution in import

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -648,7 +648,7 @@ abstract class CRM_Import_DataSource {
    */
   protected function getStatusMapping(): array {
     return [
-      CRM_Import_Parser::VALID => ['imported', 'new', 'soft_credit_imported', 'pledge_payment_imported'],
+      CRM_Import_Parser::VALID => ['imported', 'new', 'valid', 'soft_credit_imported', 'pledge_payment_imported'],
       CRM_Import_Parser::ERROR => ['error', 'invalid', 'soft_credit_error', 'pledge_payment_error'],
       CRM_Import_Parser::DUPLICATE => ['duplicate'],
       CRM_Import_Parser::NO_MATCH => ['invalid_no_match'],
@@ -657,7 +657,8 @@ abstract class CRM_Import_DataSource {
       CRM_Contribute_Import_Parser_Contribution::SOFT_CREDIT => ['soft_credit_imported'],
       CRM_Contribute_Import_Parser_Contribution::PLEDGE_PAYMENT => ['pledge_payment_imported'],
       CRM_Contribute_Import_Parser_Contribution::PLEDGE_PAYMENT_ERROR => ['pledge_payment_error'],
-      'new' => ['new'],
+      'new' => ['new', 'valid'],
+      'valid' => ['valid'],
     ];
   }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1623,7 +1623,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
         $rowNumber = $row['_id'];
         $values = array_values($row);
         $this->validateValues($values);
-        $this->setImportStatus($rowNumber, 'NEW', '');
+        $this->setImportStatus($rowNumber, 'VALID', '');
       }
       catch (CRM_Core_Exception $e) {
         $this->setImportStatus($rowNumber, 'ERROR', $e->getMessage());

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -335,6 +335,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
         $tmpContactField[$value] = $contactFields[$value];
         $title = $tmpContactField[$value]['title'] . ' ' . ts('(match to contact)');
         $tmpContactField[$value]['title'] = $title;
+        // When we switch to apiv4 getfields this will already be set for
+        // all fields (including custom which it isn't yet)
+        $tmpContactField[$value]['entity'] = 'Contact';
       }
     }
 

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -68,6 +68,7 @@ trait CRMTraits_Import_ParserTrait {
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {
       $queue = Civi::queue('user_job_' . $this->userJobID);
+      $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT COUNT(*) FROM civicrm_queue_item'));
       $runner = new CRM_Queue_Runner([
         'queue' => $queue,
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -73,7 +73,8 @@ trait CRMTraits_Import_ParserTrait {
         'queue' => $queue,
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
       ]);
-      $runner->runAll();
+      $result = $runner->runAll();
+      $this->assertEquals(TRUE, $result, $result === TRUE ? '' : $result['exception']->getMessage());
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[Ref] Import cleanup code that looks up contribution in import

Before
----------------------------------------
Lots of old bits of deprecated code check on invoice + trxn_id + id combos

After
----------------------------------------
We look it up once & then we know we have a valid combo & we can just use 'id'

Technical Details
----------------------------------------
I wrote a test for this - but in the process I found that there was a regression so the test was merged to the rc

This PR also starts the process of handling the imported entities as separate entities

Comments
----------------------------------------
