### PR TITLE
Migrate JobLog page to API4

### DIFF
--- a/CRM/Admin/Page/JobLog.php
+++ b/CRM/Admin/Page/JobLog.php
@@ -75,34 +75,27 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
   public function browse() {
     $jid = CRM_Utils_Request::retrieve('jid', 'Positive');
 
-    $sj = new CRM_Core_JobManager();
-
     if ($jid) {
       $jobName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Job', $jid);
       $this->assign('jobName', $jobName);
       $jobRunUrl = CRM_Utils_System::url('civicrm/admin/job', 'action=view&reset=1&context=joblog&id=' . $jid);
       $this->assign('jobRunUrl', $jobRunUrl);
     }
+    else {
+      $this->assign('jobName', FALSE);
+      $this->assign('jobRunUrl', FALSE);
+    }
 
-    $dao = new CRM_Core_DAO_JobLog();
-    $dao->orderBy('id desc');
-
-    // limit to last 1000 records
-    $dao->limit(1000);
+    $jobLogsQuery = \Civi\Api4\JobLog::get(FALSE)
+      ->addOrderBy('id', 'DESC')
+      ->setLimit(1000);
 
     if ($jid) {
-      $dao->job_id = $jid;
+      $jobLogsQuery->addWhere('job_id', '=', $jid);
     }
-    $dao->find();
 
-    $rows = [];
-    while ($dao->fetch()) {
-      unset($row);
-      CRM_Core_DAO::storeValues($dao, $row);
-      $rows[$dao->id] = $row;
-    }
+    $rows = $jobLogsQuery->execute()->getArrayCopy();
     $this->assign('rows', $rows);
-
     $this->assign('jobId', $jid);
   }
 

--- a/Civi/Api4/JobLog.php
+++ b/Civi/Api4/JobLog.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * JobLog entity.
+ *
+ * @searchable secondary
+ * @since 5.56
+ * @package Civi\Api4
+ */
+class JobLog extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnlyEntity;
+
+}

--- a/templates/CRM/Admin/Page/JobLog.tpl
+++ b/templates/CRM/Admin/Page/JobLog.tpl
@@ -13,13 +13,13 @@
 
 <div class="crm-content-block crm-block">
 
-{if !empty($jobId)}
+{if $jobId}
     <h3>{ts}List of log entries for:{/ts} {$jobName}</h3>
 {/if}
 
   <div class="action-link">
     <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-top" class="button"><span><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
-    {if !empty($jobRunUrl)}
+    {if $jobRunUrl}
       <a href="{$jobRunUrl}" id="jobsList-run-top" class="button"><span><i class="crm-i fa-play" aria-hidden="true"></i> {ts}Execute Now{/ts}</span></a>
     {/if}
   </div>
@@ -63,7 +63,7 @@
 
   <div class="action-link">
     <a href="{crmURL p='civicrm/admin/job' q="reset=1"}" id="jobsList-bottom" class="button"><span><i class="crm-i fa-chevron-left" aria-hidden="true"></i> {ts}Back to Scheduled Jobs Listing{/ts}</span></a>
-    {if !empty($jobRunUrl)}
+    {if $jobRunUrl}
       <a href="{$jobRunUrl}" id="jobsList-run-bottom" class="button"><span><i class="crm-i fa-play" aria-hidden="true"></i> {ts}Execute Now{/ts}</span></a>
     {/if}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Migrate JobLog page to API4

Before
----------------------------------------
The JobLog page was written in the traditional CiviCRM way using the DAO object. This led to notices on the JobLog screen from undefined array keys:

<img width="1440" alt="Screenshot 2022-09-24 at 11 58 36" src="https://user-images.githubusercontent.com/1931323/192094193-7a039b5c-202d-45c2-9e31-3a6d6296b5ed.png">

Given that up to 1000 rows are shown at the time this could lead to significant noise in the site logs.

After
----------------------------------------
The JobLog page now uses API4. API4 keys are always set (unlike DAO objects which didn't set properties for NULL values), meaning that no undefined array key warnings occur.

To faciltate this `JobLog` entitites are now exposed over the API.

I have also done some minor tidy-up of the JobLog template:

- The `$sj` variable was being set, but not referenced. Now removed.
- `jobName` and `jobRunUrl` are now always set, reducing reliance on `empty` in the Smarty template (which I think is preferable when in `CIVICRM_SMARTY_DEFAULT_ESCAPE` mode).


Comments
----------------------------------------
I'm never quite sure how quickly PRs make it into a release, so the `@since 5.56` is a bit of a guess on the new API entity.

I settled on `@searchable secondary`, but I think it's borderline whether this should be `secondary` or `none`. I don't really mind either way.

See also [dev/core#2486](https://lab.civicrm.org/dev/core/-/issues/2486)