### PR TITLE
SearchKit - New setting to "Show Count in Header"

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
@@ -20,7 +20,7 @@
     <div class="checkbox-inline form-control">
       <label>
         <input type="checkbox" ng-model="$ctrl.display.settings.pager.show_count" >
-        <span>{{:: ts('Show Count') }}</span>
+        <span>{{:: ts('Show Count in Pager') }}</span>
       </label>
     </div>
     <div class="checkbox-inline form-control">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchButtonConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchButtonConfig.html
@@ -12,6 +12,14 @@
   <input type="text" ng-show="$ctrl.display.settings.button" ng-model="$ctrl.display.settings.button" ng-model-options="{updateOn: 'blur'}" class="form-control" title="{{:: ts('Search button text') }}" placeholder="{{:: ts('Search button text') }}">
 </div>
 <div class="input-group">
+  <div class="checkbox-inline form-control">
+    <label>
+      <input type="checkbox" ng-model="$ctrl.display.settings.headerCount" >
+      <span>{{:: ts('Show Count in Header') }}</span>
+    </label>
+  </div>
+</div>
+<div class="input-group">
   <div class="checkbox-inline form-control" title="{{:: ts('Display a button for creating a new record') }}">
     <label>
       <input type="checkbox" ng-checked="$ctrl.display.settings.addButton.path" ng-click="$ctrl.parent.toggleAddButton()">

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -158,7 +158,7 @@
           if (!ctrl.rowCount || editedRow) {
             if (!ctrl.limit || ctrl.results.length < ctrl.limit) {
               ctrl.rowCount = ctrl.results.length;
-            } else if (ctrl.settings.pager) {
+            } else if (ctrl.settings.pager || ctrl.settings.headerCount) {
               var params = ctrl.getApiParams('row_count');
               crmApi4('SearchDisplay', 'run', params).then(function(result) {
                 ctrl.rowCount = result.count;

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -1,6 +1,7 @@
 <div class="crm-search-display crm-search-display-grid">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
+    <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
     <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <div

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -1,6 +1,7 @@
 <div class="crm-search-display crm-search-display-list">
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
+    <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
     <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <ol ng-if=":: $ctrl.settings.style === 'ol'" ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'" ng-style="{'list-style': $ctrl.settings.symbol}"></ol>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -2,7 +2,7 @@
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>
-    <span ng-include="'~/crmSearchDisplay/ResultCount.html'" ng-if="$ctrl.settings.button || $ctrl.settings.actions"></span>
+    <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
     <div class="btn-group pull-right" ng-include="'~/crmSearchDisplay/AddButton.html'" ng-if="$ctrl.settings.addButton.path"></div>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">


### PR DESCRIPTION
Overview
----------------------------------------
Augments #24831 by adding a new settings to show count in header

Before
----------------------------------------
Single setting to control showing results count in pager and in header, making it impossible to configure one or the other.

After
----------------------------------------
New setting just to control the header count. Pager count is back to doing just one job.

Comments
--------------------
I couldn't think of a way to always get it right with only one setting. Having two gives maximum configurability, and works in all display types not just tables.