### PR TITLE
Petition Signature: add an Edit link for admins

### DIFF
--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -11,10 +11,15 @@
 
 <script>
 {literal}
-
   if (typeof(cj) === 'undefined') cj = jQuery;
 {/literal}
 </script>
+
+{if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCampaign') }
+  {capture assign="buttonTitle"}{ts}Edit Petition{/ts}{/capture}
+  {crmButton target="_blank" p="civicrm/petition/add" q="reset=1&action=update&id=`$petition.id`" fb=1 title="$buttonTitle" icon="fa-wrench"}{ts}Configure{/ts}{/crmButton}
+  <div class='clear'></div>
+{/if}
 
 <div id="intro" class="crm-section">{$petition.instructions}</div>
 <div class="crm-block crm-petition-form-block">


### PR DESCRIPTION
Overview
----------------------------------------

Contribution Pages and Event Register pages have a handy "Configure" button at the top, so that admins can quickly edit that page.

This PR adds the same feature for the Petition Signature form.

Before
----------------------------------------

Confused admins: "how do I edit this page"?

After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/198108157-804c1275-6560-41e9-9005-3d52b3cfbeee.png)
