### PR TITLE
dev/core#3847 Display id of missing custom field in error message

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -660,7 +660,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     if (empty($fieldValues)) {
       $field->id = $fieldID;
       if (!$field->find(TRUE)) {
-        throw new CRM_Core_Exception('Cannot find Custom Field');
+        throw new CRM_Core_Exception('Cannot find Custom Field ' . $fieldID);
       }
 
       $fieldValues = [];


### PR DESCRIPTION
Overview
----------------------------------------
Always easier to find the needle if you know the right haystack
https://lab.civicrm.org/dev/core/-/issues/3847

Before
----------------------------------------
`Error message shows: Cannot find Custom Field`

After
----------------------------------------
`Cannot find Custom Field with id 1234`
