### PR TITLE
[REF][PHP8.1] Fix Extension Manager Module test failures on php8.1 du…

### DIFF
--- a/Civi/Api4/Service/LegacySpecScanner.php
+++ b/Civi/Api4/Service/LegacySpecScanner.php
@@ -53,7 +53,7 @@ class LegacySpecScanner implements AutoServiceInterface {
       array_column(\CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'filePath')
     );
     foreach ($locations as $location) {
-      $path = \CRM_Utils_File::addTrailingSlash(dirname($location)) . str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
+      $path = \CRM_Utils_File::addTrailingSlash(dirname($location ?? '')) . str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
       if (!file_exists($path) || !is_dir($path)) {
         $resource = new \Symfony\Component\Config\Resource\FileExistenceResource($path);
         $container->addResource($resource);


### PR DESCRIPTION
…e to passing in null to dirname

Overview
----------------------------------------
This fixes a couple of test errors on php8.1

Before
----------------------------------------
Following test errors on php8.1

```
1) CRM_Extension_Manager_ModuleTest::testInstall_DirtyRemove_Disable_Uninstall
dirname(): Passing null to parameter #1 ($path) of type string is deprecated

/home/seamus/buildkit/build/dtest/web/sites/all/modules/civicrm/Civi/Api4/Service/LegacySpecScanner.php:56

2) CRM_Extension_Manager_ModuleTest::testInstall_DirtyRemove_Disable_Restore
dirname(): Passing null to parameter #1 ($path) of type string is deprecated

/home/seamus/buildkit/build/dtest/web/sites/all/modules/civicrm/Civi/Api4/Service/LegacySpecScanner.php:56
```

After
----------------------------------------
No Test errors in php8.1 from these tests

ping @eileenmcnaughton @demeritcowboy @totten 