### PR TITLE
dev/core#3833 Update CRM_Extension_Downloader to not use dynamic properties

### DIFF
--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -18,9 +18,43 @@
 class CRM_Extension_Downloader {
 
   /**
+   * @var CRM_Extension_Manager
+   */
+  private $manager;
+
+  /**
+   * @var string
+   */
+  private $containerDir;
+
+  /**
+   * @var string
+   * Local path to a temporary data directory
+   */
+  public $tmpDir;
+
+  /**
    * @var GuzzleHttp\Client
    */
   protected $guzzleClient;
+
+  /**
+   * @var CRM_Extension_Container_Basic
+   * The place where downloaded extensions are ultimately stored
+   */
+  public $container;
+
+  /**
+   * @param CRM_Extension_Manager $manager
+   * @param string $containerDir
+   *   The place to store downloaded & extracted extensions.
+   * @param string $tmpDir
+   */
+  public function __construct(CRM_Extension_Manager $manager, $containerDir, $tmpDir) {
+    $this->manager = $manager;
+    $this->containerDir = $containerDir;
+    $this->tmpDir = $tmpDir;
+  }
 
   /**
    * @return \GuzzleHttp\Client
@@ -34,30 +68,6 @@ class CRM_Extension_Downloader {
    */
   public function setGuzzleClient(\GuzzleHttp\Client $guzzleClient) {
     $this->guzzleClient = $guzzleClient;
-  }
-
-  /**
-   * @var CRM_Extension_Container_Basic
-   * The place where downloaded extensions are ultimately stored
-   */
-  public $container;
-
-  /**
-   * @var string
-   * Local path to a temporary data directory
-   */
-  public $tmpDir;
-
-  /**
-   * @param CRM_Extension_Manager $manager
-   * @param string $containerDir
-   *   The place to store downloaded & extracted extensions.
-   * @param string $tmpDir
-   */
-  public function __construct(CRM_Extension_Manager $manager, $containerDir, $tmpDir) {
-    $this->manager = $manager;
-    $this->containerDir = $containerDir;
-    $this->tmpDir = $tmpDir;
   }
 
   /**
@@ -121,7 +131,6 @@ class CRM_Extension_Downloader {
    */
   public function download($key, $downloadUrl) {
     $filename = $this->tmpDir . DIRECTORY_SEPARATOR . $key . '.zip';
-    $destDir = $this->containerDir . DIRECTORY_SEPARATOR . $key;
 
     if (!$downloadUrl) {
       throw new CRM_Extension_Exception(ts('Cannot install this extension - downloadUrl is not set!'));


### PR DESCRIPTION
Overview
----------------------------------------
Update CRM_Extension_Downloader to not use dynamic properties.

First of many required changes for dev/core[#3833](https://lab.civicrm.org/dev/core/-/issues/3833)

Before
----------------------------------------
The `CRM_Extension_Downloader` class used dynamic properties which are going to be deprecated in PHP 8.2, and which harm readability.

After
----------------------------------------
`$manager` and `containerDir` are no longer dynamic properties.

I've re-arranged some of the properties and methods so that the `constructor` comes first, and so that the property order better matches the order in which they are defined.

Whilst in this file I've also removed the line `$destDir = $this->containerDir . DIRECTORY_SEPARATOR . $key;` as `$destDir` was not being used.

Technical Details
----------------------------------------
I've decided to make `manager` and `containerDir` private, as I could not see a need for them to be public. That said it required some thinking about, and happy to hear arguments to the contrary. This highlights both why resolving #3833 will be a good excercise, but also why it may be difficult and time-consuming.

I also think `guzzleClient` could be private rather than protected, but didn't change it incase there is a reason I am not seeing.
