### PR TITLE
Remove method getActionAttribute

### DIFF
--- a/CRM/Core/Selector/Base.php
+++ b/CRM/Core/Selector/Base.php
@@ -42,27 +42,6 @@ class CRM_Core_Selector_Base {
   protected $_key;
 
   /**
-   * This function gets the attribute for the action that.
-   * it matches.
-   *
-   * @param string $match the action to match against
-   * @param string $attribute the attribute to return ( name, link, title )
-   *
-   * @return string
-   *   the attribute that matches the action if any
-   */
-  public function getActionAttribute($match, $attribute = 'name') {
-    $links = &$this->links();
-
-    foreach ($link as $action => $item) {
-      if ($match & $action) {
-        return $item[$attribute];
-      }
-    }
-    return NULL;
-  }
-
-  /**
    * This is a static virtual function returning reference on links array. Each
    * inherited class must redefine this function
    *


### PR DESCRIPTION
Overview
----------------------------------------
Remove method `CRM_Core_Selector_Base::getActionAttribute`

Before
----------------------------------------
This method couldn't work, and is not used by core. The method tries to loop over `$link` but the variable that it should be looping over is `$links`. Therefore `null` is always returned.

After
----------------------------------------
The method has been removed.

An alternative would have been to deprecate the method, however, I think removing is appropriate as:

1. The function was broken (referencing a variable that does not exist)
2. The method is not referenced anywhere else in core.