### PR TITLE
Make it clear that same email for event registrations allows multiple registrations per contact

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -253,7 +253,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
     $this->addElement('checkbox',
       'allow_same_participant_emails',
-      ts('Same email address?')
+      ts('Allow same email or multiple registrations?')
     );
     $this->assign('ruleFields', json_encode($ruleFields));
 

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -253,7 +253,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
     $this->addElement('checkbox',
       'allow_same_participant_emails',
-      ts('Allow same email or multiple registrations?')
+      ts('Allow same email and multiple registrations?')
     );
     $this->assign('ruleFields', json_encode($ruleFields));
 

--- a/templates/CRM/Event/Form/ManageEvent/Registration.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.hlp
@@ -61,6 +61,7 @@
 {/htxt}
 {htxt id="id-allow_same_email"}
 <p>{ts}Check this box to allow a user to register multiple participants using the same email address. Alternatively, if you want additional participants to be registered <strong>without requiring an email address to be entered for each person</strong> - check the "Register multiple participants" option, AND include a profile in this registration form which <strong>includes First Name and Last Name fields</strong>.{/ts}</p>
+<p>{ts}Checking this box will also allow the <strong>same contact to register for this event multiple times</strong>, which is otherwise not possible.{/ts}</p>
 {/htxt}
 {htxt id="id-dedupe_rule_group_id-title"}
   {ts}Duplicate Matching Rule{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
I think wanting to allow people to register for the same event more than once is probably a somewhat common need, but currently it is unclear how to allow this in the event registration set up. This makes it clear that same email must be enabled.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/193166273-206fe7c3-ba3b-47dd-a37e-55466e3955f7.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/193166236-0fc99d8d-76ec-4b0b-a200-b9407836f50e.png)

This is also added to the bottom of the help text.
![image](https://user-images.githubusercontent.com/25517556/193166086-d66de72e-e055-4864-a6bf-66dd2fe236d3.png)

[Accompanying docs PR](https://lab.civicrm.org/documentation/docs/user-en/-/merge_requests/582)