### PR TITLE
Remove method updateDisplayNames

### DIFF
--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -344,53 +344,6 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
   }
 
   /**
-   * Regenerates display_name for contacts with given prefixes/suffixes.
-   *
-   * @param array $ids
-   *   The array with the prefix/suffix id governing which contacts to regenerate.
-   * @param int $action
-   *   The action describing whether prefix/suffix was UPDATED or DELETED.
-   */
-  public static function updateDisplayNames(&$ids, $action) {
-    // get the proper field name (prefix_id or suffix_id) and its value
-    $fieldName = '';
-    foreach ($ids as $key => $value) {
-      switch ($key) {
-        case 'individualPrefix':
-          $fieldName = 'prefix_id';
-          $fieldValue = $value;
-          break 2;
-
-        case 'individualSuffix':
-          $fieldName = 'suffix_id';
-          $fieldValue = $value;
-          break 2;
-      }
-    }
-    if ($fieldName == '') {
-      return;
-    }
-
-    // query for the affected individuals
-    $fieldValue = CRM_Utils_Type::escape($fieldValue, 'Integer');
-    $contact = new CRM_Contact_BAO_Contact();
-    $contact->$fieldName = $fieldValue;
-    $contact->find();
-
-    // iterate through the affected individuals and rebuild their display_names
-    while ($contact->fetch()) {
-      $contact = new CRM_Contact_BAO_Contact();
-      $contact->id = $contact->contact_id;
-      if ($action == CRM_Core_Action::DELETE) {
-        $contact->$fieldName = 'NULL';
-        $contact->save();
-      }
-      $contact->display_name = $contact->displayName();
-      $contact->save();
-    }
-  }
-
-  /**
    * Creates display name.
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
Remove method updateDisplayNames. 

There were multiple issues with this method, which made me think it doesn't work correctly:

1. `$contact->displayName()` should take the `contact_id` as an argument.  Calling `$contact->display_name = $contact->displayName();` would effectively set the `display_name` to `null` which would not be the expected behaviour, and could lead to unexpected data loss.
2. The call to `$contact->id = $contact->contact_id;` will do nothing, as the second `$contact = new CRM_Contact_BAO_Contact()` will mean the `$contact` variable has no contact ID at the point this line is called.
3. Not buggy per-se, but there is absolutely no need for the double call to `$contact->save();`.

This method was not used in core. 

Before
----------------------------------------
The method `CRM_Contact_BAO_Individual::updateDisplayNames` exists but is buggy.

After
----------------------------------------
Method `CRM_Contact_BAO_Individual::updateDisplayNames` removed.

Comments
----------------------------------------

I did think about removing the contents of the function but leaving a `deprecatedFunctionWarning()`. Given the very low likelyhood of this method being used, I decided against this, but it might be worth someone (@eileenmcnaughton?) doing a universe check to double-check this won't break any known plugins.