### PR TITLE
SearchKit - POC help text

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/compose.html
+++ b/ext/search_kit/ang/crmSearchAdmin/compose.html
@@ -45,7 +45,7 @@
       <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{:: ts('Where') }}" fields="fieldsForWhere" allow-functions="true" ></crm-search-clause>
     </fieldset>
     <fieldset ng-if="$ctrl.paramExists('having') && $ctrl.savedSearch.api_params.groupBy.length" class="api4-clause-fieldset">
-      <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{:: ts('Having') }}" fields="fieldsForHaving" ></crm-search-clause>
+      <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{:: ts('Having') }}" help="having" fields="fieldsForHaving" ></crm-search-clause>
     </fieldset>
   </div>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -6,11 +6,12 @@
       savedSearch: '<'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdmin.html',
-    controller: function($scope, $element, $location, $timeout, crmApi4, dialogService, searchMeta) {
+    controller: function($scope, $element, $location, $timeout, crmApi4, dialogService, searchMeta, crmUiHelp) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         afformLoad,
         fieldsForJoinGetters = {};
+      $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Compose'});
 
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
       this.afformAdminEnabled = (CRM.checkPerm('administer CiviCRM') || CRM.checkPerm('administer afform')) &&

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -10,12 +10,13 @@
       allowFunctions: '<',
       skip: '<',
       label: '@',
+      help: '@',
       hideLabel: '@',
       placeholder: '<',
       deleteGroup: '&'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchClause.html',
-    controller: function ($scope, $element, searchMeta) {
+    controller: function ($scope, $element, searchMeta, crmUiHelp) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         meta = {};
@@ -31,6 +32,7 @@
 
       this.$onInit = function() {
         ctrl.hasParent = !!$element.attr('delete-group');
+        $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Compose'});
       };
 
       // Gets the first arg of type "field"

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
@@ -1,4 +1,7 @@
-<legend ng-if="!$ctrl.hideLabel">{{ $ctrl.label || ts('%1 group', {1: $ctrl.conjunctions[$ctrl.op]}) }}</legend>
+<legend ng-if="!$ctrl.hideLabel">
+  {{ $ctrl.label || ts('%1 group', {1: $ctrl.conjunctions[$ctrl.op]}) }}
+  <a ng-if="$ctrl.help" crm-ui-help="hs({id: $ctrl.help, title: $ctrl.label})"></a>
+</legend>
 <div class="btn-group btn-group-xs" ng-if=":: $ctrl.hasParent">
   <button type="button" class="btn btn-danger-outline" ng-click="$ctrl.deleteGroup()" title="{{:: ts('Remove group') }}">
     <i class="crm-i fa-trash" aria-hidden="true"></i>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -44,6 +44,7 @@
     <input type="checkbox" ng-checked="col.rewrite" ng-click="$ctrl.parent.toggleRewrite(col)" >
     {{:: ts('Rewrite Text') }}
   </label>
+  <a crm-ui-help="hs({id: 'rewrite', title: ts('Rewrite Text')})"></a>
   <textarea rows="2" class="form-control crm-flex-1" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}"></textarea>
   <crm-search-admin-token-select ng-if="col.rewrite" model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -36,6 +36,7 @@
     <input type="checkbox" ng-checked="col.empty_value" ng-click="$ctrl.parent.toggleEmptyVal(col)" >
     {{:: ts('Empty placeholder') }}
   </label>
+  <a crm-ui-help="hs({id: 'empty', title: ts('Empty placeholder')})"></a>
   <textarea rows="2" class="form-control crm-flex-1" ng-if="col.empty_value" ng-model="col.empty_value" ng-model-options="{updateOn: 'blur'}"></textarea>
   <crm-search-admin-token-select ng-if="col.empty_value" model="col" field="empty_value" suffix=":label"></crm-search-admin-token-select>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/html.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/html.html
@@ -17,6 +17,7 @@
     <input type="checkbox" ng-checked="col.empty_value" ng-click="$ctrl.parent.toggleEmptyVal(col)" >
     {{:: ts('Empty placeholder') }}
   </label>
+  <a crm-ui-help="hs({id: 'empty', title: ts('Empty placeholder')})"></a>
   <textarea rows="2" class="form-control crm-flex-1" ng-if="col.empty_value" ng-model="col.empty_value" ng-model-options="{updateOn: 'blur'}"></textarea>
   <crm-search-admin-token-select ng-if="col.empty_value" model="col" field="empty_value" suffix=":label"></crm-search-admin-token-select>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/html.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/html.html
@@ -25,6 +25,7 @@
     <input type="checkbox" ng-checked="col.rewrite" ng-click="$ctrl.parent.toggleRewrite(col)" >
     {{:: ts('Rewrite HTML') }}
   </label>
+  <a crm-ui-help="hs({id: 'rewrite', title: ts('Rewrite HTML')})"></a>
   <textarea rows="2" class="form-control crm-flex-1" ng-if="col.rewrite" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}"></textarea>
   <crm-search-admin-token-select ng-if="col.rewrite" model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.component.js
