### PR TITLE
Switch Contact import to use new v4 dedupe lookup

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1050,7 +1050,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    *
    * @param array $params
    * @param int|null $extIDMatch
-   * @param int|null $dedupeRuleID
+   * @param int|string $dedupeRuleID
    *
    * @return int|null
    *   IDs of a possible.
@@ -1058,21 +1058,19 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  protected function getPossibleContactMatch(array $params, ?int $extIDMatch, ?int $dedupeRuleID): ?int {
-    $checkParams = ['check_permissions' => FALSE, 'match' => $params, 'dedupe_rule_id' => $dedupeRuleID];
-    $possibleMatches = civicrm_api3('Contact', 'duplicatecheck', $checkParams);
+  protected function getPossibleContactMatch(array $params, ?int $extIDMatch, $dedupeRuleID): ?int {
+    $possibleMatches = $this->getPossibleMatchesByDedupeRule($params, $dedupeRuleID);
     if (!$extIDMatch) {
-      if (count($possibleMatches['values']) === 1) {
-        return array_key_last($possibleMatches['values']);
+      if (count($possibleMatches) === 1) {
+        return array_key_last($possibleMatches);
       }
-      if (count($possibleMatches['values']) > 1) {
-        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts: ') . implode(',', array_keys($possibleMatches['values'])), CRM_Import_Parser::ERROR);
-
+      if (count($possibleMatches) > 1) {
+        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts: ') . implode(',', array_keys($possibleMatches)), CRM_Import_Parser::ERROR);
       }
       return NULL;
     }
-    if ($possibleMatches['count']) {
-      if (array_key_exists($extIDMatch, $possibleMatches['values'])) {
+    if (count($possibleMatches) > 0) {
+      if (array_key_exists($extIDMatch, $possibleMatches)) {
         return $extIDMatch;
       }
       throw new CRM_Core_Exception(ts('Matching this contact based on the de-dupe rule would cause an external ID conflict'), CRM_Import_Parser::ERROR);

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_valid_basic.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_valid_basic.csv
@@ -1,0 +1,2 @@
+Player First Name,Email,Source,Another email
+Susie,mum@example.org,Import,bob@example.org

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -69,9 +69,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   /**
    * Test that import parser will add contact with employee of relationship.
    *
-   * @throws \API_Exception
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
    */
   public function testImportParserWithEmployeeOfRelationship(): void {
     $this->organizationCreate([
@@ -560,7 +558,6 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccessGetCount('OpenID', ['contact_id' => $id], 1);
     $this->callAPISuccessGetCount('IM', ['contact_id' => $id], 1);
   }
-
 
   /**
    * Test whether importing a contact using email match will match a non-primary.
@@ -2277,7 +2274,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $parser->import($values);
     $dataSource = new CRM_Import_DataSource_SQL($userJobID);
     $row = $dataSource->getRow();
-    $this->assertEquals($expected, $row['_status']);
+    $this->assertEquals($expected, $row['_status'], print_r($row, TRUE));
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -561,6 +561,73 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->callAPISuccessGetCount('IM', ['contact_id' => $id], 1);
   }
 
+
+  /**
+   * Test whether importing a contact using email match will match a non-primary.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportMatchNonPrimary(): void {
+    $anthony = $this->individualCreate();
+    Email::create()->setValues([
+      'contact_id' => $anthony,
+      'location_type_id:name' => 'Billing',
+      'is_primary' => FALSE,
+      'email' => 'mum@example.org',
+    ])->execute();
+    $this->importCSV('individual_valid_basic.csv', [
+      ['first_name'],
+      ['email'],
+      ['source'],
+      ['do_not_import'],
+    ], ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
+    $contact = Contact::get()
+      ->addWhere('id', '=', $anthony)
+      ->execute()
+      ->first();
+    $this->assertEquals('Import', $contact['source']);
+  }
+
+  /**
+   * Test whether importing a contact using email match will match a non-primary.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportMatchSpecifiedLocationToPrimary(): void {
+    $anthony = $this->individualCreate(['email' => 'mum@example.org']);
+
+    $this->importCSV('individual_valid_basic.csv', [
+      ['first_name'],
+      ['email', CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Email', 'location_type_id', 'Other')],
+      ['source'],
+      ['do_not_import'],
+    ], ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
+    $contact = Contact::get()
+      ->addWhere('id', '=', $anthony)
+      ->execute()
+      ->first();
+    $this->assertEquals('Import', $contact['source']);
+
+    // Change the existing primary email to Bob & check that it will match the first
+    // of two emails.
+    Email::update()
+      ->addWhere('email', '=', 'mum@example.org')
+      ->addWhere('is_primary', '=', TRUE)
+      ->setValues(['email' => 'bob@example.org'])->execute();
+
+    $this->importCSV('individual_valid_basic.csv', [
+      ['first_name'],
+      ['email', CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Email', 'location_type_id', 'Other')],
+      ['middle_name'],
+      ['email', CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Email', 'location_type_id', 'Work')],
+    ], ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
+    $contact = Contact::get()
+      ->addWhere('id', '=', $anthony)
+      ->execute()
+      ->first();
+    $this->assertEquals('Import', $contact['middle_name']);
+  }
+
   /**
    * Test that the import parser adds the address to the primary location.
    *
@@ -2064,6 +2131,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
       'groups' => [],
     ], $submittedValues);
+    /* @var CRM_Contact_Import_Form_DataSource $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_DataSource', $submittedValues);
     $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
 

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -6,6 +6,7 @@
 
 use Civi\Api4\Contribution;
 use Civi\Api4\ContributionSoft;
+use Civi\Api4\Email;
 use Civi\Api4\Note;
 use Civi\Api4\OptionValue;
 use Civi\Api4\UserJob;
@@ -299,6 +300,24 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ->addWhere('entity_id', '=', $contribution['id'])
       ->addWhere('entity_table', '=', 'civicrm_contribution')->execute()->first();
     $this->assertEquals('Call him back', $note['note']);
+  }
+
+  /**
+   * Test whether importing a contribution using email match will match a non-primary.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportMatchNonPrimary(): void {
+    $anthony = $this->individualCreate();
+    Email::create()->setValues([
+      'contact_id' => $anthony,
+      'location_type_id:name' => 'Billing',
+      'is_primary' => FALSE,
+      'email' => 'mum@example.com',
+    ])->execute();
+    $this->importContributionsDotCSV();
+    $contribution = Contribution::get()->execute()->first();
+    $this->assertEquals($anthony, $contribution['contact_id']);
   }
 
   /**

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -74,7 +74,7 @@ trait CRMTraits_Import_ParserTrait {
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
       ]);
       $result = $runner->runAll();
-      $this->assertEquals(TRUE, $result, $result === TRUE ? '' : $result['exception']->getMessage());
+      $this->assertEquals(TRUE, $result, $result === TRUE ? '' : CRM_Core_Error::formatTextException($result['exception']));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[Switch Contact import to use new v4 dedupe lookup](https://github.com/civicrm/civicrm-core/commit/c18b149f7ca61983cee7c2c029536258383d4d03)

Before
----------------------------------------
Legacy method used

After
----------------------------------------
Switches to use the new api method https://github.com/civicrm/civicrm-core/pull/24384

Technical Details
----------------------------------------
I focussed on the contact import first as it has excellent test cover - but I'll try the Contribution one with this next

Comments
----------------------------------------
