### PR TITLE
SearchKit - Show result count at top of table

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -3,6 +3,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'"></div>
     <crm-search-tasks entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
+    <span ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>

--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -1,12 +1,6 @@
 <div class="crm-flex-box crm-search-display-pager" ng-if="$ctrl.rowCount && $ctrl.settings.pager">
   <div>
-    <div class="form-inline" ng-if="$ctrl.settings.pager.show_count">
-      <label ng-if="$ctrl.rowCount === 1">
-        {{ $ctrl.selectedRows && $ctrl.selectedRows.length ? ts('%1 selected of 1 result', {1: $ctrl.selectedRows.length}) : ts('1 result') }}
-      </label>
-      <label ng-if="$ctrl.rowCount === 0 || $ctrl.rowCount > 1">
-        {{ $ctrl.selectedRows && $ctrl.selectedRows.length ? ts('%1 selected of %2 results', {1: $ctrl.selectedRows.length, 2: $ctrl.rowCount}) : ts('%1 results', {1: $ctrl.rowCount}) }}
-      </label>
+    <div class="form-inline" ng-if="$ctrl.settings.pager.show_count" ng-include="'~/crmSearchDisplay/ResultCount.html'">
     </div>
   </div>
   <div class="text-center crm-flex-2">

--- a/ext/search_kit/ang/crmSearchDisplay/ResultCount.html
+++ b/ext/search_kit/ang/crmSearchDisplay/ResultCount.html
@@ -1,0 +1,6 @@
+<label ng-if="$ctrl.rowCount === 1">
+  {{ $ctrl.selectedRows && $ctrl.selectedRows.length ? ts('%1 selected of 1 result', {1: $ctrl.selectedRows.length}) : ts('1 result') }}
+</label>
+<label ng-if="$ctrl.rowCount === 0 || $ctrl.rowCount > 1">
+  {{ $ctrl.selectedRows && $ctrl.selectedRows.length ? ts('%1 selected of %2 results', {1: $ctrl.selectedRows.length, 2: $ctrl.rowCount}) : ts('%1 results', {1: $ctrl.rowCount}) }}
+</label>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -2,6 +2,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
+    <span ng-include="'~/crmSearchDisplay/ResultCount.html'" ng-if="$ctrl.settings.button || $ctrl.settings.actions"></span>
     <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3944](https://lab.civicrm.org/dev/core/-/issues/3944)
Shows result count at the top of the table, not just in the pager.
![image](https://user-images.githubusercontent.com/2874912/198341213-e9651eca-ef77-4916-bc43-39b713e73e6d.png)


Before
----------------------------------------
Count only shown at bottom (if enabled with pager)

After
----------------------------------------
Count shown at top if the search button or actions are enabled.
