### PR TITLE
Remove silly constants for Contact Types (import)

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -106,16 +106,16 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     // contact types option
     $contactTypeOptions = $contactTypeAttributes = [];
     if (CRM_Contact_BAO_ContactType::isActive('Individual')) {
-      $contactTypeOptions[CRM_Import_Parser::CONTACT_INDIVIDUAL] = ts('Individual');
-      $contactTypeAttributes[CRM_Import_Parser::CONTACT_INDIVIDUAL] = $js;
+      $contactTypeOptions['Individual'] = ts('Individual');
+      $contactTypeAttributes['Individual'] = $js;
     }
     if (CRM_Contact_BAO_ContactType::isActive('Household')) {
-      $contactTypeOptions[CRM_Import_Parser::CONTACT_HOUSEHOLD] = ts('Household');
-      $contactTypeAttributes[CRM_Import_Parser::CONTACT_HOUSEHOLD] = $js;
+      $contactTypeOptions['Household'] = ts('Household');
+      $contactTypeAttributes['Household'] = $js;
     }
     if (CRM_Contact_BAO_ContactType::isActive('Organization')) {
-      $contactTypeOptions[CRM_Import_Parser::CONTACT_ORGANIZATION] = ts('Organization');
-      $contactTypeAttributes[CRM_Import_Parser::CONTACT_ORGANIZATION] = $js;
+      $contactTypeOptions['Organization'] = ts('Organization');
+      $contactTypeAttributes['Organization'] = $js;
     }
     $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions, [], NULL, FALSE, $contactTypeAttributes);
 
