### PR TITLE
Improve Past Groups table on Contact Groups tab

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -335,7 +335,9 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
                     civicrm_group.id as group_id,
                     civicrm_group.is_hidden as is_hidden,
                     civicrm_subscription_history.date as date,
-                    civicrm_subscription_history.method as method';
+                    civicrm_subscription_history.method as method,
+                    civicrm_group.saved_search_id as saved_search_id';
+
     }
 
     $where = " WHERE contact_a.id = %1 AND civicrm_group.is_active = 1";
@@ -400,6 +402,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
         $values[$id]['title'] = ($public && !empty($group->group_public_title) ? $group->group_public_title : $dao->group_title);
         $values[$id]['visibility'] = $dao->visibility;
         $values[$id]['is_hidden'] = $dao->is_hidden;
+        $values[$id]['saved_search_id'] = $dao->saved_search_id;
         switch ($dao->status) {
           case 'Added':
             $prefix = 'in_';
@@ -415,11 +418,26 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
         $values[$id][$prefix . 'date'] = $dao->date;
         $values[$id][$prefix . 'method'] = $dao->method;
         if ($status == 'Removed') {
-          $query = "SELECT `date` as `date_added` FROM civicrm_subscription_history WHERE id = (SELECT max(id) FROM civicrm_subscription_history WHERE contact_id = %1 AND status = \"Added\" AND group_id = $dao->group_id )";
-          $dateDAO = CRM_Core_DAO::executeQuery($query, $params);
-          if ($dateDAO->fetch()) {
-            $values[$id]['date_added'] = $dateDAO->date_added;
-          }
+          $subscriptionHistory = \Civi\Api4\SubscriptionHistory::get()
+            ->addSelect('date', 'status')
+            ->addWhere('contact_id', '=', $contactId)
+            ->addWhere('group_id', '=', $values[$id]['group_id'])
+            ->addWhere('status', 'IN', ['Added', 'Deleted'])
+            ->addOrderBy('date', 'DESC')
+            ->setLimit(1)
+            ->execute()->first();
+          $values[$id]['date_added'] = ($subscriptionHistory && $subscriptionHistory['status'] === 'Added') ? $subscriptionHistory['date'] : NULL;
+
+          $subscriptionRemovedHistory = \Civi\Api4\SubscriptionHistory::get()
+            ->addSelect('date')
+            ->addWhere('date', '>', ($subscriptionHistory) ? $subscriptionHistory['date'] : NULL)
+            ->addWhere('contact_id', '=', $contactId)
+            ->addWhere('group_id', '=', $values[$id]['group_id'])
+            ->addWhere('status', '=', 'Removed')
+            ->addOrderBy('date', 'ASC')
+            ->setLimit(1)
+            ->execute()->first();
+          $values[$id]['out_date'] = ($subscriptionRemovedHistory) ? $subscriptionRemovedHistory['date'] : $values[$id]['out_date'];
         }
       }
       return $values;

--- a/templates/CRM/Contact/Page/View/GroupContact.hlp
+++ b/templates/CRM/Contact/Page/View/GroupContact.hlp
@@ -1,0 +1,19 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="actions-title"}
+  {ts}Past groups{/ts}
+{/htxt}
+{htxt id="actions"}
+    <p>{ts}For regular groups, you can add the contact to the group again by clicking Rejoin Group.{/ts}<br />
+    {ts}Deleting a contact from a group means the contact has no relationship to the group. It won't have a "removed" status in the group any more.{/ts}</p>
+    <p>{ts}* indicates a smart group.{/ts}</p>
+    <p>{ts}For smart groups, you can add the contact to the group manually.{/ts}<br />
+    {ts}If you delete a contact from a smart group, it will no longer be "removed" from the smart group, which means the contact will be in the smart group or not based on the smart group criteria.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -115,8 +115,8 @@
 
   {if $groupOut}
     <div class="ht-one"></div>
-    <h3 class="status-removed">{ts}Past Groups{/ts}</h3>
-    <div class="description">{ts 1=$displayName}%1 is no longer part of these group(s).{/ts}</div>
+    <h3 class="status-removed">{ts}Removed Groups{/ts}</h3>
+    <div class="description">{ts 1=$displayName}%1 has been removed from these group(s).{/ts}</div>
     {strip}
       <table id="past_group" class="display">
         <thead>
@@ -125,6 +125,7 @@
           <th>{ts}Status{/ts}</th>
           <th>{ts}Date Added{/ts}</th>
           <th>{ts}Date Removed{/ts}</th>
+          <th>{ts}Actions{/ts} {help id='actions' file='CRM/Contact/Page/View/GroupContact.hlp'}</th>
           <th></th>
         </tr>
         </thead>
@@ -132,17 +133,31 @@
           <tr id="group_contact-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"}">
             <td class="bold">
               <a href="{crmURL p='civicrm/group/search' q="reset=1&force=1&context=smog&gid=`$row.group_id`"}">
-                {$row.title}
+                {if $row.saved_search_id}* {/if}{$row.title}
               </a>
             </td>
             <td class="status-removed">{ts 1=$row.out_method}Removed (by %1){/ts}</td>
             <td data-order="{$row.date_added}">{$row.date_added|crmDate}</td>
             <td data-order="{$row.out_date}">{$row.out_date|crmDate}</td>
