### PR TITLE
CiviCampaign Dashboard: fix default active tab

### DIFF
--- a/CRM/Campaign/Page/DashBoard.php
+++ b/CRM/Campaign/Page/DashBoard.php
@@ -490,7 +490,8 @@ class CRM_Campaign_Page_DashBoard extends CRM_Core_Page {
       ->addScriptFile('civicrm', 'templates/CRM/common/TabHeader.js', 1, 'html-header')
       ->addSetting([
         'tabSettings' => [
-          'active' => strtolower(CRM_Utils_Array::value('subPage', $_GET, 'campaign')),
+          // Tabs should use selectedChild, but Campaign has many legacy links
+          'active' => strtolower($_GET['subPage'] ?? $_GET['selectedChild'] ?? 'campaign'),
         ],
       ]);
   }


### PR DESCRIPTION
Overview
----------------------------------------

Sometimes the CiviCampaign Dashboard goes back to the Campaign tab, instead of going to another tab such as Petition.

To reproduce:

- Go on a demo site
- Click Campaign > DashBoard (the main one, not a sub-menu)
- Click the Petition tab
- Refresh the page

You will be back on the Campaign tab, instead of Petition.

![image](https://user-images.githubusercontent.com/254741/199080827-ed893be1-86fc-4d77-a31b-5b2c8d94cb35.png)


Before
----------------------------------------

"where am I?"

After
----------------------------------------

Works as expected.

Technical Details
----------------------------------------

I hesitate to change all the links to use `selectedChild` instead of `subPage`, but I figure there must be legacy links / extensions / customizations too, and this is a low-risk fix.

I also noticed different patterns in how to do this, for example:

```
CRM/Admin/Page/MessageTemplates.php:        'tabSettings' => ['active' => $_GET['selectedChild'] ?? NULL],
CRM/Contact/Page/View/Summary.php:        'tabSettings' => ['active' => CRM_Utils_Request::retrieve('selectedChild', 'Alphanumeric', $this, FALSE, 'summary')],
```

I didn't use `CRM_Utils_Request::retrieve` because it would be very long and ugly code, but maybe there's potential for an XSS?