### PR TITLE
Add Validate and Import search kit actions to import search displays

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -80,7 +80,8 @@ class ImportSubscriber extends \Civi\Core\Service\AutoService implements EventSu
         $exists = Entity::get(FALSE)->addWhere('name', '=', 'Import_' . $event->id)->selectRowCount()->execute()->count();
         if (!$exists || $event->action === 'delete') {
           // Flush entities cache key so our new Import will load as an entity.
-          Civi::cache('metadata')->set('api4.entities.info', NULL);
+          Civi::cache('metadata')->delete('api4.entities.info');
+          Civi::cache('metadata')->delete('civiimport_tables');
           CRM_Core_DAO_AllCoreTables::flush();
           Managed::reconcile(FALSE)->setModules(['civiimport'])->execute();
         }

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -42,12 +42,23 @@ class Import extends CRM_Core_DAO {
   public static $_primaryKey = ['_id'];
 
   /**
+   * Get the array of import tables in the database.
+   *
+   * Note that this can be required early (e.g EntityTypes, even
+   * before caching & class loading is fully available (the latter could be resolved now).
+   * Where that is the case `_civiimport_civicrm_get_import_tables` should be called directly.
+   *
    * @return array
    */
   public static function getImportTables(): array {
     // This calls a function on the extension file as it is called from `entityTypes`
     // which can be called very early, before this class is available to that hook.
-    return _civiimport_civicrm_get_import_tables();
+    if (!\Civi::cache('metadata')->has('civiimport_tables')) {
+      $tables = _civiimport_civicrm_get_import_tables();
+      \Civi::cache('metadata')->set('civiimport_tables', $tables);
+      return $tables;
+    }
+    return \Civi::cache('metadata')->get('civiimport_tables');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add Validate and Import search kit actions to import search displays

This builds on https://github.com/civicrm/civicrm-core/pull/24758 and adds two actions to import searches
- validate
- import

From a workflow point of view this allows people to edit-in-place rows that fail & re-do them

To `r-run`

1. Do an import which does not fully pass validation / succeed
2. Turn on the `civiimport` extension
3. Get frustrated at the fatal error
4. Realise there is a PR that fixes it - https://github.com/civicrm/civicrm-core/pull/24807
5. Merge that & continue....
6. Go to the packaged searches screen of Search kit & go into the detail view of your import
7. you should be able to select a row & validate it or import it

Before
----------------------------------------
Nothing to see here

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/197951718-5b518060-5fb7-44e0-9670-31426ea0fad1.png)

Technical Details
----------------------------------------
Gotchas
- make sure asset caching is off  
![image](https://user-images.githubusercontent.com/336308/197952229-f26be8a4-9df7-45f1-89dd-c9a3e6b3f825.png)

- see above re PR for known bug
- The search display is slooow to render  - I don't know why as yet.... but it is unchanged by this PR

Comments
----------------------------------------
@colemanw 
