### PR TITLE
dev/financial#192 Fallback to custom currency object for codes which Brick\Money does not support.

### DIFF
--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -9,6 +9,7 @@ use Civi;
 use CRM_Core_Config;
 use CRM_Core_I18n;
 use CRM_Utils_Constant;
+use CRM_Utils_Money;
 use NumberFormatter;
 use Brick\Money\Context\AutoContext;
 
@@ -46,7 +47,8 @@ class Format {
       global $civicrmLocale;
       $locale = $civicrmLocale->moneyFormat ?? (Civi::settings()->get('format_locale') ?? CRM_Core_I18n::getLocale());
     }
-    $money = Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
+    $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
+    $money = Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP);
     $formatter = $this->getMoneyFormatter($currency, $locale);
     return $money->formatWith($formatter);
   }
@@ -94,7 +96,8 @@ class Format {
       return '';
     }
     $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL);
-    return Money::of($amount, $currency, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+    $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
+    return Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**
@@ -121,7 +124,8 @@ class Format {
    */
   public function machineMoney($amount, string $currency = 'USD'): string {
     $formatter = $this->getMoneyFormatter($currency, 'en_US', NumberFormatter::DECIMAL, [NumberFormatter::GROUPING_USED => FALSE]);
-    return Money::of($amount, $currency, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+    $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
+    return Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**
@@ -143,7 +147,8 @@ class Format {
     $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::CURRENCY, [
       NumberFormatter::MAX_FRACTION_DIGITS => 9,
     ]);
-    $money = Money::of($amount, $currency, new AutoContext());
+    $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
+    $money = Money::of($amount, $currencyObject, new AutoContext());
     return $money->formatWith($formatter);
   }
 
@@ -166,7 +171,8 @@ class Format {
     $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL, [
       NumberFormatter::MAX_FRACTION_DIGITS => 9,
     ]);
-    $money = Money::of($amount, $currency, new AutoContext());
+    $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
+    $money = Money::of($amount, $currencyObject, new AutoContext());
     return $money->formatWith($formatter);
   }
 
@@ -214,13 +220,12 @@ class Format {
     if (!isset(\Civi::$statics[$cacheKey])) {
       $formatter = new NumberFormatter($locale, $style);
 
+      $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
       if (!isset($attributes[NumberFormatter::MIN_FRACTION_DIGITS])) {
-        $attributes[NumberFormatter::MIN_FRACTION_DIGITS] = Currency::of($currency)
-          ->getDefaultFractionDigits();
+        $attributes[NumberFormatter::MIN_FRACTION_DIGITS] = $currencyObject->getDefaultFractionDigits();
       }
       if (!isset($attributes[NumberFormatter::MAX_FRACTION_DIGITS])) {
-        $attributes[NumberFormatter::MAX_FRACTION_DIGITS] = Currency::of($currency)
-          ->getDefaultFractionDigits();
+        $attributes[NumberFormatter::MAX_FRACTION_DIGITS] = $currencyObject->getDefaultFractionDigits();
       }
 
       foreach ($attributes as $attribute => $value) {

--- a/tests/phpunit/Civi/Core/FormatTest.php
+++ b/tests/phpunit/Civi/Core/FormatTest.php
@@ -281,6 +281,18 @@ class FormatTest extends CiviUnitTestCase {
         'money_long' => '$0.00',
       ],
     ];
+    $cases['en_US_ZMK'] = [
+      [
+        'amount' => '1234.56',
+        'locale' => 'en_US',
+        'currency' => 'ZMK',
+        'money' => 'ZMK 1,234.56',
+        'money_number' => '1,234.56',
+        'money_number_long' => '1,234.56',
+        'number' => '1,234.56',
+        'money_long' => 'ZMK 1,234.56',
+      ],
+    ];
     return $cases;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Resolves https://lab.civicrm.org/dev/financial/-/issues/192

Fallback to custom currency object for codes which Brick does not support.

Before
----------------------------------------
Many currency codes where installed by default in CiviCRM installations, but are not supported by the Brick/Money library CiviCRM is now using. For example, ZMK. Selecting such a currency causes widespread breakage to the installation making it difficult to even switch back to a safe currency (e.g. USD, GBP).

After
----------------------------------------
A new helper method has been introduced `getCurrencyObject` which should be used to get a safe currency object that can be passed into subsequent Brick calls. 

If the currency code is not recognised, a new custom Brick currency object is created. No currency code is passed (which is currently safe as we don't read the currency code out of Brick objects), and the number of decimal places is hardcoded to 2. This won't suit all currencies, but seems like a sensible default for what is essentially a fallback route. If desired, we could add a hook in future to `getCurrencyObject` allowing site-owners full control over the currency object.

Technical Details
----------------------------------------
I don't think any specific test changes are needed here, but I've added an extra test case for the currency which was previously failing.

I do see a risk to `getCurrencyObject` not being used when future calls to `Money::of` are added in future, but I don't really see how that can be mitigated.

I also noticed that the Symphony Intl polyfill also falls over when calling `formatCurrency` on unknown currencies. However, that doesn't affect anywhere near as many pageloads as the Brick missing currency error does, and as CiviCRM contains lots of warnings about the risks of not having the Intl extension installed, this issue feels much less important.