### PR TITLE
File::findFiles - Save 200 million nanoseconds

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -766,25 +766,11 @@ HTACCESS;
         }
       }
       // Find subdirs to recurse into.
-      if ($dh = opendir($subdir)) {
-        while (FALSE !== ($entry = readdir($dh))) {
-          $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-          // Exclude . (self) and .. (parent) to avoid infinite loop.
-          // Exclude configured exclude dirs.
-          // Exclude dirs we can't read.
-          // Exclude anything that's not a dir.
-          if (
-            $entry !== '.'
-            && $entry !== '..'
-            && (empty($excludeDirsPattern) || !preg_match($excludeDirsPattern, $path))
-            && is_dir($path)
-            && is_readable($path)
-          ) {
-            $todos[] = $path;
-          }
-        }
-        closedir($dh);
+      $subdirs = glob("$subdir/*", GLOB_ONLYDIR);
+      if (!empty($excludeDirsPattern)) {
+        $subdirs = preg_grep($excludeDirsPattern, $subdirs, PREG_GREP_INVERT);
       }
+      $todos = array_merge($todos, $subdirs);
     }
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------

This is a small performance tweak for `findFiles()` which converts `readdir()`+`is_dir()` to `glob(ONLYDIRS)`.

I benchmarked against an arbitrary sample of unit tests (*`tests/phpunit/api/v3/AddressTest.php` with `--filter testCreate`*), and the patch saved ~200 million nanoseconds (~0.2sec) on my workstation.

ping @demeritcowboy 

Before
----------------------------------------

More time:

![Screenshot from 2022-09-08 13-59-34](https://user-images.githubusercontent.com/1336047/189235274-5aa0c5fe-675f-4308-b6fe-b4602e21cb1f.png)

After
----------------------------------------

Less time:

![Screenshot from 2022-09-08 14-03-38](https://user-images.githubusercontent.com/1336047/189235321-533eac0b-99b2-4e92-8984-dca6d71a92e9.png)

Technical Details
----------------------------------------

(*Note: Before profile, I disabled the `DebugSubscriber`.*)

I profiled the following command:

```
XDEBUG_MODE=profile CIVICRM_UF=UnitTests phpunit8 tests/phpunit/api/v3/AddressTest.php --stop-on-failure --filter testCreate
```

This command was repeated a few times with different codebases:

```
TRIAL/FILE NAME                 CRM_Utils_File::findFiles       CODEBASE
cachegrind.out-none             27M ns                          (before #23854)
cachegrind.out-orig             804M ns                         (after #23854)
cachegrind.out-patch1           326M ns                         (after #23854 plus this patch)
cachegrind.out-orig-b           364M ns                         (after #23854)
cachegrind.out-patch1-b         136M ns                         (after #23854 plus this patch)
```

In the first trial (`after` vs `patch1`), it saved ~450M ns. In the second trial (`after-b` vs `patch1-b`), it saved ~230M ns. One might need more trials to establish statistical significance, but it seems consistently better so far, and the change is small.

This may be a bit academic, but I *believe* the difference turns on `is_dir()` -- with the old patch, the call to `is_dir()` would hydrate [PHP's `stat` cache](https://www.php.net/manual/en/function.clearstatcache.php) for every inode in the tree. But `glob()` doesn't affect the `stat` cache.