### PR TITLE
Added test cases for failing relationship creation

### DIFF
--- a/tests/phpunit/api/v4/Entity/RelationshipTest.php
+++ b/tests/phpunit/api/v4/Entity/RelationshipTest.php
@@ -99,7 +99,7 @@ class RelationshipTest extends Api4TestBase implements TransactionalInterface {
       ->addWhere('id', '=', $relationship['id'])
       ->execute()->first();
     $relationshipDisable = Relationship::update(FALSE)
-      ->addWHere('id','=', $relationship['id'])
+      ->addWhere('id', '=', $relationship['id'])
       ->addValue('is_active', FALSE)
       ->execute()->first();
     $relationship2 = Relationship::create(FALSE)
@@ -134,4 +134,5 @@ class RelationshipTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals($today, $cachedRecords[$c1]['start_date']);
     $this->assertEquals($future, $cachedRecords[$c1]['end_date']);
   }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

As described in [issue#3874](https://lab.civicrm.org/dev/core/-/issues/3874) I created a test scenario for relationships that cannot be created using APIv4. The scenario essential entails disabling an existing relationship and then attempting to create another with the same details. 

While I didn't test this I believe this also fails with different information but matching contacts.


