### PR TITLE
id's are no display for reports

### DIFF
--- a/CRM/Report/Form/Case/Demographics.php
+++ b/CRM/Report/Form/Case/Demographics.php
@@ -147,6 +147,7 @@ class CRM_Report_Form_Case_Demographics extends CRM_Report_Form {
           'id' => [
             'title' => ts('Case ID'),
             'required' => TRUE,
+            'no_display' => TRUE,
           ],
           'start_date' => [
             'title' => ts('Case Start'),


### PR DESCRIPTION
Overview
----------------------------------------
We don't show ids in reports. We can't uncheck the column for Case ID.

Before
----------------------------------------
 Case ID is mandatory chosen in _Demographics_ report and we don't show id' in reports as such
![case_demographics_before](https://user-images.githubusercontent.com/3455173/180951178-c509036e-1c07-4fdf-a818-a0d8602a72f2.png)


After
----------------------------------------
_Demographics_ report is consistent with other reports

![case_afterrep](https://user-images.githubusercontent.com/3455173/191518033-543d9e61-dbee-4ab1-be0b-716f725bba4b.png)

