### PR TITLE
dev/core#3941 Fix import spec class loader issue

### DIFF
--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -10,19 +10,21 @@
  +--------------------------------------------------------------------+
  */
 
-namespace Civi\Api4\Service\Spec\Provider;
+namespace Civi\Api4\Import;
 
 use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\Provider\Generic\SpecProviderInterface;
 use Civi\Api4\Service\Spec\RequestSpec;
 use Civi\Api4\UserJob;
 use Civi\BAO\Import;
+use Civi\Core\Service\AutoService;
 use CRM_Core_BAO_UserJob;
 
 /**
  * @service
  * @internal
  */
-class ImportSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+class ImportSpecProvider extends AutoService implements SpecProviderInterface {
 
   /**
    * @inheritDoc


### PR DESCRIPTION
Overview
----------------------------------------
Will update in a couple of hours

Before
----------------------------------------
On a clean civi site run and import (it can fail) THEN enable `civiimport` ... error

![image](https://user-images.githubusercontent.com/336308/197717306-8b239f70-8cd4-49fa-9f87-eac4e2d6aa5b.png)


After
----------------------------------------
Above enable works

Technical Details
----------------------------------------
I found that the error was happening when the class is loaded as a new `ReflectionClass` in the `LegacySpecScanner` - it has verified the file exists & added the directory to the `symfony` index but it must not have done some aspect of  class loading at this point.

Given that the class is ALSO being loaded by virtue of the `scan-classes` `mixin` and the class it is failing in is the `LegacySpecScanner` I tried changing the class path so the `LegacySpecScanner` wouldn't find it - which worked in a replicable way. I also prefer the flatter structure .... you really have to 'know' where to look with the more layered structure

![image](https://user-images.githubusercontent.com/336308/197717062-d8fcc91f-a897-4dc8-9ef8-600366be9357.png)

![image](https://user-images.githubusercontent.com/336308/197717142-688b1866-d0fa-4bb1-bbbf-e21d0830023d.png)


Comments
----------------------------------------

