### PR TITLE
Stop PHP notice when accessing invalid event ID

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -61,7 +61,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $values = ['event' => NULL];
     CRM_Event_BAO_Event::retrieve($params, $values['event']);
 
-    if (!$values['event']['is_active']) {
+    if (!$values['event'] || !$values['event']['is_active']) {
       CRM_Utils_System::setUFMessage(ts('The event you requested is currently unavailable (contact the site administrator for assistance).'));
       return CRM_Utils_System::permissionDenied();
     }


### PR DESCRIPTION
Overview
----------------------------------------
Stop PHP notice when accessing invalid event ID

Before
----------------------------------------

When accessing an invalid event info page (e.g. https://dmaster.demo.civicrm.org/civicrm/event/info?reset=1&id=1000) a PHP notice was thrown:

<img width="1301" alt="Screenshot 2022-08-29 at 11 49 33" src="https://user-images.githubusercontent.com/1931323/187184960-14e1ea06-3f14-4a2b-9fb9-7da1e9b83bad.png">

After
----------------------------------------
No PHP notice is thrown.

This introduces no functional changes, the info page will still (correclty) not load with an invalid ID.
