### PR TITLE
Fix `testCreateWithPrimaryAndBilling`

### DIFF
--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -31,10 +31,13 @@ use Civi\Api4\Phone;
  */
 class ContactJoinTest extends Api4TestBase {
 
-  public function testContactJoin() {
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testContactJoin(): void {
     $contact = $this->createTestRecord('Contact', [
-      'first_name' => uniqid(),
-      'last_name' => uniqid(),
+      'first_name' => 'first name',
+      'last_name' => 'last name',
     ]);
     $entitiesToTest = ['Address', 'OpenID', 'IM', 'Website', 'Email', 'Phone'];
 
@@ -53,7 +56,12 @@ class ContactJoinTest extends Api4TestBase {
     }
   }
 
-  public function testJoinToPCMWillReturnArray() {
+  /**
+   * Test preferred communication method format.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testJoinToPCMWillReturnArray(): void {
     $contact = $this->createTestRecord('Contact', [
       'preferred_communication_method' => [1, 2, 3],
       'contact_type' => 'Individual',
@@ -67,10 +75,13 @@ class ContactJoinTest extends Api4TestBase {
       ->execute()
       ->first();
 
-    $this->assertCount(3, $fetchedContact["preferred_communication_method"]);
+    $this->assertCount(3, $fetchedContact['preferred_communication_method']);
   }
 
-  public function testJoinToPCMOptionValueWillShowLabel() {
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testJoinToPCMOptionValueWillShowLabel(): void {
     $options = OptionValue::get()
       ->addWhere('option_group_id:name', '=', 'preferred_communication_method')
       ->execute()
@@ -104,18 +115,23 @@ class ContactJoinTest extends Api4TestBase {
     $this->assertEquals($labels, $fetchedContact['preferred_communication_method:label']);
   }
 
-  public function testCreateWithPrimaryAndBilling() {
+  /**
+   * Test primary & billing in create syntax.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreateWithPrimaryAndBilling(): void {
     $contact = $this->createTestRecord('Contact', [
       'email_primary.email' => 'a@test.com',
       'email_billing.email' => 'b@test.com',
       'address_billing.city' => 'Hello',
       'address_billing.state_province_id:abbr' => 'AK',
-      'address_billing.country_id:abbr' => 'USA',
+      'address_billing.country_id:abbr' => 'US',
     ]);
-    $addr = Address::get(FALSE)
+    $address = Address::get(FALSE)
       ->addWhere('contact_id', '=', $contact['id'])
       ->execute();
-    $this->assertCount(1, $addr);
+    $this->assertCount(1, $address);
     $this->assertEquals('Hello', $contact['address_billing.city']);
     $this->assertEquals(1228, $contact['address_billing.country_id']);
     $emails = Email::get(FALSE)
@@ -126,7 +142,12 @@ class ContactJoinTest extends Api4TestBase {
     $this->assertEquals('b@test.com', $contact['email_billing.email']);
   }
 
-  public function testUpdateDeletePrimaryAndBilling() {
+  /**
+   * Test update will delete a primary address.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testUpdateDeletePrimaryAndBilling(): void {
     $contact = $this->createTestRecord('Contact', [
       'phone_primary.phone' => '12345',
       'phone_billing.phone' => '54321',


### PR DESCRIPTION
Overview
----------------------------------------
Fix `testCreateWithPrimaryAndBilling`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/194700810-79e7eacd-9ca5-479e-bc4a-74d5734b4c6f.png)


After
----------------------------------------
Test passes

Technical Details
----------------------------------------
The test as written should actually never pass & it is only because USA is often the default country that it does.

The abbreviation for country_id is not `USA` as per the test - it is actually `US`

![image](https://user-images.githubusercontent.com/336308/194700860-7784a6d4-3d33-4409-a020-85d3d2950ae0.png)

This is the key change

![image](https://user-images.githubusercontent.com/336308/194700945-7cd9850a-ff61-4b28-813d-c05d3e8fd8d1.png)



Comments
----------------------------------------
Other style fixes to get clean margins