### PR TITLE
Fix participant import not to import to deleted contacts

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -150,6 +150,9 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);
+      if ($params['external_identifier']) {
+        $params['contact_id'] = $this->lookupExternalIdentifier($params['external_identifier'], $this->getContactType(), $params['contact_id'] ?? NULL);
+      }
       $session = CRM_Core_Session::singleton();
       $formatted = $params;
       // don't add to recent items, CRM-4399
@@ -271,14 +274,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         }
       }
       else {
-        if (!empty($formatValues['external_identifier'])) {
-          $checkCid = new CRM_Contact_DAO_Contact();
-          $checkCid->external_identifier = $formatValues['external_identifier'];
-          $checkCid->find(TRUE);
-          if ($checkCid->id != $formatted['contact_id']) {
-            throw new CRM_Core_Exception('Mismatch of External ID:' . $formatValues['external_identifier'] . ' and Contact Id:' . $formatted['contact_id']);
-          }
-        }
         $newParticipant = $this->deprecated_create_participant_formatted($formatted);
       }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1963,4 +1963,51 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     return is_numeric($importedValue) ? $importedValue : mb_strtolower(str_replace('’', "'", $importedValue));
   }
 
+  /**
+   * Look up for an existing contact with the given external_identifier.
+   *
+   * If the identifier is found on a deleted contact then it is not a match
+   * but it must be removed from that contact to allow the new contact to
+   * have that external_identifier.
+   *
+   * @param string|null $externalIdentifier
+   * @param string $contactType
+   * @param int|null $contactID
+   *
+   * @return int|null
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function lookupExternalIdentifier(?string $externalIdentifier, string $contactType, ?int $contactID): ?int {
+    if (!$externalIdentifier) {
+      return NULL;
+    }
+    // Check for any match on external id, deleted or otherwise.
+    $foundContact = civicrm_api3('Contact', 'get', [
+      'external_identifier' => $externalIdentifier,
+      'showAll' => 'all',
+      'sequential' => TRUE,
+      'return' => ['id', 'contact_is_deleted', 'contact_type'],
+    ]);
+    if (empty($foundContact['id'])) {
+      return NULL;
+    }
+    if (!empty($foundContact['values'][0]['contact_is_deleted'])) {
+      // If the contact is deleted, update external identifier to be blank
+      // to avoid key error from MySQL.
+      $params = ['id' => $foundContact['id'], 'external_identifier' => ''];
+      civicrm_api3('Contact', 'create', $params);
+      return NULL;
+    }
+    if ($contactType && $foundContact['values'][0]['contact_type'] !== $contactType) {
+      throw new CRM_Core_Exception('Mismatched contact Types', CRM_Import_Parser::NO_MATCH);
+    }
+    //check if external identifier exists in database
+    if ($contactID && $foundContact['id'] !== $contactID) {
+      throw new CRM_Core_Exception(ts('Existing external ID does not match the imported contact ID.'), CRM_Import_Parser::ERROR);
+    }
+    return (int) $foundContact['id'];
+  }
+
 }

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
@@ -1,0 +1,2 @@
+Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import
+Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,


### PR DESCRIPTION
Overview
----------------------------------------
Fix participant import not to import to deleted contacts

Before
----------------------------------------
If participant import finds a match on external_identifier it will import to that, even if deleted

After
----------------------------------------
Code from contact import re-used (this involved removing the external_identifier from deleted contacts on match - as has been previously agreed for that import & hence feels appropriate to all.

Test added

Also some code-removal on code which does not do anything

![image](https://user-images.githubusercontent.com/336308/186538621-a1876013-0963-4d39-a3c7-d83915a1a9a5.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
