### PR TITLE
dev/core#3956 Only show tag search option in Advanced Search when there are tags on activities or cases

### DIFF
--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -77,9 +77,8 @@ class CRM_Contact_Form_Search_Criteria {
       foreach ($used_for as $key => $value) {
         //check tags for every type and find if there are any defined
         $tags = CRM_Core_BAO_Tag::getTagsUsedFor($key, FALSE, TRUE, NULL);
-        // check if there are tags other than contact type, if no - keep checkbox hidden on adv search
-        // we will hide searching contact by attachments tags until it will be implemented in core
-        if (count($tags) && $key != 'civicrm_file' && $key != 'civicrm_contact') {
+        // check if there are tags for cases or activities, if no - keep checkbox hidden on adv search
+        if (count($tags) && ($key == 'civicrm_case' || $key == 'civicrm_activity')) {
           //if tags exists then add type to display in adv search form help text
           $tagsTypes[] = $value;
           $showAllTagTypes = TRUE;


### PR DESCRIPTION
Before
----------------------------------------
When there was a tagged SK search, this showed up:
![image](https://user-images.githubusercontent.com/25517556/198847889-72f53cb6-1976-4dbd-9d38-77145adec642.png)

After
----------------------------------------
No longer shows up.
Shows up as before when tags exist for cases or activities.

Technical Details
----------------------------------------
I think it makes more sense to check for tags specifically on cases and activities (as this is what is indicated in the help text) rather than looking for any tags on any entities except some list.
