### PR TITLE
Add runAs to import job Queue Task

### DIFF
--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -70,6 +70,9 @@ trait CRMTraits_Import_ParserTrait {
     catch (CRM_Core_Exception_PrematureExitException $e) {
       $queue = Civi::queue('user_job_' . $this->userJobID);
       $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT COUNT(*) FROM civicrm_queue_item'));
+      $item = $queue->claimItem(0);
+      $this->assertEquals(['contactId' => CRM_Core_Session::getLoggedInContactID(), 'domainId' => CRM_Core_Config::domainID()], $item->data->runAs);
+      $queue->releaseItem($item);
       $runner = new CRM_Queue_Runner([
         'queue' => $queue,
         'errorMode' => CRM_Queue_Runner::ERROR_ABORT,


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/24761 to ensure `runAs` is saved in the import queue job.

Before
----------------------------------------
The user to run the import as is not stored


After
----------------------------------------
As shown in the test & this IDE screenshot - the `runAs` is stored per https://github.com/civicrm/civicrm-core/pull/24761

In stepping through this test I was able to verify it is honoured - although I have not yet gotten the queue to process in the background via `coworker`

![image](https://user-images.githubusercontent.com/336308/197647787-5da7dcd0-7a5c-4ffc-98d0-493e1238bff5.png)


Technical Details
----------------------------------------


Comments
----------------------------------------

