### PR TITLE
(dev/core#3865) Fix css for price fields of html type Select with lon…

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -534,10 +534,20 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         else {
           $visibility_id = self::getVisibilityOptionID('public');
         }
+
+        $class = '';
+        $maxlen = max(array_map('strlen', $selectOption));
+        if ($maxlen > 25) {
+          $class = ' huge';
+        }
+        if ($maxlen > 40) {
+          $class = ' huge40';
+        }
+
         $element = &$qf->add('select', $elementName, $label, $selectOption, $useRequired && $field->is_required, [
           'placeholder' => ts('- select %1 -', [1 => $label]),
           'price' => json_encode($priceVal),
-          'class' => 'crm-select2',
+          'class' => 'crm-select2' . $class,
           'data-price-field-values' => json_encode($customOption),
         ]);
 


### PR DESCRIPTION
…g labels

Overview
----------------------------------------
Fix css for price fields of html type _Select_ with long labels

I propose based on the string length of the longest option we should provide the display,so it doesn't look wrapped for some options.

Before
----------------------------------------
Currently, the option labels are long the display looks something like this
![priceset_display](https://user-images.githubusercontent.com/3455173/191911426-3717728b-14b1-455a-af5c-a35404283420.png)

this is on dmaster


After
----------------------------------------
looks much nicer

![post](https://user-images.githubusercontent.com/3455173/191911658-f9439d78-164d-4022-9c5f-53be79493546.png)
