### PR TITLE
SearchKit - Fix php error when doing math equations in SELECT clause

### DIFF
--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -62,6 +62,17 @@ class SqlEquation extends SqlExpression {
   }
 
   /**
+   * Get the arguments and operators passed to this sql expression.
+   *
+   * For each item in the returned array, if it's an array, it's a value; if it's a string, it's an operator.
+   *
+   * @return array
+   */
+  public function getArgs(): array {
+    return $this->args;
+  }
+
+  /**
    * Render the expression for insertion into the sql query
    *
    * @param Civi\Api4\Query\Api4SelectQuery $query

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -149,7 +149,9 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
     if ($expr instanceof SqlEquation) {
       $args = [];
       foreach ($expr->getArgs() as $arg) {
-        $args[] = $this->getColumnLabel($arg['expr']);
+        if (is_array($arg) && !empty($arg['expr'])) {
+          $args[] = $this->getColumnLabel(SqlExpression::convert($arg['expr']));
+        }
       }
       return '(' . implode(',', array_filter($args)) . ')';
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1421,4 +1421,35 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('¥500', $result[2]['columns'][0]['val']);
   }
 
+  public function testSelectEquations() {
+    $activities = $this->saveTestRecords('Activity', [
+      'records' => [
+        ['duration' => 60],
+        ['duration' => 120],
+        ['duration' => 180],
+      ],
+    ]);
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Activity',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', '(duration / 60)'],
+          'where' => [['id', 'IN', $activities->column('id')]],
+        ],
+      ],
+      'display' => NULL,
+      'sort' => [['id', 'ASC']],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(3, $result);
+
+    $this->assertEquals(1, $result[0]['columns'][1]['val']);
+    $this->assertEquals(2, $result[1]['columns'][1]['val']);
+    $this->assertEquals(3, $result[2]['columns'][1]['val']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3938](https://lab.civicrm.org/dev/core/-/issues/3938)

Before
----------------------------------------
Trying to use math in the select clause fails.

After
----------------------------------------
Fixed. Test added.