### PR TITLE
dev/financial#209 Stop disabled financial types showing on price fields

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -183,6 +183,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
           '=',
           'financial_type.id',
         ])
+        ->addWhere('financial_type.is_active', '=', '1')
         ->execute()->indexBy('entity_id');
       Civi::$statics[__CLASS__][$key] = [];
       foreach ($types as $type) {


### PR DESCRIPTION
Overview
----------------------------------------
Add a simple where clause to select only for enabled financial types in regards to price fields.

Before
----------------------------------------
disabled financial type TestSet4#27231 showing.
![image](https://user-images.githubusercontent.com/116618933/199114882-692d9421-b812-4201-94e8-ee812fc58337.png)

After
----------------------------------------
disabled financial type TestSet4#27231 not showing.
![image](https://user-images.githubusercontent.com/116618933/199113921-8bbc22cd-1224-4d52-a47c-50c26a46f4de.png)
