### PR TITLE
Adding better wording to Events page for matching dates

### DIFF
--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -102,11 +102,17 @@
       <div class="label">{ts}When{/ts}</div>
       <div class="content">
         {strip}
-            {$event.event_start_date|crmDate}
+            {if $event.event_start_date && $event.event_end_date && ($event.event_end_date|crmDate:'%Y%m%d':0 == $event.event_start_date|crmDate:'%Y%m%d':0)}
+              {$event.event_start_date|crmDate:'Full':0}
+              &nbsp;{ts}from{/ts}&nbsp;
+              {$event.event_start_date|crmDate:0:1}
+            {else}
+              {$event.event_start_date|crmDate}
+            {/if}
             {if $event.event_end_date}
-                &nbsp;{ts}through{/ts}&nbsp;
+                &nbsp;{ts}to{/ts}&nbsp;
                 {* Only show end time if end date = start date *}
-                {if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}
+                {if $event.event_end_date|crmDate:"%Y%m%d":0 == $event.event_start_date|crmDate:"%Y%m%d":0}
                     {$event.event_end_date|crmDate:0:1}
                 {else}
                     {$event.event_end_date|crmDate}


### PR DESCRIPTION
Overview
----------------------------------------
Changes the Event Info page so that the event time reads "DATE from X to Y", instead of "DATE X to Y" (missing "from"). This also helps for translation in other languages, where the missing preposition is awkward.

Before
----------------------------------------
![Selection_002](https://user-images.githubusercontent.com/1126026/188714528-d22f00e6-f316-4ff6-98c5-398381efb265.png)

After
----------------------------------------
![Selection_003](https://user-images.githubusercontent.com/1126026/188714785-f5f77074-15a1-4c55-be1c-b375fa9a3587.png)

This is also going to have the added advantage of being able to properly display this is Canadian French would normally reads

_22 September 2022 de 13:00 a 14:00_


Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
