### PR TITLE
Afform - Fix console error when adding date field to form

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -247,6 +247,7 @@
 
       function setDateOptions() {
         if (_.includes(['Date', 'Timestamp'], $scope.getProp('data_type'))) {
+          ctrl.node.defn = ctrl.node.defn || {};
           ctrl.node.defn.options = $scope.getProp('search_range') ? CRM.afGuiEditor.dateRanges : CRM.afGuiEditor.dateRanges.slice(1);
           setFieldDefn();
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an Afform Admin bug I just noticed.

Before
----------------------------------------
1. Create a new Submission-type form, and drag the field "Birth Date" onto the form
2. Notice an error in the browser console.

After
----------------------------------------
Fixed