### PR TITLE
Fix accidental revert of import batch size

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -670,7 +670,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $queue = Civi::queue('user_job_' . $this->getUserJobID(), ['type' => 'Sql', 'error' => 'abort', 'runner' => 'task', 'user_job_id' => $this->getUserJobID()]);
     UserJob::update(FALSE)->setValues(['queue_id.name' => 'user_job_' . $this->getUserJobID()])->addWhere('id', '=', $this->getUserJobID())->execute();
     $offset = 0;
-    $batchSize = 5;
+    $batchSize = 50;
     while ($totalRows > 0) {
       if ($totalRows < $batchSize) {
         $batchSize = $totalRows;


### PR DESCRIPTION
Overview
----------------------------------------
We increased batch size to 50 in 5.52 but appear to have accidentally re-set it to 5. This was presumably due to code being merged that patched the code with the older value & hadn't picked up the new

Before
----------------------------------------
Each batch is 5 records

After
----------------------------------------
Each batch is 50 records

Technical Details
----------------------------------------
There seems to be consensus this should be at least 50. 100 is also on the table but I went with Andy's comment https://github.com/civicrm/civicrm-core/pull/24151#issuecomment-1284498891

The issue @andyburnsco  points out about the 3 second delay between batches seems excessive and worth digging into. There used to be a 30 second delay in the UI just to let people really luxuriate in watching our batch screen - not sure if that is still there?

