### PR TITLE
Add temporary file to help Joomla installers

### DIFF
--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -1,0 +1,4 @@
+<?php
+
+// Temporary file to ensure the old file does not linger on Joomla installs
+// who usually fail to delete files. The old file will cause an error if present

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -1,4 +1,6 @@
 <?php
 
 // Temporary file to ensure the old file does not linger on Joomla installs
-// who usually fail to delete files. The old file will cause an error if present
+// who usually fail to delete files. The old file will cause an error if present.
+// TODO: Implement proper Joomla-deletion support. For partial support:
+// @see CRM_Utils_Check_Component_Source

--- a/CRM/Contact/Import/Parser.php
+++ b/CRM/Contact/Import/Parser.php
@@ -1,6 +1,10 @@
 <?php
 
-// Temporary file to ensure the old file does not linger on Joomla installs
-// who usually fail to delete files. The old file will cause an error if present.
-// TODO: Implement proper Joomla-deletion support. For partial support:
-// @see CRM_Utils_Check_Component_Source
+/**
+ * Temporary file to ensure the old file does not linger on Joomla installs
+ * who usually fail to delete files. The old file will cause an error if present.
+ * TODO: Implement proper Joomla-deletion support. For partial support:
+ * @see CRM_Utils_Check_Component_Source
+ */
+class CRM_Contact_Import_Parser {
+}

--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -35,6 +35,8 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
     $files[] = '[civicrm.vendor]/pear/net_smtp/phpdoc.sh';
     $files[] = '[civicrm.vendor]/phpoffice/phpword/samples';
     $files[] = '[civicrm.root]/templates/CRM/common/version.tpl';
+    // TODO: We need more proactive deletion for files like:
+    // $files[]  = '[civicrm.root]/CRM/Contact/Import/Parser.php';
     $files[] = '[civicrm.packages]/Log.php';
     $files[] = '[civicrm.packages]/_ORIGINAL_/Log.php';
     $files[] = '[civicrm.packages]/Log/composite.php';


### PR DESCRIPTION
If the old version of this file is present users get
```
Whoops\Exception\ErrorException thrown with message "Declaration of CRM_Contact_Import_Parser::setImportStatus(int $id, string $status, string $message): void must be compatible with CRM_Import_Parser::setImportStatus(int $id, string $status, string $message = '', ?int $entityID = null, $additionalFields = [], $createdContactIDs = []): void"
```

This pushes a blank into the tarball - quick & dirty but might save a few dollars on the hair dye