### PR TITLE
Import regression, fix loading of saved mapping with soft-credit email mapped

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -221,7 +221,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
             if (!empty($entityData)) {
               $softCreditTypeID = (int) $entityData['soft_credit']['soft_credit_type_id'];
             }
-            $defaults["mapper[$i]"] = [$fieldMapping['name'], $softCreditTypeID];
+            $fieldName = $this->isQuickFormMode ? str_replace('.', '__', $fieldMapping['name']) : $fieldMapping['name'];
+            $defaults["mapper[$i]"] = [$fieldName, $softCreditTypeID];
           }
         }
       }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -69,6 +69,16 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected $parser;
 
   /**
+   * Is the code being accessed in QuickForm mode.
+   *
+   * If false, ie functions being called to support the angular form, then we
+   * 'quick-form-ify' the fields with dots over to double underscores.
+   *
+   * @var bool
+   */
+  protected $isQuickFormMode = TRUE;
+
+  /**
    * Get User Job.
    *
    * API call to retrieve the userJob row.
@@ -771,6 +781,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
       $contactTypes[] = ['id' => $contactType['name'], 'text' => $contactType['label']];
     }
     $parser = $this->getParser();
+    $this->isQuickFormMode = FALSE;
     Civi::resources()->addVars('crmImportUi', [
       'defaults' => $this->getDefaults(),
       'rows' => $this->getDataRows([], 2),


### PR DESCRIPTION
…

Overview
----------------------------------------
Import regression, fix loading of saved mapping with soft-credit email mapped

Before
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/24838#issuecomment-1296191831 - the soft credit email field is not loading from a saved mapping

After
----------------------------------------
it loads again

Technical Details
----------------------------------------
The js in the Quickform `hierselect` can't cope with the dots in the field name - so we are using substiution with '__'  - but this spot was missed

Comments
----------------------------------------
@Detsieber 