### PR TITLE
dev/core#3908 Fix permissions for SubscriptionHistory in SearchKit

### DIFF
--- a/Civi/Api4/SubscriptionHistory.php
+++ b/Civi/Api4/SubscriptionHistory.php
@@ -19,4 +19,15 @@ namespace Civi\Api4;
  */
 class SubscriptionHistory extends Generic\DAOEntity {
 
+  /**
+   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
+   * @return array
+   */
+  public static function permissions() {
+    // get permission is managed by ACLs
+    return [
+      'get' => [],
+    ];
+  }
+
 }

--- a/tests/phpunit/api/v4/Entity/SubscriptionHistoryTest.php
+++ b/tests/phpunit/api/v4/Entity/SubscriptionHistoryTest.php
@@ -62,4 +62,39 @@ class SubscriptionHistoryTest extends Api4TestBase {
     $this->assertLessThanOrEqual(time(), strtotime($historyRemoved->single()['date']));
   }
 
+  public function testGetPermissions() {
+    $this->createLoggedInUser();
+
+    $contact = $this->createTestRecord('Contact');
+    $group = $this->createTestRecord('Group');
+    $groupContact = $this->createTestRecord('GroupContact', [
+      'group_id' => $group['id'],
+      'contact_id' => $contact['id'],
+    ]);
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'view all contacts',
+    ];
+
+    $historyAdded = SubscriptionHistory::get()
+      ->addSelect('*')
+      ->addWhere('group_id', '=', $group['id'])
+      ->addWhere('status', '=', 'Added')
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(1, $historyAdded);
+
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+
+    $historyAdded = SubscriptionHistory::get()
+      ->addSelect('*')
+      ->addWhere('group_id', '=', $group['id'])
+      ->addWhere('status', '=', 'Added')
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(0, $historyAdded);
+
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Users without 'administer CiviCRM' permission are unable to view data from the SubscriptionHistory entity in SearchKit.

See https://lab.civicrm.org/dev/core/-/issues/3908

Before
----------------------------------------
User unable to view data.

After
----------------------------------------
User able to view data.

