### PR TITLE
Move event payment to the confirmation page

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -315,6 +315,22 @@ WHERE  ( civicrm_event.is_template IS NULL OR civicrm_event.is_template = 0 )";
   }
 
   /**
+   * Returns an array of event pages [id => title]
+   * @return array
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function getEventsForSelect2() {
+    return ['all' => ts('- all -')] +
+      \Civi\Api4\Event::get(FALSE)
+        ->addSelect('id', 'title')
+        ->addWhere('is_active', '=', TRUE)
+        ->execute()
+        ->indexBy('id')
+        ->column('title');
+  }
+
+  /**
    * Get events Summary.
    *
    * @return array

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -179,6 +179,13 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   public $paymentInstrumentID;
 
   /**
+   * Should the payment element be shown on the confirm page instead of the first page?
+   *
+   * @var bool
+   */
+  protected $showPaymentOnConfirm = FALSE;
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
@@ -217,6 +224,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     //get the additional participant ids.
     $this->_additionalParticipantIds = $this->get('additionalParticipantIds');
+
+    $this->showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
 
     if (!$this->_values) {
       // this is the first time we are hitting this, so check for permissions here

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -97,6 +97,25 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $this->set('params', $this->_params);
   }
 
+  public function setDefaultValues() {
+    if (!$this->showPaymentOnConfirm) {
+      return [];
+    }
+    // Set default payment processor as default payment_processor radio button value
+    if (!empty($this->_paymentProcessors)) {
+      foreach ($this->_paymentProcessors as $pid => $value) {
+        if (!empty($value['is_default'])) {
+          $defaults['payment_processor_id'] = $pid;
+          break;
+        }
+      }
+    }
+    if (!empty($this->_values['event']['is_pay_later']) && empty($this->_defaults['payment_processor_id'])) {
+      $defaults['is_pay_later'] = 1;
+    }
+    return $defaults ?? [];
+  }
+
   /**
    * Pre process function for Paypal Express confirm.
    * @todo this is just a step in refactor as payment processor specific code does not belong in generic forms
@@ -253,18 +272,17 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $this->assign('amounts', $this->_amount);
       $this->assign('totalAmount', $this->_totalAmount);
       $this->set('totalAmount', $this->_totalAmount);
-      $this->assign('showPaymentOnConfirm', FALSE);
 
-      //if (!empty($this->_values['event']['is_multiple_registrations'])) {
+      $showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
+      $this->assign('showPaymentOnConfirm', $showPaymentOnConfirm);
+      if ($showPaymentOnConfirm) {
         $isPayLater = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_eventId, 'is_pay_later');
         $this->setPayLaterLabel($isPayLater ? $this->_values['event']['pay_later_text'] : '');
         $this->_paymentProcessorIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_values['event']['payment_processor'] ?? NULL);
         $this->assignPaymentProcessor($isPayLater);
-
-        $this->assign('showPaymentOnConfirm', TRUE);
-        $this->addPaymentProcessorFieldsToForm();
         CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
-     // }
+        $this->addPaymentProcessorFieldsToForm();
+      }
     }
 
     if ($this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
@@ -329,7 +347,10 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     }
 
     $this->setDefaults($defaults);
-    //$this->freeze();
+    $showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
+    if (!$showPaymentOnConfirm) {
+      $this->freeze();
+    }
 
     //lets give meaningful status message, CRM-4320.
     $this->assign('isOnWaitlist', $this->_allowWaitlist);
@@ -369,6 +390,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         CRM_Core_Session::setStatus(ts('Please note that the options which are marked or selected are sold out for participant being viewed.'), ts('Sold out:'), 'error');
         CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/register', "_qf_Register_display=true&qfKey={$fields['qfKey']}"));
       }
+    }
+
+    if ($form->showPaymentOnConfirm && empty($form->_requireApproval) && !empty($form->_totalAmount)
+      && $form->_totalAmount > 0 && !isset($fields['payment_processor_id'])
+    ) {
+      $errors['payment_processor_id'] = ts('Please select a Payment Method');
     }
 
     return empty($errors) ? TRUE : $errors;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -253,6 +253,18 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $this->assign('amounts', $this->_amount);
       $this->assign('totalAmount', $this->_totalAmount);
       $this->set('totalAmount', $this->_totalAmount);
+      $this->assign('showPaymentOnConfirm', FALSE);
+
+      //if (!empty($this->_values['event']['is_multiple_registrations'])) {
+        $isPayLater = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $this->_eventId, 'is_pay_later');
+        $this->setPayLaterLabel($isPayLater ? $this->_values['event']['pay_later_text'] : '');
+        $this->_paymentProcessorIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_values['event']['payment_processor'] ?? NULL);
+        $this->assignPaymentProcessor($isPayLater);
+
+        $this->assign('showPaymentOnConfirm', TRUE);
+        $this->addPaymentProcessorFieldsToForm();
+        CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
+     // }
     }
 
     if ($this->_priceSetId && !CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
@@ -317,7 +329,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     }
 
     $this->setDefaults($defaults);
-    $this->freeze();
+    //$this->freeze();
 
     //lets give meaningful status message, CRM-4320.
     $this->assign('isOnWaitlist', $this->_allowWaitlist);

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -428,8 +428,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // https://github.com/civicrm/civicrm-core/pull/19151
       $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
       self::buildAmount($this);
-      //CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
-      //$this->addPaymentProcessorFieldsToForm();
+      if (!$this->showPaymentOnConfirm) {
+        CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
+        $this->addPaymentProcessorFieldsToForm();
+      }
     }
 
     if ($contactID === 0 && !$this->_values['event']['is_multiple_registrations']) {
@@ -905,7 +907,9 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if ($form->_values['event']['is_monetary']) {
       if (empty($form->_requireApproval) && !empty($fields['amount']) && $fields['amount'] > 0 &&
         !isset($fields['payment_processor_id'])) {
-        // $errors['payment_processor_id'] = ts('Please select a Payment Method');
+        if (!$form->showPaymentOnConfirm) {
+          $errors['payment_processor_id'] = ts('Please select a Payment Method');
+        }
       }
 
       if (self::isZeroAmount($fields, $form)) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -355,17 +355,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     // CRM-18399: used by template to pass pre profile id as a url arg
     $this->assign('custom_pre_id', $this->_values['custom_pre_id']);
 
-    // Required for currency formatting in the JS layer
-
-    // Required for currency formatting in the JS layer
-    // this is a temporary fix intended to resolve a regression quickly
-    // And assigning moneyFormat for js layer formatting
-    // will only work until that is done.
-    // https://github.com/civicrm/civicrm-core/pull/19151
-    $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
-
-    CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
-
     $contactID = $this->getContactID();
     $this->assign('contact_id', $contactID);
     if ($contactID) {
@@ -432,7 +421,15 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $this->assign('isAdditionalParticipants', $isAdditionalParticipants);
 
     if ($this->_values['event']['is_monetary']) {
+      // Required for currency formatting in the JS layer
+      // this is a temporary fix intended to resolve a regression quickly
+      // And assigning moneyFormat for js layer formatting
+      // will only work until that is done.
+      // https://github.com/civicrm/civicrm-core/pull/19151
+      $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
       self::buildAmount($this);
+      CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
+      $this->addPaymentProcessorFieldsToForm();
     }
 
     if ($contactID === 0 && !$this->_values['event']['is_multiple_registrations']) {
@@ -440,12 +437,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $this->addCIDZeroOptions();
     }
 
-    if ($this->_values['event']['is_monetary']) {
-      $this->addPaymentProcessorFieldsToForm();
-    }
-
     $this->addElement('hidden', 'bypass_payment', NULL, ['id' => 'bypass_payment']);
-
     $this->assign('bypassPayment', $bypassPayment);
 
     if (!$contactID) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -428,8 +428,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // https://github.com/civicrm/civicrm-core/pull/19151
       $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
       self::buildAmount($this);
-      CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
-      $this->addPaymentProcessorFieldsToForm();
+      //CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
+      //$this->addPaymentProcessorFieldsToForm();
     }
 
     if ($contactID === 0 && !$this->_values['event']['is_multiple_registrations']) {
@@ -905,7 +905,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     if ($form->_values['event']['is_monetary']) {
       if (empty($form->_requireApproval) && !empty($fields['amount']) && $fields['amount'] > 0 &&
         !isset($fields['payment_processor_id'])) {
-        $errors['payment_processor_id'] = ts('Please select a Payment Method');
+        // $errors['payment_processor_id'] = ts('Please select a Payment Method');
       }
 
       if (self::isZeroAmount($fields, $form)) {

--- a/settings/Event.setting.php
+++ b/settings/Event.setting.php
@@ -36,4 +36,22 @@ return [
     'help_text' => NULL,
     'pseudoconstant' => ['callback' => 'CRM_Core_SelectValues::getDashboardEntriesCount'],
   ],
+  'event_show_payment_on_confirm' => [
+    'name' => 'event_show_payment_on_confirm',
+    'settings_pages' => ['event' => ['weight' => 100]],
+    'type' => 'Array',
+    'default' => [],
+    'add' => '5.58',
+    'title' => ts('EXPERIMENTAL: Show Event Payment on Confirm?'),
+    'html_type' => 'select',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+      'multiple' => TRUE,
+    ],
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('Should payment element be shown on the confirmation page instead of the first page?'),
+    'help_text' => NULL,
+    'pseudoconstant' => ['callback' => 'CRM_Event_BAO_Event::getEventsForSelect2'],
+  ],
 ];

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -46,6 +46,26 @@
         </div>
     {/if}
 
+    {if $showPaymentOnConfirm}
+    <div class="crm-group event_info-group">
+      <div class="header-dark">
+          {ts}Payment details{/ts}
+      </div>
+    {if !empty($form.payment_processor_id.label)}
+      <fieldset class="crm-public-form-item crm-group payment_options-group" style="display:none;">
+        <legend>{ts}Payment Options{/ts}</legend>
+        <div class="crm-section payment_processor-section">
+          <div class="label">{$form.payment_processor_id.label}</div>
+          <div class="content">{$form.payment_processor_id.html}</div>
+          <div class="clear"></div>
+        </div>
+      </fieldset>
+    {/if}
+        {include file='CRM/Core/BillingBlockWrapper.tpl'}
+    {literal}<script>function calculateTotalFee() { return {/literal}{$totalAmount}{literal} }</script>{/literal}
+    </div>
+    {/if}
+
     <div class="crm-group event_info-group">
         <div class="header-dark">
             {ts}Event Information{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
For multiple event registration workflow payment details must be entered before you add the additional participants and before you know the total amount.
This is a very confusing workflow and causes big problems for payment processors such as Stripe which need to authorize the payment and present card security measures (eg. SCA / 3d secure).
It has also been reported by many as a source of confusion because it's not "normal" to put your card details in before completing all details.

This provides the option to move the payment processor onto the "Confirm" page for events.

Before
----------------------------------------
Payment details must be entered on first page before you add additional participants. Amount is not known.

After
----------------------------------------
Payment details are entered on the confirmation page when you can see all participants / fee selections and the final/total amount.

![image](https://github.com/civicrm/civicrm-core/assets/2052161/9dc965cc-4593-491d-b9f0-a912eced0d1c)

Technical Details
----------------------------------------


Comments
----------------------------------------
Updated to put payment details section at the top of confirmation page.