### PR TITLE
Improve scheduled reminder form labels. Resolves issue core/3823

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -158,7 +158,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->_freqUnits = CRM_Core_SelectValues::getRecurringFrequencyUnits();
 
     //reminder_interval
-    $this->add('number', 'start_action_offset', ts('When'), ['class' => 'six', 'min' => 0]);
+    $this->add('number', 'start_action_offset', ts('When (trigger date)'), ['class' => 'six', 'min' => 0]);
     $this->addRule('start_action_offset', ts('Value should be a positive number'), 'positiveInteger');
 
     $isActive = ts('Scheduled Reminder Active');

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -56,11 +56,11 @@
     </tr>
     <tr class="crm-scheduleReminder-effective_start_date">
       <td class="right">{$form.effective_start_date.label}</td>
-      <td colspan="3">{$form.effective_start_date.html} <div class="description"></div></td>
+      <td colspan="3">{$form.effective_start_date.html} <div class="description">{ts}Earliest trigger date to <em>include</em>.{/ts}</div></td>
     </tr>
     <tr class="crm-scheduleReminder-effective_end_date">
       <td class="right">{$form.effective_end_date.label}</td>
-      <td colspan="3">{$form.effective_end_date.html} <div class="description"></div></td>
+      <td colspan="3">{$form.effective_end_date.html} <div class="description">{ts}Earliest trigger date to <em>exclude</em>.{/ts}</div></td>
     </tr>
     <tr>
       <td class="label" width="20%">{$form.from_name.label}</td>
@@ -177,11 +177,6 @@
       var $form = $('form.{/literal}{$form.formClass}{literal}'),
         recipientMapping = eval({/literal}{$recipientMapping}{literal});
 
-      updatedEffectiveDateDescription($('#entity_0 option:selected').text(), $('#start_action_date option:selected').text());
-      $('#entity_0, #start_action_date', $form).change(function() {
-       updatedEffectiveDateDescription($('#entity_0 option:selected').text(), $('#start_action_date option:selected').text());
-      });
-
       $('#absolute_date', $form).change(function() {
         $('.crm-scheduleReminder-effective_start_date, .crm-scheduleReminder-effective_end_date').toggle(($(this).val() === null));
       });
@@ -202,11 +197,6 @@
 
       loadMsgBox();
       $('#mode', $form).change(loadMsgBox);
-
-      function updatedEffectiveDateDescription(entityText, startActionDateText) {
-        $('.crm-scheduleReminder-effective_start_date .description').text(ts('Earliest %1 %2 to include.', {1: entityText, 2: startActionDateText}));
-        $('.crm-scheduleReminder-effective_end_date .description').text(ts('Earliest %1 %2 to exclude.', {1: entityText, 2: startActionDateText}));
-      }
 
       function populateRecipient() {
         var mappingID = $('#entity_0', $form).val() || $('[name^=mappingID]', $form).val();


### PR DESCRIPTION
Overview
----------------------------------------

See <https://lab.civicrm.org/dev/core/-/issues/3823>


Before
----------------------------------------

Inaccurate confusing labels re effective start/end dates.

After
----------------------------------------

Simpler and more accurate labels.

Technical Details
----------------------------------------

The changes are to texts, but also removing the clever javascript code that was needed to write the previous nonsensical labels :laughing: 


