### PR TITLE
Stop removing Import tables during cache clearing

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -377,8 +377,14 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     }
     if (!empty($tables)) {
       $table = implode(',', $tables);
-      // drop leftover temporary tables
-      CRM_Core_DAO::executeQuery("DROP TABLE $table");
+      // If a User Job references the table do not drop it. This is a bit quick & dirty but we don't want to
+      // get into calling more sophisticated functions in a cache clear and the table names are pretty unique.
+      // A separate process will reap the UserJobs but here the goal is just not to delete them during cache clearing
+      // if they are still referenced.
+      if (!CRM_Core_DAO::executeQuery("SELECT count(*) FROM civicrm_user_job WHERE metadata LIKE '%" . $tableDAO->tableName . "%'")) {
+        // drop leftover temporary tables
+        CRM_Core_DAO::executeQuery("DROP TABLE $table");
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop removing Import tables during cache clearing

Before
----------------------------------------
Calling `clearTempTables` deletes all tables like `civicrm_tmp%`  - including ones still referenced in `civicrm_user_job`

After
----------------------------------------
Tables referenced in `civicrm_user_job` are not removed

Technical Details
----------------------------------------
Removing tables in CiviCRM user Job can cause hard-errors when the `civiimport` extension is enabled. In addition the two should be managed together - ie if we delete UserJobs that have expired via api then we can remove the tables in the delete hook (& any orphans would still be picked up by this)

I'm not totally sure about how the UserJob reaper would look - it's own api that can be scheduled - in which case does it need to be v3? Or just a function that gets called during the cache clear but is not this one

Comments
----------------------------------------
@totten - this is a first step which stops the over-flushing - I also need to add a way to remove userJobs that have passed their expires date but I wasn't planning to do it in this PR
