### PR TITLE
ClassScanner - Fix guard for preboot cache scenario

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -227,6 +227,7 @@ class ClassScanner {
     if (!isset(static::$caches[$name])) {
       switch ($name) {
         case 'index':
+          global $_DB_DATAOBJECT;
           if (empty($_DB_DATAOBJECT['CONFIG'])) {
             // Atypical example: You have a test with a @dataProvider that relies on ClassScanner. Runs before bot.
             return new \CRM_Utils_Cache_ArrayCache([]);


### PR DESCRIPTION
Overview
------------------------------

Wanted to inspect how class-scanner caches were behaving during test-runs.  So I applied this hack (*HitOrMiss reporting - https://github.com/civicrm/civicrm-core/commit/02106e8693d13ced7a151834a4188ce8b16f6444*) and then ran some tests, eg

```
CIVICRM_UF=UnitTests phpunit8 tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
```

It showed an extremely high number of non-caching calls. You can see in the HitOrMiss report below. The patch should improve caching.

Before
======

All attempts to instantiate the `ClassScanner::cache('index')` cause it to create dummy/one-off placeholders, as per

```
if (empty($_DB_DATAOBJECT['CONFIG'])) {
  return new \CRM_Utils_Cache_ArrayCache([]);
}
```

For `CaseActivityTest`, it does this 13 times.

```
OK (3 tests, 38 assertions)
HitOrMiss: {
    "ClassScanner::cache(index) => Early usage": 13,
    "ClassScanner::cache(structure) => New arraycache": 1
}
```

After
=====

Attempts to instantiate the `ClassScanner::cache('index')` can create a real cache, as per:

```php
static::$caches[$name] = \CRM_Utils_Cache::create([
  'name' => 'classes',
  'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
  'fastArray' => TRUE,
]);
```

For `CaseActivityTest`, it does this -- and it only runs 1 time.

```
OK (3 tests, 38 assertions)
HitOrMiss: {
    "ClassScanner::cache(index) => create(...)": 1,
    "ClassScanner::cache(structure) => New arraycache": 2
}
```
