### PR TITLE
dev/core#3870 - Fix price sets pre and post help display

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -381,24 +381,27 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         }
 
         foreach ($customOption as $opId => $opt) {
+          $preHelpText = $postHelpText = '';
+          $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>';
+          if (!empty($opt['help_pre'])) {
+            $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
+          }
+          if (!empty($opt['help_post'])) {
+            $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
+          }
+
           $taxAmount = $opt['tax_amount'] ?? NULL;
           if ($field->is_display_amounts) {
             $opt['label'] = !empty($opt['label']) ? $opt['label'] . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
-            $preHelpText = $postHelpText = '';
-            if (!empty($opt['help_pre'])) {
-              $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
-            }
-            if (!empty($opt['help_post'])) {
-              $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
-            }
             if (isset($taxAmount) && $invoicing) {
-              $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . self::getTaxLabel($opt, $valueFieldName);
+              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
             }
             else {
-              $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
+              $opt['label'] = $opt['label'] . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
             }
-            $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
           }
+
+          $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
           $count = CRM_Utils_Array::value('count', $opt, '');
           $max_value = CRM_Utils_Array::value('max_value', $opt, '');
           $priceVal = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
@@ -487,8 +490,17 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $count = CRM_Utils_Array::value('count', $opt, '');
           $max_value = CRM_Utils_Array::value('max_value', $opt, '');
 
+          $preHelpText = $postHelpText = '';
+          if (!empty($opt['help_pre'])) {
+            $preHelpText = $opt['help_pre'] . ':&nbsp;';
+          }
+          if (!empty($opt['help_post'])) {
+            $postHelpText = ':&nbsp;' . $opt['help_post'];
+          }
+
+          $taxAmount = $opt['tax_amount'] ?? NULL;
           if ($field->is_display_amounts) {
-            $opt['label'] .= '&nbsp;-&nbsp;';
+            $opt['label'] = !empty($opt['label']) ? $opt['label'] . '&nbsp;-&nbsp;' : '';
             if (isset($taxAmount) && $invoicing) {
               $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
             }
@@ -496,6 +508,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
               $opt['label'] = $opt['label'] . CRM_Utils_Money::format($opt[$valueFieldName]);
             }
           }
+
+          $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
 
           $priceVal[$opt['id']] = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
 
@@ -542,23 +556,28 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $count = CRM_Utils_Array::value('count', $opt, '');
           $max_value = CRM_Utils_Array::value('max_value', $opt, '');
 
+          $preHelpText = $postHelpText = '';
+          $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>';
+          if (!empty($opt['help_pre'])) {
+            $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
+          }
+          if (!empty($opt['help_post'])) {
+            $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
+          }
+
+          $taxAmount = $opt['tax_amount'] ?? NULL;
           if ($field->is_display_amounts) {
-            $preHelpText = $postHelpText = '';
-            if (isset($opt['help_pre'])) {
-              $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span>: ';
-            }
-            if (isset($opt['help_post'])) {
-              $postHelpText = ': <span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
-            }
-            $opt['label'] = '<span class="crm-price-amount-label">' . $opt['label'] . '</span>&nbsp;-&nbsp;';
+            $opt['label'] = !empty($opt['label']) ? $opt['label'] . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
             if (isset($taxAmount) && $invoicing) {
-              $opt['label'] .= self::getTaxLabel($opt, $valueFieldName);
+              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
             }
             else {
-              $opt['label'] .= CRM_Utils_Money::format($opt[$valueFieldName]);
+              $opt['label'] = $opt['label'] . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
             }
-            $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
           }
