### PR TITLE
SearchKit - Don't show custom fields from disabled field groups

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -125,7 +125,8 @@ class SpecGatherer extends AutoService {
     $query = CustomField::get(FALSE)
       ->setSelect(['custom_group_id.name', 'custom_group_id.title', '*'])
       ->addWhere('is_active', '=', TRUE)
-      ->addWhere('custom_group_id.is_multiple', '=', '0');
+      ->addWhere('custom_group_id.is_active', '=', TRUE)
+      ->addWhere('custom_group_id.is_multiple', '=', FALSE);
 
     // Contact custom groups are extra complicated because contact_type can be a value for extends
     if ($entity === 'Contact') {


### PR DESCRIPTION
Overview
----------------------------------------
Prevents disabled custom groups from showing up in SearchKit.

Before
----------------------------------------
Disabled *fields* were hidden, but inconsistently, disabled field *groups* were not.

After
----------------------------------------
Custom fields consistently hidden from SearchKit UI if either the field or the group is disabled.