### PR TITLE
Fix some inconsistent key names, as used by civiimport

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -141,7 +141,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    * @throws \CRM_Core_Exception
    */
   protected function getFieldMappings(): array {
-    $mappedFields = $this->getUserJob()['metadata']['import mappings'] ?? [];
+    $mappedFields = $this->getUserJob()['metadata']['import_mappings'] ?? [];
     if (empty($mappedFields)) {
       foreach ($this->getSubmittedValue('mapper') as $i => $mapperRow) {
         $mappedField = $this->getMappingFieldFromMapperInput($mapperRow, 0, $i);
@@ -155,8 +155,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       // This is the same data as entity_data - it is stored to the database in the contact_type field
       // slit your eyes & squint while blinking and you can almost read that as entity_type and not
       // hate it. Otherwise go & whinge on https://lab.civicrm.org/dev/core/-/issues/1172
-      $mappedFields[$index]['contact_type'] = !empty($mappedField['entity_type']) ? json_encode($mappedField['entity_type']) : NULL;
-      $mappedFields[$index]['soft_credit_type_id'] = !empty($mappedField['entity_type']) ? $mappedField['entity_type']['soft_credit']['soft_credit_type_id'] : NULL;
+      $mappedFields[$index]['contact_type'] = !empty($mappedField['entity_data']) ? json_encode($mappedField['entity_data']) : NULL;
+      $mappedFields[$index]['soft_credit_type_id'] = !empty($mappedField['entity_data']) ? $mappedField['entity_data']['soft_credit']['soft_credit_type_id'] : NULL;
     }
     return $mappedFields;
   }
@@ -224,7 +224,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
           $entityInstance = $params[$entity][$entityKey];
         }
         else {
-          $entityInstance = $mappedField['entity_data']['soft_credit'];
+          $entityInstance = (array) ($mappedField['entity_data']['soft_credit']);
           $entityInstance['Contact']['contact_type'] = $this->getContactTypeForEntity($entity);
         }
         $entityInstance['Contact'] = array_merge($entityInstance['Contact'], [$this->getFieldMetadata($mappedField['name'])['name'] => $this->getTransformedFieldValue($mappedField['name'], $fieldValue)]);

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -88,7 +88,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    * @noinspection PhpUnhandledExceptionInspection
    */
   public function postProcess() {
-    $this->updateUserJobMetadata('import_mappings', $this->getImportConfiguration());
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $this->saveMapping();
     $parser = $this->getParser();
@@ -522,22 +521,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     }
     // Infer the default from the column names if we have them
     return $this->defaultFromHeader($columnHeader, $headerPatterns);
-  }
-
-  /**
-   * Get the import configuration per the user.
-   *
-   * When we have wrangled the user's input (e.g to deal with form layer weirdness
-   * we saved the wrangled version here - leaving the submitted value as submitted.
-   *
-   * @return array
-   */
-  protected function getImportConfiguration(): array {
-    $importConfiguration = $this->getUserJob()['metadata']['import_mappings'] ?? [];
-    foreach ($this->getSubmittedValue('mapper') as $mapperField) {
-      $importConfiguration['name'] = $mapperField;
-    }
-    return $importConfiguration;
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -225,7 +225,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     ];
     $this->submitDataSourceForm('soft_credit_extended.csv', $submittedValues);
     $metadata = UserJob::get()->addWhere('id', '=', $this->userJobID)->addSelect('metadata')->execute()->first()['metadata'];
-    $metadata['import mappings'] = $importMappings;
+    $metadata['import_mappings'] = $importMappings;
     $metadata['entity_configuration'] = [
       'Contribution' => ['action' => 'create'],
       'Contact' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fix some inconsistent key names, as used by civiimport

Before
----------------------------------------
Inconsistentcies in newly added array keys

After
----------------------------------------
Consistent

Technical Details
----------------------------------------
We had `updateUserJobMetadata` saving `import_mappings` and other places referring to `import mappings` - we are saving these via js now so the call to save them in the form is not used

Comments
----------------------------------------
