### PR TITLE
dev/core#3933 Record Subscription History for GroupContact delete from API4

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -45,10 +45,13 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
    * @noinspection UnknownInspectionInspection
    */
   public static function self_hook_civicrm_post(PostEvent $event): void {
-    if (is_object($event->object) && in_array($event->action, ['create', 'edit'], TRUE)) {
+    if (is_object($event->object) && in_array($event->action, ['create', 'edit', 'delete'], TRUE)) {
       // Lookup existing info for the sake of subscription history
       if ($event->action === 'edit') {
         $event->object->find(TRUE);
+      }
+      if ($event->action === 'delete') {
+        $event->object->status = 'Deleted';
       }
 
       try {

--- a/tests/phpunit/api/v4/Entity/SubscriptionHistoryTest.php
+++ b/tests/phpunit/api/v4/Entity/SubscriptionHistoryTest.php
@@ -60,6 +60,20 @@ class SubscriptionHistoryTest extends Api4TestBase {
     $this->assertCount(1, $historyRemoved);
     $this->assertGreaterThanOrEqual($timeRemoved, strtotime($historyRemoved->single()['date']));
     $this->assertLessThanOrEqual(time(), strtotime($historyRemoved->single()['date']));
+
+    $timeDeleted = time();
+    GroupContact::delete()
+      ->addWhere('id', '=', $groupContact['id'])
+      ->execute();
+    $historyDeleted = SubscriptionHistory::get()
+      ->addSelect('*')
+      ->addWhere('group_id', '=', $group['id'])
+      ->addWhere('status', '=', 'Deleted')
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(1, $historyDeleted);
+    $this->assertGreaterThanOrEqual($timeDeleted, strtotime($historyDeleted->single()['date']));
+    $this->assertLessThanOrEqual(time(), strtotime($historyDeleted->single()['date']));
   }
 
   public function testGetPermissions() {


### PR DESCRIPTION
Overview
----------------------------------------
This change is simple enough, but I've run into an additional wrinkle that makes this more complex that could use some feedback and direction.  Basically, the Subscription History Method and Tracking variables don't seem to be being set at all for create or update GroupContacts. More details in [Issue #3940](https://lab.civicrm.org/dev/core/-/issues/3940).

Before
----------------------------------------
No subscription history for GroupContact delete via API4.

After
----------------------------------------
Subscription History added, but Method and Tracking not set.
Test added.

Technical Details
----------------------------------------
It could be a concern that this would result in double Subscription History entries if this code was used elsewhere where the Subscription History was already implemented, but I can find no sign of that. Everything else seems to use CRM_Contact_BAO_GroupContact::removeContactsFromGroup and I can't find any other calls to deleteRecord that have anything to do with GroupContacts. removeContactsFromGroup calls the hook, but it doesn't pass an object, so nothing happens (there is no change here, this was previously happening in the same way for contacts removed and added to a group through this function). In the longer term though, it would probably be better to refactor removeContactsFromGroup.
