### PR TITLE
Queue API - Expose option for delayed tasks (`$options['release_time']`)

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -130,6 +130,7 @@ abstract class CRM_Queue_Queue {
    * @param array $options
    *   Queue-dependent options; for example, if this is a
    *   priority-queue, then $options might specify the item's priority.
+   *   Ex: ['release_time' => strtotime('+3 hours')]
    */
   abstract public function createItem($data, $options = []);
 

--- a/CRM/Queue/Queue/Memory.php
+++ b/CRM/Queue/Queue/Memory.php
@@ -97,12 +97,16 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
    * @param array $options
    *   Queue-dependent options; for example, if this is a
    *   priority-queue, then $options might specify the item's priority.
+   *   Ex: ['release_time' => strtotime('+3 hours')]
    */
   public function createItem($data, $options = []) {
     $id = $this->nextQueueItemId++;
     // force copy, no unintendedsharing effects from pointers
     $this->items[$id] = serialize($data);
     $this->runCounts[$id] = 0;
+    if (isset($options['release_time'])) {
+      $this->releaseTimes[$id] = $options['release_time'];
+    }
   }
 
   /**

--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -73,6 +73,7 @@ trait CRM_Queue_Queue_SqlTrait {
    * @param array $options
    *   Queue-dependent options; for example, if this is a
    *   priority-queue, then $options might specify the item's priority.
+   *   Ex: ['release_time' => strtotime('+3 hours')]
    */
   public function createItem($data, $options = []) {
     $dao = new CRM_Queue_DAO_QueueItem();
@@ -80,6 +81,9 @@ trait CRM_Queue_Queue_SqlTrait {
     $dao->submit_time = CRM_Utils_Time::getTime('YmdHis');
     $dao->data = serialize($data);
     $dao->weight = CRM_Utils_Array::value('weight', $options, 0);
+    if (isset($options['release_time'])) {
+      $dao->release_time = date('Y-m-d H:i:s', $options['release_time']);
+    }
     $dao->save();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Queue_Queue_*::createItem()` allows you to create new tasks for separate/parallel execution. This patch adds an option for marking new tasks as *delayed* (ie they will execute at some specific time in the future).

This is an off-shoot from discussion on https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/992 (@eileenmcnaughton @jaapjansma @ErikHommel).

Before
----------------------------------------

* When creating a task with `CRM_Queue_Queue_*::createItem()`, you cannot request delayed execution explicitly.
* However, the underlying system is amenable. (*Delays are already used for locking tasks and for retrying failed tasks.*)
* Some extensions already use the SQL-backed queue for delayed tasks, and there's a public recipe for doing this. But it requires one to directly manipulate the queue via SQL/DAO.

After
----------------------------------------

All core queue types (`Sql`, `SqlParallel`, `Memory`) all you to create a delayed task:

```php
Civi::queue('todos')->createItem(
  new CRM_Queue_Task($callback, $args),
  ['release_time' => strtotime('+3 hours')]
);
```

