### PR TITLE
Ensure there is a record of queueRunner exceptions in ConfigAndLog

### DIFF
--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -275,6 +275,9 @@ class CRM_Queue_Runner {
         'queue' => $this->queue,
       ]));
 
+      if ($exception) {
+        CRM_Core_Error::debug_var('queueRunnerException', CRM_Core_Error::formatTextException($exception));
+      }
       return $this->formatTaskResult($isOK, $exception);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Ensure there is a record of queueRunner exceptions in ConfigAndLog

Before
----------------------------------------
There doesn't seem to be any retained record of errors during queue processing

After
----------------------------------------
Logged to the ConfigAndLog

Technical Details
----------------------------------------

Comments
----------------------------------------
