### PR TITLE
APIv4 - Promote option `$language` from DAOActionTrait to AbstractAction

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -32,6 +32,8 @@ use Civi\Api4\Utils\ReflectionUtils;
  * @method bool getDebug()
  * @method $this setChain(array $chain)
  * @method array getChain()
+ * @method $this setLanguage(string|null $language)
+ * @method string|null getLanguage()
  */
 abstract class AbstractAction implements \ArrayAccess {
 
@@ -43,6 +45,20 @@ abstract class AbstractAction implements \ArrayAccess {
    * @var int
    */
   protected $version = 4;
+
+  /**
+   * Preferred language (optional)
+   *
+   * This option will notify major localization subsystems (`ts()`, multilingual, etc)
+   * about which locale should be used for composing/formatting messaging.
+   *
+   * This indicates the preferred language. The effective language is determined
+   * by `Civi\Core\Locale::negotiate($preferredLanguage)`.
+   *
+   * @var string
+   * @optionsCallback getPreferredLanguageOptions
+   */
+  protected $language;
 
   /**
    * Additional api requests - will be called once per result.
@@ -562,6 +578,17 @@ abstract class AbstractAction implements \ArrayAccess {
         $this->_debugOutput['callback'] = get_class($callable);
       }
     }
+  }
+
+  /**
+   * Get available preferred languages.
+   *
+   * @return array
+   */
+  protected function getPreferredLanguageOptions(): array {
+    $languages = \CRM_Contact_BAO_Contact::buildOptions('preferred_language');
+    ksort($languages);
+    return array_keys($languages);
   }
 
 }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -19,20 +19,13 @@ use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\ReflectionUtils;
 
 /**
- * @method string getLanguage()
- * @method $this setLanguage(string $language)
+ * Common properties and helper-methods used for DB-oriented actions.
  */
 trait DAOActionTrait {
 
   /**
-   * Specify the language to use if this is a multi-lingual environment.
-   *
-   * E.g. "en_US" or "fr_CA"
-   *
-   * @var string
+   * @var array
    */
-  protected $language;
-
   private $_maxWeights = [];
 
   /**

--- a/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/AbstractActionFunctionTest.php
@@ -27,8 +27,8 @@ class AbstractActionFunctionTest extends Api4TestBase {
 
   public function testUndefinedParamException(): void {
     $this->expectException('API_Exception');
-    $this->expectExceptionMessage('Unknown api parameter: getLanguage');
-    \Civi\Api4\System::flush(FALSE)->getLanguage();
+    $this->expectExceptionMessage('Unknown api parameter: getTranslationMode');
+    \Civi\Api4\System::flush(FALSE)->getTranslationMode();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
APIv4 - Promote option `$language` from DAOActionTrait to AbstractAction

Before
----------------------------------------
`$language` only set on crud

After
----------------------------------------
Always set

Technical Details
----------------------------------------
@totten am trying to figure out how to progress this work to get it off our plates & this seemed like it was probably mergeable by itself

Comments
----------------------------------------
