### PR TITLE
Improve contribution import error handling

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1778,7 +1778,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   }
 
   /**
-   * @param $outcome
+   * @param int|null|string $outcome
    *
    * @return string
    */

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -486,11 +486,11 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   /**
    * Get the status to record.
    *
-   * @param int|null $code
+   * @param int|null|string $code
    *
    * @return string
    */
-  protected function getStatus(?int $code): string {
+  protected function getStatus($code): string {
     $errorMapping = [
       self::SOFT_CREDIT_ERROR => 'soft_credit_error',
       self::PLEDGE_PAYMENT_ERROR => 'pledge_payment_error',


### PR DESCRIPTION
Overview
----------------------------------------
Improve contribution import error handling

Before
----------------------------------------
There is a function that maps the exception string to an import status - this is expecting a number (or NULL) but it turns out the code could also be a string - in which case the handling does not let the message bubble up to the user as it becomes 'harder' when it hits the strict typing

After
----------------------------------------
Strict typing removed, it falls back to a generic status of 'ERROR' 

Technical Details
----------------------------------------
We should get this merged before the rc is cut or into the rc & consider a stable backport

Comments
----------------------------------------
I found this writing a test for another master-only regression I have found - hopefully once that is done the test should still provide cover on this