### PR TITLE
Use contribution page receipt text for offline contributions

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -966,6 +966,16 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $submittedValues['contribution_status_id'] = $this->_values['contribution_status_id'];
     }
 
+    if (isset($submittedValues['is_email_receipt']) && isset($submittedValues['contribution_page_id'])) {
+      $contributionPage = \Civi\Api4\ContributionPage::get()
+        ->addSelect('is_email_receipt', 'receipt_text')
+        ->addWhere('id', '=', $submittedValues['contribution_page_id'])
+        ->execute()->first();
+      if ($contributionPage['is_email_receipt']) {
+        $submittedValues['receipt_text'] = $contributionPage['receipt_text'];
+      }
+    }
+
     try {
       $contribution = $this->submit($submittedValues, $this->_action, $this->_ppID);
     }


### PR DESCRIPTION
Overview
----------------------------------------
I'm sure many orgs would like to send receipt text specific to different kinds of contributions when they are processed offline, but currently all offline contribution receipts have the same text at the top of the email, even if a contribution page is selected when the contribution is created. There's no way to customize the receipt text for offline contributions.

Before
----------------------------------------
All offline contributions have the default text at the top of the receipt set in the Contributions - Receipt (off-line) template.

After
----------------------------------------
When adding or editing an offline contribution, if:
- Send Receipt is checked on the offline contribution form
- a contribution page is selected and
- email receipts are enabled on that contribution page

then the receipt text from that contribution page is used in the offline receipt template.

Otherwise, no change.

Technical Details
----------------------------------------
No change to the mailing templates is required, as they already were checking for receipt_text, it was just never present.

Comments
----------------------------------------
This does seem like something we want to flag on release as there may be someone out there who is selecting contribution pages for all their offline contributions, but for whatever reason doesn't want the contribution page receipt text used. It's a change that won't be apparent to users, unless they happen to look at a generated contribution receipt email. I don't imagine a lot of orgs are using contribution page for offline contributions, but you never know.