### PR TITLE
RecentItems - additional fix for inconsistent option values

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.54.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.54.alpha1.mysql.tpl
@@ -12,3 +12,8 @@ WHERE `option_group_id` = @og_recent_items_providers;
 UPDATE `civicrm_option_value`
 SET `value` = `name`
 WHERE `option_group_id` = @og_recent_items_providers AND `value` REGEXP '^[0-9]+$';
+
+{* Fix option values created with wrong name by the 5.53.0 installer *}
+UPDATE `civicrm_option_value`
+SET `name` = `value`
+WHERE `option_group_id` = @og_recent_items_providers;


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #24632 - this fixes incorrect values created by the 5.53.0 installer.

Technical Details
----------------------------------------
The problem with https://github.com/civicrm/civicrm-core/pull/24164 is that both the installer AND the upgrader were incorrect. So it's a multi-step process to fix all permutations of incorrectness :)
#24632 fixed the incorrect data written by the upgrader, but didn't account for new sites installed with 5.53.0. This fixes the latter.

Comments
---------------
It's confusing to read because the first UPDATE sets `value` to `name` and the second sets `name` to `value`, but the WHERE clause distinguishes the data created by the upgrader vs by the installer.
