### PR TITLE
Afform: Support conditional logic

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.ang.php
+++ b/ext/afform/admin/ang/afGuiEditor.ang.php
@@ -8,7 +8,7 @@ return [
   ],
   'css' => ['ang/afGuiEditor.css'],
   'partials' => ['ang/afGuiEditor'],
-  'requires' => ['crmUi', 'crmUtil', 'dialogService', 'api4', 'crmMonaco', 'ui.sortable'],
+  'requires' => ['crmUi', 'crmUtil', 'crmDialog', 'api4', 'crmMonaco', 'ui.sortable'],
   'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getMetadata'],
   'basePages' => [],
   'exports' => [

--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -610,3 +610,101 @@ body.af-gui-dragging {
   border: 2px solid #0071bd;
   min-height: 30px;
 }
+
+/* Rules for Conditional dialog */
+#bootstrap-theme.af-gui-conditional-dialog fieldset {
+  padding: 6px;
+  border-top: 1px solid lightgrey;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  position: relative;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog fieldset fieldset {
+  padding-top: 0;
+  border-left: 1px solid lightgrey;
+  border-right: 1px solid lightgrey;
+  border-bottom: 1px solid lightgrey;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog fieldset legend {
+  background-color: white;
+  font-size: 13px;
+  margin: 0;
+  width: auto;
+  border: 0 none;
+  padding: 2px 5px;
+  text-transform: none;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog af-gui-clause > .btn-group {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog fieldset div.api4-input {
+  margin-bottom: 10px;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog fieldset div.api4-input.ui-sortable-helper {
+  background-color: rgba(255, 255, 255, .9);
+}
+
+#bootstrap-theme.af-gui-conditional-dialog fieldset div.api4-input.ui-sortable-helper {
+  background-color: rgba(255, 255, 255, .9);
+}
+
+#bootstrap-theme.af-gui-conditional-dialog .api4-clause-fieldset fieldset {
+  float: right;
+  width: calc(100% - 58px);
+  margin-top: -8px;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog .api4-clause-fieldset.api4-sorting fieldset .api4-clause-group-sortable {
+  min-height: 3.5em;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog legend[ng-click] {
+  cursor: pointer;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog .api4-input-group {
+  display: inline-block;
+}
+
+#bootstrap-theme i.crm-i.af-gui-conditional-dialog-move-icon {
+  opacity: .5;
+}
+#bootstrap-theme .crm-draggable:hover > i.crm-i.af-gui-conditional-dialog-move-icon,
+#bootstrap-theme .crm-draggable:hover > * > i.crm-i.af-gui-conditional-dialog-move-icon {
+  opacity: 1;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog .api4-clause-badge {
+  width: 55px;
+  display: inline-block;
+  cursor: move;
+}
+#bootstrap-theme.af-gui-conditional-dialog .api4-clause-badge .badge {
+  opacity: .5;
+  position: relative;
+}
+#bootstrap-theme.af-gui-conditional-dialog .api4-clause-badge .caret {
+  margin: 0;
+}
+/* Icon only shown while dragging */
+#bootstrap-theme.af-gui-conditional-dialog .api4-clause-badge .crm-i {
+  display: none;
+  padding: 0 6px;
+}
+#bootstrap-theme.af-gui-conditional-dialog .ui-sortable-helper .api4-clause-badge .badge span {
+  display: none;
+}
+#bootstrap-theme.af-gui-conditional-dialog .ui-sortable-helper .api4-clause-badge .crm-i {
+  display: inline-block;
+}
+
+#bootstrap-theme.af-gui-conditional-dialog .api4-operator {
+  width: 110px;
+}

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -210,6 +210,29 @@
           return indexBy ? _.indexBy(items, indexBy) : items;
         },
 
