### PR TITLE
DebugSubscriber - Fix activation check

### DIFF
--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -37,7 +37,8 @@ class DebugSubscriber implements EventSubscriberInterface {
         break;
 
       case '3.':
-        $xdebugMode = explode(',', ini_get('xdebug.mode'));
+        $xdebugMode = version_compare($version, '3.1', '>=')
+          ? xdebug_info('mode') : explode(',', ini_get('xdebug.mode'));
         $this->enableStats = in_array('develop', $xdebugMode);
         break;
 


### PR DESCRIPTION
Backport #24554 from 5.54-rc to 5.53-stable.

Note: This issue doesn't specifically merit a patch-release for 5.53.x. However, when doing any other patch-releases on 5.53, this should provide us with better test-suite guidance.