### PR TITLE
SearchKit - Improve icon handling

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -243,6 +243,12 @@ class FormattingUtil {
           $fieldOptions = self::getPseudoconstantList($field, $fieldName, $result, $action);
           $dataType = NULL;
         }
+        // Store contact_type value before replacing pseudoconstant (e.g. transforming it to contact_type:label)
+        // Used by self::contactFieldsToRemove below
+        if ($value && isset($field['entity']) && $field['entity'] === 'Contact' && $field['name'] === 'contact_type') {
+          $prefix = strrpos($fieldName, '.');
+          $contactTypePaths[$prefix ? substr($fieldName, 0, $prefix + 1) : ''] = $value;
+        }
         if ($fieldExpr->supportsExpansion) {
           if (!empty($field['serialize']) && is_string($value)) {
             $value = \CRM_Core_DAO::unSerializeField($value, $field['serialize']);
@@ -250,11 +256,6 @@ class FormattingUtil {
           if (isset($fieldOptions)) {
             $value = self::replacePseudoconstant($fieldOptions, $value);
           }
-        }
-        // Keep track of contact types for self::contactFieldsToRemove
-        if ($value && isset($field['entity']) && $field['entity'] === 'Contact' && $field['name'] === 'contact_type') {
-          $prefix = strrpos($fieldName, '.');
-          $contactTypePaths[$prefix ? substr($fieldName, 0, $prefix + 1) : ''] = $value;
         }
         $result[$key] = self::convertDataType($value, $dataType);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Gives the ability to have "fallback" icons, e.g. choosing the icon for contact_sub_type with a fallback to contact_type.
Also fixes a bug & adds a test.

Before
----------------------------------------
1. Icons based on `contact_sub_type` field do not work in SearchKit (because it's a serialized field).
2. Not possible to do fallbacks for SearchKit icons.
3. Weird bug in APIv4 causes `first_name` and `last_name` to come back `NULL` if the SELECT clause includes `contact_type:icon` but not `contact_type`.

After
----------------------------------------
Now you can create a nice search with appropriate icons for every contact type (also works for activity types, ECK types, etc.)

Comments
--------------
Writing a test for this surfaced a weird, unrelated bug in the API, which was causing contact names to disappear from API results under certain conditions. I've fixed that as part of this PR so now the test passes :)
