### PR TITLE
[REF] ManagedEntities - Move deprecated function

### DIFF
--- a/CRM/Case/ManagedEntities.php
+++ b/CRM/Case/ManagedEntities.php
@@ -90,7 +90,7 @@ class CRM_Case_ManagedEntities {
       if (!in_array($actType, $validActTypes)) {
         $result[] = $managed;
       }
-      elseif ($me->get($managed['module'], $managed['name'])) {
+      elseif (self::getManagedEntity($managed['module'], $managed['name'])) {
         $result[] = $managed;
       }
     }
@@ -154,11 +154,39 @@ class CRM_Case_ManagedEntities {
       if (!in_array($relType, $validRelTypes)) {
         $result[] = $managed;
       }
-      elseif ($me->get($managed['module'], $managed['name'])) {
+      elseif (self::getManagedEntity($managed['module'], $managed['name'])) {
         $result[] = $managed;
       }
     }
 
+    return $result;
+  }
+
+  /**
+   * Read a managed entity using APIv3.
+   *
+   * @param string $moduleName
+   *   The name of the module which declared entity.
+   * @param string $managedName
+   *   The symbolic name of the entity.
+   * @return array|NULL
+   *   API representation, or NULL if the entity does not exist
+   */
+  private static function getManagedEntity($moduleName, $managedName) {
+    $dao = new CRM_Core_DAO_Managed();
+    $dao->module = $moduleName;
+    $dao->name = $managedName;
+    $result = NULL;
+    if ($dao->find(TRUE)) {
+      $params = [
+        'id' => $dao->entity_id,
+      ];
+      try {
+        $result = civicrm_api3($dao->entity_type, 'getsingle', $params);
+      }
+      catch (Exception $e) {
+      }
+    }
     return $result;
   }
 

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -76,6 +76,7 @@ class CRM_Core_ManagedEntities {
    *   API representation, or NULL if the entity does not exist
    */
   public function get($moduleName, $name) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     $dao = new CRM_Core_DAO_Managed();
     $dao->module = $moduleName;
     $dao->name = $name;


### PR DESCRIPTION
Overview
----------------------------------------
This function was only used by one class and a test. I've moved a simplified version of it into those 2 classes so we can noisily deprecate the original.