### PR TITLE
dev/core#3833 Update CRM_Extension_Downloader to not use dynamic properties

### DIFF
--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -77,6 +77,11 @@ class CRM_Queue_Runner {
   public $taskCtx;
 
   /**
+   * @var string
+   */
+  public $lastTaskTitle;
+
+  /**
    * Locate a previously-created instance of the queue-runner.
    *
    * @param string $qrid


### PR DESCRIPTION
Overview
----------------------------------------
Define `CRM_Queue_Runner::lastTaskTitle` before it is used, so it is not treated as a dynamic property.

One of many required changes for dev/core[#3833](https://lab.civicrm.org/dev/core/-/issues/3833)

Comments
----------------------------------------
The property needs to be public as it is read in `CRM_Queue_ErrorPolicy`
