### PR TITLE
Remove unused variable

### DIFF
--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -209,7 +209,6 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
     }
 
     // get the count of contact
-    $contactBAO = new CRM_Contact_BAO_Contact();
     $query = new CRM_Contact_BAO_Query($searchValues);
     $searchCount = $query->searchQuery(0, 0, NULL, TRUE);
     $form->set('searchCount', $searchCount);


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variable.

Before
----------------------------------------
Unless I'm missing something, I cannot see any reason for this variable to be defined.

- The variable is not referenced, and is not global.
- Creating a new instance of `CRM_Contact_BAO_Contact` should not cause any relevant side-effects.


After
----------------------------------------
Variable removed.


Comments
----------------------------------------
Identified through the variable being greyed-out as unused in my IDE of choice.
