### PR TITLE
SearchKit - Better support for calculated fields as Afform filters

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -287,6 +287,10 @@ class SpecFormatter {
     if ($inputType == 'Date' && !empty($inputAttrs['formatType'])) {
       self::setLegacyDateFormat($inputAttrs);
     }
+    // Number input for integer fields
+    if ($inputType === 'Text' && $dataTypeName === 'Int') {
+      $inputType = 'Number';
+    }
     // Date/time settings from custom fields
     if ($inputType == 'Date' && !empty($data['custom_group_id'])) {
       $inputAttrs['time'] = empty($data['time_format']) ? FALSE : ($data['time_format'] == 1 ? 12 : 24);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -14,6 +14,7 @@
       $scope.controls = {};
       $scope.fieldList = [];
       $scope.calcFieldList = [];
+      $scope.calcFieldTitles = [];
       $scope.blockList = [];
       $scope.blockTitles = [];
       $scope.elementList = [];
@@ -29,7 +30,7 @@
           fieldGroups.push({
             text: ts('Calculated Fields'),
             children: _.transform(ctrl.display.settings.calc_fields, function(fields, el) {
-              fields.push({id: el.name, text: el.defn.label, disabled: ctrl.fieldInUse(el.name)});
+              fields.push({id: el.name, text: el.label, disabled: ctrl.fieldInUse(el.name)});
             }, [])
           });
         }
@@ -69,11 +70,28 @@
         return entity || ctrl.display.settings['saved_search_id.api_entity'];
       };
 
+      function fieldDefaults(field, prefix) {
+        var tag = {
+          "#tag": "af-field",
+          name: prefix + field.name
+        };
+        if (field.input_type === 'Select' || field.input_type === 'ChainSelect') {
+          tag.defn = {input_attrs: {multiple: true}};
+        } else if (field.input_type === 'Date') {
+          tag.defn = {input_type: 'Select', search_range: true};
+        } else if (field.options) {
+          tag.defn = {input_type: 'Select', input_attrs: {multiple: true}};
+        }
+        return tag;
+      }
+
       function buildCalcFieldList(search) {
         $scope.calcFieldList.length = 0;
+        $scope.calcFieldTitles.length = 0;
         _.each(_.cloneDeep(ctrl.display.settings.calc_fields), function(field) {
-          if (!search || _.contains(field.defn.label.toLowerCase(), search)) {
-            $scope.calcFieldList.push(field);
+          if (!search || _.contains(field.label.toLowerCase(), search)) {
+            $scope.calcFieldList.push(fieldDefaults(field, ''));
+            $scope.calcFieldTitles.push(field.label);
           }
         });
       }
@@ -149,21 +167,6 @@
               fieldList.push(fieldDefaults(field, prefix));
             }
           }, []);
-        }
-
-        function fieldDefaults(field, prefix) {
-          var tag = {
-            "#tag": "af-field",
-            name: prefix + field.name
-          };
-          if (field.input_type === 'Select' || field.input_type === 'ChainSelect') {
-            tag.defn = {input_attrs: {multiple: true}};
-          } else if (field.input_type === 'Date') {
-            tag.defn = {input_type: 'Select', search_range: true};
-          } else if (field.options) {
-            tag.defn = {input_type: 'Select', input_attrs: {multiple: true}};
-          }
-          return tag;
         }
       }
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -61,7 +61,7 @@
         <label>{{:: ts('Calculated Fields') }}</label>
         <div ui-sortable="$ctrl.editor.getSortableOptions($ctrl.editor.getSelectedEntityName())" ui-sortable-update="buildPaletteLists" ng-model="calcFieldList">
           <div ng-repeat="field in calcFieldList" ng-class="{disabled: $ctrl.fieldInUse(field.name)}">
-            <div class="af-gui-palette-item">{{:: field.defn.label }}</div>
+            <div class="af-gui-palette-item">{{:: calcFieldTitles[$index] }}</div>
           </div>
         </div>
       </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -424,7 +424,7 @@
               }
             });
           }
-          if (!entityType && fieldKey && afGui.getField(searchDisplay['saved_search_id.api_entity'], fieldKey)) {
+          if (!entityType) {
             entityType = searchDisplay['saved_search_id.api_entity'];
           }
         }

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -89,6 +89,11 @@
       // Returns the original field definition from metadata
       this.getDefn = function() {
         var defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name);
+        // Calc fields are specific to a search display, not part of the schema
+        if (!defn && ctrl.container.getSearchDisplay(ctrl.container.node)) {
+          var searchDisplay = ctrl.container.getSearchDisplay(ctrl.container.node);
+          defn = _.findWhere(searchDisplay.calc_fields, {name: ctrl.node.name});
+        }
         defn = defn || {
           label: ts('Untitled'),
           required: false

--- a/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
+++ b/ext/afform/mock/ang/testContactEmailSearchForm.aff.html
@@ -2,6 +2,7 @@
   <af-field name="source" />
   <div class="af-container af-layout-inline">
     <af-field name="Contact_Email_contact_id_01.email" />
+    <af-field name="YEAR_birth_date" defn="{search_range: true}" />
     <af-field name="Contact_Email_contact_id_01.location_type_id" defn="{input_attrs: {multiple: true}}" />
   </div>
   <crm-search-display-table filters="{last_name: 'AfformTest', contact_type: dummy_var}" search-name="TestContactEmailSearch" display-name="TestContactEmailDisplay"></crm-search-display-table>

--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -65,6 +65,13 @@ class AfformSearchMetadataInjector {
                     }
                   }
                   $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList)));
