### PR TITLE
Ensure smarty variable editSmartGroupURL is always defined on group edit

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -93,7 +93,10 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
    */
   public function preProcess() {
     $this->addOptionalQuickFormElement('parents');
-    $this->addExpectedSmartyVariable('parent_groups');
+    $this->addExpectedSmartyVariables([
+      'parent_groups',
+      'editSmartGroupURL',
+    ]);
     $this->_id = $this->get('id');
     if ($this->_id) {
       $breadCrumb = array(


### PR DESCRIPTION
Overview
----------------------------------------
Ensure smarty variable editSmartGroupURL is always defined on group edit

Before
----------------------------------------
When editing a group without an associated smart group URL a warning is thrown (I think this would be a notice below PHP8):

```
Undefined array key "editSmartGroupURL`
```

After
----------------------------------------
The warning is gone.
