### PR TITLE
Fix import classes to call `runAllInteractive()` rather than `runAllViaWeb` (which in practice currently just calls `runAllViaWeb` )

### DIFF
--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -99,6 +99,8 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
 
   /**
    * Run the import.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function runTheImport(): void {
     $parser = $this->getParser();
@@ -112,7 +114,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
         'reset' => 1,
       ], FALSE, NULL, FALSE),
     ]);
-    $runner->runAllViaWeb();
+    $runner->runAllInteractive();
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -663,10 +663,16 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     UserJob::update(FALSE)->addWhere('id', '=', $userJob['id'])->setValues(['metadata' => $this->userJob['metadata']])->execute();
   }
 
-  public function queue() {
+  /**
+   * Queue the user job as one or more tasks.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function queue(): void {
     $dataSource = $this->getDataSourceObject();
     $totalRowCount = $totalRows = $dataSource->getRowCount(['new']);
-    $queue = Civi::queue('user_job_' . $this->getUserJobID(), ['type' => 'Sql', 'error' => 'abort']);
+    $queue = Civi::queue('user_job_' . $this->getUserJobID(), ['type' => 'Sql', 'error' => 'abort', 'runner' => 'task', 'user_job_id' => $this->getUserJobID()]);
+    UserJob::update(FALSE)->setValues(['queue_id.name' => 'user_job_' . $this->getUserJobID()])->addWhere('id', '=', $this->getUserJobID())->execute();
     $offset = 0;
     $batchSize = 5;
     while ($totalRows > 0) {

--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -101,7 +101,7 @@ abstract class CRM_Queue_Queue {
   }
 
   /**
-   * Perform any registation or resource-allocation for a new queue
+   * Perform any registration or resource-allocation for a new queue
    */
   abstract public function createQueue();
 

--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -54,11 +54,11 @@ class CRM_Queue_Service {
    *
    * @return \CRM_Queue_Service
    */
-  public static function &singleton($forceNew = FALSE) {
-    if ($forceNew || !self::$_singleton) {
-      self::$_singleton = new CRM_Queue_Service();
+  public static function &singleton(bool $forceNew = FALSE) {
+    if ($forceNew || !isset(\Civi::$statics[__CLASS__]['singleton'])) {
+      \Civi::$statics[__CLASS__]['singleton'] = new CRM_Queue_Service();
     }
-    return self::$_singleton;
+    return \Civi::$statics[__CLASS__]['singleton'];
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -49,7 +49,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    *
    * @param string $thousandSeparator
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function testImportParserWithSoftCreditsByExternalIdentifier(string $thousandSeparator): void {
     $this->setCurrencySeparators($thousandSeparator);


### PR DESCRIPTION
Overview
----------------------------------------
Fix import classes to call `runAllInteractive`

Before
----------------------------------------
Import classes call `runAllViaWeb`

After
----------------------------------------
Import classes call `runAllInteractive`

Technical Details
----------------------------------------
This is a no-change PR at the moment as it will still call `runAsWeb` unless the not-yet-viable setting to drive it to the background is used - and we have a gazzillion tests that go through that path.

However, this requires some fixes to instantiate the queue more correctly & stop between-test-leakage on the queue singleton (as was hit by the test with the minor doc-block edit)

Comments
----------------------------------------
@totten this doesn't address the queue runner screen - but I think with this that is the remaining challenge