### PR TITLE
(NFC) Autoformat big clusters of `list()` statements

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -167,7 +167,7 @@ class CRM_Activity_BAO_Query {
    * @throws \CRM_Core_Exception
    */
   public static function whereClauseSingle(&$values, &$query) {
-    list($name, $op, $value, $grouping) = $values;
+    [$name, $op, $value, $grouping] = $values;
 
     $fields = CRM_Activity_BAO_Activity::exportableFields();
     $fieldSpec = $query->getFieldSpec($name);
@@ -199,7 +199,7 @@ class CRM_Activity_BAO_Query {
 
       case 'activity_priority':
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("$name.label", $op, $value, 'String');
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Activity_DAO_Activity', $name, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Activity_DAO_Activity', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [
           1 => $fields[$name]['title'],
           2 => $op,
@@ -332,7 +332,7 @@ class CRM_Activity_BAO_Query {
       case 'source_contact_id':
         $columnName = strstr($name, '_id') ? 'id' : 'sort_name';
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("source_contact.{$columnName}", $op, $value, CRM_Utils_Type::typeToString($fields[$name]['type']));
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Contact', $columnName, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Contact', $columnName, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [
           1 => $fields[$name]['title'],
           2 => $op,
@@ -626,7 +626,7 @@ class CRM_Activity_BAO_Query {
    * @throws \CRM_Core_Exception
    */
   public static function whereClauseSingleActivityText(&$values, &$query) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     $activityOptionValues = $query->getWhereValues('activity_option', $grouping);
     $activityOption = CRM_Utils_Array::value(2, $activityOptionValues, 6);
 
@@ -642,7 +642,7 @@ class CRM_Activity_BAO_Query {
     }
 
     $query->_where[$grouping][] = "( " . implode(' OR ', $clauses) . " )";
-    list($qillOp, $qillVal) = $query->buildQillForFieldValue(NULL, $name, $value, $op);
+    [$qillOp, $qillVal] = $query->buildQillForFieldValue(NULL, $name, $value, $op);
     $query->_qill[$grouping][] = ts("%1 %2 '%3'", [
       1 => $label,
       2 => $qillOp,

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1397,7 +1397,7 @@ HERESQL;
 
       $displayName = $info['display_name'] ?? NULL;
 
-      list($result[CRM_Utils_Array::value('contact_id', $info)], $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate(
+      [$result[CRM_Utils_Array::value('contact_id', $info)], $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
           'groupName' => 'msg_tpl_workflow_case',
           'workflow' => 'case_activity',
@@ -1597,7 +1597,7 @@ HERESQL;
           $groupInfo['title'] = $results['title'];
           $params = [['group', '=', $groupInfo['id'], 0, 0]];
           $return = ['contact_id' => 1, 'sort_name' => 1, 'display_name' => 1, 'email' => 1, 'phone' => 1];
-          list($globalContacts) = CRM_Contact_BAO_Query::apiQuery($params, $return, NULL, $sort, $offset, $rowCount, TRUE, $returnOnlyCount, FALSE);
+          [$globalContacts] = CRM_Contact_BAO_Query::apiQuery($params, $return, NULL, $sort, $offset, $rowCount, TRUE, $returnOnlyCount, FALSE);
 
           if ($returnOnlyCount) {
             return $globalContacts;
@@ -3074,13 +3074,13 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
         'record_type_id' => 'Activity Source',
         'return' => 'contact_id',
       ]);
-      list($name, $address) = CRM_Contact_BAO_Contact_Location::getEmailDetails($sourceContactId);
+      [$name, $address] = CRM_Contact_BAO_Contact_Location::getEmailDetails($sourceContactId);
     }
 
     // If 'From' email address not found for Source Activity Contact then
     //   fetch the email from domain or logged in user.
     if (empty($address)) {
-      list($name, $address) = CRM_Core_BAO_Domain::getDefaultReceiptFrom();
+      [$name, $address] = CRM_Core_BAO_Domain::getDefaultReceiptFrom();
     }
 
     return "$name <$address>";

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -171,7 +171,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     $result = [];
     foreach ($caseRolesXML as $caseRoleXML) {
       foreach ($caseRoleXML->RelationshipType as $relationshipTypeXML) {
-        list($relationshipTypeID,) = $this->locateNameOrLabel($relationshipTypeXML);
+        [$relationshipTypeID] = $this->locateNameOrLabel($relationshipTypeXML);
         if ($relationshipTypeID === FALSE) {
           continue;
         }
@@ -330,7 +330,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
 
     if (!empty($caseTypeXML->CaseRoles) && $caseTypeXML->CaseRoles->RelationshipType) {
       foreach ($caseTypeXML->CaseRoles->RelationshipType as $relTypeXML) {
-        list(, $relationshipTypeMachineName) = $this->locateNameOrLabel($relTypeXML);
+        [, $relationshipTypeMachineName] = $this->locateNameOrLabel($relTypeXML);
         $result[] = $relationshipTypeMachineName;
       }
     }
@@ -511,7 +511,7 @@ AND        a.is_deleted = 0
       if (!$activityDate) {
         $activityDate = $params['activity_date_time'];
       }
-      list($activity_date, $activity_time) = CRM_Utils_Date::setDateDefaults($activityDate);
+      [$activity_date, $activity_time] = CRM_Utils_Date::setDateDefaults($activityDate);
       $activityDateTime = CRM_Utils_Date::processDate($activity_date, $activity_time);
       //add reference offset to date.
       if ((int) $activityTypeXML->reference_offset) {
@@ -621,7 +621,7 @@ AND        a.is_deleted = 0
     $targetContactId = is_array($activityParams['target_contact_id'])
       ? CRM_Utils_Array::first($activityParams['target_contact_id'])
       : $activityParams['target_contact_id'];
-    list($relTypeId, $a, $b) = explode('_', $activityTypeXML->default_assignee_relationship);
+    [$relTypeId, $a, $b] = explode('_', $activityTypeXML->default_assignee_relationship);
 
     $params = [
       'relationship_type_id' => $relTypeId,

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -180,7 +180,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
   public static function getMember($groupID, $useCache = TRUE, $limit = 0) {
     $params = [['group', '=', $groupID, 0, 0]];
     $returnProperties = ['contact_id'];
-    list($contacts) = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $limit, $useCache);
+    [$contacts] = CRM_Contact_BAO_Query::apiQuery($params, $returnProperties, NULL, NULL, 0, $limit, $useCache);
 
     $aMembers = [];
     foreach ($contacts as $contact) {

--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -175,8 +175,8 @@ class CRM_Contact_BAO_ProximityQuery {
   public static function where($latitude, $longitude, $distance, $tablePrefix = 'civicrm_address') {
     self::initialize();
 
-    list($minLongitude, $maxLongitude) = self::earthLongitudeRange($longitude, $latitude, $distance);
-    list($minLatitude, $maxLatitude) = self::earthLatitudeRange($longitude, $latitude, $distance);
+    [$minLongitude, $maxLongitude] = self::earthLongitudeRange($longitude, $latitude, $distance);
+    [$minLatitude, $maxLatitude] = self::earthLatitudeRange($longitude, $latitude, $distance);
 
     // DONT consider NAN values (which is returned by rad2deg php function)
     // for checking BETWEEN geo_code's criteria as it throws obvious 'NAN' field not found DB: Error
@@ -218,7 +218,7 @@ ACOS(
    * @throws Exception
    */
   public static function process(&$query, &$values) {
-    list($name, $op, $distance, $grouping, $wildcard) = $values;
+    [$name, $op, $distance, $grouping, $wildcard] = $values;
 
     // also get values array for all address related info
     $proximityVars = [

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -789,7 +789,7 @@ class CRM_Contact_BAO_Query {
           }
         }
         elseif (isset($field['where'])) {
-          list($tableName, $fieldName) = explode('.', $field['where'], 2);
+          [$tableName, $fieldName] = explode('.', $field['where'], 2);
           if (isset($tableName)) {
             if (!empty(self::$_dependencies[$tableName])) {
               $this->_tables['civicrm_address'] = 1;
@@ -1095,7 +1095,7 @@ class CRM_Contact_BAO_Query {
         if ((in_array($elementCmpName, self::$_locationSpecificFields) || !empty($addressCustomFieldIds))
           && !in_array($elementCmpName, ['email', 'phone', 'im', 'openid'])
         ) {
-          list($aName, $addressJoin) = $this->addAddressTable($name, $lCond);
+          [$aName, $addressJoin] = $this->addAddressTable($name, $lCond);
           $locationTypeJoin[$tName] = " ( $aName.location_type_id = $ltName.id ) ";
           $processed[$aName] = 1;
         }
@@ -1103,7 +1103,7 @@ class CRM_Contact_BAO_Query {
         $cond = $elementType = '';
         if (strpos($elementName, '-') !== FALSE) {
           // this is either phone, email or IM
-          list($elementName, $elementType) = explode('-', $elementName);
+          [$elementName, $elementType] = explode('-', $elementName);
 
           if (($elementName != 'phone') && ($elementName != 'im')) {
             $cond = self::getPrimaryCondition($elementType);
@@ -1186,7 +1186,7 @@ class CRM_Contact_BAO_Query {
         }
 
         if ($field && isset($field['where'])) {
-          list($tableName, $fieldName) = explode('.', $field['where'], 2);
+          [$tableName, $fieldName] = explode('.', $field['where'], 2);
           $pf = substr($tableName, 8);
           $tName = $name . '-' . $pf . $elementType;
           if (isset($tableName)) {
@@ -1445,7 +1445,7 @@ class CRM_Contact_BAO_Query {
     else {
       if (!empty($this->_paramLookup['group'])) {
 
-        list($name, $op, $value, $grouping, $wildcard) = $this->_paramLookup['group'][0];
+        [$name, $op, $value, $grouping, $wildcard] = $this->_paramLookup['group'][0];
 
         if (is_array($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
           $this->_paramLookup['group'][0][1] = key($value);
@@ -1560,7 +1560,7 @@ class CRM_Contact_BAO_Query {
    */
   public static function fixDateValues($relative, &$from, &$to) {
     if ($relative) {
-      list($from, $to) = CRM_Utils_Date::getFromTo($relative, $from, $to);
+      [$from, $to] = CRM_Utils_Date::getFromTo($relative, $from, $to);
     }
   }
 
@@ -2061,7 +2061,7 @@ class CRM_Contact_BAO_Query {
         if ($this->_params[$id][0] == 'id' || $this->_params[$id][0] == 'contact_id') {
           $this->_where[0][] = self::buildClause("contact_a.id", $this->_params[$id][1], $this->_params[$id][2]);
           $field = $this->_fields['id'] ?? NULL;
-          list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(
+          [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue(
             'CRM_Contact_BAO_Contact',
             "contact_a.id",
             $this->_params[$id][2],
@@ -2190,7 +2190,7 @@ class CRM_Contact_BAO_Query {
 
       $this->_where[$grouping][] = self::buildClause($where, $op, $value);
       $this->_tables[$aName] = $this->_whereTables[$aName] = 1;
-      list($qillop, $qillVal) = self::buildQillForFieldValue('CRM_Core_DAO_Address', "state_province_id", $value, $op);
+      [$qillop, $qillVal] = self::buildQillForFieldValue('CRM_Core_DAO_Address', "state_province_id", $value, $op);
       $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $field['title'], 2 => $qillop, 3 => $qillVal]);
     }
     elseif (!empty($field['pseudoconstant'])) {
@@ -2221,7 +2221,7 @@ class CRM_Contact_BAO_Query {
       $this->_where[$grouping][] = self::buildClause($where, $op, $value, 'Positive');
       $this->_tables[$aName] = $this->_whereTables[$aName] = 1;
 
-      list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
+      [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
       $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $field['title'], 2 => $qillop, 3 => $qillVal]);
     }
     elseif ($name === 'world_region') {
@@ -2296,7 +2296,7 @@ class CRM_Contact_BAO_Query {
         $type = CRM_Utils_Type::typeToString($field['type']);
       }
 
-      list($tableName, $fieldName) = explode('.', $field['where'], 2);
+      [$tableName, $fieldName] = explode('.', $field['where'], 2);
 
       if (isset($locType[1]) &&
         is_numeric($locType[1])
@@ -2304,7 +2304,7 @@ class CRM_Contact_BAO_Query {
         $setTables = FALSE;
 
         //get the location name
-        list($tName, $fldName) = self::getLocationTableName($field['where'], $locType);
+        [$tName, $fldName] = self::getLocationTableName($field['where'], $locType);
         $fieldName = "`$tName`.$fldName";
 
         // we set both _tables & whereTables because whereTables doesn't seem to do what the name implies it should
@@ -2320,7 +2320,7 @@ class CRM_Contact_BAO_Query {
         }
       }
 
-      list($qillop, $qillVal) = self::buildQillForFieldValue(NULL, $field['title'], $value, $op);
+      [$qillop, $qillVal] = self::buildQillForFieldValue(NULL, $field['title'], $value, $op);
       $this->_qill[$grouping][] = ts("%1 %2 %3", [
         1 => $field['title'],
         2 => $qillop,
@@ -2359,7 +2359,7 @@ class CRM_Contact_BAO_Query {
     }
 
     if ($setTables && isset($field['where'])) {
-      list($tableName, $fieldName) = explode('.', $field['where'], 2);
+      [$tableName, $fieldName] = explode('.', $field['where'], 2);
       if (isset($tableName)) {
         $this->_tables[$tableName] = 1;
         $this->_whereTables[$tableName] = 1;
@@ -2376,7 +2376,7 @@ class CRM_Contact_BAO_Query {
    */
   public static function getLocationTableName(&$where, &$locType) {
     if (isset($locType[1]) && is_numeric($locType[1])) {
-      list($tbName, $fldName) = explode(".", $where);
+      [$tbName, $fldName] = explode(".", $where);
 
       //get the location name
       $locationType = CRM_Core_DAO_Address::buildOptions('location_type_id', 'validate');
@@ -2833,7 +2833,7 @@ class CRM_Contact_BAO_Query {
    * @param array $values
    */
   public function deletedContacts($values) {
-    list($_, $_, $value, $grouping, $_) = $values;
+    [$_, $_, $value, $grouping, $_] = $values;
     if ($value) {
       // *prepend* to the relevant grouping as this is quite an important factor
       array_unshift($this->_qill[$grouping], ts('Search in Trash'));
@@ -2848,7 +2848,7 @@ class CRM_Contact_BAO_Query {
    * @throws \CRM_Core_Exception
    */
   public function contactType(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $subTypes = [];
     $clause = [];
@@ -2868,7 +2868,7 @@ class CRM_Contact_BAO_Query {
           $subType = NULL;
           $contactType = $k;
           if (strpos($k, CRM_Core_DAO::VALUE_SEPARATOR)) {
-            list($contactType, $subType) = explode(CRM_Core_DAO::VALUE_SEPARATOR, $k, 2);
+            [$contactType, $subType] = explode(CRM_Core_DAO::VALUE_SEPARATOR, $k, 2);
           }
 
           if (!empty($subType)) {
@@ -2913,7 +2913,7 @@ class CRM_Contact_BAO_Query {
    * @param array $values
    */
   public function contactSubType(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     $this->includeContactSubTypes($value, $grouping, $op);
   }
 
@@ -2966,7 +2966,7 @@ class CRM_Contact_BAO_Query {
    * @throws \Exception
    */
   public function group($values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     // If the $value is in OK (operator as key) array format we need to extract the key as operator and value first
     if (is_array($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
@@ -3097,7 +3097,7 @@ class CRM_Contact_BAO_Query {
       $this->_where[$grouping][] = ' ( ' . implode($and, $groupClause) . ' ) ';
     }
 
-    list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Group', 'id', $value, $op);
+    [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Group', 'id', $value, $op);
     $this->_qill[$grouping][] = ts("Group(s) %1 %2", [1 => $qillop, 2 => $qillVal]);
     if (strpos($op, 'NULL') === FALSE) {
       $this->_qill[$grouping][] = ts("Group Status %1", [1 => implode(' ' . ts('or') . ' ', $this->getSelectedGroupStatuses($grouping))]);
@@ -3194,7 +3194,7 @@ WHERE  $smartGroupClause
    * @param $values
    */
   public function ufUser(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if ($value == 1) {
       $this->_tables['civicrm_uf_match'] = $this->_whereTables['civicrm_uf_match'] = ' INNER JOIN civicrm_uf_match ON civicrm_uf_match.contact_id = contact_a.id ';
@@ -3217,7 +3217,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function tagSearch(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $op = "LIKE";
     $value = "%{$value}%";
@@ -3282,7 +3282,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function tag(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     // API/Search Builder format array(operator => array(values))
     if (is_array($value)) {
@@ -3307,7 +3307,7 @@ WHERE  $smartGroupClause
       }
     }
 
-    list($qillop, $qillVal) = self::buildQillForFieldValue('CRM_Core_DAO_EntityTag', "tag_id", $value, $op, ['onlyActive' => FALSE]);
+    [$qillop, $qillVal] = self::buildQillForFieldValue('CRM_Core_DAO_EntityTag', "tag_id", $value, $op, ['onlyActive' => FALSE]);
 
     // implode array, then remove all spaces
     $value = str_replace(' ', '', implode(',', (array) $value));
@@ -3383,7 +3383,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function notes(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $noteOptionValues = $this->getWhereValues('note_option', $grouping);
     $noteOption = CRM_Utils_Array::value('2', $noteOptionValues, '6');
@@ -3417,7 +3417,7 @@ WHERE  $smartGroupClause
       $label = $label ? ts('Note: Body and Subject') : ts('Note: Subject Only');
     }
     $this->_where[$grouping][] = "( " . implode(' OR ', $clauses) . " )";
-    list($qillOp, $qillVal) = self::buildQillForFieldValue(NULL, $name, $n, $op);
+    [$qillOp, $qillVal] = self::buildQillForFieldValue(NULL, $name, $n, $op);
     $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $label, 2 => $qillOp, 3 => $qillVal]);
   }
 
@@ -3457,7 +3457,7 @@ WHERE  $smartGroupClause
    * @param array $values
    */
   public function sortName(&$values) {
-    list($fieldName, $op, $value, $grouping, $wildcard) = $values;
+    [$fieldName, $op, $value, $grouping, $wildcard] = $values;
 
     // handle IS NULL / IS NOT NULL / IS EMPTY / IS NOT EMPTY
     if ($this->nameNullOrEmptyOp($fieldName, $op, $grouping)) {
@@ -3531,10 +3531,10 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function greetings(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     $name .= '_display';
 
-    list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
+    [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
     $this->_qill[$grouping][] = ts('Greeting %1 %2', [1 => $qillop, 2 => $qillVal]);
     $this->_where[$grouping][] = self::buildClause("contact_a.{$name}", $op, $value, 'String');
   }
@@ -3548,7 +3548,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   protected function email(&$values, $isForcePrimaryOnly) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     $this->_tables['civicrm_email'] = $this->_whereTables['civicrm_email'] = 1;
 
     // CRM-18147: for Contact's GET API, email fieldname got appended with its entity as in {$apiEntiy}_{$name}
@@ -3595,7 +3595,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function phone_numeric(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     // Strip non-numeric characters; allow wildcards
     $number = preg_replace('/[^\d%]/', '', $value);
     if ($number) {
@@ -3617,7 +3617,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function phone_option_group($values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     $option = ($name == 'phone_phone_type_id' ? 'phone_type_id' : 'location_type_id');
     $options = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', $option);
     $optionName = $options[$value];
@@ -3634,7 +3634,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function street_address(&$values) {
-    list($name, $op, $value, $grouping) = $values;
+    [$name, $op, $value, $grouping] = $values;
 
     if (!$op) {
       $op = 'LIKE';
@@ -3667,7 +3667,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function street_number(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (!$op) {
       $op = '=';
@@ -3698,7 +3698,7 @@ WHERE  $smartGroupClause
    * @param array $values
    */
   public function sortByCharacter(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $name = trim($value);
     $cond = " contact_a.sort_name LIKE '" . CRM_Core_DAO::escapeWildCardString($name) . "%'";
@@ -3739,7 +3739,7 @@ WHERE  $smartGroupClause
       return;
     }
 
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     // Handle numeric postal code range searches properly by casting the column as numeric
     if (is_numeric($value)) {
@@ -3783,7 +3783,7 @@ WHERE  $smartGroupClause
    * @return string
    */
   public function locationType(&$values, $status = NULL) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (is_array($value)) {
       $this->_where[$grouping][] = 'civicrm_address.location_type_id IN (' . implode(',', $value) . ')';
@@ -3815,7 +3815,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function country(&$values, $fromStateProvince = TRUE) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (!$fromStateProvince) {
       $stateValues = $this->getWhereValues('state_province', $grouping);
@@ -3832,7 +3832,7 @@ WHERE  $smartGroupClause
       $this->_whereTables['civicrm_address'] = 1;
 
       $countryClause = self::buildClause('civicrm_address.country_id', $op, $value, 'Positive');
-      list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, 'country_id', $value, $op);
+      [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, 'country_id', $value, $op);
       $countryQill = ts("%1 %2 %3", [1 => 'Country', 2 => $qillop, 3 => $qillVal]);
 
       if (!$fromStateProvince) {
@@ -3863,7 +3863,7 @@ WHERE  $smartGroupClause
    * @return string
    */
   public function county(&$values, $status = NULL) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (!is_array($value)) {
       // force the county to be an array
@@ -3933,14 +3933,14 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function stateProvince(&$values, $status = NULL) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $stateClause = self::buildClause('civicrm_address.state_province_id', $op, $value, 'Positive');
     $this->_tables['civicrm_address'] = 1;
     $this->_whereTables['civicrm_address'] = 1;
 
     $countryValues = $this->getWhereValues('country', $grouping);
-    list($countryClause, $countryQill) = $this->country($countryValues, TRUE);
+    [$countryClause, $countryQill] = $this->country($countryValues, TRUE);
     if ($countryClause) {
       $clause = "( $stateClause AND $countryClause )";
     }
@@ -3949,7 +3949,7 @@ WHERE  $smartGroupClause
     }
 
     $this->_where[$grouping][] = $clause;
-    list($qillop, $qillVal) = self::buildQillForFieldValue('CRM_Core_DAO_Address', "state_province_id", $value, $op);
+    [$qillop, $qillVal] = self::buildQillForFieldValue('CRM_Core_DAO_Address', "state_province_id", $value, $op);
     if (!$status) {
       $this->_qill[$grouping][] = ts("State/Province %1 %2 %3", [1 => $qillop, 2 => $qillVal, 3 => $countryQill]);
     }
@@ -3964,7 +3964,7 @@ WHERE  $smartGroupClause
    * @param array $values
    */
   public function changeLog(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $targetName = $this->getWhereValues('changed_by', $grouping);
     if (!$targetName) {
@@ -3978,7 +3978,7 @@ WHERE  $smartGroupClause
     $this->_tables['civicrm_log'] = $this->_whereTables['civicrm_log'] = 1;
     $fieldTitle = ts('Altered By');
 
-    list($qillop, $qillVal) = self::buildQillForFieldValue(NULL, 'changed_by', $name, 'LIKE');
+    [$qillop, $qillVal] = self::buildQillForFieldValue(NULL, 'changed_by', $name, 'LIKE');
     $this->_qill[$grouping][] = ts("%1 %2 '%3'", [
       1 => $fieldTitle,
       2 => $qillop,
@@ -4017,7 +4017,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function demographics(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (($name == 'age_low') || ($name == 'age_high')) {
       $this->ageRangeQueryBuilder($values,
@@ -4044,7 +4044,7 @@ WHERE  $smartGroupClause
    * @param $values
    */
   public function privacy(&$values) {
-    list($name, $op, $value, $grouping) = $values;
+    [$name, $op, $value, $grouping] = $values;
     if (is_array($value)) {
       if (in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
         $op = key($value);
@@ -4063,7 +4063,7 @@ WHERE  $smartGroupClause
    * @param $values
    */
   public function privacyOptions($values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (empty($value) || !is_array($value)) {
       return;
@@ -4106,7 +4106,7 @@ WHERE  $smartGroupClause
    * @throws \CRM_Core_Exception
    */
   public function preferredCommunication(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (!is_array($value)) {
       $value = str_replace(['(', ')'], '', explode(",", $value));
@@ -4115,7 +4115,7 @@ WHERE  $smartGroupClause
       $op = key($value);
       $value = $value[$op];
     }
-    list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Contact', $name, $value, $op);
+    [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contact_DAO_Contact', $name, $value, $op);
 
     if (self::caseImportant($op)) {
       $value = implode("[[:cntrl:]]|[[:cntrl:]]", (array) $value);
@@ -4133,7 +4133,7 @@ WHERE  $smartGroupClause
    * @param array $values
    */
   public function relationship(&$values) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     if ($this->_relationshipValuesAdded) {
       return;
     }
@@ -4545,7 +4545,7 @@ civicrm_relationship.start_date > {$today}
    */
   public static function getQuery($params = NULL, $returnProperties = NULL, $count = FALSE) {
     $query = new CRM_Contact_BAO_Query($params, $returnProperties);
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
     $groupBy = ($query->_useGroupBy) ? 'GROUP BY contact_a.id' : '';
 
     $query = "$select $from $where $groupBy $having";
@@ -4617,7 +4617,7 @@ civicrm_relationship.start_date > {$today}
     // note : this modifies _fromClause and _simpleFromClause
     $query->includePseudoFieldsJoin($sort);
 
-    list($select, $from, $where, $having) = $query->query($count);
+    [$select, $from, $where, $having] = $query->query($count);
 
     if (!empty($query->_permissionWhereClause)) {
       if (!empty($query->_permissionFromClause) && !stripos($from, 'aclContactCache')) {
@@ -4720,7 +4720,7 @@ civicrm_relationship.start_date > {$today}
     $customFieldName = self::getCustomFieldName($fieldName);
 
     if (substr($fieldName, -9, 9) == '_relative') {
-      list($from, $to) = CRM_Utils_Date::getFromTo($values, NULL, NULL);
+      [$from, $to] = CRM_Utils_Date::getFromTo($values, NULL, NULL);
     }
     else {
       if ($fieldName == $customFieldName . '_to' && !empty($formValues[$customFieldName . '_from'])) {
@@ -4732,7 +4732,7 @@ civicrm_relationship.start_date > {$today}
       $to = $formValues[$customFieldName . '_to'] ?? NULL;
 
       if (self::isCustomDateField($customFieldName)) {
-        list($from, $to) = CRM_Utils_Date::getFromTo(NULL, $from, $to);
+        [$from, $to] = CRM_Utils_Date::getFromTo(NULL, $from, $to);
       }
     }
 
@@ -4843,7 +4843,7 @@ civicrm_relationship.start_date > {$today}
       $groupBy = array_map('trim', (array) $groupBy);
       $aggregateFunctions = '/(ROUND|AVG|COUNT|GROUP_CONCAT|SUM|MAX|MIN|IF)[[:blank:]]*\(/i';
       foreach ($selectClauses as $key => &$val) {
-        list($selectColumn, $alias) = array_pad(preg_split('/ as /i', $val), 2, NULL);
+        [$selectColumn, $alias] = array_pad(preg_split('/ as /i', $val), 2, NULL);
         // append ANY_VALUE() keyword
         if (!in_array($selectColumn, $groupBy) && preg_match($aggregateFunctions, trim($selectColumn)) !== 1) {
           $val = ($aggregateFunction == 'GROUP_CONCAT') ?
@@ -4906,7 +4906,7 @@ civicrm_relationship.start_date > {$today}
           }
         }
         else {
-          list($selectColumn, $alias) = array_pad($aliasArray, 2, NULL);
+          [$selectColumn, $alias] = array_pad($aliasArray, 2, NULL);
           $dateRegex = '/^(DATE_FORMAT|DATE_ADD|CASE)/i';
           $tableName = current(explode('.', $selectColumn));
           $primaryKey = "{$tableName}.id";
@@ -5020,7 +5020,7 @@ civicrm_relationship.start_date > {$today}
     CRM_Utils_Type::validateAll($cids, 'Positive');
     $this->_includeContactIds = $includeContactIds;
     $onlyDeleted = in_array(['deleted_contacts', '=', '1', '0', '0'], $this->_params);
-    list($select, $from, $where) = $this->query(FALSE, FALSE, FALSE, $onlyDeleted);
+    [$select, $from, $where] = $this->query(FALSE, FALSE, FALSE, $onlyDeleted);
     $select .= sprintf(", (%s) AS _wgt", $this->createSqlCase('contact_a.id', $cids));
     $where .= sprintf(' AND contact_a.id IN (%s)', implode(',', $cids));
     $order = 'ORDER BY _wgt';
@@ -5132,7 +5132,7 @@ civicrm_relationship.start_date > {$today}
    * @throws \CRM_Core_Exception
    */
   public function summaryContribution($context = NULL) {
-    list($innerselect, $from, $where, $having) = $this->query(TRUE);
+    [$innerselect, $from, $where, $having] = $this->query(TRUE);
     if (!empty($this->_permissionFromClause) && !stripos($from, 'aclContactCache')) {
       $from .= " $this->_permissionFromClause";
     }
@@ -5297,7 +5297,7 @@ civicrm_relationship.start_date > {$today}
     $highDBFieldName = NULL
   ) {
     // @todo - remove dateFormat - pretty sure it's never passed in...
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     if ($name !== $fieldName && $name !== "{$fieldName}_low" && $name !== "{$fieldName}_high") {
       CRM_Core_Error::deprecatedFunctionWarning('Date query builder called unexpectedly');
       return;
@@ -5436,7 +5436,7 @@ civicrm_relationship.start_date > {$today}
     $dbFieldName, $fieldTitle,
     $options = NULL
   ) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if ($name == "{$fieldName}_low" ||
       $name == "{$fieldName}_high"
@@ -5518,7 +5518,7 @@ civicrm_relationship.start_date > {$today}
     $dbFieldName, $fieldTitle,
     $options = NULL
   ) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $asofDateValues = $this->getWhereValues("{$fieldName}_asof_date", $grouping);
     // will be treated as current day
@@ -5807,7 +5807,7 @@ AND   displayRelType.is_active = 1
 ";
       }
       else {
-        list($relType, $dirOne, $dirTwo) = explode('_', $this->_displayRelationshipType);
+        [$relType, $dirOne, $dirTwo] = explode('_', $this->_displayRelationshipType);
         if ($dirOne == 'a') {
           $relationshipTypeLabel = $rTypes[$relType]['label_a_b'];
           $qcache['from'] .= "
@@ -5928,7 +5928,7 @@ AND   displayRelType.is_active = 1
       'addressee',
     ];
 
-    list($tableName, $fieldName) = explode('.', $field['where'], 2);
+    [$tableName, $fieldName] = explode('.', $field['where'], 2);
     if ($tableName == 'civicrm_contact') {
       $wc = "contact_a.$fieldName";
     }
@@ -5953,7 +5953,7 @@ AND   displayRelType.is_active = 1
       $field['name'] = $name;
     }
 
-    list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue($daoName, $field['name'], $value, $op);
+    [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue($daoName, $field['name'], $value, $op);
     $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $label, 2 => $qillop, 3 => $qillVal]);
     $this->_where[$grouping][] = self::buildClause($wc, $op, $value, $dataType);
   }
@@ -6286,7 +6286,7 @@ AND   displayRelType.is_active = 1
    * @return string
    */
   public static function getQillValue($daoName, string $name, $value, $op, string $label) {
-    list($op, $value) = self::buildQillForFieldValue($daoName, $name, $value, $op);
+    [$op, $value] = self::buildQillForFieldValue($daoName, $name, $value, $op);
     return ts('%1 %2 %3', [1 => $label, 2 => $op, 3 => $value]);
   }
 
@@ -6535,7 +6535,7 @@ AND   displayRelType.is_active = 1
    */
   public function setQillAndWhere($name, $op, $value, $grouping, $field) {
     $this->_where[$grouping][] = self::buildClause("contact_a.{$name}", $op, $value);
-    list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
+    [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $name, $value, $op);
     $this->_qill[$grouping][] = ts("%1 %2 %3", [
       1 => $field['title'],
       2 => $qillop,
@@ -6877,7 +6877,7 @@ AND   displayRelType.is_active = 1
     //CRM-15967
     $this->includePseudoFieldsJoin($sort);
 
-    list($select, $from, $where, $having) = $this->query($count, $sortByChar, $groupContacts, $onlyDeleted);
+    [$select, $from, $where, $having] = $this->query($count, $sortByChar, $groupContacts, $onlyDeleted);
 
     if ($additionalWhereClause) {
       $where = $where . ' AND ' . $additionalWhereClause;
@@ -7229,7 +7229,7 @@ AND   displayRelType.is_active = 1
    * @return string
    */
   public function getQillForField($name, $value, $op, $fieldSpec = [], $labelOverride = NULL): string {
-    list($qillop, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue($fieldSpec['bao'] ?? NULL, $name, $value, $op);
+    [$qillop, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue($fieldSpec['bao'] ?? NULL, $name, $value, $op);
     return (string) ts("%1 %2 %3", [
       1 => $labelOverride ?? $fieldSpec['title'],
       2 => $qillop,

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -245,7 +245,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
     // explode the string with _ to get the relationship type id
     // and to know which contact has to be inserted in
     // contact_id_a and which one in contact_id_b
-    list($relationshipTypeID) = explode('_', $relationshipTypes);
+    [$relationshipTypeID] = explode('_', $relationshipTypes);
 
     $relationship = new CRM_Contact_BAO_Relationship();
     if (!empty($params['id'])) {
@@ -833,7 +833,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship {
    */
   public static function checkDuplicateRelationship($params, $id, $contactId = 0, $relationshipId = 0) {
     $relationshipTypeId = $params['relationship_type_id'] ?? NULL;
-    list($type) = explode('_', $relationshipTypeId);
+    [$type] = explode('_', $relationshipTypeId);
 
     $queryString = "
 SELECT id
@@ -1203,10 +1203,10 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
       return $values;
     }
 
-    list($select1, $from1, $where1) = self::makeURLClause($contactId, $status, $numRelationship,
+    [$select1, $from1, $where1] = self::makeURLClause($contactId, $status, $numRelationship,
       $count, $relationshipId, 'a_b', $params
     );
-    list($select2, $from2, $where2) = self::makeURLClause($contactId, $status, $numRelationship,
+    [$select2, $from2, $where2] = self::makeURLClause($contactId, $status, $numRelationship,
       $count, $relationshipId, 'b_a', $params
     );
 
@@ -1551,7 +1551,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         $relTypeIds = [];
         if ($action & CRM_Core_Action::DELETE) {
           // @todo don't return relTypeId here - but it seems to be used later in a cryptic way (hint cryptic is not a complement).
-          list($relTypeId, $isDeletable) = self::isInheritedMembershipInvalidated($membershipValues, $values, $cid);
+          [$relTypeId, $isDeletable] = self::isInheritedMembershipInvalidated($membershipValues, $values, $cid);
           if ($isDeletable) {
             CRM_Member_BAO_Membership::deleteRelatedMemberships($membershipValues['owner_membership_id'], $membershipValues['contact_id']);
           }

--- a/CRM/Contact/BAO/SearchCustom.php
+++ b/CRM/Contact/BAO/SearchCustom.php
@@ -90,7 +90,7 @@ class CRM_Contact_BAO_SearchCustom {
    * @throws CRM_Core_Exception
    */
   public static function customClass($csID, $ssID) {
-    list($customSearchID, $customSearchClass, $formValues) = self::details($csID, $ssID);
+    [$customSearchID, $customSearchClass, $formValues] = self::details($csID, $ssID);
 
     if (!$customSearchID) {
       throw new CRM_Core_Exception('Could not resolve custom search ID');
@@ -124,7 +124,7 @@ class CRM_Contact_BAO_SearchCustom {
     $values = explode("\n", $args);
     $formValues = [];
     foreach ($values as $value) {
-      list($n, $v) = CRM_Utils_System::explode('=', $value, 2);
+      [$n, $v] = CRM_Utils_System::explode('=', $value, 2);
       if (!empty($v)) {
         $formValues[$n] = $v;
       }

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -523,7 +523,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   private function updateAction($params) {
-    list($params, $_) = $this->preparePostProcessParameters($params);
+    [$params, $_] = $this->preparePostProcessParameters($params);
     try {
       civicrm_api3('relationship', 'create', $params);
     }
@@ -544,7 +544,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   private function createAction($params) {
-    list($params, $primaryContactLetter) = $this->preparePostProcessParameters($params);
+    [$params, $primaryContactLetter] = $this->preparePostProcessParameters($params);
 
     $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $primaryContactLetter);
 
@@ -564,7 +564,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    */
   private function preparePostProcessParameters($values) {
     $params = $values;
-    list($relationshipTypeId, $a, $b) = explode('_', $params['relationship_type_id']);
+    [$relationshipTypeId, $a, $b] = explode('_', $params['relationship_type_id']);
 
     $params['relationship_type_id'] = $relationshipTypeId;
     $params['contact_id_' . $a] = $this->_contactId;

--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -178,7 +178,7 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
         else {
           if (substr($v[0], 0, 7) == 'custom_') {
             // Get rid of appended location type id
-            list($fieldKey) = explode('-', $v[0]);
+            [$fieldKey] = explode('-', $v[0]);
             $type = $fields[$fieldKey]['data_type'];
 
             // hack to handle custom data of type state and country
@@ -719,7 +719,7 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
         $jsSet = FALSE;
 
         if (isset($mappingId)) {
-          list($mappingName, $defaults, $noneArray, $jsSet) = $this->loadSavedMapping($mappingLocation, $x, $i, $mappingName, $mapperFields, $mappingContactType, $mappingRelation, $specialFields, $mappingPhoneType, $defaults, $noneArray, $mappingImProvider, $mappingOperator, $mappingValue);
+          [$mappingName, $defaults, $noneArray, $jsSet] = $this->loadSavedMapping($mappingLocation, $x, $i, $mappingName, $mapperFields, $mappingContactType, $mappingRelation, $specialFields, $mappingPhoneType, $defaults, $noneArray, $mappingImProvider, $mappingOperator, $mappingValue);
         }
         //Fix for Search Builder
         $j = 4;

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -221,7 +221,7 @@ class CRM_Contact_Page_AJAX {
 
     $ret = ['is_error' => 0];
 
-    list($relTypeId, $b, $a) = explode('_', $relType);
+    [$relTypeId, $b, $a] = explode('_', $relType);
 
     if ($relationshipID && $originalCid) {
       CRM_Case_BAO_Case::endCaseRole($caseID, $a, $originalCid, $relTypeId);
@@ -362,7 +362,7 @@ class CRM_Contact_Page_AJAX {
       $rowCount = Civi::settings()->get('search_autocomplete_count');
 
       // add acl clause here
-      list($aclFrom, $aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause('cc');
+      [$aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause('cc');
       if ($aclWhere) {
         $aclWhere = "AND {$aclWhere}";
       }
@@ -426,7 +426,7 @@ LIMIT {$rowCount}
       $rowCount = (int) CRM_Utils_Request::retrieveValue('rowcount', 'Integer', 20, FALSE, 'GET');
 
       // add acl clause here
-      list($aclFrom, $aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause('cc');
+      [$aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause('cc');
       if ($aclWhere) {
         $aclWhere = " AND $aclWhere";
       }

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -248,7 +248,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    * @return array
    */
   public static function &links() {
-    list($context, $contextMenu, $key) = func_get_args();
+    [$context, $contextMenu, $key] = func_get_args();
     $extraParams = ($key) ? "&key={$key}" : NULL;
     $searchContext = ($context) ? "&context=$context" : NULL;
 
@@ -413,7 +413,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             !in_array($name, $skipFields)
           ) {
             if (strpos($name, '-') !== FALSE) {
-              list($fieldName, $lType, $type) = CRM_Utils_System::explode('-', $name, 3);
+              [$fieldName, $lType, $type] = CRM_Utils_System::explode('-', $name, 3);
 
               if ($lType == 'Primary') {
                 $locationTypeName = 1;
@@ -477,7 +477,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 
       foreach ($properties as $prop) {
         if (strpos($prop, '-')) {
-          list($loc, $fld, $phoneType) = CRM_Utils_System::explode('-', $prop, 3);
+          [$loc, $fld, $phoneType] = CRM_Utils_System::explode('-', $prop, 3);
           $title = $this->_query->_fields[$fld]['title'];
           if (trim($phoneType) && !is_numeric($phoneType) && strtolower($phoneType) != $fld) {
             $title .= "-{$phoneType}";
@@ -602,7 +602,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           !in_array($key, $skipFields)
         ) {
           if (strpos($key, '-') !== FALSE) {
-            list($fieldName, $id, $type) = CRM_Utils_System::explode('-', $key, 3);
+            [$fieldName, $id, $type] = CRM_Utils_System::explode('-', $key, 3);
 
             if ($id == 'Primary') {
               $locationTypeName = 1;
@@ -715,7 +715,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           $row[$property] = $websiteUrl;
         }
         elseif (strpos($property, '-email') !== FALSE) {
-          list($locType) = explode("-email", $property);
+          [$locType] = explode("-email", $property);
           $onholdProperty = "{$locType}-on_hold";
 
           $row[$property] = $result->$property ?? NULL;

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -35,20 +35,20 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
     $this->_pages = [];
     if ($action == CRM_Core_Action::ADVANCED) {
       $this->_pages['CRM_Contact_Form_Search_Advanced'] = NULL;
-      list($task, $result) = $this->taskName($controller, 'Advanced');
+      [$task, $result] = $this->taskName($controller, 'Advanced');
     }
     elseif ($action == CRM_Core_Action::PROFILE) {
       $this->_pages['CRM_Contact_Form_Search_Builder'] = NULL;
-      list($task, $result) = $this->taskName($controller, 'Builder');
+      [$task, $result] = $this->taskName($controller, 'Builder');
     }
     // @todo - this 'should' be removable but it's getting to this controller, for now
     elseif ($action == CRM_Core_Action::COPY) {
       $this->_pages['CRM_Contact_Form_Search_Custom'] = NULL;
-      list($task, $result) = $this->taskName($controller, 'Custom');
+      [$task, $result] = $this->taskName($controller, 'Custom');
     }
     else {
       $this->_pages['CRM_Contact_Form_Search_Basic'] = NULL;
-      list($task, $result) = $this->taskName($controller, 'Basic');
+      [$task, $result] = $this->taskName($controller, 'Basic');
     }
     $this->_task = $task;
     if (is_array($task)) {

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -259,13 +259,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
     }
 
     if ($isTest && !empty($params['custom_post_id'])) {
-      $params['custom_post_id'][] = [
-        'contribution_test',
-        '=',
-        1,
-        0,
-        0,
-      ];
+      $params['custom_post_id'][] = ['contribution_test', '=', 1, 0, 0];
     }
 
     if (!$returnMessageText && !empty($gIds)) {
@@ -323,7 +317,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
             $userID = $values['related_contact'] ?? NULL;
           }
         }
-        list($values['customPost_grouptitle'], $values['customPost']) = self::getProfileNameAndFields($postID, $userID, $params['custom_post_id']);
+        [$values['customPost_grouptitle'], $values['customPost']] = self::getProfileNameAndFields($postID, $userID, $params['custom_post_id']);
       }
       // Assign honoree values for the receipt. But first, stop any leaks from
       // previously assigned values.
@@ -396,7 +390,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       // signs up. Is used for cases like - on behalf of
       // contribution / signup ..etc
       if (array_key_exists('related_contact', $values)) {
-        list($ccDisplayName, $ccEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($values['related_contact']);
+        [$ccDisplayName, $ccEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($values['related_contact']);
         $ccMailId = "{$ccDisplayName} <{$ccEmail}>";
 
         //@todo - this is the only place in this function where  $values is altered - but I can't find any evidence it is used
@@ -424,7 +418,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       ];
 
       if ($returnMessageText) {
-        list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+        [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         return [
           'subject' => $subject,
           'body' => $message,
@@ -434,7 +428,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       }
 
       if (empty($values['receipt_from_name']) && empty($values['receipt_from_name'])) {
-        list($values['receipt_from_name'], $values['receipt_from_email']) = CRM_Core_BAO_Domain::getNameAndEmail();
+        [$values['receipt_from_name'], $values['receipt_from_email']] = CRM_Core_BAO_Domain::getNameAndEmail();
       }
 
       if ($values['is_email_receipt']) {
@@ -448,7 +442,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $values['contribution_id'];
         }
-        list($sent, $subject, $message) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+        [$sent, $subject, $message] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
       }
 
       // send duplicate alert, if dupe match found during on-behalf-of processing.
@@ -591,7 +585,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $template->assign('updateSubscriptionUrl', $url);
       }
 
-      list($sent) = CRM_Core_BAO_MessageTemplate::sendTemplate($templatesParams);
+      [$sent] = CRM_Core_BAO_MessageTemplate::sendTemplate($templatesParams);
 
       if ($sent) {
         CRM_Core_Error::debug_log_message('Success: mail sent for recurring notification.');
@@ -622,7 +616,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @param array|null $fieldTypes
    */
   public static function buildCustomDisplay($gid, $name, $cid, &$template, &$params, $fieldTypes = NULL) {
-    list($groupTitle, $values) = self::getProfileNameAndFields($gid, $cid, $params, $fieldTypes);
+    [$groupTitle, $values] = self::getProfileNameAndFields($gid, $cid, $params, $fieldTypes);
     if (!empty($values)) {
       $template->assign($name, $values);
     }

--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -126,7 +126,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
    * @throws \CRM_Core_Exception
    */
   public static function whereClauseSingle(&$values, &$query) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     $quoteValue = NULL;
     $fields = self::getFields();
@@ -243,7 +243,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         $dataType = !empty($fields[$qillName]['type']) ? CRM_Utils_Type::typeToString($fields[$qillName]['type']) : 'String';
 
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution.$name", $op, $value, $dataType);
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_Contribution', $name, $value, $op, $pseudoExtraParam);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_Contribution', $name, $value, $op, $pseudoExtraParam);
         if (!($name == 'id' && $value == 0)) {
           $query->_qill[$grouping][] = ts('%1 %2 %3', [1 => $fields[$qillName]['title'], 2 => $op, 3 => $value]);
         }
@@ -265,7 +265,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_soft.$name",
           $op, $value, CRM_Utils_Type::typeToString($fields[$qillName]['type'])
         );
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_ContributionSoft', $name, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_ContributionSoft', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [1 => $fields[$qillName]['title'], 2 => $op, 3 => $value]);
         $query->_tables['civicrm_contribution_soft'] = $query->_whereTables['civicrm_contribution_soft'] = 1;
         return;
@@ -382,7 +382,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
 
       case 'contribution_recur_contribution_status_id':
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_contribution_recur.contribution_status_id", $op, $value, 'String');
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_ContributionRecur', 'contribution_status_id', $value, $op, $pseudoExtraParam);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_ContributionRecur', 'contribution_status_id', $value, $op, $pseudoExtraParam);
         $query->_qill[$grouping][] = ts("Recurring Contribution Status %1 '%2'", [1 => $op, 2 => $value]);
         $query->_tables['civicrm_contribution_recur'] = $query->_whereTables['civicrm_contribution_recur'] = 1;
         return;
@@ -421,7 +421,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         return;
 
       case 'contribution_batch_id':
-        list($qillOp, $qillValue) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Batch_BAO_EntityBatch', 'batch_id', $value, $op);
+        [$qillOp, $qillValue] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Batch_BAO_EntityBatch', 'batch_id', $value, $op);
         $query->_qill[$grouping][] = ts('Batch Name %1 %2', [1 => $qillOp, 2 => $qillValue]);
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause('civicrm_entity_batch.batch_id', $op, $value);
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
@@ -432,7 +432,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       case 'contribution_product_id':
         // CRM-16713 - contribution search by premiums on 'Find Contribution' form.
         $qillName = $name;
-        list($operator, $productValue) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_Product', $name, $value, $op);
+        [$operator, $productValue] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Contribute_DAO_Product', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [1 => $fields[$qillName]['title'], 2 => $operator, 3 => $productValue]);
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_product.id", $op, $value);
         $query->_tables['civicrm_product'] = $query->_whereTables['civicrm_product'] = 1;
@@ -447,7 +447,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause('civicrm_financial_trxn.card_type_id', $op, $value);
         $query->_tables['civicrm_financial_trxn'] = $query->_whereTables['civicrm_financial_trxn'] = 1;
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Financial_DAO_FinancialTrxn', 'card_type_id', $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Financial_DAO_FinancialTrxn', 'card_type_id', $value, $op);
         $query->_qill[$grouping][] = ts('Card Type %1 %2', [1 => $op, 2 => $value]);
         return;
 
@@ -455,7 +455,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause('civicrm_financial_trxn.pan_truncation', $op, $value);
         $query->_tables['civicrm_financial_trxn'] = $query->_whereTables['civicrm_financial_trxn'] = 1;
         $query->_tables['civicrm_contribution'] = $query->_whereTables['civicrm_contribution'] = 1;
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Financial_DAO_FinancialTrxn', 'pan_truncation', $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Financial_DAO_FinancialTrxn', 'pan_truncation', $value, $op);
         $query->_qill[$grouping][] = ts('Card Number %1 %2', [1 => $op, 2 => $value]);
         return;
 
@@ -477,7 +477,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
 
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($whereTable['where'], $op, $value, $dataType);
         $query->_qill[$grouping][] = "$whereTable[title] $op $quoteValue";
-        list($tableName) = explode('.', $whereTable['where'], 2);
+        [$tableName] = explode('.', $whereTable['where'], 2);
         $query->_tables[$tableName] = $query->_whereTables[$tableName] = 1;
         if ($tableName === 'civicrm_contribution_product') {
           $query->_tables['civicrm_product'] = $query->_whereTables['civicrm_product'] = 1;

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1057,7 +1057,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     $attributes = [];
     foreach (explode(' ', $attrString) as $at) {
       if (strpos($at, '=')) {
-        list($k, $v) = explode('=', $at);
+        [$k, $v] = explode('=', $at);
         $attributes[$k] = trim($v, ' "');
       }
     }
@@ -1430,7 +1430,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
             'entity_id',
             'file_id'
           );
-          list($path) = CRM_Core_BAO_File::path($fileID, $entityId);
+          [$path] = CRM_Core_BAO_File::path($fileID, $entityId);
           $fileHash = CRM_Core_BAO_File::generateFileHash($entityId, $fileID);
           $url = CRM_Utils_System::url('civicrm/file',
             "reset=1&id=$fileID&eid=$entityId&fcs=$fileHash",
@@ -1524,7 +1524,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       return NULL;
     }
 
-    list($tableName, $columnName, $groupID) = self::getTableColumnGroup($customFieldId);
+    [$tableName, $columnName, $groupID] = self::getTableColumnGroup($customFieldId);
 
     if (!$customValueId &&
       // we always create new entites for is_multiple unless specified

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -577,7 +577,7 @@ ORDER BY civicrm_custom_group.weight,
     }
 
     if (empty($groupTree)) {
-      list($multipleFieldGroups, $groupTree) = self::buildGroupTree($entityType, $toReturn, $subTypes, $queryString, $params, $subType);
+      [$multipleFieldGroups, $groupTree] = self::buildGroupTree($entityType, $toReturn, $subTypes, $queryString, $params, $subType);
 
       $cache->set($cacheKey, $groupTree);
       $cache->set($multipleFieldGroupCacheKey, $multipleFieldGroups);
@@ -885,10 +885,10 @@ ORDER BY civicrm_custom_group.weight,
             );
             $customValue['imageURL'] = str_replace('persist/contribute', 'custom', $config->imageUploadURL) .
               $fileDAO->uri;
-            list($path) = CRM_Core_BAO_File::path($fileDAO->id, $entityId);
+            [$path] = CRM_Core_BAO_File::path($fileDAO->id, $entityId);
             if ($path && file_exists($path)) {
-              list($imageWidth, $imageHeight) = getimagesize($path);
-              list($imageThumbWidth, $imageThumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
+              [$imageWidth, $imageHeight] = getimagesize($path);
+              [$imageThumbWidth, $imageThumbHeight] = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
               $customValue['imageThumbWidth'] = $imageThumbWidth;
               $customValue['imageThumbHeight'] = $imageThumbHeight;
             }

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -184,7 +184,7 @@ class CRM_Core_BAO_CustomQuery {
       }
 
       foreach ($values as $tuple) {
-        list($name, $op, $value, $grouping, $wildcard) = $tuple;
+        [$name, $op, $value, $grouping, $wildcard] = $tuple;
 
         $field = $this->_fields[$id];
 
@@ -333,7 +333,7 @@ class CRM_Core_BAO_CustomQuery {
               && substr($name, -5, 5) !== '_high') {
               // Relative dates are handled in the buildRelativeDateQuery function.
               $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'Date');
-              list($qillOp, $qillVal) = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $field['label'], $value, $op, [], CRM_Utils_Type::T_DATE);
+              [$qillOp, $qillVal] = CRM_Contact_BAO_Query::buildQillForFieldValue(NULL, $field['label'], $value, $op, [], CRM_Utils_Type::T_DATE);
               $this->_qill[$grouping][] = "{$field['label']} $qillOp '$qillVal'";
             }
             break;
@@ -407,7 +407,7 @@ class CRM_Core_BAO_CustomQuery {
       $joinTableAlias = $joinTable;
       // Set location-specific query
       if (isset($this->_locationSpecificCustomFields[$field['id']])) {
-        list($locationType, $locationTypeId) = $this->_locationSpecificCustomFields[$field['id']];
+        [$locationType, $locationTypeId] = $this->_locationSpecificCustomFields[$field['id']];
         $joinTableAlias = "$locationType-address";
         $joinClause = "\nLEFT JOIN $joinTable `$locationType-address` ON (`$locationType-address`.contact_id = contact_a.id AND `$locationType-address`.location_type_id = $locationTypeId)";
       }

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -133,10 +133,10 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
 
     // to get id's
     if ($overwrite && $fileTypeID) {
-      list($sql, $params) = self::sql($entityTable, $entityID, $fileTypeID);
+      [$sql, $params] = self::sql($entityTable, $entityID, $fileTypeID);
     }
     else {
-      list($sql, $params) = self::sql($entityTable, $entityID, 0);
+      [$sql, $params] = self::sql($entityTable, $entityID, 0);
     }
 
     $dao = CRM_Core_DAO::executeQuery($sql, $params);
@@ -207,7 +207,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
     CRM_Utils_Hook::pre('delete', 'File', $fileID, $fileDAO);
 
     // get the table and column name
-    list($tableName, $columnName, $groupID) = CRM_Core_BAO_CustomField::getTableColumnGroup($fieldID);
+    [$tableName, $columnName, $groupID] = CRM_Core_BAO_CustomField::getTableColumnGroup($fieldID);
 
     $entityFileDAO = new CRM_Core_DAO_EntityFile();
     $entityFileDAO->file_id = $fileID;
@@ -231,7 +231,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
    * The $useWhere is used so that the signature matches the parent class
    *
    * public function delete($useWhere = FALSE) {
-   * list($fileID, $entityID, $fieldID) = func_get_args();
+   * [$fileID, $entityID, $fieldID] = func_get_args();
    *
    * self::deleteFileReferences($fileID, $entityID, $fieldID);
    * } */
@@ -255,7 +255,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
 
     $config = CRM_Core_Config::singleton();
 
-    list($sql, $params) = self::sql($entityTable, $entityID, $fileTypeID, $fileID);
+    [$sql, $params] = self::sql($entityTable, $entityID, $fileTypeID, $fileID);
     $dao = CRM_Core_DAO::executeQuery($sql, $params);
 
     $cfIDs = [];
@@ -323,7 +323,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
 
     $config = CRM_Core_Config::singleton();
 
-    list($sql, $params) = self::sql($entityTable, $entityID, NULL);
+    [$sql, $params] = self::sql($entityTable, $entityID, NULL);
     $dao = CRM_Core_DAO::executeQuery($sql, $params);
     $results = [];
     while ($dao->fetch()) {

--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -39,7 +39,7 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
     $displayName = $result = $contactImage = NULL;
     if ($log->find(TRUE)) {
       if ($log->modified_id) {
-        list($displayName, $contactImage) = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
+        [$displayName, $contactImage] = CRM_Contact_BAO_Contact::getDisplayAndImage($log->modified_id);
       }
       $result = [
         'id' => $log->modified_id,

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -310,7 +310,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
         asort($relationshipTypes);
 
         foreach ($relationshipTypes as $key => $var) {
-          list($type) = explode('_', $key);
+          [$type] = explode('_', $key);
 
           $relationships[$key]['title'] = $var;
           $relationships[$key]['headerPattern'] = '/' . preg_quote($var, '/') . '/';
@@ -352,7 +352,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
 
         foreach ($subTypeRelationshipTypes as $key => $var) {
           if (!array_key_exists($key, $fields[$info['parent']])) {
-            list($type) = explode('_', $key);
+            [$type] = explode('_', $key);
 
             $csRelationships[$key]['title'] = $var;
             $csRelationships[$key]['headerPattern'] = '/' . preg_quote($var, '/') . '/';
@@ -488,7 +488,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
 
     // Handle mapping for 'related contact' fields
     if (count(explode('_', CRM_Utils_Array::value('1', $v))) > 2) {
-      list($id, $first, $second) = explode('_', CRM_Utils_Array::value('1', $v));
+      [$id, $first, $second] = explode('_', CRM_Utils_Array::value('1', $v));
       if (($first == 'a' && $second == 'b') || ($first == 'b' && $second == 'a')) {
 
         if (!empty($v['2'])) {

--- a/CRM/Core/BAO/PrevNextCache.php
+++ b/CRM/Core/BAO/PrevNextCache.php
@@ -35,7 +35,7 @@ class CRM_Core_BAO_PrevNextCache extends CRM_Core_DAO_PrevNextCache {
    */
   public static function getPositions($cacheKey, $id1, $id2, &$mergeId = NULL, $join = NULL, $where = NULL, $flip = FALSE) {
     if ($flip) {
-      list($id1, $id2) = [$id2, $id1];
+      [$id1, $id2] = [$id2, $id1];
     }
 
     if ($mergeId == NULL) {

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -747,7 +747,7 @@ SELECT  id
    */
   public static function assignAddressField($key, &$profileAddressFields, $profileFilter, $paymentProcessorBillingFields = NULL) {
     $billing_id = CRM_Core_BAO_LocationType::getBilling();
-    list($prefixName, $index) = CRM_Utils_System::explode('-', $key, 2);
+    [$prefixName, $index] = CRM_Utils_System::explode('-', $key, 2);
 
     $profileFields = civicrm_api3('uf_field', 'get', array_merge($profileFilter,
       [

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -338,10 +338,10 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
       $field = CRM_Core_DAO::executeQuery($query);
 
       $importableFields = self::getProfileFieldMetadata($showAll);
-      list($customFields, $addressCustomFields) = self::getCustomFields($ctype, $skipPermission ? FALSE : $permissionType);
+      [$customFields, $addressCustomFields] = self::getCustomFields($ctype, $skipPermission ? FALSE : $permissionType);
 
       while ($field->fetch()) {
-        list($name, $formattedField) = self::formatUFField($group, $field, $customFields, $addressCustomFields, $importableFields, $permissionType);
+        [$name, $formattedField] = self::formatUFField($group, $field, $customFields, $addressCustomFields, $importableFields, $permissionType);
         if ($formattedField !== NULL) {
           $fields[$name] = $formattedField;
         }
@@ -398,7 +398,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
     $profileType = CRM_Core_BAO_UFField::calculateProfileType(implode(',', $ufGroupType));
     $contactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileTypeByGroupType(implode(',', $ufGroupType));
     $importableFields = self::getImportableFields($showAll, $profileType, $contactActivityProfile);
-    list($customFields, $addressCustomFields) = self::getCustomFields($ctype, $permissionType);
+    [$customFields, $addressCustomFields] = self::getCustomFields($ctype, $permissionType);
 
     $formattedFields = [];
     foreach ($fieldArrs as $fieldArr) {
@@ -407,7 +407,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         continue;
       }
 
-      list($name, $formattedField) = self::formatUFField($group, $field, $customFields, $addressCustomFields, $importableFields, $permissionType);
+      [$name, $formattedField] = self::formatUFField($group, $field, $customFields, $addressCustomFields, $importableFields, $permissionType);
       if ($formattedField !== NULL) {
         $formattedFields[$name] = $formattedField;
       }
@@ -1177,8 +1177,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
               }
             }
             elseif ($name == 'image_URL') {
-              list($width, $height) = getimagesize(CRM_Utils_String::unstupifyUrl($details->$name));
-              list($thumbWidth, $thumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($width, $height);
+              [$width, $height] = getimagesize(CRM_Utils_String::unstupifyUrl($details->$name));
+              [$thumbWidth, $thumbHeight] = CRM_Contact_BAO_Contact::getThumbSize($width, $height);
 
               $image_URL = '<img src="' . $details->$name . '" height= ' . $thumbHeight . ' width= ' . $thumbWidth . '  />';
               $values[$index] = "<a href='#' onclick='contactImagePopUp(\"{$details->$name}\", {$width}, {$height});'>{$image_URL}</a>";
@@ -1211,7 +1211,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup {
         }
       }
       elseif (strpos($name, '-') !== FALSE) {
-        list($fieldName, $id, $type) = CRM_Utils_System::explode('-', $name, 3);
+        [$fieldName, $id, $type] = CRM_Utils_System::explode('-', $name, 3);
 
         if (!in_array($fieldName, $multipleFields)) {
           if ($id == 'Primary') {
@@ -1917,7 +1917,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       }
     }
     elseif (CRM_Utils_Array::value('name', $field) == 'membership_type') {
-      list($orgInfo, $types) = CRM_Member_BAO_MembershipType::getMembershipTypeInfo();
+      [$orgInfo, $types] = CRM_Member_BAO_MembershipType::getMembershipTypeInfo();
       $sel = &$form->addElement('hierselect', $name, $title);
       $select = ['' => ts('- select membership type -')];
       if (count($orgInfo) == 1 && $field['is_required']) {
@@ -2063,7 +2063,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       }
     }
     elseif (substr($fieldName, 0, 14) === 'address_custom') {
-      list($fName, $locTypeId) = CRM_Utils_System::explode('-', $fieldName, 2);
+      [$fName, $locTypeId] = CRM_Utils_System::explode('-', $fieldName, 2);
       $customFieldID = CRM_Core_BAO_CustomField::getKeyID(substr($fName, 8));
       if ($customFieldID) {
         CRM_Core_BAO_CustomField::addQuickFormElement($form, $name, $customFieldID, $required, $search, $title);
@@ -2077,7 +2077,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $form->addMoney("soft_credit_amount[{$rowNumber}]", ts('Amount'), FALSE, NULL, FALSE);
     }
     elseif ($fieldName === 'product_name') {
-      list($products, $options) = CRM_Contribute_BAO_Premium::getPremiumProductInfo();
+      [$products, $options] = CRM_Contribute_BAO_Premium::getPremiumProductInfo();
       $sel = &$form->addElement('hierselect', $name, $title);
       $products = ['0' => ts('- select %1 -', [1 => $title])] + $products;
       $sel->setOptions([$products, $options]);
@@ -2329,7 +2329,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
         }
         else {
           $blocks = ['email', 'phone', 'im', 'openid'];
-          list($fieldName, $locTypeId, $phoneTypeId) = CRM_Utils_System::explode('-', $name, 3);
+          [$fieldName, $locTypeId, $phoneTypeId] = CRM_Utils_System::explode('-', $name, 3);
           if (!in_array($fieldName, $multipleFields)) {
             if (is_array($details)) {
               foreach ($details as $key => $value) {
@@ -2678,7 +2678,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     );
 
     //get the default domain email address.
-    list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
+    [$domainEmailName, $domainEmailAddress] = CRM_Core_BAO_Domain::getNameAndEmail();
 
     if (!$domainEmailAddress || $domainEmailAddress == 'info@EXAMPLE.ORG') {
       $fixUrl = CRM_Utils_System::url('civicrm/admin/domain', 'action=update&reset=1');
@@ -2771,7 +2771,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
   public static function formatFields($params, $contactId = NULL) {
     if ($contactId) {
       // get the primary location type id and email
-      list($name, $primaryEmail, $primaryLocationType) = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId);
+      [$name, $primaryEmail, $primaryLocationType] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId);
     }
     else {
       $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
@@ -2783,7 +2783,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     $count = 1;
     $primaryLocation = 0;
     foreach ($params as $key => $value) {
-      list($fieldName, $locTypeId, $phoneTypeId) = explode('-', $key);
+      [$fieldName, $locTypeId, $phoneTypeId] = explode('-', $key);
 
       if ($locTypeId == 'Primary') {
         $locTypeId = $primaryLocationType;

--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -125,7 +125,7 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
 
     // add current contact to recently viewed
     if ($ufmatch->contact_id) {
-      list($displayName, $contactImage, $contactType, $contactSubtype, $contactImageUrl)
+      [$displayName, $contactImage, $contactType, $contactSubtype, $contactImageUrl]
         = CRM_Contact_BAO_Contact::getDisplayAndImage($ufmatch->contact_id, TRUE, TRUE);
 
       $otherRecent = [

--- a/CRM/Core/CommunityMessages.php
+++ b/CRM/Core/CommunityMessages.php
@@ -123,7 +123,7 @@ class CRM_Core_CommunityMessages {
    *   parsed JSON
    */
   public function fetchDocument() {
-    list($status, $json) = $this->client->get($this->getRenderedUrl());
+    [$status, $json] = $this->client->get($this->getRenderedUrl());
     if ($status != CRM_Utils_HttpClient::STATUS_OK || empty($json)) {
       return NULL;
     }

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -339,7 +339,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
     // note that this is split into two, because some versions of
     // php 5.x core dump on the triple assignment :)
     $this->_actionName = $this->getActionName();
-    list($pageName, $action) = $this->_actionName;
+    [$pageName, $action] = $this->_actionName;
 
     if ($this->isModal()) {
       if (!$this->isValid($pageName)) {
@@ -360,7 +360,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    */
   public function validate() {
     $this->_actionName = $this->getActionName();
-    list($pageName, $action) = $this->_actionName;
+    [$pageName, $action] = $this->_actionName;
 
     $page = &$this->_pages[$pageName];
 
@@ -842,7 +842,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    */
   public function cancelAction() {
     $actionName = $this->getActionName();
-    list($pageName, $action) = $actionName;
+    [$pageName, $action] = $actionName;
     return $this->_pages[$pageName]->cancelAction();
   }
 

--- a/CRM/Core/Controller/Simple.php
+++ b/CRM/Core/Controller/Simple.php
@@ -106,7 +106,7 @@ class CRM_Core_Controller_Simple extends CRM_Core_Controller {
   public function getTemplateFileName() {
     // there is only one form here, so should be quite easy
     $actionName = $this->getActionName();
-    list($pageName, $action) = $actionName;
+    [$pageName, $action] = $actionName;
 
     return $this->_pages[$pageName]->getTemplateFileName();
   }

--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -109,7 +109,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
         $this->renderFrozenDatepicker($el, $element);
       }
       elseif ($element->getAttribute('type') == 'text' && $element->getAttribute('formatType')) {
-        list($date, $time) = CRM_Utils_Date::setDateDefaults($element->getValue(), $element->getAttribute('formatType'), $element->getAttribute('format'), $element->getAttribute('timeformat'));
+        [$date, $time] = CRM_Utils_Date::setDateDefaults($element->getValue(), $element->getAttribute('formatType'), $element->getAttribute('format'), $element->getAttribute('timeformat'));
         $date .= ($element->getAttribute('timeformat')) ? " $time" : '';
         $el['html'] = $date . '<input type="hidden" value="' . $element->getValue() . '" name="' . $element->getAttribute('name') . '">';
       }

--- a/CRM/Core/Form/Tag.php
+++ b/CRM/Core/Form/Tag.php
@@ -55,7 +55,7 @@ class CRM_Core_Form_Tag {
         $tagsetItem = $tagsetElementName . 'parentId_' . $parentId;
         $tagset[$tagsetItem]['parentID'] = $parentId;
 
-        list(, $mode) = explode('_', $entityTable);
+        [, $mode] = explode('_', $entityTable);
         if (!$tagsetElementName) {
           $tagsetElementName = $mode . "_taglist";
         }

--- a/CRM/Core/Key.php
+++ b/CRM/Core/Key.php
@@ -112,7 +112,7 @@ class CRM_Core_Key {
     }
 
     if ($addSequence) {
-      list($k, $t) = explode('_', $key);
+      [$k, $t] = explode('_', $key);
       if ($t < 1 || $t > 10000) {
         return NULL;
       }

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -627,7 +627,7 @@ UNION (
 
     $elements = explode(',', $pathArgs);
     foreach ($elements as $keyVal) {
-      list($key, $val) = explode('=', $keyVal, 2);
+      [$key, $val] = explode('=', $keyVal, 2);
       $arr[$key] = $val;
     }
 

--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -338,7 +338,7 @@ class CRM_Core_OptionValue {
       if (is_array($nameTitle)) {
         foreach ($nameTitle as $name => $attribs) {
           self::$_fields[$key][$name] = $optionName;
-          list($tableName, $fieldName) = explode('.', $optionName['where']);
+          [$tableName, $fieldName] = explode('.', $optionName['where']);
           self::$_fields[$key][$name]['where'] = "{$name}.label";
           foreach ($attribs as $k => $val) {
             self::$_fields[$key][$name][$k] = $val;
@@ -362,7 +362,7 @@ class CRM_Core_OptionValue {
         if (!empty($values['pseudoconstant'])) {
           continue;
         }
-        list($tableName, $fieldName) = explode('.', $values['where']);
+        [$tableName, $fieldName] = explode('.', $values['where']);
         if (!empty($query->_returnProperties[$name])) {
           $query->_select["{$name}_id"] = "{$name}.value as {$name}_id";
           $query->_element["{$name}_id"] = 1;

--- a/CRM/Core/Page/File.php
+++ b/CRM/Core/Page/File.php
@@ -41,7 +41,7 @@ class CRM_Core_Page_File extends CRM_Core_Page {
         CRM_Core_Error::statusBounce(ts('URL for file is not valid'));
       }
 
-      list($path, $mimeType) = CRM_Core_BAO_File::path($fileId, $entityId);
+      [$path, $mimeType] = CRM_Core_BAO_File::path($fileId, $entityId);
     }
     else {
       if (!CRM_Utils_File::isValidFileName($fileName)) {

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -373,7 +373,7 @@ class CRM_Core_PseudoConstant {
         return NULL;
       }
       // We don't have good mapping so have to do a bit of guesswork from the menu
-      list(, $parent, , $child) = explode('_', $daoName);
+      [, $parent, , $child] = explode('_', $daoName);
       $sql = "SELECT path FROM civicrm_menu
         WHERE page_callback LIKE '%CRM_Admin_Page_$child%' OR page_callback LIKE '%CRM_{$parent}_Page_$child%'
         ORDER BY page_callback

--- a/CRM/Core/QuickForm/Action/Display.php
+++ b/CRM/Core/QuickForm/Action/Display.php
@@ -56,7 +56,7 @@ class CRM_Core_QuickForm_Action_Display extends CRM_Core_QuickForm_Action {
 
     // If the original action was 'display' and we have values in container then we load them
     // BTW, if the page was invalid, we should later call validate() to get the errors
-    list(, $oldName) = $page->controller->getActionName();
+    [, $oldName] = $page->controller->getActionName();
     if ('display' == $oldName) {
       // If the controller is "modal" we should not allow direct access to a page
       // unless all previous pages are valid (see also bug #2323)

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -449,7 +449,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
     ) {
       return TRUE;
     }
-    list($arg0, $arg1) = array_pad(explode('/', (CRM_Utils_System::currentPath() ?? '')), 2, '');
+    [$arg0, $arg1] = array_pad(explode('/', (CRM_Utils_System::currentPath() ?? '')), 2, '');
     return ($arg0 === 'civicrm' && in_array($arg1, ['ajax', 'angularprofiles', 'asset']));
   }
 

--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -271,7 +271,7 @@ class CRM_Core_Resources_Common {
     // Add localized jQuery UI files
     if ($tsLocale && $tsLocale != 'en_US') {
       // Search for i18n file in order of specificity (try fr-CA, then fr)
-      list($lang) = explode('_', $tsLocale);
+      [$lang] = explode('_', $tsLocale);
       $path = "bower_components/jquery-ui/ui/i18n";
       foreach ([str_replace('_', '-', $tsLocale), $lang] as $language) {
         $localizationFile = "$path/datepicker-{$language}.js";

--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -94,7 +94,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
             if (isset($replacements[$where])) {
               $where = $replacements[$where];
             }
-            list($table, $field) = explode('.', $where);
+            [$table, $field] = explode('.', $where);
             if (!in_array($table, $supportedTables)) {
               continue;
             }
@@ -220,7 +220,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
     CRM_Utils_Hook::dupeQuery($this, 'table', $tableQueries);
 
     while (!empty($tableQueries)) {
-      list($isInclusive, $isDie) = self::isQuerySetInclusive($tableQueries, $this->threshold, $exclWeightSum);
+      [$isInclusive, $isDie] = self::isQuerySetInclusive($tableQueries, $this->threshold, $exclWeightSum);
 
       if ($isInclusive) {
         // order queries by table count
@@ -379,7 +379,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
 
     if ($this->params && !$this->noRules) {
       if ($checkPermission) {
-        list($this->_aclFrom, $aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause('civicrm_contact');
+        [$this->_aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause('civicrm_contact');
         $aclWhere = $aclWhere ? "AND {$aclWhere}" : '';
       }
       $query = "SELECT {$this->temporaryTables['dedupe']}.id1 as id
@@ -390,7 +390,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
     else {
       $aclWhere = '';
       if ($checkPermission) {
-        list($this->_aclFrom, $aclWhere) = CRM_Contact_BAO_Contact_Permission::cacheClause(['c1', 'c2']);
+        [$this->_aclFrom, $aclWhere] = CRM_Contact_BAO_Contact_Permission::cacheClause(['c1', 'c2']);
         $aclWhere = $aclWhere ? "AND {$aclWhere}" : '';
       }
       $query = "SELECT IF({$this->temporaryTables['dedupe']}.id1 < {$this->temporaryTables['dedupe']}.id2, {$this->temporaryTables['dedupe']}.id1, {$this->temporaryTables['dedupe']}.id2) as id1,

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1112,7 +1112,7 @@ WHERE civicrm_event.is_active = 1
     }
 
     if ($values['event']['is_email_confirm'] || $returnMessageText) {
-      list($displayName, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
+      [$displayName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
       $notifyEmail = CRM_Utils_Array::valueByRegexKey('/^email-/', $participantParams) ?? $email;
       //send email only when email is present
       if (isset($notifyEmail) || $returnMessageText) {
@@ -1230,7 +1230,7 @@ WHERE civicrm_event.is_active = 1
         }
 
         if ($returnMessageText) {
-          list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+          [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
           return [
             'subject' => $subject,
             'body' => $message,
@@ -1600,7 +1600,7 @@ WHERE civicrm_event.is_active = 1
           $values[$index] = $campaigns[$params[$name]] ?? NULL;
         }
         elseif (strpos($name, '-') !== FALSE) {
-          list($fieldName, $id) = CRM_Utils_System::explode('-', $name, 2);
+          [$fieldName, $id] = CRM_Utils_System::explode('-', $name, 2);
           $detailName = str_replace(' ', '_', $name);
           if (in_array($fieldName, [
             'state_province',
@@ -1813,7 +1813,7 @@ WHERE  id = $cfID
             $participantParams = CRM_Utils_Array::value($pId, $values['params'], []);
           }
 
-          list($profilePre, $groupTitles) = self::buildCustomDisplay($preProfileID,
+          [$profilePre, $groupTitles] = self::buildCustomDisplay($preProfileID,
             'additionalCustomPre',
             $cId,
             $template,
@@ -1831,7 +1831,7 @@ WHERE  id = $cfID
             }
           }
 
-          list($profilePost, $groupTitles) = self::buildCustomDisplay($postProfileID,
+          [$profilePost, $groupTitles] = self::buildCustomDisplay($postProfileID,
             'additionalCustomPost',
             $cId,
             $template,
@@ -2062,7 +2062,7 @@ WHERE  ce.loc_block_id = $locBlockId";
         }
         Civi::$statics[__CLASS__]['permission']['edit'][$eventId] = FALSE;
 
-        list($allEvents, $createdEvents) = self::checkPermissionGetInfo($eventId);
+        [$allEvents, $createdEvents] = self::checkPermissionGetInfo($eventId);
         // Note: for a multisite setup, a user with edit all events, can edit all events
         // including those from other sites
         if (($permissionType == CRM_Core_Permission::EDIT) && CRM_Core_Permission::check('edit all events')) {
@@ -2081,7 +2081,7 @@ WHERE  ce.loc_block_id = $locBlockId";
         }
         Civi::$statics[__CLASS__]['permission']['view'][$eventId] = FALSE;
 
-        list($allEvents, $createdEvents) = self::checkPermissionGetInfo($eventId);
+        [$allEvents, $createdEvents] = self::checkPermissionGetInfo($eventId);
         if (CRM_Core_Permission::check('access CiviEvent')) {
           if (in_array($eventId, CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_event', $allEvents, array_keys($createdEvents)))) {
             // User created this event so has permission to view it
@@ -2158,7 +2158,7 @@ WHERE  ce.loc_block_id = $locBlockId";
    */
   public static function getAllPermissions() {
     if (!isset(Civi::$statics[__CLASS__]['permissions'])) {
-      list($allEvents, $createdEvents) = self::checkPermissionGetInfo();
+      [$allEvents, $createdEvents] = self::checkPermissionGetInfo();
 
       // Note: for a multisite setup, a user with edit all events, can edit all events
       // including those from other sites

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1422,7 +1422,7 @@ UPDATE  civicrm_participant
         $receiptFrom = $eventDetails['confirm_from_name'] . ' <' . $eventDetails['confirm_from_email'] . '>';
       }
 
-      list($mailSent, $subject) = CRM_Core_BAO_MessageTemplate::sendTemplate(
+      [$mailSent, $subject] = CRM_Core_BAO_MessageTemplate::sendTemplate(
         [
           'workflow' => 'participant_' . strtolower($mailType),
           'contactId' => $contactId,

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -236,7 +236,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
    */
   public static function whereClauseSingle(&$values, &$query) {
     $checkPermission = empty($query->_skipPermission);
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
     $fields = array_merge(CRM_Event_BAO_Event::fields(), CRM_Event_BAO_Participant::exportableFields());
     $fieldSpec = $fields[$values[0]] ?? [];
 
@@ -388,7 +388,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         }
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("$tableName.$name", $op, $value, $dataType);
 
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Participant', $name, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Participant', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [1 => $fields[$qillName]['title'], 2 => $op, 3 => $value]);
         $query->_tables['civicrm_participant'] = $query->_whereTables['civicrm_participant'] = 1;
         return;
@@ -413,7 +413,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
           $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("$tableName.$name", $op, $value, $dataType);
         }
 
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Participant', $name, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Participant', $name, $value, $op);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [1 => $fields[$qillName]['title'], 2 => $op, 3 => $value]);
         $query->_tables['civicrm_participant'] = $query->_whereTables['civicrm_participant'] = 1;
         return;
@@ -447,7 +447,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
         if (!array_key_exists($qillName, $fields)) {
           break;
         }
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Event', $name, $value, $op, ['check_permission' => $checkPermission]);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Event_DAO_Event', $name, $value, $op, ['check_permission' => $checkPermission]);
         $query->_qill[$grouping][] = ts('%1 %2 %3', [1 => $fields[$qillName]['title'], 2 => $op, 3 => $value]);
         return;
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -999,7 +999,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $params['total_amount'] = CRM_Utils_Rule::cleanMoney($params['total_amount']);
     }
     if ($this->_isPaidEvent) {
-      list($contributionParams, $lineItem, $additionalParticipantDetails, $params) = $this->preparePaidEventProcessing($params);
+      [$contributionParams, $lineItem, $additionalParticipantDetails, $params] = $this->preparePaidEventProcessing($params);
     }
 
     $this->_params = $params;
@@ -1020,7 +1020,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $userName = CRM_Core_Session::singleton()->getLoggedInContactDisplayName();
 
     if ($this->_contactId) {
-      list($this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail) = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);
+      [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);
     }
 
     //modify params according to parameter used in create
@@ -1459,7 +1459,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       foreach ($this->_contactIds as $num => $contactID) {
         // Retrieve the name and email of the contact - this will be the TO for receipt email
-        list($this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail) = CRM_Contact_BAO_Contact::getContactDetails($contactID);
+        [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($contactID);
 
         $this->_contributorDisplayName = ($this->_contributorDisplayName == ' ') ? $this->_contributorEmail : $this->_contributorDisplayName;
 
@@ -1550,7 +1550,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           $sendTemplateParams['isEmailPdf'] = TRUE;
           $sendTemplateParams['contributionId'] = $contributionId;
         }
-        list($mailSent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+        [$mailSent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         if ($mailSent) {
           $sent[] = $contactID;
           foreach ($participants as $ids => $values) {
@@ -1761,9 +1761,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     // Retrieve the name and email of the contact - form will be the TO for receipt email ( only if context is not standalone)
     if ($form->_context != 'standalone') {
       if ($form->_contactId) {
-        list($form->_contributorDisplayName,
-          $form->_contributorEmail
-          ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($form->_contactId);
+        [$form->_contributorDisplayName, $form->_contributorEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($form->_contactId);
         $form->assign('email', $form->_contributorEmail);
       }
       else {

--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -125,14 +125,14 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
     $processor->setComponentClause($componentClause);
     $processor->setIds($ids);
 
-    list($query, $queryString) = $processor->runQuery($params, $order);
+    [$query, $queryString] = $processor->runQuery($params, $order);
 
     // This perhaps only needs calling when $mergeSameHousehold == 1
     self::buildRelatedContactArray($selectAll, $ids, $processor, $componentTable);
 
     $addPaymentHeader = FALSE;
 
-    list($outputColumns) = $processor->getExportStructureArrays();
+    [$outputColumns] = $processor->getExportStructureArrays();
 
     if ($processor->isMergeSameAddress()) {
       foreach (array_keys($processor->getAdditionalFieldsForSameAddressMerge()) as $field) {
@@ -424,9 +424,9 @@ VALUES $sqlValueString
       $relationQuery = new CRM_Contact_BAO_Query(NULL, $relationReturnProperties,
         NULL, FALSE, FALSE, $queryMode
       );
-      list($relationSelect, $relationFrom, $relationWhere, $relationHaving) = $relationQuery->query();
+      [$relationSelect, $relationFrom, $relationWhere, $relationHaving] = $relationQuery->query();
 
-      list($id, $direction) = explode('_', $relationshipKey, 2);
+      [$id, $direction] = explode('_', $relationshipKey, 2);
       // identify the relationship direction
       $contactA = 'contact_id_a';
       $contactB = 'contact_id_b';

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -236,7 +236,7 @@ class CRM_Mailing_BAO_Query {
    * @param $query
    */
   public static function whereClauseSingle(&$values, &$query) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     switch ($name) {
       case 'mailing_id':
@@ -281,7 +281,7 @@ class CRM_Mailing_BAO_Query {
       case 'mailing_delivery_status':
         $options = CRM_Mailing_PseudoConstant::yesNoOptions('delivered');
 
-        list($name, $op, $value, $grouping, $wildcard) = $values;
+        [$name, $op, $value, $grouping, $wildcard] = $values;
         if ($value == 'Y') {
           self::mailingEventQueryBuilder($query, $values,
             'civicrm_mailing_event_delivered',
@@ -378,7 +378,7 @@ class CRM_Mailing_BAO_Query {
       case 'mailing_campaign_id':
         $name = 'campaign_id';
         $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("civicrm_mailing.$name", $op, $value, 'Integer');
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Mailing_DAO_Mailing', $name, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Mailing_DAO_Mailing', $name, $value, $op);
         $query->_qill[$grouping][] = ts('Campaign %1 %2', [1 => $op, 2 => $value]);
         $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;
         $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
@@ -467,7 +467,7 @@ class CRM_Mailing_BAO_Query {
    * @param $valueTitles
    */
   public static function mailingEventQueryBuilder(&$query, &$values, $tableName, $fieldName, $fieldTitle, &$valueTitles) {
-    list($name, $op, $value, $grouping, $wildcard) = $values;
+    [$name, $op, $value, $grouping, $wildcard] = $values;
 
     if (empty($value) || $value == 'A') {
       // don't do any filtering

--- a/CRM/Member/BAO/Query.php
+++ b/CRM/Member/BAO/Query.php
@@ -150,7 +150,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
       // $this->buildRelativeDateQuery($values);
       return;
     }
-    list($name, $op, $value, $grouping) = $values;
+    [$name, $op, $value, $grouping] = $values;
     $fields = self::getFields();
 
     $quoteValue = NULL;
@@ -273,7 +273,7 @@ class CRM_Member_BAO_Query extends CRM_Core_BAO_Query {
           $value,
           "Integer"
         );
-        list($op, $value) = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Member_DAO_Membership', $name, $value, $op);
+        [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Member_DAO_Membership', $name, $value, $op);
         $query->_qill[$grouping][] = $qillName . ' ' . $op . ' ' . $value;
         $query->_tables['civicrm_membership'] = $query->_whereTables['civicrm_membership'] = 1;
         return;

--- a/CRM/Member/Form/Search.php
+++ b/CRM/Member/Form/Search.php
@@ -300,7 +300,7 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
       $cid = CRM_Utils_Type::escape($cid, 'Integer');
       if ($cid > 0) {
         $this->_formValues['contact_id'] = $cid;
-        list($display, $image) = CRM_Contact_BAO_Contact::getDisplayAndImage($cid);
+        [$display, $image] = CRM_Contact_BAO_Contact::getDisplayAndImage($cid);
         $this->_defaults['sort_name'] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid,
           'sort_name'
         );
@@ -311,24 +311,24 @@ class CRM_Member_Form_Search extends CRM_Core_Form_Search {
 
     $fromDate = CRM_Utils_Request::retrieve('start', 'Date');
     if ($fromDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($fromDate);
+      [$date] = CRM_Utils_Date::setDateDefaults($fromDate);
       $this->_formValues['member_start_date_low'] = $this->_defaults['member_start_date_low'] = $date;
     }
 
     $toDate = CRM_Utils_Request::retrieve('end', 'Date');
     if ($toDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($toDate);
+      [$date] = CRM_Utils_Date::setDateDefaults($toDate);
       $this->_formValues['member_start_date_high'] = $this->_defaults['member_start_date_high'] = $date;
     }
     $joinDate = CRM_Utils_Request::retrieve('join', 'Date');
     if ($joinDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($joinDate);
+      [$date] = CRM_Utils_Date::setDateDefaults($joinDate);
       $this->_formValues['member_join_date_low'] = $this->_defaults['member_join_date_low'] = $date;
     }
 
     $joinEndDate = CRM_Utils_Request::retrieve('joinEnd', 'Date');
     if ($joinEndDate) {
-      list($date) = CRM_Utils_Date::setDateDefaults($joinEndDate);
+      [$date] = CRM_Utils_Date::setDateDefaults($joinEndDate);
       $this->_formValues['member_join_date_high'] = $this->_defaults['member_join_date_high'] = $date;
     }
 

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -787,7 +787,7 @@ SET    version = '$version'
     $restore = \CRM_Upgrade_DispatchPolicy::useTemporarily('upgrade.finish');
 
     $upgrade = new CRM_Upgrade_Form();
-    list($ignore, $latestVer) = $upgrade->getUpgradeVersions();
+    [$ignore, $latestVer] = $upgrade->getUpgradeVersions();
     // Seems extraneous in context, but we'll preserve old behavior
     $upgrade->setVersion($latestVer);
     // Going forward, any new tasks will run in `upgrade.finish` mode.

--- a/CRM/Upgrade/Headless.php
+++ b/CRM/Upgrade/Headless.php
@@ -28,7 +28,7 @@ class CRM_Upgrade_Headless {
     set_time_limit(0);
 
     $upgrade = new CRM_Upgrade_Form();
-    list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
+    [$currentVer, $latestVer] = $upgrade->getUpgradeVersions();
 
     if ($error = $upgrade->checkUpgradeableVersion($currentVer, $latestVer)) {
       throw new Exception($error);

--- a/CRM/Upgrade/Incremental/php/FiveTwenty.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwenty.php
@@ -130,7 +130,7 @@ class CRM_Upgrade_Incremental_php_FiveTwenty extends CRM_Upgrade_Incremental_Bas
         continue;
       }
       // parse out existing id and direction
-      list($relationshipTypeId, $direction1) = explode('_', $match);
+      [$relationshipTypeId, $direction1] = explode('_', $match);
       // we only care about ones that are b_a
       if ($direction1 === 'b') {
         // we only care about bidirectional

--- a/CRM/Upgrade/Incremental/php/FiveTwentyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveTwentyNine.php
@@ -42,7 +42,7 @@ class CRM_Upgrade_Incremental_php_FiveTwentyNine extends CRM_Upgrade_Incremental
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Install eventcart extension', 'installEventCart');
 
-    list($minId, $maxId) = CRM_Core_DAO::executeQuery("SELECT coalesce(min(id),0), coalesce(max(id),0)
+    [$minId, $maxId] = CRM_Core_DAO::executeQuery("SELECT coalesce(min(id),0), coalesce(max(id),0)
       FROM civicrm_relationship ")->getDatabaseResult()->fetchRow();
     for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
       $endId = $startId + self::BATCH_SIZE - 1;

--- a/CRM/Upgrade/Incremental/php/FourSeven.php
+++ b/CRM/Upgrade/Incremental/php/FourSeven.php
@@ -457,7 +457,7 @@ class CRM_Upgrade_Incremental_php_FourSeven extends CRM_Upgrade_Incremental_Base
     // CRM-20868 : Update invoice_numbers (in batch) with value in [invoice prefix][contribution id] format
     $contributionSettings = Civi::settings()->get('contribution_invoice_settings');
     if (!empty($contributionSettings['invoicing']) && !empty($contributionSettings['invoice_prefix'])) {
-      list($minId, $maxId) = CRM_Core_DAO::executeQuery("SELECT coalesce(min(id),0), coalesce(max(id),0)
+      [$minId, $maxId] = CRM_Core_DAO::executeQuery("SELECT coalesce(min(id),0), coalesce(max(id),0)
       FROM civicrm_contribution ")->getDatabaseResult()->fetchRow();
       for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
         $endId = $startId + self::BATCH_SIZE - 1;

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -27,7 +27,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     Civi::resources()->addStyleFile('civicrm', 'css/admin.css');
 
     $upgrade = new CRM_Upgrade_Form();
-    list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
+    [$currentVer, $latestVer] = $upgrade->getUpgradeVersions();
 
     CRM_Utils_System::setTitle(ts('Upgrade CiviCRM to Version %1',
       [1 => $latestVer]
@@ -66,7 +66,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
   public function runIntro() {
     $upgrade = new CRM_Upgrade_Form();
     $template = CRM_Core_Smarty::singleton();
-    list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
+    [$currentVer, $latestVer] = $upgrade->getUpgradeVersions();
     CRM_Core_Smarty::singleton()->assign('sid', CRM_Utils_System::getSiteID());
     // Show success msg if db already upgraded
     if (version_compare($currentVer, $latestVer) == 0) {
@@ -121,7 +121,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
    */
   public function runBegin() {
     $upgrade = new CRM_Upgrade_Form();
-    list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
+    [$currentVer, $latestVer] = $upgrade->getUpgradeVersions();
 
     if ($error = $upgrade->checkUpgradeableVersion($currentVer, $latestVer)) {
       throw new CRM_Core_Exception($error);
@@ -175,7 +175,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     }
 
     // do a version check - after doFinish() sets the final version
-    list($currentVer, $latestVer) = $upgrade->getUpgradeVersions();
+    [$currentVer, $latestVer] = $upgrade->getUpgradeVersions();
     if ($error = $upgrade->checkCurrentVersion($currentVer, $latestVer)) {
       throw new CRM_Core_Exception($error);
     }

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -146,16 +146,16 @@ class CRM_Utils_Mail_EmailProcessor {
         if ($usedfor == 1) {
           foreach ($mail->to as $address) {
             if (preg_match($regex, ($address->email ?? ''), $matches)) {
-              list($match, $action, $job, $queue, $hash) = $matches;
+              [$match, $action, $job, $queue, $hash] = $matches;
               break;
               // FIXME: the below elseifs should be dropped when we drop legacy support
             }
             elseif (preg_match($commonRegex, ($address->email ?? ''), $matches)) {
-              list($match, $action, $_, $job, $queue, $hash) = $matches;
+              [$match, $action, $_, $job, $queue, $hash] = $matches;
               break;
             }
             elseif (preg_match($subscrRegex, ($address->email ?? ''), $matches)) {
-              list($match, $action, $_, $job) = $matches;
+              [$match, $action, $_, $job] = $matches;
               break;
             }
           }
@@ -163,13 +163,13 @@ class CRM_Utils_Mail_EmailProcessor {
           // CRM-5471: if $matches is empty, it still might be a soft bounce sent
           // to another address, so scan the body for ‘Return-Path: …bounce-pattern…’
           if (!$matches and preg_match($rpRegex, ($mail->generateBody() ?? ''), $matches)) {
-            list($match, $action, $job, $queue, $hash) = $matches;
+            [$match, $action, $job, $queue, $hash] = $matches;
           }
 
           // if $matches is still empty, look for the X-CiviMail-Bounce header
           // CRM-9855
           if (!$matches and preg_match($rpXheaderRegex, ($mail->generateBody() ?? ''), $matches)) {
-            list($match, $action, $job, $queue, $hash) = $matches;
+            [$match, $action, $job, $queue, $hash] = $matches;
           }
           // With Mandrilla, the X-CiviMail-Bounce header is produced by generateBody
           // is base64 encoded
@@ -181,7 +181,7 @@ class CRM_Utils_Mail_EmailProcessor {
                 $p_file = $v_part->__get('fileName');
                 $c_file = file_get_contents($p_file);
                 if (preg_match($rpXheaderRegex, ($c_file ?? ''), $matches)) {
-                  list($match, $action, $job, $queue, $hash) = $matches;
+                  [$match, $action, $job, $queue, $hash] = $matches;
                 }
               }
             }
@@ -189,7 +189,7 @@ class CRM_Utils_Mail_EmailProcessor {
 
           // if all else fails, check Delivered-To for possible pattern
           if (!$matches and preg_match($regex, ($mail->getHeader('Delivered-To') ?? ''), $matches)) {
-            list($match, $action, $job, $queue, $hash) = $matches;
+            [$match, $action, $job, $queue, $hash] = $matches;
           }
         }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -126,7 +126,7 @@ class CRM_Utils_System {
       for ($i = 0, $cnt = count($qs); $i < $cnt; $i++) {
         // check first if exist a pair
         if (strstr($qs[$i], '=') !== FALSE) {
-          list($name, $value) = explode('=', $qs[$i]);
+          [$name, $value] = explode('=', $qs[$i]);
           if ($name != $urlVar) {
             $name = rawurldecode($name);
             // check for arrays in parameters: site.php?foo[]=1&foo[]=2&foo[]=3
@@ -265,15 +265,15 @@ class CRM_Utils_System {
 
     // Extract fragment from path or query if munged together
     if ($query && strstr($query, '#')) {
-      list($path, $fragment) = explode('#', $query);
+      [$path, $fragment] = explode('#', $query);
     }
     if ($path && strstr($path, '#')) {
-      list($path, $fragment) = explode('#', $path);
+      [$path, $fragment] = explode('#', $path);
     }
 
     // Extract query from path if munged together
     if ($path && strstr($path, '?')) {
-      list($path, $extraQuery) = explode('?', $path);
+      [$path, $extraQuery] = explode('?', $path);
       $query = $extraQuery . ($query ? "&$query" : '');
     }
 
@@ -723,7 +723,7 @@ class CRM_Utils_System {
     }
     elseif ($storeInSession) {
       // lets store contact id and user id in session
-      list($userID, $ufID, $randomNumber) = $result;
+      [$userID, $ufID, $randomNumber] = $result;
       if ($userID && $ufID) {
         $config = CRM_Core_Config::singleton();
         $config->userSystem->setUserSession([$userID, $ufID]);
@@ -995,7 +995,7 @@ class CRM_Utils_System {
 
     if (!array_key_exists($callback, self::$_callbacks)) {
       if (strpos($callback, '::') !== FALSE) {
-        list($className, $methodName) = explode('::', $callback);
+        [$className, $methodName] = explode('::', $callback);
         $fileName = str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
         // ignore errors if any
         @include_once $fileName;
@@ -1171,7 +1171,7 @@ class CRM_Utils_System {
    * @return string
    */
   public static function majorVersion() {
-    list($a, $b) = explode('.', self::version());
+    [$a, $b] = explode('.', self::version());
     return "$a.$b";
   }
 

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -378,7 +378,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
         (version_compare(JVERSION, '3.0', 'ge') && version_compare(JVERSION, '3.2.1', 'lt'))
       ) {
         // now check password
-        list($hash, $salt) = explode(':', $dbPassword);
+        [$hash, $salt] = explode(':', $dbPassword);
         $cryptpass = md5($password . $salt);
         if ($hash != $cryptpass) {
           return FALSE;
@@ -420,7 +420,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    *   Array with user specific data.
    */
   public function setUserSession($data) {
-    list($userID, $ufID) = $data;
+    [$userID, $ufID] = $data;
     $user = new JUser($ufID);
     $session = JFactory::getSession();
     $session->set('user', $user);
@@ -783,7 +783,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       return $civicrm_paths['cms.root']['path'];
     }
 
-    list($url, $siteName, $siteRoot) = $this->getDefaultSiteSettings();
+    [$url, $siteName, $siteRoot] = $this->getDefaultSiteSettings();
     if (file_exists("$siteRoot/administrator/index.php")) {
       return $siteRoot;
     }

--- a/Civi/API/Api3SelectQuery.php
+++ b/Civi/API/Api3SelectQuery.php
@@ -76,12 +76,12 @@ class Api3SelectQuery extends SelectQuery {
         // If we check a custom field on 'IS NULL', it should also work when there is no
         // record in the custom value table, see CRM-20740.
         $side = empty($value['IS NULL']) ? 'INNER' : 'LEFT OUTER';
-        list($table_name, $column_name) = $this->addCustomField($this->apiFieldSpec['custom_' . $cf_id], $side);
+        [$table_name, $column_name] = $this->addCustomField($this->apiFieldSpec['custom_' . $cf_id], $side);
       }
       elseif (strpos($key, '.')) {
         $fkInfo = $this->addFkField($key, 'INNER');
         if ($fkInfo) {
-          list($table_name, $column_name) = $fkInfo;
+          [$table_name, $column_name] = $fkInfo;
           $this->validateNestedInput($key, $value);
         }
       }

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -120,7 +120,7 @@ class Kernel {
 
     try {
       $this->boot($apiRequest);
-      list($apiProvider, $apiRequest) = $this->resolve($apiRequest);
+      [$apiProvider, $apiRequest] = $this->resolve($apiRequest);
       $this->authorize($apiProvider, $apiRequest);
       return TRUE;
     }
@@ -143,9 +143,9 @@ class Kernel {
   public function runRequest($apiRequest) {
     $this->boot($apiRequest);
 
-    list($apiProvider, $apiRequest) = $this->resolve($apiRequest);
+    [$apiProvider, $apiRequest] = $this->resolve($apiRequest);
     $this->authorize($apiProvider, $apiRequest);
-    list ($apiProvider, $apiRequest) = $this->prepare($apiProvider, $apiRequest);
+    [$apiProvider, $apiRequest] = $this->prepare($apiProvider, $apiRequest);
     $result = $apiProvider->invoke($apiRequest);
 
     return $this->respond($apiProvider, $apiRequest, $result);

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -156,7 +156,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
       }
 
       if (isset($apiRequest['params']['id'])) {
-        list($isValidId, $entityTable, $entityId) = $this->getDelegate($apiRequest['params']['id']);
+        [$isValidId, $entityTable, $entityId] = $this->getDelegate($apiRequest['params']['id']);
         if ($isValidId && $entityTable && $entityId) {
           $this->authorizeDelegate($apiRequest['action'], $entityTable, $entityId, $apiRequest);
           $this->preventReassignment($apiRequest['params']['id'], $entityTable, $entityId, $apiRequest);

--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -96,7 +96,7 @@ class ActionObjectProvider implements EventSubscriberInterface, ProviderInterfac
    * @throws \API_Exception
    */
   protected function runChain($request, $row) {
-    list($entity, $action, $params, $index) = $request;
+    [$entity, $action, $params, $index] = $request;
     // Swap out variables in $entity, $action & $params
     $this->resolveChainLinks($entity, $row);
     $this->resolveChainLinks($action, $row);

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -484,9 +484,9 @@ class Api4SelectQuery {
       }
       // If either the having or select field contains a pseudoconstant suffix, match and perform substitution
       else {
-        list($fieldName) = explode(':', $expr);
+        [$fieldName] = explode(':', $expr);
         foreach ($this->selectAliases as $selectAlias => $selectExpr) {
-          list($selectField) = explode(':', $selectAlias);
+          [$selectField] = explode(':', $selectAlias);
           if ($selectAlias === $selectExpr && $fieldName === $selectField && isset($this->apiFieldSpec[$fieldName])) {
             $field = $this->getField($fieldName);
             FormattingUtil::formatInputValue($value, $expr, $field, $operator);
@@ -712,7 +712,7 @@ class Api4SelectQuery {
       // First item in the array is the entity name
       $entity = array_shift($join);
       // Which might contain an alias. Split on the keyword "AS"
-      list($entity, $alias) = array_pad(explode(' AS ', $entity), 2, NULL);
+      [$entity, $alias] = array_pad(explode(' AS ', $entity), 2, NULL);
       // Ensure permissions
       if (!$this->checkEntityAccess($entity)) {
         continue;
@@ -785,7 +785,7 @@ class Api4SelectQuery {
     $stack = [NULL, NULL];
     // See if the ON clause already contains an FK reference to joinEntity
     $explicitFK = array_filter($joinTree, function($clause) use ($alias, $joinEntityFields) {
-      list($sideA, $op, $sideB) = array_pad((array) $clause, 3, NULL);
+      [$sideA, $op, $sideB] = array_pad((array) $clause, 3, NULL);
       if ($op !== '=' || !$sideB) {
         return FALSE;
       }
@@ -987,7 +987,7 @@ class Api4SelectQuery {
     $bridgeAlias = $side === 'INNER' ? $bridgeAlias : $alias;
     // Find explicit bridge join conditions and move them out of the joinTree
     $joinTree = array_filter($joinTree, function ($clause) use ($baseRef, $alias, $bridgeAlias, &$bridgeConditions) {
-      list($sideA, $op, $sideB) = array_pad((array) $clause, 3, NULL);
+      [$sideA, $op, $sideB] = array_pad((array) $clause, 3, NULL);
       // Skip AND/OR/NOT branches
       if (!$sideB) {
         return TRUE;

--- a/Civi/Core/SettingsStack.php
+++ b/Civi/Core/SettingsStack.php
@@ -43,7 +43,7 @@ class SettingsStack {
    */
   public function popAll() {
     while ($frame = array_pop($this->stack)) {
-      list($setting, $value) = $frame;
+      [$setting, $value] = $frame;
       if ($value === NULL) {
         unset($GLOBALS['civicrm_setting']['domain'][$setting]);
       }

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -287,7 +287,7 @@ class CryptoRegistry {
    * @throws CryptoException
    */
   public function parseKey($keyExpr) {
-    list($suite, $keyFunc, $keyVal) = explode(':', $keyExpr);
+    [$suite, $keyFunc, $keyVal] = explode(':', $keyExpr);
     if ($suite === '') {
       $suite = self::DEFAULT_SUITE;
     }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -639,7 +639,7 @@ trait Api3TestTrait {
     }
 
     // Handle single api call
-    list(, $chainEntity, $chainAction) = explode('.', $key);
+    [, $chainEntity, $chainAction] = explode('.', $key);
     $lcChainEntity = \CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($chainEntity);
     $chainEntity = \CRM_Core_DAO_AllCoreTables::convertEntityNameToCamel($chainEntity);
     $lcMainEntity = \CRM_Core_DAO_AllCoreTables::convertEntityNameToLower($mainEntity);

--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -139,7 +139,7 @@ trait HttpTestTrait {
    */
   protected function assertContentType($expectType, $response = NULL) {
     $response = $this->resolveResponse($response);
-    list($actualType) = explode(';', $response->getHeader('Content-Type')[0]);
+    [$actualType] = explode(';', $response->getHeader('Content-Type')[0]);
     $fmt = $actualType === $expectType ? '' : $this->formatFailure($response);
     $this->assertEquals($expectType, $actualType, "Expected content-type $expectType. Received content-type $actualType.\n$fmt");
     return $this;

--- a/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ActivitySearchTest.php
@@ -119,7 +119,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
       'expected_contact' => [$this->_contactID],
     ];
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
     $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
     foreach ($groupContacts as $key => $value) {
       $groupContacts[$key] = $value['id'];
@@ -146,7 +146,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
       'expected_contact' => [$this->_contactID],
     ];
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
     $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
     foreach ($groupContacts as $key => $value) {
       $groupContacts[$key] = $value['id'];
@@ -173,7 +173,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
       'expected_contact' => [$this->_contactID],
     ];
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
     $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
     foreach ($groupContacts as $key => $value) {
       $groupContacts[$key] = $value['id'];
@@ -200,7 +200,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
       'expected_contact' => [$this->_contactID],
     ];
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
     $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id $from $where")->fetchAll();
     foreach ($groupContacts as $key => $value) {
       $groupContacts[$key] = $value['id'];
@@ -238,7 +238,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
       'expected_contact' => [$this->_contactID],
     ];
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
 
     $expectedQill = [
       0 => [
@@ -292,7 +292,7 @@ class CRM_Contact_BAO_ActivitySearchTest extends CiviUnitTestCase {
       'expected_contact' => [$this->_contactID],
     ];
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
 
     $expectedQill = [
       0 => [

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -405,7 +405,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties);
     try {
       $this->assertLike($expectedSQL, $queryObj->getSearchSQL());
-      list($select, $from, $where, $having) = $queryObj->query();
+      [$select, $from, $where, $having] = $queryObj->query();
       $dao = CRM_Core_DAO::executeQuery("$select $from $where $having");
       $dao->fetch();
       $this->assertEquals('Anderson, Anthony', $dao->sort_name);
@@ -500,7 +500,7 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
       TRUE, FALSE
     );
 
-    list($select) = $query->query();
+    [$select] = $query->query();
     $this->assertEquals('SELECT contact_a.id as contact_id', $select);
   }
 
@@ -1203,7 +1203,7 @@ civicrm_relationship.is_active = 1 AND
       TRUE, FALSE
     );
 
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
     $this->assertEquals($expectedWhere, $where);
   }
 
@@ -1395,13 +1395,13 @@ civicrm_relationship.is_active = 1 AND
       ],
     ];
     $query = new CRM_Contact_BAO_Query($params);
-    list($select, $from, $where) = $query->query();
+    [$select, $from, $where] = $query->query();
     $this->assertStringContainsString("contact_a.sort_name LIKE '%John%Doe%'", $where);
 
     //Check for NO wildcard due to comma
     $params[0][2] = 'Doe, John';
     $query = new CRM_Contact_BAO_Query($params);
-    list($select, $from, $where) = $query->query();
+    [$select, $from, $where] = $query->query();
     $this->assertStringContainsString("contact_a.sort_name LIKE '%Doe, John%'", $where);
   }
 

--- a/tests/phpunit/CRM/Contribute/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/SearchTest.php
@@ -106,7 +106,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
     foreach ($entities['values'] as $value) {
       $ids[] = $value['entity_id'];
     }
-    list($batchContriID1, $batchContriID2) = $ids;
+    [$batchContriID1, $batchContriID2] = $ids;
 
     $useCases = [
       // Case 1: Search for ONLY those contributions which are created from batch
@@ -135,7 +135,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $fv = $case['form_value'];
       CRM_Contact_BAO_Query::processSpecialFormValue($fv, ['contribution_batch_id']);
       $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($fv));
-      list($select, $from, $where) = $query->query();
+      [$select, $from, $where] = $query->query();
 
       // get and assert contribution count
       $contributions = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT civicrm_contribution.id %s %s AND civicrm_contribution.id IS NOT NULL', $from, $where))->fetchAll();
@@ -237,7 +237,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $fv = $case['form_value'];
       CRM_Contact_BAO_Query::processSpecialFormValue($fv, ['financial_trxn_card_type_id']);
       $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($fv));
-      list($select, $from, $where) = $query->query();
+      [$select, $from, $where] = $query->query();
 
       // get and assert contribution count
       $contributions = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT civicrm_contribution.id %s %s AND civicrm_contribution.id IS NOT NULL', $from, $where))->fetchAll();
@@ -334,7 +334,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $fv = $case['form_value'];
       CRM_Contact_BAO_Query::processSpecialFormValue($fv, ['financial_trxn_pan_truncation']);
       $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($fv));
-      list($select, $from, $where) = $query->query();
+      [$select, $from, $where] = $query->query();
 
       // get and assert contribution count
       $contributions = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT civicrm_contribution.id %s %s AND civicrm_contribution.id IS NOT NULL', $from, $where))->fetchAll();
@@ -359,7 +359,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
     $fv = ['contact_id' => $contactID];
     $queryParams = CRM_Contact_BAO_Query::convertFormValues($fv);
     $selector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::ADD);
-    list($select, $from, $where) = $selector->getQuery()->query();
+    [$select, $from, $where] = $selector->getQuery()->query();
 
     // get and assert contribution count
     $contributions = CRM_Core_DAO::executeQuery("{$select} {$from} {$where}")->fetchAll();
@@ -372,7 +372,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       'contact_id' => $contactID,
     ]);
     $selector = new CRM_Contribute_Selector_Search($queryParams, CRM_Core_Action::ADD);
-    list($select, $from, $where) = $selector->getQuery()->query();
+    [$select, $from, $where] = $selector->getQuery()->query();
 
     // get and assert contribution count
     $contributions = CRM_Core_DAO::executeQuery("{$select} {$from} {$where}")->fetchAll();
@@ -388,7 +388,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
     $this->setUpRecurringContributions();
 
     $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($formValues));
-    list($select, $from, $where, $having) = $query->query();
+    [$select, $from, $where, $having] = $query->query();
 
     // get and assert contribution count
     $contacts = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT contact_a.id, contact_a.display_name %s %s AND contact_a.id IS NOT NULL', $from, $where))->fetchAll();
@@ -478,7 +478,7 @@ class CRM_Contribute_Form_SearchTest extends CiviUnitTestCase {
       $fv = $case['form_value'];
       CRM_Contact_BAO_Query::processSpecialFormValue($fv, ['cancel_reason']);
       $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($fv));
-      list($select, $from, $where) = $query->query();
+      [$select, $from, $where] = $query->query();
 
       // get and assert contribution count
       $contributions = CRM_Core_DAO::executeQuery(sprintf('SELECT DISTINCT civicrm_contribution.id %s %s AND civicrm_contribution.id IS NOT NULL AND civicrm_contribution.contribution_status_id = 3', $from, $where))->fetchAll();

--- a/tests/phpunit/CRM/Extension/Container/BasicTest.php
+++ b/tests/phpunit/CRM/Extension/Container/BasicTest.php
@@ -13,12 +13,12 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   }
 
   public function testGetKeys() {
-    list($basedir, $c) = $this->_createContainer();
+    [$basedir, $c] = $this->_createContainer();
     $this->assertEquals($c->getKeys(), ['test.foo', 'test.foo.bar']);
   }
 
   public function testGetPath() {
-    list($basedir, $c) = $this->_createContainer();
+    [$basedir, $c] = $this->_createContainer();
     try {
       $c->getPath('un.kno.wn');
     }
@@ -32,7 +32,7 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   }
 
   public function testGetPath_extraSlashFromConfig() {
-    list($basedir, $c) = $this->_createContainer(NULL, NULL, '/');
+    [$basedir, $c] = $this->_createContainer(NULL, NULL, '/');
     try {
       $c->getPath('un.kno.wn');
     }
@@ -46,7 +46,7 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   }
 
   public function testGetResUrl() {
-    list($basedir, $c) = $this->_createContainer();
+    [$basedir, $c] = $this->_createContainer();
     try {
       $c->getResUrl('un.kno.wn');
     }
@@ -60,7 +60,7 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   }
 
   public function testGetResUrl_extraSlashFromConfig() {
-    list($basedir, $c) = $this->_createContainer(NULL, NULL, '/');
+    [$basedir, $c] = $this->_createContainer(NULL, NULL, '/');
     try {
       $c->getResUrl('un.kno.wn');
     }
@@ -76,7 +76,7 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   public function testCaching() {
     $cache = new CRM_Utils_Cache_Arraycache([]);
     $this->assertTrue(!is_array($cache->get('basic-scan')));
-    list($basedir, $c) = $this->_createContainer($cache, 'basic-scan');
+    [$basedir, $c] = $this->_createContainer($cache, 'basic-scan');
     $this->assertEquals('http://example/basedir/foo', $c->getResUrl('test.foo'));
     $this->assertTrue(is_array($cache->get('basic-scan')));
 

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -138,7 +138,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
 
       $this->assertTrue($message->body instanceof ezcMailMultipartAlternative);
 
-      list($textPart, $htmlPart) = $message->body->getParts();
+      [$textPart, $htmlPart] = $message->body->getParts();
 
       $this->assertEquals('html', $htmlPart->subType);
       $this->assertRegExp(
@@ -195,7 +195,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
 
       $this->assertTrue($message->body instanceof ezcMailMultipartAlternative);
 
-      list($textPart, $htmlPart) = $message->body->getParts();
+      [$textPart, $htmlPart] = $message->body->getParts();
 
       $this->assertEquals('html', $htmlPart->subType);
       $this->assertRegExp(
@@ -339,7 +339,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
 
       $this->assertTrue($message->body instanceof ezcMailMultipartAlternative);
 
-      list($textPart, $htmlPart) = $message->body->getParts();
+      [$textPart, $htmlPart] = $message->body->getParts();
 
       if ($htmlUrlRegex) {
         $caseName = print_r(['inputHtml' => $inputHtml, 'params' => $params, 'htmlUrlRegex' => $htmlUrlRegex, 'htmlPart' => $htmlPart->text], 1);

--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -79,19 +79,19 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
   }
 
   public function testGetHttp() {
-    list($status, $data) = $this->client->get(self::VALID_HTTP_URL);
+    [$status, $data] = $this->client->get(self::VALID_HTTP_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $status);
     $this->assertRegExp(self::VALID_HTTP_REGEX, $data);
   }
 
   public function testGetHttps_valid() {
-    list($status, $data) = $this->client->get(self::VALID_HTTPS_URL);
+    [$status, $data] = $this->client->get(self::VALID_HTTPS_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $status);
     $this->assertRegExp(self::VALID_HTTPS_REGEX, $data);
   }
 
   public function testGetHttps_invalid_verify() {
-    list($status, $data) = $this->client->get(self::SELF_SIGNED_HTTPS_URL);
+    [$status, $data] = $this->client->get(self::SELF_SIGNED_HTTPS_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_DL_ERROR, $status);
     $this->assertEquals('', $data);
   }
@@ -103,7 +103,7 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
     ]);
     $this->assertAPISuccess($result);
 
-    list($status, $data) = $this->client->get(self::SELF_SIGNED_HTTPS_URL);
+    [$status, $data] = $this->client->get(self::SELF_SIGNED_HTTPS_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $status);
     $this->assertRegExp(self::SELF_SIGNED_HTTPS_REGEX, $data);
   }

--- a/tests/phpunit/E2E/Cache/TwoInstancesTest.php
+++ b/tests/phpunit/E2E/Cache/TwoInstancesTest.php
@@ -108,7 +108,7 @@ class E2E_Cache_TwoInstancesTest extends CiviEndToEndTestCase {
    * @dataProvider getTwoGenerators
    */
   public function testDiff_clearA($cacheA, $cacheB) {
-    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    [$a, $b] = $this->createTwoCaches($cacheA, $cacheB);
     $a->set('foo', 1234);
     $b->set('foo', 5678);
     $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
@@ -129,7 +129,7 @@ class E2E_Cache_TwoInstancesTest extends CiviEndToEndTestCase {
    * @dataProvider getTwoGenerators
    */
   public function testDiff_clearB($cacheA, $cacheB) {
-    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    [$a, $b] = $this->createTwoCaches($cacheA, $cacheB);
     $a->set('foo', 1234);
     $b->set('foo', 5678);
     $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
@@ -150,13 +150,13 @@ class E2E_Cache_TwoInstancesTest extends CiviEndToEndTestCase {
    * @dataProvider getTwoGenerators
    */
   public function testDiff_reload($cacheA, $cacheB) {
-    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    [$a, $b] = $this->createTwoCaches($cacheA, $cacheB);
     $a->set('foo', 1234);
     $b->set('foo', 5678);
     $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
     $this->assertEquals(5678, $b->get('foo'), 'Check value B after initial setup');
 
-    list($a, $b) = $this->createTwoCaches($cacheA, $cacheB);
+    [$a, $b] = $this->createTwoCaches($cacheA, $cacheB);
     $this->assertEquals(1234, $a->get('foo'), 'Check value A after initial setup');
     $this->assertEquals(5678, $b->get('foo'), 'Check value B after initial setup');
   }


### PR DESCRIPTION
Overview
----------------------------------------

PHPStorm is quite eager to reformat the array-unpack statements, eg

```diff
-list($a,$b) = $array;
+[$a, $b] = $array;
```

I couldn't find a flag to turn this off, and it adds distractions during development (eg you get spurious changes in unrelated commits; or you have to do `git add -p`, or you have to repeatedly edit back to the original notation).

So I searched for clusters of `list()` statements and then open/resaved those files -- thereby running the autoformat.