### PR TITLE
dev/core#3826 Fix regression on contribution search tasks in search-kit

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -140,7 +140,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       // FIXME: tasks() function always checks permissions, should respect `$this->checkPermissions`
       foreach (\CRM_Contribute_Task::tasks() as $id => $task) {
         if (!empty($task['url'])) {
-          $key = \CRM_Core_Key::get(\CRM_Utils_Array::first((array) $task['class']), TRUE);
+          $key = \CRM_Core_Key::get('CRM_Contribute_Controller_Task', TRUE);
           $tasks[$entity['name']]['contribution.' . $id] = [
             'title' => $task['title'],
             'icon' => $task['icon'] ?? 'fa-gear',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3826 Fix regression on contribution search tasks in search-kit

When switching from GET to POST calls (to support greater numbers of ids) the fix required the qfKey to be set in search-kit. However, the selected class name for the qfKey for contribution tasks was wrong - leading to a validation error

https://lab.civicrm.org/dev/core/-/issues/3826

Before
----------------------------------------
Contribution search tasks no longer work from search kit

After
----------------------------------------
They---'re back - did you miss them?

Technical Details
----------------------------------------
@demeritcowboy this returns it to working for core tasks - which feels like the priority - but I'm not sure what has been happening in the extension space

Comments
----------------------------------------