-            <td>{if $permission EQ 'edit'}
-                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
-                  {ts}Rejoin Group{/ts}</a>
-              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2? (this group will no longer be listed under Past Groups).{/ts}">
-                {ts}Delete{/ts}</a>{/if}
+            <td>
+              {if $permission EQ 'edit'}
+              {if $row.saved_search_id}
+              <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
+                {ts}Manual Add{/ts}
+              {else}
+              <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
+                {ts}Rejoin Group{/ts}
+              {/if}
+              </td><td>
+              </a>
+              {if $row.saved_search_id}
+              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
+              {else}
+              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
+              {/if}
+                {ts}Delete{/ts}
+              </a>
+              {/if}
             </td>
           </tr>
         {/foreach}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -144,13 +144,16 @@
                 {if $row.saved_search_id}
                 <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
                   {ts}Manual Add{/ts}
+                </a>
                 {else}
                 <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
                   {ts}Rejoin Group{/ts}
+                </a>
                 {/if}
+              {/if}
             </td>
             <td>
-                </a>
+              {if $permission EQ 'edit'}
                 {if $row.saved_search_id}
                 <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
                   {ts}Delete{/ts}

--- a/templates/CRM/Contact/Page/View/GroupContact.tpl
+++ b/templates/CRM/Contact/Page/View/GroupContact.tpl
@@ -141,22 +141,25 @@
             <td data-order="{$row.out_date}">{$row.out_date|crmDate}</td>
             <td>
               {if $permission EQ 'edit'}
-              {if $row.saved_search_id}
-              <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
-                {ts}Manual Add{/ts}
-              {else}
-              <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
-                {ts}Rejoin Group{/ts}
-              {/if}
-              </td><td>
-              </a>
-              {if $row.saved_search_id}
-              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
-              {else}
-              <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
-              {/if}
-                {ts}Delete{/ts}
-              </a>
+                {if $row.saved_search_id}
+                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 manually into %2, overriding smart group critera?{/ts}">
+                  {ts}Manual Add{/ts}
+                {else}
+                <a class="action-item crm-hover-button" href="#Added" title="{ts 1=$displayName 2=$row.title}Add %1 back into %2?{/ts}">
+                  {ts}Rejoin Group{/ts}
+                {/if}
+            </td>
+            <td>
+                </a>
+                {if $row.saved_search_id}
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}They will be in the smart group or not based on the smart group criteria.{/ts}">
+                  {ts}Delete{/ts}
+                </a>
+                {else}
+                <a class="action-item crm-hover-button" href="#Deleted" title="{ts 1=$displayName 2=$row.title}Delete %1 from %2?{/ts} {ts}This group will no longer be listed under Removed Groups.{/ts}">
+                  {ts}Delete{/ts}
+                </a>
+                {/if}
               {/if}
             </td>
           </tr>


### PR DESCRIPTION
Overview
----------------------------------------
The Past groups table on the Contact Groups tab is somewhat confusing and sometimes provides unexpected results for Date Added or Date Removed. In general this table uses concepts that encourage misunderstandings of what it means for a contact to be removed from a group, doesn't differentiate between smart and regular groups even though these behave very differently here, and possibly leads to users doing something they don't intend to do (putting a contact back in a smart group by deleting them from a group, for example).

While group memberships concepts remain confusing, I hope these changes clarify the situation somewhat for users.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/194783150-7a36818b-b6c7-4c00-958d-072fa2b5d95d.png)

<img width="500" alt="Screen Shot 2022-10-09 at 4 46 29 PM" src="https://user-images.githubusercontent.com/25517556/194783182-67bd2aa8-12e4-4818-be28-2ad65e690983.png">

<img width="650" alt="Screen Shot 2022-10-09 at 4 46 29 PM" src="https://user-images.githubusercontent.com/25517556/194783167-88357827-1b59-48aa-81c0-bcc4befa674c.png">

After
----------------------------------------
<img width="1008" alt="Screen Shot 2022-10-09 at 4 10 39 PM" src="https://user-images.githubusercontent.com/25517556/194783252-d0b5f92c-5c01-49c5-a6a7-7e1209139202.png">

Changed heading to Removed Groups (some of the groups may not in fact be past groups, because a contact can be removed from a group they were never in). I think it's important not to encourage that misunderstanding (I know I misunderstood this for years).
Added * to indicate smart groups.
Changed "Rejoin Group" text for smart groups to "Manual Add" to indicate that this action has different results.

The less obvious change here is what the Date Added and Date Removed are in special cases.
- If a contact has been removed more than once from a group since the most recent date they were added or deleted, the Date Removed is the earliest date after they were added or deleted. If they were never added or deleted, the date is the earliest removed date. In other words, we show the date that the contact was effectively removed from the group, not the most recent date their status was set to removed. I think this is much more in line with what removed intuitively means and I can't see much reason you'd want to know the date the contact was most recently removed again instead.
- If a contact has been deleted from a group and then removed after that, they no longer show a Date Added (because at the time of removal, they were not in the group). 
 
At some point, I plan to add a History link that will show the complete Subscription History for each group.

Added help text and Actions header to attach it to.
<img width="366" alt="Screen Shot 2022-10-09 at 4 10 47 PM" src="https://user-images.githubusercontent.com/25517556/194783377-4e65051c-b4dd-4bdb-86da-01c34806ecab.png">

For smart groups, changed the confirmation popup text:
<img width="500" alt="Screen Shot 2022-10-09 at 4 46 29 PM" src="https://user-images.githubusercontent.com/25517556/194783546-4ffe9a4b-aafe-4298-87d7-8ae05da5898c.png">

<img width="650" alt="Screen Shot 2022-10-09 at 4 46 42 PM" src="https://user-images.githubusercontent.com/25517556/194784691-09cfef69-891f-41fc-a4bc-6b337b1179f1.png">
Confirmation popups for regular groups are the same, except the delete one says "This group will no longer be listed under Removed Groups."

Unfortunately, this adds a number of translation strings, but I think the added clarity is worth it. I've tried to minimize this where possible.