### PR TITLE
dev/core#3870 - Description of description is wrong for "Display amounts"

### DIFF
--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -156,7 +156,7 @@
       <td class="label">{$form.is_display_amounts.label}</td>
       <td>{$form.is_display_amounts.html}
       {if $action neq 4}
-        <div class="description">{ts}Display amount next to each option? If no, then the amount should be in the option description.{/ts}</div>
+        <div class="description">{ts}Display amount next to each option? If no, then you may include the amount in the option pre/post help text.{/ts}</div>
       {/if}
       </td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/24624.

Before
-------
In the price field configuration, the description for Display Amount says:

_If no, then the amount should be in the option description._

But the description never displays. It doesn't seem to have ever displayed. See also https://issues.civicrm.org/jira/browse/CRM-12252.

After
-----
_If no, then you may include the amount in the option pre/post help text._

FYI @larssandergreen 