### PR TITLE
(dev/core#3857) Only public custom groups should be shown in offline …

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -405,6 +405,11 @@ class CRM_Contribute_Form_AdditionalInfo {
         if ($groupID == 'info') {
           continue;
         }
+
+        $is_public = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $groupID, 'is_public');
+        if (!$is_public) {
+          continue;
+        }
         foreach ($group['fields'] as $k => $field) {
           $field['title'] = $field['label'];
           $customFields["custom_{$k}"] = $field;


### PR DESCRIPTION
…contribution receipts

Overview
----------------------------------------
If a custom group is public, by definition it says : Check this box if you want this custom group to be displayed on public forms e.g. Event Information page. Only public custom groups will be included in event receipts.

But when you have non public custom groups on contributions they show up in the offline receipts.

Before
----------------------------------------
non public custom group
![pub](https://user-images.githubusercontent.com/3455173/192957616-bd9c4800-b9f1-4101-a084-324b19a62c60.png)

shows up in the receipt

![wfsb_custom_fields_before](https://user-images.githubusercontent.com/3455173/192957033-ef0c735f-f879-4fca-986d-8835cbd65ebf.png)


After
----------------------------------------
gone!
![wfsb_custom_fields_after](https://user-images.githubusercontent.com/3455173/192957076-22c154b5-2760-4d38-865f-0cdc4675476b.png)
