### PR TITLE
dev/core/#3849 Fix profile group add for events

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1073,13 +1073,15 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     if (!empty($form->_values[$topProfile])) {
       $profiles[] = $form->_values[$topProfile];
     }
-    $uFGroups = \Civi\Api4\UFGroup::get()
-      ->addSelect('add_to_group_id')
-      ->addWhere('id', 'IN', $profiles)
-      ->execute();
-    foreach ($uFGroups as $uFGroup) {
-      if (!empty($uFGroup['add_to_group_id'])) {
-        $addToGroups[$uFGroup['add_to_group_id']] = $uFGroup['add_to_group_id'];
+    if (!empty($profiles)) {
+      $uFGroups = \Civi\Api4\UFGroup::get()
+        ->addSelect('add_to_group_id')
+        ->addWhere('id', 'IN', $profiles)
+        ->execute();
+      foreach ($uFGroups as $uFGroup) {
+        if (!empty($uFGroup['add_to_group_id'])) {
+          $addToGroups[$uFGroup['add_to_group_id']] = $uFGroup['add_to_group_id'];
+        }
       }
     }
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1061,12 +1061,23 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
     // get the add to groups
     $addToGroups = [];
-
-    if (!empty($form->_fields)) {
-      foreach ($form->_fields as $key => $value) {
-        if (!empty($value['add_to_group_id'])) {
-          $addToGroups[$value['add_to_group_id']] = $value['add_to_group_id'];
-        }
+    if (empty($params['registered_by_id'])) {
+      $topProfile = 'custom_pre_id';
+      $additionalProfiles = 'custom_post_id';
+    }
+    else {
+      $topProfile = 'additional_custom_pre_id';
+      $additionalProfiles = 'additional_custom_post_id';
+    }
+    $profiles = $form->_values[$additionalProfiles] ?? [];
+    $profiles[] = $form->_values[$topProfile];
+    $uFGroups = \Civi\Api4\UFGroup::get()
+      ->addSelect('add_to_group_id')
+      ->addWhere('id', 'IN', $profiles)
+      ->execute();
+    foreach ($uFGroups as $uFGroup) {
+      if (!empty($uFGroup['add_to_group_id'])) {
+        $addToGroups[$uFGroup['add_to_group_id']] = $uFGroup['add_to_group_id'];
       }
     }
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1070,7 +1070,9 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $additionalProfiles = 'additional_custom_post_id';
     }
     $profiles = $form->_values[$additionalProfiles] ?? [];
-    $profiles[] = $form->_values[$topProfile];
+    if (!empty($form->_values[$topProfile])) {
+      $profiles[] = $form->_values[$topProfile];
+    }
     $uFGroups = \Civi\Api4\UFGroup::get()
       ->addSelect('add_to_group_id')
       ->addWhere('id', 'IN', $profiles)


### PR DESCRIPTION
Overview
----------------------------------------
This code didn't properly add contacts to groups when using profiles that were set to add to groups in event registrations with multiple participants or multiple profiles.

Before
----------------------------------------
Secondary registrants were added to groups for the primary registrant profiles.
Additionally, when more than two profiles were in use, contacts were not added to all groups, depending on configuration of the event (didn't spend too much time digging into the details on what exactly was happening).

After
----------------------------------------
All registrants are added to the appropriate groups for the profiles set in the event registration.