### PR TITLE
[REF][PHP8.2] Fix some instances of properties not being declared on …

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -18,6 +18,12 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
   protected $defaultAssigneeOptionsValues = [];
 
   /**
+   * Does Cases support Multiple Clients.
+   * @var bool
+   */
+  public $_isMultiClient = FALSE;
+
+  /**
    * Run.
    *
    * @param string $caseType

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -75,6 +75,27 @@ abstract class CRM_Core_Component_Info {
   protected $keyword;
 
   /**
+   * Component Name.
+   *
+   * @var string
+   */
+  public $name;
+
+  /**
+   * Component namespace.
+   * e.g. CRM_Contribute.
+   *
+   * @var string
+   */
+  public $namespace;
+
+  /**
+   * Component ID
+   * @var int
+   */
+  public $componentID;
+
+  /**
    * @param string $name
    *   Name of the component.
    * @param string $namespace

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -43,6 +43,7 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
   protected $_id;
 
   /**
+   * Lock Timeout
    * @var int
    */
   protected $_timeout;

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -15,6 +15,7 @@ namespace Civi\Api4\Service\Spec;
 /**
  * Contains APIv4 field metadata
  */
+#[\AllowDynamicProperties]
 class FieldSpec {
 
   // BasicSpecTrait: name, title, description

--- a/Civi/Core/DAO/Event/PostDelete.php
+++ b/Civi/Core/DAO/Event/PostDelete.php
@@ -28,6 +28,11 @@ class PostDelete extends \Symfony\Component\EventDispatcher\Event {
   public $result;
 
   /**
+   * @var string
+   */
+  public $eventID;
+
+  /**
    * @param \CRM_Core_DAO $object
    * @param int|false $result
    */

--- a/Civi/Core/DAO/Event/PostUpdate.php
+++ b/Civi/Core/DAO/Event/PostUpdate.php
@@ -28,6 +28,11 @@ class PostUpdate extends \Symfony\Component\EventDispatcher\Event {
   public $result;
 
   /**
+   * @var string
+   */
+  public $eventID;
+
+  /**
    * @param $object
    * @param $result
    */

--- a/Civi/Core/DAO/Event/PreDelete.php
+++ b/Civi/Core/DAO/Event/PreDelete.php
@@ -23,6 +23,11 @@ class PreDelete extends \Symfony\Component\EventDispatcher\Event {
   public $object;
 
   /**
+   * @var string
+   */
+  public $eventID;
+
+  /**
    * @param $object
    */
   public function __construct($object) {

--- a/Civi/Core/DAO/Event/PreUpdate.php
+++ b/Civi/Core/DAO/Event/PreUpdate.php
@@ -23,6 +23,11 @@ class PreUpdate extends \Symfony\Component\EventDispatcher\Event {
   public $object;
 
   /**
+   * @var string
+   */
+  public $eventID;
+
+  /**
    * @param $object
    */
   public function __construct($object) {

--- a/Civi/WorkflowMessage/FieldSpec.php
+++ b/Civi/WorkflowMessage/FieldSpec.php
@@ -16,6 +16,7 @@ use Civi\Schema\Traits\BasicSpecTrait;
 use Civi\Schema\Traits\PhpDataTypeSpecTrait;
 use Civi\Schema\Traits\OptionsSpecTrait;
 
+#[\AllowDynamicProperties]
 class FieldSpec {
 
   // BasicSpecTrait: name, title, description


### PR DESCRIPTION
…classes

Overview
----------------------------------------
This fixes some instances were Dynamic Properties were being created because they weren't defined in the class similar to #24849 

Before
----------------------------------------
Deprecation warnings in php8.2

After
----------------------------------------
Less Deprecation warnings

ping @eileenmcnaughton @demeritcowboy @totten 