### PR TITLE
Add system check for clean URL configuration

### DIFF
--- a/CRM/Utils/Check/Component/Cms.php
+++ b/CRM/Utils/Check/Component/Cms.php
@@ -134,6 +134,15 @@ class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
   }
 
   /**
+   * For sites running in WordPress, make sure clean URLs are properly set in settings file.
+   *
+   * @return CRM_Utils_Check_Message[]
+   */
+  public static function checkCleanurls() {
+    return CRM_Core_Config::singleton()->userSystem->checkCleanurls();
+  }
+
+  /**
    * See if a page exists and is published.
    *
    * @param string $slug

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1110,4 +1110,8 @@ abstract class CRM_Utils_System_Base {
     return TRUE;
   }
 
+  public function checkCleanurls() {
+    return [];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
[https://lab.civicrm.org/dev/core/-/issues/3839](https://lab.civicrm.org/dev/core/-/issues/3839)

Before
----------------------------------------
Clean URL settings are often not updated by unsuspecting admins as older sites are upgraded to versions of CiviCRM where they should be required.

After
----------------------------------------
System check warning appears for Wordpress users if civicrm.settings.php does not include up-to-date clean URL settings.

Technical Details
----------------------------------------
[WIP] because I am having trouble with both `$civicrm_settings['CIVICRM_CLEANURL']` not updating properly each time in my testing when swapping between `define('CIVICRM_CLEANURL', 0);` and `define('CIVICRM_CLEANURL', 1);`... and because I cannot manage to cURL or GuzzleHttpClient() without breaking the system status page, and i'm really not quite sure why yet... but I need to stop here and spend some time on other things today.

Any thoughts welcome!