### PR TITLE
dev/core#3914 Add getRoleNames() method for WordPress

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1283,6 +1283,15 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       session_start();
     }
   }
+  
+  /**
+   * Get role names
+   *
+   * @return array
+   */
+  public function getRoleNames() {
+    return wp_roles()->role_names;
+  }
 
   /**
    * Perform any necessary actions prior to redirecting via POST.

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1283,7 +1283,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       session_start();
     }
   }
-  
+
   /**
    * Get role names
    *


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the [Missing getRoleNames() method in WordPress System Utility](https://lab.civicrm.org/dev/core/-/issues/3914) issue.

Some extensions use the CRM_Core_Config::singleton()->userSystem->getRoleNames() method, which is not implemented for WordPress

Before
----------------------------------------

On a WordPress install, `CRM_Core_Config::singleton()->userSystem->getRoleNames()` return **NULL**;

After
----------------------------------------

`CRM_Core_Config::singleton()->userSystem->getRoleNames()` returns

```php
Array
(
    [administrator] => Administrator
    [editor] => Editor
    [author] => Author
    [contributor] => Contributor
    [subscriber] => Subscriber
    [anonymous_user] => Anonymous User
)
```

Technical Details
----------------------------------------
Uses [`wp_roles()`](https://developer.wordpress.org/reference/classes/wp_roles/)


