### PR TITLE
Resolve Issue #3927: contact import failure of different related contact typess

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -12,6 +12,7 @@
 use Civi\Api4\Contact;
 use Civi\Api4\RelationshipType;
 use Civi\Api4\StateProvince;
+use Civi\Api4\DedupeRuleGroup;
 
 require_once 'api/v3/utils.php';
 
@@ -1628,7 +1629,19 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if (isset($params['relationship'])) {
         unset($params['relationship']);
       }
-      $id = $this->getPossibleContactMatch($params, $extIDMatch, $this->getSubmittedValue('dedupe_rule_id') ?: NULL);
+      $ruleId = $this->getSubmittedValue('dedupe_rule_id') ?: NULL;
+      // if this is not the main contact and the contact types are not the same
+      $mainContactType = $this->getSubmittedValue('contactType');
+      if (!$isMainContact && $params['contact_type'] !== $mainContactType) {
+        // use the unsupervised dedupe rule for this contact type
+        $ruleId = DedupeRuleGroup::get(FALSE)
+          ->addSelect('id')
+          ->addWhere('contact_type', '=', $params['contact_type'])
+          ->addWhere('used', '=', 'Unsupervised')
+          ->execute()
+          ->first()['id'];
+      }
+      $id = $this->getPossibleContactMatch($params, $extIDMatch, $ruleId);
       if ($id && $isMainContact && $this->isSkipDuplicates()) {
         throw new CRM_Core_Exception(ts('Contact matched by dedupe rule already exists in the database.'), CRM_Import_Parser::DUPLICATE);
       }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -17,6 +17,7 @@
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\ContactType;
+use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Email;
 use Civi\Api4\Group;
 use Civi\Api4\GroupContact;
@@ -79,13 +80,21 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $contactImportValues = [
       'first_name' => 'Alok',
       'last_name' => 'Patel',
+      'email' => 'alok@email.com',
       'Employee of' => 'Agileware',
     ];
 
     $values = array_values($contactImportValues);
+    $ruleGroupId = DedupeRuleGroup::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('contact_type', '=', 'Individual')
+      ->addWhere('used', '=', 'Unsupervised')
+      ->execute()
+      ->first()['id'];
     $userJobID = $this->getUserJobID([
-      'mapper' => [['first_name'], ['last_name'], ['5_a_b', 'organization_name']],
+      'mapper' => [['first_name'], ['last_name'], ['email'], ['5_a_b', 'organization_name']],
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
+      'dedupe_rule_id' => $ruleGroupId,
     ]);
 
     $this->importValues($userJobID, $values, 'IMPORTED');


### PR DESCRIPTION
Overview
----------------------------------------
This PR resolves [issue 3927](https://lab.civicrm.org/dev/core/-/issues/3927), which flags that the Contact Import was failing when the related contact was of a different contact type as the main contact being imported.

Issue replication steps:
1. Create a csv file to import that, at a minimum, has a column for each First Name, Last Name, Email, and Organization Name
1. Go to **Contacts >> Import Contacts**
1. Upload the test csv file, check the box if your file does include column headers, make sure Contact Type is Individual, For Duplicate Contacts select **Update**, and then set the Dedupe Rule to **Email - Unsupervised**. Click **Continue**
1. On the field mapping page, select the First Name, Last Name, and Email options from the corresponding drop down menu next to those columns. For the column in which the organization is listed, select **Employee of** and then **Organization Name** from the secondary drop down menu that will appear after the first selection. Click **Continue**
1. Click **Import Now** on the next screen
1. After the Queue Runner finished, click **Download Errors** from the Invalid Rows (skipped) row from the table on the Contact Import screen
1.  The reason given on the errors download is "Mismatched contact type."


Before
----------------------------------------
When importing contacts when the main contact was an Individual and the contact related contact was an Organization (i.e. to create an "Employee of" relationship on import), the import failed with a reason of "Mismatched contact types." This scenario was caused by the dedupe rule for the main contact being applied to the contact related contact as well.

After
----------------------------------------
With this patch, the Contact Import no longer applies the same dedupe rule to the contact related contact if it is of a different contact type than the main contact. As a result, the import does not fail when establishing a relationship between two different contact types on import.

Technical Details
----------------------------------------
The original code was not comparing the contact types to determine which dedupe rule should be applied, so this patch initiates a comparison of the contact types via `$this->getSubmittedValue('contactType')` and  `$params['contact_type']` and then makes an APIv4 call to `DedupeRuleGroup` to get the id of `unsupervised` rule that corresponds with the correct contact type.

This PR also includes modifications to `testImportParserWithEmployeeOfRelationship`. This test was passing both with and without the above changes, as it was not actually testing the dedupe portion of the import. Previously, this test did not set an email as part of `contactImportValues`  for deduping the main contact or pass a `'dedupe_rule_id'` to `$this->getUserJobID` so the dedupe rule was using the default value of `NULL`.  By modifying these aspects of the test and using an APIv4 call to get the `$ruleGroupId`, this code more accurately tests importing-and deduping- contacts of two different types. 

