### PR TITLE
Return success from cleanup job

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -619,6 +619,7 @@ function civicrm_api3_job_run_payment_cron($params) {
  *
  * @param array $params
  *   Sends in various config parameters to decide what needs to be cleaned.
+ * @return array
  */
 function civicrm_api3_job_cleanup($params) {
   $session   = CRM_Utils_Array::value('session', $params, TRUE);
@@ -655,6 +656,8 @@ function civicrm_api3_job_cleanup($params) {
   if ($wordRplc) {
     CRM_Core_BAO_WordReplacement::rebuild();
   }
+
+  return civicrm_api3_create_success();
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Return success from cleanup job.

Before
----------------------------------------
The function `civicrm_api3_job_cleanup` had no return. This is very unusual for a API3 action, and is the first such example I have seen in core. All other actions that I have seen return `civicrm_api3_create_success` (unless there is an error).

After
----------------------------------------
The cleanup job returns an explicit success, consistent with other API3 actions.

Comments
----------------------------------------
The lack of return is currently causing a notice `trying to access array offset on value of type null` in `JobManager.php` whenever the cleanup is run via a scheduled job. This is because `JobManager.php` always expects the standard success or error array to be returned from an API3 action.
