### PR TITLE
dev/core#3852 - Classload extension test folders during tests

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -164,6 +164,11 @@ class CRM_Extension_ClassLoader {
 
           case 'psr4':
             $loader->addPsr4($mapping['prefix'], $path . '/' . $mapping['path']);
+            if (defined('CIVICRM_TEST')) {
+              if (is_dir($path . '/tests/phpunit/' . $mapping['path'])) {
+                $loader->addPsr4($mapping['prefix'], $path . '/tests/phpunit/' . $mapping['path']);
+              }
+            }
             break;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3852

Before
----------------------------------------
Some extension actions like install fail if class scanning tries to scan them during tests.

After
----------------------------------------


Technical Details
----------------------------------------
Scanning runs more often after https://github.com/civicrm/civicrm-core/pull/24276, and the test folders weren't included in classloading.

Comments
----------------------------------------
I could include the unit test from the lab ticket, but it's a bit of a goofy test. Trying to think of something more likely to see in real life.
For what it's worth the drupal/mink tests now pass with this applied: e.g. https://github.com/SemperIT/CiviCARROT/actions/runs/3073761641/jobs/4966094386#step:19:4