@@ -162,7 +162,7 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $defaults = [
       'dataSource' => $this->getDefaultDataSource(),
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'fieldSeparator' => CRM_Core_Config::singleton()->fieldSeparator,
       'disableUSPS' => TRUE,
     ];

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -483,22 +483,7 @@ LIMIT {$offset}, {$rowCount}
   }
 
   public static function buildDedupeRules() {
-    $parent = CRM_Utils_Request::retrieve('parentId', 'Positive');
-
-    switch ($parent) {
-      case 1:
-        $contactType = 'Individual';
-        break;
-
-      case 2:
-        $contactType = 'Household';
-        break;
-
-      case 4:
-        $contactType = 'Organization';
-        break;
-    }
-
+    $contactType = CRM_Utils_Request::retrieve('parentId', 'Positive');
     $dedupeRules = CRM_Dedupe_BAO_DedupeRuleGroup::getByType($contactType);
 
     CRM_Utils_JSON::output($dedupeRules);

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -101,7 +101,7 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   public function setDefaultValues(): array {
     $config = CRM_Core_Config::singleton();
     $defaults = [
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'fieldSeparator' => $config->fieldSeparator,
       // Perhaps never used, but permits url passing of the group.
       'multipleCustomData' => CRM_Utils_Request::retrieve('id', 'Positive', $this),

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -126,18 +126,18 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
     //contact types option
     $contactTypeOptions = [];
     if (CRM_Contact_BAO_ContactType::isActive('Individual')) {
-      $contactTypeOptions[CRM_Import_Parser::CONTACT_INDIVIDUAL] = ts('Individual');
+      $contactTypeOptions['Individual'] = ts('Individual');
     }
     if (CRM_Contact_BAO_ContactType::isActive('Household')) {
-      $contactTypeOptions[CRM_Import_Parser::CONTACT_HOUSEHOLD] = ts('Household');
+      $contactTypeOptions['Household'] = ts('Household');
     }
     if (CRM_Contact_BAO_ContactType::isActive('Organization')) {
-      $contactTypeOptions[CRM_Import_Parser::CONTACT_ORGANIZATION] = ts('Organization');
+      $contactTypeOptions['Organization'] = ts('Organization');
     }
     $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions);
 
     $this->setDefaults([
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
     ]);
   }
 

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -343,9 +343,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function getContactType(): string {
     $contactTypeMapping = [
-      CRM_Import_Parser::CONTACT_INDIVIDUAL => 'Individual',
-      CRM_Import_Parser::CONTACT_HOUSEHOLD => 'Household',
-      CRM_Import_Parser::CONTACT_ORGANIZATION => 'Organization',
+      'Individual' => 'Individual',
+      'Household' => 'Household',
+      'Organization' => 'Organization',
     ];
     return $contactTypeMapping[$this->getSubmittedValue('contactType')];
   }

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -216,9 +216,9 @@ class CRM_Import_ImportProcessor {
    */
   public function setContactTypeByConstant($contactTypeKey) {
     $constantTypeMap = [
-      CRM_Import_Parser::CONTACT_INDIVIDUAL => 'Individual',
-      CRM_Import_Parser::CONTACT_HOUSEHOLD => 'Household',
-      CRM_Import_Parser::CONTACT_ORGANIZATION => 'Organization',
+      'Individual' => 'Individual',
+      'Household' => 'Household',
+      'Organization' => 'Organization',
     ];
     $this->contactType = $constantTypeMap[$contactTypeKey];
   }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -52,8 +52,10 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
   /**
    * Contact types
+   *
+   * @deprecated
    */
-  const CONTACT_INDIVIDUAL = 1, CONTACT_HOUSEHOLD = 2, CONTACT_ORGANIZATION = 4;
+  const CONTACT_INDIVIDUAL = 'Individual', CONTACT_HOUSEHOLD = 'Household', CONTACT_ORGANIZATION = 'Organization';
 
   /**
    * User job id.
@@ -205,9 +207,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected function getContactType(): string {
     if (!$this->_contactType) {
       $contactTypeMapping = [
-        CRM_Import_Parser::CONTACT_INDIVIDUAL => 'Individual',
-        CRM_Import_Parser::CONTACT_HOUSEHOLD => 'Household',
-        CRM_Import_Parser::CONTACT_ORGANIZATION => 'Organization',
+        'Individual' => 'Individual',
+        'Household' => 'Household',
+        'Organization' => 'Organization',
       ];
       $this->_contactType = $contactTypeMapping[$this->getSubmittedValue('contactType')];
     }

--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -56,7 +56,7 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
       'metadata' => [
         'DataSource' => ['table_name' => 'abc', 'column_headers' => ['External Identifier', 'Amount Given', 'Date Received', 'Financial Type', 'In honor']],
         'submitted_values' => [
-          'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+          'contactType' => 'Individual',
           'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -359,7 +359,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
-          'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+          'contactType' => 'Individual',
           'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT first_name FROM civicrm_contact',

--- a/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
@@ -62,7 +62,7 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
     $sqlFormValues = [
       'dataSource' => 'CRM_Import_DataSource_SQL',
       'sqlQuery' => 'SELECT "bob" as first_name FROM civicrm_option_value LIMIT 5',
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
     ];
     $form = $this->submitDataSourceForm($sqlFormValues);
     $userJobID = $form->getUserJobID();
@@ -89,7 +89,7 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
     $csvFormValues = [
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'skipColumnHeader' => 1,
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'uploadFile' => [
         'name' => __DIR__ . '/data/yogi.csv',
         'type' => 'text/csv',

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -146,7 +146,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
   public function getMapFieldFormObject(array $submittedValues = []): CRM_Contact_Import_Form_MapField {
     CRM_Core_DAO::executeQuery('CREATE TABLE IF NOT EXISTS civicrm_tmp_d_import_job_xxx (`nada` text, `first_name` text, `last_name` text, `address` text) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci');
     $submittedValues = array_merge([
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'contactSubType' => '',
       'dataSource' => 'CRM_Import_DataSource_SQL',
       'sqlQuery' => 'SELECT * FROM civicrm_tmp_d_import_job_xxx',
@@ -227,7 +227,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     $this->assertEquals($this->getCustomFieldName('text'), $processor->getFieldName(4));
     $this->assertEquals('url', $processor->getFieldName(8));
 
-    $processor->setContactTypeByConstant(CRM_Import_Parser::CONTACT_HOUSEHOLD);
+    $processor->setContactTypeByConstant('Household');
     $this->assertEquals('Household', $processor->getContactType());
   }
 
@@ -346,7 +346,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     $processor->setMappingID($mappingID);
     $processor->setFormName('document.forms.MapField');
     $processor->setMetadata($this->getContactImportMetadata());
-    $processor->setContactTypeByConstant(CRM_Import_Parser::CONTACT_INDIVIDUAL);
+    $processor->setContactTypeByConstant('Individual');
 
     $defaults = [];
     $defaults["mapper[$columnNumber]"] = $processor->getSavedQuickformDefaultsForColumn($columnNumber);
@@ -362,7 +362,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
    */
   private function setUpMapFieldForm(): void {
     $this->form = $this->getMapFieldFormObject();
-    $this->form->set('contactType', CRM_Import_Parser::CONTACT_INDIVIDUAL);
+    $this->form->set('contactType', 'Individual');
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1110,14 +1110,14 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
         'csv' => 'organization_email_no_organization_name.csv',
         'mapper' => [['email'], ['phone', 1, 1]],
         'expected_error' => 'Missing required fields: Organization Name',
-        'submitted_values' => ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP, 'contactType' => CRM_Import_Parser::CONTACT_ORGANIZATION],
+        'submitted_values' => ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP, 'contactType' => 'Organization'],
       ],
       'organization_email_no_organization_name_update_mode' => [
         // Email is enough in upgrade mode (at least to pass validate).
         'csv' => 'organization_email_no_organization_name.csv',
         'mapper' => [['email'], ['phone', 1, 1]],
         'expected_error' => '',
-        'submitted_values' => ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE, 'contactType' => CRM_Import_Parser::CONTACT_ORGANIZATION],
+        'submitted_values' => ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE, 'contactType' => 'Organization'],
       ],
     ];
   }