@@ -11,9 +11,10 @@
       parent: '^crmSearchAdminDisplay'
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayGrid.html',
-    controller: function($scope, searchMeta) {
+    controller: function($scope, searchMeta, crmUiHelp) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
+      $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Display'});
 
       this.getColTypes = function() {
         return ctrl.parent.colTypes;

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.component.js
@@ -11,9 +11,10 @@
       parent: '^crmSearchAdminDisplay'
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayList.html',
-    controller: function($scope, searchMeta) {
+    controller: function($scope, searchMeta, crmUiHelp) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
+      $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Display'});
 
       this.getColTypes = function() {
         return ctrl.parent.colTypes;

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -11,9 +11,10 @@
       parent: '^crmSearchAdminDisplay'
     },
     templateUrl: '~/crmSearchAdmin/displays/searchAdminDisplayTable.html',
-    controller: function($scope, searchMeta, formatForSelect2) {
+    controller: function($scope, searchMeta, formatForSelect2, crmUiHelp) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
+      $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Display'});
 
       this.tableClasses = [
         {name: 'table', label: ts('Row Borders')},

--- a/ext/search_kit/templates/CRM/Search/Help/Compose.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/Compose.hlp
@@ -1,0 +1,4 @@
+{htxt id="having"}
+  <p>{ts}Unlike the WHERE clause which filters data in the database, HAVING filters the results shown in the table. This allows filtering of aggregate data or field transformations.{/ts}</p>
+  <p>{ts}Note: Rewrite occurs after HAVING has been applied, so does not affect the HAVING filter.{/ts}</p>
+{/htxt}

--- a/ext/search_kit/templates/CRM/Search/Help/Display.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/Display.hlp
@@ -1,3 +1,7 @@
 {htxt id="rewrite"}
   <p>{ts}Both search tokens and smarty tags are supported when rewriting fields.{/ts}</p>
+  <p>{ts}SMARTY conditions can be used by placing quotations around the values that should be evaluated.{/ts}</p>
+{/htxt}
+{htxt id="empty"}
+  <p>{ts}SMARTY conditions can be used by placing quotations around the values that should be evaluated.{/ts}</p>
 {/htxt}

--- a/ext/search_kit/templates/CRM/Search/Help/Display.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/Display.hlp
@@ -1,0 +1,3 @@
+{htxt id="rewrite"}
+  <p>{ts}Both search tokens and smarty tags are supported when rewriting fields.{/ts}</p>
+{/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
This gives a little nudge to https://lab.civicrm.org/dev/user-interface/-/issues/49 with some examples of how to add help text in SearchKit.

Before
----------------------------------------
No help

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/197896829-80f77f32-a7e8-4df9-b482-a9f4cfeb79a6.png)

Comments
----------------
@shaneonabike has asked how to do this. This PR gets the process started and hopefully makes it easy to add more.
To add more help text, simply add more to one of the two `.hlp` files I've added, and then add a new `<a crm-ui-help...` to an angular .html file.