### PR TITLE
fix error for ended events in CRM_Event_ICalendar

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2423,20 +2423,23 @@ WHERE  ce.loc_block_id = $locBlockId";
     $query = [
       'reset' => 1,
     ];
+
     if ($eventId) {
       $query['id'] = $eventId;
-    }
-    $return[] = [
-      'url' => CRM_Utils_System::url('civicrm/event/ical', $query, TRUE, NULL, TRUE),
-      'text' => $eventId ? ts('Download iCalendar entry for this event.') : ts('Download iCalendar entry for current and future public events.'),
-      'icon' => 'fa-download',
-    ];
-    if ($eventId) {
-      $return[] = [
-        'url' => CRM_Utils_System::url('civicrm/event/ical', ['gCalendar' => 1] + $query, TRUE, NULL, TRUE),
-        'text' => ts('Add event to Google Calendar'),
-        'icon' => 'fa-share',
-      ];
+      $endDate = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $eventId, 'end_date');
+      if (empty($endDate) || strtotime($endDate) >= time()) {
+        $return[] = [
+          'url' => CRM_Utils_System::url('civicrm/event/ical', $query, TRUE, NULL, TRUE),
+          'text' => ts('Download iCalendar entry for this event.'),
+          'icon' => 'fa-download',
+        ];
+
+        $return[] = [
+          'url' => CRM_Utils_System::url('civicrm/event/ical', ['gCalendar' => 1] + $query, TRUE, NULL, TRUE),
+          'text' => ts('Add event to Google Calendar'),
+          'icon' => 'fa-share',
+        ];
+      }
     }
     else {
       $return[] = [
@@ -2445,6 +2448,7 @@ WHERE  ce.loc_block_id = $locBlockId";
         'icon' => 'fa-link',
       ];
     }
+
     return $return;
   }
 

--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -46,7 +46,7 @@ class CRM_Event_ICalendar {
 
     $info = CRM_Event_BAO_Event::getCompleteInfo($start, $type, $id, $end);
 
-    if ($gCalendar) {
+    if ($gCalendar && count($info) === 1) {
       return self::gCalRedirect($info);
     }
 
@@ -69,17 +69,23 @@ class CRM_Event_ICalendar {
       $calendar = $template->fetch('CRM/Core/Calendar/GData.tpl');
     }
     else {
-      $date_min = min(
-        array_map(function ($event) {
-          return strtotime($event['start_date']);
-        }, $info)
-      );
-      $date_max = max(
-        array_map(function ($event) {
-          return strtotime($event['end_date'] ?? $event['start_date']);
-        }, $info)
-      );
-      $template->assign('timezones', CRM_Utils_ICalendar::generate_timezones($timezones, $date_min, $date_max));
+      if (count($info) > 0) {
+        $date_min = min(
+          array_map(function ($event) {
+            return strtotime($event['start_date']);
+          }, $info)
+        );
+        $date_max = max(
+          array_map(function ($event) {
+            return strtotime($event['end_date'] ?? $event['start_date']);
+          }, $info)
+        );
+        $template->assign('timezones', CRM_Utils_ICalendar::generate_timezones($timezones, $date_min, $date_max));
+      }
+      else {
+        $template->assign('timezones', NULL);
+      }
+
       $calendar = $template->fetch('CRM/Core/Calendar/ICal.tpl');
       $calendar = preg_replace('/(?<!\r)\n/', "\r\n", $calendar);
     }
@@ -100,10 +106,6 @@ class CRM_Event_ICalendar {
   }
 
   protected static function gCalRedirect(array $events) {
-    if (count($events) != 1) {
-      throw new CRM_Core_Exception(ts('Expected one %1, found %2', [1 => ts('Event'), 2 => count($events)]));
-    }
-
     $event = reset($events);
 
     // Fetch the required Date TimeStamps


### PR DESCRIPTION
Overview
----------------------------------------

see https://github.com/civicrm/civicrm-core/pull/24634
see https://lab.civicrm.org/dev/core/-/issues/3873

Before
----------------------------------------
error for ended events

After
----------------------------------------
no error
For Event pages the links are only shown if the event is not ended.

Technical Details
----------------------------------------


Comments
----------------------------------------
I tink the changes in [/ICalendar.php](https://github.com/civicrm/civicrm-core/pull/24647/files#diff-27d4f1b5607c670d64ba0a0297c9c42de59b514119dfa7ffa6ddf8e3bbda2363) are still needed, because this is also called from different templates.