### PR TITLE
Fix contribution import mapping validation, add test

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -181,15 +181,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
         if (array_key_exists($val, $ruleFields)) {
           $weightSum += $ruleFields[$val];
         }
-        if ($val == "soft_credit") {
-          $mapperKey = CRM_Utils_Array::key('soft_credit', $importKeys);
-          if (empty($fields['mapper'][$mapperKey][1])) {
-            if (empty($errors['_qf_default'])) {
-              $errors['_qf_default'] = '';
-            }
-            $errors['_qf_default'] .= ts('Missing required fields: Soft Credit') . '<br />';
-          }
-        }
       }
       foreach ($ruleFields as $field => $weight) {
         $fieldMessage .= ' ' . $field . '(weight ' . $weight . ')';

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -21,38 +21,6 @@
 class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
-   * Check if required fields are present.
-   *
-   * @param CRM_Contribute_Import_Form_MapField $self
-   * @param string $contactORContributionId
-   * @param array $importKeys
-   * @param array $errors
-   * @param int $weightSum
-   * @param int $threshold
-   * @param string $fieldMessage
-   *
-   * @return array
-   */
-  protected static function checkRequiredFields($self, string $contactORContributionId, array $importKeys, array $errors, int $weightSum, $threshold, string $fieldMessage): array {
-    // FIXME: should use the schema titles, not redeclare them
-    $requiredFields = [
-      'contribution_contact_id' => ts('Contact ID'),
-    ];
-
-    foreach ($requiredFields as $field => $title) {
-      if (!in_array($field, $importKeys)) {
-        if ($field == 'contribution_contact_id') {
-          if (!($weightSum >= $threshold || in_array('external_identifier', $importKeys))
-          ) {
-            $errors['_qf_default'] .= ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', [1 => $threshold]) . '<br />';
-          }
-        }
-      }
-    }
-    return $errors;
-  }
-
-  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
@@ -162,41 +130,25 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
    *   list of errors to be posted back to the form
    */
   public static function formRule($fields, $files, $self) {
-    $errors = [];
-    $fieldMessage = NULL;
-    $contactORContributionId = $self->isUpdateExisting() ? 'contribution_id' : 'contribution_contact_id';
-    if (!array_key_exists('savedMapping', $fields)) {
-      $importKeys = [];
-      foreach ($fields['mapper'] as $mapperPart) {
-        $importKeys[] = $mapperPart[0];
-      }
-
-      $params = [
-        'used' => 'Unsupervised',
-        'contact_type' => $self->getContactType(),
-      ];
-      [$ruleFields, $threshold] = CRM_Dedupe_BAO_DedupeRuleGroup::dedupeRuleFieldsWeight($params);
-      $weightSum = 0;
-      foreach ($importKeys as $key => $val) {
-        if (array_key_exists($val, $ruleFields)) {
-          $weightSum += $ruleFields[$val];
+    $mapperError = [];
+    try {
+      $parser = $self->getParser();
+      $rule = $parser->getDedupeRule($self->getContactType() . 'Unsupervised');
+      if (!$self->isUpdateExisting()) {
+        $missingDedupeFields = $self->validateDedupeFieldsSufficientInMapping($rule, $fields['mapper']);
+        if ($missingDedupeFields) {
+          $mapperError[] = $missingDedupeFields;
         }
       }
-      foreach ($ruleFields as $field => $weight) {
-        $fieldMessage .= ' ' . $field . '(weight ' . $weight . ')';
-      }
-      try {
-        $parser = $self->getParser();
-        $parser->validateMapping($fields['mapper']);
-      }
-      catch (CRM_Core_Exception $e) {
-        $errors['_qf_default'] = $e->getMessage();
-      }
-      if (!$self->isUpdateExisting()) {
-        $errors = self::checkRequiredFields($self, $contactORContributionId, $importKeys, $errors, $weightSum, $threshold, $fieldMessage);
-      }
+      $parser->validateMapping($fields['mapper']);
     }
-    return !empty($errors) ? $errors : TRUE;
+    catch (CRM_Core_Exception $e) {
+      $mapperError[] = $e->getMessage();
+    }
+    if (!empty($mapperError)) {
+      return ['_qf_default' => implode('<br/>', $mapperError)];
+    }
+    return TRUE;
   }
 
   /**
@@ -251,6 +203,35 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     return $defaults;
+  }
+
+  /**
+   * Validate the the mapped fields contain enough to meet the dedupe rule lookup requirements.
+   *
+   * @param array $rule
+   * @param array $mapper
+   *
+   * @return string|false
+   *   Error string if insufficient.
+   */
+  protected function validateDedupeFieldsSufficientInMapping(array $rule, array $mapper): ?string {
+    $threshold = $rule['threshold'];
+    $ruleFields = $rule['fields'];
+    $weightSum = 0;
+    foreach ($mapper as $mapping) {
+      if ($mapping[0] === 'external_identifier') {
+        // It is enough to have external identifier mapped.
+        $weightSum = $threshold;
+        break;
+      }
+      if (array_key_exists($mapping[0], $ruleFields)) {
+        $weightSum += $ruleFields[$mapping[0]];
+      }
+    }
+    if ($weightSum < $threshold) {
+      return $rule['rule_message'];
+    }
+    return NULL;
   }
 
 }

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -276,9 +276,10 @@ abstract class CRM_Import_DataSource {
    *
    * The array has all values.
    *
+   * @param array $statuses
+   *
    * @return int
    *
-   * @throws \API_Exception
    * @throws \CRM_Core_Exception
    */
   public function getRowCount(array $statuses = []): int {

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -176,7 +176,7 @@ trait CRMTraits_Custom_CustomDataTrait {
    * @noinspection PhpDocMissingThrowsInspection
    * @noinspection PhpUnhandledExceptionInspection
    */
-  protected function getCustomFieldName(string $key, $version = 3): string {
+  protected function getCustomFieldName(string $key = 'text', int $version = 3): string {
     if ($version === 4) {
       $field = CustomField::get(FALSE)->addWhere('id', '=', $this->getCustomFieldID($key))
         ->addSelect('name', 'custom_group_id.name')->execute()->first();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3366,7 +3366,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *
    * @param string $thousandSeparator
    */
-  protected function setCurrencySeparators($thousandSeparator) {
+  protected function setCurrencySeparators(string $thousandSeparator): void {
     Civi::settings()->set('monetaryThousandSeparator', $thousandSeparator);
     Civi::settings()->set('monetaryDecimalPoint', ($thousandSeparator === ',' ? '.' : ','));
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix contribution import mapping validation, add test 

Before
----------------------------------------
Testing has been added to the form validation function for the mapper when importing contributions - but not on the validation of the fields required for a dedupe match - which was hard to read & turned out to not handle custom fields in the dedupe rule ( a bit of an artificial scenario as that can't be configured via the UI and it isn't currently possible to select a different rule than the reserved one)

After
----------------------------------------
- tests added
- code cleaned up
- code is apiv4 friendly & will also work with apiv4 style fields once we switch over

Technical Details
----------------------------------------
- only affects contribution import, similar code for participant import not touched.

Comments
----------------------------------------
once the rc is cut I'll do another round of UI testing