### PR TITLE
Fix event template cache not updating. Replace some deprecated functions with API4

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -104,8 +104,10 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       }
       $this->_single = TRUE;
 
-      $params = ['id' => $this->_id];
-      CRM_Event_BAO_Event::retrieve($params, $eventInfo);
+      $eventInfo = \Civi\Api4\Event::get(FALSE)
+        ->addWhere('id', '=', $this->_id)
+        ->execute()
+        ->first();
 
       // its an update mode, do a permission check
       if (!CRM_Event_BAO_Event::checkPermission($this->_id, CRM_Core_Permission::EDIT)) {
@@ -228,15 +230,15 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
    */
   public function setDefaultValues() {
     $defaults = [];
+    $event = \Civi\Api4\Event::get(FALSE);
     if (isset($this->_id)) {
-      $params = ['id' => $this->_id];
-      CRM_Event_BAO_Event::retrieve($params, $defaults);
-
+      $event->addWhere('id', '=', $this->_id);
+      $defaults = $event->execute()->first();
       $this->_campaignID = $defaults['campaign_id'] ?? NULL;
     }
     elseif ($this->_templateId) {
-      $params = ['id' => $this->_templateId];
-      CRM_Event_BAO_Event::retrieve($params, $defaults);
+      $event->addWhere('id', '=', $this->_templateId);
+      $defaults = $event->execute()->first();
       $defaults['is_template'] = $this->_isTemplate;
       $defaults['template_id'] = $defaults['id'];
       unset($defaults['id']);

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -123,7 +123,12 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     }
 
     if ($this->_action & CRM_Core_Action::ADD) {
-      $eventTemplates = CRM_Event_PseudoConstant::eventTemplates();
+      $eventTemplates = \Civi\Api4\Event::get(FALSE)
+        ->addWhere('is_template', '=', TRUE)
+        ->addWhere('is_active', '=', TRUE)
+        ->execute()
+        ->indexBy('id')
+        ->column('template_title');
       if (CRM_Utils_System::isNull($eventTemplates) && !$this->_isTemplate) {
         $url = CRM_Utils_System::url('civicrm/admin/eventTemplate', ['reset' => 1]);
         CRM_Core_Session::setStatus(ts('If you find that you are creating multiple events with similar settings, you may want to use the <a href="%1">Event Templates</a> feature to streamline your workflow.', [1 => $url]), ts('Tip'), 'info');

--- a/CRM/Event/PseudoConstant.php
+++ b/CRM/Event/PseudoConstant.php
@@ -254,8 +254,11 @@ class CRM_Event_PseudoConstant extends CRM_Core_PseudoConstant {
    *
    * @return array
    *   Array of event id → template title pairs
+   *
+   * @deprecated Use the API instead
    */
   public static function &eventTemplates($id = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('Use the api');
     if (!self::$eventTemplates) {
       CRM_Core_PseudoConstant::populate(self::$eventTemplates,
         'CRM_Event_DAO_Event',

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1129,7 +1129,7 @@ AND civicrm_membership.is_test = %2";
    * @param \CRM_Contribute_BAO_Contribution|\CRM_Contribute_DAO_Contribution $contribution
    */
   public static function updateRecurMembership(CRM_Member_DAO_Membership $membership, CRM_Contribute_BAO_Contribution $contribution) {
-    CRM_Core_Error::deprecatedFunctionWarning('Use the API instead');
+    CRM_Core_Error::deprecatedFunctionWarning('Use the api');
 
     if (empty($contribution->contribution_recur_id)) {
       return;

--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -278,7 +278,12 @@ abstract class Mapping implements MappingInterface {
       $valueLabelMap['event_type'] = \CRM_Event_PseudoConstant::eventType();
       $valueLabelMap['civicrm_event'] = \CRM_Event_PseudoConstant::event(NULL, FALSE, "( is_template IS NULL OR is_template != 1 )");
       $valueLabelMap['civicrm_participant_status_type'] = \CRM_Event_PseudoConstant::participantStatus(NULL, NULL, 'label');
-      $valueLabelMap['event_template'] = \CRM_Event_PseudoConstant::eventTemplates();
+      $valueLabelMap['event_template'] = \Civi\Api4\Event::get(FALSE)
+        ->addWhere('is_template', '=', TRUE)
+        ->addWhere('is_active', '=', TRUE)
+        ->execute()
+        ->indexBy('id')
+        ->column('template_title');
       $valueLabelMap['auto_renew_options'] = \CRM_Core_OptionGroup::values('auto_renew_options');
       $valueLabelMap['contact_date_reminder_options'] = \CRM_Core_OptionGroup::values('contact_date_reminder_options');
       $valueLabelMap['civicrm_membership_type'] = \CRM_Member_PseudoConstant::membershipType();


### PR DESCRIPTION
Overview
----------------------------------------
When adding or deleting an event template it does not appear in the list of templates for "New event template" or for "New event" until caches are cleared.

Note: Tested on CiviCRM 5.51 through 5.54.

Before
----------------------------------------
Adding or deleting an event template does not update the select2 list until you clear civicrm caches.

After
----------------------------------------
Adding or deleting an event template updates the select2 list as soon as you reload the page (the list is generated on page load and not via AJAX).

Technical Details
----------------------------------------
Deprecated methods were being used which cache this data. It is not clear when these caches would be cleared without a manual cache clear. Instead of spending time investigating deprecated functions I just converted then to use API4 and this fixed the issue.

Comments
----------------------------------------

