### PR TITLE
[REF] Update Zetacomponents/mail to be 1.9.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "tecnickcom/tcpdf" : "6.4.*",
     "totten/ca-config": "~22.05",
     "zetacomponents/base": "1.9.*",
-    "zetacomponents/mail": "~1.9.3",
+    "zetacomponents/mail": "~1.9.4",
     "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^0.18.0",
     "pear/validate_finance_creditcard": "0.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dabb3c7d59caccf8b70e618133cea611",
+    "content-hash": "b95f6dae53ed863eb029cc464ca1de97",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5630,16 +5630,16 @@
         },
         {
             "name": "zetacomponents/mail",
-            "version": "1.9.3",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Mail.git",
-                "reference": "7f7cf8135320fabf27f6530381da4977a31e1c78"
+                "reference": "83ba646f36f753c0bbc8b2189c88d41ece326ea0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/7f7cf8135320fabf27f6530381da4977a31e1c78",
-                "reference": "7f7cf8135320fabf27f6530381da4977a31e1c78",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/83ba646f36f753c0bbc8b2189c88d41ece326ea0",
+                "reference": "83ba646f36f753c0bbc8b2189c88d41ece326ea0",
                 "shasum": ""
             },
             "require": {
@@ -5704,9 +5704,9 @@
             "homepage": "https://github.com/zetacomponents",
             "support": {
                 "issues": "https://github.com/zetacomponents/Mail/issues",
-                "source": "https://github.com/zetacomponents/Mail/tree/1.9.3"
+                "source": "https://github.com/zetacomponents/Mail/tree/1.9.4"
             },
-            "time": "2022-08-09T09:42:33+00:00"
+            "time": "2022-09-14T10:13:21+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Overview
----------------------------------------
Title says it all

Before
----------------------------------------
Version 1.9.3 used

After
----------------------------------------
Version 1.9.4 used

ping @eileenmcnaughton @demeritcowboy 

We unit tests that should cover us here