### PR TITLE
PHP 8.2 - Fix some random warnings

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -43,6 +43,11 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
   protected $_id;
 
   /**
+   * @var int
+   */
+  protected $_timeout;
+
+  /**
    * Use MySQL's GET_LOCK(). Locks are shared across all Civi instances
    * on the same MySQL server.
    *
@@ -158,7 +163,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
    *
    * @todo document naming convention for CiviMail locks as this is key to ensuring they work properly.
    *
-   * @param int $timeout
+   * @param int|null $timeout
    *
    * @return bool
    * @throws \CRM_Core_Exception

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -96,6 +96,66 @@ class CRM_Extension_Info {
   public $upgrader = NULL;
 
   /**
+   * @var array|null
+   */
+  public $civix;
+
+  /**
+   * @var string|null
+   */
+  public $comments;
+
+  /**
+   * @var array
+   *   Ex: ['ver' => '5.50']
+   */
+  public $compatibility;
+
+  /**
+   * @var string|null
+   */
+  public $description;
+
+  /**
+   * @var string|null
+   *   Ex: 'stable', 'alpha', 'beta'
+   */
+  public $develStage;
+
+  /**
+   * Full URL of the zipball for this extension/version.
+   *
+   * This property is (usually) only provided on the feed of new/available extensions.
+   *
+   * @var string|null
+   */
+  public $downloadUrl;
+
+  /**
+   * @var string|null
+   *   Ex: 'GPL-3.0'
+   */
+  public $license;
+
+  /**
+   * @var string|null
+   *   Ex: '2025-01-02'
+   */
+  public $releaseDate;
+
+  /**
+   * @var array|null
+   *   Ex: ['Documentation' => 'https://example.org/my-extension/docs']
+   */
+  public $urls;
+
+  /**
+   * @var string|null
+   *   Ex: '1.2.3'
+   */
+  public $version;
+
+  /**
    * Load extension info an XML file.
    *
    * @param string $file

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -104,7 +104,7 @@ class CRM_Extension_Info {
    * @return CRM_Extension_Info
    */
   public static function loadFromFile($file) {
-    list ($xml, $error) = CRM_Utils_XML::parseFile($file);
+    [$xml, $error] = CRM_Utils_XML::parseFile($file);
     if ($xml === FALSE) {
       throw new CRM_Extension_Exception_ParseException("Failed to parse info XML: $error");
     }
@@ -124,7 +124,7 @@ class CRM_Extension_Info {
    * @return CRM_Extension_Info
    */
   public static function loadFromString($string) {
-    list ($xml, $error) = CRM_Utils_XML::parseString($string);
+    [$xml, $error] = CRM_Utils_XML::parseString($string);
     if ($xml === FALSE) {
       throw new CRM_Extension_Exception_ParseException("Failed to parse info XML: $string");
     }

--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -18,6 +18,11 @@
 class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
 
   /**
+   * @var \CRM_Extension_Mapper
+   */
+  protected $mapper;
+
+  /**
    * @param CRM_Extension_Mapper $mapper
    */
   public function __construct(CRM_Extension_Mapper $mapper) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a few random warnings when running on PHP 8.2.

Comments
----------------------------------------

Basically, I just ran `cv ext:list` under PHP 8.2 and 