### PR TITLE
(dev/core#3790) Pledge status is missing on View Pledge page

### DIFF
--- a/CRM/Pledge/Form/PledgeView.php
+++ b/CRM/Pledge/Form/PledgeView.php
@@ -58,7 +58,7 @@ class CRM_Pledge_Form_PledgeView extends CRM_Core_Form {
     $values['financial_type'] = CRM_Utils_Array::value($values['financial_type_id'], CRM_Contribute_PseudoConstant::financialType());
 
     if ($values['status_id']) {
-      $values['pledge_status'] = CRM_Core_PseudoConstant::getKey('CRM_Pledge_BAO_Pledge', 'status_id', $values['status_id']);
+      $values['pledge_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Pledge_BAO_Pledge', 'status_id', $values['status_id']);
     }
 
     $url = CRM_Utils_System::url('civicrm/contact/view/pledge',


### PR DESCRIPTION
Overview
----------------------------------------
When clicking on View Pledge, pledge status is blank.

Fix this bug to display the pledge status.

Before
----------------------------------------
![pledge_Status_missing](https://user-images.githubusercontent.com/3455173/189347075-f5e49b4f-55bf-4d70-b2ff-8541fb0bf179.png)


After
----------------------------------------
status appears