### PR TITLE
Contact Phone Edit: make it possible for extensions to hide the phone_ext field

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -24,7 +24,7 @@
   </tr>
 {/if}
 <tr id="Phone_Block_{$blockId}">
-  <td>{$form.phone.$blockId.phone.html} {$form.phone.$blockId.phone_ext.label}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
+  <td>{$form.phone.$blockId.phone.html}<span class="crm-phone-ext">{ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
   {if $className eq 'CRM_Contact_Form_Contact'}
   <td>{$form.phone.$blockId.location_type_id.html}</td>
   {/if}

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -31,7 +31,7 @@
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
     <tr id="Phone_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-        <td>{$form.phone.$blockId.phone.html} {$form.phone.$blockId.phone_ext.label}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</td>
+        <td>{$form.phone.$blockId.phone.html}<span class="crm-phone-ext"> {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
         <td>{$form.phone.$blockId.location_type_id.html}</td>
         <td>{$form.phone.$blockId.phone_type_id.html}</td>
         <td align="center" class="crm-phone-is_primary">{$form.phone.$blockId.is_primary.1.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------

Many countries do not have the concept of phone extensions. Even if they do, they are rarely used when most of the data tracked is for individuals. Hiding phone-ext fields can be a good uncluttering for extension, which is what the [ducttape](https://civicrm.org/extensions/duct-tape) extension does.

This PR only makes it possible for extensions to hide the field. It does not change the default behaviour.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/197031587-d929b428-6d66-43e7-898c-e5a2b3ef56f1.png)

After
----------------------------------------

When using the Duct-Tape extension:

![image](https://user-images.githubusercontent.com/254741/197031452-640da738-2a4c-47e2-a227-23086cde175a.png)

the phone-ext field is gone.