### PR TITLE
dev/core#3939 Fix import mandatory field validation regression

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -247,13 +247,17 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
     $ruleFields = $rule['fields'];
     $weightSum = 0;
     foreach ($mapper as $mapping) {
-      if ($mapping[0] === 'external_identifier' || $mapping[0] === 'contribution_contact_id' || $mapping[0] === 'contact__id') {
+      // Because api v4 style fields have a . and QuickForm multiselect js does
+      // not cope with a . the quick form layer will use a double underscore
+      // as a stand in (the angular layer will not)
+      $fieldName = str_replace('__', '.', $mapping[0]);
+      if ($fieldName === 'external_identifier' || $fieldName === 'contribution_contact_id' || $fieldName === 'contact__id') {
         // It is enough to have external identifier mapped.
         $weightSum = $threshold;
         break;
       }
-      if (array_key_exists($mapping[0], $ruleFields)) {
-        $weightSum += $ruleFields[$mapping[0]];
+      if (array_key_exists($fieldName, $ruleFields)) {
+        $weightSum += $ruleFields[$fieldName];
       }
     }
     if ($weightSum < $threshold) {

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -457,6 +457,24 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Tests the form flow copes with QuickForm style dots.
+   *
+   * Because the QuickForm hierarchical select won't cope with dots
+   * we are using a double underscore on that form. The test checks that works.
+   */
+  public function testImportQuickFormEmailMatch() :void {
+    $this->individualCreate(['email' => 'jenny@example.com']);
+    $this->importCSV('checkboxes.csv', [
+      ['name' => 'total_amount'],
+      ['name' => 'receive_date'],
+      ['name' => 'financial_type_id'],
+      ['name' => ''],
+      ['name' => 'email_primary__email'],
+      ['name' => ''],
+    ]);
+  }
+
+  /**
    * Test whether importing a contribution using email match will match a non-primary.
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/checkboxes.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/checkboxes.csv
@@ -1,0 +1,3 @@
+Total Amount,Date Received,Financial Type,Colour,Contact email,Soft credit email
+50,2022-03-09,Donation,"Red,Yellow,Blue",jenny@example.com,demo@example.com
+60,2022-04-09,Donation,"1,2,3",jenny@example.com,demo@example.com


### PR DESCRIPTION
Overview
----------------------------------------
Fix import mandatory field validation regression

Before
----------------------------------------
Despite email being a valid match it does not pass the mandatory field validation rule
![image](https://user-images.githubusercontent.com/336308/198436988-5db3082b-6ef3-466f-bae2-95a177bd1acf.png)


After
----------------------------------------
The mapping above passes validation

Technical Details
----------------------------------------
We are now using apiv4 under the hood. The api v4 field name is `email_primary.email` - but presenting that field name in the import mapping ui causes a js error due to the `.` having another meaning in js. The work around is to replace it at the js layer with `__` & swap it back in the form layer to process normally. (The angular layer  just uses the 'right' name).

However, it seems this handling was missing in the validate function so I have added there

Comments
----------------------------------------
@seamuslee001 this should be an easy merge - I have UI-tested against 5.55 rc & added unit test


5.54 affect as issue was reported against it - https://github.com/civicrm/civicrm-core/pull/24839
 https://lab.civicrm.org/dev/core/-/issues/3939