### PR TITLE
dev/core#3885 Only find fee levels with qty > 0 for participant and advanced search

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -335,6 +335,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
           $labels[] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $val, 'label');
         }
         $query->_where[$grouping][] = "civicrm_line_item.price_field_value_id IN (" . implode(', ', $value) . ")";
+        $query->_where[$grouping][] = "civicrm_line_item.qty > 0";
         $query->_qill[$grouping][] = ts("Fee level") . " IN " . implode(', ', $labels);
         $query->_tables['civicrm_participant'] = $query->_tables['civicrm_line_item'] = $query->_whereTables['civicrm_line_item'] = 1;
         return;


### PR DESCRIPTION
Overview
----------------------------------------
When event registrations with a price set are changed, price set options / fee levels that a participant are removed from are set to quantity = 0, rather than being removed entirely (the line item qty is set to 0).

When using Advanced Search or Participant Search by Fee Level, participants with qty = 0 are included in the search results, so the search results include participants who were previously registered but have been de-registered from that option. I think generally when someone is searching for participants with a certain fee level, they are looking for participants who are currently registered for that option.

I can't think of many use cases for finding participants who have deregistered for a fee option, but if anyone needed to do so, this could still be achieved in Search Kit. 

Before
----------------------------------------
Searching by Fee Level included participants with qty = 0.

After
----------------------------------------
Searching by Fee Level includes only participants with qty > 0.

Technical Details
----------------------------------------
This doesn't change anything about the display of line items for participants (on their contact page, in search results, etc) or anything in either API.

This is also consistent with the fee_level field in the participant table, which does not include qty 0 options.