### PR TITLE
APIv4 - Fix Get operation to load options that depend on other options

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -82,22 +82,23 @@ class FormattingUtil {
    * @param $value
    * @param string|null $fieldName
    * @param array $fieldSpec
+   * @param array $params
    * @param string|null $operator (only for 'get' actions)
    * @param null $index (for recursive loops)
    * @throws \CRM_Core_Exception
    */
-  public static function formatInputValue(&$value, ?string $fieldName, array $fieldSpec, &$operator = NULL, $index = NULL) {
+  public static function formatInputValue(&$value, ?string $fieldName, array $fieldSpec, array $params = [], &$operator = NULL, $index = NULL) {
     // Evaluate pseudoconstant suffix
     $suffix = strpos(($fieldName ?? ''), ':');
     if ($suffix) {
-      $options = self::getPseudoconstantList($fieldSpec, $fieldName, [], $operator ? 'get' : 'create');
+      $options = self::getPseudoconstantList($fieldSpec, $fieldName, $params, $operator ? 'get' : 'create');
       $value = self::replacePseudoconstant($options, $value, TRUE);
       return;
     }
     elseif (is_array($value)) {
       $i = 0;
       foreach ($value as &$val) {
-        self::formatInputValue($val, $fieldName, $fieldSpec, $operator, $i++);
+        self::formatInputValue($val, $fieldName, $fieldSpec, $params, $operator, $i++);
       }
       return;
     }

--- a/tests/phpunit/api/v4/Custom/CustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomGroupTest.php
@@ -51,4 +51,27 @@ class CustomGroupTest extends CustomTestBase {
     $this->assertEquals('Contribution', $groups[1]['extends']);
   }
 
+  public function testGetExtendsEntityColumnValuePseudoconstant() {
+    $activityTypeName = uniqid();
+    $activityType = $this->createTestRecord('OptionValue', [
+      'option_group_id:name' => 'activity_type',
+      'name' => $activityTypeName,
+    ]);
+    $customGroup1 = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'extends_entity_column_value:name' => [$activityTypeName],
+    ]);
+    $customGroup2 = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+    ]);
+    $this->assertEquals([$activityType['value']], $customGroup1['extends_entity_column_value']);
+
+    $result = CustomGroup::get(FALSE)
+      ->addWhere('extends_entity_column_value:name', 'CONTAINS', $activityTypeName)
+      ->addWhere('extends:name', '=', 'Activities')
+      ->execute()->single();
+
+    $this->assertEquals([$activityType['value']], $result['extends_entity_column_value']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3866](https://lab.civicrm.org/dev/core/-/issues/3866)

Before
----------------------------------------
Looking up pseudoconstants in Get doesn't work if they depend on other fields (e.g. ChainSelect)

After
----------------------------------------
Works. Test added.