### PR TITLE
(REF) authx - Move listener to service class

### DIFF
--- a/ext/authx/Civi/Authx/LegacyRestAuthenticator.php
+++ b/ext/authx/Civi/Authx/LegacyRestAuthenticator.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Authx;
 
+use Civi\Core\Event\GenericHookEvent;
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -21,8 +22,19 @@ use GuzzleHttp\Psr7\Response;
  * authentication style of 'extern/rest.php'.
  *
  * @package Civi\Authx
+ * @service authx.legacy_authenticator
  */
 class LegacyRestAuthenticator extends Authenticator {
+
+  public function on_civi_invoke_auth(GenericHookEvent $e) {
+    // Accept legacy auth (?key=...&api_key=...) for 'civicrm/ajax/rest' and 'civicrm/ajax/api4/*'.
+    // The use of `?key=` could clash on some endpoints. Only accept on a small list of endpoints that are compatible with it.
+    if (count($e->args) > 2 && $e->args[1] === 'ajax' && in_array($e->args[2], ['rest', 'api4'])) {
+      if ((!empty($_REQUEST['api_key']) || !empty($_REQUEST['key']))) {
+        return $this->auth($e, ['flow' => 'legacyrest', 'cred' => 'Bearer ' . $_REQUEST['api_key'] ?? '', 'siteKey' => $_REQUEST['key'] ?? NULL]);
+      }
+    }
+  }
 
   protected function reject($message = 'Authentication failed') {
     $data = ["error_message" => "FATAL: $message", "is_error" => 1];

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -27,6 +27,7 @@
   </classloader>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>
   <civix>


### PR DESCRIPTION
Overview
----------------------------------------

This is a slight refactoring - it basically just moves an event-listener from `authx.php` to `Civi/Authx/Authenticator.php`.

Before
----------------------------------------

Authx registers a listener for `civi.invoke.auth`.

After
----------------------------------------

Authx registers a listener for `civi.invoke.auth`.

Technical Details
----------------------------------------

This functionality is generally covered by `AllFlowsTest`, which passes on my local. We'll see if `civibot` agrees.

For a typical web-request, there shouldn't be much difference, but it's technically cleaner when you consider extension-lifecycle (enable/disable/etc):

* In the old code, it registers a listener while loading `authx.php`. This means that it registers the listener during the first bootstrap. If you have multiple bootstraps (cache-clears/unit-testing/etc), the listener would not re-register.
* In the new code, the listener is registered during each bootstrap. If you alternately enable/reboot/disable/reboot/etc then it will be registered only when expected (ie only when the extension is active).

