### PR TITLE
[WIP] Changes to reconcile PRs #24264 -> #24080 

### DIFF
--- a/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
@@ -148,7 +148,8 @@ class AfformSubmitEvent extends AfformBaseEvent {
    * @return $this
    */
   public function setJoinIds($index, $joinEntity, $joinIds) {
-    $this->entityIds[$this->entityName][$index]['joins'][$joinEntity] = $joinIds;
+    $idField = CoreUtil::getIdFieldName($joinEntity);
+    $this->entityIds[$this->entityName][$index]['_joins'][$joinEntity] = \CRM_Utils_Array::filterColumns($joinIds, [$idField]);
     return $this;
   }
 

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -47,7 +47,7 @@ class FormDataModel {
     $this->entities = array_column(AHQ::getTags($root, 'af-entity'), NULL, 'name');
     foreach (array_keys($this->entities) as $entity) {
       $this->entities[$entity] = array_merge($this->defaults, $this->entities[$entity]);
-      $this->entities[$entity]['fields'] = $this->entities[$entity]['joins'] = [];
+      $this->entities[$entity]['fields'] = $this->entities[$entity]['_joins'] = [];
     }
     // Pre-load full list of afforms in case this layout embeds other afform directives
     $this->blocks = (array) Afform::get(FALSE)->setSelect(['name', 'directive_name'])->execute()->indexBy('directive_name');
@@ -155,14 +155,14 @@ class FormDataModel {
       }
       elseif ($entity && $node['#tag'] === 'af-field') {
         if ($join) {
-          $this->entities[$entity]['joins'][$join]['fields'][$node['name']] = AHQ::getProps($node);
+          $this->entities[$entity]['_joins'][$join]['fields'][$node['name']] = AHQ::getProps($node);
         }
         else {
           $this->entities[$entity]['fields'][$node['name']] = AHQ::getProps($node);
         }
       }
       elseif ($entity && !empty($node['af-join'])) {
-        $this->entities[$entity]['joins'][$node['af-join']] = AHQ::getProps($node);
+        $this->entities[$entity]['_joins'][$node['af-join']] = AHQ::getProps($node);
         $this->parseFields($node['#children'] ?? [], $entity, $node['af-join']);
       }
       elseif (!empty($node['#children'])) {

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -52,7 +52,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    * Each key in the array corresponds to the name of an entity,
    * and the value is an array of arrays
    * (because of `<af-repeat>` all entities are treated as if they may be multi)
-   * E.g. $entityIds['Individual1'] = [['id' => 1, 'joins' => ['Email' => [1,2,3]]];
+   * E.g. $entityIds['Individual1'] = [['id' => 1, '_joins' => ['Email' => [['id' => 1], ['id' => 2]]];
    *
    * @var array
    */
@@ -117,19 +117,20 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     ])->indexBy($idField);
     foreach ($ids as $index => $id) {
       $this->_entityIds[$entity['name']][$index] = [
-        'id' => isset($result[$id]) ? $id : NULL,
-        'joins' => [],
+        $idField => isset($result[$id]) ? $id : NULL,
+        '_joins' => [],
       ];
       if (isset($result[$id])) {
         $data = ['fields' => $result[$id]];
-        foreach ($entity['joins'] ?? [] as $joinEntity => $join) {
-          $data['joins'][$joinEntity] = (array) $api4($joinEntity, 'get', [
+        foreach ($entity['_joins'] ?? [] as $joinEntity => $join) {
+          $joinIdField = CoreUtil::getIdFieldName($joinEntity);
+          $data['_joins'][$joinEntity] = (array) $api4($joinEntity, 'get', [
             'where' => self::getJoinWhereClause($this->_formDataModel, $entity['name'], $joinEntity, $id),
             'limit' => !empty($join['af-repeat']) ? $join['max'] ?? 0 : 1,
-            'select' => array_keys($join['fields']),
+            'select' => array_unique(array_merge([$joinIdField], array_keys($join['fields']))),
             'orderBy' => self::getEntityField($joinEntity, 'is_primary') ? ['is_primary' => 'DESC'] : [],
           ]);
-          $this->_entityIds[$entity['name']][$index]['joins'][$joinEntity] = array_column($data['joins'][$joinEntity], 'id');
+          $this->_entityIds[$entity['name']][$index]['_joins'][$joinEntity] = \CRM_Utils_Array::filterColumns($data['_joins'][$joinEntity], [$joinIdField]);
         }
         $this->_entityValues[$entity['name']][$index] = $data;
       }
@@ -190,7 +191,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     $params = [];
 
     // Add data as clauses e.g. `is_primary: true`
-    foreach ($entity['joins'][$joinEntityType]['data'] ?? [] as $key => $val) {
+    foreach ($entity['_joins'][$joinEntityType]['data'] ?? [] as $key => $val) {
       $params[] = [$key, '=', $val];
     }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -112,15 +112,17 @@ class Submit extends AbstractProcessor {
    * Recursively add entity IDs to the values.
    */
   protected function array_insert($arr, $ins) {
-    if (is_array($arr) && is_array($ins)) foreach ($ins as $k => $v) {
-      if (isset($arr[$k]) && is_array($v) && is_array($arr[$k])) {
-        $arr[$k] = $this->array_insert($arr[$k], $v);
+    if (is_array($arr) && is_array($ins)) {
+      foreach ($ins as $k => $v) {
+        if (isset($arr[$k]) && is_array($v) && is_array($arr[$k])) {
+          $arr[$k] = $this->array_insert($arr[$k], $v);
+        }
+        else {
+          $arr[$k] = $v;
+        }
       }
-      else {
-        $arr[$k] = $v;
-      }
+      return($arr);
     }
-    return($arr);
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -68,11 +68,12 @@ class SubmitFile extends AbstractProcessor {
     $apiEntity = $this->joinEntity ?: $afformEntity['type'];
     $entityIndex = (int) $this->entityIndex;
     $joinIndex = (int) $this->joinIndex;
+    $idField = CoreUtil::getIdFieldName($apiEntity);
     if ($this->joinEntity) {
-      $entityId = $this->_entityIds[$this->modelName][$entityIndex]['joins'][$this->joinEntity][$joinIndex] ?? NULL;
+      $entityId = $this->_entityIds[$this->modelName][$entityIndex]['_joins'][$this->joinEntity][$joinIndex][$idField] ?? NULL;
     }
     else {
-      $entityId = $this->_entityIds[$this->modelName][$entityIndex]['id'] ?? NULL;
+      $entityId = $this->_entityIds[$this->modelName][$entityIndex][$idField] ?? NULL;
     }
 
     if (!$entityId) {
@@ -101,7 +102,7 @@ class SubmitFile extends AbstractProcessor {
     if (strpos($apiEntity, 'Custom_') === 0) {
       civicrm_api4($apiEntity, 'update', [
         'values' => [
-          'id' => $entityId,
+          $idField => $entityId,
           $this->fieldName => $file['id'],
         ],
       ]);


### PR DESCRIPTION
Overview
----------------------------------------
See conversations on PRs [#24264](https://github.com/civicrm/civicrm-core/pull/24264) and [#24080](https://github.com/civicrm/civicrm-core/pull/24080/files)

Before
----------------------------------------
![Selection_055](https://user-images.githubusercontent.com/87245718/189684519-beb09e08-38bc-4fc5-82da-38bf5e3a36e3.png)

After
----------------------------------------
![Selection_056](https://user-images.githubusercontent.com/87245718/189684448-eee9cc16-2e35-47e7-9392-f5b52561e054.png)



Technical Details
----------------------------------------
`'joins'` was changed to `'_joins'` in AbstractProcessor.php, Submit.php, FormDataModel.php (and the previously changed one's in AfformSubmitEvent.php that were originally a part of #24264.

Also added a recursive function in Submit.php to remove the `'joins'` array from `$submissionData`

Comments
----------------------------------------
This is a work in progress to test that the reconciling changes do not break any other functionality
