### PR TITLE
SpecScanner - Fix installation error ("Class XyzSpecProvider does not exist")

### DIFF
--- a/Civi/Api4/Service/LegacySpecScanner.php
+++ b/Civi/Api4/Service/LegacySpecScanner.php
@@ -26,6 +26,9 @@ class LegacySpecScanner implements AutoServiceInterface {
   public static function buildContainer(ContainerBuilder $container): void {
     $classNames = static::findClasses('Civi\Api4\Service\Spec\Provider', $container);
     foreach ($classNames as $className) {
+      if (!class_exists($className)) {
+        continue;
+      }
       $class = new \ReflectionClass($className);
       if ($class->implementsInterface(AutoServiceInterface::class)) {
         // This is already handled by the main scanner.

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -11,7 +11,6 @@ use CRM_Search_ExtensionUtil as E;
 function search_kit_civicrm_config(&$config) {
   _search_kit_civix_civicrm_config($config);
   Civi::dispatcher()->addListener('hook_civicrm_alterAngular', ['\Civi\Search\AfformSearchMetadataInjector', 'preprocess'], 1000);
-  Civi::dispatcher()->addSubscriber(new Civi\Api4\Event\Subscriber\SearchKitSubscriber());
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------

(This is inspired by @eileenmcnaughton's #24807. It does not preclude #24807, but it should fix more symptoms.)

This addresses a regression affecting `civiimport` and `search_kit` (and probably `civigeometry`, but I haven't tested that one). The problem arises as follows:

1. Take an extension that includes an APIv4 `SpecProvider` (such as `civiimport` or `search_kit`).
2. Ensure the extension is not installed.
3. In the web UI (`civicrm/admin/extensions`), install the extension.

Before (5.54.0)
----------------------------------------

It appears to work.

Internally, the installation flushes various caches in various ways. It does not flush/rebuild the container (in local/PHP memory). This can be confusing when doing automated tests, but (for production) it ultimately works out anyway. (It deletes the container-cache-file, so the future page-views will rebuild, and the final content will be correct.)

Before (5.54.1, 5.55.beta)
----------------------------------------

It appears to fail.

Internally, the installation flushes various caches in various ways. This includes flushing the container (in local/PHP memory as well as the file-based cache). This is better for automated tests, but (for production) one of the interim flushes occurs at a poor moment -- when `LegacySpecScanner` sees an inconsistent world and crashes with:

> Class "Civi\Api4\Service\Spec\Provider\ImportSpecProvider" does not exist

After
----------------------------------------

It appears to work.

Internally, the installation flushes various caches, including the container (in local/PHP memory as well as the file-based cache). This is better for automated tests. For production, it basically works -- it ignores the inconsistent interim state (seen in 5.54.1), and it ultimately works because (as in 5.54.0) the final content of the container is correct.

