### PR TITLE
Fix PHPDoc comment for CRM_Financial_BAO_FinancialItem::add

### DIFF
--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -41,8 +41,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
    * @param object $contribution
    *   Contribution object.
    * @param bool $taxTrxnID
-   *
-   * @param int $trxnId
+   * @param array|null $trxnId
    *
    * @return CRM_Financial_DAO_FinancialItem
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fix PHPDoc comment for `CRM_Financial_BAO_FinancialItem::add`

Before
----------------------------------------
Previously the 4th argument was specified as `int`, but this was not correct; `$trxnId` is used as an array unless `NULL`, and this matches the arguments passed to `CRM_Financial_BAO_FinancialItem::add` throughout the codebase. 

After
----------------------------------------
The inline documentation is correct.