### PR TITLE
demoqueue - fix job_type parameter

### DIFF
--- a/tools/extensions/org.civicrm.demoqueue/CRM/Demoqueue/Page/DemoQueue.php
+++ b/tools/extensions/org.civicrm.demoqueue/CRM/Demoqueue/Page/DemoQueue.php
@@ -32,7 +32,7 @@ class CRM_Demoqueue_Page_DemoQueue extends CRM_Core_Page {
     }
 
     \Civi\Api4\UserJob::create()->setValues([
-      'type_id:label' => 'Contact Import',
+      'job_type' => 'contact_import',
       'status_id:name' => 'in_progress',
       'queue_id.name' => $queue->getName(),
     ])->execute();


### PR DESCRIPTION
Overview
----------------------------------------
Crash

Before
----------------------------------------
1. Enable the demoqueue extension.
2. Visit `/civicrm/demo-queue?reset=1`
3. Error: Mandatory values missing from Api4 UserJob::create: job_type

After
----------------------------------------
ok

Technical Details
----------------------------------------
I'm guessing this has had 1000 iterations lately and just didn't get updated, but the extension is referenced in the dev docs as an example extension.

Comments
----------------------------------------
I'm not sure label would have been good as an example to use anyway even if it worked.
