### PR TITLE
SearchKit - Make ID fields available for display

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -522,16 +522,29 @@
         function formatFields(fields, result, prefix) {
           prefix = typeof prefix === 'undefined' ? '' : prefix;
           _.each(fields, function(field) {
-            var item = {
-              id: prefix + field.name + (field.suffixes && _.includes(field.suffixes, suffix.replace(':', '')) ? suffix : ''),
-              text: field.label,
-              description: field.description
-            };
-            if (disabledIf(item.id)) {
-              item.disabled = true;
-            }
             if (_.includes(allowedTypes, field.type)) {
+              var fieldSuffix = field.suffixes && _.includes(field.suffixes, suffix.replace(':', '')) ? suffix : '';
+              var item = {
+                id: prefix + field.name + fieldSuffix,
+                text: field.label,
+                description: field.description
+              };
+              if (disabledIf(item.id)) {
+                item.disabled = true;
+              }
               result.push(item);
+              // For fields with both an FK and a pseudoconstant, show the id as well.
+              if (fieldSuffix && field.fk_entity) {
+                var idItem = {
+                  id: prefix + field.name,
+                  text: field.title,
+                  description: field.description
+                };
+                if (disabledIf(idItem.id)) {
+                  idItem.disabled = true;
+                }
+                result.push(idItem);
+              }
             }
           });
           return result;


### PR DESCRIPTION
Overview
----------------------------------------
This makes ID fields available for selection in addition to names for FK fields with option lists.

Before
----------------------------------------
Create a search for Custom Fields. You can add the custom group title as a column, but not the custom group id.
![image](https://user-images.githubusercontent.com/2874912/189934903-15772b06-46ad-4274-9f25-6df83e16975a.png)


After
----------------------------------------
Both are available.
