### PR TITLE
ManagedEntity - Don't delete managed records with cleanup policy = 'n…

### DIFF
--- a/CRM/Core/BAO/Managed.php
+++ b/CRM/Core/BAO/Managed.php
@@ -26,10 +26,12 @@ class CRM_Core_BAO_Managed extends CRM_Core_DAO_Managed implements Civi\Core\Hoo
    */
   public static function on_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
     // When an entity is deleted, delete the corresponding Managed record
+    // Unless the cleanup policy is "never"
     if ($event->action === 'delete' && $event->id && self::isApi4ManagedType($event->entity)) {
       \Civi\Api4\Managed::delete(FALSE)
         ->addWhere('entity_type', '=', $event->entity)
         ->addWhere('entity_id', '=', $event->id)
+        ->addWhere('cleanup', '!=', 'never')
         ->execute();
     }
     // When an entity is updated, update the timestamp in corresponding Managed record


### PR DESCRIPTION
Overview
----------------------------------------
Draft PR for discussion purposes. Whether the current behavior is ever desirable is debatable (although I cannot think of a scenario in which it would be desired). The proposed solution in this PR is imperfect but arguably better than the status-quo.

Before
----------------------------------------
When a managed record is manually deleted by the user, it will get re-created during the next cache flush. This is due to the fact that the corresponding row in the `civicrm_managed` table was deleted via hook.

After
----------------------------------------
When a managed record is manually deleted by the user, it will get re-created during the next cache flush *only if* the cleanup policy is `always` or `unused`. If the cleanup policy is `never`, then deletion by the user will be permanent (unless the extension gets completely uninstalled and reinstalled).

Technical Details
--------------------------
Deleting a row from the `civicrm_managed` table causes CiviCRM to "forget" it was ever created in the first place, and attempt to create it again during the next cache flush. This is something of a grey area as the user's intent is difficult to infer. This PR changes the triggered deletion of `civicrm_managed` rows to leave them orphaned if `cleanup == never`, which prevents respawning of the records.

Comments
------------------------
My first inclination was to follow the `update` policy for this behavior, but I went with the `cleanup` policy because it was much easier to implement (since `update` is not stored in the `civicrm_managed` table, it's far more difficult to retrieve).
