### PR TITLE
Remove un-failable soft credit validation 

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -181,15 +181,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         if (array_key_exists($val, $ruleFields)) {
           $weightSum += $ruleFields[$val];
         }
-        if ($val == "soft_credit") {
-          $mapperKey = CRM_Utils_Array::key('soft_credit', $importKeys);
-          if (empty($fields['mapper'][$mapperKey][1])) {
-            if (empty($errors['_qf_default'])) {
-              $errors['_qf_default'] = '';
-            }
-            $errors['_qf_default'] .= ts('Missing required fields: Soft Credit') . '<br />';
-          }
-        }
       }
       foreach ($ruleFields as $field => $weight) {
         $fieldMessage .= ' ' . $field . '(weight ' . $weight . ')';


### PR DESCRIPTION

Overview
----------------------------------------
Remove un-failable soft credit validation 

It is not possible in the UI to deselect the soft-credit-field field so
let's not validate


Before
----------------------------------------
An error WOULD occur if (eg. ) contact id we deselected & it was subitted - but it is required in the UI so validation is irrelevant (& doesn't validate the more problematic second field anyway)

![image](https://user-images.githubusercontent.com/336308/188046734-041db052-e076-43cf-9d56-2292fe5dc0c3.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
