### PR TITLE
Fix language negotiation exception to be standard

### DIFF
--- a/Civi/Core/Locale.php
+++ b/Civi/Core/Locale.php
@@ -169,11 +169,12 @@ class Locale {
    *   Ex: `en_US`, `es_ES`, `fr_CA`
    * @return \Civi\Core\Locale
    *   The effective locale specification.
+   * @throws \CRM_Core_Exception
    */
   public static function negotiate(string $preferred): Locale {
     // Create a locale for the requested language
     if (!preg_match(';^[a-z][a-z]_[A-Z][A-Z]$;', $preferred)) {
-      throw new \RuntimeException("Cannot instantiate malformed locale: $preferred");
+      throw new \CRM_Core_Exception("Cannot instantiate malformed locale: $preferred");
     }
 
     $systemDefault = \Civi::settings()->get('lcMessages');


### PR DESCRIPTION
Overview
----------------------------------------
Fix language negotiation exception to be standard

Before
----------------------------------------
`CRM_Core_Locale::negotiate` throws a `RunTime` exception when provided bad data

After
----------------------------------------
`CRM_Core_Locale::negotiate` throws a `CRM_Core_Exception`

Technical Details
----------------------------------------
`RunTime exceptions are defined as 
"Exception thrown if an error which can only be found on runtime occurs."

I guess you could argue that any place in the code that fails when data is bad / fails validation is a runTime exception - but in practice in our codebase historical bad database data (e.g having an invalid value in ` civicrm_contact.preferred_language` or an invalid email would generally throw a `CRM_Core_Exception` and most code that calls CiviCRM function expects and handles this). Where I see `runTime` exceptions in Civi code is mostly where a site is misconfigured - so not something that an extension would need to know about or handle.

This function is a utility function that is frequently called from sending messages & it seems wrong to have an exception thrown that bypasses 99% of civicrm exception handling

Side note - the type of exception thrown should have been documented in the docblock & we should possibly document the reason whenever it isn't a derivative of `CRM_Core_Exception`

Comments
----------------------------------------
@totten 

