### PR TITLE
SearchKit - Respect currency when formatting monetary fields

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -132,14 +132,14 @@ trait SavedSearchInspectorTrait {
           'expr' => $expr,
           'dataType' => $expr->getDataType(),
         ];
-        foreach ($expr->getFields() as $fieldName) {
-          $fieldMeta = $this->getField($fieldName);
+        foreach ($expr->getFields() as $fieldAlias) {
+          $fieldMeta = $this->getField($fieldAlias);
           if ($fieldMeta) {
-            $item['fields'][] = $fieldMeta;
+            $item['fields'][$fieldAlias] = $fieldMeta;
           }
         }
         if (!isset($item['dataType']) && $item['fields']) {
-          $item['dataType'] = $item['fields'][0]['data_type'];
+          $item['dataType'] = \CRM_Utils_Array::first($item['fields'])['data_type'];
         }
         $this->_selectClause[$expr->getAlias()] = $item;
       }
@@ -152,6 +152,7 @@ trait SavedSearchInspectorTrait {
    * @return array{fields: array, expr: SqlExpression, dataType: string}|NULL
    */
   protected function getSelectExpression($key) {
+    $key = explode(' AS ', $key)[1] ?? $key;
     return $this->getSelectClause()[$key] ?? NULL;
   }
 

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -172,6 +172,16 @@ abstract class SqlExpression {
   }
 
   /**
+   * Checks the name of this sql expression class.
+   *
+   * @param $type
+   * @return bool
+   */
+  public function isType($type): bool {
+    return $this->getType() === $type;
+  }
+
+  /**
    * @return string
    */
   abstract public static function getTitle(): string;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -972,6 +972,19 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         }
       }
     }
+    // If the base entity has a field named 'currency', fall back on that.
+    if ($this->getField('currency')) {
+      return 'currency';
+    }
+    // Finally, if there's a FK field to civicrm_contribution, we can use an implicit join
+    // E.G. the LineItem entity has no `currency` field of its own & uses that of the contribution record
+    if ($entityDao) {
+      foreach ($entityDao::getSupportedFields() as $fieldName => $field) {
+        if (($field['FKClassName'] ?? NULL) === 'CRM_Contribute_DAO_Contribution') {
+          return $prefix . $fieldName . '.currency';
+        }
+      }
+    }
     return NULL;
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -775,7 +775,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
       case 'Money':
         $currencyField = $this->getCurrencyField($key);
-        $formatted = \CRM_Utils_Money::format($rawValue, $data[$currencyField] ?? NULL);
+        $currency = is_string($data[$currencyField] ?? NULL) ? $data[$currencyField] : NULL;
+        $formatted = \Civi::format()->money($rawValue, $currency);
         break;
 
       case 'Date':

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1,6 +1,10 @@
 <?php
 namespace api\v4\SearchDisplay;
 
+// Not sure why this is needed but without it Jenkins crashed
+require_once __DIR__ . '/../../../../../../../tests/phpunit/api/v4/Api4TestBase.php';
+
+use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
@@ -10,13 +14,12 @@ use Civi\Api4\Phone;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\SearchDisplay;
 use Civi\Api4\UFMatch;
