### PR TITLE
SearchKit - Expose 'is_current' field to the ON clause e.g. when join…

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -471,7 +471,7 @@
       };
 
       function getFieldsForJoin(joinEntity) {
-        return {results: ctrl.getAllFields(':name', ['Field'], null, joinEntity)};
+        return {results: ctrl.getAllFields(':name', ['Field', 'Extra'], null, joinEntity)};
       }
 
       // @return {function}


### PR DESCRIPTION
Overview
----------------------------------------
This makes it possible in SearchKit to join on related contacts, limited to only those with a current relationship.

It's a partial fix for https://lab.civicrm.org/dev/core/-/issues/3878

Before
----------------------------------------
"Is Current" was available in the WHERE clause but not under the join (ON clause).

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/194603834-40c20ce5-2643-4175-96ac-1b349ce06ca8.png)

