### PR TITLE
APIv4 - Add contact.getDuplicates action

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3474,11 +3474,29 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
     $dedupeParams['rule'] = $rule;
     $dedupeParams['rule_group_id'] = $ruleGroupID;
     $dedupeParams['excluded_contact_ids'] = $excludedContactIDs;
-    $dedupeResults['ids'] = [];
-    $dedupeResults['handled'] = FALSE;
+    return self::findDuplicates($dedupeParams, $contextParams ?: []);
+  }
+
+  /**
+   * @param array $dedupeParams
+   * @param array $contextParams
+   * @return array
+   * @throws CRM_Core_Exception
+   */
+  public static function findDuplicates(array $dedupeParams, array $contextParams = []): array {
+    $dedupeResults = [
+      'ids' => [],
+      'handled' => FALSE,
+    ];
     CRM_Utils_Hook::findDuplicates($dedupeParams, $dedupeResults, $contextParams);
     if (!$dedupeResults['handled']) {
-      $dedupeResults['ids'] = CRM_Dedupe_Finder::dupesByParams($dedupeParams, $contactType, $rule, $excludedContactIDs, $ruleGroupID);
+      $dedupeParams += [
+        'contact_type' => NULL,
+        'rule' => NULL,
+        'rule_group_id' => NULL,
+        'excluded_contact_ids' => [],
+      ];
+      $dedupeResults['ids'] = CRM_Dedupe_Finder::dupesByParams($dedupeParams, $dedupeParams['contact_type'], $dedupeParams['rule'], $dedupeParams['excluded_contact_ids'], $dedupeParams['rule_group_id']);
     }
     return $dedupeResults['ids'] ?? [];
   }

