### PR TITLE
dev/core#3890 Rebuild smart groups included in mailing on scheduling

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -459,6 +459,25 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
     // Create parent job if not yet created.
     // Condition on the existence of a scheduled date.
     if (!empty($params['scheduled_date']) && $params['scheduled_date'] != 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
+
+      if (!isset($params['is_completed']) || $params['is_completed'] !== 1) {
+        $mailingGroups = \Civi\Api4\MailingGroup::get()
+          ->addSelect('group.id')
+          ->addJoin('Group AS group', 'LEFT', ['entity_id', '=', 'group.id'])
+          ->addWhere('mailing_id', '=', $mailing->id)
+          ->addWhere('entity_table', '=', 'civicrm_group')
+          ->addWhere('group_type', 'IN', ['Include', 'Exclude'])
+          ->addClause('OR', ['group.saved_search_id', 'IS NOT NULL'], ['group.children', 'IS NOT NULL'])
+          ->execute();
+        foreach ($mailingGroups as $mailingGroup) {
+          CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($mailingGroup['group.id']);
+          $group = new CRM_Contact_DAO_Group();
+          $group->find(TRUE);
+          $group->id = $mailingGroup['group.id'];
+          CRM_Contact_BAO_GroupContactCache::load($group);
+        }
+      }
+
       $job = new CRM_Mailing_BAO_MailingJob();
       $job->mailing_id = $mailing->id;
       // If we are creating a new Completed mailing (e.g. import from another system) set the job to completed.


### PR DESCRIPTION
Overview
----------------------------------------
Smart group recipients should be totally up to date when a mailing is scheduled.

Before
----------------------------------------
Smart group recipients for a mailing were based on the smart group cache, potentially resulting in out of date recipients.

After
----------------------------------------
Smart groups that are included or excluded from a mailing are rebuilt at time of scheduling, so recipients are fully up to date. Parent groups are rebuilt as well. This also includes hidden smart groups (mailings created from search results using All NNN Contacts).

Technical Details
----------------------------------------
This may not look like the most logical place for this to happen (but if this is in getRecipients, it will run a dozen times by the time a mailing is created and sent) or the simplest way to go about it (you'd think the params we'd need would be there - they are earlier, but they aren't at scheduling time).