### PR TITLE
dev/drupal#174 - Don't use internal CMS identifier as a human label - Option 2

### DIFF
--- a/CRM/Admin/Form/CMSUser.php
+++ b/CRM/Admin/Form/CMSUser.php
@@ -29,6 +29,7 @@ class CRM_Admin_Form_CMSUser extends CRM_Core_Form {
    * Build the form object.
    */
   public function buildQuickForm() {
+    $this->assign('ufLabel', CRM_Core_Config::singleton()->userSystem->getLabel());
 
     $this->addButtons([
       [

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -326,7 +326,6 @@ class CRM_Contact_Form_Search_Criteria {
    *
    */
   public static function getBasicSearchFields() {
-    $userFramework = CRM_Core_Config::singleton()->userFramework;
     return [
       // For now an empty array is still left in place for ordering.
       'sort_name' => [],
@@ -385,7 +384,7 @@ class CRM_Contact_Form_Search_Criteria {
       ],
       'uf_user' => [
         'name' => 'uf_user',
-        'description' => ts('Does the contact have a %1 Account?', [$userFramework]),
+        'description' => ts('Does the contact have a %1 Account?', [1 => CRM_Core_Config::singleton()->userSystem->getLabel()]),
       ],
     ];
   }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1080,4 +1080,11 @@ AND    u.status = 1
     ];
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getLabel(): string {
+    return ts('Backdrop');
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1110,4 +1110,13 @@ abstract class CRM_Utils_System_Base {
     return TRUE;
   }
 
+  /**
+   * The human label for this CMS, as opposed to CIVICRM_UF which is an
+   * internal name.
+   * @return string
+   */
+  public function getLabel(): string {
+    return ts('CMS');
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -721,4 +721,11 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     ];
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getLabel(): string {
+    return ts('Drupal');
+  }
+
 }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -962,4 +962,11 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     ];
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getLabel(): string {
+    return ts('Joomla!');
+  }
+
 }

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -625,4 +625,11 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   public function invalidateRouteCache() {
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getLabel(): string {
+    return '';
+  }
+
 }

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -166,4 +166,11 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     throw new Exception("Method not implemented: getLoginURL");
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getLabel(): string {
+    return ts('Unit Tests');
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1509,4 +1509,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     return apply_filters('civicrm_exit_after_fatal', $ret);
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getLabel(): string {
+    return ts('WordPress');
+  }
+
 }

--- a/templates/CRM/Admin/Form/CMSUser.tpl
+++ b/templates/CRM/Admin/Form/CMSUser.tpl
@@ -10,7 +10,7 @@
 {* this template is for synchronizing CMS user*}
 <div class="crm-block crm-form-block crm-cms-user-form-block">
 <div class="help">
-    <p>{ts 1=$config->userFramework}Synchronize %1 Users{/ts}</p>
+    <p>{ts 1=$ufLabel}Synchronize %1 Users{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 <div class="messages status no-popup">


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/174

Before
----------------------------------------
Mostly that it says Drupal8 when it's Drupal 9. The two screens are `civicrm/admin/synchUser?reset=1` and `civicrm/contact/search/advanced?reset=1`

Also for standalone cms saying "standalone" isn't going to make sense.

After
----------------------------------------
This is option 2. It adds labels for each CMS reducing DrupalN to just Drupal.

Technical Details
----------------------------------------
CIVICRM_UF is an internal name not a human label.

Comments
----------------------------------------
I'm not sure ts'ing the cms label is useful, but this allows for word replacements.
