### PR TITLE
Make mailing name and campaign editable in place on Find Mailings

### DIFF
--- a/templates/CRM/Mailing/Page/Browse.tpl
+++ b/templates/CRM/Mailing/Page/Browse.tpl
@@ -47,8 +47,8 @@
 
       {counter start=0 skip=1 print=false}
       {foreach from=$rows item=row}
-      <tr id="crm-mailing_{$row.id}" class="{cycle values="odd-row,even-row"} crm-mailing crm-mailing_status-{$row.status}">
-        <td class="crm-mailing-name">{$row.name}</td>
+      <tr id="mailing-{$row.id}" class="{cycle values="odd-row,even-row"} crm-mailing crm-mailing_status-{$row.status} crm-entity" data-action="create">
+        <td class="crm-mailing-name crm-editable crmf-name">{$row.name}</td>
         {if $multilingual}
           <td class="crm-mailing-language">{$row.language}</td>
         {/if}
@@ -68,7 +68,7 @@
         <td class="crm-mailing-start">{$row.start}</td>
         <td class="crm-mailing-end">{$row.end}</td>
        {if call_user_func(array('CRM_Campaign_BAO_Campaign','isComponentEnabled'))}
-          <td class="crm-mailing-campaign">{$row.campaign}</td>
+          <td class="crm-mailing-campaign crm-editable crmf-campaign_id" data-type="select" data-empty-option="{ts}- none -{/ts}">{$row.campaign}</td>
       {/if}
         <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
       </tr>


### PR DESCRIPTION
Overview
----------------------------------------
There is currently no way to edit the mailing name or campaign for a scheduled, sent or archived mailing in the UI. If you have a naming system for mailings and someone sends a mailing that doesn't conform, you can't fix it and you can't change the campaign if it is incorrect.

Before
----------------------------------------
Mailing name and campaign not editable.

After
----------------------------------------
<img width="700" alt="image" src="https://user-images.githubusercontent.com/25517556/194714773-aa3a1ac9-a2b2-4712-94d8-ded6745bcc22.png">
Mailing name and campaign editable in place on Find Mailings.

Technical Details
----------------------------------------
The id for the tr was changed from crm-mailing_{$row.id}, which does not appear to be used for anything, to mailing-{$row.id}.