### PR TITLE
Ensure that class-index is up-to-date after toggling extensions (A)

### DIFF
--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -34,6 +34,10 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
     $this->callHook($info, 'enable');
   }
 
+  public function onPostInstall(CRM_Extension_Info $info) {
+    \Civi\Core\ClassScanner::cache('index')->flush();
+  }
+
   /**
    * @param CRM_Extension_Info $info
    */
@@ -80,6 +84,7 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
    * @param CRM_Extension_Info $info
    */
   public function onPostUninstall(CRM_Extension_Info $info) {
+    \Civi\Core\ClassScanner::cache('index')->flush();
   }
 
   /**
@@ -89,12 +94,20 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
     $this->callHook($info, 'disable');
   }
 
+  public function onPostDisable(CRM_Extension_Info $info) {
+    \Civi\Core\ClassScanner::cache('index')->flush();
+  }
+
   /**
    * @param CRM_Extension_Info $info
    */
   public function onPreEnable(CRM_Extension_Info $info) {
     $this->registerClassloader($info);
     $this->callHook($info, 'enable');
+  }
+
+  public function onPostEnable(CRM_Extension_Info $info) {
+    \Civi\Core\ClassScanner::cache('index')->flush();
   }
 
   public function onPostReplace(CRM_Extension_Info $oldInfo, CRM_Extension_Info $newInfo) {

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -9,6 +9,7 @@ use Civi\Api4\ContributionSoft;
 use Civi\Api4\DedupeRule;
 use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Email;
+use Civi\Api4\Import;
 use Civi\Api4\Note;
 use Civi\Api4\OptionValue;
 use Civi\Api4\UserJob;
@@ -43,6 +44,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     DedupeRule::delete()
       ->addWhere('rule_table', '!=', 'civicrm_email')
       ->addWhere('dedupe_rule_group_id.name', '=', 'IndividualUnsupervised')->execute();
+    $this->callAPISuccess('Extension', 'disable', ['key' => 'civiimport']);
     parent::tearDown();
   }
 
@@ -815,6 +817,16 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'rule_table' => 'civicrm_contact',
       'rule_field' => 'last_name',
     ]);
+  }
+
+  /**
+   * Test the Import api works from the extension when the extension is enabled after the import.
+   */
+  public function testEnableExtension(): void {
+    $this->importContributionsDotCSV();
+    $this->callAPISuccess('Extension', 'enable', ['key' => 'civiimport']);
+    $result = Import::get($this->userJobID)->execute();
+    $this->assertEquals('ERROR', $result->first()['_status']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

After enabling or disabling an extension, you may end up with inconsistent (stale/incorrect) data in the `Container`. Fix that.

The problem arises because `Container` now depends on the class-index (ie `ClassScanner`'s `index` cache), and the `index` is not cleared early enough.

Builds on #24712. Note that #24743 and #24744 are two similar alternatives. (*Note: I've filled-in the description to reflect current understanding+commits. The discussion below starts during testing/drafting period.*)

Before
----------------------------------------

Consider Eileen's test from #24712 -- this enables an extension (`civiimport`) which has a service-class (`ImportSubscriber`) and then expects that `ImportSubscriber` is fully loaded/operational.

The test was failing because the order of operations was (effectively):

1. Enable the extension
2. Rebuild the container
3. Clear the class index

Step 2 needs the current class-index, but it's stale - because it's not cleared until step 3. Consequently, the container is built with the *old* class-list. This gives us an inconsistent status -- because (eg) `civiimport` is partially active but not fully active.

After
----------------------------------------

The test from #24712 passes (with some tangential revisions on `tearDown()`).

The order of operations is (effectively):

1. Enable the extension
2. Clear the class index
3. Rebuild the container

Comments
----------------------------------------

* The class-index may still be cleared an extra time after enabling. But at least it will be correct.

* This patch affects the class-index cache (*the summary of active classes across all active extensions*).  I have fingers-crossed that this won't affect test performance much -- because (a) the class-structure cache is still left in place and (b) the test was already clearing the class-index.