### PR TITLE
[REF] Update Tplaner/when package to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
     "league/csv": "~9.6.2",
     "league/oauth2-client": "^2.4",
     "league/oauth2-google": "^3.0",
-    "tplaner/when": "~3.0.0",
+    "tplaner/when": "~3.1",
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^2 || ^3.0",
     "brick/money": "~0.5",
@@ -125,25 +125,6 @@
       "bash tools/scripts/composer/phpword-jquery.sh",
       "bash tools/scripts/composer/guzzle-mockhandler-fix.sh"
     ]
-  },
-  "repositories": {
-    "tplaner-when-1ec099f421bff354cc5c929f83b94031423fc80": {
-      "type": "package",
-      "package": {
-        "version": "3.0.0+php53",
-        "dist": {"url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip", "type": "zip"},
-        "name": "tplaner/when",
-        "type": "library",
-        "description": "Date/Calendar recursion library.",
-        "keywords": ["recurrence", "date", "time", "DateTime"],
-        "homepage": "https://github.com/tplaner/When",
-        "license": "MIT",
-        "authors": [{"name": "Tom Planer", "email": "tplaner@gmail.com"}],
-        "require": {"php": ">=5.3.0"},
-        "require-dev": {"phpunit/phpunit": "~4.0"},
-        "autoload": {"psr-4": {"When\\": "src/"}}
-      }
-    }
   },
   "extra": {
     "downloads": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3111ffc7dadaf54de6e97cc171d95c39",
+    "content-hash": "49bdc3c77688ecfe94af007136590489",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5351,16 +5351,23 @@
         },
         {
             "name": "tplaner/when",
-            "version": "3.0.0+php53",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tplaner/When.git",
+                "reference": "8865acc235df8f57c2b229517c57c613b11ce4aa"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/tplaner/When/archive/c1ec099f421bff354cc5c929f83b94031423fc80.zip"
+                "url": "https://api.github.com/repos/tplaner/When/zipball/8865acc235df8f57c2b229517c57c613b11ce4aa",
+                "reference": "8865acc235df8f57c2b229517c57c613b11ce4aa",
+                "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "autoload": {
@@ -5368,6 +5375,7 @@
                     "When\\": "src/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -5380,11 +5388,17 @@
             "description": "Date/Calendar recursion library.",
             "homepage": "https://github.com/tplaner/When",
             "keywords": [
-                "DateTime",
                 "date",
+                "datetime",
                 "recurrence",
+                "repeat",
                 "time"
-            ]
+            ],
+            "support": {
+                "issues": "https://github.com/tplaner/When/issues",
+                "source": "https://github.com/tplaner/When/tree/v3.1.5"
+            },
+            "time": "2021-09-24T14:09:59+00:00"
         },
         {
             "name": "tubalmartin/cssmin",


### PR DESCRIPTION
Overview
----------------------------------------
This updates tplaner/when package to be the latest version

Before
----------------------------------------
Old custom defined package version which had php5.3 as the required php level used

After
----------------------------------------
Latest from upstream

Technical Details
----------------------------------------
Back when we had minimum of php5.6 support we needed this custom package but now that we have minimum php greater than or at least the same as this package we should upgrade to the upstream

ping @demeritcowboy @totten this should also be covered by unit tests.  It seems to be used by the Recurring Entity class