### PR TITLE
Fix undefined included mailing names in A/B test report, improve readability

### DIFF
--- a/ang/crmMailing/ViewRecipCtrl.js
+++ b/ang/crmMailing/ViewRecipCtrl.js
@@ -57,7 +57,7 @@
           CRM.api3('Mailing', 'get', {'id': {"IN": mids}}).then(function(result) {
             _.each(result.values, function(mail) {
               if (_.isEmpty(_.where(civimails, {id: parseInt(mail.id)}))) {
-                civimails.push({id: parseInt(mail.id), name: mail.label});
+                civimails.push({id: parseInt(mail.id), name: mail.name});
               }
             });
             CRM.crmMailing.civiMails = civimails;

--- a/ang/crmMailingAB/EditCtrl/report.html
+++ b/ang/crmMailingAB/EditCtrl/report.html
@@ -122,7 +122,7 @@
     </tr>
     <tr ng-controller="ViewRecipCtrl">
       <td>{{:: ts('Recipients') }}</td>
-      <td ng-repeat="am in getActiveMailings()">
+      <td colspan="2" ng-repeat="am in getActiveMailings()|limitTo:1">
         <div ng-show="getIncludesAsString(am.mailing)">
           <strong>{{:: ts('Include:') }}</strong> {{getIncludesAsString(am.mailing)}}
         </div>


### PR DESCRIPTION
Before
----------------------------------------
Mailing names included or excluded from A/B tests were undefined. All groups and mailings squished into one column.

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/25517556/195494007-30fa6d88-66ed-4c4a-8998-dd01f60be912.png">

After
----------------------------------------
Mailing names appear. Groups and mailings span two columns.

![image](https://user-images.githubusercontent.com/25517556/195493858-711e3ec9-1bf4-4d55-907e-e91f602e76a1.png)

Comments
----------------------------------------
Spanning three columns here might make more sense, but for whatever reason, when the final mailing is not yet sent, so there is no data in the third column, colspan of 3 causes the row to widen the entire table if there are enough groups. Tables are fun! I figure perhaps spanning just two columns is more readable anyways, though if anyone knows how to prevent the row from expanding with colspan 3, that might be more logical.