### PR TITLE
Update help text for Display Amount? for Price Fields

### DIFF
--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -156,7 +156,7 @@
       <td class="label">{$form.is_display_amounts.label}</td>
       <td>{$form.is_display_amounts.html}
       {if $action neq 4}
-        <div class="description">{ts}Display amount next to each option? If no, then the amount should be in the option description.{/ts}</div>
+        <div class="description">{ts}Display amount next to each option?{/ts}</div>
       {/if}
       </td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Per @demeritcowboy suggestion. This refers to description, but there is no description field.

Before
----------------------------------------
Display amount next to each option? If no, then the amount should be in the option description.

After
----------------------------------------
Display amount next to each option?

Comments
----------------------------------------
Users could put the price in any number of places (pre or post help for the field, pre or post help for the option) or leave it out completely for $0 options. I think we can assume a certain sophistication from someone setting up a price set and don't need to over explain.