### PR TITLE
(dev/core#3905) Need to increase data size for 'data' column on 'civi…

### DIFF
--- a/CRM/Core/DAO/JobLog.php
+++ b/CRM/Core/DAO/JobLog.php
@@ -97,7 +97,7 @@ class CRM_Core_DAO_JobLog extends CRM_Core_DAO {
    * Potential extended data for specific job run (e.g. tracebacks).
    *
    * @var string|null
-   *   (SQL type: text)
+   *   (SQL type: longtext)
    *   Note that values will be retrieved from the database as a string.
    */
   public $data;
@@ -250,7 +250,7 @@ class CRM_Core_DAO_JobLog extends CRM_Core_DAO {
         ],
         'data' => [
           'name' => 'data',
-          'type' => CRM_Utils_Type::T_TEXT,
+          'type' => CRM_Utils_Type::T_LONGTEXT,
           'title' => ts('Extended Data'),
           'description' => ts('Potential extended data for specific job run (e.g. tracebacks).'),
           'where' => 'civicrm_job_log.data',

--- a/CRM/Upgrade/Incremental/sql/5.56.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.56.alpha1.mysql.tpl
@@ -1,5 +1,8 @@
 {* file to handle db changes in 5.56.alpha1 during upgrade *}
 
+-- dev/core#3905 Update data type for data to LONGTEXT
+ALTER TABLE civicrm_job_log MODIFY COLUMN data LONGTEXT COMMENT 'Potential extended data for specific job run (e.g. tracebacks).';
+
 -- Add in missing indian states as per iso-3166-2
 SELECT @indianCountryID := id FROM civicrm_country WHERE name = 'India' AND iso_code = 'IN';
 INSERT INTO civicrm_state_province (country_id, abbreviation, name) VALUES

--- a/xml/schema/Core/JobLog.xml
+++ b/xml/schema/Core/JobLog.xml
@@ -85,7 +85,7 @@
   <field>
     <name>data</name>
     <title>Extended Data</title>
-    <type>text</type>
+    <type>longtext</type>
     <comment>Potential extended data for specific job run (e.g. tracebacks).</comment>
     <add>4.1</add>
   </field>


### PR DESCRIPTION
…crm_job_log' table

Overview
----------------------------------------
Currently _data_ column of the _civicrm_job_log_ table is of data type TEXT. This is sufficient for running most jobs. However we have a some comprehensive log for mailchimp sync extension and it would throw errors when running the job.
`INSERT INTO civicrm_job_log (domain_id , job_id , name , command , ...", "1406 ** Data too long for column 'data' at row 1`

Before
----------------------------------------
The data type for the _data_ column on the  _civicrm_job_log_  is TEXT

After
----------------------------------------
The data type for the _data_ column on the  _civicrm_job_log_ is now LONGTEXT
