### PR TITLE
Remove notice-causing do-nothing script

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -181,15 +181,6 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       }
     }
 
-    if (!isset($this->_id)) {
-      $formName = 'document.forms.' . $this->_name;
-
-      $js = "<script type='text/javascript'>\n";
-      $js .= "{$formName}['extends_1'].style.display = 'none';\n";
-      $js .= "</script>";
-      $this->assign('initHideBlocks', $js);
-    }
-
     $sel = &$this->add('hierselect',
       'extends',
       ts('Used For'),

--- a/templates/CRM/Custom/Form/Group.tpl
+++ b/templates/CRM/Custom/Form/Group.tpl
@@ -73,7 +73,7 @@
       {crmButton p='civicrm/admin/custom/group/field' q="action=browse&reset=1&gid=$gid" icon="th-list"}{ts}Custom Fields for this Set{/ts}{/crmButton}
     </div>
 {/if}
-{if !empty($initHideBlocks|smarty:nodefaults)}{$initHideBoxes|smarty:nodefaults}{/if}
+
 {literal}
 <script type="text/Javascript">
 CRM.$(function($) {
@@ -102,7 +102,7 @@ CRM.$(function($) {
   function showHideStyle() {
     var
       extend = $(this).val(),
-      contactTypes = {/literal}{$contactTypes}{literal},
+      contactTypes = {/literal}{$contactTypes|smarty:nodefaults}{literal},
       showStyle = "{/literal}{$showStyle}{literal}",
       showMultiple = "{/literal}{$showMultiple}{literal}",
       showMaxMultiple = "{/literal}{$showMaxMultiple}{literal}",


### PR DESCRIPTION
Overview
----------------------------------------
Remove notice-causing do-nothing script

Before
----------------------------------------
With debugging enabled there is a notice when creating a new custom group

![image](https://user-images.githubusercontent.com/336308/198421335-94f3801a-20f7-474a-aa64-85a6301eac0c.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
The field `inithideboxes` is hiding is 'extends_1'

The code sets it to hide when `$initHideBoxes` is SET - which is when there is no group_id

So hidden looks like

![image](https://user-images.githubusercontent.com/336308/198421071-09867a1e-9901-4715-a278-748be1f105a0.png)

And not hidden looks like

![image](https://user-images.githubusercontent.com/336308/198421373-4d469d95-875e-4cf9-bd07-08a5e215e92f.png)


However, even without the `initHideBoxes` js something, is already hiding it appropriately - I had to us js  `cj('#extends_1').show()` to make it show. There is a whole lot of seemingly related show-hide js in the tpl file so I think it became obsolete but was not removed

So - the script appears to do nothing, other than notice out.

I tested r-run on new & edit & when you select a type you DO get the options


Comments
----------------------------------------

