### PR TITLE
Pass correct variable type to CRM_Core_OptionValue::getValues

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -179,6 +179,7 @@ class CRM_Core_I18n {
     static $enabled = NULL;
 
     if (!$all) {
+      $optionValues = [];
       // Use `getValues`, not `buildOptions` to bypass hook_civicrm_fieldOptions.  See core#1132.
       CRM_Core_OptionValue::getValues(['name' => 'languages'], $optionValues, 'weight', TRUE);
       $all = array_column($optionValues, 'label', 'name');


### PR DESCRIPTION
Overview
----------------------------------------
Pass correct variable type to CRM_Core_OptionValue::getValues

Before
----------------------------------------
This PR https://github.com/civicrm/civicrm-core/pull/24538 has triggered an error that is clearly should not be triggerable (perhaps it should fail in some other way but not this)
Fatal error: Uncaught TypeError: array_column(): Argument #1 ($array) must be of type array, null given in /home/jenkins/bknix-dfl/build/core-24538-8t3as/web/sites/all/modules/civicrm/CRM/Core/I18n.php on line 184

TypeError: array_column(): Argument #1 ($array) must be of type array, null given in /home/jenkins/bknix-dfl/build/core-24538-8t3as/web/sites/all/modules/civicrm/CRM/Core/I18n.php on line 184

After
----------------------------------------
We instantiate `$optionValues` as the right variable type (an array) before passing by reference

Technical Details
----------------------------------------
I need to check out the other separately but this is a clear code smell / trap in the code

Comments
----------------------------------------