+        // Recursively searches part of a form and returns all elements matching predicate
+        // Will recurse into block elements
+        // Will stop recursing when it encounters an element matching 'exclude'
+        getFormElements: function getFormElements(collection, predicate, exclude) {
+          var childMatches = [],
+            items = _.filter(collection, predicate),
+            isExcluded = exclude ? (_.isFunction(exclude) ? exclude : _.matches(exclude)) : _.constant(false);
+          function isIncluded(item) {
+            return !isExcluded(item);
+          }
+          _.each(_.filter(collection, isIncluded), function(item) {
+            if (_.isPlainObject(item) && item['#children']) {
+              childMatches = getFormElements(item['#children'], predicate, exclude);
+            } else if (item['#tag'] && item['#tag'] in CRM.afGuiEditor.blocks) {
+              childMatches = getFormElements(CRM.afGuiEditor.blocks[item['#tag']].layout, predicate, exclude);
+            }
+            if (childMatches.length) {
+              Array.prototype.push.apply(items, childMatches);
+            }
+          });
+          return items;
+        },
+
         // Applies _.remove() to an item and its children
         removeRecursive: function removeRecursive(collection, removeParams) {
           _.remove(collection, removeParams);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiClause.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiClause.component.js
@@ -1,0 +1,78 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('afGuiEditor').component('afGuiClause', {
+    bindings: {
+      fields: '<',
+      fieldDefns: '<',
+      clauses: '<',
+      skip: '<',
+      op: '@',
+      label: '@',
+      hideLabel: '@',
+      placeholder: '<',
+      deleteGroup: '&'
+    },
+    templateUrl: '~/afGuiEditor/afGuiClause.html',
+    controller: function ($scope, $element) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
+        ctrl = this,
+        meta = {};
+      this.conjunctions = {AND: ts('And'), OR: ts('Or'), NOT: ts('Not')};
+      this.sortOptions = {
+        axis: 'y',
+        connectWith: '.api4-clause-group-sortable',
+        containment: $element.closest('.api4-clause-fieldset'),
+        over: onSortOver,
+        start: onSort,
+        stop: onSort
+      };
+
+      this.$onInit = function() {
+        ctrl.hasParent = !!$element.attr('delete-group');
+      };
+
+      this.getField = function(expr) {
+        return ctrl.fieldDefns[expr];
+      };
+
+      this.addGroup = function(op) {
+        ctrl.clauses.push([op, []]);
+      };
+
+      function onSort(event, ui) {
+        $($element).closest('.api4-clause-fieldset').toggleClass('api4-sorting', event.type === 'sortstart');
+        $('.api4-input.form-inline').css('margin-left', '');
+      }
+
+      // Indent clause while dragging between nested groups
+      function onSortOver(event, ui) {
+        var offset = 0;
+        if (ui.sender) {
+          offset = $(ui.placeholder).offset().left - $(ui.sender).offset().left;
+        }
+        $('.api4-input.form-inline.ui-sortable-helper').css('margin-left', '' + offset + 'px');
+      }
+
+      this.addClause = function(value) {
+        if (value) {
+          var newIndex = ctrl.clauses.length;
+          ctrl.clauses.push([value, '=', '""']);
+        }
+      };
+
+      this.deleteRow = function(index) {
+        ctrl.clauses.splice(index, 1);
+      };
+
+      // Remove empty values
+      this.changeClauseField = function(clause, index) {
+        if (clause[0] === '') {
+          ctrl.deleteRow(index);
+        }
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiClause.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiClause.html
@@ -1,0 +1,43 @@
+<legend ng-if="!$ctrl.hideLabel">{{ $ctrl.label || ts('%1 group', {1: $ctrl.conjunctions[$ctrl.op]}) }}</legend>
+<div class="btn-group btn-group-xs" ng-if=":: $ctrl.hasParent">
+  <button type="button" class="btn btn-danger-outline" ng-click="$ctrl.deleteGroup()" title="{{:: ts('Remove group') }}">
+    <i class="crm-i fa-trash" aria-hidden="true"></i>
+  </button>
+</div>
+<div class="api4-clause-group-sortable" ng-model="$ctrl.clauses" ui-sortable="$ctrl.sortOptions">
+  <div class="api4-input form-inline clearfix" ng-repeat="(index, clause) in $ctrl.clauses" ng-class="{hiddenElement: index &lt; ($ctrl.skip || 0)}">
+    <div ng-if="index &gt;= ($ctrl.skip || 0)">
+      <div class="api4-clause-badge" title="{{:: ts('Drag to reposition') }}">
+        <span class="badge badge-info">
+          <span ng-if="index === ($ctrl.skip || 0) && !$ctrl.hasParent">{{ $ctrl.label }}</span>
+          <span ng-if="index &gt; ($ctrl.skip || 0) || $ctrl.hasParent">{{ $ctrl.conjunctions[$ctrl.op] }}</span>
+          <i class="crm-i fa-arrows" aria-hidden="true"></i>
+        </span>
+      </div>
+      <div ng-if="!$ctrl.conjunctions[clause[0]]" class="api4-input-group">
+        <input class="form-control collapsible-optgroups" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
+        <af-gui-condition clause="clause" field="$ctrl.getField(clause[0])" offset="1" format="$ctrl.format" class="form-group"></af-gui-condition>
+      </div>
+      <fieldset class="clearfix" ng-if="$ctrl.conjunctions[clause[0]]">
+        <af-gui-clause clauses="clause[1]" fields="$ctrl.fields" field-defns="$ctrl.fieldDefns" op="{{ clause[0] }}" delete-group="$ctrl.deleteRow(index)"></af-gui-clause>
+      </fieldset>
+    </div>
+  </div>
+</div>
+<div class="api4-input form-inline">
+  <div class="api4-clause-badge">
+    <div class="btn-group btn-group-xs" title="{{ $ctrl.hasParent ? ts('Add a subgroup of clauses') : ts('Add a group of clauses') }}">
+      <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{ $ctrl.conjunctions[$ctrl.op] }} <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu api4-add-where-group-menu">
+        <li ng-repeat="(con, label) in $ctrl.conjunctions" ng-show="$ctrl.op !== con">
+          <a href ng-click="$ctrl.addGroup(con)">{{ label }}</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <input class="form-control collapsible-optgroups"
+         on-crm-ui-select="$ctrl.addClause(selection)"
+         crm-ui-select="{data: $ctrl.fields, placeholder: $ctrl.placeholder || ts('Select field')}" >
+</div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -1,0 +1,100 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('afGuiEditor').component('afGuiCondition', {
+    bindings: {
+      field: '<',
+      clause: '<',
+      format: '<',
+      optionKey: '<',
+      offset: '<'
+    },
+    templateUrl: '~/afGuiEditor/afGuiCondition.html',
+    controller: function ($scope) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
+        ctrl = this;
+      this.operators = [
+        {
+          "key": "==",
+          "value": "=",
+        },
+        {
+          "key": "!=",
+          "value": "≠",
+        },
+        {
+          "key": ">",
+          "value": ">",
+        },
+        {
+          "key": "<",
+          "value": "<",
+        },
+        {
+          "key": ">=",
+          "value": "≥",
+        },
+        {
+          "key": "<=",
+          "value": "≤",
+        }
+      ];
+
+      this.$onInit = function() {
+        $scope.$watch('$ctrl.field', updateOperators);
+      };
+
+      function getOperator() {
+        return ctrl.clause[ctrl.offset];
+      }
+
+      function setOperator(op) {
+        if (op !== getOperator()) {
+          ctrl.clause[ctrl.offset] = op;
+          ctrl.changeClauseOperator();
+        }
+      }
+
+      function getValue() {
+        return JSON.parse(ctrl.clause[1 + ctrl.offset]);
+      }
+
+      function setValue(val) {
+        ctrl.clause[1 + ctrl.offset] = JSON.stringify(val);
+      }
+
+      // Getter/setter for use with ng-model
+      this.getSetOperator = function(op) {
+        if (arguments.length) {
+          setOperator(op);
+        }
+        return getOperator();
+      };
+
+      // Getter/setter for use with ng-model
+      this.getSetValue = function(val) {
+        if (arguments.length) {
+          setValue(val);
+        }
+        return getValue();
+      };
+
+      // Return a list of operators allowed for the current field
+      this.getOperators = function() {
+        return ctrl.operators;
+      };
+
+      // Ensures clause is using an operator that is allowed for the field
+      function updateOperators() {
+        if ((!getOperator() || !_.includes(_.pluck(ctrl.getOperators(), 'key'), getOperator()))) {
+          setOperator(ctrl.getOperators()[0].key);
+        }
+      }
+
+      this.changeClauseOperator = function() {
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
@@ -1,0 +1,2 @@
+<select class="form-control api4-operator" ng-model="$ctrl.getSetOperator" ng-if="$ctrl.getOperators().length > 1" ng-model-options="{getterSetter: true}" ng-options="o.key as o.value for o in $ctrl.getOperators()" ng-change="$ctrl.changeClauseOperator()" ></select>
+<input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValue" ng-model-options="{getterSetter: true}" class="form-control"></input>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
@@ -14,13 +14,16 @@
       if (!ctrl.conditions.length) {
         delete ctrl.node['af-if'];
       } else {
-        ctrl.node['af-if'] = '(' + JSON.stringify(ctrl.conditions) + ')';
+        ctrl.node['af-if'] = '(' + JSON.stringify(ctrl.conditions).replace(/"/g, '&quot;') + ')';
       }
       dialogService.close('afformGuiConditionalDialog');
     };
 
     function parseConditions() {
-      var ngIf = _.trim(ctrl.node['af-if']);
+      if (!ctrl.node['af-if']) {
+        return [];
+      }
+      var ngIf = _.trim(ctrl.node['af-if'].replace(/&quot;/g, '"'));
       if (!_.startsWith(ngIf, '(')) {
         return [];
       }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
@@ -1,0 +1,59 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('afGuiEditor').controller('AfGuiConditionalDialog', function($scope, $parse, afGui, dialogService) {
+    var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
+      ctrl = $scope.$ctrl = this;
+    this.node = $scope.model.node;
+    this.editor = $scope.model.editor;
+    this.conditions = parseConditions();
+    loadAllFields();
+
+    this.save = function() {
+      if (!ctrl.conditions.length) {
+        delete ctrl.node['af-if'];
+      } else {
+        ctrl.node['af-if'] = '(' + JSON.stringify(ctrl.conditions) + ')';
+      }
+      dialogService.close('afformGuiConditionalDialog');
+    };
+
+    function parseConditions() {
+      var ngIf = _.trim(ctrl.node['af-if']);
+      if (!_.startsWith(ngIf, '(')) {
+        return [];
+      }
+      return $parse(ngIf.slice(1, -1))();
+    }
+
+    function loadAllFields() {
+      ctrl.fieldSelector = [];
+      ctrl.fieldDefns = {};
+      _.each(ctrl.editor.getEntities(), function(entity) {
+        var entityFields = ctrl.editor.getEntityFields(entity.name),
+          items = _.transform(entityFields.fields, function(items, field) {
+            var key = entity.name + "[0][fields][" + field.name + "]";
+            ctrl.fieldDefns[key] = field;
+            items.push({id: key, text: field.label});
+          });
+        _.each(entityFields.joins, function(join) {
+          items.push({
+            text: afGui.getEntity(join.entity).label,
+            children: _.transform(join.fields, function(items, field) {
+              var key = entity.name + "[0][joins][" + join.entity + "][0][" + field.name + "]";
+              ctrl.fieldDefns[key] = field;
+              items.push({id: key, text: field.label});
+            })
+          });
+        });
+        ctrl.fieldSelector.push({
+          text: entity.label,
+          children: items
+        });
+      });
+    }
+
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.html
@@ -1,0 +1,7 @@
+<div id="bootstrap-theme" class="af-gui-conditional-dialog" crm-dialog="afformGuiConditionalDialog" ng-controller="AfGuiConditionalDialog">
+  <form class="api4-clause-fieldset" ng-if="$ctrl.fieldSelector.length">
+    <label>{{:: ts('Element will be shown if') }}</label>
+    <af-gui-clause clauses="$ctrl.conditions" fields="$ctrl.fieldSelector" field-defns="$ctrl.fieldDefns" op="AND" label="{{:: ts('If') }}" hide-label="true"></af-gui-clause>
+  </form>
+  <crm-dialog-button text="ts('Apply Changes')" icons="{primary: 'fa-check'}" on-click="$ctrl.save()" />
+</div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -41,7 +41,7 @@
               if (field.fk_entity === 'Contact' && (!filters.contact_type || filters.contact_type === 'Individual')) {
                 options.push('user_contact_id');
               }
-              _.each(ctrl.editor.getEntities({type: field.fk_entity}), function(entity) {
+              _.each(ctrl.editor ? ctrl.editor.getEntities({type: field.fk_entity}) : [], function(entity) {
                 // Check if field filters match entity data (e.g. contact_type)
                 var filtersMatch = true;
                 _.each(filters, function(value, key) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -10,7 +10,7 @@
       },
       require: {
         ngModel: 'ngModel',
-        editor: '^^afGuiEditor'
+        editor: '?^^afGuiEditor'
       },
       controller: function ($element, $timeout) {
         var ts = CRM.ts('org.civicrm.afform_admin'),

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton-menu.html
@@ -6,5 +6,7 @@
     </select>
   </div>
 </li>
+<li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>
+
 <li role="separator" class="divider"></li>
 <li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this button') }}</span></a></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.component.js
@@ -8,6 +8,9 @@
       node: '=',
       deleteThis: '&'
     },
+    require: {
+      editor: '^^afGuiEditor',
+    },
     controller: function($scope, afGui) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiConditionalMenu.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiConditionalMenu.directive.js
@@ -1,0 +1,18 @@
+(function(angular, $, _) {
+  angular.module('afGuiEditor').directive('afGuiConditionalMenu', function() {
+    return {
+      restrict: 'A',
+      templateUrl: '~/afGuiEditor/elements/afGuiConditionalMenu.html',
+      require: {
+        editor: '^^afGuiEditor'
+      },
+      bindToController: {
+        node: '<afGuiConditionalMenu'
+      },
+      controller: function($scope) {
+        var ts = CRM.ts('org.civicrm.afform_admin'),
+          ctrl = this;
+      }
+    };
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiConditionalMenu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiConditionalMenu.html
@@ -1,0 +1,9 @@
+<a href crm-dialog-popup="afformGuiConditionalDialog" popup-tpl="~/afGuiEditor/afGuiConditionalDialog.html" popup-data="{editor: $ctrl.editor, node: $ctrl.node}" title="{{:: ts('Conditional Rules') }}">
+  <i ng-class="{disabled: !$ctrl.node['af-if'] || !$ctrl.node['af-if'].length}" class="crm-i fa-code-fork"></i>
+  <span ng-if="!$ctrl.node['af-if'].length">
+    {{:: ts('Add Conditional Rules') }}
+  </span>
+  <strong ng-if="$ctrl.node['af-if'].length">
+    {{:: ts('Edit Conditional Rules') }}
+  </strong>
+</a>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -34,5 +34,7 @@
 <li><af-gui-menu-item-style node="$ctrl.node"></af-gui-menu-item-style></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
+<li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>
+
 <li role="separator" class="divider"></li>
 <li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{ !block ? ts('Remove container') : ts('Remove block') }}</span></a></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -92,6 +92,7 @@
     {{:: ts('Post help text') }}
   </a>
 </li>
+
 <li role="separator" class="divider" ng-if="$ctrl.canBeRange() || $ctrl.canBeMultiple()"></li>
 <li ng-if="$ctrl.canBeMultiple()" ng-click="$event.stopPropagation()">
   <a href ng-click="toggleMultiple()" title="{{:: ts('Search multiple values') }}">
@@ -121,6 +122,9 @@
     </select>
   </div>
 </li>
+
+<li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>
+
 <li role="separator" class="divider" ng-if="hasOptions()"></li>
 <li ng-if="hasOptions()" ng-click="$event.stopPropagation()">
   <a href ng-click="resetOptions()" title="{{:: ts('Reset the option list for this field') }}">
@@ -134,6 +138,7 @@
     {{:: ts('Customize options') }}
   </a>
 </li>
+
 <li role="separator" class="divider"></li>
 <li>
   <a href ng-click="$ctrl.deleteThis()" title="{{:: ts('Remove field from form') }}">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup-menu.html
@@ -1,9 +1,12 @@
 <li>
   <a href ng-click="edit()">{{:: ts('Edit content') }}</a>
 </li>
+
 <li role="separator" class="divider"></li>
 <li><af-gui-menu-item-border node="$ctrl.node"></af-gui-menu-item-border></li>
 <li><af-gui-menu-item-background node="$ctrl.node"></af-gui-menu-item-background></li>
+<li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>
+
 <li role="separator" class="divider"></li>
 <li>
   <a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this content') }}</span></a>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiMarkup.component.js
@@ -10,6 +10,9 @@
       node: '=',
       deleteThis: '&'
     },
+    require: {
+      editor: '^^afGuiEditor',
+    },
     controller: function($scope, $sce, $timeout) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText-menu.html
@@ -23,6 +23,8 @@
     </select>
   </div>
 </li>
+<li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>
+
 <li role="separator" class="divider"></li>
 <li>
   <a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash"></i> {{:: ts('Delete this text') }}</span></a>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
@@ -8,6 +8,9 @@
       node: '=',
       deleteThis: '&'
     },
+    require: {
+      editor: '^^afGuiEditor',
+    },
     controller: function($scope, afGui) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;

--- a/ext/afform/core/ang/af/afIf.directive.js
+++ b/ext/afform/core/ang/af/afIf.directive.js
@@ -1,0 +1,80 @@
+(function(angular, $, _) {
+  // A modified version of ngIf to use afform.checkConditions
+  angular.module('af').directive('afIf', function($compile, $animate, $parse) {
+    return {
+      multiElement: true,
+      transclude: 'element',
+      priority: 601,
+      terminal: true,
+      restrict: 'A',
+      require: ['^^afForm'],
+      $$tlb: true,
+      link: function($scope, $element, $attr, ctrl, $transclude) {
+        var block, childScope, previousElements;
+
+        function watcher() {
+          var conditions = $parse($attr.afIf)();
+          return ctrl[0].checkConditions(conditions);
+        }
+
+        $scope.$watch(watcher, function(value) {
+          if (value) {
+            if (!childScope) {
+              $transclude(function(clone, newScope) {
+                childScope = newScope;
+                clone[clone.length++] = $compile.$$createComment('end afIf', $attr.afIf);
+                // Note: We only need the first/last node of the cloned nodes.
+                // However, we need to keep the reference to the jqlite wrapper as it might be changed later
+                // by a directive with templateUrl when its template arrives.
+                block = {
+                  clone: clone
+                };
+                $animate.enter(clone, $element.parent(), $element);
+              });
+            }
+          } else {
+            if (previousElements) {
+              previousElements.remove();
+              previousElements = null;
+            }
+            if (childScope) {
+              childScope.$destroy();
+              childScope = null;
+            }
+            if (block) {
+              previousElements = getBlockNodes(block.clone);
+              $animate.leave(previousElements).done(function(response) {
+                if (response !== false) previousElements = null;
+              });
+              block = null;
+            }
+          }
+        });
+      }
+    };
+  });
+
+  /**
+   * Return the DOM siblings between the first and last node in the given array.
+   * @param {Array} array like object
+   * @returns {Array} the inputted object or a jqLite collection containing the nodes
+   */
+  function getBlockNodes(nodes) {
+    // TODO(perf): update `nodes` instead of creating a new object?
+    var node = nodes[0];
+    var endNode = nodes[nodes.length - 1];
+    var blockNodes;
+
+    for (var i = 1; node !== endNode && (node = node.nextSibling); i++) {
+      if (blockNodes || nodes[i] !== node) {
+        if (!blockNodes) {
+          blockNodes = $(slice.call(nodes, 0, i));
+        }
+        blockNodes.push(node);
+      }
+    }
+
+    return blockNodes || nodes;
+  }
+
+})(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Adds client-side support for conditional logic to hide fields and containers based on rules using and/or/not logic.

Before
----------------------------------------
Afforms lacked conditional logic to show/hide fields

After
----------------------------------------
Any field, button, fieldset or other element can have conditional rules:
![image](https://user-images.githubusercontent.com/2874912/194727414-3d283215-c072-424c-8d49-d37c17ff26c2.png)
