### PR TITLE
Event/registration PHP 8 compatibility improvements

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1344,7 +1344,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
 
     //set defaults if mode is registration
-    if (!trim($value) &&
+    if (!trim($value ?? '') &&
       ($value !== 0) &&
       (!in_array($mode, [CRM_Profile_Form::MODE_EDIT, CRM_Profile_Form::MODE_SEARCH]))
     ) {

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -282,7 +282,7 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
       $this
     );
     $createdId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE, 0);
-    if (strtolower($this->_sortByCharacter) == 'all' ||
+    if ((!empty($this->_sortByCharacter) && strtolower($this->_sortByCharacter) == 'all') ||
       !empty($_POST)
     ) {
       $this->_sortByCharacter = '';


### PR DESCRIPTION
Before
----------------------------------------

On 'Manage Events':

`Deprecated function: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in CRM_Event_Page_ManageEvent->browse() (line 285 of...modules/contrib/civicrm/CRM/Event/Page/ManageEvent.php).`

On event registration forms:

`Deprecated function: trim(): Passing null to parameter #1 ($string) of type string is deprecated in CRM_Core_BAO_CustomField::setProfileDefaults() (line 1347 of ...modules/contrib/civicrm/CRM/Core/BAO/CustomField.php).`


After
----------------------------------------
Fewer PHP warnings

Technical Details
----------------------------------------

- Check if empty before the strtolower call
- Also removed an unused variable in the 'browse' method.