### PR TITLE
APIv3 - Fix Case entityRef to exclude deleted cases & contacts

### DIFF
--- a/CRM/Case/Form/ActivityToCase.php
+++ b/CRM/Case/Form/ActivityToCase.php
@@ -98,7 +98,6 @@ class CRM_Case_Form_ActivityToCase extends CRM_Core_Form {
         'extra' => ['contact_id'],
         'params' => [
           'case_id' => ['!=' => $this->_currentCaseId],
-          'case_id.is_deleted' => 0,
           'case_id.status_id' => ['!=' => "Closed"],
           'case_id.end_date' => ['IS NULL' => 1],
         ],

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -742,6 +742,14 @@ function civicrm_api3_case_getList($params) {
     $params['params']['case_id'] = ['IN' => $params['id']];
     unset($params['id']);
   }
+  if (empty($params['params']['case_id']) || is_array($params['params']['case_id'])) {
+    // Default to hiding deleted cases & deleted contacts
+    $params += ['params' => []];
+    $params['params'] += [
+      'case_id.is_deleted' => 0,
+      'contact_id.is_deleted' => 0,
+    ];
+  }
   $params['id_field'] = 'case_id';
   $params['label_field'] = $params['search_field'] = 'contact_id.sort_name';
   $params['description_field'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the entityRef autocomplete widget for cases to *not* show deleted cases & contacts by default.

Before
----------------------------------------
Deleted cases or cases belonging to deleted contacts show up in the autocomplete.

After
----------------------------------------
Now they don't.