### PR TITLE
Minor cleanup in label test, use `PrematureExitException`

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -318,10 +318,6 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
       $rows[$id] = [$formatted];
     }
 
-    if (!empty($fv['is_unit_testing'])) {
-      return $rows;
-    }
-
     //call function to create labels
     $this->createLabel($rows, $fv['label_name']);
     CRM_Utils_System::civiExit();
@@ -353,10 +349,8 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
    *   Associated array of contact data.
    * @param string $format
    *   Format in which labels needs to be printed.
-   * @param string $fileName
-   *   The name of the file to save the label in.
    */
-  private function createLabel($contactRows, $format, $fileName = 'MailingLabels_CiviCRM.pdf') {
+  private function createLabel(array $contactRows, $format) {
     $pdf = new CRM_Utils_PDF_Label($format, 'mm');
     $pdf->Open();
     $pdf->AddPage();
@@ -371,7 +365,10 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
       $pdf->AddPdfLabel($val);
       $val = '';
     }
-    $pdf->Output($fileName, 'D');
+    if (CIVICRM_UF === 'UnitTests') {
+      throw new CRM_Core_Exception_PrematureExitException('pdf output called', ['contactRows' => $contactRows, 'format' => $format, 'pdf' => $pdf]);
+    }
+    $pdf->Output('MailingLabels_CiviCRM.pdf', 'D');
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
@@ -11,47 +11,35 @@
 
  /**
   * Test class for CRM_Contact_Form_Task_Label.
+  *
   * @group headless
   */
 class CRM_Contact_Form_Task_PrintMailingLabelTest extends CiviUnitTestCase {
 
-  protected $_contactIds;
-
-  protected function setUp(): void {
-    parent::setUp();
-    $this->_contactIds = [
+  /**
+   * Test the mailing label rows contain the primary addresses when location_type_id = none (as primary) is chosen in form.
+   *
+   * core/issue-1158:
+   */
+  public function testMailingLabel(): void {
+    $contactIDs = [
       $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']),
       $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']),
     ];
-  }
-
-  /**
-   * Clean up after test.
-   */
-  protected function tearDown(): void {
-    unset($this->_contactIds);
-    parent::tearDown();
-  }
-
-  /**
-   * core/issue-1158: Test the mailing label rows contain the primary addresses when location_type_id = none (as primary) is chosen in form
-   */
-  public function testMailingLabel() {
     // Disable searchPrimaryDetailsOnly civi settings so we could test the functionality without it.
     Civi::settings()->set('searchPrimaryDetailsOnly', '0');
 
     $addresses = [];
     // create non-primary and primary addresses of each contact
-    foreach ($this->_contactIds as $contactID) {
+    foreach ($contactIDs as $contactID) {
       // create the non-primary address first
       foreach (['non-primary', 'primary'] as $flag) {
         // @TODO: bug - this doesn't affect as if its the first and only address created for a contact then it always consider it as primary
         $isPrimary = ($flag === 'primary');
-        $streetName = substr(sha1(rand()), 0, 7);
         $addresses[$contactID][$flag] = $this->callAPISuccess('Address', 'create', [
-          'street_name' => $streetName,
+          'street_name' => 'Main Street',
           'street_number' => '23',
-          'street_address' => "$streetName 23",
+          'street_address' => 'Main Street 23',
           'postal_code' => '6971 BN',
           'country_id' => '1152',
           'city' => 'Brummen',
@@ -72,16 +60,21 @@ class CRM_Contact_Form_Task_PrintMailingLabelTest extends CiviUnitTestCase {
     }
 
     $form = new CRM_Contact_Form_Task_Label();
-    $form->_contactIds = $this->_contactIds;
+    $form->_contactIds = $contactIDs;
     $params = [
       'label_name' => 3475,
       'location_type_id' => NULL,
       'do_not_mail' => 1,
-      'is_unit_testing' => 1,
     ];
-    $rows = $form->postProcess($params);
+    try {
+      $rows = $form->postProcess($params);
+      $this->fail('PrematureExitException expected');
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $rows = $e->errorData['contactRows'];
+    }
 
-    foreach ($this->_contactIds as $contactID) {
+    foreach ($contactIDs as $contactID) {
       // ensure that the address printed in the mailing labe is always primary if 'location_type_id' - none (as Primary) is chosen
       $this->assertStringContainsString($addresses[$contactID]['primary']['street_address'], $rows[$contactID][0]);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Minor cleanup in label test, use `PrematureExitException` - addresses the following
- passing a parameter for unit tests instead of throwing a `PrematureExitException`
- `createLabel` is a private function & the class never passes the 3rd parameter - hence remove it. (Can also safely array hint the first parameter but not sure about the second yet)
- Unnecessarly use of class properties for a variable used in only one test. This is trivial but I mention it because it's worth noting that all the UnitTest classes instantiated are kept in memory until the end - so any data kept in class properties is not released. Obviously this matters more for objects & large arrays


Before
----------------------------------------
Fuglier

After
----------------------------------------
fugli-less

Technical Details
----------------------------------------

Comments
----------------------------------------
