### PR TITLE
Docblock fix - findOrphanedFiles method

### DIFF
--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -58,7 +58,7 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
   }
 
   /**
-   * @return CRM_Utils_Check_Message[]
+   * @return array
    *   Each item is an array with keys:
    *     - name: string, an abstract name
    *     - path: string, a full file path


### PR DESCRIPTION
Overview
----------------------------------------
Fix PHPDoc comment.

Before
----------------------------------------
Method incorrectly documented as returning an array of `CRM_Utils_Check_Message`. Actually an array of arrays is returned. (I think this was a copy/paste error from the `checkOrphans` method in the same file).

After
----------------------------------------
Documentation fixed.