### PR TITLE
Standardise names as camelcase for "SearchKit" and "FormBuilder"

### DIFF
--- a/ext/afform/README.md
+++ b/ext/afform/README.md
@@ -1,4 +1,4 @@
-# Form builder (afform)
+# FormBuilder (afform)
 
 ![Screenshot](docs/sandbox/3-Free-Blocks-Parent.png)
 

--- a/ext/afform/admin/CRM/AfformAdmin/Page/Base.php
+++ b/ext/afform/admin/CRM/AfformAdmin/Page/Base.php
@@ -17,7 +17,7 @@ class CRM_AfformAdmin_Page_Base extends CRM_Core_Page {
 
   public function run() {
     $breadCrumb = [
-      'title' => E::ts('Form Builder'),
+      'title' => E::ts('FormBuilder'),
       'url' => CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, '/'),
     ];
     CRM_Utils_System::appendBreadCrumb([$breadCrumb]);

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme" class="afadmin-list">
-  <h1 crm-page-title>{{:: ts('Form Builder') }}</h1>
+  <h1 crm-page-title>{{:: ts('FormBuilder') }}</h1>
 
   <ul class="nav nav-tabs">
     <li role="presentation" ng-repeat="tab in $ctrl.tabs" ng-class="{active: tab.name === $ctrl.tab}">

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme">
-  <h1 crm-page-title>{{ ts('Form Builder: %1', {1: editor.afform.title || ts('Untitled')}) }}</h1>
+  <h1 crm-page-title>{{ ts('FormBuilder: %1', {1: editor.afform.title || ts('Untitled')}) }}</h1>
   <div id="afGuiEditor" class="crm-flex-box">
     <div id="afGuiEditor-palette" class="crm-flex-3" ng-include="'~/afGuiEditor/afGuiEditorPalette.html'"></div>
     <div id="afGuiEditor-canvas" class="crm-flex-5" ng-include="'~/afGuiEditor/afGuiEditorCanvas.html'"></div>

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <extension key="org.civicrm.afform_admin" type="module">
   <file>afform_admin</file>
-  <name>Form Builder</name>
+  <name>FormBuilder</name>
   <description>Administer, edit and compose dynamic forms</description>
   <license>AGPL-3.0</license>
   <maintainer>
@@ -18,7 +18,7 @@
   <compatibility>
     <ver>5.56</ver>
   </compatibility>
-  <comments>Form Builder provides a UI to administer and edit forms. It is an optional admin tool and not required for the forms to function.</comments>
+  <comments>FormBuilder provides a UI to administer and edit forms. It is an optional admin tool and not required for the forms to function.</comments>
   <requires>
     <ext>org.civicrm.afform</ext>
     <ext>org.civicrm.search_kit</ext>

--- a/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
+++ b/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
@@ -15,7 +15,7 @@ foreach ($domains as $domain) {
       'version' => 4,
       'values' => [
         'name' => 'afform_admin',
-        'label' => E::ts('Form Builder'),
+        'label' => E::ts('FormBuilder'),
         'permission' => [
           'administer CiviCRM',
           'administer afform',

--- a/ext/afform/core/CRM/Afform/DAO/AfformSubmission.php
+++ b/ext/afform/core/CRM/Afform/DAO/AfformSubmission.php
@@ -87,7 +87,7 @@ class CRM_Afform_DAO_AfformSubmission extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? E::ts('Form Builder Submissions') : E::ts('Form Builder Submission');
+    return $plural ? E::ts('FormBuilder Submissions') : E::ts('FormBuilder Submission');
   }
 
   /**

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -31,7 +31,7 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
         if ($afform['type'] !== 'system' &&
           \CRM_Extension_System::singleton()->getMapper()->isActiveModule('afform_admin')
         ) {
-          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Form Builder'), 'url' => CRM_Utils_System::url('civicrm/admin/afform')]]);
+          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('FormBuilder'), 'url' => CRM_Utils_System::url('civicrm/admin/afform')]]);
           CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Edit Form'), 'url' => CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, '/edit/' . $pageArgs['afform'])]]);
         }
       }

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -424,7 +424,7 @@ function afform_civicrm_alterMenu(&$items) {
  */
 function afform_civicrm_permission(&$permissions) {
   $permissions['administer afform'] = [
-    E::ts('Form Builder: edit and delete forms'),
+    E::ts('FormBuilder: edit and delete forms'),
     E::ts('Allows non-admin users to create, update and delete forms'),
   ];
 }
@@ -538,7 +538,7 @@ function afform_civicrm_alterApiRoutePermissions(&$permissions, $entity, $action
 function afform_civicrm_preProcess($formName, &$form) {
   if ($formName === 'CRM_Core_Form_ShortCode') {
     $form->components['afform'] = [
-      'label' => E::ts('Form Builder'),
+      'label' => E::ts('FormBuilder'),
       'select' => [
         'key' => 'name',
         'entity' => 'Afform',

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -18,7 +18,7 @@
   <compatibility>
     <ver>5.56</ver>
   </compatibility>
-  <comments>The Form Core extension is required to use any dynamic form. To administer and edit forms, also install the Form Builder extension.</comments>
+  <comments>The Form Core extension is required to use any dynamic form. To administer and edit forms, also install the FormBuilder extension.</comments>
   <civix>
     <namespace>CRM/Afform</namespace>
   </civix>

--- a/ext/afform/core/xml/schema/CRM/Afform/AfformSubmission.xml
+++ b/ext/afform/core/xml/schema/CRM/Afform/AfformSubmission.xml
@@ -5,7 +5,7 @@
   <class>AfformSubmission</class>
   <name>civicrm_afform_submission</name>
   <comment>Recorded form submissions</comment>
-  <title>Form Builder Submission</title>
+  <title>FormBuilder Submission</title>
   <log>true</log>
 
   <field>

--- a/ext/search_kit/CRM/Search/Page/Admin.php
+++ b/ext/search_kit/CRM/Search/Page/Admin.php
@@ -18,7 +18,7 @@ class CRM_Search_Page_Admin extends CRM_Core_Page {
 
   public function run() {
     $breadCrumb = [
-      'title' => E::ts('Search Kit'),
+      'title' => E::ts('SearchKit'),
       'url' => CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, '/list'),
     ];
     CRM_Utils_System::appendBreadCrumb([$breadCrumb]);

--- a/ext/search_kit/CRM/Search/Page/Search.php
+++ b/ext/search_kit/CRM/Search/Page/Search.php
@@ -21,7 +21,7 @@ class CRM_Search_Page_Search extends CRM_Core_Page {
     Civi::service('angularjs.loader')->useApp();
 
     if (CRM_Core_Permission::check('administer CiviCRM')) {
-      CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Search Kit'), 'url' => CRM_Utils_System::url('civicrm/admin/search')]]);
+      CRM_Utils_System::appendBreadCrumb([['title' => E::ts('SearchKit'), 'url' => CRM_Utils_System::url('civicrm/admin/search')]]);
     }
 
     parent::run();

--- a/ext/search_kit/README.md
+++ b/ext/search_kit/README.md
@@ -1,10 +1,10 @@
-# CiviCRM Search Kit
+# CiviCRM SearchKit
 
 A core extension to create complex searches, reports & smart groups.
 
 ## Usage
 
-Once enabled, navigate to **Search > Search Kit** in the menu.
+Once enabled, navigate to **Search > SearchKit** in the menu.
 
 ## Development
 

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -72,7 +72,7 @@
         // Customize the noResultsText
         $scope.$watch('$ctrl.filters', function() {
           ctrl.settings.noResultsText = (angular.equals(['has_base'], getActiveFilters())) ?
-            ts('Welcome to Search Kit. Click the New Search button above to start composing your first search.') :
+            ts('Welcome to SearchKit. Click the New Search button above to start composing your first search.') :
             ts('No Saved Searches match filter criteria.');
         }, true);
       };

--- a/ext/search_kit/css/crmSearchDisplayGrid.css
+++ b/ext/search_kit/css/crmSearchDisplayGrid.css
@@ -1,4 +1,4 @@
-/* search kit grid layout styling */
+/* SearchKit grid layout styling */
 .crm-search-display-grid-container {
   display: grid;
   grid-gap: 1em;

--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -1,4 +1,4 @@
-/* search kit table display styling */
+/* SearchKit table display styling */
 
 #bootstrap-theme .crm-search-display-table > table.table > thead > tr > th.crm-search-result-select {
   padding-left: 0;

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <extension key="org.civicrm.search_kit" type="module">
   <file>search_kit</file>
-  <name>Search Kit</name>
+  <name>SearchKit</name>
   <description>Create searches for a wide variety of CiviCRM entities</description>
   <license>AGPL-3.0</license>
   <maintainer>

--- a/ext/search_kit/managed/Navigation_search_kit.mgd.php
+++ b/ext/search_kit/managed/Navigation_search_kit.mgd.php
@@ -14,7 +14,7 @@ foreach ($domains as $domain) {
     'params' => [
       'version' => 4,
       'values' => [
-        'label' => E::ts('Search Kit'),
+        'label' => E::ts('SearchKit'),
         'name' => 'search_kit',
         'url' => 'civicrm/admin/search',
         'icon' => 'crm-i fa-search-plus',

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -32,8 +32,8 @@ function search_kit_civicrm_container($container) {
  */
 function search_kit_civicrm_permission(&$permissions) {
   $permissions['administer search_kit'] = [
-    E::ts('Search Kit: edit and delete searches'),
-    E::ts('Gives non-admin users access to the Search Kit UI to create, update and delete searches and displays'),
+    E::ts('SearchKit: edit and delete searches'),
+    E::ts('Gives non-admin users access to the SearchKit UI to create, update and delete searches and displays'),
   ];
 }
 

--- a/ext/search_kit/xml/schema/CRM/Search/SearchDisplay.xml
+++ b/ext/search_kit/xml/schema/CRM/Search/SearchDisplay.xml
@@ -4,7 +4,7 @@
   <base>CRM/Search</base>
   <class>SearchDisplay</class>
   <name>civicrm_search_display</name>
-  <comment>Search Kit - saved search displays</comment>
+  <comment>SearchKit - saved search displays</comment>
   <log>true</log>
   <icon>fa-clone</icon>
 


### PR DESCRIPTION
Overview
----------------------------------------
Standardise on camelcase for 'SearchKit' and 'FormBuilder'

Before
----------------------------------------
Some places show 'Search Kit' and 'Form Builder'

After
----------------------------------------
Fewer (hopefully none) instances of 'Search Kit' and 'Form Builder'

Technical Details
----------------------------------------


Comments
----------------------------------------
#ManchesterSprint
