### PR TITLE
Use INSERT IGNORE when inserting new states on upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.56.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.56.alpha1.mysql.tpl
@@ -5,7 +5,7 @@ ALTER TABLE civicrm_job_log MODIFY COLUMN data LONGTEXT COMMENT 'Potential exten
 
 -- Add in missing indian states as per iso-3166-2
 SELECT @indianCountryID := id FROM civicrm_country WHERE name = 'India' AND iso_code = 'IN';
-INSERT INTO civicrm_state_province (country_id, abbreviation, name) VALUES
+INSERT IGNORE INTO civicrm_state_province (country_id, abbreviation, name) VALUES
  (@indianCountryID, "LA", "Ladākh"),
  (@indianCountryID, "DH", "Dādra and Nagar Haveli and Damān and Diu");
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/24706

Before
----------------------------------------
Crash on upgrade if somebody has already manually added the new states, or re-runs the upgrade.

After
----------------------------------------
Not crash.

Technical Details
----------------------------------------
Comparing to previous examples they use INSERT IGNORE.

Comments
----------------------------------------
@seamuslee001 
