### PR TITLE
Warning popup about copy of extension in system path disappears too fast

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -175,7 +175,7 @@ class CRM_Extension_Manager {
           CRM_Core_Session::setStatus(ts('A copy of the extension (%1) is in a system folder (%2). The system copy will be preserved, but the new copy will be used.', [
             1 => $newInfo->key,
             2 => $oldPath,
-          ]));
+          ]), '', 'alert', ['expires' => 0]);
         }
         break;
 


### PR DESCRIPTION
Overview
----------------------------------------
When you upgrade/install you can get a warning about a copy of an extension in a system path. It disappears before you can understand what it's saying, and it isn't stored in the log or anywhere.

Before
----------------------------------------
_What just happened?_

  OR

_Oblivious that something happened since you looked away and didn't see it at all._

After
----------------------------------------
Message stays until you dismiss.

Technical Details
----------------------------------------


Comments
----------------------------------------
In my case it seems like a false positive because I think it gets path comparison on windows wrong, but I don't remember seeing it before, but see "oblivious" above.