### PR TITLE
[REF] Update github action deprecations

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -115,7 +115,7 @@ jobs:
           git commit -m "regenerate civicrm_generated" sql/civicrm_generated.mysql
           git remote add mine https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git
           git push mine
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ success() }}
         with:
           name: the_file_you_requested


### PR DESCRIPTION
Overview
----------------------------------------
Github actions is deprecating nodejs v12.

Before
----------------------------------------
You can run regen online in your fork using the github action script included in the .github folder in the tree. Here's a recent example:

* https://github.com/demeritcowboy/civicrm-core/actions/runs/3351612928

Note the warning on the page:

* Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/upload-artifact

After
----------------------------------------

Technical Details
----------------------------------------
The script uses another action to make the generated file available as a download. It's an older version that uses nodejs v12.

Comments
----------------------------------------
This is the same as https://github.com/colemanw/webform_civicrm/pull/806 but is shorter since there's only one deprecated thing used here.
