### PR TITLE
[REF] Remove calls to settings from angularjs to php layer to assist …

### DIFF
--- a/CRM/Core/Page/AJAX/Attachment.php
+++ b/CRM/Core/Page/AJAX/Attachment.php
@@ -137,6 +137,7 @@ class CRM_Core_Page_AJAX_Attachment {
   public static function angularSettings() {
     return [
       'token' => self::createToken(),
+      'maxFileSize' => Civi::settings()->get('maxFileSize'),
     ];
   }
 

--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -110,6 +110,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
       'reportIds' => $reportIds,
       'enabledLanguages' => $enabledLanguages,
       'isMultiLingual' => $isMultiLingual,
+      'autoRecipientRebuild' => Civi::settings()->get('auto_recipient_rebuild'),
     ];
     return $crmMailingSettings;
   }

--- a/ang/crmAttachment.js
+++ b/ang/crmAttachment.js
@@ -156,11 +156,7 @@
         var model = $parse(attr.crmAttachments);
         scope.att = model(scope.$parent);
         scope.ts = CRM.ts(null);
-        CRM.api4('Setting', 'get', {
-          select: ["maxFileSize"]
-        }).then(function(settings) {
-          scope.max_size = settings[0].value;
-        });
+        scope.max_size = CRM.crmAttachment.maxFileSize;
         scope.inclUrl = '~/crmAttachment/attachments.html';
 
         // delay rendering of child tree until after model has been populated

--- a/ang/crmMailing/EditRecipCtrl.js
+++ b/ang/crmMailing/EditRecipCtrl.js
@@ -73,9 +73,7 @@
     // refresh setting at a duration on 5sec
     var refreshSetting = _.debounce(function() {
       $scope.$apply(function() {
-        crmApi('Setting', 'getvalue', {"name": 'auto_recipient_rebuild', "return": "value"}).then(function(response) {
-          $scope.permitRecipientRebuild = (response.result === 0);
-        });
+        $scope.permitRecipientRebuild = !$scope.$parent.crmMailingConst.autoRecipientRebuild;
       });
     }, SETTING_DEBOUNCE_MS);
     $scope.$watchCollection("permitRecipientRebuild", refreshSetting);


### PR DESCRIPTION
…with less permissioned users using civimail

Overview
----------------------------------------
This moves the retrieval of CiviCRM settings for maxfilesize and if mailing recipients should be auto recalculated from the angularjs layer into the php layer which means that users without administer CiviCRM should still be able to use CiviMail without any console errors

Before
----------------------------------------
Console errors because of permission denied issues when retriving settings related to civimail for users without administer civicrm

After
----------------------------------------
No console errors related to settings permission denied issues

ping @johntwyman @eileenmcnaughton @colemanw @totten 
