### PR TITLE
AllFlowsTest - Fix failure on Drupal 7 + php81

### DIFF
--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -428,7 +428,15 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
   public function testMultipleStateless(): void {
     \Civi::settings()->set("authx_header_cred", ['api_key']);
     $cookieJar = new CookieJar();
-    $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => $cookieJar]);
+    $http = $this->createGuzzle([
+      'http_errors' => FALSE,
+      'cookies' => $cookieJar,
+      'headers' => [
+        // This header should be set in real REST-style flows. It takes on extra significance in Drupal,
+        // where session-based logging is toggled based on XMLHttpRequest.
+        'X-Requested-With' => 'XMLHttpRequest',
+      ],
+    ]);
 
     /** @var \Psr\Http\Message\RequestInterface $request */
 


### PR DESCRIPTION
Overview
----------------------------------------

Update `AllFlowsTest` to fix a failure.

Note: @seamuslee001's https://github.com/civicrm/civicrm-packages/pull/350 is parallel+complementary. They address different issues behind the same symptom.

Background
----------------------------------------

If you send a regular request to D7, and if that request happens to generates a PHP warning, then D7 will put the warning in a session-based log. This may auto-create a session.

However, this is not true for XMLHttpRequests. Warnings in AJAX/REST requests do not auto-create sessions.

Before
----------------------------------------

While executing `AllFlowsTest::testMultipleStateless()`, there is a PHP warning about PHPIDS. This initiates a superfluous session and causes `testMultipleStateless()` to fail. However, this is not representative of stateless REST interactions -- because they don't set `X-Requested-With`.

After
----------------------------------------

The test sets `X-Requested-With`.  This is more representative of REST interactions, and it prevents PHP warnings from creating a session.

Comments
----------------------------------------

I'm a little on the fence about this. The patch is appealing because it makes the test more representative and makes the error go away. However, the underlying behavior is a bit quirky/surprising (*"If there's a PHP warning, then stateless requests become stateful requests."*) But off the top of my head, I'm not sure a better rule, and it seems kind of edge-casey.
