### PR TITLE
php8 compatibility, replace array_key_exists() on non-array.

### DIFF
--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -101,7 +101,7 @@ class CRM_Utils_Address_USPS {
       return FALSE;
     }
 
-    if (array_key_exists('Error', $xml->Address)) {
+    if (property_exists($xml->Address, 'Error')) {
       $session->setStatus(ts('Address not found in USPS database.'));
       return FALSE;
     }
@@ -112,7 +112,7 @@ class CRM_Utils_Address_USPS {
     $values['postal_code'] = (string) $xml->Address->Zip5;
     $values['postal_code_suffix'] = (string) $xml->Address->Zip4;
 
-    if (array_key_exists('Address1', $xml->Address)) {
+    if (property_exists($xml->Address, 'Address1')) {
       $values['supplemental_address_1'] = (string) $xml->Address->Address1;
     }
 

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -272,6 +272,10 @@
 
 - name        : Christophe Golle
 
+- github      : christopher-yu
+  name        : Christopher Yu
+  organization: Giant Rabbit
+
 - github      : clarkac1
   name        : Andy Clark
 


### PR DESCRIPTION
Overview
----------------------------------------
On php8 sites, when USPS address validation is enabled, editing a Civi address will give an error because array_key_exists() is being called without an array as the second argument. From: https://www.php.net/manual/en/function.array-key-exists.php

Note:
    For backward compatibility reasons, array_key_exists() will also return true if key is a property defined within an object given as array. This behaviour is deprecated as of PHP 7.4.0, and removed as of PHP 8.0.0.
    To check whether a property exists in an object, [property_exists()](https://www.php.net/manual/en/function.property-exists.php) should be used.