### PR TITLE
Add help text for event scheduled reminders relative and absolute dates

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -33,7 +33,10 @@
 
     <tr id="relativeDate" class="crm-scheduleReminder-form-block-description">
         <td class="right"></td>
-        <td colspan="3">{$form.start_action_offset.html}&nbsp;&nbsp;&nbsp;{$form.start_action_unit.html}&nbsp;&nbsp;&nbsp;{$form.start_action_condition.html}&nbsp;&nbsp;&nbsp;{$form.start_action_date.html}</td>
+        <td colspan="3">
+          {$form.start_action_offset.html}&nbsp;&nbsp;&nbsp;{$form.start_action_unit.html}&nbsp;&nbsp;&nbsp;{$form.start_action_condition.html}&nbsp;&nbsp;&nbsp;{$form.start_action_date.html}
+          {if $context === "event"}&nbsp;{help id="relative_absolute_schedule_dates"}{/if}
+        </td>
     </tr>
     <tr id="recordActivity" class="crm-scheduleReminder-form-block-record_activity"><td class="label" width="20%">{$form.record_activity.label}</td>
         <td>{$form.record_activity.html}</td>

--- a/templates/CRM/Admin/Page/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Page/ScheduleReminders.hlp
@@ -7,9 +7,19 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+
+{htxt id='relative_absolute_schedule_dates-title'}
+  {ts}When scheduled reminders will or won't be sent{/ts}
+{/htxt}
+{htxt id="relative_absolute_schedule_dates"}
+  <p>{ts}If you set a scheduled reminder for an event to be sent on a specific date, it will be sent only on that date.{/ts} {ts}Contacts who registered before that date will receive the scheduled reminder shortly after midnight and contacts who register on that date will receive the reminder shortly after they register. Contacts who register after that date will not receive the reminder.{/ts}</p>
+  <p>{ts}If you set a scheduled reminder relative to the event start or end (e.g. 24 hours before the event start), reminders will generally also be sent to contacts who register after that time.{/ts} {ts}If you set a reminder for before the event start or end, it will be sent to all registrants who register before the event ends.{/ts} {ts}If you set a reminder for after the event start or end, it will be sent to any registrant, no matter when they register.{/ts}</p>
+<p>{ts}If you set a reminder for before the registration start or end, it will be sent to any contacts who register up to the registration end.{/ts} {ts}Reminders set for after the registration start or end won't be sent at all.{/ts}</p>
+{/htxt}
+
 {htxt id="limit_to"}
   <p>{ts}Select 'Limit to' if you want to only send reminders to contacts with the criteria selected above AND who ALSO match this criteria. If you select 'Choose Recipients' - only the chosen contacts will receive the reminder (AND only if they ALSO match the criteria above).{/ts}</p>
-  <p>{ts}Select 'Also include' if you want to also send reminders to contacts who match this criteria. If you select 'Choose Recipients' - the chosen contacts will also receive the reminder (in ADDITION TO the contacts who match the criteria above).{/ts}
+  <p>{ts}Select 'Also include' if you want to also send reminders to contacts who match this criteria. If you select 'Choose Recipients' - the chosen contacts will also receive the reminder (in ADDITION TO the contacts who match the criteria above).{/ts}</p>
 {/htxt}
 
 {htxt id="recipient"}


### PR DESCRIPTION
Overview
----------------------------------------
This has been the source of a lot of confusion (e.g. recently [issue #3959](https://lab.civicrm.org/dev/core/-/issues/3959), but I've been caught out by this one too in the past). Hopefully this help text (and similar documentation also added), which is only shown for scheduled reminders when configuring an event, will help clarify the situation. It's long, but I wanted to cover all the different conditions.

![image](https://user-images.githubusercontent.com/25517556/199302225-c5fef0d8-23d7-4525-bdd5-b00d26f91cd7.png)
