### PR TITLE
Remove never-changing variable

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -298,13 +298,7 @@ class CRM_Utils_Address {
   ) {
     static $config = NULL;
 
-    if (!$format) {
-      $format = Civi::settings()->get('address_format');
-    }
-
-    if ($mailing) {
-      $format = Civi::settings()->get('mailing_format');
-    }
+    $format = Civi::settings()->get('mailing_format');
 
     $formatted = $format;
 
@@ -328,7 +322,7 @@ class CRM_Utils_Address {
     }
 
     //CRM-16876 Display countries in all caps when in mailing mode.
-    if ($mailing && !empty($fields['country'])) {
+    if (!empty($fields['country'])) {
       if (Civi::settings()->get('hideCountryMailingLabels')) {
         $domain = CRM_Core_BAO_Domain::getDomain();
         $domainLocation = CRM_Core_BAO_Location::getValues(['contact_id' => $domain->contact_id]);

--- a/tests/phpunit/CRM/Utils/AddressTest.php
+++ b/tests/phpunit/CRM/Utils/AddressTest.php
@@ -25,7 +25,7 @@ class CRM_Utils_AddressTest extends CiviUnitTestCase {
     $addressDetails = $address['values'][$address['id']];
     $countries = CRM_Core_PseudoConstant::country();
     $addressDetails['country'] = $countries[$addressDetails['country_id']];
-    $formatted_address = CRM_Utils_Address::formatMailingLabel($addressDetails, 'mailing_format', FALSE, TRUE);
+    $formatted_address = CRM_Utils_Address::formatMailingLabel($addressDetails);
     $this->assertTrue((bool) strstr($formatted_address, 'UNITED STATES'));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Utils_Address::formatMailingLabel` is called from 3 places in the code & I found none in the rest of universe. Of those 3
all pass the same values for `$mailing` - ie TRUE. This PR removes the usage of that variable - such that it is assumed to be TRUE (as this stage the signature is unchanged)

![image](https://user-images.githubusercontent.com/336308/197887950-18c7547f-345a-45d7-ba04-fae42e8410c2.png)


Before
----------------------------------------
Always true variable passed in

After
----------------------------------------
Variable no longer relevant - the test instance no longer passes the unused params but the others still do as `$tokens` at the end is still populated

![image](https://user-images.githubusercontent.com/336308/197888411-00f5e14d-751e-45f3-bc37-b88edd482ff3.png)


Technical Details
----------------------------------------

Comments
----------------------------------------