### PR TITLE
Remove more front-end-only handling from back-office contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1368,23 +1368,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       CRM_Core_BAO_Note::add($noteParams, []);
     }
 
-    //create contribution activity w/ individual and target
-    //activity w/ organisation contact id when onbelf, CRM-4027
-    $actParams = [];
-    $targetContactID = NULL;
-    if (!empty($params['onbehalf_contact_id'])) {
-      $actParams = [
-        'source_contact_id' => $params['onbehalf_contact_id'],
-        'on_behalf' => TRUE,
-      ];
-      $targetContactID = $contribution->contact_id;
-    }
-
-    // create an activity record
-    if ($contribution) {
-      CRM_Activity_BAO_Activity::addActivity($contribution, 'Contribution', $targetContactID, $actParams);
-    }
-
     $transaction->commit();
     return $contribution;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Remove more front-end-only handling from back-office contribution form

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/187322398-91e8b858-43d8-4f4d-a481-a8b3f1a25770.png)


After
----------------------------------------
Code removed

Technical Details
----------------------------------------
The activity is already added in the `Contribution::create` - this would add the on behalf contact - but not for this form - only the front end form

Comments
----------------------------------------
