### PR TITLE
dev/core#3836 : Searching by phone in Advanced Search 

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1276,10 +1276,6 @@ class CRM_Contact_BAO_Query {
 
                   //build locationType join
                   $locationTypeJoin[$tName] = " ( `$tName`.location_type_id = $ltName.id )";
-
-                  if ($addWhere) {
-                    $this->_whereTables[$tName] = $this->_tables[$tName];
-                  }
                   break;
 
                 case 'civicrm_state_province':

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -234,6 +234,104 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
     }
   }
 
+  public function testSearchProfileWithPhone() {
+    $ufGroupID = $this->callAPISuccess('UFGroup', 'create', [
+      'group_type' => 'Individual,Contact',
+      'title' => 'Test Search Profile',
+      'name' => 'test_search_profile',
+    ])['id'];
+    $this->callAPISuccess('UFField', 'create', [
+      'uf_group_id' => $ufGroupID,
+      'field_name' => 'first_name',
+      'is_required' => FALSE,
+      'visibility' => 'Public Pages and Listings',
+      'label' => 'First Name',
+      'field_type' => 'Individual',
+    ]);
+    $this->callAPISuccess('UFField', 'create', [
+      'uf_group_id' => $ufGroupID,
+      'field_name' => 'last_name',
+      'is_required' => FALSE,
+      'visibility' => 'Public Pages and Listings',
+      'label' => 'Last Name',
+      'field_type' => 'Individual',
+    ]);
+    $this->callAPISuccess('UFField', 'create', [
+      'uf_group_id' => $ufGroupID,
+      'field_name' => 'phone',
+      'is_required' => FALSE,
+      'visibility' => 'Public Pages and Listings',
+      'location_type_id' => 1,
+      'phone_type_id' => 1,
+      'label' => 'Phone-Phone (Primary)',
+      'field_type' => 'Contact',
+    ]);
+    $this->callAPISuccess('UFField', 'create', [
+      'uf_group_id' => $ufGroupID,
+      'field_name' => 'city',
+      'is_required' => FALSE,
+      'visibility' => 'Public Pages and Listings',
+      'in_selector' => 1,
+      'label' => 'City (Primary)',
+      'field_type' => 'Contact',
+    ]);
+
+    Civi::settings()->set('defaultSearchProfileID', $ufGroupID);
+    $params = array(
+      0 => array(
+        0 => 'entryURL',
+        1 => '=',
+        2 => 'http://dmaster.brienne/civicrm/contact/search/advanced?reset=1',
+        3 => 0,
+        4 => 0,
+      ),
+      1 => array(
+        0 => 'group_search_selected',
+        1 => '=',
+        2 => 'group',
+        3 => 0,
+        4 => 0,
+      ),
+      2 => array(
+        0 => 'privacy_operator',
+        1 => '=',
+        2 => 'OR',
+        3 => 0,
+        4 => 0,
+      ),
+      3 => array(
+        0 => 'privacy_toggle',
+        1 => '=',
+        2 => '1',
+        3 => 0,
+        4 => 0,
+      ),
+      4 => array(
+        0 => 'phone_numeric',
+        1 => '=',
+        2 => '301',
+        3 => 0,
+        4 => 0,
+      ),
+    );
+    $returnProperties = array(
+      'first_name' => 1,
+      'last_name' => 1,
+      'location' => array(
+        1 => array(
+          'location_type' => 'Primary',
+          'phone-1' => 1,
+          'city' => 1,
+        ),
+      ),
+      'contact_type' => 1,
+      'contact_sub_type' => 1,
+      'sort_name' => 1,
+    );
+    $queryObj = new CRM_Contact_BAO_Query($params, $returnProperties, NULL, FALSE, FALSE, 1, FALSE, TRUE, FALSE, "");
+    $queryObj->alphabetQuery();
+  }
+
   /**
    * Check that we get a successful result querying for home address.
    * CRM-14263 search builder failure with search profile & address in criteria


### PR DESCRIPTION
Overview
----------------------------------------
**Addresses [Issue #3836](https://lab.civicrm.org/dev/core/-/issues/3836) on on lab.civicrm**

If a user tries to search by a phone number via Advanced Search and uses a non-default Search Profile that includes a phone number and at least one location field (i.e. city), then the search produces an error with the message DB error: no such field.


Reproduction steps
----------------------------------------
1. Go to **Administer > Custom Data and Screens > Profiles**
1. Click **Add Profile**
1. Enter a Profile Name and check the box next/to the left of *Search Views*
1. Add fields to your Profile. At a minimum, be sure to add **Contacts > Phone > Primary > Phone** and one address field, such as **Contacts > City > Primary**. (I also included first and last name as fields)
1. Go to **Administer > Custom Data and Screens > Search Preferences**. Select the name of your test Profile from the drop down menu for the **Default Contact Search Profile** (roughly halfway down on the settings page).
1. Hover over **Search** on the navbar and click **Advanced Search** 
1. Enter a phone number (or even just a number/partial number) and click **Search**
1. At this point, the user will receive an error that states `DB error: no such field`


Before
----------------------------------------
Instead of returning the results when a user searches by phone number when a non-default Search Profile includes at least one address field, the user receives an error message that the field does not exist. From the SQL displayed in the error message, this happens because the query does not include a statement to join on the address table, but references it in another join statement in the `ON` clause.

```
| Type      | DB_Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Code      | -19                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
| Message   | DB Error: no such field                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| Mode      | 16                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| UserInfo  | SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name FROM civicrm_contact contact_a LEFT JOIN civicrm_phone `1-phone-1` ON contact_a.id = `1-phone-1`.contact_id AND ( `1-phone-1`.phone_type_id = '1' OR `1-phone-1`.phone_type_id IS NULL ) AND ( `1-phone-1`.is_primary = 1 ) LEFT JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id AND civicrm_phone.is_primary = 1) LEFT JOIN civicrm_location_type `1-location_type` ON ( ( `1-address`.location_type_id = `1-location_type`.id ) ) WHERE ( civicrm_phone.phone_numeric LIKE '%301%' ) AND ( 1 ) AND (contact_a.is_deleted = 0) [nativecode=1054 ** Unknown column '1-address.location_type_id' in 'on clause'] |
| DebugInfo | SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name FROM civicrm_contact contact_a LEFT JOIN civicrm_phone `1-phone-1` ON contact_a.id = `1-phone-1`.contact_id AND ( `1-phone-1`.phone_type_id = '1' OR `1-phone-1`.phone_type_id IS NULL ) AND ( `1-phone-1`.is_primary = 1 ) LEFT JOIN civicrm_phone ON (contact_a.id = civicrm_phone.contact_id AND civicrm_phone.is_primary = 1) LEFT JOIN civicrm_location_type `1-location_type` ON ( ( `1-address`.location_type_id = `1-location_type`.id ) ) WHERE ( civicrm_phone.phone_numeric LIKE '%301%' ) AND ( 1 ) AND (contact_a.is_deleted = 0) [nativecode=1054 ** Unknown column '1-address.location_type_id' in 'on clause'] |
```

After
----------------------------------------
With this fix, a user is able to search by a phone number via Advanced Search with a non-default Search Profile that includes at least one address field and be directed to a page with the search results (i.e. no error).

Technical Details
----------------------------------------
The problem  was traced through the code to lines 1280 - 1282  within /civicrm/CRM/Contact/BAO/Query.php
```
 if ($addWhere) {
   $this->_whereTables[$tName] = $this->_tables[$tName];
 }
```
Reassigning `$this->_whereTables[$tName]` to `$this->_tables[$tName]` within an if block of the `addHierarchicalElements()` function, corresponded with `$this->_simpleFromClause`- which sets up the query for the search results- to include the address table, even when not needed, such as for the phone entity.

`addHierarchicalElements()` only appeared to run when a non-default Search Profile was used with Advanced Search.

Removing this if block resulted in the search completing without errors and did not appear to break/alter any other functionality of the search.

Comments 
----------------------------------------
A unit test (`testSearchProfileWithPhone()` within QueryTest.php) is included in this PR.
