### PR TITLE
Fix unreleased regression on soft credit imports

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_amount_validate.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_amount_validate.csv
@@ -1,3 +1,3 @@
-Total Amount,Receive Date,Financial Type,External identifier,Soft Credit Ext ID
-"1,230.99",2008-09-20,Donation,ext-1,ext-2
-"1.230,99",2008-09-20,Donation,ext-1,ext-2
+Total Amount,Receive Date,Financial Type,External identifier,Soft Credit Ext ID,Email,Email - soft credit
+"1,230.99",2008-09-20,Donation,ext-1,ext-2,harry@example.com,the-firm@example.com
+"1.230,99",2008-09-20,Donation,ext-1,ext-2,,


### PR DESCRIPTION


Overview
----------------------------------------
Fixes an unreleased regression whereby it was only permitting an email match with the same contact type as the main contact for a soft credit import

Before
----------------------------------------
Importing a contribution with a soft credit where the soft credit email matches an existing contact BUT the contact type is different to the main contact's contact type fails

After
----------------------------------------
For the soft credit we do not legitimately know the contact type so we now try to find the contact by the Unsupervised rule for EACH contact type. In practice this means that email would always be a match for default-weight installs which brings us back to the behaviour in the last release. However, this makes the use of dedupe rules more consistent.


Technical Details
----------------------------------------

Test added

Comments
----------------------------------------
If the rc is forked before this is merged it needs to go with the rc