### PR TITLE
Remove stray character in income report

### DIFF
--- a/CRM/Report/Form/Event/Income.php
+++ b/CRM/Report/Form/Event/Income.php
@@ -73,7 +73,7 @@ class CRM_Report_Form_Event_Income extends CRM_Report_Form {
       $eventSummary[$eventDAO->event_id][ts('End Date')] = CRM_Utils_Date::customFormat($eventDAO->end_date);
       $eventSummary[$eventDAO->event_id][ts('Event Type')] = $eventDAO->event_type;
       $eventSummary[$eventDAO->event_id][ts('Event Income')] = CRM_Utils_Money::format($eventDAO->total, $eventDAO->currency);
-      $eventSummary[$eventDAO->event_id][ts('Registered Participant')] = "{$eventDAO->participant} ({" . implode(', ', $this->getActiveParticipantStatuses()) . ")";
+      $eventSummary[$eventDAO->event_id][ts('Registered Participant')] = "{$eventDAO->participant} (" . implode(', ', $this->getActiveParticipantStatuses()) . ")";
       $currency[$eventDAO->event_id] = $eventDAO->currency;
     }
     $this->assign_by_ref('summary', $eventSummary);


### PR DESCRIPTION
Overview
----------------------------------------
Removes a stray character in the Registered Participant value: 

<img width="1170" alt="Screenshot 2022-09-19 at 16 15 49" src="https://user-images.githubusercontent.com/1931323/191052115-9935d251-6e6a-4284-be98-5b648d048017.png">

Specifically note the `{`, which should not be there.