### PR TITLE
Tidy up whereClause method of mailing browse

### DIFF
--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -283,7 +283,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $url = CRM_Utils_System::url($urlString, $urlParams);
     $session->pushUserContext($url);
 
-    // CRM-6862 -run form cotroller after
+    // CRM-6862 -run form controller after
     // selector, since it erase $_POST
     $this->search();
 
@@ -315,11 +315,8 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
    * @return string
    */
   public function whereClause(&$params, $sortBy = TRUE) {
-    $values = [];
-
     $clauses = [];
     $title = $this->get('mailing_name');
-    // echo " name=$title  ";
     if ($title) {
       $clauses[] = 'name LIKE %1';
       if (strpos($title, '%') !== FALSE) {
@@ -336,12 +333,12 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       $clauses[] = "name LIKE '" . strtolower(CRM_Core_DAO::escapeWildCardString($this->_sortByCharacter)) . "%'";
     }
 
-    $campainIds = $this->get('campaign_id');
-    if (!CRM_Utils_System::isNull($campainIds)) {
-      if (!is_array($campainIds)) {
+    $campaignIds = $this->get('campaign_id');
+    if (!CRM_Utils_System::isNull($campaignIds)) {
+      if (!is_array($campaignIds)) {
         $campaignIds = [$campaignIds];
       }
-      $clauses[] = '( campaign_id IN ( ' . implode(' , ', array_values($campainIds)) . ' ) )';
+      $clauses[] = '( campaign_id IN ( ' . implode(' , ', array_values($campaignIds)) . ' ) )';
     }
 
     return implode(' AND ', $clauses);


### PR DESCRIPTION
Overview
----------------------------------------
`campain`, `campaign`; Spot the typo.

This tidies up some ancient buggy code, plus removes the unused variable `$values`, removes an old echo, and fixes a typo in a comment.

Given that it's never worked until now I thought about removing the `is_array` check completely, but it's a pattern that is used elsewhere so I opted to keep it.
