### PR TITLE
dev/drupal#174 - Don't use internal CMS identifier as a human label - Option 1

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -326,7 +326,6 @@ class CRM_Contact_Form_Search_Criteria {
    *
    */
   public static function getBasicSearchFields() {
-    $userFramework = CRM_Core_Config::singleton()->userFramework;
     return [
       // For now an empty array is still left in place for ordering.
       'sort_name' => [],
@@ -385,7 +384,6 @@ class CRM_Contact_Form_Search_Criteria {
       ],
       'uf_user' => [
         'name' => 'uf_user',
-        'description' => ts('Does the contact have a %1 Account?', [$userFramework]),
       ],
     ];
   }

--- a/templates/CRM/Admin/Form/CMSUser.tpl
+++ b/templates/CRM/Admin/Form/CMSUser.tpl
@@ -10,7 +10,7 @@
 {* this template is for synchronizing CMS user*}
 <div class="crm-block crm-form-block crm-cms-user-form-block">
 <div class="help">
-    <p>{ts 1=$config->userFramework}Synchronize %1 Users{/ts}</p>
+    <p>{ts}Synchronize Users{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 <div class="messages status no-popup">


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/174

Before
----------------------------------------
Mostly that it says Drupal8 when it's Drupal 9. The two screens are `civicrm/admin/synchUser?reset=1` and `civicrm/contact/search/advanced?reset=1`

Also for standalone cms saying "standalone" isn't going to make sense.

After
----------------------------------------
This is option 1. It just removes all the extra wording which I'm not sure really adds anything. If someone needs clarification then maybe a link to more complete docs explaining the difference between users and contacts and what CMS means would be more useful.

Technical Details
----------------------------------------
CIVICRM_UF is an internal name not a human label.

Comments
----------------------------------------

