### PR TITLE
Add unit test & handling  for processing from UserJob configuration rather than form submitted values

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/soft_credit_extended.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/soft_credit_extended.csv
@@ -1,0 +1,3 @@
+Organization Name,Amount,Financial Type,Source,Date,Soft credi contact email,Soft credit first name,Soft Credit last name
+Big Firm,800,,Import,2022-09-08,jenny@example.org,Jenny,Hawthorn
+Small Firm,70,Check,Import,2022-09-08,sarah@example.org,Sarah,Windsor


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test & handling for processing from UserJob configuration rather than form submitted values

Before
----------------------------------------
Processing of imports deeping tied to quickform form set up

After
----------------------------------------
Starting to move to support the configuration being saved into the `UserJob` table as two arrays

`'import mappings'` - which is the row by row information of what field each csv column maps to, and potentially other data
`entity_configuration` - this isn't covered in this PR but will hold the stuff that relates to the entity rather than the rows

Technical Details
----------------------------------------
The import flow only supports limited config at the moment because of quickform challenges - this starts to add the support for config-based imports - where the config is stored in the `UserJob` rather than being tightly tied to the form.

When the import cleanup started the config was passed around in a whole lot of crazy ways. It has been consolidated to the `submitted_values` array which is stored in the user job but the next step in the evolution is for the form layer to transform the config to a sensible format & save it like that rather than drive everything from what the form supports

Comments
----------------------------------------