### PR TITLE
resetNavigation() - Don't reset quite so much

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -479,8 +479,6 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $query = "UPDATE civicrm_setting SET value = '$ser' WHERE name='navigation' AND contact_id IS NOT NULL";
       CRM_Core_DAO::executeQuery($query);
       Civi::cache('navigation')->flush();
-      // reset ACL and System caches
-      CRM_Core_BAO_Cache::resetCaches();
     }
     else {
       // before inserting check if contact id exists in db


### PR DESCRIPTION
Overview
----------------------------------------

This reduces the number of times that `CRM_Utils_System::flushCache()` runs.

Before
----------------------------------------

If you run `cv flush`, it calls `flushCache()` many times. (Twelve times on my system.)

After
----------------------------------------

If you run `cv flush`, it calls `flushCache()` only once.

Technical Details
----------------------------------------

(A) To see the number of invocations, I hacked in a print statement:

```diff
diff --git a/CRM/Utils/System.php b/CRM/Utils/System.php
index 345db10a47..2c1c7e547d 100644
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1487,6 +1487,13 @@ class CRM_Utils_System {
    * Reset the various system caches and some important static variables.
    */
   public static function flushCache() {
+    fprintf(STDERR, "flushCache!\n%s\n\n", implode("\n", $miniBacktrace));
+
```

(B) I am still able to use "Administer => Customize => Navigation Menu" to edit nav-labels. 

(C) I'm not sure if this will have a performance impact. It may just be a tidiness thing.

(D) It appears that the code was added as part of 96689db3d7b9276b10db3ee21b4cb9eed9ffc166, which was a bigger update that included a couple of flushes, eg

1. After changing "Localization" settings, it flushed navigation and lots of other things.
2. After changing "Navigation", it flushed `navigation` and lots of other things.

The first one feels reasonable. I'm struggling to understand the second one. Could it have been a copy-paste from 1=>2?

In isolation, it might not be that big of a deal -- but it gets a little silly when combined with ManagedEntities. If you have several navigation items registered via ManagedEntities, then a "system flush" causes them all to be written, and each one of them fires a separate/general flush.

(E) If this flush does serve a purpose, then an alternative is to figure some optimization for `ManagedEntities` or `Navigation` where it skips flushes if the menu hasn't had an actual change.

ping @seamuslee001 @demeritcowboy 