@@ -1209,7 +1209,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
           CRM_Import_Parser::ERROR => 1,
         ],
         'submitted_values' => [
-          'contactType' => CRM_Import_Parser::CONTACT_ORGANIZATION,
+          'contactType' => 'Organization',
         ],
       ],
       //Matching this contact based on the de-dupe rule would cause an external ID conflict
@@ -1788,7 +1788,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'mapper' => $mapper,
       'dataSource' => 'CRM_Import_DataSource_CSV',
     ], $submittedValues));
@@ -2046,7 +2046,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
-          'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+          'contactType' => 'Individual',
           'contactSubType' => '',
           'doGeocodeAddress' => 0,
           'disableUSPS' => 0,
@@ -2120,7 +2120,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'uploadFile' => ['name' => __DIR__ . '/../Form/data/' . $csv],
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'mapper' => $mapper,
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -355,7 +355,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $form = $this->getMapFieldForm([
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
       'mapper' => $this->getMapperFromFieldMappings($mappings),
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
     ]);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
@@ -407,7 +407,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $form = $this->getMapFieldForm([
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
       'mapper' => $this->getMapperFromFieldMappings($fieldMappings),
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
     ]);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
@@ -535,7 +535,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
-          'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+          'contactType' => 'Individual',
           'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT first_name FROM civicrm_contact',

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -71,7 +71,7 @@ class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
       'uploadFile' => ['name' => __DIR__ . '/data/' . $csv],
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'mapper' => $this->getMapperFromFieldMappings($fieldMappings),
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],
@@ -207,7 +207,7 @@ class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
-          'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+          'contactType' => 'Individual',
           'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT first_name FROM civicrm_contact',

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -164,7 +164,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
         'name' => __DIR__ . '/' . $csvFileName,
       ],
       'skipColumnHeader' => TRUE,
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'dataSource' => 'CRM_Import_DataSource_CSV',
     ]);
     $form->buildForm();

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -342,7 +342,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
-          'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+          'contactType' => 'Individual',
           'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT first_name FROM civicrm_contact',
@@ -468,7 +468,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       'uploadFile' => ['name' => __DIR__ . '/data/' . $csv],
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'mapper' => $this->getMapperFromFieldMappings($fieldMappings),
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -34,7 +34,7 @@ trait CRMTraits_Import_ParserTrait {
     $submittedValues = array_merge([
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'mapper' => $this->getMapperFromFieldMappings($fieldMappings),
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],
@@ -107,7 +107,7 @@ trait CRMTraits_Import_ParserTrait {
       'uploadFile' => ['name' => $directory . '/data/' . $csv],
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+      'contactType' => 'Individual',
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],
       'dateFormats' => CRM_Core_Form_Date::DATE_yyyy_mm_dd,


### PR DESCRIPTION
Overview
----------------------------------------
Remove silly constants for Contact Types (import)

Before
----------------------------------------
Rather than using the unique name for the three high level contact types a constant is used e.g `CRM_Import_Parser::CONTACT_INDIVIDUAL`

After
----------------------------------------
We just use the name - eg. 'Individual'

Technical Details
----------------------------------------
The constants are kept, but deprecated, so any code referring to them will still get an (ahem) constant value. The value is now the string rather than that 'good idea at the time' int - but any code referring to it will be doing so consistently as it is not meaningful as  number. It's possible custom code with strict typing could care - but the code interacting with the import was checked out for the last cleanup & it's mostly too old to be using typing (the exception being probably my extension)

Comments
----------------------------------------
