### PR TITLE
Use array_key_exists to avoid warning on report GroupBy.tpl template

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -21,7 +21,7 @@ class CRM_Report_Form extends CRM_Core_Form {
    *
    * @var string[]
    */
-  public $expectedSmartyVariables = ['pager', 'skip', 'sections', 'grandStat', 'chartEnabled', 'uniqueId', 'rows'];
+  public $expectedSmartyVariables = ['pager', 'skip', 'sections', 'grandStat', 'chartEnabled', 'uniqueId', 'rows', 'group_bys_freq'];
 
   /**
    * Deprecated constant, Reports should be updated to use the getRowCount function.

--- a/templates/CRM/Report/Form/Tabs/GroupBy.tpl
+++ b/templates/CRM/Report/Form/Tabs/GroupBy.tpl
@@ -15,7 +15,7 @@
         {assign var="count" value=`$count+1`}
         <td width="25%">
           {$form.group_bys[$gbElem].html}
-          {if $form.group_bys_freq[$gbElem].html}:<br>
+          {if $form.group_bys_freq && array_key_exists($gbElem, $form.group_bys_freq)}:<br>
             &nbsp;&nbsp;{$form.group_bys_freq[$gbElem].label}&nbsp;{$form.group_bys_freq[$gbElem].html}
           {/if}
         </td>


### PR DESCRIPTION
Overview
----------------------------------------
Use array_key_exists to avoid warning on report GroupBy.tpl template.

Before
----------------------------------------
PHP warnings (notice up until PHP8) were thrown whenever a report with group options was loaded. `Undefined array key`. As the warnings were happening in a loop this could cause a lot of noise when viewing error logs.

After
----------------------------------------
This warning is gone (lots still remaining on reports - baby steps)

Technical Details
----------------------------------------
Tested with and without `CIVICRM_SMARTY_DEFAULT_ESCAPE`, and on a handful of reports.