### PR TITLE
CiviCRM-Admin-UI - Fix Contact Types search display

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Contact_Types',
     'entity' => 'SavedSearch',
-    'cleanup' => 'always',
+    'cleanup' => 'unused',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/search_kit/ang/crmSearchDisplay/AddButton.html
+++ b/ext/search_kit/ang/crmSearchDisplay/AddButton.html
@@ -1,4 +1,4 @@
-<a href="{{ $ctrl.settings.addButton.url }}" class="btn btn-primary" target="crm-popup">
-  <i ng-if="$ctrl.settings.addButton.icon" class="crm-i {{:: $ctrl.settings.addButton.icon }}"></i>
-  {{:: $ctrl.settings.addButton.text }}
+<a ng-href="{{ $ctrl.addButton.url }}" class="btn btn-primary" target="crm-popup">
+  <i ng-if="$ctrl.addButton.icon" class="crm-i {{:: $ctrl.addButton.icon }}"></i>
+  {{:: $ctrl.addButton.text }}
 </a>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -26,9 +26,14 @@
         for (var p=0; p < placeholderCount; ++p) {
           this.placeholders.push({});
         }
-
+        // Calculate URL of addButton and copy addButton to controller property
+        // It has to be copied rather than simply adding this.settings.addButton.url,
+        // because settings cannot be changed when they are supplied from the markup
         if (this.settings.addButton && this.settings.addButton.path) {
-          this.settings.addButton.url = CRM.url(this.settings.addButton.path);
+          // Clone the variable to prevent polluting it during Preview mode in the Admin UI
+          this.addButton = _.cloneDeep(this.settings.addButton);
+          // TODO: Evaluate variables in the path
+          this.addButton.url = CRM.url(this.addButton.path);
         }
 
         this.getResults = _.debounce(function() {

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -1,7 +1,7 @@
 <div class="crm-search-display crm-search-display-grid">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.url"></div>
+    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.addButton"></div>
   </div>
   <div
     class="crm-search-display-grid-container crm-search-display-grid-layout-{{$ctrl.settings.colno}}"

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -1,7 +1,7 @@
 <div class="crm-search-display crm-search-display-list">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.url"></div>
+    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.addButton"></div>
   </div>
   <ol ng-if=":: $ctrl.settings.style === 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ol>
   <ul ng-if=":: $ctrl.settings.style !== 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ul>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -2,7 +2,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.url"></div>
+    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.addButton"></div>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3854](https://lab.civicrm.org/dev/core/-/issues/3854)

Before
----------------------------------------
With the CiviCRM Admin UI extension enabled, "Administer Contact Types" screen does not work.

After
----------------------------------------
Works

Technical Details
----------------------------------------
`.mgd` was missing from the file extension.

