### PR TITLE
Fix smarty notices on localization page

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Localization.tpl
+++ b/templates/CRM/Admin/Form/Setting/Localization.tpl
@@ -19,7 +19,7 @@
                 <td class="label">{$form.lcMessages.label}</td>
                 <td>{$form.lcMessages.html}</td>
             </tr>
-           {if !empty($form.languageLimit)}
+           {if array_key_exists('languageLimit', $form)}
              <tr class="crm-localization-form-block-languageLimit">
                  <td class="label">{$form.languageLimit.label}</td>
                  <td>{$form.languageLimit.html}<br />
@@ -37,7 +37,7 @@
                 <span class="description">{$settings_fields.inheritLocale.description}</span>
               </td>
             </tr>
-          {if empty($form.languageLimit)}
+          {if !array_key_exists('languageLimit', $form)}
             <tr class="crm-localization-form-block-uiLanguages">
                 <td class="label">{$form.uiLanguages.label}</td>
                 <td>{$form.uiLanguages.html}</td>
@@ -115,7 +115,7 @@
         </table>
     <h3>{ts}Multiple Languages Support{/ts}</h3>
       <table class="form-layout-compressed">
-        {if !empty($form.makeSinglelingual)}
+        {if array_key_exists('makeSinglelingual', $form)}
           <tr class="crm-localization-form-block-makeSinglelingual_description">
               <td></td>
               <td><span class="description">{ts 1="http://documentation.civicrm.org"}This is a multilingual installation. It contains certain schema differences compared to regular installations of CiviCRM. Please <a href="%1">refer to the documentation</a> for details.{/ts}</span></td>


### PR DESCRIPTION
Overview
----------------------------------------
civicrm/admin/setting/localization?reset=1

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/191879552-83977505-f297-41da-a761-b3437032b376.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/191879680-03dea948-cdf1-47de-8391-1e062a89ab8d.png)


Technical Details
----------------------------------------
Remaining one is in a different tpl

Comments
----------------------------------------
