### PR TITLE
dev/financial#208 - Fix crash for invoice button

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -231,7 +231,7 @@ AND    {$this->_componentClause}";
    *   Contribution Id.
    * @param array $params
    *   Parameter for pdf or email invoices.
-   * @param array $contactIds
+   * @param array|int $contactIds
    *   Contact Id.
    * @param bool $isCreatePDF
    *
@@ -240,7 +240,7 @@ AND    {$this->_componentClause}";
    *
    * @throws \CiviCRM_API3_Exception
    */
-  public static function getElements(array $contribIds, array $params, array $contactIds, bool $isCreatePDF): array {
+  public static function getElements(array $contribIds, array $params, $contactIds, bool $isCreatePDF): array {
     $pdfElements = [];
     $pdfElements['details'] = self::getDetails(implode(',', $contribIds));
     $excludeContactIds = [];

--- a/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
@@ -15,6 +15,32 @@
 class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
 
   /**
+   * @var int
+   */
+  private $contact_id;
+
+  /**
+   * @var array
+   */
+  private $contribution;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->contact_id = $this->individualCreate();
+    $this->contribution = $this->callAPISuccess('Contribution', 'create', [
+      'contact_id' => $this->contact_id,
+      'financial_type_id' => 'Donation',
+      'total_amount' => '10',
+    ]);
+  }
+
+  public function tearDown(): void {
+    $this->callAPISuccess('Contribution', 'delete', ['id' => $this->contribution['id']]);
+    $this->callAPISuccess('Contact', 'delete', ['id' => $this->contact_id]);
+    parent::tearDown();
+  }
+
+  /**
    * Test that can still view a contribution without full permissions.
    */
   public function testContributionViewLimitedPermissions() {
@@ -26,19 +52,13 @@ class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
       'edit contributions',
       'delete in CiviContribute',
     ];
-    $contact_id = $this->individualCreate();
-    $contribution = $this->callAPISuccess('Contribution', 'create', [
-      'contact_id' => $contact_id,
-      'financial_type_id' => 'Donation',
-      'total_amount' => '10',
-    ]);
 
-    $_SERVER['REQUEST_URI'] = "civicrm/contact/view/contribution?reset=1&action=view&id={$contribution['id']}&cid={$contact_id}";
+    $_SERVER['REQUEST_URI'] = "civicrm/contact/view/contribution?reset=1&action=view&id={$this->contribution['id']}&cid={$this->contact_id}";
     $_GET['q'] = $_REQUEST['q'] = 'civicrm/contact/view/contribution';
     $_GET['reset'] = $_REQUEST['reset'] = 1;
     $_GET['action'] = $_REQUEST['action'] = 'view';
-    $_GET['id'] = $_REQUEST['id'] = $contribution['id'];
-    $_GET['cid'] = $_REQUEST['cid'] = $contact_id;
+    $_GET['id'] = $_REQUEST['id'] = $this->contribution['id'];
+    $_GET['cid'] = $_REQUEST['cid'] = $this->contact_id;
 
     $item = CRM_Core_Invoke::getItem(['civicrm/contact/view/contribution']);
     ob_start();
@@ -53,6 +73,42 @@ class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
 
     $this->assertRegExp('/Contribution Total:\s+\$10\.00/', $contents);
     $this->assertStringContainsString('Mr. Anthony Anderson II', $contents);
+  }
+
+  public function testInvoiceDownload() {
+    Civi::settings()->set('invoicing', 1);
+
+    $_SERVER['REQUEST_URI'] = "civicrm/contribute/invoice?reset=1&id={$this->contribution['id']}&cid={$this->contact_id}";
+    $_GET['q'] = $_REQUEST['q'] = 'civicrm/contribute/invoice';
+    $_GET['reset'] = $_REQUEST['reset'] = 1;
+    $_GET['id'] = $_REQUEST['id'] = $this->contribution['id'];
+    $_GET['cid'] = $_REQUEST['cid'] = $this->contact_id;
+
+    $item = CRM_Core_Invoke::getItem(['civicrm/contribute/invoice']);
+    ob_start();
+    $isOk = FALSE;
+    try {
+      CRM_Core_Invoke::runItem($item);
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $this->assertEquals(0, $e->errorData['error_code']);
+      $this->assertEquals('pdf', $e->errorData['output']);
+      $this->assertEquals("INV_{$this->contribution['id']}", $e->errorData['fileName']);
+      $this->assertStringContainsString('INVOICE', $e->errorData['html']);
+      $isOk = TRUE;
+    }
+    finally {
+      ob_end_clean();
+
+      unset($_GET['q'], $_REQUEST['q']);
+      unset($_GET['reset'], $_REQUEST['reset']);
+      unset($_GET['id'], $_REQUEST['id']);
+      unset($_GET['cid'], $_REQUEST['cid']);
+      Civi::settings()->set('invoicing', 0);
+    }
+    if (!$isOk) {
+      $this->fail('It should have entered the catch block.');
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/208

Before
----------------------------------------
1. Turn on tax and invoicing at Administer - CiviContribute - Component Settings.
2. View a contribution.
3. Click the invoice button.
4. TypeError: CRM_Contribute_Form_Task_PDF::getElements(): Argument 3 ($contactIds) must be of type array, int given, called in ...\CRM\Contribute\Form\Task\Invoice.php on line 225

After
----------------------------------------
Invoice appears. Test passes.

Technical Details
----------------------------------------


Comments
----------------------------------------
