### PR TITLE
dev/core#3850 Fix checkboxes handling for custom fields in contact import

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -812,9 +812,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           $data[$blockName][$loc]['is_primary'] = 1;
         }
 
-        if (0) {
-        }
-        else {
+        if (1) {
           if ($fieldName === 'state_province') {
             // CRM-3393
             if (is_numeric($value) && ((int ) $value) >= 1000) {
@@ -844,72 +842,27 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           }
         }
       }
-      else {
-        if (($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key))) {
-          // for autocomplete transfer hidden value instead of label
-          if ($params[$key] && isset($params[$key . '_id'])) {
-            $value = $params[$key . '_id'];
-          }
-
-          // we need to append time with date
-          if ($params[$key] && isset($params[$key . '_time'])) {
-            $value .= ' ' . $params[$key . '_time'];
-          }
-
-          // if auth source is not checksum / login && $value is blank, do not proceed - CRM-10128
-          if (($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 &&
-            ($value == '' || !isset($value))
-          ) {
-            continue;
-          }
-
-          $valueId = NULL;
-
-          //CRM-13596 - check for contact_sub_type_hidden first
-          if (array_key_exists('contact_sub_type_hidden', $params)) {
-            $type = $params['contact_sub_type_hidden'];
-          }
-          else {
-            $type = $data['contact_type'];
-            if (!empty($data['contact_sub_type'])) {
-              $type = CRM_Utils_Array::explodePadded($data['contact_sub_type']);
-            }
-          }
-
-          CRM_Core_BAO_CustomField::formatCustomField($customFieldId,
-            $data['custom'],
-            $value,
-            $type,
-            $valueId,
-            $contactID,
-            FALSE,
-            FALSE
-          );
-        }
-        elseif ($key === 'edit') {
-          continue;
-        }
-        else {
-          if ($key === 'location') {
-            foreach ($value as $locationTypeId => $field) {
-              foreach ($field as $block => $val) {
-                if ($block === 'address' && array_key_exists('address_name', $val)) {
-                  $value[$locationTypeId][$block]['name'] = $value[$locationTypeId][$block]['address_name'];
-                }
+      if (TRUE) {
+        // @todo - meaningless IF - left to keep whitespace clean in PR.
+        if ($key === 'location') {
+          foreach ($value as $locationTypeId => $field) {
+            foreach ($field as $block => $val) {
+              if ($block === 'address' && array_key_exists('address_name', $val)) {
+                $value[$locationTypeId][$block]['name'] = $value[$locationTypeId][$block]['address_name'];
               }
             }
           }
-          if (in_array($key, ['nick_name', 'job_title', 'middle_name', 'birth_date', 'gender_id', 'current_employer', 'prefix_id', 'suffix_id'])
-            && ($value == '' || !isset($value)) &&
-            ($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 ||
-            ($key === 'current_employer' && empty($params['current_employer']))) {
-            // CRM-10128: if auth source is not checksum / login && $value is blank, do not fill $data with empty value
-            // to avoid update with empty values
-            continue;
-          }
-          else {
-            $data[$key] = $value;
-          }
+        }
+        if (in_array($key, ['nick_name', 'job_title', 'middle_name', 'birth_date', 'gender_id', 'current_employer', 'prefix_id', 'suffix_id'])
+          && ($value == '' || !isset($value)) &&
+          ($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 ||
+          ($key === 'current_employer' && empty($params['current_employer']))) {
+          // CRM-10128: if auth source is not checksum / login && $value is blank, do not fill $data with empty value
+          // to avoid update with empty values
+          continue;
+        }
+        else {
+          $data[$key] = $value;
         }
       }
     }

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_with_custom_checkbox_field.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_with_custom_checkbox_field.csv
@@ -1,0 +1,3 @@
+First Name,Last name,Colour
+Bob,Smith,"Red,Yellow,Blue"
+Mary,Smith,"1,2,3"

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -855,6 +855,49 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test values import correctly when they are numbers.
+   *
+   * https://lab.civicrm.org/dev/core/-/issues/3850
+   * @throws \CRM_Core_Exception
+   */
+  public function testCustomCheckboxNumericValues(): void {
+    $this->createCustomGroupWithFieldOfType([], 'checkbox', '', [
+      'option_values' => [
+        [
+          'label' => 'Red',
+          'value' => '1',
+          'weight' => 1,
+          'is_active' => 1,
+        ],
+        [
+          'label' => 'Yellow',
+          'value' => '2',
+          'weight' => 2,
+          'is_active' => 1,
+        ],
+        [
+          'label' => 'Blue',
+          'value' => '3',
+          'weight' => 3,
+          'is_active' => 1,
+        ],
+      ],
+    ]);
+    $this->importCSV('individual_with_custom_checkbox_field.csv', [
+      [0 => 'first_name'],
+      [0 => 'last_name'],
+      [0 => $this->getCustomFieldName('checkbox')],
+    ]);
+    $contacts = Contact::get()->addWhere('last_name', '=', 'Smith')
+      ->addSelect($this->getCustomFieldName('checkbox', 4))
+      ->execute();
+    $this->assertCount(2, $contacts);
+    foreach ($contacts as $contact) {
+      $this->assertEquals([1, 2, 3], $contact[$this->getCustomFieldName('checkbox', 4)]);
+    }
+  }
+
+  /**
    * Test importing in the Preferred Language Field
    *
    * @throws \CRM_Core_Exception
@@ -2095,6 +2138,8 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    *   e.g [['first_name']['email', 1]].
    *   {@see \CRM_Contact_Import_Parser_Contact::getMappingFieldFromMapperInput}
    * @param array $submittedValues
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function importCSV(string $csv, array $mapper, array $submittedValues = []): void {
     $submittedValues = array_merge([


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3850 Fix checkboxes handling for custom fields in contact import

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/3850 multiple item checkboxes are mis-saved in Contact import

After
----------------------------------------
Save correctly (description on gitlab of steps)

Technical Details
----------------------------------------
This code has 'evolved' from what was originally probably a copy & paste of the form layer. The function `formatProfileContact` was used to to prepare values that had been lovingly crafted into form-like format to be passed to the `BAO_Contact::create'.

Over time the function started to call the api instead of `Contact::create` making much of what was happening in `formatProfileContact` redundant. Because that function was serving multiple masters & crazy-complex a copy of the function was taken & it was moved onto the import class where we could start to unravel it (knowing ti would only affect import). However the function still contains much code that grew up for it's other use-cases, rather than import.

Paralell to that `      $params = $this->getMappedRow($values);` evolved into a function which generally took the input & returned it in an api-ready format.

Hence the go-to solution for any import data format related issues is to try removing code :-)

In this case the worker function `CRM_Core_BAO_CustomField::formatCustomField` is already called in the api - but along the way handing was added for exactly this type of field - so if we just let the api do the work the bug is fixed

Comments
----------------------------------------
