### PR TITLE
SearchKit - Process tokens in the "Add new" button

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchAdminCustomFields.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminCustomFields.aff.html
@@ -1,15 +1,3 @@
 <div af-fieldset="">
-  <div class="af-markup">
-    <div class="form-inline">
-      <a class="btn btn-primary" target="crm-popup" ng-href="{{ crmUrl('civicrm/admin/custom/group/field/add', {gid: routeParams.gid, reset: 1}) }}">
-        <i class="crm-i fa-plus-circle"></i>
-        {{:: ts('Add Field') }}
-      </a>
-      <a class="btn btn-secondary" ng-href="{{ crmUrl('civicrm/admin/custom/group') }}">
-        <i class="crm-i fa-times"></i>
-        {{:: ts('Done') }}
-      </a>
-    </div>
-  </div>
   <crm-search-display-table search-name="Administer_Custom_Fields" display-name="Table" filters="{custom_group_id: routeParams.gid}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
@@ -193,6 +193,11 @@ return [
               FALSE,
             ],
           ],
+          'addButton' => [
+            'path' => 'civicrm/admin/custom/group/field/add?reset=1&action=add&gid=[custom_group_id]',
+            'text' => E::ts('Add Custom Field'),
+            'icon' => 'fa-plus',
+          ],
         ],
         'acl_bypass' => FALSE,
       ],

--- a/ext/search_kit/ang/crmSearchDisplay/AddButton.html
+++ b/ext/search_kit/ang/crmSearchDisplay/AddButton.html
@@ -1,4 +1,4 @@
-<a ng-href="{{ $ctrl.addButton.url }}" class="btn btn-primary" target="crm-popup">
-  <i ng-if="$ctrl.addButton.icon" class="crm-i {{:: $ctrl.addButton.icon }}"></i>
-  {{:: $ctrl.addButton.text }}
+<a ng-href="{{ $ctrl.getButtonUrl() }}" class="btn btn-primary" target="crm-popup">
+  <i ng-if="$ctrl.settings.addButton.icon" class="crm-i {{:: $ctrl.settings.addButton.icon }}"></i>
+  {{:: $ctrl.settings.addButton.text }}
 </a>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -26,15 +26,6 @@
         for (var p=0; p < placeholderCount; ++p) {
           this.placeholders.push({});
         }
-        // Calculate URL of addButton and copy addButton to controller property
-        // It has to be copied rather than simply adding this.settings.addButton.url,
-        // because settings cannot be changed when they are supplied from the markup
-        if (this.settings.addButton && this.settings.addButton.path) {
-          // Clone the variable to prevent polluting it during Preview mode in the Admin UI
-          this.addButton = _.cloneDeep(this.settings.addButton);
-          // TODO: Evaluate variables in the path
-          this.addButton.url = CRM.url(this.addButton.path);
-        }
 
         this.getResults = _.debounce(function() {
           $scope.$apply(function() {
@@ -103,6 +94,10 @@
         return this.settings.actions || this.settings.draggable || (this.settings.tally && this.settings.tally.label);
       },
 
+      getFilters: function() {
+        return _.assign({}, this.getAfformFilters(), this.filters);
+      },
+
       getAfformFilters: function() {
         return _.pick(this.afFieldset ? this.afFieldset.getFieldData() : {}, function(val) {
           return val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length);
@@ -118,9 +113,19 @@
           sort: this.sort,
           limit: this.limit,
           seed: this.seed,
-          filters: _.assign({}, this.getAfformFilters(), this.filters),
+          filters: this.getFilters(),
           afform: this.afFieldset ? this.afFieldset.getFormName() : null
         };
+      },
+
+      // Get path for the addButton
+      getButtonUrl: function() {
+        var path = this.settings.addButton.path,
+          filters = this.getFilters();
+        _.each(filters, function(value, key) {
+          path = path.replace('[' + key + ']', value);
+        });
+        return CRM.url(path);
       },
 
       onClickSearchButton: function() {

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -1,7 +1,7 @@
 <div class="crm-search-display crm-search-display-grid">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.addButton"></div>
+    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <div
     class="crm-search-display-grid-container crm-search-display-grid-layout-{{$ctrl.settings.colno}}"

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -1,7 +1,7 @@
 <div class="crm-search-display crm-search-display-list">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.addButton"></div>
+    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <ol ng-if=":: $ctrl.settings.style === 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ol>
   <ul ng-if=":: $ctrl.settings.style !== 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ul>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -2,7 +2,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
-    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.addButton"></div>
+    <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>


### PR DESCRIPTION
Overview
----------------------------------------
Allows an "Add new" button on drilldown searches.

Before
----------------------------------------
SearchKit has an automatic "Add New" button for creating a new item. But it doesn't work with dynamic parameters, e.g. on the search of Custom Fields for a particular Custom Group (where `custom_group_id` is the param).

After
----------------------------------------
Feature added, and the "Administer Custom Fields" form switched from custom code to using the feature.
