### PR TITLE
Test - Fix backwards params to assertEquals

### DIFF
--- a/tests/phpunit/Civi/Angular/PartialSyntaxTest.php
+++ b/tests/phpunit/Civi/Angular/PartialSyntaxTest.php
@@ -94,7 +94,7 @@ class PartialSyntaxTest extends \CiviUnitTestCase {
         $count++;
         if (!$coder->checkConsistentHtml($html)) {
           $recodedHtml = $coder->recode($html);
-          $this->assertEquals($html, $recodedHtml, "File $path has inconsistent HTML. Use tools/scripts/check-angular.php to debug. ");
+          $this->assertEquals($recodedHtml, $html, "File $path has inconsistent HTML. Use tools/scripts/check-angular.php to debug. ");
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This unit test tends to be ornery. In #24860  it failed an html template for no apparent reason (I changed some irrelevant whitespace in the file and then the mysterious failure disappeared).
The failure was especially difficult to interpret because this call to `assertEquals` had the order of params mixed up.

Before
--------------
Mystery errors; diff backwards.

After
----------
Mystery errors but at least the diff is in the correct order.