### PR TITLE
closes #3745 Fixes Rewrite of Multi-Select Token in Search Kit

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -728,14 +728,19 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @param int $index
    * @return string
    */
-  private function replaceTokens($tokenExpr, $data, $format, $index = 0) {
+  private function replaceTokens($tokenExpr, $data, $format, $index = NULL) {
     if (strpos(($tokenExpr ?? ''), '[') !== FALSE) {
       foreach ($this->getTokens($tokenExpr) as $token) {
         $val = $data[$token] ?? NULL;
         if (isset($val) && $format === 'view') {
           $val = $this->formatViewValue($token, $val);
         }
-        $replacement = is_array($val) ? $val[$index] ?? '' : $val;
+        if (!(is_null($index))) {
+          $replacement = is_array($val) ? $val[$index] ?? '' : $val;
+        }
+        else {
+          $replacement = implode(', ', (array) $val);
+        }
         // A missing token value in a url invalidates it
         if ($format === 'url' && (!isset($replacement) || $replacement === '')) {
           return NULL;

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/AbstractRunActionTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/AbstractRunActionTest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace api\v4\SearchDisplay;
+
+use Civi\Api4\CustomGroup;
+use Civi\Api4\CustomField;
+use Civi\Api4\Contact;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testReplaceTokens() {
+    CustomGroup::create(FALSE)
+      ->addValue('title', 'Foods')
+      ->addValue('name', 'Foods')
+      ->execute();
+
+    CustomField::create(FALSE)
+      ->addValue('custom_group_id.name', 'Foods')
+      ->addValue('label', 'I Like')
+      ->addValue('serialize:name', \CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND)
+      ->addValue('html_type', 'Autocomplete-Select')
+      ->addValue('data_type', 'String')
+      ->addValue('option_values', ['Pie', 'Cake', 'Anything you make'])
+      ->execute();
+
+    Contact::create(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('first_name', 'Lee')
+      ->addValue('last_name', 'Morse')
+      ->addValue('Foods.I_Like', [0, 1, 2])
+      ->execute();
+
+    $entity = 'SearchDisplay';
+    $action = 'run';
+    $params = array(
+      'return' => 'page:1',
+      'savedSearch' =>
+      array(
+        'id' => 1,
+        'name' => 'Multi_Select_Test',
+        'label' => 'Multi Select Test',
+        'form_values' => NULL,
+        'mapping_id' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'Contact',
+        'api_params' =>
+        array(
+          'version' => 4,
+          'select' =>
+          array(
+            0 => 'display_name',
+            1 => 'Foods.I_Like:label',
+          ),
+          'orderBy' =>
+          array(),
+          'where' =>
+          array(
+            0 =>
+            array(
+              0 => 'contact_type:name',
+              1 => '=',
+              2 => 'Individual',
+            ),
+            1 =>
+            array(
+              0 => 'Foods.I_Like:name',
+              1 => 'IS NOT EMPTY',
+            ),
+          ),
+          'groupBy' =>
+          array(
+            0 => 'id',
+          ),
+          'having' =>
+          array(),
+        ),
+        'created_id' => 203,
+        'modified_id' => 203,
+        'expires_date' => NULL,
+        'created_date' => '2022-08-12 13:49:17',
+        'modified_date' => '2022-08-12 17:18:24',
+        'description' => NULL,
+        'tag_id' =>
+        array(),
+        'groups' =>
+        array(),
+        'displays' =>
+        array(
+          0 =>
+          array(
+            'id' => 1,
+            'name' => 'Contacts_Table_1',
+            'label' => 'Contacts Table 1',
+            'saved_search_id' => 1,
+            'type' => 'table',
+            'settings' =>
+            array(
+              'actions' => TRUE,
+              'limit' => 50,
+              'classes' =>
+              array(
+                0 => 'table',
+                1 => 'table-striped',
+              ),
+              'pager' =>
+              array(),
+              'placeholder' => 5,
+              'sort' =>
+              array(
+                0 =>
+                array(
+                  0 => 'sort_name',
+                  1 => 'ASC',
+                ),
+              ),
+              'columns' =>
+              array(
+                0 =>
+                array(
+                  'type' => 'field',
+                  'key' => 'display_name',
+                  'dataType' => 'String',
+                  'label' => 'Display Name',
+                  'sortable' => TRUE,
+                  'link' =>
+                  array(
+                    'path' => '',
+                    'entity' => 'Contact',
+                    'action' => 'view',
+                    'join' => '',
+                    'target' => '_blank',
+                  ),
+                  'title' => 'View Contact',
+                ),
+                1 =>
+                array(
+                  'type' => 'field',
+                  'key' => 'Foods.I_Like:label',
+                  'dataType' => 'String',
+                  'label' => 'Foods: I Like',
+                  'sortable' => TRUE,
+                  'rewrite' => '[Foods.I_Like:label]',
+                ),
+              ),
+            ),
+            'acl_bypass' => FALSE,
+          ),
+        ),
+      ),
+      'display' =>
+      array(
+        'id' => 1,
+        'name' => 'Contacts_Table_1',
+        'label' => 'Contacts Table 1',
+        'saved_search_id' => 1,
+        'type' => 'table',
+        'settings' =>
+        array(
+          'actions' => TRUE,
+          'limit' => 50,
+          'classes' =>
+          array(
+            0 => 'table',
+            1 => 'table-striped',
+          ),
+          'pager' =>
+          array(),
+          'placeholder' => 5,
+          'sort' =>
+          array(
+            0 =>
+            array(
+              0 => 'sort_name',
+              1 => 'ASC',
+            ),
+          ),
+          'columns' =>
+          array(
+            0 =>
+            array(
+              'type' => 'field',
+              'key' => 'display_name',
+              'dataType' => 'String',
+              'label' => 'Display Name',
+              'sortable' => TRUE,
+              'link' =>
+              array(
+                'path' => '',
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => '',
+                'target' => '_blank',
+              ),
+              'title' => 'View Contact',
+            ),
+            1 =>
+            array(
+              'type' => 'field',
+              'key' => 'Foods.I_Like:label',
+              'dataType' => 'String',
+              'label' => 'Foods: I Like',
+              'sortable' => TRUE,
+              'rewrite' => '[Foods.I_Like:label]',
+            ),
+          ),
+        ),
+        'acl_bypass' => FALSE,
+      ),
+      'sort' =>
+      array(
+        0 =>
+        array(
+          0 => 'sort_name',
+          1 => 'ASC',
+        ),
+      ),
+      'limit' => 50,
+      'seed' => 1660599799146,
+      'filters' =>
+      array(),
+      'afform' => NULL,
+      'debug' => TRUE,
+      'checkPermissions' => TRUE,
+    );
+    $result = civicrm_api4($entity, $action, $params);
+    $resultData = $result[0]['data']['Foods.I_Like:label'];
+    $this->assertTrue(implode(', ', $resultData) === $result[0]['columns'][1]['val']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The **Rewrite** option for editing a display in a saved Search Kit search had a bug so that the token would only return the first value of a multi-select (i.e. multiple values) field.

Replication steps are available on the lab.civicrm [issue](https://lab.civicrm.org/dev/core/-/issues/3745)

Before
----------------------------------------
Before this fix, if a token was used on the **Rewrite** option for a multi-select custom field, the display would only return the first value .

![Selection_049](https://user-images.githubusercontent.com/87245718/186996210-9906872c-b6ad-4b73-aa49-b49f9cfd1955.png)

![Selection_046](https://user-images.githubusercontent.com/87245718/186994419-e69f2af7-107d-420d-ae72-e8c0125238d6.png)

After
----------------------------------------
With the fix, the Search Kit display returns all values of the multi-select field when a token is used via the **Rewrite** option.

![Selection_048](https://user-images.githubusercontent.com/87245718/186996240-fbb0aa9e-b0c6-490a-a3b4-550897440628.png)

![Selection_047](https://user-images.githubusercontent.com/87245718/186994458-bdee1c52-537b-4935-a1e2-4d33c188853f.png)

Technical Details
----------------------------------------
The bug was rooted in the `replaceToken()` function. `$index` had a default argument of 0 in the function's parameters  and with the way that `$replacement` was being set on line 738, the function was only returning the first index of an array. This fix replaces the default argument with `NULL` and puts the assignment of `$replacement` as it was originally written within an `if` statement that accounts for an `$index` that is not `NULL`.

Comments
----------------------------------------
A unit test is included as part of this PR.
