### PR TITLE
SearchKit - Set button size default to `btn-xs` to match existing UI

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
@@ -108,7 +108,7 @@ return [
               'editable' => TRUE,
             ],
             [
-              'size' => 'btn-sm',
+              'size' => 'btn-xs',
               'links' => [
                 [
                   'entity' => 'ContactType',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
@@ -98,7 +98,7 @@ return [
               'editable' => TRUE,
             ],
             [
-              'size' => 'btn-sm',
+              'size' => 'btn-xs',
               'links' => [
                 [
                   'entity' => 'RelationshipType',

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -54,7 +54,7 @@
           label: ts('Buttons'),
           icon: 'fa-square-o',
           defaults: {
-            size: 'btn-sm',
+            size: 'btn-xs',
             links: []
           }
         },


### PR DESCRIPTION
Overview
----------------------------------------
During the sprint one of the screens converted to SearchKit accidentally set the wrong button size, which is an easy mistake to make since the "wrong" size is the default. This fixes it and also changes the default to prevent more such accidents.

Before
----------------------------------------
Default of `btn-sm` which tends to make tables with lots of buttons feel crowded.

After
----------------------------------------
For buttons in a table, `btn-xs` generally fits the best, so let's make that the default.
