### PR TITLE
Fix lack of price set options for edit registration from search results

### DIFF
--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -118,7 +118,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    if (($context == 'standalone' || $context === 'search') && $this->_action !== CRM_Core_Action::VIEW) {
+    if (($context == 'standalone' || $context === 'search') && ($this->_action !== CRM_Core_Action::VIEW && $this->_action !== CRM_Core_Action::UPDATE)) {
       $this->_action = CRM_Core_Action::ADD;
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
A regression was introduced in 5.33 in #19125 that prevents the display of selected price set options when editing a registration from search results (but not from the contact events tab). That PR forced the form to action ADD when the context was search. This didn't seem to be a problem for editing the registration in general (the action was still UPDATE for the main body of the form, but it was ADD for the price set template embedded in it, causing it to not display correctly). Not entirely clear to me why the action was different, but this fixes the problem by not changing the action if it is UPDATE.

![image](https://user-images.githubusercontent.com/25517556/193956111-d5e28c17-bffd-4c6e-b17b-9dbf4676386f.png)
Notice that the action at the top of the page is 2 in Participant.tpl, but then when Participant.tpl comes back for another round to show the fee block, the action has changed to 1 (not sure why or how Participant.tpl is called a second time inside itself).

Before
----------------------------------------
<img width="700" alt="image" src="https://user-images.githubusercontent.com/25517556/193957116-b428a401-4edd-46d1-a142-f40902f521d2.png">

After
----------------------------------------
<img width="700" alt="image" src="https://user-images.githubusercontent.com/25517556/193956545-dd51a2c5-f3d4-4d01-92ac-242475925910.png">

Technical Details
----------------------------------------
Can't say this looks good, but it works and this already stretched my understanding of contexts and actions so I'm not seeing a better solution (other than separating the forms of course).