### PR TITLE
Allow second participant registration with same email, when enabled

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -388,12 +388,9 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       CRM_Event_Form_Registration_Register::checkProfileComplete($fields, $errors, $self->_eventId);
 
       //Additional Participant can also register for an event only once
-      $isRegistered = CRM_Event_Form_Registration_Register::checkRegistration($fields, $self, TRUE);
-      if ($isRegistered) {
-        if ($self->_values['event']['allow_same_participant_emails']) {
-          $errors['_qf_default'] = ts('A person is already registered for this event.');
-        }
-        else {
+      if (!$self->_values['event']['allow_same_participant_emails']) {
+        $isRegistered = CRM_Event_Form_Registration_Register::checkRegistration($fields, $self, TRUE);
+        if ($isRegistered) {
           $errors["email-{$self->_bltID}"] = ts('A person with this email address is already registered for this event.');
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
When "Same email address" is enabled for an event, participants with the same email address as an existing participant should be allowed to register. They were, when they were the primary participant, but not when they were an additional participant.

Before
----------------------------------------
Attempting to register an additional participant with an email address for an existing participant results in an error, and the registration cannot not be completed without changing or skipping the participant.

After
----------------------------------------
No error, registration proceeds as normal.
If "Same email address" isn't enabled, no change.