### PR TITLE
fix fee amount when contributions have multiple associated participants

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3748,7 +3748,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @return bool
    * @throws \CiviCRM_API3_Exception
    */
-  public static function isSingleLineItem($id) {
+  public static function isSingleLineItem(int $id) : bool {
     $lineItemCount = civicrm_api3('LineItem', 'getcount', ['contribution_id' => $id]);
     return ($lineItemCount == 1);
   }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1607,11 +1607,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         $entityTable = 'participant';
         $entityID = $pId;
         $isRelatedId = FALSE;
-        $participantParams = [
-          'fee_amount' => $submittedValues['total_amount'],
-          'id' => $entityID,
-        ];
-        CRM_Event_BAO_Participant::add($participantParams);
+        if (CRM_Contribute_BAO_Contribution::isSingleLineItem($this->_id)) {
+          $participantParams = [
+            'fee_amount' => $submittedValues['total_amount'],
+            'id' => $entityID,
+          ];
+          CRM_Event_BAO_Participant::add($participantParams);
+        }
         if (empty($this->_lineItems)) {
           $this->_lineItems[] = CRM_Price_BAO_LineItem::getLineItems($entityID, 'participant', TRUE);
         }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/3859 for replication steps and a description of the bug.

This PR handles the most immediate issue - when a contribution has a single line item, the existing code works.  With multiple line items, it changes a value to be incorrect.  This ensures the code only works on contributions with a single line item.

Before
----------------------------------------
Editing a contribution (through the UI) changes `civicrm_participant.fee_amount` to match the value of the entire contribution - even when there are multiple line items.

After
----------------------------------------
The `fee_amount` is only changed when a single line item exists.

Comments
----------------------------------------
This is just an `if` statement, with a tiny bit of strict type enforcement while there are only two places `isSingleLineItem()` is referenced.