### PR TITLE
Add DATEDIFF to calculate days between two dates

### DIFF
--- a/Civi/Api4/Query/SqlFunctionDATEDIFF.php
+++ b/Civi/Api4/Query/SqlFunctionDATEDIFF.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionDATEDIFF extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static $dataType = 'Integer';
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 2,
+        'min_expr' => 2,
+        'optional' => FALSE,
+        'label' => ts('diff'),
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Days between two dates');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Number of days between two dates.');
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -214,6 +214,36 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('q', $result['LOWER:middle_name']);
   }
 
+  public function testDateFunctions() {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'abc', 'last_name' => $lastName, 'birth_date' => '2009-11-11'],
+      ['first_name' => 'def', 'last_name' => $lastName, 'birth_date' => '2010-01-01'],
+    ];
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => $sampleData,
+    ]);
+
+    $result = Contact::get(FALSE)
+      ->addSelect('DATEDIFF("2010-01-01", birth_date) AS diff')
+      ->addSelect('YEAR(birth_date) AS year')
+      ->addSelect('MONTH(birth_date) AS month')
+      ->addSelect('EXTRACT(YEAR_MONTH FROM birth_date) AS year_month')
+      ->addWhere('last_name', '=', $lastName)
+      ->addOrderBy('id')
+      ->execute();
+
+    $this->assertEquals(51, $result[0]['diff']);
+    $this->assertEquals(2009, $result[0]['year']);
+    $this->assertEquals(11, $result[0]['month']);
+    $this->assertEquals('200911', $result[0]['year_month']);
+
+    $this->assertEquals(0, $result[1]['diff']);
+    $this->assertEquals(2010, $result[1]['year']);
+    $this->assertEquals(1, $result[1]['month']);
+    $this->assertEquals('201001', $result[1]['year_month']);
+  }
+
   public function testIncorrectNumberOfArguments() {
     try {
       Activity::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Allow to calculate number of days between two dates.

Eg. to calculate days between case start date and first activity of a specific type.

Before
----------------------------------------
Can't calculate days between dates.

After
----------------------------------------
Can calculate days between dates.

Technical Details
----------------------------------------
Adds the mysql DATEDIFF function

Comments
----------------------------------------
@colemanw Does this look ok?
