### PR TITLE
Stop PHP notice on Find Mailings page

### DIFF
--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -243,6 +243,9 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $controller->setEmbedded(TRUE);
     $controller->run();
 
+    $this->assign('unscheduled', FALSE);
+    $this->assign('archived', FALSE);
+
     $urlParams = 'reset=1';
     $urlString = 'civicrm/mailing/browse';
     if ($this->get('sms')) {


### PR DESCRIPTION
Overview
----------------------------------------
Stop PHP notice on Find Mailings page.

Before
----------------------------------------
PHP notices, as shown in this screenshot:

<img width="1222" alt="Screenshot 2022-09-19 at 17 02 49" src="https://user-images.githubusercontent.com/1931323/191062028-71e1b74a-fbbd-4bca-b3ad-0fa7baab07d7.png">

After
----------------------------------------
The notices are gone. (unscheduled and archived are initially set to false, and overwritten with true as needed further down the file. This is a pattern we've repeated elsewhere).