### PR TITLE
Fix is_override variable in MembershipView

### DIFF
--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -44,7 +44,7 @@
         {if $has_related}
             <tr><td class="label">{ts}Max related{/ts}</td><td>{$max_related}</td></tr>
         {/if}
-        <tr><td class="label">{ts}Status{/ts}</td><td>{$status} {if $member_is_override}({ts}Overridden{/ts}){/if}</td></tr>
+        <tr><td class="label">{ts}Status{/ts}</td><td>{$status} {if $is_override}({ts}Overridden{/ts}){/if}</td></tr>
         <tr><td class="label">{ts}Source{/ts}</td><td>{$source}</td></tr>
   {if $campaign}<tr><td class="label">{ts}Campaign{/ts}</td><td>{$campaign}</td></tr>{/if}
         <tr><td class="label">{ts}Member Since{/ts}</td><td>{$join_date|crmDate}</td></tr>


### PR DESCRIPTION
Overview
----------------------------------------
Fix is_override variable in MembershipView.

Before
----------------------------------------
This fixes a regression from https://github.com/civicrm/civicrm-core/pull/22664, which meant the "Overridden" would never be displayed.

MembershipView was migrated to API4, but it wasn't taken into account that the `CRM_Member_BAO_Membership` previously used the `uniqueName` `member_is_override`, whereas API4 uses the `name` `is_override`.

After
----------------------------------------
The override text once again displays as expected.
