### PR TITLE
dev/core#3862 - Crash when creating message template

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -778,6 +778,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function copyValues($params) {
     $allNull = TRUE;
+    $primaryKey = $this->getFirstPrimaryKey();
     foreach ($this->fields() as $uniqueName => $field) {
       $dbName = $field['name'];
       if (array_key_exists($dbName, $params)) {
@@ -795,7 +796,19 @@ class CRM_Core_DAO extends DB_DataObject {
       // if there is no value then make the variable NULL
       if ($exists) {
         if ($value === '') {
-          $this->$dbName = 'null';
+          if ($dbName === $primaryKey && $field['type'] === CRM_Utils_Type::T_INT) {
+            // See also \Civi\Api4\Utils\FormattingUtil::formatWriteParams().
+            // The string 'null' is used in pear::db to "unset" values, whereas
+            // it skips over fields where the param is real null. However
+            // "unsetting" a primary key doesn't make sense - you can't convert
+            // an existing record to a "new" one. And then having string 'null'
+            // in the dao object can confuse later code, in particular save()
+            // which then calls the update hook instead of the create hook.
+            $this->$dbName = NULL;
+          }
+          else {
+            $this->$dbName = 'null';
+          }
         }
         elseif (is_array($value) && !empty($field['serialize'])) {
           $this->$dbName = CRM_Core_DAO::serializeField($value, $field['serialize']);

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -50,6 +50,18 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * @return string
+   */
+  protected function getFirstPrimaryKey(): string {
+    // Historically it was always 'id'. It is now the case that some entities (import entities)
+    // have a single key that is NOT 'id'. However, for entities that have multiple
+    // keys (which we support in codegen if not many other places) we return 'id'
+    // simply because that is what we historically did & we don't want to 'just change'
+    // it & break those extensions without doing the work to create an alternative.
+    return count($this->getPrimaryKey()) > 1 ? 'id' : $this->getPrimaryKey()[0];
+  }
+
+  /**
    * How many times has this instance been cloned.
    *
    * @var int
@@ -546,9 +558,7 @@ class CRM_Core_DAO extends DB_DataObject {
   public function sequenceKey() {
     static $sequenceKeys;
     if (!isset($sequenceKeys)) {
-      // See comments in 'save' function about use of 'id' for multiple key extensions.
-      $key = count($this->getPrimaryKey()) > 1 ? 'id' : $this->getPrimaryKey()[0];
-      $sequenceKeys = [$key, TRUE];
+      $sequenceKeys = [$this->getFirstPrimaryKey(), TRUE];
     }
     return $sequenceKeys;
   }
@@ -646,12 +656,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public function save($hook = TRUE) {
     $eventID = uniqid();
-    // Historically it was always 'id'. It is now the case that some entities (import entities)
-    // have a single key that is NOT 'id'. However, for entities that have multiple
-    // keys (which we support in codegen if not many other places) we return 'id'
-    // simply because that is what we historically did & we don't want to 'just change'
-    // it & break those extensions without doing the work to create an alternative.
-    $primaryField = count($this->getPrimaryKey()) > 1 ? 'id' : $this->getPrimaryKey()[0];
+    $primaryField = $this->getFirstPrimaryKey();
     if (!empty($this->$primaryField)) {
       if ($hook) {
         $preEvent = new PreUpdate($this);

--- a/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
+++ b/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
@@ -116,4 +116,18 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
     return [$first->single()['id'], $second->single()['id']];
   }
 
+  /**
+   * Test save with no id
+   */
+  public function testSaveNoId() {
+    $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['is_reserved' => 0], $this->baseTpl)]]);
+  }
+
+  /**
+   * Test save with an explicit null id
+   */
+  public function testSaveNullId() {
+    $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['id' => NULL, 'is_reserved' => 0], $this->baseTpl)]]);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3862

Before
----------------------------------------
1. Create a message template
2. Crash

After
----------------------------------------
1. Create a message template
2. Not crash

Technical Details
----------------------------------------
* In https://github.com/civicrm/civicrm-core/commit/5191e633f0 it no longer skips the id field for create specs.
* In [FormattingUtil](https://github.com/civicrm/civicrm-core/blob/e926faf1137dbe40c1a2b90a9e16905aa6fb9a89/Civi/Api4/Utils/FormattingUtil.php#L57) it does some special handling for null values.
  * A similar thing happens in DAO::copyValues which also does some special handling for null, because pear::db uses string 'null' to mean "unset the field", and skips over fields where the params have real null.
* DAO::save decides which hook to call based on the primary key. If it's string 'null' it thinks it's an update not a create. This leads to a crash.
* This doesn't come up for e.g. contact or activity, because their BAOs have code, either on purpose or by happenstance, that either unsets or explicitly sets the primary key to real null in between the copyValues and DAO::save.

Note that string 'null' is a bit meaningless for primary keys, because you can't "unset" a primary key. A db row that exists can't be turned into a new row.

So there's multiple places to attack this:
* One is to add special handling for string 'null' in DAO::save. A downside is it leaves string 'null' in the dao object so later code might get confused.
* Another is in FormattingUtil, but we don't have easy access to which field is primary key.
* Another is put special handling in the MessageTemplate BAO, but then we're only addressing the MessageTemplate and potentially this is an issue elsewhere I just haven't surveyed.
* I've chosen to put it in copyValues, letting the value be real null for primary keys.

Comments
----------------------------------------
The first unit test passes either way. The second fails without the patch.

The actual fix is just the part in copyValues. The 2nd commit is just putting a repeated line of code into a function for re-use.
