### PR TITLE
[REF] Fix syntax of var docblocks

### DIFF
--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -48,7 +48,7 @@ class CRM_Campaign_BAO_Campaign extends CRM_Campaign_DAO_Campaign {
       }
     }
 
-    /* @var \CRM_Campaign_DAO_Campaign $campaign */
+    /** @var \CRM_Campaign_DAO_Campaign $campaign */
     $campaign = self::writeRecord($params);
 
     /* Create the campaign group record */

--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -521,7 +521,7 @@ ORDER BY   gc.contact_id, g.children
     if (empty($apiParams['limit']) && empty($apiParams['offset'])) {
       unset($apiParams['orderBy']);
     }
-    /* @var $api \Civi\Api4\Generic\DAOGetAction */
+    /** @var \Civi\Api4\Generic\DAOGetAction $api */
     $api = Request::create($savedSearch['api_entity'], 'get', $apiParams);
     $query = new Api4SelectQuery($api);
     $query->forceSelectId = FALSE;

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -150,8 +150,8 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
     if ($types === NULL) {
       $types = [];
       $classes = ClassScanner::get(['interface' => UserJobInterface::class]);
+      /** @var \Civi\UserJob\UserJobInterface $class */
       foreach ($classes as $class) {
-        /* @var UserJobInterface $class */
         $declaredTypes = $class::getUserJobInfo();
         foreach ($declaredTypes as $index => $declaredType) {
           $declaredTypes[$index]['class'] = $class;

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2554,7 +2554,6 @@ SELECT contact_id
 
     $occurrences = [];
     foreach ($links as $refSpec) {
-      /** @var $refSpec CRM_Core_Reference_Interface */
       $daoName = CRM_Core_DAO_AllCoreTables::getClassForTable($refSpec->getReferenceTable());
       $result = $refSpec->findReferences($this);
       if ($result) {
@@ -2583,7 +2582,6 @@ SELECT contact_id
 
     $counts = [];
     foreach ($links as $refSpec) {
-      /** @var $refSpec CRM_Core_Reference_Interface */
       $count = $refSpec->getReferenceCount($this);
       if (!empty($count['count'])) {
         $counts[] = $count;
@@ -2591,7 +2589,6 @@ SELECT contact_id
     }
 
     foreach (CRM_Core_Component::getEnabledComponents() as $component) {
-      /** @var $component CRM_Core_Component_Info */
       $counts = array_merge($counts, $component->getReferenceCounts($this));
     }
     CRM_Utils_Hook::referenceCounts($this, $counts);
@@ -2621,7 +2618,7 @@ SELECT contact_id
       $links = $daoClassName::getReferenceColumns();
 
       foreach ($links as $refSpec) {
-        /** @var $refSpec CRM_Core_Reference_Interface */
+        /** @var CRM_Core_Reference_Interface $refSpec */
         if ($refSpec->matchesTargetTable($tableName)) {
           $refsFound[] = $refSpec;
         }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -429,7 +429,7 @@ class CRM_Core_PseudoConstant {
       return $var;
     }
 
-    /* @var CRM_Core_DAO $object */
+    /** @var CRM_Core_DAO $object */
     $object = new $name();
 
     $object->selectAdd();
@@ -1492,7 +1492,7 @@ WHERE  id = %1
       return FALSE;
     }
     // Get list of fields for the option table
-    /* @var CRM_Core_DAO $dao * */
+    /** @var CRM_Core_DAO $dao * */
     $dao = new $daoName();
     $availableFields = array_keys($dao->fieldKeys());
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2716,8 +2716,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    * @param array $locks
    */
   protected static function releaseLocks(array $locks) {
+    /** @var Civi\Core\Lock\LockInterface $lock */
     foreach ($locks as $lock) {
-      /* @var Civi\Core\Lock\LockInterface $lock */
       $lock->release();
     }
   }

--- a/CRM/Financial/BAO/FinancialTypeAccount.php
+++ b/CRM/Financial/BAO/FinancialTypeAccount.php
@@ -101,7 +101,7 @@ class CRM_Financial_BAO_FinancialTypeAccount extends CRM_Financial_DAO_EntityFin
     foreach ($dependency as $name) {
       $daoString = 'CRM_' . $name[0] . '_DAO_' . $name[1];
       if (class_exists($daoString)) {
-        /* @var \CRM_Core_DAO $dao */
+        /** @var \CRM_Core_DAO $dao */
         $dao = new $daoString();
         $dao->financial_type_id = $financialTypeId;
         if ($dao->find(TRUE)) {

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -566,7 +566,7 @@ abstract class CRM_Import_DataSource {
         break;
       }
     }
-    /* @var \CRM_Import_Parser */
+    /** @var \CRM_Import_Parser $parser */
     $parser = new $parserClass();
     $parser->setUserJobID($this->getUserJobID());
     return $parser;

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -288,7 +288,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected function getDataSourceObject(): ?CRM_Import_DataSource {
     $className = $this->getDataSourceClassName();
     if ($className) {
-      /* @var CRM_Import_DataSource $dataSource */
       return new $className($this->getUserJobID());
     }
     return NULL;
@@ -304,7 +303,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected function getDataSourceFields(): array {
     $className = $this->getDataSourceClassName();
     if ($className) {
-      /* @var CRM_Import_DataSource $dataSourceClass */
+      /** @var CRM_Import_DataSource $dataSourceClass */
       $dataSourceClass = new $className();
       return $dataSourceClass->getSubmittableFields();
     }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -167,7 +167,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected function getDataSourceObject(): ?CRM_Import_DataSource {
     $className = $this->getSubmittedValue('dataSource');
     if ($className) {
-      /* @var CRM_Import_DataSource $dataSource */
       return new $className($this->getUserJobID());
     }
     return NULL;
@@ -1320,7 +1319,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     if (!isset($fieldSpec['bao'])) {
       return $submittedValue;
     }
-    /* @var \CRM_Core_DAO $bao */
+    /** @var \CRM_Core_DAO $bao */
     $bao = $fieldSpec['bao'];
     // For historical reasons use validate as context - ie disabled name matches ARE permitted.
     $nameOptions = $bao::buildOptions($fieldSpec['name'], 'validate');
@@ -2077,7 +2076,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
         $parserClass = $userJobType['class'];
       }
     }
-    /* @var \CRM_Import_Parser $parser */
+    /** @var \CRM_Import_Parser $parser */
     $parser = new $parserClass();
     $parser->setUserJobID($userJobID);
     // Not sure if we still need to init....

--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -209,7 +209,7 @@ class CRM_Utils_Check {
     $checksNeeded = $statusNames;
     foreach (glob(__DIR__ . '/Check/Component/*.php') as $filePath) {
       $className = 'CRM_Utils_Check_Component_' . basename($filePath, '.php');
-      /* @var CRM_Utils_Check_Component $component */
+      /** @var CRM_Utils_Check_Component $component */
       $component = new $className();
       if ($includeDisabled || $component->isEnabled()) {
         $messages = array_merge($messages, $component->checkAll($statusNames, $includeDisabled));

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -205,7 +205,7 @@ class CRM_Utils_VersionCheck {
     ];
     foreach ($tables as $daoName => $where) {
       if (class_exists($daoName)) {
-        /* @var \CRM_Core_DAO $dao */
+        /** @var \CRM_Core_DAO $dao */
         $dao = new $daoName();
         if ($where) {
           $dao->whereAdd($where);

--- a/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
@@ -37,7 +37,7 @@ class PermissionCheckSubscriber implements EventSubscriberInterface {
    *   API authorization event.
    */
   public function onApiAuthorize(\Civi\API\Event\AuthorizeEvent $event) {
-    /* @var \Civi\Api4\Generic\AbstractAction $apiRequest */
+    /** @var \Civi\Api4\Generic\AbstractAction $apiRequest */
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] == 4) {
       if (!$apiRequest->getCheckPermissions() || $apiRequest->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID())) {

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -896,7 +896,7 @@ class Api4SelectQuery {
    */
   private function getBridgeRefs(string $bridgeEntity, string $joinEntity): array {
     $bridges = CoreUtil::getInfoItem($bridgeEntity, 'bridge') ?? [];
-    /* @var \CRM_Core_DAO $bridgeDAO */
+    /** @var \CRM_Core_DAO $bridgeDAO */
     $bridgeDAO = CoreUtil::getInfoItem($bridgeEntity, 'dao');
     $bridgeEntityFields = \Civi\API\Request::create($bridgeEntity, 'get', ['version' => 4, 'checkPermissions' => $this->getCheckPermissions()])->entityFields();
     $bridgeTable = $bridgeDAO::getTableName();

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -374,7 +374,7 @@ function civicrm_api3_generic_getrefcount($apiRequest) {
   }
   $daoClass = $entityToClassMap[$apiRequest['entity']];
 
-  /* @var $dao CRM_Core_DAO */
+  /** @var CRM_Core_DAO $dao */
   $dao = new $daoClass();
   $dao->id = $apiRequest['params']['id'];
   if ($dao->find(TRUE)) {

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -111,7 +111,6 @@ function _civicrm_api3_payment_processor_getlist_defaults(&$request) {
  * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_payment_processor_pay($params) {
-  /* @var CRM_Core_Payment $processor */
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', ['id' => $params['payment_processor_id']]));
   try {

--- a/api/v3/ReportTemplate.php
+++ b/api/v3/ReportTemplate.php
@@ -129,7 +129,7 @@ function _civicrm_api3_report_template_getrows($params) {
   ]
   );
 
-  /* @var \CRM_Report_Form $reportInstance */
+  /** @var \CRM_Report_Form $reportInstance */
   $reportInstance = new $class();
   if (!empty($params['instance_id'])) {
     $reportInstance->setID($params['instance_id']);

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1774,7 +1774,7 @@ function _civicrm_api3_validate_constraint($fieldValue, $fieldName, $fieldInfo, 
   $fieldInfo = [$fieldName => $fieldInfo];
   $params = [$fieldName => $fieldValue];
   _civicrm_api3_validate_fields($entity, NULL, $params, $fieldInfo);
-  /* @var CRM_Core_DAO $dao*/
+  /** @var CRM_Core_DAO $dao */
   $dao = new $daoName();
   $dao->id = $params[$fieldName];
   $dao->selectAdd();

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchKitSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchKitSubscriber.php
@@ -36,7 +36,7 @@ class SearchKitSubscriber implements EventSubscriberInterface {
    *   API authorization event.
    */
   public function onApiAuthorize(\Civi\API\Event\AuthorizeEvent $event) {
-    /* @var \Civi\Api4\Generic\AbstractAction $apiRequest */
+    /** @var \Civi\Api4\Generic\AbstractAction $apiRequest */
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] == 4 && $apiRequest->getEntityName() === 'SavedSearch') {
       if (\CRM_Core_Permission::check('administer search_kit')) {

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -248,7 +248,7 @@ class Admin {
       }
       // Non-custom DAO entities
       elseif (!empty($entity['dao'])) {
-        /* @var \CRM_Core_DAO $daoClass */
+        /** @var \CRM_Core_DAO $daoClass */
         $daoClass = $entity['dao'];
         $references = $daoClass::getReferenceColumns();
         $fields = array_column($entity['fields'], NULL, 'name');

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1379,7 +1379,7 @@ $text
 
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    /* @var CRM_Activity_Form_Task_Email $form */
+    /** @var CRM_Activity_Form_Task_Email $form */
     $form = $this->getCaseEmailTaskForm($contactId, [
       'subject' => '',
       'html_message' => $html,
@@ -1447,7 +1447,7 @@ $text
   public function testSendSmsMobilePhoneNumber(): void {
     $sent = $this->createSendSmsTest(TRUE, 2);
     $this->assertEquals(TRUE, $sent[0]);
-    /* @var CiviTestSMSProvider $provider $provider['id']*/
+    /** @var CiviTestSMSProvider $providerObj */
     $providerObj = CRM_SMS_Provider::singleton(['provider_id' => $this->ids['SmsProvider'][0]]);
     $this->assertEquals('text Anthony', $providerObj->getSentMessage());
   }
@@ -1661,7 +1661,7 @@ $text
     $html = __FUNCTION__ . ' html' . '{contact.display_name}';
     $text = __FUNCTION__ . ' text' . '{contact.display_name}';
 
-    /* @var CRM_Contact_Form_Task_Email $form */
+    /** @var CRM_Contact_Form_Task_Email $form */
     $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
       'subject' => $subject,
       'html_message' => $html,
@@ -2658,7 +2658,7 @@ $textValue
   protected function getCaseEmailTaskForm(int $contactId, array $submittedValues): CRM_Case_Form_Task_Email {
     $_REQUEST['cid'] = $contactId;
     $_REQUEST['caseid'] = $this->getCaseID();
-    /* @var CRM_Case_Form_Task_Email $form */
+    /** @var CRM_Case_Form_Task_Email $form */
     $form = $this->getFormObject('CRM_Case_Form_Task_Email', array_merge([
       'to' => $contactId . '::' . 'email@example.com',
       'from_email_address' => 'from@example.com',
@@ -2675,7 +2675,7 @@ $textValue
    */
   protected function getContactEmailTaskForm(int $contactId, array $submittedValues): CRM_Contact_Form_Task_Email {
     $_REQUEST['cid'] = $contactId;
-    /* @var CRM_Contact_Form_Task_Email $form */
+    /** @var CRM_Contact_Form_Task_Email $form */
     $form = $this->getFormObject('CRM_Contact_Form_Task_Email', array_merge([
       'to' => $contactId . '::' . 'email@example.com',
       'from_email_address' => 'from@example.com',

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -392,7 +392,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getDataSourceForm(array $submittedValues): CRM_Activity_Import_Form_DataSource {
-    /* @var \CRM_Activity_Import_Form_DataSource $form */
+    /** @var \CRM_Activity_Import_Form_DataSource $form */
     $form = $this->getFormObject('CRM_Activity_Import_Form_DataSource', $submittedValues);
     return $form;
   }
@@ -408,7 +408,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getMapFieldForm(array $submittedValues): CRM_Activity_Import_Form_MapField {
-    /* @var \CRM_Activity_Import_Form_MapField $form */
+    /** @var \CRM_Activity_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Activity_Import_Form_MapField', $submittedValues);
     return $form;
   }
@@ -424,7 +424,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getPreviewForm(array $submittedValues): CRM_Activity_Import_Form_Preview {
-    /* @var CRM_Activity_Import_Form_Preview $form */
+    /** @var CRM_Activity_Import_Form_Preview $form */
     $form = $this->getFormObject('CRM_Activity_Import_Form_Preview', $submittedValues);
     return $form;
   }

--- a/tests/phpunit/CRM/Contact/Form/Task/AddToGroupTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/AddToGroupTest.php
@@ -21,7 +21,7 @@ class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
   protected function getSearchTaskFormObject(array $formValues) {
     $_POST = $formValues;
     $_SERVER['REQUEST_METHOD'] = 'GET';
-    /* @var CRM_Core_Form $form */
+    /** @var CRM_Core_Form $form */
     $form = new CRM_Contact_Form_Task_AddToGroup();
     $form->controller = new CRM_Contact_Controller_Search();
     $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));

--- a/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
@@ -95,7 +95,7 @@ class CRM_Contact_Form_Task_EmailTest extends CiviUnitTestCase {
     }
     $deceasedContactID = $this->individualCreate(['is_deceased' => 1, 'email' => 'dead@example.com']);
     $to[] = $deceasedContactID . '::' . 'dead@example.com';
-    /* @var CRM_Contact_Form_Task_Email $form*/
+    /** @var CRM_Contact_Form_Task_Email $form */
     $form = $this->getFormObject('CRM_Contact_Form_Task_Email', [
       'to' => implode(',', $to),
       'subject' => 'Really interesting stuff',

--- a/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PDFLetterCommonTest.php
@@ -132,7 +132,7 @@ class CRM_Contact_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   protected function getPDFForm(array $formValues, array $contactIDs, ?bool $isLiveMode = TRUE): CRM_Contact_Form_Task_PDF {
     // pretty cludgey.
     $_REQUEST['cid'] = $contactIDs[0];
-    /* @var CRM_Contact_Form_Task_PDF $form */
+    /** @var CRM_Contact_Form_Task_PDF $form */
     $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', array_merge([
       'pdf_file_name' => 'pdf_file_name',
       'subject' => 'subject',

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
@@ -51,7 +51,7 @@ class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
    */
   public function _testDocumentContent($formValues, $type) {
     $html = [];
-    /* @var CRM_Contact_Form_Task_PDF $form */
+    /** @var CRM_Contact_Form_Task_PDF $form */
     $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [], NULL, [
       'radio_ts' => 'ts_sel',
       'task' => CRM_Member_Task::PDF_LETTER,

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -163,7 +163,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
 
     $dataSource = new CRM_Import_DataSource_SQL($userJobID);
     $null = NULL;
-    /* @var CRM_Contact_Import_Form_MapField $form */
+    /** @var CRM_Contact_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_MapField', $submittedValues);
     $form->set('user_job_id', $userJobID);
     $dataSource->initialize();

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -2128,7 +2128,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
       'groups' => [],
     ], $submittedValues);
-    /* @var CRM_Contact_Import_Form_DataSource $form */
+    /** @var CRM_Contact_Import_Form_DataSource $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_DataSource', $submittedValues);
     $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
 
@@ -2139,13 +2139,13 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     // This gets reset in DataSource so re-do....
     $_SESSION['_' . $form->controller->_name . '_container']['values'] = $values;
 
-    /* @var CRM_Contact_Import_Form_MapField $form */
+    /** @var CRM_Contact_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_MapField', $submittedValues);
 
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
     $form->postProcess();
-    /* @var CRM_Contact_Import_Form_MapField $form */
+    /** @var CRM_Contact_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_Preview', $submittedValues);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
@@ -2177,8 +2177,8 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   private function validateMultiRowCsv(string $csv, array $mapper, string $field, array $submittedValues = []): void {
-    /* @var CRM_Import_DataSource_CSV $dataSource */
-    /* @var \CRM_Contact_Import_Parser_Contact $parser */
+    /** @var CRM_Import_DataSource_CSV $dataSource */
+    /** @var \CRM_Contact_Import_Parser_Contact $parser */
     [$dataSource, $parser] = $this->getDataSourceAndParser($csv, $mapper, $submittedValues);
     while ($values = $dataSource->getRow()) {
       try {

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1137,7 +1137,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $this->enableTaxAndInvoicing();
     $financialType = $this->createFinancialType();
     $financialAccount = $this->addTaxAccountToFinancialType($financialType['id']);
-    /* @var CRM_Contribute_Form_Contribution $form */
+    /** @var CRM_Contribute_Form_Contribution $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution', [
       'total_amount' => $params['total_amount'],
       'financial_type_id' => $financialType['id'],

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -394,7 +394,7 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       ];
     }
     $_REQUEST['id'] = $this->ids['Contribution'][0] ?? $this->_contributionId;
-    /* @var CRM_Contribute_Form_AdditionalPayment $form*/
+    /** @var CRM_Contribute_Form_AdditionalPayment $form*/
     $form = $this->getFormObject('CRM_Contribute_Form_AdditionalPayment', $submitParams);
     $form->buildForm();
     $form->postProcess();

--- a/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
@@ -24,7 +24,7 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CiviUnitTestCase {
   public function testMail(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $this->addContribution();
-    /* @var CRM_Contribute_Form_CancelSubscription $form */
+    /** @var CRM_Contribute_Form_CancelSubscription $form */
     $form = $this->getFormObject('CRM_Contribute_Form_CancelSubscription', ['is_notify' => TRUE]);
     $form->set('crid', $this->getContributionRecurID());
     $form->buildForm();
@@ -65,7 +65,7 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CiviUnitTestCase {
    */
   public function testCancelSubscriptionForm(): void {
     $this->addContribution();
-    /* @var CRM_Contribute_Form_CancelSubscription $form */
+    /** @var CRM_Contribute_Form_CancelSubscription $form */
     $form = $this->getFormObject('CRM_Contribute_Form_CancelSubscription', ['is_notify' => TRUE]);
     $form->set('crid', $this->getContributionRecurID());
     $form->buildForm();

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -57,7 +57,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     // create a contribution page which is later used to make online payment for pending contribution
     $contributionPageID2 = $this->createContributionPage(['payment_processor' => $paymentProcessorID]);
 
-    /* @var CRM_Contribute_Form_Contribution_Confirm $form*/
+    /** @var CRM_Contribute_Form_Contribution_Confirm $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution_Confirm');
     $form->_id = $contributionPageID2;
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -2186,7 +2186,7 @@ Paid By: Check',
    * @return \CRM_Contribute_Form_Contribution
    */
   protected function getContributionForm(array $formValues): CRM_Contribute_Form_Contribution {
-    /* @var CRM_Contribute_Form_Contribution $form */
+    /** @var CRM_Contribute_Form_Contribution $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution', $formValues);
     $form->buildForm();
     return $form;

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -80,7 +80,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'receive_date' => '2021-02-01 2:21',
       'currency' => 'USD',
     ])['id'];
-    /* @var CRM_Contribute_Form_Task_PDFLetter $form */
+    /** @var CRM_Contribute_Form_Task_PDFLetter $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', [
       'campaign_id' => '',
       'subject' => '',
@@ -208,7 +208,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ];
 
       $contributionId = $this->createContribution();
-      /* @var $form CRM_Contribute_Form_Task_PDFLetter */
+      /** @var $form CRM_Contribute_Form_Task_PDFLetter */
       $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
       $form->setContributionIds([$contributionId]);
       $format = Civi::settings()->get('dateformatFull');
@@ -248,7 +248,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'html_message' => '{contact.display_name}',
       'document_type' => 'pdf',
     ];
-    /* @var $form CRM_Contribute_Form_Task_PDFLetter */
+    /** @var $form CRM_Contribute_Form_Task_PDFLetter */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
     $form->setContributionIds([$this->createContribution()]);
     try {
@@ -282,7 +282,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       $formValues['html_message'] .= "$token : {contribution.$token}\n";
     }
     $formValues['html_message'] .= '{emoji.favourite_emoticon}';
-    /* @var $form CRM_Contribute_Form_Task_PDFLetter */
+    /** @var $form CRM_Contribute_Form_Task_PDFLetter */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
     $form->setContributionIds([$this->createContribution(array_merge(['campaign_id' => $tokens['campaign_id:label']], $tokens))]);
     try {
@@ -429,7 +429,7 @@ emo
     ]);
     $contributionIDs[] = $contribution['id'];
 
-    /* @var \CRM_Contribute_Form_Task_PDFLetter $form */
+    /** @var \CRM_Contribute_Form_Task_PDFLetter $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
     $form->setContributionIds($contributionIDs);
 

--- a/tests/phpunit/CRM/Contribute/Form/TaskTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/TaskTest.php
@@ -71,7 +71,7 @@ class CRM_Contribute_Form_TaskTest extends CiviUnitTestCase {
 
     foreach ($fields as $val) {
       // Assert contribIds are returned in a sorted order.
-      /* @var CRM_Contribute_Form_Task $form */
+      /** @var CRM_Contribute_Form_Task $form */
       $form = $this->getFormObject('CRM_Contribute_Form_Task', ['radio_ts' => 'ts_all'], 'Search');
       $form->set(CRM_Utils_Sort::SORT_ORDER, "`{$val}` asc");
       CRM_Contribute_Form_Task::preProcessCommon($form);

--- a/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/UpdateSubscriptionTest.php
@@ -24,7 +24,7 @@ class CRM_Contribute_Form_UpdateSubscriptionTest extends CiviUnitTestCase {
   public function testMail(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $this->addContribution();
-    /* @var CRM_Contribute_Form_UpdateSubscription $form */
+    /** @var CRM_Contribute_Form_UpdateSubscription $form */
     $form = $this->getFormObject('CRM_Contribute_Form_UpdateSubscription', ['is_notify' => TRUE]);
     $form->set('crid', $this->getContributionRecurID());
     $form->buildForm();

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -632,7 +632,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getMapFieldForm(array $submittedValues): CRM_Contribute_Import_Form_MapField {
-    /* @var \CRM_Contribute_Import_Form_MapField $form */
+    /** @var \CRM_Contribute_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Contribute_Import_Form_MapField', $submittedValues);
     return $form;
   }
@@ -648,7 +648,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getPreviewForm(array $submittedValues): CRM_Contribute_Import_Form_Preview {
-    /* @var CRM_Contribute_Import_Form_Preview $form */
+    /** @var CRM_Contribute_Import_Form_Preview $form */
     $form = $this->getFormObject('CRM_Contribute_Import_Form_Preview', $submittedValues);
     return $form;
   }

--- a/tests/phpunit/CRM/Core/DAOTest.php
+++ b/tests/phpunit/CRM/Core/DAOTest.php
@@ -245,7 +245,7 @@ class CRM_Core_DAOTest extends CiviUnitTestCase {
   public function testFindById() {
     $params = $this->sampleContact('Individual', 4);
     $existing_contact = $this->callAPISuccess('Contact', 'create', $params);
-    /* @var CRM_Contact_DAO_Contact $contact */
+    /** @var CRM_Contact_DAO_Contact $contact */
     $contact = CRM_Contact_BAO_Contact::findById($existing_contact['id']);
     $this->assertEquals($existing_contact['id'], $contact->id);
     $deleted_contact_id = $existing_contact['id'];

--- a/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
+++ b/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
@@ -50,7 +50,7 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getDataSourceForm(array $submittedValues): CRM_Custom_Import_Form_DataSource {
-    /* @var \CRM_Custom_Import_Form_DataSource $form */
+    /** @var \CRM_Custom_Import_Form_DataSource $form */
     $form = $this->getFormObject('CRM_Custom_Import_Form_DataSource', $submittedValues);
     return $form;
   }
@@ -66,7 +66,7 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getMapFieldForm(array $submittedValues): CRM_Custom_Import_Form_MapField {
-    /* @var \CRM_Custom_Import_Form_MapField $form */
+    /** @var \CRM_Custom_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Custom_Import_Form_MapField', $submittedValues);
     return $form;
   }
@@ -82,7 +82,7 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
    * @noinspection PhpUnnecessaryLocalVariableInspection
    */
   protected function getPreviewForm(array $submittedValues): CRM_Custom_Import_Form_Preview {
-    /* @var CRM_Custom_Import_Form_Preview $form */
+    /** @var CRM_Custom_Import_Form_Preview $form */
     $form = $this->getFormObject('CRM_Custom_Import_Form_Preview', $submittedValues);
     return $form;
   }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -836,7 +836,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($contribution['id']);
     $this->assertCount(2, $lineItems);
     $participantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $contribution['id'], 'participant_id', 'contribution_id');
-    /* @var CRM_Event_Form_SelfSvcTransfer $form */
+    /** @var CRM_Event_Form_SelfSvcTransfer $form */
     $form = $this->getFormObject('CRM_Event_Form_SelfSvcTransfer');
     $toContactId = $this->individualCreate();
     $mut = new CiviMailUtils($this);

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -88,7 +88,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->setCurrencySeparators($thousandSeparator);
     $mut = new CiviMailUtils($this);
     $paymentProcessorID = $this->processorCreate();
-    /* @var \CRM_Core_Payment_Dummy $processor */
+    /** @var \CRM_Core_Payment_Dummy $processor */
     $processor = Civi\Payment\System::singleton()->getById($paymentProcessorID);
     $processor->setDoDirectPaymentResult(['fee_amount' => 1.67]);
     $params = ['is_monetary' => 1, 'financial_type_id' => 1];
@@ -216,7 +216,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     // @todo - figure out why this doesn't pass validate financials
     $this->isValidateFinancialsOnPostAssert = FALSE;
     $paymentProcessorID = $this->processorCreate();
-    /* @var \CRM_Core_Payment_Dummy $processor */
+    /** @var \CRM_Core_Payment_Dummy $processor */
     $processor = Civi\Payment\System::singleton()->getById($paymentProcessorID);
     $processor->setDoDirectPaymentResult(['fee_amount' => 1.67]);
     $params = ['is_monetary' => 1, 'financial_type_id' => 1];
@@ -530,7 +530,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $this->createJoinedProfile(['entity_table' => 'civicrm_event', 'entity_id' => $event['id']]);
 
     $_REQUEST['id'] = $event['id'];
-    /* @var \CRM_Event_Form_Registration_Confirm $form */
+    /** @var \CRM_Event_Form_Registration_Confirm $form */
     $form = $this->getFormObject('CRM_Event_Form_Registration_Confirm');
     $form->set('params', [[]]);
     $form->set('values', [
@@ -631,7 +631,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     }
 
     $_REQUEST['id'] = $event['id'];
-    /* @var \CRM_Event_Form_Registration_Confirm $form */
+    /** @var \CRM_Event_Form_Registration_Confirm $form */
     $form = $this->getFormObject('CRM_Event_Form_Registration_Confirm');
     $form->set('params', [[]]);
     $form->set('values', [

--- a/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
@@ -99,7 +99,7 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
    * @return CRM_Event_Form_Registration_Register
    */
   protected function getEventForm(int $eventID): CRM_Event_Form_Registration_Register {
-    /* @var \CRM_Event_Form_Registration_Register $form */
+    /** @var \CRM_Event_Form_Registration_Register $form */
     $form = $this->getFormObject('CRM_Event_Form_Registration_Register');
     $_REQUEST['id'] = $eventID;
     return $form;

--- a/tests/phpunit/CRM/Event/Form/SelfSvcTransferTest.php
+++ b/tests/phpunit/CRM/Event/Form/SelfSvcTransferTest.php
@@ -20,7 +20,7 @@ class CRM_Event_Form_SelfSvcTransferTest extends CiviUnitTestCase {
     $this->addLocationBlockToDomain();
     $this->individualCreate(['email' => 'new@example.org']);
     $mut = new CiviMailUtils($this);
-    /* @var CRM_Event_Form_SelfSvcTransfer $form*/
+    /** @var CRM_Event_Form_SelfSvcTransfer $form*/
     $form = $this->getFormObject('CRM_Event_Form_SelfSvcTransfer', [
       'email' => 'new@example.org',
     ]);

--- a/tests/phpunit/CRM/Event/Form/SelfSvcUpdateTest.php
+++ b/tests/phpunit/CRM/Event/Form/SelfSvcUpdateTest.php
@@ -20,7 +20,7 @@ class CRM_Event_Form_SelfSvcUpdateTest extends CiviUnitTestCase {
     $this->addLocationBlockToDomain();
     $this->individualCreate(['email' => 'new@example.org']);
     $mut = new CiviMailUtils($this);
-    /* @var CRM_Event_Form_SelfSvcUpdate $form*/
+    /** @var CRM_Event_Form_SelfSvcUpdate $form */
     $form = $this->getFormObject('CRM_Event_Form_SelfSvcUpdate', [
       'email' => 'new@example.org',
       'action' => 2,

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -45,7 +45,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
     $_REQUEST['context'] = 'view';
     $_REQUEST['id'] = $participantID;
     $_REQUEST['cid'] = $contactID;
-    /* @var CRM_Event_Form_Task_Badge $form */
+    /** @var CRM_Event_Form_Task_Badge $form */
     $form = $this->getFormObject(
       'CRM_Event_Form_Task_Badge',
       ['badge_id' => 1],

--- a/tests/phpunit/CRM/Event/Form/Task/BatchTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BatchTest.php
@@ -19,7 +19,7 @@ class CRM_Event_Form_Task_BatchTest extends CiviUnitTestCase {
     $participant = $this->callAPISuccessGetSingle('Participant', ['id' => $participantID]);
     $this->assertEquals(2, $participant['participant_status_id']);
 
-    /* @var CRM_Event_Form_Task_Batch $form */
+    /** @var CRM_Event_Form_Task_Batch $form */
     $form = $this->getFormObject('CRM_Event_Form_Task_Batch');
     $form->submit(['field' => [$participantID => ['participant_status_id' => 1, 'custom_' . $field['id'] => ['two' => 1, 'four' => 1]]]]);
 
@@ -42,7 +42,7 @@ class CRM_Event_Form_Task_BatchTest extends CiviUnitTestCase {
     $this->createEventOrder(['source' => 'Online Event Registration', 'is_pay_later' => 1]);
     $participantCancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Cancelled');
 
-    /* @var CRM_Event_Form_Task_Batch $form */
+    /** @var CRM_Event_Form_Task_Batch $form */
     $form = $this->getFormObject('CRM_Event_Form_Task_Batch');
     $form->submit(['field' => [$this->ids['Participant'][0] => ['participant_status' => $participantCancelledStatusID]]]);
 

--- a/tests/phpunit/CRM/Event/Form/Task/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/RegisterTest.php
@@ -14,7 +14,7 @@ class CRM_Event_Form_Task_RegisterTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testGet() {
-    /* @var CRM_Event_Form_Task_Register $form */
+    /** @var CRM_Event_Form_Task_Register $form */
     $form = $this->getFormObject('CRM_Event_Form_Task_Register');
     $this->assertEquals(FALSE, $form->_single);
   }

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -82,7 +82,7 @@ class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
       'saveMappingName' => 'my mapping',
       'saveMappingDesc' => 'new mapping',
     ], $submittedValues);
-    /* @var \CRM_Event_Import_Form_DataSource $form */
+    /** @var \CRM_Event_Import_Form_DataSource $form */
     $form = $this->getFormObject('CRM_Event_Import_Form_DataSource', $submittedValues);
     $values = $_SESSION['_' . $form->controller->_name . '_container']['values'];
     $form->buildForm();
@@ -91,13 +91,13 @@ class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $_SESSION['_' . $form->controller->_name . '_container']['values'] = $values;
 
     $this->userJobID = $form->getUserJobID();
-    /* @var CRM_Event_Import_Form_MapField $form */
+    /** @var CRM_Event_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Event_Import_Form_MapField', $submittedValues);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
     $this->assertTrue($form->validate());
     $form->postProcess();
-    /* @var CRM_Event_Import_Form_Preview $form */
+    /** @var CRM_Event_Import_Form_Preview $form */
     $form = $this->getFormObject('CRM_Event_Import_Form_Preview', $submittedValues);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -158,7 +158,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    */
   protected function submitDatasourceForm(string $csvFileName): CRM_Contact_Import_Form_DataSource {
     $_GET['dataSource'] = 'CRM_Import_DataSource_CSV';
-    /* @var CRM_Contact_Import_Form_DataSource $form */
+    /** @var CRM_Contact_Import_Form_DataSource $form */
     $form = $this->getFormObject('CRM_Contact_Import_Form_DataSource', [
       'uploadFile' => [
         'name' => __DIR__ . '/' . $csvFileName,

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -638,7 +638,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
    * @throws \CiviCRM_API3_Exception
    */
   protected function getForm($formValues = [], $mode = 'test'): CRM_Member_Form_MembershipRenewal {
-    /* @var CRM_Member_Form_MembershipRenewal $form */
+    /** @var CRM_Member_Form_MembershipRenewal $form */
     $form = $this->getFormObject('CRM_Member_Form_MembershipRenewal', $formValues);
 
     $form->_bltID = 5;

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1092,7 +1092,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    */
   public function testSubmitRecurCompleteInstant(): void {
     $mut = new CiviMailUtils($this, TRUE);
-    /* @var \CRM_Core_Payment_Dummy $processor */
+    /** @var \CRM_Core_Payment_Dummy $processor */
     $processor = Civi\Payment\System::singleton()->getById($this->_paymentProcessorID);
     $processor->setDoDirectPaymentResult([
       'payment_status_id' => 1,
@@ -1307,7 +1307,7 @@ Expires: ',
     if (isset($_REQUEST['cid'])) {
       unset($_REQUEST['cid']);
     }
-    /* @var CRM_Member_Form_Membership $form*/
+    /** @var CRM_Member_Form_Membership $form*/
     $form = $this->getFormObject('CRM_Member_Form_Membership', $formValues);
     $form->preProcess();
     return $form;
@@ -1427,7 +1427,7 @@ Expires: ',
    * @return \CRM_Contribute_Form_Contribution
    */
   protected function getContributionForm(array $formValues): CRM_Contribute_Form_Contribution {
-    /* @var CRM_Contribute_Form_Contribution $form */
+    /** @var CRM_Contribute_Form_Contribution $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution', $formValues);
     $form->buildForm();
     return $form;

--- a/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
@@ -29,7 +29,7 @@ class CRM_Member_Form_Task_LabelTest extends CiviUnitTestCase {
     $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::EDIT);
     $this->assertArrayHasKey(201, $tasks);
     $membershipID = $this->contactMembershipCreate(['contact_id' => $this->individualCreate()]);
-    /* @var CRM_Member_Form_Task_Label $form */
+    /** @var CRM_Member_Form_Task_Label $form */
     $form = $this->getFormObject('CRM_Member_Form_Task_Label', [
       'task' => 201,
       'radio_ts' => 'ts_sel',

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
@@ -78,7 +78,7 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
       }
     }
 
-    /* @var CRM_Member_Form_Task_PDFLetter $form */
+    /** @var CRM_Member_Form_Task_PDFLetter $form */
     $form = $this->getFormObject('CRM_Member_Form_Task_PDFLetter', [
       'subject' => '{contact.first_name} {membership.source}',
       'html_message' => $htmlMessage,

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -488,7 +488,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
     $form->postProcess();
-    /* @var CRM_Member_Import_Form_MapField $form */
+    /** @var CRM_Member_Import_Form_MapField $form */
     $form = $this->getFormObject('CRM_Member_Import_Form_Preview', $submittedValues);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();

--- a/tests/phpunit/CRM/Price/Form/FieldTest.php
+++ b/tests/phpunit/CRM/Price/Form/FieldTest.php
@@ -124,7 +124,7 @@ class CRM_Price_Form_FieldTest extends CiviUnitTestCase {
     $membershipTypeID2 = $this->membershipTypeCreate(['member_of_contact_id' => $this->setupIDs['contact']]);
 
     $priceSetID = $this->callAPISuccess('PriceSet', 'create', ['title' => 'blah', 'extends' => 'CiviMember'])['id'];
-    /* @var \CRM_Price_Form_Field $form */
+    /** @var \CRM_Price_Form_Field $form */
     $form = $this->getFormObject('CRM_Price_Form_Field');
     $_REQUEST['sid'] = $priceSetID;
     $form->preProcess();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3230,7 +3230,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    */
   public function getFormObject($class, $formValues = [], $pageName = '', $searchFormValues = []) {
     $_POST = $formValues;
-    /* @var CRM_Core_Form $form */
+    /** @var CRM_Core_Form $form */
     $form = new $class();
     $_SERVER['REQUEST_METHOD'] = 'GET';
     switch ($class) {

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3557,7 +3557,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $_REQUEST['id'] = $this->getContributionID();
     $_REQUEST['action'] = 'update';
     // change pending contribution to completed
-    /* @var CRM_Contribute_Form_Contribution $form */
+    /** @var CRM_Contribute_Form_Contribution $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution', [
       'total_amount' => 20,
       'net_amount' => 20,

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -506,7 +506,7 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
   public function testTriggerOutput(): void {
     Civi::settings()->set('logging_no_trigger_permission', TRUE);
     Civi::settings()->set('logging', TRUE);
-    /* @var \Civi\Core\SqlTriggers $sqlTriggers */
+    /** @var \Civi\Core\SqlTriggers $sqlTriggers */
     $sqlTriggers = Civi::service('sql_triggers');
     $fileName = $sqlTriggers->getFile();
     $triggerOutPut = file_get_contents($fileName);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -209,7 +209,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $_REQUEST['action'] = 'update';
     $_REQUEST['id'] = $order['id'];
     // Change Payment Status to Completed
-    /* @var CRM_Contribute_Form_Contribution $form */
+    /** @var CRM_Contribute_Form_Contribution $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution', [
       'total_amount' => 150,
       'financial_type_id' => '1',

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -364,7 +364,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    */
   public function alterReportVarHook($varType, &$var, &$object) {
     if ($varType === 'sql' && $object instanceof CRM_Report_Form_Contribute_Summary) {
-      /* @var CRM_Report_Form $var */
       $from = $var->getVar('_from');
       $from .= ' LEFT JOIN civicrm_financial_type as temp ON temp.id = contribution_civireport.financial_type_id';
       $var->setVar('_from', $from);

--- a/tools/bin/scripts/set-version.php
+++ b/tools/bin/scripts/set-version.php
@@ -84,15 +84,15 @@ $infoXmls = findCoreInfoXml();
 foreach ($infoXmls as $infoXml) {
   updateXmlFile($infoXml, function (DOMDocument $dom) use ($newVersion) {
     // Update extension version
+    /** @var \DOMNode $tag */
     foreach ($dom->getElementsByTagName('version') as $tag) {
-      /* @var \DOMNode $tag */
       $tag->textContent = $newVersion;
     }
     // Update compatability - set to major version of core
+    /** @var \DOMNode $compat */
     foreach ($dom->getElementsByTagName('compatibility') as $compat) {
-      /* @var \DOMNode $compat */
+      /** @var \DOMNode $tag */
       foreach ($compat->getElementsByTagName('ver') as $tag) {
-        /* @var \DOMNode $tag */
         $tag->textContent = implode('.', array_slice(explode('.', $newVersion), 0, 2));
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the syntax of `@var` statements for variables, so that they are correctly recognised by all IDEs.

Before
----------------------------------------
To be picked up by all IDEs,  `@var` comments need to:

- Use a comment style with two astrisks; `/**` not `/*`. 
- Specify the type before the variable name.

The de-facto standard can be found here, https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/var.html. (There are some variations, but the two rules above will work with any phpdoc implementation). 

After
----------------------------------------
Minor syntax changes to ensure the annotations are correctly picked up. This should make it easier to debug and avoid bugs in future.

Comments
----------------------------------------
I use VSCode. It is possible that PHPStorm is more lenient and supported `/* @var ... */`, but I've not tested this. Any IDE that supported a single astrisk should support a double astrisk.

In a few cases the variable did not need to be documented as the type could be infered from the `@return` on the function being called. In these cases I've removed the `@var`.

In a few cases I've also moved the `@var` above a `foreach`, which makes more logical sense as it is within the `foreach` that the variable is defined. This fits with the recomendation on https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/var.html
