### PR TITLE
dev/core#3825 - CiviReport - number of rows to show parameter not working

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -628,7 +628,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     // Ensure smarty variables are assigned here since this function is called from
     // the report api and the main buildForm is not.
     self::$_template->ensureVariablesAreAssigned($this->expectedSmartyVariables);
-    $this->_dashBoardRowCount = CRM_Utils_Request::retrieve('rowCount', 'Integer');
+    $this->_dashBoardRowCount = CRM_Utils_Request::retrieve('rowCount', 'Integer') ?? CRM_Utils_Request::retrieve('crmRowCount', 'Integer');
 
     $this->_section = CRM_Utils_Request::retrieve('section', 'Integer');
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3825

Before
----------------------------------------
1. Change the number of rows to show in the pager.
2. It doesn't change the number of rows that get shown.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
I don't know when this broke or why there are two similar named params that seem to do the same thing. The problem is at least as old as 5.44.

Comments
----------------------------------------
There are some positive reviews in the lab ticket.
