### PR TITLE
Afform - Fix ability to add items to an empty fieldset

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -236,6 +236,10 @@ class CRM_Afform_ArrayHtml {
           $arr['#children'] = $this->convertNodesToArray($node->childNodes);
         }
       }
+      // Empty containers should still get a #children attribute
+      elseif (in_array($node->tagName, ['div', 'fieldset'], TRUE)) {
+        $arr['#children'] = [];
+      }
       return $arr;
     }
     elseif ($node instanceof DOMText) {

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
@@ -55,6 +55,22 @@ class AfformGetTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     $this->assertArrayNotHasKey('base_module', $result);
   }
 
+  public function testGetLayoutWithEmptyNode() {
+    Afform::create(FALSE)
+      ->addValue('name', $this->formName)
+      ->addValue('title', 'Test Form')
+      ->addValue('layout', '<af-form><af-entity name="a"></af-entity><div></div></af-form>')
+      ->execute();
+
+    $layout = Afform::get(FALSE)
+      ->addWhere('name', '=', $this->formName)
+      ->execute()->single()['layout'];
+
+    // Ensure container elements like <div> always have #children even if empty
+    $this->assertEquals([], $layout[0]['#children'][1]['#children']);
+    $this->assertArrayNotHasKey('#children', $layout[0]['#children'][0]);
+  }
+
   public function testAfformAutocomplete(): void {
     $title = uniqid();
     Afform::create()


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug in the AfformAdmin GUI which prevents adding items to an empty fieldset.

Before
----------------------------------------
1. Add an empty fieldset to an afform (or delete all the contents of a fieldset).
2. Save the form and exit the edit screen.
3. Go back to edit the form.
4. Try dragging anything into to that fieldset. It doesn't work.

After
----------------------------------------
Fixed, with test.