### PR TITLE
[NFC] Assert something in unit test

### DIFF
--- a/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
+++ b/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
@@ -120,14 +120,18 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
    * Test save with no id
    */
   public function testSaveNoId() {
-    $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['is_reserved' => 0], $this->baseTpl)]]);
+    $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['is_reserved' => 0], $this->baseTpl)]])->first();
+    $this->assertDBQuery('My Template', 'SELECT msg_title FROM civicrm_msg_template WHERE id = %1', [1 => [$saved['id'], 'Int']]);
+    $this->assertDBQuery('<p>My body as HTML</p>', 'SELECT msg_html FROM civicrm_msg_template WHERE id = %1', [1 => [$saved['id'], 'Int']]);
   }
 
   /**
    * Test save with an explicit null id
    */
   public function testSaveNullId() {
-    $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['id' => NULL, 'is_reserved' => 0], $this->baseTpl)]]);
+    $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['id' => NULL, 'is_reserved' => 0], $this->baseTpl)]])->first();
+    $this->assertDBQuery('My Template', 'SELECT msg_title FROM civicrm_msg_template WHERE id = %1', [1 => [$saved['id'], 'Int']]);
+    $this->assertDBQuery('<p>My body as HTML</p>', 'SELECT msg_html FROM civicrm_msg_template WHERE id = %1', [1 => [$saved['id'], 'Int']]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
When I wrote this in https://github.com/civicrm/civicrm-core/pull/24586 it was just to demonstrate the fail. But then when I redid the PR against 5.54 and added the fix, I forgot to update the test to make an assertion of some kind.

Civi has `beStrictAboutTestsThatDoNotTestAnything` set to false in phpunit.xml. I'm not sure if that's intentional but normally such a test would have passed but been flagged as "risky".