### PR TITLE
Handle all from and to relative dates in API4

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -159,9 +159,20 @@ class FormattingUtil {
       case 'LIKE':
       case 'NOT LIKE':
         $operator = ($operator === '=' || $operator === 'LIKE') ? 'BETWEEN' : 'NOT BETWEEN';
-        return [self::formatDateValue($format, $dateFrom), self::formatDateValue($format, $dateTo)];
 
-      // Less-than or greater-than-equal-to comparisons use the lower value
+        if (is_null($dateFrom) && !is_null($dateTo)) {
+          $operator = '<=';
+          return self::formatDateValue($format, $dateTo);
+        }
+        elseif (!is_null($dateFrom) && is_null($dateTo)) {
+          $operator = '>=';
+          return self::formatDateValue($format, $dateFrom);
+        }
+        else {
+          return [self::formatDateValue($format, $dateFrom), self::formatDateValue($format, $dateTo)];
+        }
+
+        // Less-than or greater-than-equal-to comparisons use the lower value
       case '<':
       case '>=':
         return self::formatDateValue($format, $dateFrom);

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -161,11 +161,11 @@ class FormattingUtil {
         $operator = ($operator === '=' || $operator === 'LIKE') ? 'BETWEEN' : 'NOT BETWEEN';
 
         if (is_null($dateFrom) && !is_null($dateTo)) {
-          $operator = '<=';
+          $operator = ($operator === 'BETWEEN') ? '<=' : '>=';
           return self::formatDateValue($format, $dateTo);
         }
         elseif (!is_null($dateFrom) && is_null($dateTo)) {
-          $operator = '>=';
+          $operator = ($operator === 'BETWEEN') ? '>=' : '<=';
           return self::formatDateValue($format, $dateFrom);
         }
         else {

--- a/tests/phpunit/api/v4/Action/DateTest.php
+++ b/tests/phpunit/api/v4/Action/DateTest.php
@@ -197,6 +197,48 @@ class DateTest extends Api4TestBase implements TransactionalInterface {
       ->addWhere('id', '=', $c1)
       ->execute();
     $this->assertCount(2, $contact);
+
+    // Find contributions To end of previous calendar year
+    $contact = \Civi\Api4\Contact::get()
+      ->addSelect('id', 'contribution.total_amount')
+      ->setJoin([
+        ['Contribution AS contribution', FALSE, NULL, ['contribution.receive_date', '=', '"earlier.year"']],
+      ])
+      ->addWhere('id', '=', $c1)
+      ->execute();
+    $this->assertCount(2, $contact);
+
+    // Find contributions not To end of previous calendar year
+    $contact = \Civi\Api4\Contact::get()
+      ->addSelect('id', 'contribution.total_amount')
+      ->setJoin([
+        ['Contribution AS contribution', FALSE, NULL, ['contribution.receive_date', '!=', '"earlier.year"']],
+      ])
+      ->addWhere('id', '=', $c1)
+      ->execute();
+    $this->assertCount(1, $contact);
+    $this->assertEquals(6, $contact[0]['contribution.total_amount']);
+
+    // Find contributions From start of current calendar year
+    $contact = \Civi\Api4\Contact::get()
+      ->addSelect('id', 'contribution.total_amount')
+      ->setJoin([
+        ['Contribution AS contribution', FALSE, NULL, ['contribution.receive_date', '=', '"greater.year"']],
+      ])
+      ->addWhere('id', '=', $c1)
+      ->execute();
+    $this->assertCount(1, $contact);
+    $this->assertEquals(6, $contact[0]['contribution.total_amount']);
+
+    // Find contributions not From start of current calendar year
+    $contact = \Civi\Api4\Contact::get()
+      ->addSelect('id', 'contribution.total_amount')
+      ->setJoin([
+        ['Contribution AS contribution', FALSE, NULL, ['contribution.receive_date', '!=', '"greater.year"']],
+      ])
+      ->addWhere('id', '=', $c1)
+      ->execute();
+    $this->assertCount(2, $contact);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
API4 does not work correctly with relative dates that are open ended (e.g. From start of current calendar year). The open ended date is set to NULL [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Date.php#L1142) and then that is somewhere converted to a 0 timestamp, so one side of the comparison is Jan 1, 1970. That works half the time and doesn't work the other half of the time (when the To date is 1970).

Before
----------------------------------------
The unspecified date was set to 0.

After
----------------------------------------
Open ended relative date API calls with =, !=, <>, LIKE or NOT LIKE are converted to >= or <= as appropriate.
Nothing is changed for BETWEEN or NOT BETWEEN calls.

Technical Details
----------------------------------------
It is possible (for example in Search Kit) to specify a BETWEEN with relative date ranges as the From and To dates. That works fine in general, but won't work with half of the open ended relative dates. Such a query is pretty nonsensical and I don't think we need to worry about what it returns.

It would have been nice if BETWEEN date and NULL was equivalent to >= date in SQL, but it isn't.