### PR TITLE
Remove obsolete param from duplicated function

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1243,7 +1243,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  protected function processFormContribution(
+  private function processFormContribution(
     $params,
     $result,
     $contributionParams,
@@ -1257,9 +1257,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $contactID = $contributionParams['contact_id'];
 
     $isEmailReceipt = !empty($form->_values['is_email_receipt']);
-    $isSeparateMembershipPayment = !empty($params['separate_membership_payment']);
     $pledgeID = !empty($params['pledge_id']) ? $params['pledge_id'] : $form->_values['pledge_id'] ?? NULL;
-    if (!$isSeparateMembershipPayment && !empty($form->_values['pledge_block_id']) &&
+    if (!empty($form->_values['pledge_block_id']) &&
       (!empty($params['is_pledge']) || $pledgeID)) {
       $isPledge = TRUE;
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1258,8 +1258,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $isEmailReceipt = !empty($form->_values['is_email_receipt']);
     $pledgeID = !empty($params['pledge_id']) ? $params['pledge_id'] : $form->_values['pledge_id'] ?? NULL;
-    if (!empty($form->_values['pledge_block_id']) &&
-      (!empty($params['is_pledge']) || $pledgeID)) {
+    if ((!empty($params['is_pledge']) || $pledgeID)) {
       $isPledge = TRUE;
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Remove obsolete param from duplicated function

`processFormContribution` is one of those functions that used to be shared - but each form (Front end & back end contribution forms) now have their own copy. `isSeparateMembershipPayment` and `pledge_block_id` only apply to the front end form so can be removed from the back end form

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/187315276-c0e07633-868d-4107-b5cb-3a06b4e5ff41.png)


![image](https://user-images.githubusercontent.com/336308/187315654-43665cb1-14ba-4cd6-a4f6-414909778235.png)

After
----------------------------------------
Poof

Technical Details
----------------------------------------
I also made it private rather than protected to make the function ownership even clearer

Comments
----------------------------------------
