### PR TITLE
dev/core#1172 Fix Contribution import to handle ContributionSoft in a storable way

### DIFF
--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -79,6 +79,9 @@ trait CRM_Contact_Import_MetadataTrait {
   /**
    * Get an array of header patterns for importable keys.
    *
+   * We should do this work on the form layer.
+   *
+   * @deprecated
    * @return array
    */
   public function getHeaderPatterns(): array {

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -637,7 +637,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   public function getMappingFieldFromMapperInput(array $fieldMapping, int $mappingID, int $columnNumber): array {
     return [
-      'name' => $fieldMapping[0],
+      // The double __ is a quickform hack - the 'real' name is dotted - eg. 'soft_credit.contact.id'
+      'name' => str_replace('__', '.', $fieldMapping[0]),
       'mapping_id' => $mappingID,
       'column_number' => $columnNumber,
       // The name of the field to match the soft credit on is (crazily)

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -88,6 +88,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    * @noinspection PhpUnhandledExceptionInspection
    */
   public function postProcess() {
+    $this->updateUserJobMetadata('import_configuration', $this->getImportConfiguration());
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $this->saveMapping();
     $parser = $this->getParser();
@@ -479,6 +480,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
         'text' => $field['title'],
         'id' => $fieldName,
         'has_location' => !empty($field['hasLocationType']),
+        'default_value' => $field['default_value'] ?? '',
+        'contact_type' => $field['contact_type'] ?? NULL,
+        'match_rule' => $field['match_rule'] ?? NULL,
       ];
       if (in_array($fieldName, $highlightedFields, TRUE)) {
         $childField['text'] .= '*';
@@ -518,6 +522,22 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     }
     // Infer the default from the column names if we have them
     return $this->defaultFromHeader($columnHeader, $headerPatterns);
+  }
+
+  /**
+   * Get the import configuration per the user.
+   *
+   * When we have wrangled the user's input (e.g to deal with form layer weirdness
+   * we saved the wrangled version here - leaving the submitted value as submitted.
+   *
+   * @return array
+   */
+  protected function getImportConfiguration(): array {
+    $importConfiguration = [];
+    foreach ($this->getSubmittedValue('mapper') as $mapperField) {
+      $importConfiguration[] = $mapperField;
+    }
+    return $importConfiguration;
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -590,6 +590,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
         // but is now loaded in the Parser for the LexIM variant.
         continue;
       }
+      // Swap out dots for double underscores so as not to break the quick form js.
+      // We swap this back on postProcess.
+      $name = str_replace('.', '__', $name);
       $return[$name] = $field['html']['label'] ?? $field['title'];
     }
     return $return;
@@ -702,7 +705,17 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @return array
    */
   public function getHeaderPatterns(): array {
-    return $this->getParser()->getHeaderPatterns();
+    $headerPatterns = [];
+    foreach ($this->getFields() as $name => $field) {
+      if (empty($field['headerPattern']) || $field['headerPattern'] === '//') {
+        continue;
+      }
+      // Swap out dots for double underscores so as not to break the quick form js.
+      // The parser class undoes this when looking up the field.
+      $name = str_replace('.', '__', $name);
+      $headerPatterns[$name] = $field['headerPattern'];
+    }
+    return $headerPatterns;
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -711,7 +711,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
         continue;
       }
       // Swap out dots for double underscores so as not to break the quick form js.
-      // The parser class undoes this when looking up the field.
+      // We swap this back on postProcess.
       $name = str_replace('.', '__', $name);
       $headerPatterns[$name] = $field['headerPattern'];
     }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -517,6 +517,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
+   * The form can do it's own work now...
+   *
+   * @deprecated
    * @return array
    */
   public function getHeaderPatterns(): array {

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -79,7 +79,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
       ['name' => 'external_identifier'],
-      ['name' => 'soft_credit', 'soft_credit_type_id' => 1, 'soft_credit_match_field' => 'external_identifier'],
+      ['name' => 'soft_credit.contact.external_identifier', 'soft_credit_type_id' => 1],
     ];
     $this->importCSV('contributions_amount_validate.csv', $mapping, ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -79,8 +79,7 @@ trait CRMTraits_Import_ParserTrait {
     foreach ($mappings as $mapping) {
       $fieldInput = [$mapping['name']];
       if (!empty($mapping['soft_credit_type_id'])) {
-        $fieldInput[1] = $mapping['soft_credit_match_field'];
-        $fieldInput[2] = $mapping['soft_credit_type_id'];
+        $fieldInput[1] = $mapping['soft_credit_type_id'];
       }
       $mapper[] = $fieldInput;
     }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#1172 Fix Contribution import to handle ContributionSoft in a storable way

Before
----------------------------------------
When importing with a saved mapping it is not possible to store the soft_credit_type _id

After
----------------------------------------
The soft_credit_type_id is stored to the mapping

Technical Details
----------------------------------------
There is a bit going on here. We discussed adding `entity_metadata` to the `civicrm_mapping_field` table to store this additional info. That PR is still open & I was on the fence & decided this is a good approach for now - instead of storing

field_name `soft_credit`
contact_type `external_identifier`
not saved `soft_credit_type_id`

it now saves 

`field_name` `soft_credt.contact.external_identifer`
`contact_type` `{'soft_credit' => {'soft_credit_type_id' => 9}}`

In other words everything we know about the field is now in the `field_name` and the rest is in the `contact_type`. I kinda wanted to drop contact type for `entity_type` & I think that would be OK - but I also concluded that medium term we might be able to move this stuff to the user_job table with `is_template` set to true. So this is slightly less butchery & doesn't lose the data.

In combination with previous work & added tests this allows the `import` function to be significantly stripped down

Comments
----------------------------------------
