### PR TITLE
dev/core#3952 Add in Upgrade script to fix up print labels where " wa…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyFive.php
@@ -31,9 +31,8 @@ class CRM_Upgrade_Incremental_php_FiveFiftyFive extends CRM_Upgrade_Incremental_
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
-  public function upgrade_5_55_0($rev): void {
+  public function upgrade_5_55_beta1($rev): void {
     $this->addTask(ts('Fix Event Badge Upgrade'), 'fix_event_badge_upgrade');
-    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
   public static function fix_event_badge_upgrade() {

--- a/CRM/Upgrade/Incremental/php/FiveFiftyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyFive.php
@@ -31,4 +31,19 @@ class CRM_Upgrade_Incremental_php_FiveFiftyFive extends CRM_Upgrade_Incremental_
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
+  public function upgrade_5_55_0($rev): void {
+    $this->addTask(ts('Fix Event Badge Upgrade'), 'fix_event_badge_upgrade');
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+  }
+
+  public static function fix_event_badge_upgrade() {
+    $problematic_fields = CRM_Core_DAO::executeQuery('SELECT id, data FROM civicrm_print_label WHERE data like \'%crmDate:\"%B %E%f\"%\'');
+    while ($problematic_fields->fetch()) {
+      $data = $problematic_fields->data;
+      $data = str_replace('crmDate:"%B %E%f"', 'crmDate:\\\"%B %E%f\\\"', $data);
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_print_label SET data = '{$data}' WHERE id = %1", [1 => [$problematic_fields->id, 'Positive']]);
+    }
+    return TRUE;
+  }
+
 }

--- a/CRM/Upgrade/Incremental/php/FiveFiftyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyFive.php
@@ -31,7 +31,7 @@ class CRM_Upgrade_Incremental_php_FiveFiftyFive extends CRM_Upgrade_Incremental_
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
-  public function upgrade_5_55_beta1($rev): void {
+  public function upgrade_5_55_beta2($rev): void {
     $this->addTask(ts('Fix Event Badge Upgrade'), 'fix_event_badge_upgrade');
   }
 

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-02-11</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-01-02</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-11-11</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-08-11</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-05-23</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-12</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/elavon/info.xml
+++ b/ext/elavon/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-08-05</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-03</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-07</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-27</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-05</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-07-21</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-07-25</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:hidden</tag>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-06-12</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-23</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-13</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-03</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-01-06</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.55</ver>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-28</releaseDate>
-  <version>5.55.beta1</version>
+  <version>5.55.beta2</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -3057,7 +3057,7 @@ UNLOCK TABLES;
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
 INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES
- (1,'Default Domain Name',NULL,'5.55.beta1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+ (1,'Default Domain Name',NULL,'5.55.beta2',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -902,4 +902,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.55.beta1';
+UPDATE civicrm_domain SET version = '5.55.beta2';

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/FiveFiftyFiveTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/FiveFiftyFiveTest.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once 'CiviTest/CiviCaseTestCase.php';
+
+/**
+ * Class CRM_Upgrade_Incremental_php_FiveFiftyFiveTest
+ * @group headless
+ */
+class CRM_Upgrade_Incremental_php_FiveFiftyFiveTest extends CiviCaseTestCase {
+
+  public function testFixingPrintLabelUpgrade() {
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_print_label (title, name, description, label_format_name, label_type_id, is_default, is_reserved, is_active, data) VALUES ('Annual Conference Hanging Badge (Avery 5395) Busted', 'Annual_Conference_Hanging_Badge_busted', 'For our annual conference', 'Avery 5395', 1, 1, 1, 1, '" . '{"title":"Annual Conference Hanging Badge (Avery 5395)","label_format_name":"Avery 5395","description":"For our annual conference","token":{"1":"{event.title}","2":"{contact.display_name}","3":"{contact.current_employer}","4":"{event.start_date|crmDate:\"%B %E%f\"}"},"font_name":{"1":"dejavusans","2":"dejavusans","3":"dejavusans","4":"dejavusans"},"font_size":{"1":"9","2":"20","3":"15","4":"9"},"font_style":{"1":"","2":"","3":"","4":""},"text_alignment":{"1":"L","2":"C","3":"C","4":"R"},"barcode_type":"barcode","barcode_alignment":"R","image_1":"","image_2":"","is_default":"1","is_active":"1","is_reserved":"1","_qf_default":"Layout:next","_qf_Layout_refresh":"Save and Preview"}' . "'),('Annual Conference Hanging Badge (Avery 5395) Fixed', 'Annual_Conference_Hanging_Badge_fixed', 'For our annual conference', 'Avery 5395', 1, 1, 1, 1, '" . '{"title":"Annual Conference Hanging Badge (Avery 5395)","label_format_name":"Avery 5395","description":"For our annual conference","token":{"1":"{event.title}","2":"{contact.display_name}","3":"{contact.current_employer}","4":"{event.start_date|crmDate:\\\"%B %E%f\\\"}"},"font_name":{"1":"dejavusans","2":"dejavusans","3":"dejavusans","4":"dejavusans"},"font_size":{"1":"9","2":"20","3":"15","4":"9"},"font_style":{"1":"","2":"","3":"","4":""},"text_alignment":{"1":"L","2":"C","3":"C","4":"R"},"barcode_type":"barcode","barcode_alignment":"R","image_1":"","image_2":"","is_default":"1","is_active":"1","is_reserved":"1","_qf_default":"Layout:next","_qf_Layout_refresh":"Save and Preview"}' . "')");
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM civicrm_print_label WHERE data like '%" . 'crmDate:\"%B %E%f\"' . "%'"));
+    $originalFixed = CRM_Core_DAO::singleValueQuery("SELECT data FROM civicrm_print_label WHERE name = 'Annual_Conference_Hanging_Badge_fixed'");
+    $originalBusted = CRM_Core_DAO::singleValueQuery("SELECT data FROM civicrm_print_label WHERE name = 'Annual_Conference_Hanging_Badge_busted'");
+    $this->assertEquals(NULL, json_decode($originalBusted));
+    $this->assertFalse(NULL === json_decode($originalFixed));
+    CRM_Upgrade_Incremental_php_FiveFiftyFive::fix_event_badge_upgrade();
+    $fixedBusted = CRM_Core_DAO::singleValueQuery('SELECT data FROM civicrm_print_label WHERE name = \'Annual_Conference_Hanging_Badge_busted\'');
+    $fixedFixed = CRM_Core_DAO::singleValueQuery("SELECT data FROM civicrm_print_label WHERE name = 'Annual_Conference_Hanging_Badge_fixed'");
+    $this->assertEquals($originalFixed, $fixedFixed);
+    $this->assertFalse(NULL === json_decode($fixedBusted));
+  }
+
+}

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.55.beta1</version_no>
+  <version_no>5.55.beta2</version_no>
 </version>


### PR DESCRIPTION
…s not being properly escaped for json purposes on previous upgrade process

Overview
----------------------------------------
This aims to replicate the fix that was put in for new installs in #24695 but this does this for sites that had upgraded using hte previous upgrade step.

Before
----------------------------------------
Print labels in already installed sites may not be able to be json_decoded properly due to date upgrade issue

After
----------------------------------------
Should be fixed now

ping @eileenmcnaughton @totten @demeritcowboy 