### PR TITLE
[REF] Fix importing contributions with a campaign id rather than a t…

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1632,7 +1632,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       }
       if ($fieldMetadata['name'] === 'campaign_id') {
         if (!isset(Civi::$statics[__CLASS__][$fieldName][$importedValue])) {
-          $campaign = Campaign::get()->addClause('OR', ['title', '=', $importedValue], ['name', '=', $importedValue])->addSelect('id')->execute()->first();
+          $campaign = Campaign::get()->addClause('OR', ['title', '=', $importedValue], ['name', '=', $importedValue], ['id', '=', $importedValue])->addSelect('id')->execute()->first();
           Civi::$statics[__CLASS__][$fieldName][$importedValue] = $campaign['id'] ?? FALSE;
         }
         return Civi::$statics[__CLASS__][$fieldName][$importedValue] ?? 'invalid_import_value';


### PR DESCRIPTION
…itle

Overview
----------------------------------------
This fixes a situation where in your csv if you have a campaign id rather than a title of the campaign or a name the import of contributions for example will fail

Before
----------------------------------------
Import fails on a constraint violation error because campaign_id is cast to FALSE which eventually gets interpreted as a 0

After
----------------------------------------
Import Succeeds

ping @eileenmcnaughton @demeritcowboy @andrew-cormick-dockery @johntwyman 