### PR TITLE
Add missing th element to note.tpl

### DIFF
--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -31,7 +31,7 @@
         <legend>{ts}Comments{/ts}</legend>
             <table class="display">
                 <thead>
-                    <tr><th>{ts}Comment{/ts}</th><th>{ts}Created By{/ts}</th><th>{ts}Date{/ts}</th></tr>
+                    <tr><th>{ts}Comment{/ts}</th><th>{ts}Created By{/ts}</th><th>{ts}Date{/ts}</th><th>{ts}Modified Date{/ts}</th></tr>
                 </thead>
                 {foreach from=$comments item=comment}
                   <tr class="{cycle values='odd-row,even-row'}"><td>{$comment.note}</td><td>{$comment.createdBy}</td><td>{$comment.note_date}</td><td>{$comment.modified_date}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Add missing th element to note.tpl

Before
----------------------------------------
4 columns of data were output, but only 3 columns of heading:

<img width="1384" alt="Screenshot 2022-09-24 at 13 36 34" src="https://user-images.githubusercontent.com/1931323/192098338-1a8345c9-1e96-44af-a24d-0cf89c0b3539.png">


After
----------------------------------------
The missing heading cell has been added:

<img width="1390" alt="Screenshot 2022-09-24 at 13 36 23" src="https://user-images.githubusercontent.com/1931323/192098360-4a4bc141-4558-43d3-9f74-57c1d062cbd1.png">


Comments
----------------------------------------
This is the single note view, which you can get to from the notes tab on a contact. I'm not really sure the modified date is that useful, there could possibly be an argument for just removing the 4th column all together. 
