### PR TITLE
[REF] Cleanup on CRM_Admin_Form_Options

### DIFF
--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -15,6 +15,9 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\OptionGroup;
+use Civi\Api4\OptionValue;
+
 /**
  * This class generates form components for Options.
  */
@@ -124,7 +127,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       'postal_greeting',
       'addressee',
     ])) {
-      $defaults['contactOptions'] = (CRM_Utils_Array::value('filter', $defaults)) ? $defaults['filter'] : NULL;
+      $defaults['contact_type_id'] = (CRM_Utils_Array::value('filter', $defaults)) ? $defaults['filter'] : NULL;
     }
     // CRM-11516
     if ($this->_gName == 'payment_instrument' && $this->_id) {
@@ -138,8 +141,10 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     parent::buildQuickForm();
     $this->setPageTitle(ts('%1 Option', [1 => $this->_gLabel]));
 
@@ -147,7 +152,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       return;
     }
 
-    $optionGroup = \Civi\Api4\OptionGroup::get(FALSE)
+    $optionGroup = OptionGroup::get(FALSE)
       ->addWhere('id', '=', $this->_gid)
       ->execute()->first();
 
@@ -313,16 +318,20 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
     }
 
     // get contact type for which user want to create a new greeting/addressee type, CRM-4575
-    if (in_array($this->_gName, ['email_greeting', 'postal_greeting', 'addressee'])
+    if (in_array($optionGroup['name'], ['email_greeting', 'postal_greeting', 'addressee'], TRUE)
       && !$isReserved
     ) {
       $values = [
         1 => ts('Individual'),
         2 => ts('Household'),
         3 => ts('Organization'),
-        4 => ts('Multiple Contact Merge'),
       ];
-      $this->add('select', 'contactOptions', ts('Contact Type'), ['' => '-select-'] + $values, TRUE);
+      if ($optionGroup['name'] !== 'email_greeting') {
+        // This isn't really a contact type - but it becomes available when exporting
+        // if 'Merge All Contacts with the Same Address' is selected.
+        $values[4] = ts('Multiple Contact Merge during Export');
+      }
+      $this->add('select', 'contact_type_id', ts('Contact Type'), ['' => '-select-'] + $values, TRUE);
       $this->assign('showContactFilter', TRUE);
     }
 
@@ -355,28 +364,24 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
    */
   public static function formRule($fields, $files, $self) {
     $errors = [];
-    if ($self->_gName == 'case_status' && empty($fields['grouping'])) {
+    $optionGroupName = $self->_gName;
+    if ($optionGroupName === 'case_status' && empty($fields['grouping'])) {
       $errors['grouping'] = ts('Status class is a required field');
     }
 
-    if (in_array($self->_gName, ['email_greeting', 'postal_greeting', 'addressee'])
-      && empty($self->_defaultValues['is_reserved'])
+    if (
+      // We are checking no other option value exists for this label+contact type combo.
+      // @todo - bypassing reserved is historical - why would we not do this check for reserved options?
+      empty($self->_defaultValues['is_reserved'])
+      && in_array($optionGroupName, ['email_greeting', 'postal_greeting', 'addressee'], TRUE)
     ) {
-      $label = $fields['label'];
-      $condition = " AND v.label = '{$label}' ";
-      $values = CRM_Core_OptionGroup::values($self->_gName, FALSE, FALSE, FALSE, $condition, 'filter');
-      $checkContactOptions = TRUE;
-
-      if ($self->_id && ($self->_defaultValues['contactOptions'] == $fields['contactOptions'])) {
-        $checkContactOptions = FALSE;
-      }
-
-      if ($checkContactOptions && in_array($fields['contactOptions'], $values)) {
+      if (self::greetingExists($self->_id, $fields['label'], $fields['contact_type_id'], $optionGroupName)) {
         $errors['label'] = ts('This Label already exists in the database for the selected contact type.');
       }
+
     }
 
-    if ($self->_gName == 'from_email_address') {
+    if ($optionGroupName === 'from_email_address') {
       $formEmail = CRM_Utils_Mail::pluckEmailFromHeader($fields['label']);
       if (!CRM_Utils_Rule::email($formEmail)) {
         $errors['label'] = ts('Please enter a valid email address.');
@@ -388,8 +393,8 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       }
     }
 
-    $dataType = self::getOptionGroupDataType($self->_gName);
-    if ($dataType && $self->_gName !== 'activity_type') {
+    $dataType = self::getOptionGroupDataType($optionGroupName);
+    if ($dataType && $optionGroupName !== 'activity_type') {
       $validate = CRM_Utils_Type::validate($fields['value'], $dataType, FALSE);
       if ($validate === FALSE) {
         CRM_Core_Session::setStatus(
@@ -398,6 +403,31 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       }
     }
     return $errors;
+  }
+
+  /**
+   * Does an existing option already have this label for this contact type.
+   *
+   * @param int|null $id
+   * @param string $label
+   * @param int $contactTypeID
+   * @param string $optionGroupName
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected static function greetingExists(?int $id, string $label, int $contactTypeID, string $optionGroupName): bool {
+    $query = OptionValue::get(FALSE)
+      ->addWhere('label', '=', $label)
+      ->addWhere('option_group_id.name', '=', $optionGroupName)
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('filter', '=', (int) $contactTypeID)
+      ->addSelect('rowCount');
+    if ($id) {
+      $query->addWhere('id', '<>', $id);
+    }
+    return (bool) $query->execute()->count();
   }
 
   /**
@@ -443,7 +473,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
         if ($this->_gName == 'from_email_address') {
           $params['reset_default_for'] = ['domain_id' => CRM_Core_Config::domainID()];
         }
-        elseif ($filter = CRM_Utils_Array::value('contactOptions', $params)) {
+        elseif ($filter = CRM_Utils_Array::value('contact_type_id', $params)) {
           $params['filter'] = $filter;
           $params['reset_default_for'] = ['filter' => "0, " . $params['filter']];
         }

--- a/templates/CRM/Admin/Form/Options.tpl
+++ b/templates/CRM/Admin/Form/Options.tpl
@@ -153,8 +153,8 @@
         {/if}
         {if !empty($showContactFilter)}{* contactOptions is exposed for email/postal greeting and addressee types to set filter for contact types *}
            <tr class="crm-admin-options-form-block-contactOptions">
-             <td class="label">{$form.contactOptions.label}</td>
-             <td>{$form.contactOptions.html}</td>
+             <td class="label">{$form.contact_type_id.label}</td>
+             <td>{$form.contact_type_id.html}</td>
            </tr>
         {/if}
     </table>


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Cleanup on CRM_Admin_Form_Options

Before
----------------------------------------
I coulldn't figure out what the code was doing & why

After
----------------------------------------
- Form Field `contactOptions` renamed to `contact_type_id` - which is almost correct - it has a (hard-coded, I didn't change that) list of contact types to which it adds the mysterious ' "Multiple Contact Merge". Despite this extra it 'mostly' means 'contact_type_id'
- less use of the mysterious `$this->_gName` - as with most abbreviations the meaning of this is clear right up until the end of the coding session at which point it becomes hard to decipher.
- simplification around the validation of the submitted greeting - understanding this was where I started. I no longer call the cached function because for an admin form reducing complexity is more important that hitting the cache. I decided that all that was happening was it was ensuring that there were not 2 records for the same greeting + contact type + label & I r-run tested to check that didn't happen 
![image](https://user-images.githubusercontent.com/336308/198157186-cd38368f-4015-41f6-a8a1-d1018065778f.png)
- separating the check into a function allows sensible levels of code commenting
- I determined the magic last merge option is not actually used for email_greetings so I removed from there

![image](https://user-images.githubusercontent.com/336308/198157347-9b691543-8c69-4261-933a-cd71fd1f0591.png)


Technical Details
----------------------------------------


Comments
----------------------------------------
