### PR TITLE
AdminUI - Always cleanup saved searches during uninstall

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Assigned_Financial_Accounts',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -51,7 +51,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Assigned_Financial_Accounts_SearchDisplay_Entity_Financial_Accounts_Table',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Contact_Types',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Custom_Fields',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -42,7 +42,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Custom_Fields_SearchDisplay_Table',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Custom_Groups',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -53,7 +53,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Custom_Groups_SearchDisplay_Table',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Financial_Types',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -59,7 +59,7 @@ return [
   [
     'name' => 'SavedSearch_Financial_Types_SearchDisplay_Financial_Types_Table_1',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Profile_Fields',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -42,7 +42,7 @@ return [
   [
     'name' => 'SavedSearch_Profile_Fields_SearchDisplay_Profile_Fields',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Profiles.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Profiles.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_User_defined_Profiles',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -55,7 +55,7 @@ return [
   [
     'name' => 'SavedSearch_User_defined_Profiles_SearchDisplay_User_defined_Profiles',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
@@ -5,7 +5,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Relationship_Types',
     'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
@@ -39,7 +39,7 @@ return [
   [
     'name' => 'SavedSearch_Administer_Relationship_Types_SearchDisplay_Administer_Relationship_Types_Table_1',
     'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
+    'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
@@ -20,7 +20,7 @@
       ];
 
       this.$onInit = function() {
-        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php&id=' + ctrl.savedSearchId);
+        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php&cleanup=always&id=' + ctrl.savedSearchId);
 
         var findDisplays = _.transform(ctrl.displayNames, function(findDisplays, displayName) {
           findDisplays.push(['search_displays', 'CONTAINS', ctrl.savedSearchName + '.' + displayName]);


### PR DESCRIPTION
Overview
----------------------------------------
This sets all AdminUI saved searches to be deleted during uninstall, for a cleaner uninstall process. It also sets cleanup=always as the default for SavedSearch export, since the expectation is generally for packaged searches to be cleaned up along with their extensions.

Before
----------------------------------------
SavedSearches not cleaned up when uninstalling the CiviCRM Admin UI extension.

After
----------------------------------------
SavedSearches cleaned up when uninstalling the CiviCRM Admin UI extension.
