### PR TITLE
dev/core#3863 - Default email location on contact is always Billing

### DIFF
--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -87,6 +87,8 @@ class CRM_Contact_Form_Location {
         }
         switch ($blockName) {
           case 'Email':
+            // setDefaults uses this to tell which instance
+            $form->set('Email_Block_Count', $instance);
             CRM_Contact_Form_Edit_Email::buildQuickForm($form, $instance);
             // Only display the signature fields if this contact has a CMS account
             // because they can only send email if they have access to the CRM


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3863

Before
----------------------------------------
1. Go to customize - dropdown options - location types and note that Home is the default.
1. Create a new individual.
1. Note the location type for email is Billing not Home.

After
----------------------------------------
Home

Technical Details
----------------------------------------
This commit removed the form->set that is used later by setDefault: https://github.com/civicrm/civicrm-core/commit/7a673a8ec369cc9434e2c79376bbbc93d33c8cd0

Comments
----------------------------------------

