### PR TITLE
SearchKit - Fix arithmetic in WHERE clause

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -452,7 +452,7 @@ class Api4SelectQuery {
 
     // For WHERE clause, expr must be the name of a field.
     if ($type === 'WHERE' && !$isExpression) {
-      $expr = $this->getExpression($expr, ['SqlField', 'SqlFunction']);
+      $expr = $this->getExpression($expr, ['SqlField', 'SqlFunction', 'SqlEquation']);
       if ($expr->getType() === 'SqlField') {
         $fieldName = count($expr->getFields()) === 1 ? $expr->getFields()[0] : NULL;
         $field = $this->getField($fieldName, TRUE);

--- a/tests/phpunit/api/v4/Action/SqlExpressionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlExpressionTest.php
@@ -114,7 +114,7 @@ class SqlExpressionTest extends Api4TestBase implements TransactionalInterface {
         // This field will be null
         '(hold_date + 5) AS null_plus_five',
       ])
-      ->addWhere('contact_id', '=', $contact['id'])
+      ->addWhere('(contact_id + 1)', '=', 1 + $contact['id'])
       ->setLimit(1)
       ->execute()
       ->first();


### PR DESCRIPTION
Overview
----------------------------------------
Permit SqlEquation in APIv4 WHERE clauses so it works in SearchKit. 
Fixes [dev/core#3845](https://lab.civicrm.org/dev/core/-/issues/3845)

Before
----------------------------------------
Trying to use arithmetic in the WHERE clause will fail.

After
----------------------------------------
Works + test.