### PR TITLE
SearchKit - Add modulo operator to math function

### DIFF
--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -29,6 +29,7 @@ class SqlEquation extends SqlExpression {
     '-',
     '*',
     '/',
+    '%',
   ];
 
   /**

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -45,12 +45,20 @@
       });
 
       this.addArg = function(exprType) {
-        var param = ctrl.getParam(ctrl.args.length);
+        var param = ctrl.getParam(ctrl.args.length),
+          val = '';
+        if (exprType === 'SqlNumber') {
+          // Number: default to 0
+          val = 0;
+        } else if (exprType === 'SqlField') {
+          // Field: Default to first available field, making it easier to delete the value
+          val = ctrl.getFields().results[0].children[0].id;
+        }
         ctrl.args.push({
           type: ctrl.exprTypes[exprType].type,
           flag_before: _.filter(_.keys(param.flag_before))[0],
           name: param.name,
-          value: exprType === 'SqlNumber' ? 0 : ''
+          value: val
         });
       };
 

--- a/tests/phpunit/api/v4/Action/SqlExpressionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlExpressionTest.php
@@ -113,6 +113,7 @@ class SqlExpressionTest extends Api4TestBase implements TransactionalInterface {
         '(illegal * stuff) AS illegal_stuff',
         // This field will be null
         '(hold_date + 5) AS null_plus_five',
+        '(1 % 2) AS one_is_odd',
       ])
       ->addWhere('(contact_id + 1)', '=', 1 + $contact['id'])
       ->setLimit(1)
@@ -126,6 +127,7 @@ class SqlExpressionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue($result['is_between']);
     $this->assertArrayNotHasKey('illegal_stuff', $result);
     $this->assertEquals('5', $result['null_plus_five']);
+    $this->assertEquals('1', $result['one_is_odd']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds support for the modulo operator to SearchKit math equations. This is mostly useful for testing whether a number is even or odd.

Example
---------------
The following clause will only return contacts for whom the value of a custom field is an odd number:
![image](https://user-images.githubusercontent.com/2874912/198184170-69eaed5d-8160-460a-92ab-3d18cff5cd13.png)

Comments
----------------
This math widget is a little tricky to use. By default it wants you to compare the field with another field, and switching that to a fixed value (in this case the number 2) means selecting and then deselecting a field to clear it out. I've simplified that process a bit in this PR by auto-picking the first available field so you at least have a way to clear it out immediately and don't have to select a dummy value.