### PR TITLE
Adjust contribution metadata to filter at display not load

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -72,6 +72,18 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
   }
 
   /**
+   * Should contact fields be filtered which determining fields to show.
+   *
+   * This applies to Contribution import as we put all contact fields in the metadata
+   * but only present those used for a match - but will permit create via LeXIM.
+   *
+   * @return bool
+   */
+  protected function isFilterContactFields() : bool {
+    return TRUE;
+  }
+
+  /**
    * Build the form object.
    *
    * @throws \CiviCRM_API3_Exception

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -585,9 +585,26 @@ class CRM_Import_Forms extends CRM_Core_Form {
         // Duplicates are being skipped so id matching is not available.
         continue;
       }
+      if (($field['entity'] ?? '') === 'Contact' && $this->isFilterContactFields() && empty($field['match_rule'])) {
+        // Filter out metadata that is intended for create & update - this is not available in the quick-form
+        // but is now loaded in the Parser for the LexIM variant.
+        continue;
+      }
       $return[$name] = $field['html']['label'] ?? $field['title'];
     }
     return $return;
+  }
+
+  /**
+   * Should contact fields be filtered which determining fields to show.
+   *
+   * This applies to Contribution import as we put all contact fields in the metadata
+   * but only present those used for a match - but will permit create via LeXIM.
+   *
+   * @return bool
+   */
+  protected function isFilterContactFields() : bool {
+    return FALSE;
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -324,19 +324,17 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $contactFields = $this->getAllContactFields('');
     $dedupeFields = $this->getDedupeFields($contactType);
 
-    $contactFieldsForContactLookup = [];
     foreach ($dedupeFields as $fieldName => $dedupeField) {
       if (!isset($contactFields[$fieldName])) {
         continue;
       }
-      $contactFieldsForContactLookup[$fieldName] = $contactFields[$fieldName];
-      $contactFieldsForContactLookup[$fieldName]['title'] . ' ' . ts('(match to contact)');
-      $contactFieldsForContactLookup[$fieldName]['entity'] = 'Contact';
+      $contactFields[$fieldName]['title'] . ' ' . ts('(match to contact)');
+      $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($contactType);
     }
 
-    $contactFieldsForContactLookup['external_identifier'] = $contactFields['external_identifier'];
-    $contactFieldsForContactLookup['external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' ' . ts('(match to contact)');
-    return $contactFieldsForContactLookup;
+    $contactFields['external_identifier']['title'] .= ts('(match to contact)');
+    $contactFields['external_identifier']['match_rule'] = '*';
+    return $contactFields;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Adjust contribution metadata to filter at display not load

Before
----------------------------------------
The parser restricts the contact fields it loads metadata for

After
----------------------------------------
The form restricts the fields it displays

Technical Details
----------------------------------------
This makes the metadata more functional & less restrictive - but there is no change in the UI or functionality at this stage 
- unfortunately I can't screen shot the input when open when it's the 'old style' - but I did r-run
-
Comments
----------------------------------------
