### PR TITLE
dev/core#3922 Fix fiscal year end when fiscal year starts on Jan 1.

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1316,11 +1316,12 @@ class CRM_Utils_Date {
             }
             else {
               $from['Y'] = $fYear - $relativeTermSuffix;
-              $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + 1);
+              $fiscalYear = mktime(0, 0, 0, $from['M'], $from['d'] - 1, $from['Y'] + $relativeTermSuffix);
               $fiscalEnd = explode('-', date("Y-m-d", $fiscalYear));
               $to['d'] = $fiscalEnd['2'];
               $to['M'] = $fiscalEnd['1'];
-              $to['Y'] = $fYear;
+              // We need the year from FiscalEnd, instead of just fYear, because these differ if the FY starts on Jan 1
+              $to['Y'] = $fiscalEnd['0'];
               $to['H'] = 23;
               $to['i'] = $to['s'] = 59;
             }


### PR DESCRIPTION
Before
----------------------------------------
With previous_n.fiscal_year, the dates were correct if a fiscal year start date other than Jan 1 was set. If Jan 1 was the FY start date, then the year was one too large.

After
----------------------------------------
Correct fiscal year end date for Jan 1 and other FY start dates.

Thanks @demeritcowboy for noticing this one.