### PR TITLE
Fix creating related membership when contact already has a NOT current membership of that type

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1775,7 +1775,12 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    * @throws \CRM_Core_Exception
    */
   protected static function hasExistingInheritedMembership($params) {
-    foreach (civicrm_api3('Membership', 'get', ['contact_id' => $params['contact_id']])['values'] as $membership) {
+    $currentMemberships = \Civi\Api4\Membership::get(FALSE)
+      ->addJoin('MembershipStatus AS membership_status', 'LEFT')
+      ->addWhere('membership_status.is_current_member', '=', TRUE)
+      ->addWhere('contact_id', '=', $params['contact_id'])
+      ->execute();
+    foreach ($currentMemberships as $membership) {
       if (!empty($membership['owner_membership_id'])
         && $membership['membership_type_id'] === $params['membership_type_id']
         && (int) $params['owner_membership_id'] !== (int) $membership['owner_membership_id']

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -570,7 +570,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     // there is an inactive existing membership of the
     // same type.  civicrm/civicrm-core/pull/24866
     $employerId[3] = $this->organizationCreate([], 1);
-    $memberContactId[4] = $this->individualCreate(['employer_id' => $employerId[0]], 0);
+    $memberContactId[4] = $this->individualCreate([], 0);
 
     $activeMembershipParams = [
       'contact_id' => $employerId[3],
@@ -603,6 +603,9 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     // Check no current membership
     $result = $this->callAPISuccess('membership', 'get', $getActiveMembershipParams);
     $this->assertEquals(0, $result['count']);
+
+    // Add new employer relationship to contact
+    $this->callAPISuccess('Contact', 'create', ['id' => $memberContactId[4], 'employer_id' => $employerId[3]]);
 
     // Add inherited membership
     $this->contactMembershipCreate($activeMembershipParams);


### PR DESCRIPTION
Overview
----------------------------------------
If a contact has an inherited membership of a specific type it will not create another inherited membership of the same type from a different contact.
That works fine if the contact has an inherited membership that is current. But does not give the expected behaviour if the existing inherited membership is not current (eg. cancelled).

Example:
- Contact has an inherited membership of type "Sole Trader" that was cancelled in 2016 but still provides a historical record of that membership.
- Contact should inherit current membership from their organisation contact record which *does* have a current membership.


Before
----------------------------------------
Contacts do not inherit a current membership if there is already a non-current (eg. cancelled) membership of the same type. They will only inherit one current membership of that type.

After
----------------------------------------
Contacts inherit a current membership if there is already a non-current (eg. cancelled) membership of the same type. They will only inherit one current membership of that type.

Technical Details
----------------------------------------


Comments
----------------------------------------

