### PR TITLE
Move header handling to the Form layer in import

### DIFF
--- a/CRM/Contact/Import/MetadataTrait.php
+++ b/CRM/Contact/Import/MetadataTrait.php
@@ -79,6 +79,9 @@ trait CRM_Contact_Import_MetadataTrait {
   /**
    * Get an array of header patterns for importable keys.
    *
+   * We should do this work on the form layer.
+   *
+   * @deprecated
    * @return array
    */
   public function getHeaderPatterns(): array {

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -637,7 +637,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   public function getMappingFieldFromMapperInput(array $fieldMapping, int $mappingID, int $columnNumber): array {
     return [
-      'name' => $fieldMapping[0],
+      // The double __ is a quickform hack - the 'real' name is dotted - eg. 'soft_credit.contact.id'
+      'name' => str_replace('__', '.', $fieldMapping[0]),
       'mapping_id' => $mappingID,
       'column_number' => $columnNumber,
       // The name of the field to match the soft credit on is (crazily)

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -590,6 +590,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
         // but is now loaded in the Parser for the LexIM variant.
         continue;
       }
+      // Swap out dots for double underscores so as not to break the quick form js.
+      // We swap this back on postProcess.
+      $name = str_replace('.', '__', $name);
       $return[$name] = $field['html']['label'] ?? $field['title'];
     }
     return $return;
@@ -702,7 +705,17 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @return array
    */
   public function getHeaderPatterns(): array {
-    return $this->getParser()->getHeaderPatterns();
+    $headerPatterns = [];
+    foreach ($this->getFields() as $name => $field) {
+      if (empty($field['headerPattern']) || $field['headerPattern'] === '//') {
+        continue;
+      }
+      // Swap out dots for double underscores so as not to break the quick form js.
+      // The parser class undoes this when looking up the field.
+      $name = str_replace('.', '__', $name);
+      $headerPatterns[$name] = $field['headerPattern'];
+    }
+    return $headerPatterns;
   }
 
   /**

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -517,6 +517,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
+   * The form can do it's own work now...
+   *
+   * @deprecated
    * @return array
    */
   public function getHeaderPatterns(): array {


### PR DESCRIPTION
Overview
----------------------------------------
Move header handling to the Form layer in import

Before
----------------------------------------
`getHeaders` is on the parser & the metadatatrait - but really it's a form function & the form has the metadata

After
----------------------------------------
Form does it's own work. In addition I added handling for fields to be `contact.external_identifer` on the form layer, but transposed to `contact__external_identifer` at the quick form layer. This should be unique enough - we are talking about db-fields & custom fields here so unless custom fields could already have the underscores going on? Otherwise I can use another char or add more slashes. The `hierselect` breaks on the dots but I don't want to make everything else use the 'wrong' syntax just to suit quickform (we have a whole code-base that does that....)

Technical Details
----------------------------------------

Comments
----------------------------------------
