### PR TITLE
.htaccess support for OpenLiteSpeed webservers.

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -531,6 +531,11 @@ class CRM_Utils_File {
     if (!empty($dir) && is_dir($dir)) {
       $htaccess = <<<HTACCESS
 <Files "*">
+# OpenLiteSpeed 1.4.38+
+  <IfModule !authz_core_module>
+    RewriteRule .* - [F,L]
+  </IfModule>
+
 # Apache 2.2
   <IfModule !authz_core_module>
     Order allow,deny


### PR DESCRIPTION
Overview
----------------------------------------
The current rewrite rules existing in the created .htaccess files are only supported for Apache webservers, and leaves files exposed on OpenLiteSpeed webservers by default. This is the easiest way to add support for OpenLiteSpeed 1.4.38+.
This pull request was born from [this mattermost chat discussion](https://chat.civicrm.org/civicrm/pl/1b5hnwio7tyg7qdanbey7r5izr) 

Before
----------------------------------------
Before the rewrite rules for OpenLiteSpeed are added to the .htaccess files, the CiviCRM system status produces warnings about Private Files being Readable when running on a drupal 9 site on a OpenLiteSpeed webserver.
<img width="1610" alt="image" src="https://user-images.githubusercontent.com/54978466/193626011-6448c13b-b5e2-4a49-affa-4044777688a0.png">

After
----------------------------------------
After the rewrite rules for OpenLiteSpeed are added to the .htaccess files, the CiviCRM system status no longer produces warnings about Private Files being Readable when running on a drupal 9 site on a OpenLiteSpeed webserver.

Notes
----------------------------------------
To make sure this will work on OpenLiteSpeed, `Enable Rewrite` and `Auto Load from .htaccess` has to be set to `Yes`
 in the Rewrite Control settings of the vhost. 
 <img width="1437" alt="image" src="https://user-images.githubusercontent.com/54978466/193764966-b2546a0e-de44-4b84-b068-e8acd53c2ffa.png">
