### PR TITLE
dev/core#3828 Fix required fields check to accept 0

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1301,7 +1301,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       }
       else {
         foreach ($required as $field => $label) {
-          if (empty($params[$field])) {
+          if (!isset($params[$field]) || $params[$field] === '') {
             $missing[$field] = $label;
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3828 Fix required fields check to accept 0

Before
----------------------------------------
After the code cleanup the check for required fields is an `empty` check - which is rejecting a value of 0 for contribution.total_amount

After
----------------------------------------
It checks for `''` or NULL

Technical Details
----------------------------------------
Given the data is coming in from a csv anything other than `''` (which could be converted to `NULL` in initial processing would seem like something has been input - which is the point of this level of validation. If a contact id was set to 0 it should fail when we move onto verification - ie when we actually do a lookup 

Comments
----------------------------------------
