### PR TITLE
dev/events#56 Allow backend (de)registration changes for sold out price set items, refactor

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -795,11 +795,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $option['total_option_count'] = $dbTotalCount + $currentTotalCount;
       }
 
-      //ignore option full for offline registration.
-      if ($className == 'CRM_Event_Form_Participant' || $className === 'CRM_Event_Form_Task_Register') {
-        $optionFullIds = [];
-      }
-
       //finally get option ids in.
       $field['option_full_ids'] = $optionFullIds;
     }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -295,6 +295,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
       $useRequired = FALSE;
     }
 
+    $className = CRM_Utils_System::getClassName($qf);
+    $formClasses = ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register', 'CRM_Event_Form_ParticipantFeeSelection'];
+    $isFrontEnd = (!in_array($className, $formClasses));
+
     $customOption = $fieldOptions;
     if (!is_array($customOption)) {
       $customOption = CRM_Price_BAO_PriceField::getOptions($field->id, $inactiveNeeded);
@@ -302,26 +306,14 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
     //use value field.
     $valueFieldName = 'amount';
-    $separator = '|';
-    $taxTerm = Civi::settings()->get('tax_term');
-    $displayOpt = Civi::settings()->get('tax_display_settings');
-    $invoicing = Civi::settings()->get('invoicing');
     switch ($field->html_type) {
       case 'Text':
         $optionKey = key($customOption);
-        $count = CRM_Utils_Array::value('count', $customOption[$optionKey], '');
-        $max_value = CRM_Utils_Array::value('max_value', $customOption[$optionKey], '');
-        $taxAmount = $customOption[$optionKey]['tax_amount'] ?? NULL;
-        if (isset($taxAmount) && $displayOpt && $invoicing) {
-          $qf->assign('displayOpt', $displayOpt);
-          $qf->assign('taxTerm', $taxTerm);
-          $qf->assign('invoicing', $invoicing);
-        }
-        $priceVal = implode($separator, [
-          $customOption[$optionKey][$valueFieldName] + $taxAmount,
-          $count,
-          $max_value,
-        ]);
+
+        // Text elements have a label before and this second label after with amount etc, added here starting with a NULL label
+        $customOption[$optionKey]['label'] = NULL;
+        $priceOptionText = self::buildPriceOptionText($customOption[$optionKey], $field->is_display_amounts, $valueFieldName);
+        $elementLabelAfter = &$qf->add('static', $elementName . '_label_after', $priceOptionText['label']);
 
         $extra = [];
         if (!empty($qf->_membershipBlock) && !empty($qf->_quickConfig) && $field->name == 'other_amount' && empty($qf->_contributionAmount)) {
@@ -343,7 +335,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $element = &$qf->add('text', $elementName, $label,
           array_merge($extra,
             [
-              'price' => json_encode([$optionKey, $priceVal]),
+              'price' => json_encode([$optionKey, $priceOptionText['priceVal']]),
               'size' => '4',
             ]
           ),
@@ -355,9 +347,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         // CRM-6902 - Add "max" option for a price set field
         if (in_array($optionKey, $freezeOptions)) {
-          self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
-          // CRM-14696 - Improve display for sold out price set options
-          $element->setLabel($label . '&nbsp;<span class="sold-out-option">' . ts('Sold out') . '</span>');
+          if ($isFrontEnd) {
+            self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
+          }
+          $elementLabelAfter->setLabel('<span class="sold-out-option">' . $elementLabelAfter->getLabel() . '&nbsp;(' . ts('Sold out') . ')</span>');
         }
 
         //CRM-10117
@@ -381,30 +374,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         }
 
         foreach ($customOption as $opId => $opt) {
-          $preHelpText = $postHelpText = '';
-          $opt['label'] = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' : '';
-          if (!empty($opt['help_pre'])) {
-            $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
-          }
-          if (!empty($opt['help_post'])) {
-            $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
-          }
+          $priceOptionText = self::buildPriceOptionText($opt, $field->is_display_amounts, $valueFieldName);
 
-          $taxAmount = $opt['tax_amount'] ?? NULL;
-          if ($field->is_display_amounts) {
-            $opt['label'] = !empty($opt['label']) ? $opt['label'] . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
-            if (isset($taxAmount) && $invoicing) {
-              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
-            }
-            else {
-              $opt['label'] = $opt['label'] . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
-            }
-          }
-
-          $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
-          $count = CRM_Utils_Array::value('count', $opt, '');
-          $max_value = CRM_Utils_Array::value('max_value', $opt, '');
-          $priceVal = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
           if (isset($opt['visibility_id'])) {
             $visibility_id = $opt['visibility_id'];
           }
@@ -412,7 +383,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             $visibility_id = self::getVisibilityOptionID('public');
           }
           $extra = [
-            'price' => json_encode([$elementName, $priceVal]),
+            'price' => json_encode([$elementName, $priceOptionText['priceVal']]),
             'data-amount' => $opt[$valueFieldName],
             'data-currency' => $currencyName,
             'data-price-field-values' => json_encode($customOption),
@@ -429,7 +400,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             $qf->assign('membershipFieldID', $field->id);
           }
 
-          $choice[$opt['id']] = $opt['label'];
+          $choice[$opt['id']] = $priceOptionText['label'];
           $choiceAttrs[$opt['id']] = $extra;
           if ($is_pay_later) {
             $qf->add('text', 'txt-' . $elementName, $label, ['size' => '4']);
@@ -456,7 +427,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             $none = ts('- none -');
           }
 
-          $choice['0'] = $none;
+          $choice['0'] = '<span class="crm-price-amount-label">' . $none . '</span>';
           $choiceAttrs['0'] = ['price' => json_encode([$elementName, '0'])];
         }
 
@@ -464,7 +435,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         foreach ($element->getElements() as $radioElement) {
           // CRM-6902 - Add "max" option for a price set field
           if (in_array($radioElement->getValue(), $freezeOptions)) {
-            self::freezeIfEnabled($radioElement, $customOption[$radioElement->getValue()]);
+            if ($isFrontEnd) {
+              self::freezeIfEnabled($radioElement, $customOption[$radioElement->getValue()]);
+            }
             // CRM-14696 - Improve display for sold out price set options
             $radioElement->setText('<span class="sold-out-option">' . $radioElement->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
           }
@@ -483,46 +456,24 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         break;
 
       case 'Select':
-        $selectOption = $allowedOptions = $priceVal = [];
+        $selectOption = $allowedOptions = [];
 
         foreach ($customOption as $opt) {
-          $taxAmount = $opt['tax_amount'] ?? NULL;
-          $count = CRM_Utils_Array::value('count', $opt, '');
-          $max_value = CRM_Utils_Array::value('max_value', $opt, '');
-
-          $preHelpText = $postHelpText = '';
-          if (!empty($opt['help_pre'])) {
-            $preHelpText = $opt['help_pre'] . ':&nbsp;';
-          }
-          if (!empty($opt['help_post'])) {
-            $postHelpText = ':&nbsp;' . $opt['help_post'];
-          }
-
-          $taxAmount = $opt['tax_amount'] ?? NULL;
-          if ($field->is_display_amounts) {
-            $opt['label'] = !empty($opt['label']) ? $opt['label'] . '&nbsp;-&nbsp;' : '';
-            if (isset($taxAmount) && $invoicing) {
-              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
-            }
-            else {
-              $opt['label'] = $opt['label'] . CRM_Utils_Money::format($opt[$valueFieldName]);
-            }
-          }
-
-          $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
-
-          $priceVal[$opt['id']] = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
+          $priceOptionText = self::buildPriceOptionText($opt, $field->is_display_amounts, $valueFieldName);
+          $priceOptionText['label'] = strip_tags($priceOptionText['label']);
 
           if (!in_array($opt['id'], $freezeOptions)) {
             $allowedOptions[] = $opt['id'];
           }
           // CRM-14696 - Improve display for sold out price set options
           else {
-            $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
-            $opt['label'] = $opt['label'] . ' (' . ts('Sold out') . ')';
+            if ($isFrontEnd) {
+              $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
+            }
+            $priceOptionText['label'] = $priceOptionText['label'] . ' (' . ts('Sold out') . ')';
           }
 
-          $selectOption[$opt['id']] = $opt['label'];
+          $selectOption[$opt['id']] = $priceOptionText['label'];
 
           if ($is_pay_later) {
             $qf->add('text', 'txt-' . $elementName, $label, ['size' => '4']);
@@ -546,64 +497,36 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         $element = &$qf->add('select', $elementName, $label, $selectOption, $useRequired && $field->is_required, [
           'placeholder' => ts('- select %1 -', [1 => $label]),
-          'price' => json_encode($priceVal),
+          'price' => json_encode($priceOptionText['priceVal']),
           'class' => 'crm-select2' . $class,
           'data-price-field-values' => json_encode($customOption),
         ]);
 
-        // CRM-6902 - Add "max" option for a price set field
-        $button = substr($qf->controller->getButtonName(), -4);
-        if (!empty($freezeOptions) && $button != 'skip') {
-          $qf->addRule($elementName, ts('Sorry, this option is currently sold out.'), 'regex', "/" . implode('|', $allowedOptions) . "/");
-        }
         break;
 
       case 'CheckBox':
 
         $check = [];
         foreach ($customOption as $opId => $opt) {
-          $taxAmount = $opt['tax_amount'] ?? NULL;
-          $count = CRM_Utils_Array::value('count', $opt, '');
-          $max_value = CRM_Utils_Array::value('max_value', $opt, '');
+          $priceOptionText = self::buildPriceOptionText($opt, $field->is_display_amounts, $valueFieldName);
 
-          $preHelpText = $postHelpText = '';
-          $opt['label'] = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' : '';
-          if (!empty($opt['help_pre'])) {
-            $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
-          }
-          if (!empty($opt['help_post'])) {
-            $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
-          }
-
-          $taxAmount = $opt['tax_amount'] ?? NULL;
-          if ($field->is_display_amounts) {
-            $opt['label'] = !empty($opt['label']) ? $opt['label'] . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
-            if (isset($taxAmount) && $invoicing) {
-              $opt['label'] = $opt['label'] . self::getTaxLabel($opt, $valueFieldName);
-            }
-            else {
-              $opt['label'] = $opt['label'] . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
-            }
-          }
-
-          $opt['label'] = $preHelpText . $opt['label'] . $postHelpText;
-
-          $priceVal = implode($separator, [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
-          $check[$opId] = &$qf->createElement('checkbox', $opt['id'], NULL, $opt['label'],
+          $check[$opId] = &$qf->createElement('checkbox', $opt['id'], NULL, $priceOptionText['label'],
             [
-              'price' => json_encode([$opt['id'], $priceVal]),
+              'price' => json_encode([$opt['id'], $priceOptionText['priceVal']]),
               'data-amount' => $opt[$valueFieldName],
               'data-currency' => $currencyName,
               'visibility' => $opt['visibility_id'],
             ]
           );
           if ($is_pay_later) {
-            $txtcheck[$opId] =& $qf->createElement('text', $opId, $opt['label'], ['size' => '4']);
+            $txtcheck[$opId] =& $qf->createElement('text', $opId, $priceOptionText['label'], ['size' => '4']);
             $qf->addGroup($txtcheck, 'txt-' . $elementName, $label);
           }
           // CRM-6902 - Add "max" option for a price set field
           if (in_array($opId, $freezeOptions)) {
-            self::freezeIfEnabled($check[$opId], $customOption[$opId]);
+            if ($isFrontEnd) {
+              self::freezeIfEnabled($check[$opId], $customOption[$opId]);
+            }
             // CRM-14696 - Improve display for sold out price set options
             $check[$opId]->setText('<span class="sold-out-option">' . $check[$opId]->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
           }
@@ -849,6 +772,48 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
         $error['_qf_default'] = ts('Please select at least one option from price set.');
       }
     }
+  }
+
+  /**
+   * Build the label and priceVal string for a price option.
+   *
+   * @param array $opt
+   *   Price field option.
+   * @param bool $isDisplayAmounts
+   * @param string $valueFieldName
+   *
+   * @return array
+   *   Price field option label, price value
+   */
+  public static function buildPriceOptionText($opt, $isDisplayAmounts, $valueFieldName) {
+    $preHelpText = $postHelpText = '';
+    $optionLabel = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' : '';
+    if (!empty($opt['help_pre'])) {
+      $preHelpText = '<span class="crm-price-amount-help-pre description">' . $opt['help_pre'] . '</span><span class="crm-price-amount-help-pre-separator">:&nbsp;</span>';
+    }
+    if (!empty($opt['help_post'])) {
+      $postHelpText = '<span class="crm-price-amount-help-post-separator">:&nbsp;</span><span class="crm-price-amount-help-post description">' . $opt['help_post'] . '</span>';
+    }
+
+    $invoicing = Civi::settings()->get('invoicing');
+    $taxAmount = $opt['tax_amount'] ?? NULL;
+    if ($isDisplayAmounts) {
+      $optionLabel = !empty($optionLabel) ? $optionLabel . '<span class="crm-price-amount-label-separator">&nbsp;-&nbsp;</span>' : '';
+      if (isset($taxAmount) && $invoicing) {
+        $optionLabel = $optionLabel . self::getTaxLabel($opt, $valueFieldName);
+      }
+      else {
+        $optionLabel = $optionLabel . '<span class="crm-price-amount-amount">' . CRM_Utils_Money::format($opt[$valueFieldName]) . '</span>';
+      }
+    }
+
+    $optionLabel = $preHelpText . $optionLabel . $postHelpText;
+
+    $count = CRM_Utils_Array::value('count', $opt, '');
+    $max_value = CRM_Utils_Array::value('max_value', $opt, '');
+    $priceVal = implode('|', [$opt[$valueFieldName] + $taxAmount, $count, $max_value]);
+
+    return ['label' => $optionLabel, 'priceVal' => $priceVal];
   }
 
   /**

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -67,7 +67,8 @@ div.crm-container fieldset label {
 }
 
 input.crm-form-radio + label,
-input.crm-form-checkbox + label {
+input.crm-form-checkbox + label,
+.crm-frozen-field .sold-out-option {
   margin-left: 7px;
 }
 
@@ -832,6 +833,14 @@ input.crm-form-entityref {
   line-height: inherit;
   padding: 0;
   margin: 0;
+}
+
+.crm-container .description.help_post {
+  margin-top: 0.45em;
+}
+
+.crm-container .description.help_pre {
+  margin-bottom: 0.45em;
 }
 
 .crm-container .price-set-option-content .description {
@@ -3800,12 +3809,8 @@ span.crm-status-icon {
   display: none;
 }
 
-#crm-container .sold-out-option,
-#crm-container .price-set-row span.sold-out-option .crm-price-amount-label,
-#crm-container .price-set-row span.sold-out-option .crm-price-amount-amount {
-  font-style: italic !important;
-  font-weight: normal !important;
-  font-size: 15px;
+.crm-container span.sold-out-option,
+.crm-container span.sold-out-option span {
   color: #666 !important;
 }
 

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -28,12 +28,12 @@
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
         {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
-            {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
             <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_"|cat:$field_id}
               <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name}-content">
+              {if $element.help_pre}<div class="description  help_pre">{$element.help_pre}</div>{/if}
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
@@ -53,7 +53,7 @@
                   {/if}
                 {/foreach}
                 {if $element.help_post}
-                  <div class="description">{$element.help_post}</div>
+                  <div class="description help_post">{$element.help_post}</div>
                 {/if}
               </div>
             {else}
@@ -62,36 +62,13 @@
 
                 <div class="label">{$form.$element_name.label}</div>
                 <div class="content {$element.name}-content">
+                  {if $element.help_pre}<div class="description  help_pre">{$element.help_pre}</div>{/if}
                   {$form.$element_name.html}
-                  {if $element.html_type eq 'Text'}
-                    {if $element.is_display_amounts}
-                    <span class="price-field-amount{if $form.$element_name.frozen EQ 1} sold-out-option{/if}">
-                    {foreach item=option from=$element.options}
-                      {if ($option.tax_amount || $option.tax_amount == "0") && $displayOpt && $invoicing}
-                        {assign var="amount" value=`$option.amount+$option.tax_amount`}
-                        {if $displayOpt == 'Do_not_show'}
-                          {$amount|crmMoney:$currency}
-                        {elseif $displayOpt == 'Inclusive'}
-                          {$amount|crmMoney:$currency}
-                          <span class='crm-price-amount-tax'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney:$currency}(includes %1 of %2){/ts}</span>
-                        {else}
-                          {$option.amount|crmMoney:$currency}
-                          <span class='crm-price-amount-tax'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
-                        {/if}
-                      {else}
-                        {$option.amount|crmMoney:$currency} {$fieldHandle} {$form.$fieldHandle.frozen}
-                      {/if}
-                      {if $form.$element_name.frozen EQ 1} ({ts}Sold out{/ts}){/if}
-                    {/foreach}
-                    </span>
-                    {else}
-                      {* Not showing amount, but still need to conditionally show Sold out marker *}
-                      {if $form.$element_name.frozen EQ 1}
-                        <span class="sold-out-option">({ts}Sold out{/ts})<span>
-                      {/if}
+                    {if $element.html_type eq 'Text'}
+                      {assign var="element_name_label_after" value="`$element_name`_label_after"}
+                      {$form.$element_name_label_after.label}
                     {/if}
-                  {/if}
-                  {if $element.help_post}<br /><span class="description">{$element.help_post}</span>{/if}
+                  {if $element.help_post}<div class="description help_post">{$element.help_post}</div>{/if}
                 </div>
 
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This replaces #20252, which I cannot re-open — but it now includes some refactoring and even more clean up of styles.

Currently, when editing price set selections for an event registrant, you cannot add or remove sold out items. This PR makes it possible for backend users to add or remove price set selections that are sold out from registrations. It also ensures that all full selections show (Sold out) text, both on the Register Participant form and the Change Selections and Edit Event Registration forms.

It also fixes some inconsistent fonts, margins, spacing, etc in price sets.

Perhaps most importantly, it refactors some of the very repetitive Quickform code for price sets to hopefully make that a little more maintainable (though there still a lot more that could be done).

Before
----------------------------------------
If a price set selection is sold out, back-end users can add this selection on Events - Register Event Participant, but if they edit a existing registration they cannot either add or subtract from sold out selections as these are disabled/frozen (except for removing select fields, which was possible). Back-end users may add registrants to sold out selections unintentionally, as there is no warning that selections are sold out on the Register Participant Form. Backend users cannot remove registrants from sold out selections, which should clearly be possible. They cannot override price set limits if required to add participants to sold out selections.

Register Participant: Backend user can register participant for sold out selections, they are unmarked
<img width="726" alt="image" src="https://user-images.githubusercontent.com/25517556/198738854-5ca65f82-bd46-4992-8320-63a5ad898c5a.png">

Change Selections: Participant cannot be added or removed from sold out selections
<img width="755" alt="image" src="https://user-images.githubusercontent.com/25517556/198738790-61c75fc7-e876-41e1-b034-08f76356d7c4.png">

Front end registration, lots of odd styling
<img width="778" alt="image" src="https://user-images.githubusercontent.com/25517556/198738721-4098eaa0-8e89-4812-8579-0f342770e161.png">

After
----------------------------------------
Backend users can register and deregister participants for any price set selection. All price set selections that are sold out are now marked as sold out.

Register participant: Sold out selections are now marked
![image](https://user-images.githubusercontent.com/25517556/198738202-a07ddeb6-fb40-407c-ba26-65960477ba0a.png)

Change Selections: Participant can be added to or removed from all selections.
<img width="711" alt="image" src="https://user-images.githubusercontent.com/25517556/198738391-56002ddd-a8b1-43e7-bfae-97de1764e0da.png">

Front end registration, a little more readable and consistent
<img width="823" alt="image" src="https://user-images.githubusercontent.com/25517556/198738317-4a4604de-7e23-4f4a-96f7-060809ea98ca.png">

I've also removed the italics, font size and weight from sold out items so the form is less busy and more consistent, enclosed the none option in a span to match other radio options, and added the light sold out grey colour to all sold out options (except the select options). I removed the double 'Sold out' for text fields and added the missing 'Sold out' on select options. Added space between frozen checkbox and radios and text. Fixed inconsistent font size and spacing for pre and post field help.

Comments
----------------------------------------
I've moved the great concatenate fest that was building the labels for price set options into a separate function so it isn't repeated four times. I've also aligned the process for Text fields with the process for all the other types by moving this from the tpl to the Price Field BAO, so it can use the same function rather than implementing the same logic in Smarty. This required a small change that is a bit odd to get the label for the text field to the tpl, introducing an auxiliary form element that holds the label that goes after the text field, since the text field has two labels. This is all working around the unfortunate situation where text fields are both price fields and price options at the same time.

I've removed some now unneeded code that set form rules for selects and some other repeated code.

The warning found in the previous PR by @BettyDolfing and @jaapjansma has been fixed in the refactoring (thanks for testing and sorry to have been unable to respond at the time). I'm unable to reproduce the blank preview issue.
