### PR TITLE
dev/core#3853 - Still need the exception aliases

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -158,6 +158,7 @@ class Kernel {
    * @throws \CRM_Core_Exception
    */
   public function boot($apiRequest) {
+    require_once 'api/Exception.php';
     // the create error function loads some functions from utils
     // so this require is also needed for apiv4 until such time as
     // we alter create error.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3853

Before
----------------------------------------
* Can't install civirules.
* Or any code that references API3_Exception or CiviCRM_API3_Exception probably doesn't work as expected.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
One way to quickly see this is run `cv -vvv ev "try { civicrm_api3('OptionGroup', 'getsingle', ['name' => 'aaaaaaaaa']); } catch (CiviCRM_API3_Exception $e) { echo 'should be here'; }"`. It should get caught (assuming you don't have an option group named aaaaaaaaa).
