### PR TITLE
Use shared parent formRule in custom import api

### DIFF
--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -8,11 +8,10 @@ class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
   /**
    * Build the form object.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
-    $savedMappingID = (int) $this->getSubmittedValue('savedMapping');
-    $this->buildSavedMappingFields($savedMappingID);
+  public function buildQuickForm(): void {
+    $this->addSavedMappingFields();
     $this->addFormRule(['CRM_Custom_Import_Form_MapField', 'formRule']);
     $this->addMapper();
     $this->addFormButtons();
@@ -27,7 +26,7 @@ class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @return array|bool
    *   list of errors to be posted back to the form
    */
-  public static function formRule($fields) {
+  public static function formRule(array $fields) {
     // todo - this could be shared with other mapFields forms.
     $errors = [];
     if (!array_key_exists('savedMapping', $fields)) {
@@ -44,37 +43,7 @@ class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
         $errors['_qf_default'] .= ts('Missing required field: %1', [1 => ts('Contact ID or External Identifier')]);
       }
     }
-
-    if (!empty($fields['saveMapping'])) {
-      $nameField = $fields['saveMappingName'] ?? NULL;
-      if (empty($nameField)) {
-        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
-      }
-      else {
-        if (CRM_Core_BAO_Mapping::checkMapping($nameField, CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Multi value custom data'))) {
-          $errors['saveMappingName'] = ts('Duplicate Mapping Name');
-        }
-      }
-    }
-
-    //display Error if loaded mapping is not selected
-    if (array_key_exists('loadMapping', $fields)) {
-      $getMapName = $fields['savedMapping'] ?? NULL;
-      if (empty($getMapName)) {
-        $errors['savedMapping'] = ts('Select saved mapping');
-      }
-    }
-
-    if (!empty($errors)) {
-      if (!empty($errors['saveMappingName'])) {
-        $_flag = 1;
-        $assignError = new CRM_Core_Page();
-        $assignError->assign('mappingDetailsError', $_flag);
-      }
-      return $errors;
-    }
-
-    return TRUE;
+    return empty($errors) ? TRUE : $errors;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Same as https://github.com/civicrm/civicrm-core/pull/24388

Before
----------------------------------------
Copy & paste

After
----------------------------------------
Parent function is used



Technical Details
----------------------------------------
`   if (array_key_exists('loadMapping', $fields)) {` is never true as the field is not on the form now (if it ever was)

Comments
----------------------------------------
