### PR TITLE
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, non-static method CRM_Case_Page_AJAX::addClient() cannot be called statically

### DIFF
--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -104,7 +104,7 @@ class CRM_Case_Page_AJAX {
   /**
    * @throws \CRM_Core_Exception
    */
-  public function addClient() {
+  public static function addClient() {
     $caseId = CRM_Utils_Type::escape($_POST['caseID'], 'Positive');
     $contactId = CRM_Utils_Type::escape($_POST['contactID'], 'Positive');
 


### PR DESCRIPTION
Overview
----------------------------------------
Make static function static

Before
----------------------------------------
1. Administer - civicase settings - allow multiple clients
2. Add a case client to an existing case using the little icon next to the case client name.
3. Spinner just spins.
4. `TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, non-static method CRM_Case_Page_AJAX::addClient() cannot be called statically`

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

