### PR TITLE
Require search kit & form builder for `civiimport`

### DIFF
--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -20,7 +20,11 @@
   <compatibility>
     <ver>5.54</ver>
   </compatibility>
-  <comments>Core extension for us to start moving import logic into</comments>
+  <comments>Core extension for us to start moving import logic into, has more functionality</comments>
+  <requires>
+    <ext>org.civicrm.afform</ext>
+    <ext>org.civicrm.search_kit</ext>
+  </requires>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>


### PR DESCRIPTION
Overview
----------------------------------------
Require search kit & form builder for `civiimport`

Before
----------------------------------------
Search kit & form builder not required

After
----------------------------------------
Search kit & form builder required, enabled on install

Technical Details
----------------------------------------
The other extensions are technically not required yet - but it will be easier to manage later on if we add the requirement now so anyone who enables the extension is known to have them

Comments
----------------------------------------
@colemanw as discussed