### PR TITLE
Crash when trying to retrieve a completed queue

### DIFF
--- a/CRM/Queue/BAO/Queue.php
+++ b/CRM/Queue/BAO/Queue.php
@@ -41,7 +41,7 @@ class CRM_Queue_BAO_Queue extends CRM_Queue_DAO_Queue implements \Civi\Core\Hook
     return [
       'active' => ts('Active'),
       // ^^ The queue is active. It will execute tasks at the nearest convenience.
-      'complete' => ts('Complete'),
+      'completed' => ts('Complete'),
       // ^^ The queue will no longer execute tasks - because no new tasks are expected. Everything is complete.
       'draft' => ts('Draft'),
       // ^^ The queue is not ready to execute tasks - because we are still curating a list of tasks.

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -97,7 +97,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     $this->assertTrue($q1 instanceof CRM_Queue_Queue_Sql);
     $this->assertDBQuery('active', "SELECT status FROM civicrm_queue WHERE name = 'test/valid/default'");
 
-    foreach (['draft', 'active', 'complete', 'aborted'] as $n => $exampleStatus) {
+    foreach (['draft', 'active', 'completed', 'aborted'] as $n => $exampleStatus) {
       $q1 = Civi::queue("test/valid/$n", [
         'type' => 'Sql',
         'runner' => 'task',


### PR DESCRIPTION
Overview
----------------------------------------
Crash if you try to retrieve a queue that has completed.

Before
----------------------------------------
1. Do queue stuff. (You may already have a completed queue in the db from doing imports - look in civicrm_queue to get the name. Or install the demoqueue extension and then visit /civicrm/demo-queue?reset=1)
2. Afterwards try to retrieve your queue, e.g. `cv ev "\Civi::queue('my_queue_name');"`
3. Crash with invalid status "completed".

After
----------------------------------------
Ok

Technical Details
----------------------------------------
In [UserJob](https://github.com/civicrm/civicrm-core/blob/7060726d8a182341f0a467e4a7ec21932fcb184c/CRM/Core/BAO/UserJob.php#L43) it sets it to "completed", and everywhere else references "completed", and there isn't a spot that references "complete", so I figure it's a typo.

Comments
----------------------------------------

