### PR TITLE
Follow up code simplification - no need to map 'Individual' to 'Individual'

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -205,15 +205,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @return string
    */
   protected function getContactType(): string {
-    if (!$this->_contactType) {
-      $contactTypeMapping = [
-        'Individual' => 'Individual',
-        'Household' => 'Household',
-        'Organization' => 'Organization',
-      ];
-      $this->_contactType = $contactTypeMapping[$this->getSubmittedValue('contactType')];
-    }
-    return $this->_contactType;
+    return $this->getSubmittedValue('contactType');
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Follow up code simplification - no need to map 'Individual' to 'Individual'

Before
----------------------------------------
This function used to help us map a silly constant to a useful ContactType.name - now they are both the same so it's a whole lotta nothing

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
