### PR TITLE
dev/core#3837 - Error about form BAO deprecation when saving contact after checking a box for preferred communication method

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -957,6 +957,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     if (array_key_exists('CommunicationPreferences', $this->_editOptions)) {
       // this is a chekbox, so mark false if we dont get a POST value
       $params['is_opt_out'] = CRM_Utils_Array::value('is_opt_out', $params, FALSE);
+
+      CRM_Utils_Array::formatArrayKeys($params['preferred_communication_method']);
     }
 
     // process shared contact address.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3837

Before
----------------------------------------
`User deprecated function: Form layer formatting should never get to the BAO Caller: CRM_Contact_BAO_Contact::create in CRM_Core_Error::deprecatedWarning() (line 1111 of .../CRM/Core/Error.php).`

After
----------------------------------------


Technical Details
----------------------------------------
??

Comments
----------------------------------------

