### PR TITLE
[REF] Add in Test for importing a deliberately bad campaign id

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -235,7 +235,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
           $params[$entity] = [];
           $params[$entity]['contact_type'] = $this->getContactTypeForEntity($entity) ?: $this->getContactType();
         }
-        $params[$entity][$this->getFieldMetadata($mappedField['name'])['name']] = $this->getTransformedFieldValue($mappedField['name'], $fieldValue);
+        $params[$entity][$mappedField['name'] === 'contribution_campaign_id' ? $mappedField['name'] : $this->getFieldMetadata($mappedField['name'])['name']] = $this->getTransformedFieldValue($mappedField['name'], $fieldValue);
       }
     }
     return $params;

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1636,7 +1636,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       if ($fieldMetadata['name'] === 'campaign_id') {
         if (!isset(Civi::$statics[__CLASS__][$fieldName][$importedValue])) {
           $campaign = Campaign::get()->addClause('OR', ['title', '=', $importedValue], ['name', '=', $importedValue], ['id', '=', $importedValue])->addSelect('id')->execute()->first();
-          Civi::$statics[__CLASS__][$fieldName][$importedValue] = $campaign['id'] ?? FALSE;
+          Civi::$statics[__CLASS__][$fieldName][$importedValue] = $campaign['id'] ?? NULL;
         }
         return Civi::$statics[__CLASS__][$fieldName][$importedValue] ?? 'invalid_import_value';
       }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_bad_campaign.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions_bad_campaign.csv
@@ -1,0 +1,2 @@
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to,Source,Note,Transaction ID,Campaign ID
+bob,65,2008-09-20,Donation,mum@example.com,Word of mouth,Call him back,999,999


### PR DESCRIPTION
Overview
----------------------------------------
This aims to demonstrate a problem where by if you try and do a contribution import with a campaign_id that is not valid you wind up in a constraint violation rather than a normal error

Before
----------------------------------------
No Normal Error present, DB Error present

ping @eileenmcnaughton @andrew-cormick-dockery 