### PR TITLE
Stop PHP warning on installations with no contributions

### DIFF
--- a/CRM/Contribute/BAO/Contribution/Utils.php
+++ b/CRM/Contribute/BAO/Contribution/Utils.php
@@ -22,7 +22,7 @@ class CRM_Contribute_BAO_Contribution_Utils {
    * @param int $param
    *   Year.
    *
-   * @return array
+   * @return array|null
    *   associated array
    */
   public static function contributionChartMonthly($param) {
@@ -61,7 +61,7 @@ INNER JOIN   civicrm_contact AS contact ON ( contact.id = contrib.contact_id )
   /**
    * Get the contribution details by year.
    *
-   * @return array
+   * @return array|null
    *   associated array
    */
   public static function contributionChartYearly() {

--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -118,7 +118,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     $chartInfoYearly = CRM_Contribute_BAO_Contribution_Utils::contributionChartYearly();
 
     //get the years.
-    $this->_years = $chartInfoYearly['By Year'];
+    $this->_years = $chartInfoYearly['By Year'] ?? [];
     $hasContributions = FALSE;
     if (is_array($chartInfoYearly)) {
       $hasContributions = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Stop PHP warning on installations with no contributions.

Before
----------------------------------------
Likely only something which would affect new installs, but visiting the contributions dashboard with no contributions caused a PHP warning:

<img width="1385" alt="Screenshot 2022-08-31 at 17 32 21" src="https://user-images.githubusercontent.com/1931323/187731647-4bb078e4-e395-4422-9bb0-1c72f199a0ee.png">



After
----------------------------------------
The null-coalescing operator has been utilised to keep PHP happy.