### PR TITLE
Flush old user jobs

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -19,6 +19,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\UserJob;
+
 require_once 'Log.php';
 require_once 'Mail.php';
 
@@ -266,7 +268,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
   public function cleanupCaches($sessionReset = TRUE) {
     // cleanup templates_c directory
     $this->cleanup(1, FALSE);
-
+    UserJob::delete(FALSE)->addWhere('expires_date', '<', 'now')->execute();
     // clear all caches
     self::clearDBCache();
     Civi::cache('session')->clear();


### PR DESCRIPTION
Overview
----------------------------------------
Flush old user jobs

This will remove on UserJob entries & the api will be removed - the SavedSearches will linger until a reconcile runs & we should come up with something better to do that more often - maybe that could be the scheduled job? But for the rc I think it's urgent that https://github.com/civicrm/civicrm-core/pull/24538 is merged & with this there should be no crashing UNLESS the specific packaged search is hit. Another mitigation is that the searches themselves 'expire' based on the expires_date so we may not need to do more.

Before
----------------------------------------


After
----------------------------------------

Technical Details
----------------------------------------


Comments
----------------------------------------
@totten we can go ahead with thi s& the other as is I think
