### PR TITLE
Add EntityReference custom field type

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -999,7 +999,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
           }
           $fieldAttributes['class'] = ltrim(($fieldAttributes['class'] ?? '') . ' crm-form-entity-reference huge');
           // TODO: Add "data-api-entity" attribute depending on referenced entity type.
-//          $fieldAttributes['data-api-entity'] = 'Contact';
+          // $fieldAttributes['data-api-entity'] = 'Contact';
           if (!empty($field->serialize) || $search) {
             $fieldAttributes['multiple'] = TRUE;
           }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1907,7 +1907,7 @@ ORDER BY civicrm_custom_group.weight,
             // also return entity reference entity id if user has view all or edit permissions for that entity type.
             if ($details[$groupID][$values['id']]['fields'][$k]['field_data_type'] === 'EntityReference'
               // TODO: Check permissions for referenced entity type.
-//              && CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])
+              // && CRM_Core_Permission::check([['view all contacts', 'edit all contacts']])
             ) {
               $details[$groupID][$values['id']]['fields'][$k]['entity_ref_links'] = [];
               parse_str($details[$groupID][$values['id']]['fields'][$k]['filter'], $params);

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -216,6 +216,7 @@ class CRM_Core_BAO_CustomQuery {
           case 'StateProvince':
           case 'Country':
           case 'ContactReference':
+          case 'EntityReference':
 
             if ($field['is_search_range'] && is_array($value)) {
               //didn't found any field under any of these three data-types as searchable by range

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -186,6 +186,7 @@ class CRM_Core_BAO_CustomValueTable {
               break;
 
             case 'ContactReference':
+            case 'EntityReference':
               if ($value == NULL || $value === '' || $value === $VS . $VS) {
                 $type = 'Timestamp';
                 $value = NULL;
@@ -315,6 +316,7 @@ class CRM_Core_BAO_CustomValueTable {
       // the below three are FK's, and have constraints added to them
 
       case 'ContactReference':
+      case 'EntityReference':
       case 'StateProvince':
       case 'Country':
       case 'File':

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -632,6 +632,7 @@ SELECT count(*)
           }
           $self->setDefaults(['filter_selected', $fields['filter_selected']]);
           break;
+
         case 'EntityReference':
           if (!empty($fields['filter'])) {
             if (strpos($fields['filter'], 'action=get') === FALSE) {

--- a/Civi/Api4/Service/Spec/CustomFieldSpec.php
+++ b/Civi/Api4/Service/Spec/CustomFieldSpec.php
@@ -37,6 +37,7 @@ class CustomFieldSpec extends FieldSpec {
         $this->setFkEntity('Contact');
         $dataType = 'Integer';
         break;
+
       case 'EntityReference':
         $dataType = 'Integer';
         break;

--- a/Civi/Api4/Service/Spec/CustomFieldSpec.php
+++ b/Civi/Api4/Service/Spec/CustomFieldSpec.php
@@ -37,6 +37,9 @@ class CustomFieldSpec extends FieldSpec {
         $this->setFkEntity('Contact');
         $dataType = 'Integer';
         break;
+      case 'EntityReference':
+        $dataType = 'Integer';
+        break;
 
       case 'File':
       case 'StateProvince':

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -37,6 +37,11 @@ class SpecFormatter {
         $field->setType('Field');
         $field->setTableName($data['custom_group_id.table_name']);
       }
+      if ($data['data_type'] == 'EntityReference') {
+        // Extract FK entity from the filter string.
+        parse_str($data['filter'], $params);
+        $field->setFkEntity($params['entity']);
+      }
       $field->setColumnName($data['column_name']);
       $field->setNullable(empty($data['is_required']));
       $field->setCustomFieldId($data['id'] ?? NULL);

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -35,6 +35,14 @@
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value}</div>
           {/if}
+          {if $element.field_data_type EQ 'EntityReference' && $element.entity_ref_links}
+            {*Entity ref id passed if user has sufficient permissions - so make a link.*}
+            <div class="crm-content crm-custom-data crm-entity-reference">
+              {', '|implode:$element.entity_ref_links}
+            </div>
+          {else}
+            <div class="crm-content crm-custom-data">{$element.field_value}</div>
+          {/if}
         {/if}
       </div>
     {/foreach}

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -67,6 +67,14 @@
         <span class="description">{ts}Filter contact search results for this field using Contact get API parameters. EXAMPLE: To list Students in group 3:{/ts} "action=get&group=3&contact_sub_type=Student" {docURL page="dev/api"}</span>
       </td>
     </tr>
+    <tr id="entity_reference_group">
+      <td class="label">{$form.entity_type.label}</td>
+      <td class="html-adjust">{$form.entity_type.html}</td>
+    </tr>
+    <tr id="entityref_advance_filter">
+      <td class="label">{$form.entityref_filter.label}</td>
+      <td class="html-adjust">{$form.entityref_filter.html}</td>
+    </tr>
     <tr class="crm-custom-field-form-block-options_per_line" id="optionsPerLine" {if $action neq 2 && ($form.data_type.value.0.0 >= 4 && $form.data_type.value.1.0 neq 'CheckBox' || $form.data_type.value.1.0 neq 'Radio' )}class="hiddenElement"{/if}>
       <td class="label">{$form.options_per_line.label}</td>
       <td class="html-adjust">{$form.options_per_line.html|crmAddClass:two}</td>
@@ -229,6 +237,7 @@
       e && e.preventDefault && e.preventDefault();
     }
     $('.toggle-contact-ref-mode', $form).click(toggleContactRefFilter);
+    $('.toggle-contact-ref-mode', $form).click(toggleContactRefFilter);
 
     function customOptionHtmlType(dataType) {
       var htmlType = $("#html_type", $form).val(),
@@ -239,9 +248,14 @@
       }
 
       if (dataType === 'ContactReference') {
+        $('#field_advance_filter, #entity_reference_group, #entityref_advance_filter', $form).hide();
         toggleContactRefFilter();
+      } else if (dataType === 'EntityReference') {
+        $('#field_advance_filter, #contact_reference_group', $form).hide();
+        $('#entity_reference_group, #entityref_advance_filter', $form).show();
       } else {
         $('#field_advance_filter, #contact_reference_group', $form).hide();
+        $('#entity_reference_group, #entityref_advance_filter', $form).hide();
       }
 
       if (_.includes(['String', 'Int', 'Float', 'Money'], dataType)) {

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -71,6 +71,8 @@
                         <td class="html-adjust">
                           {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
                             {', '|implode:$element.contact_ref_links}
+                          {elseif $element.field_data_type EQ 'EntityReference' && $element.entity_ref_links}
+                            {', '|implode:$element.entity_ref_links}
                           {elseif $element.field_data_type == 'Memo'}
                             {$element.field_value|nl2br}
                           {else}
@@ -124,6 +126,8 @@
                   <div class="content">
                     {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
                       {', '|implode:$element.contact_ref_links}
+                    {elseif $element.field_data_type EQ 'EntityReference' && $element.entity_ref_links}
+                      {', '|implode:$element.entity_ref_links}
                     {elseif $element.field_data_type == 'Memo'}
                       {if $element.field_value}{$element.field_value|nl2br}{else}<br/>{/if}
                     {else}


### PR DESCRIPTION
This is a first attempt towards [dev/core#3721](https://lab.civicrm.org/dev/core/-/issues/3721), introducing a custom field type for generic entity references implementing the `EntityRef` QuickForm type, basically following what's being done for the *ContactReference* custom field type.

As the discussion in the issue seems to be leading into a conceptual phase for this first, I wanted to share my naive adaptions I made while scrolling through relevant code. This is not yet functional, hence this PR being a draft for now.

Note: This will of course have to be rebased, I just played around in a current local environment that had `5.53.0`.