### PR TITLE
Class scanner - do not throw runTime Exception if class not loaded

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -202,7 +202,7 @@ class ClassScanner {
         }
         elseif (!interface_exists($class) && !trait_exists($class)) {
           // If you get this error, then perhaps (a) you need to fix the name of file/class/namespace or (b) you should disable class-scanning.
-          throw new \RuntimeException("Scanned file {$relFile} for class {$class}, but it was not found.");
+          \Civi::log('class_scanner')->warning("Scanned file {$relFile} for class {$class}, but it was not found.");
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Class scanner - do not throw runTime Exception if class not loaded

Before
----------------------------------------
On running unit tests in a non-core extenstion that triggers the class scanner I was getting a run-time error because a different unit test class that was not being run 'did not exist' - this was because php had never loaded it (as it was not included in the test run). 

After
----------------------------------------
Doing an `include_once` before deciding the class is invalid prevents run time errors in this scenario

Technical Details
----------------------------------------
Once I had added this patch it kept working even after I stashed it - I guess some caching was going on

Comments
----------------------------------------
@totten 