### PR TITLE
Mark some more fields deprecated or readonly

### DIFF
--- a/xml/schema/Contact/Contact.xml
+++ b/xml/schema/Contact/Contact.xml
@@ -817,6 +817,7 @@
     <type>varchar</type>
     <length>255</length>
     <import>true</import>
+    <deprecated>true</deprecated>
     <headerPattern>/^Open\s?ID|u(niq\w*)?\s?ID/i</headerPattern>
     <dataPattern>/^[\w\/\:\.]+$/</dataPattern>
     <comment>the OpenID (or OpenID-style http://username.domain/) unique identifier for this contact mainly used for logging in to CiviCRM</comment>

--- a/xml/schema/Core/Address.xml
+++ b/xml/schema/Core/Address.xml
@@ -352,6 +352,7 @@
     <title>USPS Code</title>
     <type>varchar</type>
     <length>32</length>
+    <deprecated>true</deprecated>
     <comment>USPS Bulk mailing code.</comment>
     <add>1.1</add>
   </field>

--- a/xml/schema/Core/Email.xml
+++ b/xml/schema/Core/Email.xml
@@ -143,6 +143,7 @@
     <name>hold_date</name>
     <type>datetime</type>
     <comment>When the address went on bounce hold</comment>
+    <readonly>true</readonly>
     <html>
       <label>Hold Date</label>
       <type>Select Date</type>

--- a/xml/schema/Core/Phone.xml
+++ b/xml/schema/Core/Phone.xml
@@ -97,6 +97,7 @@
     <name>mobile_provider_id</name>
     <title>Mobile Provider</title>
     <type>int unsigned</type>
+    <deprecated>true</deprecated>
     <comment>Which Mobile Provider does this phone belong to.</comment>
     <add>1.1</add>
   </field>
@@ -139,6 +140,7 @@
     <name>phone_numeric</name>
     <type>varchar</type>
     <length>32</length>
+    <readonly>true</readonly>
     <comment>Phone number stripped of all whitespace, letters, and punctuation.</comment>
     <html>
       <label>Numeric</label>


### PR DESCRIPTION
Overview
----------------------------------------
Mark some more fields deprecated or readonly as follows (this means they won't show in afform / other metadata based ui

|table|field|Mark as|Notes|
|------|------|-----|----|
|civicrm_phone|phone_numeric|readonly|Updated by a trigger|
|civicrm_phone|mobile_provider_id|deprecated|field doesn't show in the UI|
|civicrm_contact|user_unique_id|deprecated|field doesn't show in the UI - openid related|
|civicrm_email|hold_date|readonly|set by code when put on hold|
|civicrm_address|usps_adc|deprecated|field doesn't show in the UI|

@colemanw @seamuslee001  - if we agree to these I propose we merge the xml changes & I do the dao as a follow up - there is another conflicty PR open & the dao can be done all at once
