### PR TITLE
Fix import to support entity_configuration

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -157,7 +157,7 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     $mapperError = [];
     try {
       $parser = $self->getParser();
-      $rule = $parser->getDedupeRule($self->getContactType());
+      $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
       if (!$self->isUpdateExisting()) {
         $missingDedupeFields = $self->validateDedupeFieldsSufficientInMapping($rule, $fields['mapper']);
         if ($missingDedupeFields) {

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -88,7 +88,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    * @noinspection PhpUnhandledExceptionInspection
    */
   public function postProcess() {
-    $this->updateUserJobMetadata('import_configuration', $this->getImportConfiguration());
+    $this->updateUserJobMetadata('import_mappings', $this->getImportConfiguration());
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $this->saveMapping();
     $parser = $this->getParser();
@@ -487,7 +487,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       if (in_array($fieldName, $highlightedFields, TRUE)) {
         $childField['text'] .= '*';
       }
-      $category = ($childField['has_location'] || $field['name'] === 'contact_id') ? 'Contact' : ($field['entity'] ?? $entity);
+      $category = ($childField['has_location'] || $field['name'] === 'contact_id') ? 'Contact' : $field['entity_instance'] ?? ($field['entity'] ?? $entity);
       if (empty($categories[$category])) {
         $category = $entity;
       }
@@ -533,9 +533,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    * @return array
    */
   protected function getImportConfiguration(): array {
-    $importConfiguration = [];
+    $importConfiguration = $this->getUserJob()['metadata']['import_mappings'] ?? [];
     foreach ($this->getSubmittedValue('mapper') as $mapperField) {
-      $importConfiguration[] = $mapperField;
+      $importConfiguration['name'] = $mapperField;
     }
     return $importConfiguration;
   }

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -41,8 +41,6 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Clean up after test.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function tearDown():void {
     $this->quickCleanup(['civicrm_contact', 'civicrm_email', 'civicrm_activity', 'civicrm_activity_contact', 'civicrm_user_job', 'civicrm_queue', 'civicrm_queue_item'], TRUE);
@@ -93,9 +91,10 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    *
    * @param array $values
    * @param int $expectedOutcome
+   *
    * @return string The error message
    */
-  protected function importValues(array $values, $expectedOutcome = 1): string {
+  protected function importValues(array $values, int $expectedOutcome = 1): string {
     $importer = $this->createImportObject(array_keys($values));
     try {
       $importer->validateValues(array_values($values));

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/soft_credit_extended.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/soft_credit_extended.csv
@@ -1,3 +1,3 @@
-Organization Name,Amount,Financial Type,Source,Date,Soft credi contact email,Soft credit first name,Soft Credit last name
-Big Firm,800,,Import,2022-09-08,jenny@example.org,Jenny,Hawthorn
-Small Firm,70,Check,Import,2022-09-08,sarah@example.org,Sarah,Windsor
+Organization Name,Legal Name,Amount,Financial Type,Source,Date,Soft credi contact email,Soft credit first name,Soft Credit last name
+Big Firm,Big Firm inc.,800,,Import,2022-09-08,jenny@example.org,Jenny,Hawthorn
+Small Firm,Small Firm inc.,70,Check,Import,2022-09-08,sarah@example.org,Sarah,Windsor

--- a/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
+++ b/tests/phpunit/CRM/Custom/Import/Parser/ApiTest.php
@@ -18,6 +18,8 @@ class CRM_Custom_Import_Parser_ApiTest extends CiviUnitTestCase {
 
   /**
    * Test the full form-flow import.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testImport(): void {
     $this->individualCreate();

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -49,10 +49,20 @@ trait CRMTraits_Import_ParserTrait {
     $form->buildForm();
     $this->assertTrue($form->validate());
     $form->postProcess();
+    $this->submitPreviewForm($submittedValues);
+  }
+
+  /**
+   * Submit the preview form, triggering the import.
+   *
+   * @param array $submittedValues
+   */
+  protected function submitPreviewForm(array $submittedValues): void {
     $form = $this->getPreviewForm($submittedValues);
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
     $this->assertTrue($form->validate());
+
     try {
       $form->postProcess();
       $this->fail('Expected a redirect');


### PR DESCRIPTION
Overview
----------------------------------------
Fix import to support entity_configuration

Before
----------------------------------------
It is not possible to import a contribution & contact together

After
----------------------------------------
It is possible at the parser level, however the Quickform form does not allow it to be configured - this will be available through an extension leap / angular form with a similar process to the export leap

Technical Details
----------------------------------------

Comments
----------------------------------------
Note related changes are in the rc so will prob target the rc - once I can see this is passing
