### PR TITLE
Contribution import - test notes, cleanup notes, fix regression found  in test writing

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -300,6 +300,18 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ->addWhere('entity_id', '=', $contribution['id'])
       ->addWhere('entity_table', '=', 'civicrm_contribution')->execute()->first();
     $this->assertEquals('Call him back', $note['note']);
+
+    // Now change the note & re-do it. The same note should be updated.
+    Note::update()
+      ->addWhere('entity_id', '=', $contribution['id'])
+      ->addValue('note', 'changed')
+      ->execute();
+    $this->importContributionsDotCSV(['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
+    $note = Note::get()
+      ->addWhere('entity_id', '=', $contribution['id'])
+      ->addWhere('entity_table', '=', 'civicrm_contribution')->execute()->first();
+    $this->assertEquals('Call him back', $note['note']);
+
   }
 
   /**
@@ -534,7 +546,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   /**
    * @return \CRM_Import_DataSource_CSV
    */
-  private function importContributionsDotCSV(): CRM_Import_DataSource_CSV {
+  private function importContributionsDotCSV($submittedValues = []): CRM_Import_DataSource_CSV {
     $this->importCSV('contributions.csv', [
       ['name' => 'first_name'],
       ['name' => 'total_amount'],
@@ -543,7 +555,8 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'email'],
       ['name' => 'contribution_source'],
       ['name' => 'note'],
-    ]);
+      ['name' => 'trxn_id'],
+    ], $submittedValues);
     return new CRM_Import_DataSource_CSV($this->userJobID);
   }
 

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
@@ -1,2 +1,2 @@
-External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to,Source,Note
-bob,65,2008-09-20,Donation,mum@example.com,Word of mouth,Call him back
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to,Source,Note,Transaction ID
+bob,65,2008-09-20,Donation,mum@example.com,Word of mouth,Call him back,999


### PR DESCRIPTION
Overview
----------------------------------------
Contribution import - test notes, cleanup notes, fix master-only regression found in test writing

Before
----------------------------------------
Import relies on BAO to create not for new contributions but does it itself for new

In the process of adding a test I found it had recently regressed to throwing an exception when a match on trxn_id is not found in create mode

After
----------------------------------------
Uses api for both, regression fixed & test cover added

Technical Details
----------------------------------------

Comments
----------------------------------------
I did reduce the detail in the not-matched message - it's a lot of code for something that is in the csv + it wasn't translated