-use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+class SearchRunTest extends Api4TestBase implements TransactionalInterface {
   use \Civi\Test\ACLPermissionTrait;
 
   public function setUpHeadless() {
@@ -1355,6 +1358,44 @@ class SearchRunTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertTrue(!isset($result[3]['columns'][0]['edit']));
     $this->assertTrue(!isset($result[3]['columns'][1]['edit']));
     $this->assertEquals($expectedFirstNameEdit, $result[3]['columns'][2]['edit']);
+  }
+
+  public function testContributionCurrency():void {
+    $contributions = $this->saveTestRecords('Contribution', [
+      'records' => [
+        ['total_amount' => 100, 'currency' => 'GBP'],
+        ['total_amount' => 200, 'currency' => 'USD'],
+        ['total_amount' => 500, 'currency' => 'JPY'],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contribution',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['total_amount'],
+          'where' => [['id', 'IN', $contributions->column('id')]],
+        ],
+      ],
+      'display' => NULL,
+      'sort' => [['id', 'ASC']],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(3, $result);
+
+    // Currency should have been fetched automatically and used to format the value
+    $this->assertEquals('GBP', $result[0]['data']['currency']);
+    $this->assertEquals('£ 100.00', $result[0]['columns'][0]['val']);
+
+    $this->assertEquals('USD', $result[1]['data']['currency']);
+    $this->assertEquals('$ 200.00', $result[1]['columns'][0]['val']);
+
+    $this->assertEquals('JPY', $result[2]['data']['currency']);
+    $this->assertEquals('¥ 500.00', $result[2]['columns'][0]['val']);
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1389,13 +1389,13 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
     // Currency should have been fetched automatically and used to format the value
     $this->assertEquals('GBP', $result[0]['data']['currency']);
-    $this->assertEquals('£ 100.00', $result[0]['columns'][0]['val']);
+    $this->assertEquals('£100.00', $result[0]['columns'][0]['val']);
 
     $this->assertEquals('USD', $result[1]['data']['currency']);
-    $this->assertEquals('$ 200.00', $result[1]['columns'][0]['val']);
+    $this->assertEquals('$200.00', $result[1]['columns'][0]['val']);
 
     $this->assertEquals('JPY', $result[2]['data']['currency']);
-    $this->assertEquals('¥ 500.00', $result[2]['columns'][0]['val']);
+    $this->assertEquals('¥500', $result[2]['columns'][0]['val']);
 
     // Now do a search for the contribution line-items
     $params['savedSearch'] = [
@@ -1412,13 +1412,13 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
     // An automatic join should have been added to fetch the contribution currency
     $this->assertEquals('GBP', $result[0]['data']['contribution_id.currency']);
-    $this->assertEquals('£ 100.00', $result[0]['columns'][0]['val']);
+    $this->assertEquals('£100.00', $result[0]['columns'][0]['val']);
 
     $this->assertEquals('USD', $result[1]['data']['contribution_id.currency']);
-    $this->assertEquals('$ 200.00', $result[1]['columns'][0]['val']);
+    $this->assertEquals('$200.00', $result[1]['columns'][0]['val']);
 
     $this->assertEquals('JPY', $result[2]['data']['contribution_id.currency']);
-    $this->assertEquals('¥ 500.00', $result[2]['columns'][0]['val']);
+    $this->assertEquals('¥500', $result[2]['columns'][0]['val']);
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1396,6 +1396,29 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
     $this->assertEquals('JPY', $result[2]['data']['currency']);
     $this->assertEquals('¥ 500.00', $result[2]['columns'][0]['val']);
+
+    // Now do a search for the contribution line-items
+    $params['savedSearch'] = [
+      'api_entity' => 'LineItem',
+      'api_params' => [
+        'version' => 4,
+        'select' => ['line_total'],
+        'where' => [['contribution_id', 'IN', $contributions->column('id')]],
+      ],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(3, $result);
+
+    // An automatic join should have been added to fetch the contribution currency
+    $this->assertEquals('GBP', $result[0]['data']['contribution_id.currency']);
+    $this->assertEquals('£ 100.00', $result[0]['columns'][0]['val']);
+
+    $this->assertEquals('USD', $result[1]['data']['contribution_id.currency']);
+    $this->assertEquals('$ 200.00', $result[1]['columns'][0]['val']);
+
+    $this->assertEquals('JPY', $result[2]['data']['contribution_id.currency']);
+    $this->assertEquals('¥ 500.00', $result[2]['columns'][0]['val']);
   }
 
 }

--- a/release-notes/5.18.0.md
+++ b/release-notes/5.18.0.md
@@ -259,7 +259,7 @@ Released October 2, 2019
   ([dev/core#1188](https://lab.civicrm.org/dev/core/issues/1188):
   [15043](https://github.com/civicrm/civicrm-core/pull/15043))**
 
-  Ensures that the Psalm Autoloader can find `CiviCRM_API3_Exception`.
+  Ensures that the Psalm Autoloader can find `CRM_Core_Exception`.
 
 - **File attachment uploads - pptx issue
   ([dev/core#1190](https://lab.civicrm.org/dev/core/issues/1190):


### PR DESCRIPTION
Overview
----------------------------------------
This fixes SearchKit to correctly format a monetary amount when it's different than the site default currency.
Fixes: https://lab.civicrm.org/dev/core/-/issues/3428

Before
----------------------------------------
All amounts were shown in the site default (e.g. USD) instead of the correct currency.
![image](https://user-images.githubusercontent.com/2874912/190493156-39785981-7669-4066-a104-9f0782a8477d.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/190633059-634966a4-ad40-4784-9569-2c28e67f06a0.png)


Technical Details
----------------------------------------
This supports entities who have their own `currency` column. ~This excludes line_item~ I've fixed `LineItem` so it now works by pulling in a join from the associated `Contribution` record to look up the currency.