### PR TITLE
dev/core#3877 - APIv4 - Save time part to subsciption history date

### DIFF
--- a/CRM/Contact/BAO/SubscriptionHistory.php
+++ b/CRM/Contact/BAO/SubscriptionHistory.php
@@ -31,7 +31,7 @@ class CRM_Contact_BAO_SubscriptionHistory extends CRM_Contact_DAO_SubscriptionHi
    */
   public static function create($params) {
     $history = new CRM_Contact_BAO_SubscriptionHistory();
-    $history->date = date('Ymd');
+    $history->date = date('YmdHis');
     $history->copyValues($params);
     $history->save();
     return $history;

--- a/tests/phpunit/api/v4/Entity/SubscriptionHistoryTest.php
+++ b/tests/phpunit/api/v4/Entity/SubscriptionHistoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Entity;
+
+use Civi\Api4\SubscriptionHistory;
+use Civi\Api4\GroupContact;
+use api\v4\Api4TestBase;
+
+/**
+ * @group headless
+ */
+class SubscriptionHistoryTest extends Api4TestBase {
+
+  public function testGet() {
+    $contact = $this->createTestRecord('Contact');
+    $group = $this->createTestRecord('Group');
+    $timeAdded = time();
+    $groupContact = $this->createTestRecord('GroupContact', [
+      'group_id' => $group['id'],
+      'contact_id' => $contact['id'],
+    ]);
+    $historyAdded = SubscriptionHistory::get()
+      ->addSelect('*')
+      ->addWhere('group_id', '=', $group['id'])
+      ->addWhere('status', '=', 'Added')
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(1, $historyAdded);
+    $this->assertGreaterThanOrEqual($timeAdded, strtotime($historyAdded->single()['date']));
+    $this->assertLessThanOrEqual(time(), strtotime($historyAdded->single()['date']));
+
+    $timeRemoved = time();
+    GroupContact::update()
+      ->addValue('status', 'Removed')
+      ->addWhere('id', '=', $groupContact['id'])
+      ->execute();
+    $historyRemoved = SubscriptionHistory::get()
+      ->addSelect('*')
+      ->addWhere('group_id', '=', $group['id'])
+      ->addWhere('status', '=', 'Removed')
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(1, $historyRemoved);
+    $this->assertGreaterThanOrEqual($timeRemoved, strtotime($historyRemoved->single()['date']));
+    $this->assertLessThanOrEqual(time(), strtotime($historyRemoved->single()['date']));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3877

Before
----------------------------------------
Date was initialized with date part only when using APIv4.

After
----------------------------------------
Date also contains time part.
