### PR TITLE
[REF] CiviGrant - Remove redundant icon from Afform entity file

### DIFF
--- a/ext/civigrant/afformEntities/Grant.php
+++ b/ext/civigrant/afformEntities/Grant.php
@@ -1,5 +1,4 @@
 <?php
 return [
   'defaults' => "{'url-autofill': '1'}",
-  'icon' => 'fa-money',
 ];


### PR DESCRIPTION
Overview
----------------------------------------
Small code simplification with no functional change.

Technical Details
----------------------------------------
No need to redeclare the icon already set in `CRM_Grant_DAO_Grant`.