### PR TITLE
CRM_Admin_Form - Support standalone forms

### DIFF
--- a/CRM/Admin/Form.php
+++ b/CRM/Admin/Form.php
@@ -49,14 +49,24 @@ class CRM_Admin_Form extends CRM_Core_Form {
   }
 
   /**
-   * Basic setup.
+   * Note: This type of form was traditionally embedded in a page, with values like _id and _action
+   * being `set()` by the page controller.
+   * Nowadays the preferred approach is to place these forms at their own url, so this function
+   * handles both scenarios. It will retrieve id either from a value stored by the page controller
+   * if embedded, or from the url if standalone.
    */
   public function preProcess() {
     Civi::resources()->addStyleFile('civicrm', 'css/admin.css');
     Civi::resources()->addScriptFile('civicrm', 'js/jquery/jquery.crmIconPicker.js');
 
-    $this->_id = $this->get('id');
+    // Lookup id from URL or stored value in controller
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
     $this->_BAOName = $this->get('BAOName');
+    // If BAOName not explicitly set, look it up from the api entity name
+    if (!$this->_BAOName) {
+      $this->_BAOName = CRM_Core_DAO_AllCoreTables::getBAOClassName(CRM_Core_DAO_AllCoreTables::getFullName($this->getDefaultEntity()));
+    }
     $this->_values = [];
     if (isset($this->_id)) {
       $params = ['id' => $this->_id];

--- a/CRM/Admin/Form/ContactType.php
+++ b/CRM/Admin/Form/ContactType.php
@@ -20,11 +20,11 @@
  */
 class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
 
-  public function preProcess(): void {
-    CRM_Utils_Request::retrieve('action', 'String', $this);
-    CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $this->set('BAOName', 'CRM_Contact_BAO_ContactType');
-    parent::preProcess();
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'ContactType';
   }
 
   /**

--- a/CRM/Admin/Form/LocationType.php
+++ b/CRM/Admin/Form/LocationType.php
@@ -25,11 +25,11 @@ class CRM_Admin_Form_LocationType extends CRM_Admin_Form {
    */
   public $submitOnce = TRUE;
 
-  public function preProcess(): void {
-    CRM_Utils_Request::retrieve('action', 'String', $this);
-    CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $this->set('BAOName', 'CRM_Core_BAO_LocationType');
-    parent::preProcess();
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'LocationType';
   }
 
   /**

--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -106,9 +106,6 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $this->set('BAOName', 'CRM_Financial_BAO_PaymentProcessor');
-
     parent::preProcess();
 
     $this->setPaymentProcessorTypeID();

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -22,6 +22,8 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
 
   use CRM_Core_Form_EntityFormTrait;
 
+  protected $_BAOName = 'CRM_Contact_BAO_RelationshipType';
+
   /**
    * Fields for the entity to be assigned to the template.
    *
@@ -40,13 +42,6 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
    * @var array
    */
   protected $entityFields = [];
-
-  public function preProcess(): void {
-    CRM_Utils_Request::retrieve('action', 'String', $this);
-    CRM_Utils_Request::retrieve('id', 'Positive', $this, FALSE, 0);
-    $this->set('BAOName', 'CRM_Contact_BAO_RelationshipType');
-    parent::preProcess();
-  }
 
   /**
    * Set entity fields to be assigned to the form.

--- a/CRM/Tag/Form/Edit.php
+++ b/CRM/Tag/Form/Edit.php
@@ -28,12 +28,6 @@ class CRM_Tag_Form_Edit extends CRM_Admin_Form {
     return 'Tag';
   }
 
-  public function preProcess() {
-    CRM_Utils_Request::retrieve('id', 'Integer', $this, FALSE);
-    $this->set('BAOName', 'CRM_Core_BAO_Tag');
-    parent::preProcess();
-  }
-
   /**
    * Build the form object.
    */


### PR DESCRIPTION
Overview
----------------------------------------
This allows Admin forms to be placed at their own url without any refactoring.

Before
----------------------------------------
Preprocess function only works if form is embedded in a page.

After
----------------------------------------
Works either way

Technical Details
----------------------------------------
This type of form was traditionally embedded in a page, with values like _id and _action `set()` by the page controller.