### PR TITLE
🪥 Fix spelling mistake showHideSeletorSearch should be showHideSelectorSearch

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -411,7 +411,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
       ts('Visibility'),
       CRM_Core_SelectValues::ufVisibility(),
       TRUE,
-      ['onChange' => "showHideSeletorSearch(this.value);"]
+      ['onChange' => "showHideSelectorSearch(this.value);"]
     );
 
     //CRM-4363

--- a/templates/CRM/UF/Form/Field.tpl
+++ b/templates/CRM/UF/Form/Field.tpl
@@ -154,9 +154,9 @@ function showLabel( ) {
 }
 
 {/literal}{if $action neq 8}{literal}
-showHideSeletorSearch();
+showHideSelectorSearch();
 
-function showHideSeletorSearch() {
+function showHideSelectorSearch() {
   var is_search = cj('#is_search_label, #is_search_html');
   var in_selector = cj('#in_selector_label, #in_selector_html');
   if (cj("#visibility").val() == "User and User Admin Only") {
@@ -179,7 +179,7 @@ function showHideSeletorSearch() {
 }
 
 cj("#field_name_1").bind( 'change blur', function( ) {
-  showHideSeletorSearch( );
+  showHideSelectorSearch( );
 });
 
 CRM.$(function($) {


### PR DESCRIPTION
Fix spelling mistake showHideSeletorSearch should be showHideSelectorSearch

Overview
----------------------------------------
Fixes spelling mistake in Javascript function, showHideSeletorSearch

Before
----------------------------------------
Javascript function, showHideSeletorSearch

After
----------------------------------------
Javascript function, showHideSelectorSearch

Technical Details
----------------------------------------
Limited use of this function.

Comments
----------------------------------------

[Agileware Ref](https://agileware.com.au): CIVICRM-2045 
