### PR TITLE
Migrate single note view to API4, avoid PHP warnings

### DIFF
--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -30,19 +30,16 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
    * View details of a note.
    */
   public function view() {
-    $note = new CRM_Core_DAO_Note();
-    $note->id = $this->_id;
-    if ($note->find(TRUE)) {
+    $note = \Civi\Api4\Note::get()
+      ->addSelect('*', 'privacy:label')
+      ->addWhere('id', '=', $this->_id)
+      ->execute()
+      ->single();
+    $note['privacy'] = $note['privacy:label'];
+    $this->assign('note', $note);
 
-      CRM_Core_DAO::storeValues($note, $this->values);
-      $this->values['privacy'] = CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_Note', 'privacy', $this->values['privacy']);
-      $this->assign('note', $this->values);
-    }
-
-    $comments = CRM_Core_BAO_Note::getNoteTree($this->values['id'], 1);
-    if (!empty($comments)) {
-      $this->assign('comments', $comments);
-    }
+    $comments = CRM_Core_BAO_Note::getNoteTree($this->_id, 1);
+    $this->assign('comments', $comments);
 
     // add attachments part
     $currentAttachmentInfo = CRM_Core_BAO_File::getEntityFile('civicrm_note', $this->_id);


### PR DESCRIPTION
Overview
----------------------------------------
Migrate single note view to API4, avoid PHP warnings.

Before
----------------------------------------
When viewing a single contact note, multiple warnings could occur (depending on which note fields had been completed:

<img width="1393" alt="Screenshot 2022-09-24 at 13 57 48" src="https://user-images.githubusercontent.com/1931323/192099269-b21ced2a-d213-4014-a201-e027c62f8adc.png">


After
----------------------------------------
Migrating to API4 and refactoring some of the logic removes the bulk of these warnings.

Comments
----------------------------------------
This doesn't address the warnings coming from `contactFooter.tpl`, which I can't work out why is being loaded. This also only addresses the single note view, not the browse notes or delete note templates.
