### PR TITLE
Languages - Dropdown lists should reflect supported languages

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -99,14 +99,6 @@ class GetActions extends BasicGetAction {
           }
           if ($this->_isFieldSelected('params')) {
             $this->_actions[$actionName]['params'] = $action->getParamInfo();
-            // Language param is only relevant on multilingual sites
-            $languageLimit = (array) \Civi::settings()->get('languageLimit');
-            if (count($languageLimit) < 2) {
-              unset($this->_actions[$actionName]['params']['language']);
-            }
-            elseif (isset($this->_actions[$actionName]['params']['language'])) {
-              $this->_actions[$actionName]['params']['language']['options'] = array_keys($languageLimit);
-            }
           }
         }
       }

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -56,7 +56,7 @@ abstract class AbstractAction implements \ArrayAccess {
    * by `Civi\Core\Locale::negotiate($preferredLanguage)`.
    *
    * @var string
-   * @optionsCallback getPreferredLanguageOptions
+   * @optionsCallback getLanguageOptions
    */
   protected $language;
 
@@ -585,10 +585,15 @@ abstract class AbstractAction implements \ArrayAccess {
    *
    * @return array
    */
-  protected function getPreferredLanguageOptions(): array {
+  protected function getLanguageOptions(): array {
     $languages = \CRM_Contact_BAO_Contact::buildOptions('preferred_language');
     ksort($languages);
-    return array_keys($languages);
+    $result = array_keys($languages);
+    if (!\Civi::settings()->get('partial_locales')) {
+      $uiLanguages = \CRM_Core_I18n::uiLanguages(TRUE);
+      $result = array_values(array_intersect($result, $uiLanguages));
+    }
+    return $result;
   }
 
 }

--- a/ext/message_admin/CRM/MessageAdmin/Settings.php
+++ b/ext/message_admin/CRM/MessageAdmin/Settings.php
@@ -9,8 +9,15 @@ class CRM_MessageAdmin_Settings {
       ->addSelect('name', 'label')
       ->addOrderBy('label')
       ->execute();
+    $allLangsIdx = array_combine($allLangs->column('name'), $allLangs->column('label'));
+
+    $usableLangs = \Civi\Api4\MessageTemplate::getActions(0)
+      ->addWhere("name", "=", "get")
+      ->execute()
+      ->single()['params']['language']['options'];
+
     return [
-      'allLanguages' => array_combine($allLangs->column('name'), $allLangs->column('label')),
+      'allLanguages' => CRM_Utils_Array::subset($allLangsIdx, $usableLangs),
       'uiLanguages' => CRM_Core_I18n::uiLanguages(),
     ];
   }

--- a/ext/message_admin/ang/crmMsgadm/Workflow.js
+++ b/ext/message_admin/ang/crmMsgadm/Workflow.js
@@ -7,14 +7,8 @@
         controller: 'MsgtpluiListCtrl',
         controllerAs: '$ctrl',
         templateUrl: function() {
-          // The original drafts had a mode where the "Translate" button was conditioned on some kind of language-opt-in.
-          // However, uiLanguages isn't giving that signal anymore, and that opt-in isn't strictly needed since htis
-          // is currently packaged as an opt-in extension. Maybe we should just remove `~/crmMsgadm/Workflow.html` in a few months.
-          // But for the moment, keep it around it in case we have to pivot.
-
-          // var supportsTranslation = CRM.crmMsgadm.uiLanguages && _.size(CRM.crmMsgadm.uiLanguages) > 1;
-          // return supportsTranslation ? '~/crmMsgadm/WorkflowTranslated.html' : '~/crmMsgadm/Workflow.html';
-          return '~/crmMsgadm/WorkflowTranslated.html';
+          var supportsTranslation = CRM.crmMsgadm.allLanguages && _.size(CRM.crmMsgadm.allLanguages) > 1;
+          return supportsTranslation ? '~/crmMsgadm/WorkflowTranslated.html' : '~/crmMsgadm/Workflow.html';
         },
         resolve: {
           prefetch: function(crmApi4, crmStatus) {


### PR DESCRIPTION
Overview
----------------------------------------

Recent updates introduced the possibility of using negotiated/partially-supported locales. This influences which locales are available at which times. This patch updates a couple of UI's to present a more attuned list of languages.

This is a follow-up to #24430 and #24403. The basic rule is this:

* If "Partial Locale" support is enabled, then you can use `setLocale()` with any language. It will make a best effort to respect the locale, even if this requires some compromise or substitution.
    * Ex: `setLocale('es_PR')` will enable currency-formatting rules for `es_PR` and `ts()` strings for `es_MX`.
* If "Partial Locale" support is disabled, then you can only *meaningfully* use `setLocale()` with languages that are clearly+fully supported. To satisfy full support, you should have`*.mo` files and mark the locale as active.
    * Ex: `setLocale('es_PR')` will always switch to another locale (eg `en_US` or` es_MX`). This is because `es_PR` has no `*.mo` files, so it is not fully supported.

cc @eileenmcnaughton 

Before
----------------------------------------

* In "APIv4 Explorer", the "Languages" option is only displayed on multi-lingual sites.
    * This means that it can show *too few languages*. For example, if you have `partial_locales=true`, then you should be able to send REST API requests with `es_PR` (*even if the site does not have multi-lingual schema*).
* In the "Message Admin" extension, it unconditionally presents all "Languages" as available.
    * This means that it can show *too many languages*. For example, if you have `partial_locales=false`, then `es_PR` is not truly usable (*as language-negotiation will switch it away*).

After
----------------------------------------

* In both "APIv4 Explorer" and "Message Admin", the list of languages will be attuned as follow:
    * If you have "Partial Locale" support enabled, then it will show all locales.
    * If you have "Partial Locale" support disabled, then it will only show `uiLanguages()`. (In basic schema, that's the list of enabled mo files. In multilingual schema, that's the list of DB locales.)
