### PR TITLE
Sync api & form layer permissions for jobLog

### DIFF
--- a/CRM/Admin/Page/JobLog.php
+++ b/CRM/Admin/Page/JobLog.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\JobLog;
+
 /**
  * Page for displaying list of jobs.
  */
@@ -25,7 +27,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    *
    * @var array
    */
-  public static $_links = NULL;
+  public static $_links;
 
   /**
    * Get BAO Name.
@@ -33,7 +35,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * @return string
    *   Classname of BAO.
    */
-  public function getBAOName() {
+  public function getBAOName(): string {
     return 'CRM_Core_BAO_Job';
   }
 
@@ -43,7 +45,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * @return array
    *   (reference) of action links
    */
-  public function &links() {
+  public function &links(): array {
     return self::$_links;
   }
 
@@ -54,25 +56,25 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * type of action and executes that action.
    * Finally it calls the parent's run method.
    */
-  public function run() {
-    // set title and breadcrumb
+  public function run(): void {
     CRM_Utils_System::setTitle(ts('Settings - Scheduled Jobs Log'));
-    $breadCrumb = array(
-      array(
+    CRM_Utils_System::appendBreadCrumb([
+      [
         'title' => ts('Administration'),
         'url' => CRM_Utils_System::url('civicrm/admin',
           'reset=1'
         ),
-      ),
-    );
-    CRM_Utils_System::appendBreadCrumb($breadCrumb);
-    return parent::run();
+      ],
+    ]);
+    parent::run();
   }
 
   /**
    * Browse all jobs.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function browse() {
+  public function browse(): void {
     $jid = CRM_Utils_Request::retrieve('jid', 'Positive');
 
     if ($jid) {
@@ -86,7 +88,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
       $this->assign('jobRunUrl', FALSE);
     }
 
-    $jobLogsQuery = \Civi\Api4\JobLog::get(FALSE)
+    $jobLogsQuery = JobLog::get()
       ->addOrderBy('id', 'DESC')
       ->setLimit(1000);
 
@@ -105,7 +107,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * @return string
    *   Classname of edit form.
    */
-  public function editForm() {
+  public function editForm(): string {
     return 'CRM_Admin_Form_Job';
   }
 
@@ -115,7 +117,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * @return string
    *   name of this page.
    */
-  public function editName() {
+  public function editName(): string {
     return 'Scheduled Jobs';
   }
 
@@ -127,7 +129,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
    * @return string
    *   user context.
    */
-  public function userContext($mode = NULL) {
+  public function userContext($mode = NULL): string {
     return 'civicrm/admin/job';
   }
 

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1235,6 +1235,7 @@ class CRM_Core_Permission {
     $permissions['job'] = [
       'process_batch_merge' => ['merge duplicate contacts'],
     ];
+    $permissions['job_log'] = ['default' => 'administer CiviCRM system'];
     $permissions['rule_group']['get'] = [['merge duplicate contacts', 'administer CiviCRM']];
     // Loc block is only used for events
     $permissions['loc_block'] = $permissions['event'];


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow up to https://github.com/civicrm/civicrm-core/pull/24606 - I checked the form permissions for the `JobLog` form & they differed slightly from the api layer so I synced & removed the `checkPermissions(FALSE)`

Before
----------------------------------------
Api for `JobLog` falls back to default of `Administer CiviCRM` but form allows contacts with `access CiviCRM` AND `administer CiviCRM system`

After
----------------------------------------
Api tuned to `administer CiviCRM system` - the access CiviCRM check seems more a form layer thing & not in keeping with other entities

UI unchanged

![image](https://user-images.githubusercontent.com/336308/192380222-433ef8cd-3e8e-44f0-b36f-b3ca33657708.png)


Technical Details
----------------------------------------
Other superficial cleanup

Comments
----------------------------------------
