### PR TITLE
[REF][PHP8.2] Remove usage of utf8_decode in favour of mb_strlen

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -222,7 +222,7 @@ class CRM_Utils_Rule {
       $url = 'http://' . $_SERVER['HTTP_HOST'] . $url;
     }
     // Convert URLs with Unicode to ASCII
-    if (strlen($url) != strlen(utf8_decode($url))) {
+    if (strlen($url) != mb_strlen($url)) {
       $url = self::idnToAsci($url);
     }
     return (bool) filter_var($url, FILTER_VALIDATE_URL);

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -2288,8 +2288,8 @@ function _civicrm_api3_validate_string(&$params, &$fieldName, &$fieldInfo, $enti
     }
   }
   // Check our field length
-  elseif (is_string($fieldValue) && !empty($fieldInfo['maxlength']) && strlen(utf8_decode($fieldValue)) > $fieldInfo['maxlength']) {
-    throw new CRM_Core_Exception("Value for $fieldName is " . strlen(utf8_decode($value)) . " characters  - This field has a maxlength of {$fieldInfo['maxlength']} characters.",
+  elseif (is_string($fieldValue) && !empty($fieldInfo['maxlength']) && mb_strlen($fieldValue ?? '') > $fieldInfo['maxlength']) {
+    throw new CRM_Core_Exception("Value for $fieldName is " . mb_strlen($value ?? '') . " characters  - This field has a maxlength of {$fieldInfo['maxlength']} characters.",
       2100, ['field' => $fieldName]
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a PHP8.2 deprecation issue where utf8_encode and uft8_decode have been deprecated

Before
----------------------------------------
Deprecated functions used

After
----------------------------------------
Non Deprecated functions used

ping @demeritcowboy @totten @braders @eileenmcnaughton 