### PR TITLE
SearchKit - Expose SearchSegment fields as filters

### DIFF
--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
@@ -30,6 +30,7 @@ class SearchSegmentExtraFieldProvider implements Generic\SpecProviderInterface {
       $field->setOptions(array_column($set['items'], 'label'));
       $field->setSuffixes(['label']);
       $field->setSqlRenderer([__CLASS__, 'renderSql']);
+      $field->setInputType('Select');
       $spec->addFieldSpec($field);
     }
   }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchSegment/SearchSegmentTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchSegment/SearchSegmentTest.php
@@ -85,6 +85,7 @@ class SearchSegmentTest extends \PHPUnit\Framework\TestCase implements HeadlessI
 
     $this->assertEquals('Giving Tier', $getField['label']);
     $this->assertEquals('Extra', $getField['type']);
+    $this->assertEquals('Select', $getField['input_type']);
     $this->assertEquals(['Low ball', 'Minor league', 'Major league', 'Heavy hitter'], $getField['options']);
 
     $params = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/3929

Before
----------------------------------------
SearchSegment fields cannot be added as filters to a search form.

After
----------------------------------------
Now they appear as dropdown multiselects.

Technical Details
----------------------------------------
By adding an input type to SearchSegments, Afform now picks them up as filter fields.