### PR TITLE
Add psr0 to afform extensions

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -28,6 +28,7 @@
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
+    <psr0 prefix="CRM_" path="."/>
   </classloader>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -24,6 +24,7 @@
   </civix>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
+    <psr0 prefix="CRM_" path="."/>
   </classloader>
   <requires>
     <ext>authx</ext>


### PR DESCRIPTION
Overview
----------------------------------------
Add psr0 to afform extensions

Before
----------------------------------------
Possible to get this obscure fail https://github.com/civicrm/civicrm-core/pull/24712

After
----------------------------------------
That one is working again

Technical Details
----------------------------------------
We added psr0 to `civix` but core extensions need it added - not all however, only those with `CRM` classes. I was going to run `civix upgrade` on all of them but hit a couple of things

1) I wanted to resolve this first - https://github.com/totten/civix/pull/263#issuecomment-1271496159 -(I don't think the comments are blocking)
2) I hit some errors around mgd version

So I focused on quickly fixing the ones I knew to be problems.  Note I did check the line is where civix puts it (below the psr4 line) 

Comments
----------------------------------------
