### PR TITLE
Don't repeat email twice on the contribution confirm/thank-you pages

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -577,6 +577,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
     $this->assignPaymentFields();
     $this->assignEmailField();
+    $this->assign('emailExists', $this->_emailExists);
 
     // also assign the receipt_text
     if (isset($this->_values['receipt_text'])) {

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -225,7 +225,7 @@
         </div>
       {/if}
     {/if}
-    {if $email}
+    {if !$emailExists}
       <div class="crm-group contributor_email-group">
         <div class="header-dark">
           {ts}Your Email{/ts}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -255,7 +255,7 @@
         </div>
       {/if}
     {/if}
-    {if $email}
+    {if !$emailExists}
       <div class="crm-group contributor_email-group">
         <div class="header-dark">
           {ts}Your Email{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3858
If you have a profile on your contribution page that includes an email field, the email appears twice on the Confirmation and Thank-You pages.

Reproduction steps in Gitlab.

Before
----------------------------------------
![Selection_1638](https://user-images.githubusercontent.com/1796012/191070956-83107c32-c777-4f0b-9a4e-4dee932769a7.png)

After
----------------------------------------
![Selection_1637](https://user-images.githubusercontent.com/1796012/191070899-9f7968e6-f1c8-4b3d-8496-cf24020b2d4e.png)

Technical Details
----------------------------------------
The template currently checks for the existence of the `$email` template variable - but there should no longer be any scenario in which that variable isn't populated.

Comments
----------------------------------------
When an email field is present in a profile, we correctly hide the email field from the main contribution page.  This extends that behavior to the confirmation and thank-you.