### PR TITLE
Remove call to deprecated `CRM_Contribute_PseudoConstant::contributionStatus`

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -353,7 +353,7 @@ DESC limit 1");
 
     $subscriptionCancelled = FALSE;
     if (!empty($defaults['id'])) {
-      $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled($this->_id);
+      $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled((int) $this->_id);
     }
 
     $alreadyAutoRenew = FALSE;
@@ -1562,7 +1562,7 @@ DESC limit 1");
     if ($this->_action & CRM_Core_Action::UPDATE
       && CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->getEntityId(),
         'contribution_recur_id')
-      && !CRM_Member_BAO_Membership::isSubscriptionCancelled($this->getEntityId())) {
+      && !CRM_Member_BAO_Membership::isSubscriptionCancelled((int) $this->getEntityId())) {
 
       $isRecur = TRUE;
     }

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -399,7 +399,7 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
       $values['membership_type'] = CRM_Core_TestEntity::appendTestText($values['membership_type']);
     }
 
-    $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled($this->membershipID);
+    $subscriptionCancelled = CRM_Member_BAO_Membership::isSubscriptionCancelled((int) $this->membershipID);
     $values['auto_renew'] = ($autoRenew && !$subscriptionCancelled) ? 'Yes' : 'No';
 
     //do check for campaigns

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -167,7 +167,7 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
 
       // Display Auto-renew status on page (0=disabled, 1=enabled, 2=enabled, but error
       if (!empty($membership[$dao->id]['contribution_recur_id'])) {
-        if (CRM_Member_BAO_Membership::isSubscriptionCancelled($membership[$dao->id]['membership_id'])) {
+        if (CRM_Member_BAO_Membership::isSubscriptionCancelled((int) $membership[$dao->id]['membership_id'])) {
           $membership[$dao->id]['auto_renew'] = 2;
         }
         else {

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -423,7 +423,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
 
       // Display Auto-renew status on page (0=disabled, 1=enabled, 2=enabled, but error
       if (!empty($result->membership_recur_id)) {
-        if (CRM_Member_BAO_Membership::isSubscriptionCancelled($row['membership_id'])) {
+        if (CRM_Member_BAO_Membership::isSubscriptionCancelled((int) $row['membership_id'])) {
           $row['auto_renew'] = 2;
         }
         else {

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1583,15 +1583,12 @@ Expires: ',
   /**
    * Test Membership Payment owned by other contact, membership view should show all contribution records in listing.
    * is other contact.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \Exception
    */
-  public function testMembershipViewContributionOwnerDifferent() {
+  public function testMembershipViewContributionOwnerDifferent(): void {
     // Membership Owner
     $contactId1 = $this->individualCreate();
 
-    // Contribution Onwer
+    // Contribution Owner
     $contactId2 = $this->individualCreate();
 
     // create new membership type
@@ -1608,7 +1605,7 @@ Expires: ',
       'financial_type_id' => 2,
     ]);
 
-    // create Membership
+    // Create Membership.
     $membershipId = $this->contactMembershipCreate([
       'contact_id' => $contactId1,
       'membership_type_id' => $membershipTypeAnnualFixed['id'],
@@ -1616,24 +1613,24 @@ Expires: ',
     ]);
 
     // 1st Payment
-    $contriParams = [
+    $contributionParams = [
       'membership_id' => $membershipId,
       'total_amount' => 25,
       'financial_type_id' => 2,
       'contact_id' => $contactId2,
       'receive_date' => '2020-08-08',
     ];
-    $contribution1 = CRM_Member_BAO_Membership::recordMembershipContribution($contriParams);
+    $contribution1 = CRM_Member_BAO_Membership::recordMembershipContribution($contributionParams);
 
     // 2nd Payment
-    $contriParams = [
+    $contributionParams = [
       'membership_id' => $membershipId,
       'total_amount' => 25,
       'financial_type_id' => 2,
       'contact_id' => $contactId2,
       'receive_date' => '2020-07-08',
     ];
-    $contribution2 = CRM_Member_BAO_Membership::recordMembershipContribution($contriParams);
+    $contribution2 = CRM_Member_BAO_Membership::recordMembershipContribution($contributionParams);
 
     // View Membership record
     $membershipViewForm = new CRM_Member_Form_MembershipView();
@@ -1643,7 +1640,7 @@ Expires: ',
     $membershipViewForm->controller->setEmbedded(TRUE);
     $membershipViewForm->preProcess();
 
-    // get contribution rows related to membership payments
+    // Get contribution rows related to membership payments.
     $templateVar = $membershipViewForm::getTemplate()->get_template_vars('rows');
 
     $this->assertEquals($templateVar[0]['contribution_id'], $contribution1->id);
@@ -1651,7 +1648,7 @@ Expires: ',
 
     $this->assertEquals($templateVar[1]['contribution_id'], $contribution2->id);
     $this->assertEquals($templateVar[1]['contact_id'], $contactId2);
-    $this->assertEquals(count($templateVar), 2);
+    $this->assertCount(2, $templateVar);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove call to deprecated `CRM_Contribute_PseudoConstant::contributionStatus`

Before
----------------------------------------
Legacy function used ``CRM_Contribute_PseudoConstant::contributionStatus``

After
----------------------------------------
api does the work

Technical Details
----------------------------------------
Test cover in 
`testMembershipViewContributionOwnerDifferent`

Will be hit in https://github.com/civicrm/civicrm-core/pull/24529

Comments
----------------------------------------
@seamuslee001 