### PR TITLE
When running unit tests don't accidentally overwrite your db

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -99,8 +99,13 @@ if (!defined('CIVICRM_UF_DSN') && CIVICRM_UF !== 'UnitTests') {
  *
  */
 if (!defined('CIVICRM_DSN')) {
-  if (CIVICRM_UF === 'UnitTests' && isset($GLOBALS['_CV']['TEST_DB_DSN'])) {
-    define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
+  if (CIVICRM_UF === 'UnitTests') {
+    if (isset($GLOBALS['_CV']['TEST_DB_DSN'])) {
+      define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
+    }
+    else {
+      throw new \Exception('$GLOBALS["_CV"]["TEST_DB_DSN"] is not set');
+    }
   }
   else {
     define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true%%dbSSL%%');


### PR DESCRIPTION
Overview
----------------------------------------
Update civicrm.settings.php to abort instead of falling back your "real" db.

Before
----------------------------------------
As currently written, this if-block will fall back to your "real" db if for whatever reason `$GLOBALS['_CV']['TEST_DB_DSN']` isn't set, potentially causing the test sytem to overwrite the data.

```php
  if (CIVICRM_UF === 'UnitTests' && isset($GLOBALS['_CV']['TEST_DB_DSN'])) {
    define('CIVICRM_DSN', $GLOBALS['_CV']['TEST_DB_DSN']);
   }
   else {
     define('CIVICRM_DSN', 'mysql://%%dbUser%%:%%dbPass%%@%%dbHost%%/%%dbName%%?new_link=true%%dbSSL%%');
```

After
----------------------------------------
Aborts instead.

Technical Details
----------------------------------------
I'm not sure why `$GLOBALS['_CV']['TEST_DB_DSN']` wasn't set in my case, possibly a windows+cv+drupal8 situation failing to find some path - I don't usually run core tests with that combo. So the actual problem might be elsewhere but I'm thinking better to abort so you can then go search for the problem rather than overwrite the db.

Comments
----------------------------------------
There might be a legitimate configuration where the expectation is it uses the value in civicrm.settings.php instead of the test db when it's blank, but I'm not sure what that would be.
