### PR TITLE
Afform - Ensure afField ids contain only allowed characters

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -29,7 +29,7 @@
       this.$onInit = function() {
         var closestController = $($element).closest('[af-fieldset],[af-join],[af-repeat-item]');
         $scope.dataProvider = closestController.is('[af-repeat-item]') ? ctrl.afRepeatItem : ctrl.afJoin || ctrl.afFieldset;
-        $scope.fieldId = ctrl.fieldName + '-' + id++;
+        $scope.fieldId = _.kebabCase(ctrl.fieldName) + '-' + id++;
 
         $element.addClass('af-field-type-' + _.kebabCase(ctrl.defn.input_type));
 


### PR DESCRIPTION
Overview
----------------------------------------
Ensures the `id` attribute for `afField`s only contains characters suitable for an id.

Before
----------------------------------------
Fieldnames sometimes contain a dot (e.g. custom fields), which is not allowed in the html spec.

After
----------------------------------------
Funny characters replaced with dashes.