### PR TITLE
fix throwing error for past events in ICalendar

### DIFF
--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -86,7 +86,7 @@ class CRM_Event_ICalendar {
       else {
         $template->assign('timezones', NULL);
       }
-      
+
       $calendar = $template->fetch('CRM/Core/Calendar/ICal.tpl');
       $calendar = preg_replace('/(?<!\r)\n/', "\r\n", $calendar);
     }

--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -69,17 +69,24 @@ class CRM_Event_ICalendar {
       $calendar = $template->fetch('CRM/Core/Calendar/GData.tpl');
     }
     else {
-      $date_min = min(
-        array_map(function ($event) {
-          return strtotime($event['start_date']);
-        }, $info)
-      );
-      $date_max = max(
-        array_map(function ($event) {
-          return strtotime($event['end_date'] ?? $event['start_date']);
-        }, $info)
-      );
-      $template->assign('timezones', CRM_Utils_ICalendar::generate_timezones($timezones, $date_min, $date_max));
+      if (count($info) > 0) {
+        $date_min = min(
+          array_map(function ($event) {
+            return strtotime($event['start_date']);
+          }, $info)
+        );
+        $date_max = max(
+          array_map(function ($event) {
+            return strtotime($event['end_date'] ?? $event['start_date']);
+          }, $info)
+        );
+
+        $template->assign('timezones', CRM_Utils_ICalendar::generate_timezones($timezones, $date_min, $date_max));
+      }
+      else {
+        $template->assign('timezones', NULL);
+      }
+      
       $calendar = $template->fetch('CRM/Core/Calendar/ICal.tpl');
       $calendar = preg_replace('/(?<!\r)\n/', "\r\n", $calendar);
     }

--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -46,7 +46,7 @@ class CRM_Event_ICalendar {
 
     $info = CRM_Event_BAO_Event::getCompleteInfo($start, $type, $id, $end);
 
-    if ($gCalendar) {
+    if ($gCalendar && count($info) > 0) {
       return self::gCalRedirect($info);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
see #https://lab.civicrm.org/dev/core/-/issues/3873

Before
----------------------------------------
error for past events on ICalendar download

After
----------------------------------------
no error

Technical Details
----------------------------------------

Comments
----------------------------------------
If the event is in the past the downloaded file is empty. I think this was also the behave for iCalnder ( bevore adding gCalender). In a ideal world the ics files would only show up if the downloaded files also contains a valid event. 
