### PR TITLE
[REF] Variable use cleanup

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -215,17 +215,17 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
         // ensure there does not exists a contact_id / uf_id pair
         // in the DB. This might be due to multiple emails per contact
         // CRM-9091
-        $sql = "
+        $sql = '
 SELECT id
 FROM   civicrm_uf_match
 WHERE  contact_id = %1
 AND    domain_id = %2
-";
-        $params = [
+';
+
+        $conflict = CRM_Core_DAO::singleValueQuery($sql, [
           1 => [$dao->contact_id, 'Integer'],
           2 => [CRM_Core_Config::domainID(), 'Integer'],
-        ];
-        $conflict = CRM_Core_DAO::singleValueQuery($sql, $params);
+        ]);
 
         if (!$conflict) {
           $found = TRUE;
@@ -291,14 +291,13 @@ OR     uf_name      = %2
 OR     uf_id        = %3 )
 AND    domain_id    = %4
 ";
-      $params = [
+
+      $conflict = CRM_Core_DAO::singleValueQuery($sql, [
         1 => [$ufmatch->contact_id, 'Integer'],
         2 => [$ufmatch->uf_name, 'String'],
         3 => [$ufmatch->uf_id, 'Integer'],
         4 => [$ufmatch->domain_id, 'Integer'],
-      ];
-
-      $conflict = CRM_Core_DAO::singleValueQuery($sql, $params);
+      ]);
 
       if (!$conflict) {
         $ufmatch = CRM_Core_BAO_UFMatch::create((array) $ufmatch);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Variable use cleanup

Before
----------------------------------------
`$params` is re-used & potentially overwritten

After
----------------------------------------
We just pass the array into `CRM_Core_DAO::executeQuery` - it hasn't been pass-by-ref for a long time

Technical Details
----------------------------------------

Comments
----------------------------------------
@demeritcowboy this is just the minor cleanup from that other PR on `synchronizeContact`