### PR TITLE
dev/core/#3361 Add Change Selections button when viewing price set registrations with no contribution associated

### DIFF
--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -12,18 +12,18 @@
     <div class="action-link">
         <div class="crm-submit-buttons">
             {if call_user_func(array('CRM_Core_Permission','check'), 'edit event participants')}
-         {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event"}
+         {assign var='editUrlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event"}
          {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-         {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event&key=$searchKey"}
+         {assign var='editUrlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event&key=$searchKey"}
          {/if}
-               <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$urlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
+               <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$editUrlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
             {/if}
             {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviEvent')}
-                {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&selectedChild=event"}
+                {assign var='deleteUrlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&selectedChild=event"}
           {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-          {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&selectedChild=event&key=$searchKey"}
+          {assign var='deleteUrlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&selectedChild=event&key=$searchKey"}
           {/if}
-                <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$urlParams}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
+                <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$deleteUrlParams}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
             {/if}
             {include file="CRM/common/formButtons.tpl" location="top"}
         </div>
@@ -99,7 +99,9 @@
                 <td>{include file="CRM/Price/Page/LineItem.tpl" context="Event"}
                 {if call_user_func(array('CRM_Core_Permission','check'), 'edit event participants')}
                     {if $hasPayment or $parentHasPayment}
-                        <a class="action-item crm-hover-button" href='{crmURL p="civicrm/event/participant/feeselection" q="reset=1&id=`$participantId`&cid=`$contactId`&action=update"}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
+                      <a class="action-item crm-hover-button" href='{crmURL p="civicrm/event/participant/feeselection" q="reset=1&id=`$participantId`&cid=`$contactId`&action=update"}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
+                    {else}
+                      <a class="action-item crm-hover-button" href='{crmURL p="civicrm/contact/view/participant" q=$editUrlParams}'><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Change Selections{/ts}</a>
                     {/if}
                     {if $transferOrCancelLink}
                       <a class="action-item crm-hover-button" href={$transferOrCancelLink}><i class="crm-i fa-times" aria-hidden="true"></i> {ts}Transfer or Cancel{/ts}</a>
@@ -126,21 +128,12 @@
         {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
     {/if}
     <div class="crm-submit-buttons">
-        {if call_user_func(array('CRM_Core_Permission','check'), 'edit event participants')}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event"}
-    {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=update&context=$context&selectedChild=event&key=$searchKey"}
-    {/if}
-
-           <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$urlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
-        {/if}
-        {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviEvent')}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&selectedChild=event"}
-    {if ( $context eq 'fulltext' || $context eq 'search' ) && $searchKey}
-    {assign var='urlParams' value="reset=1&id=$id&cid=$contact_id&action=delete&context=$context&selectedChild=event&key=$searchKey"}
-    {/if}
-            <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$urlParams}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
-        {/if}
-        {include file="CRM/common/formButtons.tpl" location="bottom"}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'edit event participants')}
+        <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$editUrlParams}" accesskey="e"><span><i class="crm-i fa-pencil" aria-hidden="true"></i> {ts}Edit{/ts}</span></a>
+      {/if}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviEvent')}
+        <a class="button" href="{crmURL p='civicrm/contact/view/participant' q=$deleteUrlParams}"><span><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}Delete{/ts}</span></a>
+      {/if}
+      {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Just a simple change for consistency. When an event used a price set, there was a Change Selections button on the View Participant page for participants where there was a contribution associated, but there was no Change Selections button for participants with no contribution associated.

This sort of makes sense as the edit page for no contribution participants directly allows editing of price set selections, but from the user's perspective it is confusing because it looks like you can't change the selections for some reason (at least it was to this user). Better for these to be the same in both cases.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/193376463-91493e33-fa99-4bb8-9f28-cb0222bc6751.png)
No Change Selections for participants without an associated contribution.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/193376497-410f90e3-31da-4c51-a635-485ff29969cc.png)
The Change Selections button just goes to the edit page for the participant, same as the Edit button.

Technical Details
----------------------------------------
Also cleaned up a little redundant template code that this touched.