### PR TITLE
Update Contribution import to use new v4 dedupe lookup

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -283,7 +283,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $dataSource = $this->importContributionsDotCSV();
     $row = $dataSource->getRow();
     $this->assertEquals('ERROR', $row['_status']);
-    $this->assertEquals('No matching Contact found for (mum@example.com )', $row['_status_message']);
+    $this->assertEquals('No matching Contact found', $row['_status_message']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Update Contribution import to use new v4 dedupe lookup


Before
----------------------------------------
Mulitple places in the code do contact lookup using legacy methods

After
----------------------------------------
The new function based on https://github.com/civicrm/civicrm-core/pull/24384 is used

Technical Details
----------------------------------------
I added some tests first & also did Contact (which has more tests) https://github.com/civicrm/civicrm-core/pull/24401 - I did make a small change to the error message - which makes is slightly less informative, but the information is otherwise in the same row of the output (ie what was attempted to be imported) and in doing so re-used a string that has ts on the contact class

Comments
----------------------------------------
