### PR TITLE
Remove attempt to match on soft credit header

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -299,7 +299,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         'entity' => 'Contact',
         'entity_instance' => 'SoftCreditContact',
         'entity_prefix' => 'soft_credit.contact.',
-        'headerPattern' => '/Soft Credit/i',
         'options' => FALSE,
         'type' => CRM_Utils_Type::T_STRING,
         'contact_type' => ['Individual' => 'Individual', 'Household' => 'Household', 'Organization' => 'Organization'],


### PR DESCRIPTION
Overview
----------------------------------------
Remove attempt to match on soft credit header

Before
----------------------------------------
If the import column name starts with 'Soft Credit' it is auto-matched to 'Soft credit contact, contact ID' - this is rarely correct as it could be external id or email - so better not to do a match

After
----------------------------------------
no match done

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw 