### PR TITLE
Import Remove no-longer needed storage of file path

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -142,17 +142,6 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
   }
 
   /**
-   * Store form values.
-   *
-   * @param array $names
-   */
-  protected function storeFormValues($names) {
-    foreach ($names as $name) {
-      $this->set($name, $this->controller->exportValue($this->_name, $name));
-    }
-  }
-
-  /**
    * Common postProcessing.
    */
   public function postProcess() {

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -108,7 +108,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
     // other imports, ditto uploadFile.
     'skipColumnHeader' => 'DataSource',
     'fieldSeparator' => 'DataSource',
-    'uploadFile' => 'DataSource',
     'contactType' => 'DataSource',
     'contactSubType' => 'DataSource',
     'dateFormats' => 'DataSource',


### PR DESCRIPTION
Overview
----------------------------------------
Import Remove no-longer needed storage of file path

Before
----------------------------------------
As part of the code cleanup `uploadFile` was being stored to the `UserJob` table - this value held the path on the server to the csv file. However, the need for this value to be retained awas transitional. We have now gotten to the point where saving the `DataSource` form uploads the file to a table and no other code needs to know about the source file

After
----------------------------------------
The file name is only accessable / used in the `DataSource` form

Technical Details
----------------------------------------
this is a hygeine issue - it prevents informaiton about the path to the csv from being known - however, the handling of the file is already strictly within the form itself so altering it in the UserJob table would not allow someone to interact with a different file in any way. 

Comments
----------------------------------------
