### PR TITLE
Ensure children key is always set in tag buildTree

### DIFF
--- a/CRM/Core/BAO/Tag.php
+++ b/CRM/Core/BAO/Tag.php
@@ -89,6 +89,7 @@ class CRM_Core_BAO_Tag extends CRM_Core_DAO_Tag {
       $thisref['name'] = $dao->name;
       $thisref['description'] = $dao->description;
       $thisref['is_selectable'] = $dao->is_selectable;
+      $thisref['children'] = [];
 
       if (!$dao->parent_id) {
         $this->tree[$dao->id] = &$thisref;


### PR DESCRIPTION
Overview
----------------------------------------
Ensure children key is always set in tag buildTree

Before
----------------------------------------
CRM_Core_BAO_Tag::buildTree would only set `children` to an array on tag's that actually had children. On tags without children, `$tag['children']` would be undefined.

This led to a PHP warning when viewing a contact's tags tab:

```
PHP Warning:  Undefined array key "children" 
```

After
----------------------------------------
Each element in the tag tree has an array of `children` even when that array is empty.

Comments
----------------------------------------
There are still more warnings to sort on the tags tab; this is just a small first step.