+                  // Add field metadata for aggregate fields because they are not in the schema.
+                  // Normal entity fields will be handled by AfformMetadataInjector
+                  foreach (Meta::getCalcFields($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']) as $fieldInfo) {
+                    foreach (pq("af-field[name='{$fieldInfo['name']}']", $doc) as $afField) {
+                      \Civi\Afform\AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
+                    }
+                  }
                 }
               }
             }
@@ -72,7 +79,6 @@ class AfformSearchMetadataInjector {
         }
       });
     $e->angular->add($changeSet);
-
   }
 
 }

--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Search;
+
+use CRM_Search_ExtensionUtil as E;
+use Civi\Api4\Query\SqlExpression;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Search Metadata utilities
+ * @package Civi\Search
+ */
+class Meta {
+
+  /**
+   * Get calculated fields used by a saved search
+   *
+   * @param string $apiEntity
+   * @param array $apiParams
+   * @return array
+   */
+  public static function getCalcFields($apiEntity, $apiParams): array {
+    $calcFields = [];
+    $api = \Civi\API\Request::create($apiEntity, 'get', $apiParams);
+    $selectQuery = new \Civi\Api4\Query\Api4SelectQuery($api);
+    $joinMap = $joinCount = [];
+    foreach ($apiParams['join'] ?? [] as $join) {
+      [$entityName, $alias] = explode(' AS ', $join[0]);
+      $num = '';
+      if (!empty($joinCount[$entityName])) {
+        $num = ' ' . (++$joinCount[$entityName]);
+      }
+      else {
+        $joinCount[$entityName] = 1;
+      }
+      $label = CoreUtil::getInfoItem($entityName, 'title');
+      $joinMap[$alias] = $label . $num;
+    }
+
+    $dataTypeToInputType = [
+      'Integer' => 'Number',
+      'Date' => 'Date',
+      'Timestamp' => 'Date',
+      'Boolean' => 'CheckBox',
+    ];
+
+    foreach ($apiParams['select'] ?? [] as $select) {
+      if (strstr($select, ' AS ')) {
+        $expr = SqlExpression::convert($select, TRUE);
+        $label = $expr::getTitle();
+        foreach ($expr->getFields() as $num => $fieldName) {
+          $field = $selectQuery->getField($fieldName);
+          $joinName = explode('.', $fieldName)[0];
+          $label .= ($num ? ', ' : ': ') . (isset($joinMap[$joinName]) ? $joinMap[$joinName] . ' ' : '') . $field['title'];
+        }
+        if ($expr::getDataType()) {
+          $dataType = $expr::getDataType();
+          $inputType = $dataTypeToInputType[$dataType] ?? 'Text';
+        }
+        else {
+          $dataType = $field['data_type'] ?? 'String';
+          $inputType = $field['input_type'] ?? $dataTypeToInputType[$dataType] ?? 'Text';
+        }
+
+        $calcFields[] = [
+          'name' => $expr->getAlias(),
+          'label' => $label,
+          'input_type' => $inputType,
+          'data_type' => $dataType,
+        ];
+      }
+    }
+    return $calcFields;
+  }
+
+}

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -45,6 +45,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             'id',
             'display_name',
             'GROUP_CONCAT(DISTINCT Contact_Email_contact_id_01.email) AS GROUP_CONCAT_Contact_Email_contact_id_01_email',
+            'YEAR(birth_date) AS YEAR_birth_date',
           ],
           'orderBy' => [],
           'where' => [],
@@ -89,6 +90,12 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
               'dataType' => 'String',
               'type' => 'field',
             ],
+            [
+              'key' => 'YEAR_birth_date',
+              'label' => 'Contact ID',
+              'dataType' => 'Integer',
+              'type' => 'field',
+            ],
           ],
         ],
         'acl_bypass' => FALSE,
@@ -101,6 +108,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
       ->addValue('first_name', 'tester')
       ->addValue('last_name', 'AfformTest')
       ->addValue('source', 'afform_test')
+      ->addValue('birth_date', '2020-01-01')
       ->addChain('emails', Email::save()
         ->addDefault('contact_id', '$id')
         ->addRecord(['email' => $email, 'location_type_id:name' => 'Home'])
@@ -112,6 +120,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
       ->addValue('first_name', 'tester2')
       ->addValue('last_name', 'AfformTest')
       ->addValue('source', 'afform_test2')
+      ->addValue('birth_date', '2010-01-01')
       ->addChain('emails', Email::save()
         ->addDefault('contact_id', '$id')
         ->addRecord(['email' => 'other@test.com', 'location_type_id:name' => 'Other'])
@@ -160,6 +169,13 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
 
     // Filter by email address
     $params['filters'] = ['Contact_Email_contact_id_01.email' => $email];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+
+    // Filter by YEAR(birth_date)
+    $params['filters'] = [
+      'YEAR_birth_date' => ['>=' => 2019],
+    ];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(1, $result);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Improves on #19612 with more support for calculated fields in the Afform Admin UI, allowing them to be configured more like real fields. This allows e.g. a SUM() aggregate to be made a "search by range" filter.

Before
----------------------------------------
Errors in the Form Builder UI when adding calc fields to the layout. No configuration options.

After
----------------------------------------
Calculated fields function like regular fields with the same configuration options.