### PR TITLE
Remove references to old temp table names

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -39,7 +39,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
       ts('Settings - %1 Integration', [1 => $this->_uf])
     );
 
-    if ($this->_uf == 'WordPress') {
+    if ($this->_uf === 'WordPress') {
       $this->_settings['wpBasePage'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
       $this->assign('wpBasePageEnabled', TRUE);
     }
@@ -50,7 +50,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
     }
 
     // find out if drupal has its database prefixed
-    if ($this->_uf == 'Drupal8') {
+    if ($this->_uf === 'Drupal8') {
       $databases['default'] = Drupal\Core\Database\Database::getConnectionInfo('default');
     }
     else {

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -323,7 +323,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
   /**
    * Clear db cache.
    */
-  public static function clearDBCache() {
+  public static function clearDBCache(): void {
     $queries = [
       'TRUNCATE TABLE civicrm_acl_cache',
       'TRUNCATE TABLE civicrm_acl_contact_cache',
@@ -356,20 +356,15 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    *   Optional time interval for mysql date function.g '2 day'. This can be used to prevent
    *   tables created recently from being deleted.
    */
-  public static function clearTempTables($timeInterval = FALSE) {
+  public static function clearTempTables($timeInterval = FALSE): void {
 
     $dao = new CRM_Core_DAO();
     $query = "
       SELECT TABLE_NAME as tableName
       FROM   INFORMATION_SCHEMA.TABLES
       WHERE  TABLE_SCHEMA = %1
-      AND (
-        TABLE_NAME LIKE 'civicrm_import_job_%'
-        OR TABLE_NAME LIKE 'civicrm_report_temp%'
-        OR TABLE_NAME LIKE 'civicrm_tmp_d%'
-        )
+      AND TABLE_NAME LIKE 'civicrm_tmp_d%'
     ";
-    // NOTE: Cannot find use-cases where "civicrm_report_temp" would be durable. Could probably remove.
 
     if ($timeInterval) {
       $query .= " AND CREATE_TIME < DATE_SUB(NOW(), INTERVAL {$timeInterval})";

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1079,16 +1079,16 @@ class CRM_Core_DAO extends DB_DataObject {
    *
    * @return array
    */
-  public static function getTableNames() {
+  public static function getTableNames(): array {
     $dao = CRM_Core_DAO::executeQuery(
       "SELECT TABLE_NAME
        FROM information_schema.TABLES
        WHERE TABLE_SCHEMA = '" . CRM_Core_DAO::getDatabaseName() . "'
          AND TABLE_NAME LIKE 'civicrm_%'
-         AND TABLE_NAME NOT LIKE 'civicrm_import_job_%'
-         AND TABLE_NAME NOT LIKE '%_temp%'
+         AND TABLE_NAME NOT LIKE '%_tmp%'
       ");
 
+    $values = [];
     while ($dao->fetch()) {
       $values[] = $dao->TABLE_NAME;
     }
@@ -1107,8 +1107,6 @@ class CRM_Core_DAO extends DB_DataObject {
        WHERE ENGINE = 'MyISAM'
          AND TABLE_SCHEMA = '" . CRM_Core_DAO::getDatabaseName() . "'
          AND TABLE_NAME LIKE 'civicrm_%'
-         AND TABLE_NAME NOT LIKE 'civicrm_import_job_%'
-         AND TABLE_NAME NOT LIKE '%_temp%'
          AND TABLE_NAME NOT LIKE 'civicrm_tmp_%'
       ");
   }

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -142,12 +142,13 @@ AND    TABLE_NAME LIKE 'civicrm_%'
     }
 
     // do not log temp import, cache, menu and log tables
-    $this->tables = preg_grep('/^civicrm_import_job_/', $this->tables, PREG_GREP_INVERT);
     $this->tables = preg_grep('/_cache$/', $this->tables, PREG_GREP_INVERT);
     $this->tables = preg_grep('/_log/', $this->tables, PREG_GREP_INVERT);
     $this->tables = preg_grep('/^civicrm_queue_/', $this->tables, PREG_GREP_INVERT);
     //CRM-14672
     $this->tables = preg_grep('/^civicrm_menu/', $this->tables, PREG_GREP_INVERT);
+    // CiviCRM no longer creates temp tables with `_temp` - they are `tmp` - but this is being left in
+    // in case extensions do - since we don't want to suddenly start logging them.
     $this->tables = preg_grep('/_temp_/', $this->tables, PREG_GREP_INVERT);
     // CRM-18178
     $this->tables = preg_grep('/_bak$/', $this->tables, PREG_GREP_INVERT);


### PR DESCRIPTION
Overview
----------------------------------------
Remove references to old temp table names

Before
----------------------------------------
References to old-style names for temp tables

After
----------------------------------------
poof

Technical Details
----------------------------------------
We used to have multiple naming conventions for temp tables but now they all use the `civicrm_tmp_...` naming so we can remove the old references where were from reports & imports 
```
   TABLE_NAME LIKE 'civicrm_import_job_%'
   TABLE_NAME LIKE 'civicrm_report_temp%'
```

In most of these cases the only usage is cleanup/ system check related & hence low-impact - but the last one is logging so I took a more conservative approach there - in order to protect any extensions that might be creating tables with _temp in the name. (It's OK if they stop being cleaned up - it might push them to use the TemporaryTable class but not ok to suddely start logging them)

Comments
----------------------------------------
I've targetted the rc as I'm going to follow on with a patch against the rc to stop over-aggressive removal of import temp tables