### PR TITLE
dev/core#3838 - Addressee token evaluates middle_name as literal string null

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2749,6 +2749,10 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
     // adds in `phone` and `email`
     // in a weird & likely obsolete way....
     $contactArray = array_intersect_key((array) $contact, $contact->fields());
+    // blech
+    $contactArray = array_map(function($v) {
+      return $v === 'null' ? NULL : $v;
+    }, $contactArray);
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
       'smarty' => TRUE,
       'class' => __CLASS__,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3838

aka Restore string "null" handling when processing greetings

Before
----------------------------------------
1. Create a contact with a blank middle name.
2. Look at the addressee display in the communication prefs section on contact summary: "John null Smith"

After
----------------------------------------
Better

Technical Details
----------------------------------------
Previously it used to call DAO::storeValues which does a check for string "null", but the reason it was changed was because it was completely bypassing them. So this restores handling, but converts it to null null.

Comments
----------------------------------------
I had trouble writing a test for this because it seems to depend a little on the form. It wasn't clear why though, and then I gave up.
