### PR TITLE
deprecate FinancialType create/add in favor of writeRecord

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -68,23 +68,16 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
    * @param array $params
    *
    * @return \CRM_Financial_DAO_FinancialType
+   * @deprecated
    */
   public static function create(array $params) {
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'FinancialType', $params['id'] ?? NULL, $params);
-    $financialType = self::add($params);
-    CRM_Utils_Hook::post($hook, 'FinancialType', $financialType->id, $financialType);
-    return $financialType;
+    return self::writeRecord($params);
   }
 
   /**
    * Add the financial types.
    *
-   * Note that add functions are being deprecated in favour of create.
-   * The steps here are to remove direct calls to this function from
-   * core & then move the innids of the function to the create function.
-   * This function would remain for 6 months or so as a wrapper of create with
-   * a deprecation notice.
+   * Note that $ids isn't passed anywhere except tests, which pass an empty array.
    *
    * @param array $params
    *   Values from the database object.
@@ -92,18 +85,10 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
    *   Array that we wish to deprecate and remove.
    *
    * @return object
+   * @deprecated
    */
   public static function add(array $params, $ids = []) {
-    // @todo deprecate this function, move the code to create & call create from add.
-    $financialType = new CRM_Financial_DAO_FinancialType();
-    $financialType->copyValues($params);
-    $financialType->save();
-    // CRM-12470
-    if (empty($ids['financialType']) && empty($params['id'])) {
-      $titles = CRM_Financial_BAO_FinancialTypeAccount::createDefaultFinancialAccounts($financialType);
-      $financialType->titles = $titles;
-    }
-    return $financialType;
+    return self::writeRecord($params);
   }
 
   /**
@@ -158,6 +143,10 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
    * @param \Civi\Core\Event\PostEvent $event
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    if ($event->action === 'create') {
+      $titles = CRM_Financial_BAO_FinancialTypeAccount::createDefaultFinancialAccounts($event->object);
+      $event->object->titles = $titles;
+    }
     if ($event->action === 'delete') {
       \Civi\Api4\EntityFinancialAccount::delete(FALSE)
         ->addWhere('entity_id', '=', $event->id)


### PR DESCRIPTION
Overview
----------------------------------------
Code quality cleanup - move the FinancialType entity to using `writeRecord()`.

Before
----------------------------------------
FinancialType create/add use the same copy/paste code as everywhere else.

After
----------------------------------------
We deprecate and pass everything through to writeRecord.

Comments
----------------------------------------
`CRM_Financial_BAO_FinancialType::add()` takes a second parameter, but nowhere in the codebase is the parameter used, except in tests, where we pass the default value anyway.

Moreover, I don't see how `$ids` would be used.  Maybe it had another purpose previously, but the only purpose it serves currently is to prevent adding default financial accounts on a new financial type, which I don't see a use case for.