### PR TITLE
Handle unexpected API result in JobManager (Avoid PHP warning)

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -259,7 +259,7 @@ class CRM_Core_JobManager {
    * @return string
    */
   private function _apiResultToMessage($apiResult) {
-    $status = $apiResult['is_error'] ? ts('Failure') : ts('Success');
+    $status = ($apiResult['is_error'] ?? FALSE) ? ts('Failure') : ts('Success');
     $msg = CRM_Utils_Array::value('error_message', $apiResult, 'empty error_message!');
     $vals = CRM_Utils_Array::value('values', $apiResult, 'empty values!');
     if (is_array($msg)) {
@@ -268,7 +268,7 @@ class CRM_Core_JobManager {
     if (is_array($vals)) {
       $vals = serialize($vals);
     }
-    $message = $apiResult['is_error'] ? ', Error message: ' . $msg : " (" . $vals . ")";
+    $message = ($apiResult['is_error'] ?? FALSE) ? ', Error message: ' . $msg : " (" . $vals . ")";
     return $status . $message;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Handle unexpected API result in JobManager (Avoid PHP warning)

Before
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/24604.

ScheduledJobs run API3 actions. Occassionally these API actions may fail to return the standard API3 success array (this is currently the case with the cleanup job, resolved in #24604).

When the standard success array is not returned you get an error like this:

```
[24-Sep-2022 11:29:12 Europe/London] PHP Warning:  Trying to access array offset on value of type null in [redacted]civicrm/CRM/Core/JobManager.php on line 271
[24-Sep-2022 11:29:12 Europe/London] PHP Stack trace:
...
[24-Sep-2022 11:29:12 Europe/London] PHP  11. civicrm_api() [redacted]civicrm/CRM/Utils/REST.php:300
[24-Sep-2022 11:29:12 Europe/London] PHP  12. Civi\API\Kernel->runSafe() [redacted]civicrm/api/api.php:22
[24-Sep-2022 11:29:12 Europe/London] PHP  13. Civi\API\Kernel->runRequest() [redacted]civicrm/Civi/API/Kernel.php:81
[24-Sep-2022 11:29:12 Europe/London] PHP  14. Civi\API\Provider\MagicFunctionProvider->invoke() [redacted]civicrm/Civi/API/Kernel.php:149
[24-Sep-2022 11:29:12 Europe/London] PHP  15. civicrm_api3_job_execute() [redacted]civicrm/Civi/API/Provider/MagicFunctionProvider.php:89
[24-Sep-2022 11:29:12 Europe/London] PHP  16. CRM_Core_JobManager->execute() [redacted]civicrm/api/v3/Job.php:118
[24-Sep-2022 11:29:12 Europe/London] PHP  17. CRM_Core_JobManager->executeJob() [redacted]civicrm/CRM/Core/JobManager.php:63
[24-Sep-2022 11:29:12 Europe/London] PHP  18. CRM_Core_JobManager->_apiResultToMessage() [redacted]civicrm/CRM/Core/JobManager.php:138
```

After
----------------------------------------
The PHP null collapse operator has been utilised when reading `$apiResult['is_error']` so that no warning is thrown when `$apiResult` is not an array, or contains no `is_error` key.

Comments
----------------------------------------
This shouldn't really be needed once #24604 is merged, but I still think it's a good idea on the basis that there might be poorly written scheduled jobs in extensions.
