### PR TITLE
CiviEvent Import - Remove broken call to parent constructor (dev/core#3932)

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -65,7 +65,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
    * @param array $mapperKeys
    */
   public function __construct(&$mapperKeys = []) {
-    parent::__construct();
     $this->_mapperKeys = &$mapperKeys;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Resolves [Issue 3932](https://lab.civicrm.org/dev/core/-/issues/3932) on lab.civicrm, in which the Event Participant Import attempts to call a parent constructor that does not exist

Before
----------------------------------------
Before this patch, when a user goes to **Events > Import Participants**, fills out the first screen and then clicks **Continue** they receive a critical error.

After
----------------------------------------
With this patch, when a user follows the above steps, they move on to the second screen of the import process (field mapping).

Technical Details
----------------------------------------

Removed line 68 within the `__construct` function (aka constructor) within Participant.php  that attempted to call a constructor in `CRM_Import_Parser`, though one does not exist.

----------------------------------------

