### PR TITLE
dev/core#3831 Deprecated string interpolation

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -591,7 +591,7 @@ class CRM_Core_CodeGen_Specification {
     // all fieldnames have to be defined and should exist in schema.
     foreach ($primaryKey['field'] as $fieldName) {
       if (!$fieldName) {
-        echo "Invalid field definition for index '$name' in table ${table['name']}\n";
+        echo "Invalid field definition for index '$name' in table {$table['name']}\n";
         return;
       }
       $parenOffset = strpos($fieldName, '(');
@@ -599,7 +599,7 @@ class CRM_Core_CodeGen_Specification {
         $fieldName = substr($fieldName, 0, $parenOffset);
       }
       if (!array_key_exists($fieldName, $fields)) {
-        echo "Missing definition of field '$fieldName' for index '$name' in table ${table['name']}\n";
+        echo "Missing definition of field '$fieldName' for index '$name' in table {$table['name']}\n";
         print_r($fields);
         exit();
       }

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1888,7 +1888,7 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
     $timenow = new Datetime();
     if (!$isBackOffice && isset($time_limit)) {
       $cancelHours = abs($time_limit);
-      $cancelInterval = new DateInterval("PT${cancelHours}H");
+      $cancelInterval = new DateInterval("PT{$cancelHours}H");
       $cancelInterval->invert = $time_limit < 0 ? 1 : 0;
       $cancelDeadline = (new Datetime($start_date))->sub($cancelInterval);
       if ($timenow > $cancelDeadline) {

--- a/CRM/Extension/Container/Default.php
+++ b/CRM/Extension/Container/Default.php
@@ -32,7 +32,7 @@ class CRM_Extension_Container_Default extends CRM_Extension_Container_Basic {
     // unless baseDir is set, so this error condition is more theoretical.
     if (empty($this->baseDir) || !is_dir($this->baseDir)) {
       $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
-      $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
+      $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination={$civicrmDestination}");
       $errors[] = array(
         'title' => ts('Invalid Base Directory'),
         'message' => ts('The extensions directory is not properly set. Please go to the <a href="%1">path setting page</a> and correct it.<br/>',
@@ -44,7 +44,7 @@ class CRM_Extension_Container_Default extends CRM_Extension_Container_Basic {
     }
     if (empty($this->baseUrl)) {
       $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
-      $url = CRM_Utils_System::url('civicrm/admin/setting/url', "reset=1&civicrmDestination=${civicrmDestination}");
+      $url = CRM_Utils_System::url('civicrm/admin/setting/url', "reset=1&civicrmDestination={$civicrmDestination}");
       $errors[] = array(
         'title' => ts('Invalid Base URL'),
         'message' => ts('The extensions URL is not properly set. Please go to the <a href="%1">URL setting page</a> and correct it.<br/>',

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -73,7 +73,7 @@ class CRM_Extension_Downloader {
 
     if (!$this->containerDir || !is_dir($this->containerDir) || !is_writable($this->containerDir)) {
       $civicrmDestination = urlencode(CRM_Utils_System::url('civicrm/admin/extensions', 'reset=1'));
-      $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination=${civicrmDestination}");
+      $url = CRM_Utils_System::url('civicrm/admin/setting/path', "reset=1&civicrmDestination={$civicrmDestination}");
       $errors[] = array(
         'title' => ts('Directory Unwritable'),
         'message' => ts("Your extensions directory is not set or is not writable. Click <a href='%1'>here</a> to set the extensions directory.",

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -685,7 +685,7 @@ VALUES (%1, %2, %3, %4, %5, %6, %7)
         // Handle SMS errors: CRM-15426
         $job_id = intval($this->id);
         $mailing_id = intval($mailing->id);
-        CRM_Core_Error::debug_log_message("Failed to send SMS message. Vars: mailing_id: ${mailing_id}, job_id: ${job_id}. Error message follows.");
+        CRM_Core_Error::debug_log_message("Failed to send SMS message. Vars: mailing_id: {$mailing_id}, job_id: {$job_id}. Error message follows.");
         CRM_Core_Error::debug_log_message($result->getMessage());
       }
       else {

--- a/CRM/Mailing/BAO/SMSJob.php
+++ b/CRM/Mailing/BAO/SMSJob.php
@@ -78,7 +78,7 @@ class CRM_Mailing_BAO_SMSJob extends CRM_Mailing_BAO_MailingJob {
         // Handle SMS errors: CRM-15426
         $job_id = (int) $this->id;
         $mailing_id = (int) $mailing->id;
-        CRM_Core_Error::debug_log_message("Failed to send SMS message. Vars: mailing_id: ${mailing_id}, job_id: ${job_id}. Error message follows.");
+        CRM_Core_Error::debug_log_message("Failed to send SMS message. Vars: mailing_id: {$mailing_id}, job_id: {$job_id}. Error message follows.");
         CRM_Core_Error::debug_log_message($e->getMessage());
       }
 

--- a/CRM/Report/Form/Case/Summary.php
+++ b/CRM/Report/Form/Case/Summary.php
@@ -267,18 +267,18 @@ class CRM_Report_Form_Case_Summary extends CRM_Report_Form {
     if ($this->_relField) {
       $this->_from = "
             FROM civicrm_contact $c
-inner join civicrm_relationship $cr on {$c}.id = ${cr}.contact_id_b OR {$c}.id = ${cr}.contact_id_a
-inner join civicrm_case $cc on ${cc}.id = ${cr}.case_id
-inner join civicrm_relationship_type $crt on ${crt}.id=${cr}.relationship_type_id
-inner join civicrm_case_contact $ccc on ${ccc}.case_id = ${cc}.id
-inner join civicrm_contact $c2 on ${c2}.id=${ccc}.contact_id
+inner join civicrm_relationship $cr on {$c}.id = {$cr}.contact_id_b OR {$c}.id = {$cr}.contact_id_a
+inner join civicrm_case $cc on {$cc}.id = {$cr}.case_id
+inner join civicrm_relationship_type $crt on {$crt}.id={$cr}.relationship_type_id
+inner join civicrm_case_contact $ccc on {$ccc}.case_id = {$cc}.id
+inner join civicrm_contact $c2 on {$c2}.id={$ccc}.contact_id
 ";
     }
     else {
       $this->_from = "
             FROM civicrm_case $cc
-inner join civicrm_case_contact $ccc on ${ccc}.case_id = ${cc}.id
-inner join civicrm_contact $c2 on ${c2}.id=${ccc}.contact_id
+inner join civicrm_case_contact $ccc on {$ccc}.case_id = {$cc}.id
+inner join civicrm_contact $c2 on {$c2}.id={$ccc}.contact_id
 ";
     }
   }

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -284,7 +284,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     foreach ($include_dirs as $include_dir) {
       foreach ([$camelName, 'Generic'] as $name) {
         $action_dir = implode(DIRECTORY_SEPARATOR,
-          [$include_dir, 'api', "v${version}", $name]);
+          [$include_dir, 'api', "v{$version}", $name]);
         // see note above in getEntityNames about open_basedir
         if (!\CRM_Utils_File::isDir($action_dir)) {
           continue;

--- a/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php
+++ b/tests/phpunit/CRM/Core/Payment/ProcessorFormTest.php
@@ -83,7 +83,7 @@ class CRM_Core_Payment_ProcessorFormTest extends CiviUnitTestCase {
     $profile = $this->callAPISuccess('UFGroup', 'create', [
       'group_type' => 'Contact',
       'title' => "Billing fields: $name",
-      'name' => "${name}_billing",
+      'name' => "{$name}_billing",
     ]);
 
     $this->callAPISuccess('UFField', 'create', [

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -203,7 +203,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       SELECT SUM(fi.amount) total
       FROM civicrm_financial_item fi
         INNER JOIN civicrm_line_item li ON li.id = fi.entity_id AND fi.entity_table = 'civicrm_line_item'
-      WHERE li.entity_table = 'civicrm_participant' AND li.entity_id = ${participantId}
+      WHERE li.entity_table = 'civicrm_participant' AND li.entity_id = {$participantId}
     ";
     $dao = CRM_Core_DAO::executeQuery($query);
 

--- a/tests/phpunit/CRM/Utils/SignerTest.php
+++ b/tests/phpunit/CRM/Utils/SignerTest.php
@@ -134,7 +134,7 @@ class CRM_Utils_SignerTest extends CiviUnitTestCase {
       $isValid = $validator->validate($signature, $case['validateParams']);
 
       if ($isValid !== $case['isValid']) {
-        $this->fail("Case ${caseId}: Mismatch: " . var_export($case, TRUE));
+        $this->fail("Case {$caseId}: Mismatch: " . var_export($case, TRUE));
       }
       $this->assertTrue(TRUE, 'Validation yielded expected result');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Resolves [#3831](https://lab.civicrm.org/dev/core/-/issues/3831)

In PHP 8.2 (planned to be released this November) ${} string interpolation has been deprecated:
https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

```
echo "Hello ${name}"; // Deprecated
echo "Hello {$name}"; // Supported
```

Please note that I have not checked any third-party packages or libraries, which may also need fixing.
