### PR TITLE
dev/core#3814 Use fastArray cache for extension system

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -251,7 +251,10 @@ class CRM_Extension_System {
   }
 
   /**
+   * Get the cache object.
+   *
    * @return CRM_Utils_Cache_Interface
+   * @throws \CRM_Core_Exception
    */
   public function getCache() {
     if ($this->cache === NULL) {
@@ -261,6 +264,7 @@ class CRM_Extension_System {
         'name' => $cacheGroup,
         'type' => ['*memory*', 'SqlGroup', 'ArrayCache'],
         'prefetch' => TRUE,
+        'withArray' => 'fast',
       ]);
     }
     return $this->cache;


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#3814 Use fastArray cache for extension system

This reduces repetitive array hits on the Redis or other cache as they are stored in the php layer. The Redis hits are not slow - but the serializing & unserializing is so this is a performance improvement


Before
----------------------------------------
`Extension_System` cache always hits the caching provider

After
----------------------------------------
Cache uses php array cache after the first hit per process

Technical Details
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3814#note_81152

Comments
----------------------------------------
