### PR TITLE
[REF] DAO - Add helper function to check if component is enabled

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -500,7 +500,7 @@ class CRM_Activity_BAO_Query {
     // Add engagement level CRM-7775.
     $buildEngagementLevel = FALSE;
     $buildSurveyResult = FALSE;
-    if (CRM_Campaign_BAO_Campaign::isCampaignEnable() &&
+    if (CRM_Campaign_BAO_Campaign::isComponentEnabled() &&
       CRM_Campaign_BAO_Campaign::accessCampaign()
     ) {
       $buildEngagementLevel = TRUE;

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -683,7 +683,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // Add engagement level CRM-7775
     $buildEngagementLevel = FALSE;
-    if (CRM_Campaign_BAO_Campaign::isCampaignEnable() &&
+    if (CRM_Campaign_BAO_Campaign::isComponentEnabled() &&
       CRM_Campaign_BAO_Campaign::accessCampaign()
     ) {
       $buildEngagementLevel = TRUE;
@@ -698,7 +698,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
     // check for survey activity
     $this->_isSurveyActivity = FALSE;
 
-    if ($this->_activityId && CRM_Campaign_BAO_Campaign::isCampaignEnable() &&
+    if ($this->_activityId && CRM_Campaign_BAO_Campaign::isComponentEnabled() &&
       CRM_Campaign_BAO_Campaign::accessCampaign()
     ) {
 

--- a/CRM/Campaign/BAO/Campaign.php
+++ b/CRM/Campaign/BAO/Campaign.php
@@ -255,7 +255,7 @@ Order By  camp.title";
 
       //do check for component.
       if ($doCheckForComponent) {
-        $campaigns['isCampaignEnabled'] = $isValid = self::isCampaignEnable();
+        $campaigns['isCampaignEnabled'] = $isValid = self::isComponentEnabled();
       }
 
       //do check for permissions.
@@ -283,11 +283,12 @@ Order By  camp.title";
 
   /**
    * Is CiviCampaign enabled.
-   *
+   * @deprecated
    * @return bool
    */
   public static function isCampaignEnable(): bool {
-    return CRM_Core_Component::isEnabled('CiviCampaign');
+    CRM_Core_Error::deprecatedFunctionWarning('isComponentEnabled');
+    return self::isComponentEnabled();
   }
 
   /**

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -30,11 +30,12 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
 
   /**
    * Is CiviCase enabled?
-   *
+   * @deprecated
    * @return bool
    */
   public static function enabled() {
-    return CRM_Core_Component::isEnabled('CiviCase');
+    CRM_Core_Error::deprecatedFunctionWarning('isComponentEnabled');
+    return self::isComponentEnabled();
   }
 
   /**
@@ -63,7 +64,7 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
    */
   public static function on_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
     // FIXME: The EventScanner ought to skip over disabled components when registering HookInterface
-    if (!CRM_Core_Component::isEnabled('CiviCase')) {
+    if (!self::isComponentEnabled()) {
       return;
     }
     if ($e->entity === 'Activity' && in_array($e->action, ['create', 'edit'])) {
@@ -2467,7 +2468,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
     }
 
     //do check for civicase component enabled.
-    if ($checkComponent && !self::enabled()) {
+    if ($checkComponent && !self::isComponentEnabled()) {
       return $allow;
     }
 
@@ -2709,7 +2710,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
    * or 'access all cases and activities'
    */
   public static function accessCiviCase() {
-    if (!self::enabled()) {
+    if (!self::isComponentEnabled()) {
       return FALSE;
     }
 
@@ -2732,7 +2733,7 @@ WHERE id IN (' . implode(',', $copiedActivityIds) . ')';
    * @return bool
    */
   public static function accessCase($caseId, $denyClosed = TRUE) {
-    if (!$caseId || !self::enabled()) {
+    if (!$caseId || !self::isComponentEnabled()) {
       return FALSE;
     }
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2164,7 +2164,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $form->add('textarea', $name, $title, CRM_Core_DAO::getAttribute('CRM_Core_DAO_Email', $fieldName));
     }
     elseif (substr($fieldName, -11) == 'campaign_id') {
-      if (CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
+      if (CRM_Campaign_BAO_Campaign::isComponentEnabled()) {
         $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(CRM_Utils_Array::value($contactId,
           $form->_componentCampaigns
         ));

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3366,4 +3366,14 @@ SELECT contact_id
     $this->name = $name . $suffix;
   }
 
+  /**
+   * Check if component is enabled for this DAO class
+   *
+   * @return bool
+   */
+  public static function isComponentEnabled(): bool {
+    $daoName = static::class;
+    return !defined("$daoName::COMPONENT") || CRM_Core_Component::isEnabled($daoName::COMPONENT);
+  }
+
 }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -409,7 +409,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     // 'not a real field' offered up by case - seems like an oddity
     // we should skip at the top level for now.
     $fields = ['tags'];
-    if (!CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
+    if (!CRM_Campaign_BAO_Campaign::isComponentEnabled()) {
       $fields[] = 'campaign_id';
     }
     return $fields;

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -504,7 +504,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
 
     foreach (CRM_Core_DAO_AllCoreTables::daoToClass() as $entity => $daoName) {
       // Skip DAOs of disabled components
-      if (defined("$daoName::COMPONENT") && !CRM_Core_Component::isEnabled($daoName::COMPONENT)) {
+      if (!$daoName::isComponentEnabled()) {
         continue;
       }
       $baoName = str_replace('_DAO_', '_BAO_', $daoName);

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -162,7 +162,7 @@ class CRM_Mailing_Selector_Browse extends CRM_Core_Selector_Base implements CRM_
         ]
       );
 
-      if (CRM_Campaign_BAO_Campaign::isCampaignEnable()) {
+      if (CRM_Campaign_BAO_Campaign::isComponentEnabled()) {
         self::$_columnHeaders[] = [
           'name' => ts('Campaign'),
           'sort' => 'campaign_id',

--- a/CRM/Utils/Check/Component/Case.php
+++ b/CRM/Utils/Check/Component/Case.php
@@ -40,7 +40,7 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
    * @inheritDoc
    */
   public function isEnabled() {
-    return CRM_Case_BAO_Case::enabled();
+    return CRM_Case_BAO_Case::isComponentEnabled();
   }
 
   /**

--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -52,7 +52,7 @@ class Request {
         }
         // Check enabled components
         $daoName = \CRM_Core_DAO_AllCoreTables::getFullName($entity);
-        if ($daoName && defined("{$daoName}::COMPONENT") && !\CRM_Core_Component::isEnabled($daoName::COMPONENT)) {
+        if ($daoName && !$daoName::isComponentEnabled()) {
           throw new \Civi\API\Exception\NotImplementedException("$entity API is not available because " . $daoName::COMPONENT . " component is disabled");
         }
         $args = (array) CoreUtil::getInfoItem($entity, 'class_args');

--- a/Civi/Api4/Action/Entity/Get.php
+++ b/Civi/Api4/Action/Entity/Get.php
@@ -35,7 +35,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
     return array_filter($provider->getEntities(), function($entity) {
       // Only include DAO entities from enabled components
       $daoName = $entity['dao'] ?? NULL;
-      return (!$daoName || !defined("{$daoName}::COMPONENT") || \CRM_Core_Component::isEnabled($daoName::COMPONENT));
+      return (!$daoName || $daoName::isComponentEnabled());
     });
   }
 

--- a/templates/CRM/Activity/Form/ActivityView.tpl
+++ b/templates/CRM/Activity/Form/ActivityView.tpl
@@ -36,7 +36,7 @@
         {/if}
 
   {if $values.engagement_level AND
-      call_user_func( array( 'CRM_Campaign_BAO_Campaign', 'isCampaignEnable' ) )}
+      call_user_func( array( 'CRM_Campaign_BAO_Campaign', 'isComponentEnabled' ) )}
       <td class="label">{ts}Engagement Level{/ts}</td><td class="view-value">{$values.engagement_level}</td>
   {/if}
 

--- a/templates/CRM/Contribute/Page/ContributionPage.tpl
+++ b/templates/CRM/Contribute/Page/ContributionPage.tpl
@@ -37,7 +37,7 @@
                  <th>{ts}Title{/ts}</th>
                <th>{ts}ID{/ts}</th>
                <th>{ts}Enabled?{/ts}</th>
-             {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
+             {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
              <th>{ts}Campaign{/ts}</th>
             {/if}
             <th></th>
@@ -48,7 +48,7 @@
                      <td><strong>{$row.title}</strong></td>
                      <td>{$row.id}</td>
                      <td id="row_{$row.id}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-          {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
+          {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
           <td>{$row.campaign}</td>
           {/if}
           <td class="crm-contribution-page-actions right nowrap">

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -41,7 +41,7 @@
         <th>{ts}Public?{/ts}</th>
         <th>{ts}Starts{/ts}</th>
         <th>{ts}Ends{/ts}</th>
-        {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
+        {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
           <th>{ts}Campaign{/ts}</th>
         {/if}
         <th>{ts}Active?{/ts}</th>
@@ -64,7 +64,7 @@
           <td class="crm-event-is_public">{if $row.is_public eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td class="crm-event-start_date" data-order="{$row.start_date|crmDate:'%Y-%m-%d'}">{$row.start_date|crmDate:"%b %d, %Y %l:%M %P"}</td>
           <td class="crm-event-end_date" data-order="{$row.end_date|crmDate:'%Y-%m-%d'}">{$row.end_date|crmDate:"%b %d, %Y %l:%M %P"}</td>
-          {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
+          {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
             <td class="crm-event-campaign">{$row.campaign}</td>
           {/if}
           <td class="crm-event_status" id="row_{$row.id}_status">

--- a/templates/CRM/Mailing/Page/Browse.tpl
+++ b/templates/CRM/Mailing/Page/Browse.tpl
@@ -67,7 +67,7 @@
         <td class="crm-mailing-scheduled">{$row.scheduled}</td>
         <td class="crm-mailing-start">{$row.start}</td>
         <td class="crm-mailing-end">{$row.end}</td>
-       {if call_user_func(array('CRM_Campaign_BAO_Campaign','isCampaignEnable'))}
+       {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
           <td class="crm-mailing-campaign">{$row.campaign}</td>
       {/if}
         <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a helper function to make it easier to check if a DAO or BAO file belongs to a disabled component.

Before
----------------------------------------
A couple add-hoc functions in CiviCase & CiviCampaign

After
----------------------------------------
Deprecated those in favor of central function that works for every BAO & DAO.

Technical Details
----------------------------------------
Yay for late-static binding.

Comments
--------------
This is covered by APIv4 tests.