### PR TITLE
[REF] Fix passing null into string functions in translation BAO

### DIFF
--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -218,12 +218,12 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookI
       ->addWhere('entity_table', '=', CRM_Core_DAO_AllCoreTables::getTableForEntityName($apiRequest['entity']))
       ->setCheckPermissions(FALSE)
       ->setSelect(['entity_field', 'entity_id', 'string', 'language']);
-    if ((substr($userLocale->nominal, '-3', '3') !== '_NO')) {
+    if ((substr($userLocale->nominal ?? '', '-3', '3') !== '_NO')) {
       // Generally we want to check for any translations of the base language
       // and prefer, for example, French French over US English for French Canadians.
       // Sites that genuinely want to cater to both will add translations for both
       // and we work through preferences below.
-      $translations->addWhere('language', 'LIKE', substr($userLocale->nominal, 0, 2) . '%');
+      $translations->addWhere('language', 'LIKE', substr($userLocale->nominal ?? '', 0, 2) . '%');
     }
     else {
       // And here we have ... the Norwegians. They have three main variants which


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a couple of PHP8.1 issues in translation and tokens 

Before
----------------------------------------
```
1) CRM_Core_BAO_MessageTemplateTest::testDomainTokens
substr(): Passing null to parameter #1 ($string) of type string is deprecated

/home/seamus/buildkit/build/dtest/web/sites/all/modules/civicrm/CRM/Core/BAO/Translation.php:221
``` 

```
1) CRM_Core_BAO_MessageTemplateTest::testDomainTokens
substr(): Passing null to parameter #1 ($string) of type string is deprecated

/home/seamus/buildkit/build/dtest/web/sites/all/modules/civicrm/CRM/Core/BAO/Translation.php:226
```

ping @demeritcowboy 