--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -93,7 +93,7 @@ class CRM_Dedupe_Finder {
     if (!$params) {
       return [];
     }
-    $checkPermission = CRM_Utils_Array::value('check_permission', $params, TRUE);
+    $checkPermission = $params['check_permission'] ?? TRUE;
     // This may no longer be required - see https://github.com/civicrm/civicrm-core/pull/13176
     $params = array_filter($params);
 

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -1384,12 +1384,29 @@ class CRM_Utils_Array {
    * @param string $prefix
    * @return array
    */
-  public static function prefixKeys(array $collection, string $prefix) {
+  public static function prefixKeys(array $collection, string $prefix): array {
     $result = [];
     foreach ($collection as $key => $value) {
       $result[$prefix . $key] = $value;
     }
     return $result;
+  }
+
+  /**
+   * Removes all items from an array whose keys have a given prefix, and returns them unprefixed.
+   *
+   * @param array $collection
+   * @param string $prefix
+   */
+  public static function filterByPrefix(array &$collection, string $prefix): array {
+    $filtered = [];
+    foreach (array_keys($collection) as $key) {
+      if (!$prefix || strpos($key, $prefix) === 0) {
+        $filtered[substr($key, strlen($prefix))] = $collection[$key];
+        unset($collection[$key]);
+      }
+    }
+    return $filtered;
   }
 
 }

--- a/Civi/Api4/Action/Contact/ContactSaveTrait.php
+++ b/Civi/Api4/Action/Contact/ContactSaveTrait.php
@@ -13,7 +13,6 @@
 namespace Civi\Api4\Action\Contact;
 
 use Civi\Api4\Utils\CoreUtil;
-use Civi\Api4\Utils\FormattingUtil;
 
 /**
  * Code shared by Contact create/update/save actions
@@ -58,7 +57,7 @@ trait ContactSaveTrait {
     foreach (['Address', 'Email', 'Phone', 'IM'] as $entity) {
       foreach (['primary', 'billing'] as $type) {
         $prefix = strtolower($entity) . '_' . $type . '.';
-        $item = FormattingUtil::filterByPrefix($params, $prefix . '*', '*');
+        $item = \CRM_Utils_Array::filterByPrefix($params, $prefix);
         // Not allowed to update by id or alter primary or billing flags
         unset($item['id'], $item['is_primary'], $item['is_billing']);
         if ($item) {

--- a/Civi/Api4/Action/Contact/GetDuplicates.php
+++ b/Civi/Api4/Action/Contact/GetDuplicates.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Contact;
+
+use Civi\Api4\DedupeRuleGroup;
+use Civi\Api4\Generic\BasicGetFieldsAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Utils\FormattingUtil;
+
+/**
+ * Get matching contacts based on a dedupe rule
+ * @method setDedupeRule(string $dedupeRule)
+ * @method string getDedupeRule()
+ */
+class GetDuplicates extends \Civi\Api4\Generic\DAOCreateAction {
+
+  /**
+   * Name of dedupe rule to use.
+   *
+   * A default rule group can be used such as "Individual.Unsupervised" or "Household.Supervised"
+   * or else the name of a specific rule group can be given.
+   *
+   * @var string
+   * @optionsCallback getRuleGroupNames
+   * @required
+   */
+  protected $dedupeRule;
+
+  /**
+   * Options callback for dedupeRule param
+   * @return string[]
+   */
+  protected function getRuleGroupNames() {
+    $rules = [];
+    foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
+      $rules[] = $contactType . '.Unsupervised';
+      $rules[] = $contactType . '.Supervised';
+    }
+    $specific = DedupeRuleGroup::get(FALSE)
+      ->addSelect('name')
+      ->execute()->column('name');
+    return array_merge($rules, $specific);
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $dedupeParams = [
+      'check_permission' => $this->getCheckPermissions(),
+    ];
+    $item = $this->values;
+
+    $this->formatWriteValues($item);
+
+    if (strpos($this->dedupeRule, '.Unsupervised') || strpos($this->dedupeRule, '.Supervised')) {
+      [$contactType, $ruleType] = explode('.', $this->dedupeRule);
+      if (!empty($item['contact_type']) && $contactType !== $item['contact_type']) {
+        throw new \API_Exception('Mismatched contact type.');
+      }
+      $item['contact_type'] = $contactType;
+      $dedupeParams['rule'] = $ruleType;
+    }
+    else {
+      $ruleGroup = DedupeRuleGroup::get(FALSE)
+        ->addWhere('name', '=', $this->dedupeRule)
+        ->addSelect('id', 'contact_type')
+        ->execute()->single();
+      if (!empty($item['contact_type']) && $ruleGroup['contact_type'] !== $item['contact_type']) {
+        throw new \API_Exception('Mismatched contact type.');
+      }
+      $item['contact_type'] = $ruleGroup['contact_type'];
+      $dedupeParams['rule_group_id'] = $ruleGroup['id'];
+    }
+
+    $this->formatDedupeParams($item, $dedupeParams);
+
+    foreach (\CRM_Contact_BAO_Contact::findDuplicates($dedupeParams) as $id) {
+      $result[] = ['id' => $id];
+    }
+  }
+
+  /**
+   * Sorts fields by table+column name per deduper expectations.
+   *
+   * @param array $item
+   * @param array $dedupeParams
+   */
+  private function formatDedupeParams(array $item, array &$dedupeParams) {
+    foreach (['Email', 'Phone', 'Address', 'IM'] as $entity) {
+      $prefix = strtolower($entity) . '_primary.';
+      $entityValues = \CRM_Utils_Array::filterByPrefix($item, $prefix);
+      $this->transformCustomParams($entityValues, $dedupeParams);
+      if ($entityValues) {
+        $dedupeParams['civicrm_' . strtolower($entity)] = $entityValues;
+      }
+    }
+    // After removing all other entity fields, remaining fields belong to contact
+    $this->transformCustomParams($item, $dedupeParams);
+    $dedupeParams['civicrm_contact'] = $item;
+    $dedupeParams['contact_type'] = $item['contact_type'];
+  }
+
+  /**
+   * Sorts custom fields by table+column name per deduper expectations.
+   *
+   * @param array $entityValues
+   * @param array $dedupeParams
+   * @throws \API_Exception
+   */
+  private function transformCustomParams(array &$entityValues, array &$dedupeParams) {
+    foreach ($entityValues as $name => $value) {
+      $field = $this->getCustomFieldInfo($name);
+      if ($field) {
+        unset($entityValues[$name]);
+        if (isset($value)) {
+          if ($field['suffix']) {
+            $options = FormattingUtil::getPseudoconstantList($field, $name, $entityValues, 'create');
+            $value = FormattingUtil::replacePseudoconstant($options, $value, TRUE);
+          }
+          $dedupeParams[$field['table_name']][$field['column_name']] = $value;
+        }
+      }
+    }
+  }
+
+  /**
+   * Combines getFields from Contact + related entities into a flat array
+   *
+   * @return array
+   */
+  public static function fields(BasicGetFieldsAction $action) {
+    $fields = [];
+    $ignore = ['id', 'contact_id', 'is_primary', 'on_hold', 'location_type_id', 'phone_type_id'];
+    foreach (['Contact', 'Email', 'Phone', 'Address', 'IM'] as $entity) {
+      $entityFields = (array) civicrm_api4($entity, 'getFields', [
+        'action' => 'create',
+        'loadOptions' => $action->getLoadOptions(),
+        'where' => [['name', 'NOT IN', $ignore], ['type', 'IN', ['Field', 'Custom']]],
+      ]);
+      if ($entity !== 'Contact') {
+        $prefix = strtolower($entity) . '_primary.';
+        foreach ($entityFields as &$field) {
+          $field['name'] = $prefix . $field['name'];
+        }
+      }
+      $fields = array_merge($fields, $entityFields);
+    }
+    return $fields;
+  }
+
+}

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -81,4 +81,13 @@ class Contact extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Contact\GetDuplicates
+   */
+  public static function getDuplicates($checkPermissions = TRUE) {
+    return (new Action\Contact\GetDuplicates(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -89,7 +89,7 @@ class BasicGetFieldsAction extends BasicGetAction {
     catch (NotImplementedException $e) {
     }
     if (isset($actionClass) && method_exists($actionClass, 'fields')) {
-      $values = $actionClass->fields();
+      $values = $actionClass->fields($this);
     }
     else {
       $values = $this->getRecords();

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -310,11 +310,13 @@ trait DAOActionTrait {
     if (!isset($info[$fieldName])) {
       $info = [];
       $fields = CustomField::get(FALSE)
-        ->addSelect('id', 'name', 'html_type', 'data_type', 'custom_group_id.extends')
+        ->addSelect('id', 'name', 'html_type', 'data_type', 'custom_group_id.extends', 'column_name', 'custom_group_id.table_name')
         ->addWhere('custom_group_id.name', '=', $groupName)
         ->execute()->indexBy('name');
       foreach ($fields as $name => $field) {
         $field['custom_field_id'] = $field['id'];
+        $field['table_name'] = $field['custom_group_id.table_name'];
+        unset($field['custom_group_id.table_name']);
         $field['name'] = $groupName . '.' . $name;
         $field['entity'] = CustomGroupJoinable::getEntityFromExtends($field['custom_group_id.extends']);
         $info[$name] = $field;

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -261,7 +261,7 @@ class FormattingUtil {
     // Use BAO::buildOptions if possible
     if ($baoName) {
       $fieldName = empty($field['custom_field_id']) ? $field['name'] : 'custom_' . $field['custom_field_id'];
-      $options = $baoName::buildOptions($fieldName, $context, self::filterByPrefix($params, $fieldPath, $field['name']));
+      $options = $baoName::buildOptions($fieldName, $context, self::filterByPath($params, $fieldPath, $field['name']));
     }
     // Fallback for option lists that exist in the api but not the BAO
     if (!isset($options) || $options === FALSE) {
@@ -308,7 +308,7 @@ class FormattingUtil {
    * @param mixed $value
    */
   private static function applyFormatters(array $result, string $fieldPath, array $field, &$value) {
-    $row = self::filterByPrefix($result, $fieldPath, $field['name']);
+    $row = self::filterByPath($result, $fieldPath, $field['name']);
 
     foreach ($field['output_formatters'] as $formatter) {
       $formatter($value, $row, $field);
@@ -382,8 +382,7 @@ class FormattingUtil {
    * Given a field belonging to either the main entity or a joined entity,
    * and a values array of [path => value], this returns all values which share the same root path.
    *
-   * Works by filtering array keys to only include those with the same prefix as a given field,
-   * stripping them of that prefix.
+   * Note: Unlike CRM_Utils_Array::filterByPrefix this does not mutate the original array.
    *
    * Ex:
    * ```
@@ -409,15 +408,9 @@ class FormattingUtil {
    * @param string $fieldName
    * @return array
    */
-  public static function filterByPrefix(array $values, string $fieldPath, string $fieldName): array {
-    $filtered = [];
+  public static function filterByPath(array $values, string $fieldPath, string $fieldName): array {
     $prefix = substr($fieldPath, 0, strpos($fieldPath, $fieldName));
-    foreach ($values as $key => $val) {
-      if (!$prefix || strpos($key, $prefix) === 0) {
-        $filtered[substr($key, strlen($prefix))] = $val;
-      }
-    }
-    return $filtered;
+    return \CRM_Utils_Array::filterByPrefix($values, $prefix);
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
@@ -87,7 +87,7 @@ class GetOptions extends AbstractProcessor {
       'where' => [['name', '=', $fieldName]],
       'select' => ['options'],
       'loadOptions' => ['id', 'label'],
-      'values' => FormattingUtil::filterByPrefix($this->values, $this->fieldName, $fieldName),
+      'values' => FormattingUtil::filterByPath($this->values, $this->fieldName, $fieldName),
     ], 0)['options'] ?: [];
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -560,7 +560,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $editable['value'] = $data[$editable['value_path']];
       // Ensure field is appropriate to this entity sub-type
       $field = $this->getField($column['key']);
-      $entityValues = FormattingUtil::filterByPrefix($data, $editable['id_path'], $editable['id_key']);
+      $entityValues = FormattingUtil::filterByPath($data, $editable['id_path'], $editable['id_key']);
       if (!$this->fieldBelongsToEntity($editable['entity'], $field['name'], $entityValues)) {
         return NULL;
       }

--- a/tests/phpunit/api/v4/Action/ContactGetDuplicatesTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetDuplicatesTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\Custom\CustomTestBase;
+use Civi\Api4\Contact;
+
+/**
+ * @group headless
+ */
+class ContactGetDuplicatesTest extends CustomTestBase {
+
+  public function testGetDuplicatesUnsupervised() {
+    $email = uniqid('test@');
+
+    $testContacts = $this->saveTestRecords('Contact', [
+      'records' => [[], [], [], ['email_primary.email' => 'something@el.se']],
+      'defaults' => ['email_primary.email' => $email],
+    ])->column('id');
+
+    $found = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('Individual.Unsupervised')
+      ->addValue('email_primary.email', $email)
+      ->execute()->column('id');
+
+    $this->assertCount(3, $found);
+    $this->assertNotContains($testContacts[3], $found);
+  }
+
+  public function testGetFieldsForContactGetDuplicatesAction() {
+    $fields = Contact::getFields(FALSE)
+      ->setAction('getDuplicates')
+      ->execute()
+      ->indexBy('name');
+
+    $this->assertEquals('Contact', $fields['contact_type']['entity']);
+    $this->assertEquals('Email', $fields['email_primary.email']['entity']);
+  }
+
+  public function testGetRuleGroupNames() {
+    $this->createTestRecord('DedupeRuleGroup', [
+      'contact_type' => 'Individual',
+      'name' => 'houseRule',
+      'used' => 'General',
+      'threshold' => 10,
+    ]);
+
+    $meta = Contact::getActions(FALSE)
+      ->addWhere('name', '=', 'getDuplicates')
+      ->execute()
+      ->first();
+
+    // Default rules
+    $this->assertContains('Individual.Unsupervised', $meta['params']['dedupeRule']['options']);
+    $this->assertContains('Individual.Supervised', $meta['params']['dedupeRule']['options']);
+    $this->assertContains('Organization.Unsupervised', $meta['params']['dedupeRule']['options']);
+    $this->assertContains('Organization.Supervised', $meta['params']['dedupeRule']['options']);
+
+    // The rule we just made up
+    $this->assertContains('houseRule', $meta['params']['dedupeRule']['options']);
+  }
+
+  public function testDedupeWithCustomFields() {
+    $customGroup = $this->createTestRecord('CustomGroup', ['name' => 'test1']);
+
+    $customFieldText = $this->createTestRecord('CustomField', [
+      'name' => 'text',
+      'custom_group_id.name' => 'test1',
+    ]);
+    $customFieldSelect = $this->createTestRecord('CustomField', [
+      'name' => 'select',
+      'custom_group_id.name' => 'test1',
+      'html_type' => 'Select',
+      'option_values' => ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'],
+    ]);
+
+    $customRuleGroup = $this->createTestRecord('DedupeRuleGroup', [
+      'contact_type' => 'Individual',
+      'name' => 'customRule',
+      'used' => 'General',
+      'threshold' => 10,
+    ]);
+    $this->saveTestRecords('DedupeRule', [
+      'defaults' => ['dedupe_rule_group_id' => $customRuleGroup['id'], 'rule_weight' => 5],
+      'records' => [
+        ['rule_table' => 'civicrm_contact', 'rule_field' => 'last_name'],
+        ['rule_table' => $customGroup['table_name'], 'rule_field' => $customFieldText['column_name']],
+        ['rule_table' => $customGroup['table_name'], 'rule_field' => $customFieldSelect['column_name']],
+      ],
+    ]);
+
+    $testContacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['last_name' => 'A1', 'test1.select' => 'g'],
+        ['last_name' => 'A1', 'test1.text' => 'T1'],
+        ['last_name' => 'A2', 'test1.text' => 'T1', 'test1.select' => 'r'],
+        ['last_name' => 'A2', 'test1.text' => 'T1', 'test1.select' => 'g'],
+        ['last_name' => 'A2', 'test1.text' => 'T2', 'test1.select' => 'g'],
+      ],
+    ])->column('id');
+
+    $found = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('customRule')
+      ->addValue('last_name', 'A1')
+      ->addValue('test1.text', 'T1')
+      ->addValue('test1.select:label', 'Green')
+      ->execute()->column('id');
+
+    $this->assertCount(3, $found);
+    $this->assertContains($testContacts[0], $found);
+    $this->assertContains($testContacts[1], $found);
+    $this->assertContains($testContacts[3], $found);
+
+    $found = Contact::getDuplicates(FALSE)
+      ->setDedupeRule('customRule')
+      ->addValue('last_name', 'A2')
+      ->addValue('test1.text', 'T2')
+      ->addValue('test1.select:label', 'Red')
+      ->execute()->column('id');
+
+    $this->assertCount(2, $found);
+    $this->assertContains($testContacts[2], $found);
+    $this->assertContains($testContacts[4], $found);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds an API for finding duplicate contacts given a set of values to match.

Technical Details
-------------------
This is an updated version of #21690. The blocker which killed that PR was the lack of integration between the Contact API and location fields (email, address, phone, IM). That's been solved now so this PR incorporates the new syntax (e.g. `phone_primary.phone`). Note that only "primary" locations are supported, and this is actually a limitation in the core deduper.

Comments
------------------
This PR should unblock a deduping feature for Afform.