### PR TITLE
Avoid PHP notices in Add Contacts to Household task

### DIFF
--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -44,6 +44,7 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
 
     $searchRows = $this->get('searchRows');
     $searchCount = $this->get('searchCount');
+    $this->assign('searchRows', FALSE);
     if ($searchRows) {
       $checkBoxes = [];
       $chekFlag = 0;

--- a/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
@@ -86,9 +86,6 @@
                     </div>
                <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
             </div>
-  <div class="form-item">
-  {$form.status.label} {$form.status.html}
-  </div>
 
 
             </div></fieldset>


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP notices in Add Contacts to Household task.

Before
----------------------------------------

1. Undefined SearchRows notice (before search applied)
<img width="974" alt="Screenshot 2022-09-19 at 17 57 19" src="https://user-images.githubusercontent.com/1931323/191072083-c7f6c47e-ddab-4dca-ae80-28220954e975.png">
2. More notices (after search applied)
<img width="1083" alt="Screenshot 2022-09-19 at 17 58 04" src="https://user-images.githubusercontent.com/1931323/191072208-ac34c340-b735-4f93-b3be-35efbab1cff0.png">

After
----------------------------------------
Notices gone.

Technical Details
----------------------------------------
The second set of notices were coming from the reference to `$form.status`. Although I am slightly nervy removing a field like this, I can see no evidence that it is ever actually set at the PHP end, and so it seems more sensible to remove than surround it in a new `if` check. It would be worth reviewers just checking they can't think of a reason where this would be set (within an extension maybe?)
