### PR TITLE
Remove remnant of the great psuedoconstant title fight

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -511,7 +511,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   protected function guessMappingBasedOnColumns(string $columnHeader): string {
     $headerPatterns = $this->getHeaderPatterns();
     // do array search first to see if has mapped key
-    $columnKey = array_search($columnHeader, $this->_mapperFields, TRUE);
+    $columnKey = array_search($columnHeader, $this->getAvailableFields(), TRUE);
     if ($columnKey && empty($this->_fieldUsed[$columnKey])) {
       $this->_fieldUsed[$columnKey] = TRUE;
       return $columnKey;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -324,7 +324,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($contactType);
     }
 
-    $contactFields['external_identifier']['title'] .= ts('(match to contact)');
+    $contactFields['external_identifier']['title'] .= (' ' . ts('(match to contact)'));
     $contactFields['external_identifier']['match_rule'] = '*';
     return $contactFields;
   }
@@ -1421,7 +1421,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @throws \API_Exception
    */
   private function getActionForEntity(string $entity): string {
-    return $this->getUserJob()['metadata']['entity_metadata'][$entity]['action'] ?? $this->getImportEntities()[$entity]['default_action'];
+    return $this->getUserJob()['metadata']['entity_metadata'][$entity]['action'] ?? ($this->getImportEntities()[$entity]['default_action'] ?? '');
   }
 
   /**
@@ -2391,7 +2391,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       // Set entity to contact as primary fields used in Contact actions
       $field['entity'] = 'Contact';
       $field['name'] = 'address_primary.' . $fieldName;
-      $field['contact_type'] = ['Individual', 'Organization', 'Household'];
+      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
       $prefixedFields[$prefix . 'address_primary.' . $fieldName] = $field;
     }
 
@@ -2405,7 +2405,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     foreach ($phoneFields as $fieldName => $field) {
       $field['entity'] = 'Contact';
       $field['name'] = 'phone_primary.' . $fieldName;
-      $field['contact_type'] = ['Individual', 'Organization', 'Household'];
+      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
       $prefixedFields[$prefix . 'phone_primary.' . $fieldName] = $field;
     }
 
@@ -2420,7 +2420,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     foreach ($emailFields as $fieldName => $field) {
       $field['entity'] = 'Contact';
       $field['name'] = 'email_primary.' . $fieldName;
-      $field['contact_type'] = ['Individual', 'Organization', 'Household'];
+      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
       $prefixedFields[$prefix . 'email_primary.' . $fieldName] = $field;
     }
     return $prefixedFields;


### PR DESCRIPTION
Overview
----------------------------------------
Remove remnant of the great psuedoconstant title match

Before
----------------------------------------
Lines of code that do nothing

After
----------------------------------------
poof

Technical Details
----------------------------------------
These lines altered the title from the schema title ("Contribution Status ID") back to the field input appropriate title ("Contribution Status") - but  long ago @colemanw & I stopped fighting of which should be assigned to the schema title for the field & started using `html.label` in the schema - which is already being done & hence the UI is the same with & without this line

Comments
----------------------------------------