### PR TITLE
dev/core#3861 - add message template id to sendmail function

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -748,6 +748,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $additionalDetails = NULL,
     $campaignId = NULL,
     $caseId = NULL
+    $template
   ) {
 
     $userID = CRM_Core_Session::getLoggedInContactID();
@@ -760,6 +761,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
       $contactId = $values['contact_id'];
       $emailAddress = $values['email'];
       $renderedTemplate = CRM_Core_BAO_MessageTemplate::renderTemplate([
+        'messageTemplateID' => $template,
         'messageTemplate' => [
           'msg_text' => $text,
           'msg_html' => $html,


### PR DESCRIPTION
Overview
----------------------------------------
In trying to use AlterMailParams I ran into this 'bug'. The MessageTemplateID is a field that is used in the email workflow functions, but when manually sending an email using a message template the ID is not passed on.

Before
----------------------------------------
Message Template ID is not passed on to send email functions

After
----------------------------------------
Message Template ID is passed on to send email functions