### PR TITLE
Put back exception during class scanning

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -202,7 +202,8 @@ class ClassScanner {
         }
         elseif (!interface_exists($class) && !trait_exists($class)) {
           // If you get this error, then perhaps (a) you need to fix the name of file/class/namespace or (b) you should disable class-scanning.
-          \Civi::log('class_scanner')->warning("Scanned file {$relFile} for class {$class}, but it was not found.");
+          // throw new \RuntimeException("Scanned file {$relFile} for class {$class}, but it was not found.");
+          // We can't throw an exception since it breaks some test environments. We can't log because this happens too early and it leads to an infinite loop. error_log() works but is debatable if anyone will look there.
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/24580 the exception was changed to a log call to avoid problems with test environments. But it can cause infinite loops with some extensions.

Before
----------------------------------------
On a site with, e.g. the csvimport extension installed, an infinite loop gives out of memory on every page. No error actually gets logged.

After
----------------------------------------
Error logged, but back to the original problem.

Technical Details
----------------------------------------


Comments
----------------------------------------
An intermediate option might be trigger_error() with E_USER_DEPRECATED, but whether that helps the original problem depends on that test environment's config on how it handles php deprecations during tests.

@eileenmcnaughton 
