### PR TITLE
allow contact reference custom fields to have lengths greater than 255 characters

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2810,7 +2810,9 @@ WHERE cf.id = %1 AND cg.is_multiple = 1";
       }
     }
     if ($field->serialize) {
-      $params['type'] = 'varchar(255)';
+      // Ensure length is at least 255, but allow it to go higher.
+      $text_length = intval($field->text_length) < 255 ? 255 : $field->text_length;
+      $params['type'] = 'varchar(' . $text_length . ')';
     }
     if (isset($field->default_value)) {
       $params['default'] = "'{$field->default_value}'";


### PR DESCRIPTION
Overview
----------------------------------------
Currently, when creating contact reference custom fields via the UI, the text length field is hidden and the field length is set to varchar(255).

When creating these fields via a `mgd` file, you can specify a text length, but that value is ignored.

It's unusual to have a contact reference field that needs more then 255 characters, but there are times when it's important. In my particular case, it's an email petition field that needs to send to all the members of a state legilstature. The 255 character limit is particularly hard to navigate because the actual number of contacts you can put in there depends on the length of the IDs.

Before
----------------------------------------
The `text_length` value of a contact reference custom field is ignored and the field length is set to 255.

After
----------------------------------------
The `text_length` value of a contact reference custom field is respected, provided it's at least 255 characters.

If the `text_length` field is absent, NULL, False or set to anything other then an integer value higher then 255, then the default value of 255 is used.


