### PR TITLE
REF] Standardise validation of mapped fields in imports, fix over-zealous requirements when matching on trxn_id, invoice_id for update

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -179,7 +179,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
    * @return array
    */
   protected function getRequiredFields(): array {
-    return [['activity_type_id' => ts('Activity Type'), 'activity_date_time' => ts('Activity Date')]];
+    return [['activity_type_id', 'activity_date_time']];
   }
 
   /**

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -93,7 +93,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
    * @return array
    */
   public function getRequiredFields(): array {
-    return ['contact_id' => ts('Contact ID'), 'external_identifier' => ts('External Identifier')];
+    return [['contact_id'], ['external_identifier']];
   }
 
   /**

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -518,7 +518,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    * @return array
    */
   protected function getRequiredFields(): array {
-    return [['event_id' => ts('Event'), 'status_id' => ts('Status')]];
+    return [['event_id', 'status_id']];
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1070,7 +1070,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'individual_required' => [
         'csv' => 'individual_invalid_missing_name.csv',
         'mapper' => [['last_name']],
-        'expected_error' => 'Missing required fields: First Name OR Email Address',
+        'expected_error' => 'Missing required fields: First Name OR Email',
       ],
       'individual_related_required_met' => [
         'csv' => 'individual_valid_with_related_email.csv',
@@ -1080,7 +1080,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'individual_related_required_not_met' => [
         'csv' => 'individual_invalid_with_related_phone.csv',
         'mapper' => [['first_name'], ['last_name'], ['1_a_b', 'phone', 1, 2]],
-        'expected_error' => '(Child of) Missing required fields: First Name and Last Name OR Email Address OR External Identifier',
+        'expected_error' => '(Child of) Missing required fields: First Name and Last Name OR Email OR External Identifier',
       ],
       'individual_bad_email' => [
         'csv' => 'individual_invalid_email.csv',
@@ -1096,7 +1096,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         // External identifier is only enough in upgrade mode.
         'csv' => 'individual_invalid_external_identifier_only.csv',
         'mapper' => [['external_identifier'], ['gender_id']],
-        'expected_error' => 'Missing required fields: First Name and Last Name OR Email Address',
+        'expected_error' => 'Missing required fields: First Name and Last Name OR Email',
       ],
       'individual_invalid_external_identifier_only_update_mode' => [
         // External identifier only enough in upgrade mode, so no error here.

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -31,10 +31,7 @@ trait CRMTraits_Import_ParserTrait {
    * @param array $submittedValues
    */
   protected function importCSV(string $csv, array $fieldMappings, array $submittedValues = []): void {
-    $reflector = new ReflectionClass(get_class($this));
-    $directory = dirname($reflector->getFileName());
     $submittedValues = array_merge([
-      'uploadFile' => ['name' => $directory . '/data/' . $csv],
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
       'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
@@ -45,13 +42,7 @@ trait CRMTraits_Import_ParserTrait {
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
       'groups' => [],
     ], $submittedValues);
-    $form = $this->getDataSourceForm($submittedValues);
-    $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
-    $form->buildForm();
-    $form->postProcess();
-    $this->userJobID = $form->getUserJobID();
-    // This gets reset in DataSource so re-do....
-    $_SESSION['_' . $form->controller->_name . '_container']['values'] = $values;
+    $this->submitDataSourceForm($csv, $submittedValues);
 
     $form = $this->getMapFieldForm($submittedValues);
     $form->setUserJobID($this->userJobID);
@@ -101,6 +92,35 @@ trait CRMTraits_Import_ParserTrait {
    */
   protected function getDataSource(): CRM_Import_DataSource {
     return new CRM_Import_DataSource_CSV($this->userJobID);
+  }
+
+  /**
+   * Submit the data source form.
+   *
+   * @param string $csv
+   * @param array $submittedValues
+   */
+  protected function submitDataSourceForm(string $csv, $submittedValues): void {
+    $reflector = new ReflectionClass(get_class($this));
+    $directory = dirname($reflector->getFileName());
+    $submittedValues = array_merge([
+      'uploadFile' => ['name' => $directory . '/data/' . $csv],
+      'skipColumnHeader' => TRUE,
+      'fieldSeparator' => ',',
+      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'dataSource' => 'CRM_Import_DataSource_CSV',
+      'file' => ['name' => $csv],
+      'dateFormats' => CRM_Core_Form_Date::DATE_yyyy_mm_dd,
+      'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
+      'groups' => [],
+    ], $submittedValues);
+    $form = $this->getDataSourceForm($submittedValues);
+    $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
+    $form->buildForm();
+    $form->postProcess();
+    $this->userJobID = $form->getUserJobID();
+    // This gets reset in DataSource so re-do....
+    $_SESSION['_' . $form->controller->_name . '_container']['values'] = $values;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Standardise validation of mapped fields in imports, fix excessive required fields when matching on `trxn_id`, invoice_id`

Before
----------------------------------------
Validattion is still happening in multiple places & each is a bit different

Importing contributions with 'update existing' + trxn_id  unnecessarily requires create fields like total_amount & financial type

After
----------------------------------------
Single place which processes an and/or array  - form starts to call the parser layer

Possible to import with `trxn_id` and do an update without all create fields


Technical Details
----------------------------------------
This has new test cover for the Contribution import, including the `trxn_id` situation described and substantial test cover in `CRM_Contact_Import_Parser_ContactTest` - in particular `testValidation`

Comments
----------------------------------------
