### PR TITLE
Check if profile contact employer name matches existing contact employer name when saving profile

### DIFF
--- a/templates/CRM/Contact/Form/Task/Batch.tpl
+++ b/templates/CRM/Contact/Form/Task/Batch.tpl
@@ -19,7 +19,12 @@
       {if $field.skipDisplay}
         {continue}
       {/if}
-      <td>{copyIcon name=$field.name title=$field.title}{$field.title}</td>
+      <td>
+      {if !$field.is_view}
+        {copyIcon name=$field.name title=$field.title}
+      {/if}
+        {$field.title}
+      </td>
     {/foreach}
     </tr>
     </thead>


### PR DESCRIPTION
Overview
----------------------------------------
The employer field in profiles is not a contact reference, but just a text field. Consequently, when updating a contact from a profile, a duplicate is sought for the contact employer name. If the organizational dedupe rule does not allow matches on just the organization name (e.g. it requires email as well or matches only on email), then no dupe can ever be found and a new org is created, the old relationship is ended and a new employee-employer relationship is created with the new org.

If, for instance, you happen to be batch updating a large number of contacts at once with a profile that includes employer (even if employer is view only), then even when none of the employer fields is changed, new employers and relationships will be created for every non-empty employer field.

Before
----------------------------------------
When a contact is being created/updated with CRM_Contact_BAO_Contact::add(), if the employer is provided by name rather than contact id, check for a dupe of the employer name with the Unsupervised org dedupe rule. Use the first dupe found or if none is found, create a new contact.

Related bonus:
![image](https://user-images.githubusercontent.com/25517556/194433858-48a4077a-9c0e-4cf5-a3c1-0ba7800fa0fd.png)
View only fields in batch profile update have a copy button.

After
----------------------------------------
When a contact is being created/updated,  if the employer is provided by name, check if the provided employer name matches the current contact employer name and use that employer contact id if so. If not, then check for a dupe and proceed as above.

Related bonus:
![image](https://user-images.githubusercontent.com/25517556/194435294-a750139d-6deb-4c88-981a-1eec0c174dc0.png)
No more useless copy buttons for view only fields in batch profile update.