### PR TITLE
(REF) SettingsMetadata - Small cleanup to prevent duplicate slashes

### DIFF
--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -61,7 +61,7 @@ class SettingsMetadata {
 
     if (!is_array($settingsMetadata)) {
       global $civicrm_root;
-      $metaDataFolders = [$civicrm_root . '/settings'];
+      $metaDataFolders = [\CRM_Utils_File::addTrailingSlash($civicrm_root) . 'settings'];
       \CRM_Utils_Hook::alterSettingsFolders($metaDataFolders);
       $settingsMetadata = self::loadSettingsMetaDataFolders($metaDataFolders);
       \CRM_Utils_Hook::alterSettingsMetaData($settingsMetadata, $domainID, NULL);


### PR DESCRIPTION
Overview
----------------------------------------

Small cleanup to make the path nicer.

Before
----------------------------------------


If `$civicrm_root` has a trailing slash (`/path/to/civicrm/`, then it searches for double-slash `/path/to/civicrm//settings`).

After
----------------------------------------

Always has single slash (`/path/to/civicrm/settings`).

