### PR TITLE
Simplify description text for Display amounts on price fields, add help text for Description on price options

### DIFF
--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -156,7 +156,7 @@
       <td class="label">{$form.is_display_amounts.label}</td>
       <td>{$form.is_display_amounts.html}
       {if $action neq 4}
-        <div class="description">{ts}Display amount next to each option? If no, then the amount should be in the option description.{/ts}</div>
+        <div class="description">{ts}Display amount next to each option?{/ts}</div>
       {/if}
       </td>
     </tr>

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -40,7 +40,7 @@
         <td>{$form.non_deductible_amount.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-description">
-        <td class="label">{$form.description.label}</td>
+        <td class="label">{$form.description.label}<br />{help id="description" file="CRM/Price/Page/Field.hlp"}</td>
         <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_price_field_value' field='description' id=$optionId}{/if}{$form.description.html}</td>
       </tr>
       <tr class="crm-price-option-form-block-help-pre">

--- a/templates/CRM/Price/Page/Field.hlp
+++ b/templates/CRM/Price/Page/Field.hlp
@@ -89,5 +89,12 @@
   {ts}Membership Type{/ts}
 {/htxt}
 {htxt id="id-membership-type"}
-    {ts}If you select a membership type, a membership will be created or renewed when users select this option. Leave this column blank for non-membership options (e.g. magazine subscription).{/ts} 
+    {ts}If you select a membership type, a membership will be created or renewed when users select this option. Leave this column blank for non-membership options (e.g. magazine subscription).{/ts}
+{/htxt}
+
+{htxt id="description-title"}
+  {ts}Description{/ts}
+{/htxt}
+{htxt id="description"}
+    {ts}Description is not shown publicly.{/ts}
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Per @demeritcowboy suggestion in #24624.

Before
----------------------------------------
<img width="720" alt="image" src="https://user-images.githubusercontent.com/25517556/192577557-33bc6434-dc1f-41b8-8d39-64b750d443e5.png">

<img width="360" alt="image" src="https://user-images.githubusercontent.com/25517556/192577721-16954a20-1fd5-45d7-b0ac-4b4a06883551.png">

After
----------------------------------------
<img width="360" alt="image" src="https://user-images.githubusercontent.com/25517556/192577095-421638ba-dbb6-4f6f-a8c2-3bc6933ed1f6.png">

<img width="360" alt="image" src="https://user-images.githubusercontent.com/25517556/192578204-68fd74ee-377f-449d-921c-984572cc366c.png">
Help text says:  Description is not shown publicly.

Comments
----------------------------------------
Description is not shown anywhere, so telling users to put something there is not helpful.
Users could put the price in any number of places (pre or post help for the field, pre or post help for the option) or leave it out completely for $0 options. I think we can assume a certain sophistication from someone setting up a price set and don't need to over explain.