### PR TITLE
CRM_Queue_Queue - Add 'getStatistic($name)'. Deprecate 'numberOfItems()'

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -38,7 +38,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
     /** @var \CRM_Queue_Queue $queue */
     $queue = $e->queue;
     $userJobId = static::findUserJobId($queue->getName());
-    if ($userJobId && $queue->numberOfItems() < 1) {
+    if ($userJobId && $queue->getStatistic('total') < 1) {
       $queue->setStatus('completed');
     }
   }

--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -138,8 +138,28 @@ abstract class CRM_Queue_Queue {
    * Determine number of items remaining in the queue.
    *
    * @return int
+   * @deprecated
+   *   Use `getStatistic(string $name)` instead.
+   *   The definition of `numberOfItems()` has become conflicted among different subclasses.
    */
-  abstract public function numberOfItems();
+  public function numberOfItems() {
+    // This is the statistic traditionally reported by core queue implementations.
+    // However, it may not be as useful, and subclasses may have different interpretations.
+    return $this->getStatistic('total');
+  }
+
+  /**
+   * Get summary information about items in the queue.
+   *
+   * @param string $name
+   *   The desired statistic. Ex:
+   *   - 'ready': The number of items ready for execution (not currently claimed, not scheduled for future).
+   *   - 'blocked': The number of items that may be runnable in the future, but cannot be run right now.
+   *   - 'total': The total number of items known to the queue, regardless of whether their current status.
+   * @return int|float|null
+   *   The value of the statistic, or NULL if the queue backend does not unsupport this statistic.
+   */
+  abstract public function getStatistic(string $name);
 
   /**
    * Get the next item.

--- a/CRM/Queue/Queue/Memory.php
+++ b/CRM/Queue/Queue/Memory.php
@@ -114,7 +114,7 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
    *
    * @return int
    */
-  public function numberOfItems() {
+  public function numberOfItems(): int {
     return count($this->items);
   }
 

--- a/CRM/Queue/Queue/Memory.php
+++ b/CRM/Queue/Queue/Memory.php
@@ -110,12 +110,35 @@ class CRM_Queue_Queue_Memory extends CRM_Queue_Queue {
   }
 
   /**
-   * Determine number of items remaining in the queue.
-   *
-   * @return int
+   * @param string $name
+   * @return int|float|null
+   * @see \CRM_Queue_Queue::getStatistic()
    */
-  public function numberOfItems(): int {
-    return count($this->items);
+  public function getStatistic(string $name) {
+    $ready = function(): int {
+      $now = CRM_Utils_Time::time();
+      $ready = 0;
+      foreach ($this->items as $id => $item) {
+        if (empty($this->releaseTimes[$id]) || $this->releaseTimes[$id] <= $now) {
+          $ready++;
+        }
+      }
+      return $ready;
+    };
+
+    switch ($name) {
+      case 'ready':
+        return $ready();
+
+      case 'blocked':
+        return count($this->items) - $ready();
+
+      case 'total':
+        return count($this->items);
+
+      default:
+        return NULL;
+    }
   }
 
   /**

--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -56,11 +56,11 @@ trait CRM_Queue_Queue_SqlTrait {
    * @return int
    */
   public function numberOfItems() {
-    return CRM_Core_DAO::singleValueQuery("
+    return (int) CRM_Core_DAO::singleValueQuery('
       SELECT count(*)
       FROM civicrm_queue_item
       WHERE queue_name = %1
-    ", [
+    ', [
       1 => [$this->getName(), 'String'],
     ]);
   }

--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -47,22 +47,34 @@ trait CRM_Queue_Queue_SqlTrait {
    * @return bool
    */
   public function existsQueue() {
-    return ($this->numberOfItems() > 0);
+    return ($this->getStatistic('total') > 0);
   }
 
   /**
-   * Determine number of items remaining in the queue.
-   *
-   * @return int
+   * @param string $name
+   * @return int|float|null
+   * @see \CRM_Queue_Queue::getStatistic()
    */
-  public function numberOfItems() {
-    return (int) CRM_Core_DAO::singleValueQuery('
-      SELECT count(*)
-      FROM civicrm_queue_item
-      WHERE queue_name = %1
-    ', [
-      1 => [$this->getName(), 'String'],
-    ]);
+  public function getStatistic(string $name) {
+    switch ($name) {
+      case 'ready':
+        return (int) CRM_Core_DAO::singleValueQuery(
+          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1 AND (release_time is null OR release_time <= FROM_UNIXTIME(%2))',
+          [1 => [$this->getName(), 'String'], 2 => [CRM_Utils_Time::time(), 'Int']]);
+
+      case 'blocked':
+        return (int) CRM_Core_DAO::singleValueQuery(
+          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1 AND release_time > FROM_UNIXTIME(%2)',
+          [1 => [$this->getName(), 'String'], 2 => [CRM_Utils_Time::time(), 'Int']]);
+
+      case 'total':
+        return (int) CRM_Core_DAO::singleValueQuery(
+          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1',
+          [1 => [$this->getName(), 'String']]);
+
+      default:
+        return NULL;
+    }
   }
 
   /**

--- a/Civi/Test/QueueTestTrait.php
+++ b/Civi/Test/QueueTestTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Civi\Test;
+
+/**
+ * Helper functions for testing queues.
+ */
+trait QueueTestTrait {
+
+  protected function assertQueueStats(int $total, int $ready, int $blocked, \CRM_Queue_Queue $queue) {
+    $format = 'total=%d ready=%d blocked=%d';
+    $expect = [$total, $ready, $blocked];
+    $actual = [$queue->getStatistic('total'), $queue->getStatistic('ready'), $queue->getStatistic('blocked')];
+    $this->assertEquals(sprintf($format, ...$expect), sprintf($format, ...$actual));
+
+    // Deprecated - but checking for continuity.
+    $this->assertEquals($total, $queue->numberOfItems());
+  }
+
+}

--- a/templates/CRM/Queue/Page/Runner.tpl
+++ b/templates/CRM/Queue/Page/Runner.tpl
@@ -63,7 +63,7 @@ CRM.$(function($) {
     if (!data.is_error) {
       queueRunnerData.completed++;
     }
-    if (data.numberOfItems) {
+    if ('numberOfItems' in data && data.numberOfItems !== null) {
       queueRunnerData.numberOfItems = parseInt(data.numberOfItems);
     }
 

--- a/tests/phpunit/CRM/Queue/Queue/SqlTest.php
+++ b/tests/phpunit/CRM/Queue/Queue/SqlTest.php
@@ -18,6 +18,8 @@
  */
 class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
 
+  use \Civi\Test\QueueTestTrait;
+
   /* ----------------------- Queue providers ----------------------- */
 
   /* Define a list of queue providers which should be tested */
@@ -73,12 +75,12 @@ class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
       'test-key' => 'c',
     ]);
 
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
     $item = $this->queue->claimItem();
     $this->assertEquals('a', $item->data['test-key']);
     $this->queue->deleteItem($item);
 
-    $this->assertEquals(2, $this->queue->numberOfItems());
+    $this->assertQueueStats(2, 2, 0, $this->queue);
     $item = $this->queue->claimItem();
     $this->assertEquals('b', $item->data['test-key']);
     $this->queue->deleteItem($item);
@@ -103,27 +105,27 @@ class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
       'test-key' => 'd',
     ]);
 
-    $this->assertEquals(4, $this->queue->numberOfItems());
+    $this->assertQueueStats(4, 4, 0, $this->queue);
     $item = $this->queue->claimItem();
     $this->assertEquals('start', $item->data['test-key']);
     $this->queue->deleteItem($item);
 
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
     $item = $this->queue->claimItem();
     $this->assertEquals('c', $item->data['test-key']);
     $this->queue->deleteItem($item);
 
-    $this->assertEquals(2, $this->queue->numberOfItems());
+    $this->assertQueueStats(2, 2, 0, $this->queue);
     $item = $this->queue->claimItem();
     $this->assertEquals('d', $item->data['test-key']);
     $this->queue->deleteItem($item);
 
-    $this->assertEquals(1, $this->queue->numberOfItems());
+    $this->assertQueueStats(1, 1, 0, $this->queue);
     $item = $this->queue->claimItem();
     $this->assertEquals('end', $item->data['test-key']);
     $this->queue->deleteItem($item);
 
-    $this->assertEquals(0, $this->queue->numberOfItems());
+    $this->assertQueueStats(0, 0, 0, $this->queue);
   }
 
 }

--- a/tests/phpunit/CRM/Queue/RunnerTest.php
+++ b/tests/phpunit/CRM/Queue/RunnerTest.php
@@ -16,6 +16,8 @@
  */
 class CRM_Queue_RunnerTest extends CiviUnitTestCase {
 
+  use \Civi\Test\QueueTestTrait;
+
   public function setUp(): void {
     parent::setUp();
     $this->queueService = CRM_Queue_Service::singleton(TRUE);
@@ -61,11 +63,11 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
       'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
     ]);
     $this->assertEquals(self::$_recordedValues, []);
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
     $result = $runner->runAll();
     $this->assertEquals(TRUE, $result);
     $this->assertEquals(self::$_recordedValues, ['a', 'b', 'c']);
-    $this->assertEquals(0, $this->queue->numberOfItems());
+    $this->assertQueueStats(0, 0, 0, $this->queue);
   }
 
   /**
@@ -97,11 +99,11 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
       'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
     ]);
     $this->assertEquals(self::$_recordedValues, []);
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
     $result = $runner->runAll();
     $this->assertEquals(TRUE, $result);
     $this->assertEquals(self::$_recordedValues, ['a', 1, 2, 3, 'b']);
-    $this->assertEquals(0, $this->queue->numberOfItems());
+    $this->assertQueueStats(0, 0, 0, $this->queue);
   }
 
   /**
@@ -132,12 +134,13 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
       'errorMode' => CRM_Queue_Runner::ERROR_CONTINUE,
     ]);
     $this->assertEquals(self::$_recordedValues, []);
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
+
     $result = $runner->runAll();
     // FIXME useless return
     $this->assertEquals(TRUE, $result);
     $this->assertEquals(self::$_recordedValues, ['a', 'c']);
-    $this->assertEquals(0, $this->queue->numberOfItems());
+    $this->assertQueueStats(0, 0, 0, $this->queue);
   }
 
   /**
@@ -168,13 +171,14 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
       'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
     ]);
     $this->assertEquals(self::$_recordedValues, []);
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
+
     $result = $runner->runAll();
     $this->assertEquals(1, $result['is_error']);
     // nothing from 'c'
     $this->assertEquals(self::$_recordedValues, ['a']);
     // 'b' and 'c' remain
-    $this->assertEquals(2, $this->queue->numberOfItems());
+    $this->assertQueueStats(2, 2, 0, $this->queue);
   }
 
   /**
@@ -205,13 +209,13 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
       'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
     ]);
     $this->assertEquals(self::$_recordedValues, []);
-    $this->assertEquals(3, $this->queue->numberOfItems());
+    $this->assertQueueStats(3, 3, 0, $this->queue);
     $result = $runner->runAll();
     $this->assertEquals(1, $result['is_error']);
     // nothing from 'c'
     $this->assertEquals(self::$_recordedValues, ['a']);
     // 'b' and 'c' remain
-    $this->assertEquals(2, $this->queue->numberOfItems());
+    $this->assertQueueStats(2, 2, 0, $this->queue);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

(This is an off-shoot from #24408.)

Should `numberOfItems()` tell you the _total_ number of items -- or the number of _ready_ items?  Trick question.  They can tell you different    things:

* When implementing a task-worker (which loops through available tasks, and stops when there's nothing to do), you'd use _ready_ items.
* When implementing `existsQueue()` (which tells if you the queue has anything at all), you'd use _total_ items.

This trick-question is why different implementations have computed `numberOfItems()` in different ways.

This patch resolves the trick-question by deprecating `numberOfItems()` and replacing it with `getStatistic($name)`.

Before
----------------------------------------

* `numberOfItems()` is ambiguous

After
----------------------------------------

* `numberOfItems()` is ambiguous
* `getStatistics($name)` replaces it

