### PR TITLE
ClaimItems API - Optionally return the "run as" (contact ID/domain ID)

### DIFF
--- a/Civi/Api4/Action/Queue/ClaimItems.php
+++ b/Civi/Api4/Action/Queue/ClaimItems.php
@@ -71,6 +71,10 @@ class ClaimItems extends \Civi\Api4\Generic\AbstractAction {
           $array['data'] = (array) $item->data;
           break;
 
+        case 'run_as':
+          $array['run_as'] = ($item->data instanceof \CRM_Queue_Task) ? $item->data->runAs : NULL;
+          break;
+
         case 'queue':
           $array['queue'] = $this->queue;
           break;


### PR DESCRIPTION
Overview
----------------------------------------

The `ClaimItems` API provides a facade for remote workers calling `CRM_Queue_Queue_*::claimItems()`. Some items have "run as" flags (eg `CRM_Queue_Task::$runAs`). This patch makes it easier to read "runAs".

Before
----------------------------------------

Not specifically returned.

After
----------------------------------------

Available as an optional value "select" field.

Comments
----------------------------------------

This makes it easier/cheaper for `coworker` to run tasks from various users/domains. It complements this draft update: https://lab.civicrm.org/dev/coworker/-/commit/d92fe0892b2602a99df78ed7f74b381925d481eb

This currently only returns the "run as" for `CRM_Queue_Task`. Using identities with other types of queue-items is currently hypothetical. Dealing with that hypothetical is a longer write-up/topic, but IMHO this is reasonably aligned with how that edge-case should get resolved.