### PR TITLE
Deprecate handling for removed silly constant

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -275,7 +275,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $processor->setMappingID((int) $this->getSubmittedValue('savedMapping'));
     $processor->setFormName($formName);
     $processor->setMetadata($this->getContactImportMetadata());
-    $processor->setContactTypeByConstant($this->getSubmittedValue('contactType'));
+    $processor->setContactType($this->getSubmittedValue('contactType'));
     $processor->setContactSubType($this->getSubmittedValue('contactSubType'));
     $mapper = $this->getSubmittedValue('mapper');
 

--- a/CRM/Import/ImportProcessor.php
+++ b/CRM/Import/ImportProcessor.php
@@ -212,9 +212,12 @@ class CRM_Import_ImportProcessor {
   /**
    * Set the contact type  according to the constant.
    *
+   * @deprecated
+   *
    * @param int $contactTypeKey
    */
   public function setContactTypeByConstant($contactTypeKey) {
+    CRM_Core_Error::deprecatedFunctionWarning('no replacement');
     $constantTypeMap = [
       'Individual' => 'Individual',
       'Household' => 'Household',

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -226,9 +226,6 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     $this->assertEquals('street_address', $processor->getFieldName(3));
     $this->assertEquals($this->getCustomFieldName('text'), $processor->getFieldName(4));
     $this->assertEquals('url', $processor->getFieldName(8));
-
-    $processor->setContactTypeByConstant('Household');
-    $this->assertEquals('Household', $processor->getContactType());
   }
 
   /**
@@ -346,7 +343,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
     $processor->setMappingID($mappingID);
     $processor->setFormName('document.forms.MapField');
     $processor->setMetadata($this->getContactImportMetadata());
-    $processor->setContactTypeByConstant('Individual');
+    $processor->setContactType('Individual');
 
     $defaults = [];
     $defaults["mapper[$columnNumber]"] = $processor->getSavedQuickformDefaultsForColumn($columnNumber);


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate handling for removed silly constant

Before
----------------------------------------
These two functions now do exactly the same thing -  as the constant now === the contactType
```
 $processor->setContactTypeByConstant($this->getSubmittedValue('contactType'));
 $processor->setContactType($this->getSubmittedValue('contactType'));
```

After
----------------------------------------
No more calls to ` $processor->setContactTypeByConstant($this->getSubmittedValue('contactType'));` - it is deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------