+
+          $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
+
           $priceVal = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
           $check[$opId] = &$qf->createElement('checkbox', $opt['id'], NULL, $opt['label'],
             [

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -834,6 +834,10 @@ input.crm-form-entityref {
   margin: 0;
 }
 
+.crm-price-amount-help-pre.description, .crm-price-amount-help-post.description {
+  font-size: 1em;
+}
+
 .crm-container .form-layout-compressed td.description,
 .crm-container .form-layout td.description {
   padding: 0 5px 5px 5px;
@@ -3781,7 +3785,6 @@ span.crm-status-icon {
 
 #crm-container.crm-public .price-set-row .crm-price-amount-label {
   color: #444444;
-  font-weight: bold;
 }
 
 #crm-container.crm-public .price-set-row .highlight label {

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -834,8 +834,7 @@ input.crm-form-entityref {
   margin: 0;
 }
 
-.crm-price-amount-help-pre.description,
-.crm-price-amount-help-post.description {
+.crm-container .price-set-option-content .description {
   font-size: 1em;
 }
 

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -834,7 +834,8 @@ input.crm-form-entityref {
   margin: 0;
 }
 
-.crm-price-amount-help-pre.description, .crm-price-amount-help-post.description {
+.crm-price-amount-help-pre.description,
+.crm-price-amount-help-post.description {
   font-size: 1em;
 }
 

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -73,10 +73,10 @@
                           {$amount|crmMoney:$currency}
                         {elseif $displayOpt == 'Inclusive'}
                           {$amount|crmMoney:$currency}
-                          <span class='crm-price-amount-label'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney:$currency}(includes %1 of %2){/ts}</span>
+                          <span class='crm-price-amount-tax'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney:$currency}(includes %1 of %2){/ts}</span>
                         {else}
                           {$option.amount|crmMoney:$currency}
-                          <span class='crm-price-amount-label'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
+                          <span class='crm-price-amount-tax'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
                         {/if}
                       {else}
                         {$option.amount|crmMoney:$currency} {$fieldHandle} {$form.$fieldHandle.frozen}


### PR DESCRIPTION
Overview
----------------------------------------
Always display pre and post help for price options, which were previously dependent on Display amount being selected or simply not present for selects.
Additionally, minor style changes to increase consistency of price set option display and make them a little less busy.
[Issue #3870
](https://lab.civicrm.org/dev/core/-/issues/3870)

Before
----------------------------------------
For selects, no pre or post help was displayed.
<img width="310" alt="Screen Shot 2022-09-26 at 5 39 53 PM" src="https://user-images.githubusercontent.com/25517556/192414494-735cb994-facd-4aa2-821d-ef7860d90c82.png">

For checkboxes and radio, pre and post help were only displayed when amount was visible.
<img width="310" alt="image" src="https://user-images.githubusercontent.com/25517556/192414005-071b379e-45a0-445e-9b28-027f5c2e6ac6.png">

Page is busy and visually rough with price option labels bolded when amount is visible, but not when amount is not shown (when they are not enclosed in a span).
Slightly smaller font size for pre and post help compared to label and amount — on the same line — is visually distracting and doesn't add information (pre and post help are already in a lighter grey).
<img width="310" alt="image" src="https://user-images.githubusercontent.com/25517556/192415462-faa785be-f2a6-43fd-af73-3c9c67fc9390.png">


After
----------------------------------------
Pre and post help are always displayed.
<img width="310" src="https://user-images.githubusercontent.com/25517556/192413259-0e153f4f-797d-4624-b59c-648d83ff16ee.png">

<img width="310" src="https://user-images.githubusercontent.com/25517556/192414148-f144a46a-4711-47f6-8688-62be69a49477.png">

Amount labels are never bolded (amount label is now always enclosed in a span with .crm-price-amount-label).
Pre and post help for price options are the same font size as the rest of the line.
<img width="310" alt="image" src="https://user-images.githubusercontent.com/25517556/192414825-3f935880-8a52-4e7c-8b45-d93a79b4a527.png">

Technical Details
----------------------------------------
I also changed the class of [these two spans](https://github.com/civicrm/civicrm-core/blob/8c371c3b58e28d04b261107b77fd2773081ccf49/templates/CRM/Price/Form/PriceSet.tpl#L76) to crm-price-amount-tax, as it appears that's what they should be for consistency with price options. Nothing changes visually as these are not within a .price-set-row, so the style change doesn't apply to them, but this made sense to change anyways.