### PR TITLE
dev/core#2542 Avoid collision with Bootstrap for .disabled links

### DIFF
--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -694,7 +694,7 @@ ORDER BY UPPER(LEFT(title, 1))
         if (isset($link['class'])) {
           $classes = $link['class'];
         }
-        $link['class'] = array_merge($classes, array('disabled'));
+        $link['class'] = array_merge($classes, array('crm-disabled'));
       }
     }
 

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2784,6 +2784,7 @@ tbody.scrollContent tr.alternateRow {
 }
 
 .crm-container .disabled,
+.crm-container .crm-disabled,
 .crm-container .disabled *,
 .crm-container .cancelled,
 .crm-container .cancelled td,


### PR DESCRIPTION
Overview
----------------------------------------
On Manage Contribution Page, links under Configure for each contribution page that were not active had .disabled. .disabled is used in Bootstrap for links and buttons to actually disable them (make them non-clickable). Consequently, with Boostrap, the .disabled links were not clickable (e.g. in Shoreditch). It's probably for the best in the long term not to collide with Bootstrap, so I've changed this to .crm-disable and added this to civicrm.css.

There is an accompanying [PR](https://github.com/civicrm/org.civicrm.shoreditch/pull/547) on Shoreditch that makes these links grey again.

Before
----------------------------------------
With Bootstrap, links were not clickable.

After
----------------------------------------
Visually nothing is changed, except the links are clickable with Bootstrap.

Comments
----------------------------------------
If there's a better way to handle this, I'm all ears. Not a huge deal at the moment, but seems like a good bit of future-proofing to remove this collision with Bootstrap. This same class can be used anywhere else that .disabled is used with a link or a button (in most cases, it is used on tds, which is fine).