### PR TITLE
Add unit test to hit class-loader issue

### DIFF
--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -9,6 +9,7 @@ use Civi\Api4\ContributionSoft;
 use Civi\Api4\DedupeRule;
 use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Email;
+use Civi\Api4\Import;
 use Civi\Api4\Note;
 use Civi\Api4\OptionValue;
 use Civi\Api4\UserJob;
@@ -43,6 +44,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     DedupeRule::delete()
       ->addWhere('rule_table', '!=', 'civicrm_email')
       ->addWhere('dedupe_rule_group_id.name', '=', 'IndividualUnsupervised')->execute();
+    $this->callAPISuccess('Extension', 'disable', ['key' => 'civiimport']);
     parent::tearDown();
   }
 
@@ -815,6 +817,16 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'rule_table' => 'civicrm_contact',
       'rule_field' => 'last_name',
     ]);
+  }
+
+  /**
+   * Test the Import api works from the extension when the extension is enabled after the import.
+   */
+  public function testEnableExtension(): void {
+    $this->importContributionsDotCSV();
+    $this->callAPISuccess('Extension', 'enable', ['key' => 'civiimport']);
+    $result = Import::get($this->userJobID)->execute();
+    $this->assertEquals('ERROR', $result->first()['_status']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test to hit class-loader issue

Before
----------------------------------------
I hit an issue enabling `civiimport` on master / the rc where it failed on a class not found when an import already exists (it registers the import subscriber to create entities so having already done an import matters here).

When I tried to replicate in a test it got weird fast. Locally this is now failing on not finding an afform class after running this test

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
This is the backtrace & it fails on the afform extension currenlty
![image](https://user-images.githubusercontent.com/336308/195014889-5f382d24-a3d6-497f-aa3d-b5638b0ffe0c.png)

![image](https://user-images.githubusercontent.com/336308/195015166-99212298-c5cf-4193-88c9-189e9dd26647.png)

![image](https://user-images.githubusercontent.com/336308/195015253-de882f90-d03b-403f-95aa-57fffa2b425b.png)



Comments
----------------------------------------
_Anything else you would like the reviewer to note_
