### PR TITLE
Fix paypal subscription 'things don't seem to be working at the moment' if frequency_interval not specified

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -1017,10 +1017,11 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
         throw new CRM_Core_Exception(ts('Recurring contribution, but no database id'));
       }
 
+      // See https://developer.paypal.com/api/nvp-soap/paypal-payments-standard/integration-guide/Appx-websitestandard-htmlvariables/#link-recurringpaymentvariables
       $paypalParams += [
         'cmd' => '_xclick-subscriptions',
         'a3' => $this->getAmount($params),
-        'p3' => $params['frequency_interval'],
+        'p3' => $params['frequency_interval'] ?? 1,
         't3' => ucfirst(substr($params['frequency_unit'], 0, 1)),
         'src' => 1,
         'sra' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
If recurring parameters passed to paypal (standard) do not include `frequency_interval` then paypal fails with the message "Things don't seem to be working at the moment".

See: https://developer.paypal.com/api/nvp-soap/paypal-payments-standard/integration-guide/Appx-websitestandard-htmlvariables/#link-recurringpaymentvariables
The issue is that `p3` MUST have a value if t3 is set. If `frequency_interval` is not set then the value of p3 gets set to NULL.

CiviCRM will usually default to `frequency_interval=1` but in some cases it is not set - eg. when called from webform_civicrm and frequency_interval was not added to the form.

See related: https://github.com/colemanw/webform_civicrm/pull/676

Before
----------------------------------------
Paypal sometimes fails to submit a subscription.

After
----------------------------------------
Paypal successfully submits a subscription.

Technical Details
----------------------------------------


Comments
----------------------------------------
@jitendrapurohit @KarinG 