### PR TITLE
Remove misleading comment.

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -590,9 +590,6 @@ class CRM_Utils_REST {
     }
 
     if (!CRM_Utils_System::authenticateKey(FALSE)) {
-      // FIXME: At time of writing, this doesn't actually do anything because
-      // authenticateKey abends, but that's a bad behavior which sends a
-      // malformed response.
       CRM_Utils_System::loadBootStrap([], FALSE, FALSE);
       return self::error('Failed to authenticate key');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Passing false to authenticateKey means execution doesn't actually abort,
and so the 'Failed to authenticate key' error is actually reached.

Before
----------------------------------------
The comment contradicted reality. The comment was 10 years old, and so whilst possibly correct at the time of writing it was no longer correct in recent versions of CiviCRM.

After
----------------------------------------
Misleading comment removed. No functional changes.