### PR TITLE
[REF][PHP8.1] Fix test failure on civiimport unit test because sequen…

### DIFF
--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -251,4 +251,24 @@ class Import extends CRM_Core_DAO {
     return array_merge(self::getFieldsForTable($tableName), self::getSupportedFields());
   }
 
+  /**
+   * Defines the default key as 'id'.
+   *
+   * @return array
+   */
+  public function keys() {
+    return ['_id'];
+  }
+
+  /**
+   * Tells DB_DataObject which keys use autoincrement.
+   * 'id' is autoincrementing by default.
+   *
+   *
+   * @return array
+   */
+  public function sequenceKey() {
+    return ['_id', TRUE];
+  }
+
 }


### PR DESCRIPTION
…ce key and keys are using id not _id

Overview
----------------------------------------
This fixes the following test failure

```
CiviApiImportTest::testApiActions
PEAR_Exception: DB_DataObject Error: update: trying to perform an update without
                        the key set, and argument to update is not
                        DB_DATAOBJECT_WHEREADD_ONLY
                    Array
(
    [seq] => Array
        (
            [0] => id
            [1] => 1
        )

    [keys] => Array
        (
            [0] => id
        )

)


/home/jenkins/bknix-edge/build/build-2/web/sites/all/modules/civicrm/CRM/Core/Error.php:955
```

Before
----------------------------------------
Test fails on php8.1

After
----------------------------------------
Test passes on php8.1 

