### PR TITLE
APIv4 - Accept `match` param for Export action

### DIFF
--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -38,6 +38,7 @@ use Civi\Api4\Utils\CoreUtil;
  * @package Civi\Api4\Generic
  */
 abstract class AbstractSaveAction extends AbstractAction {
+  use Traits\MatchParamTrait;
 
   /**
    * Array of $ENTITIES to save.
@@ -70,20 +71,6 @@ abstract class AbstractSaveAction extends AbstractAction {
    * @var bool
    */
   protected $reload = FALSE;
-
-  /**
-   * Specify fields to match for update.
-   *
-   * Normally each record is either created or updated based on the presence of an `id`.
-   * Specifying `$match` fields will also perform an update if an existing $ENTITY matches all specified fields.
-   *
-   * Note: the fields named in this param should be without any options suffix (e.g. `my_field` not `my_field:name`).
-   * Any options suffixes in the $records will be resolved by the api prior to matching.
-   *
-   * @var array
-   * @optionsCallback getMatchFields
-   */
-  protected $match = [];
 
   /**
    * @throws \API_Exception
@@ -192,21 +179,6 @@ abstract class AbstractSaveAction extends AbstractAction {
   public function addDefault(string $fieldName, $defaultValue) {
     $this->defaults[$fieldName] = $defaultValue;
     return $this;
-  }
-
-  /**
-   * Options callback for $this->match
-   * @return array
-   */
-  protected function getMatchFields() {
-    return (array) civicrm_api4($this->getEntityName(), 'getFields', [
-      'checkPermissions' => FALSE,
-      'action' => 'get',
-      'where' => [
-        ['type', 'IN', ['Field', 'Custom']],
-        ['name', 'NOT IN', (array) CoreUtil::getInfoItem($this->getEntityName(), 'primary_key')],
-      ],
-    ], ['name']);
   }
 
 }

--- a/Civi/Api4/Generic/ExportAction.php
+++ b/Civi/Api4/Generic/ExportAction.php
@@ -29,6 +29,7 @@ use Civi\Api4\Utils\CoreUtil;
  * @method string getUpdate()
  */
 class ExportAction extends AbstractAction {
+  use Traits\MatchParamTrait;
 
   /**
    * Id of $ENTITY to export
@@ -145,7 +146,7 @@ class ExportAction extends AbstractAction {
         unset($record[$fieldName]);
       }
     }
-    $result[] = [
+    $export = [
       'name' => $name,
       'entity' => $entityType,
       'cleanup' => $this->cleanup,
@@ -155,6 +156,10 @@ class ExportAction extends AbstractAction {
         'values' => $record,
       ],
     ];
+    foreach (array_intersect($this->match, array_keys($allFields)) as $match) {
+      $export['params']['match'][] = $match;
+    }
+    $result[] = $export;
     // Export entities that reference this one
     $daoName = CoreUtil::getInfoItem($entityType, 'dao');
     if ($daoName) {

--- a/Civi/Api4/Generic/Traits/MatchParamTrait.php
+++ b/Civi/Api4/Generic/Traits/MatchParamTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic\Traits;
+
+/**
+ * @method $this setMatch(array $match) Specify fields to match for update.
+ * @method bool getMatch()
+ * @package Civi\Api4\Generic
+ */
+trait MatchParamTrait {
+
+  /**
+   * Specify fields to match for update.
+   *
+   * The API will perform an update if an existing $ENTITY matches all specified fields.
+   *
+   * Note: the fields named in this param should be without any options suffix (e.g. `my_field` not `my_field:name`).
+   * Any options suffixes in the $records will be resolved by the api prior to matching.
+   *
+   * @var array
+   * @optionsCallback getMatchFields
+   */
+  protected $match = [];
+
+  /**
+   * Options callback for $this->match
+   * @return array
+   */
+  protected function getMatchFields() {
+    return (array) civicrm_api4($this->getEntityName(), 'getFields', [
+      'checkPermissions' => FALSE,
+      'action' => 'get',
+      'where' => [
+        ['type', 'IN', ['Field', 'Custom']],
+        ['readonly', '!=', TRUE],
+      ],
+    ], ['name']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This makes API Export code generator a little friendlier by inserting the `match` param for you, if specified.

Before
----------------------------------------
Param had to be inserted manually into `.mgd.php` code.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/186469937-9e0a73ec-abf9-4f17-b52f-517f03a4fba8.png)
