### PR TITLE
dev/core#2535 Scheduled reminders: Add error if both absolute and relative date entered

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -333,6 +333,9 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $errors['entity'] = ts('Please select entity value');
     }
 
+    if (!CRM_Utils_System::isNull($fields['absolute_date']) && !CRM_Utils_System::isNull($fields['start_action_offset'])) {
+      $errors['absolute_date'] = ts('Only an absolute date or a relative date or time can be entered, not both.');
+    }
     if (!CRM_Utils_System::isNull($fields['absolute_date'])) {
       if ($fields['absolute_date'] < date('Y-m-d')) {
         $errors['absolute_date'] = ts('Absolute date cannot be earlier than the current time.');


### PR DESCRIPTION
Overview
----------------------------------------
Prevents users from saving a scheduled reminder that has both an absolute and relative date set, resulting in the relative date being ignored.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/193357930-9b264db6-a8d1-447f-9ae4-de4099eb33fd.png)
This can be submitted successfully, though only the absolute date is actually saved, potentially creating confusion.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/193357981-85343df3-4ec3-48d6-bf2b-ff5e4bcc3010.png)
The form cannot be submitted if both relative and absolutes dates are filled in.