### PR TITLE
DebugSubscriber - Fix activation check

### DIFF
--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -37,7 +37,8 @@ class DebugSubscriber implements EventSubscriberInterface {
         break;
 
       case '3.':
-        $xdebugMode = explode(',', ini_get('xdebug.mode'));
+        $xdebugMode = version_compare($version, '3.1', '>=')
+          ? xdebug_info('mode') : explode(',', ini_get('xdebug.mode'));
         $this->enableStats = in_array('develop', $xdebugMode);
         break;
 


### PR DESCRIPTION
Overview
----------------------------------------

This component injects debug info about API calls. It only does so if XDebug is configured with the suitable mode (ie `xdebug.mode=develop` or `XDEBUG_MODE=develop`)

This requires a guard based on XDebug configuration. This guard is slightly wrong, which can sometimes raise [spurious errors](https://test.civicrm.org/job/CiviCRM-Core-Matrix/11517/BKPROF=max,CIVIVER=5.54,SUITES=phpunit-api3,label=bknix-tmp/#showFailuresLink).

The key thing is that XDebug reads configuration from multiple sources (eg `php.ini` or env-var). A recent buildkit update relied on env-var working (https://github.com/civicrm/civicrm-buildkit/pull/727).

Before
----------------------------------------

The guard only consults `ini_get('xdebug.mode')`. If an env-var exists (eg `XDEBUG_MODE`), then `ini_get()` does not correctly reveal the effective policy.

This sometimes leads to failures like this (*where in `xdebug.mode` looked like it had `develop` enabled, but `XDEBUG_MODE` actually disabled it, so anything that relies on `develop` mode fails*):

```
1) api_v3_ACLCachingTest::testActivityCreateCustomBefore with data set "APIv3" (3)
Failure in api call for custom_field getoptions:  Function must be enabled in php.ini by setting 'xdebug.mode' to 'develop'
#0 [internal function]: PHPUnit\Util\ErrorHandler->__invoke(2, 'Function must b...', '/home/jenkins/b...', 99)
#1 /home/jenkins/bknix-max/build/delme-2-2/web/sites/all/modules/civicrm/Civi/API/Subscriber/DebugSubscriber.php(99): xdebug_time_index()
#2 /home/jenkins/bknix-max/build/delme-2-2/web/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/EventDispatcher.php(264): Civi\API\Subscriber\DebugSubscriber->onApiRespond(Object(Civi\API\Event\RespondEvent), 'civi.api.respon...',
```

After
----------------------------------------

The guard works with both php.ini's `xdebug.mode` and env-var `XDEBUG_MODE`. It does this by asking XDebug for the *effective* mode (*rather than looking at specific config flags*).


Technical Details
----------------------------------------

See also: https://xdebug.org/docs/all_functions#xdebug_info

The option will behave correctly on XDebug 3.1+. On 3.0, it falls back to the older (less-accurate) check. All the systems I care about have 3.1.+