### PR TITLE
[REF][PHP8.2] Add patches to pear upstream packages to fix issues with PHP8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -279,8 +279,12 @@
       "html2text/html2text": {
         "Fix deprecation warning in php8.1 on html_entity_decode": "https://raw.githubusercontent.com/civicrm/civicrm-core/e758d20e9f613ca6c4cf652c23d2cd7e5d3af3ce/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch"
       },
+      "pear/pear-core-minimal": {
+        "Apply patch to fix creation of dynamic properties in PEAR_Error class": "https://patch-diff.githubusercontent.com/raw/pear/pear-core-minimal/pull/11.patch"
+      },
       "pear/db": {
         "Apply patch to ensure that MySQLI reporting remains the same in php8.1": "https://patch-diff.githubusercontent.com/raw/pear/DB/pull/13.patch",
+        "Apply patch to fix deprecations in php8.2": "https://patch-diff.githubusercontent.com/raw/pear/DB/pull/14.patch",
         "Apply CiviCRM Customisations for the pear:db package": "https://raw.githubusercontent.com/civicrm/civicrm-core/2ad420c394/tools/scripts/composer/pear_db_civicrm_changes.patch"
       },
       "pear/log": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77915211e70259ae67353768d5655313",
+    "content-hash": "9a339b4f8757345e4953ef53bf75e7b0",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
This applies some patches / fixes based on upstream PRs to pear/db and pear/core-minimal packages to fix issues in PHP8.2

Before
----------------------------------------
Pear db and pear core minimal code not compatible for PHP8.2

After
----------------------------------------
Code seems to work fine for PHP8.2

ping @eileenmcnaughton @demeritcowboy @totten 