### PR TITLE
Fix missing links in SearchKit results

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetDefault.php
@@ -199,7 +199,7 @@ class GetDefault extends \Civi\Api4\Generic\AbstractAction {
    */
   private function getColumnLink(&$col, $clause) {
     if ($clause['expr'] instanceof SqlField || $clause['expr'] instanceof SqlFunctionGROUP_CONCAT) {
-      $field = $clause['fields'][0] ?? NULL;
+      $field = \CRM_Utils_Array::first($clause['fields'] ?? []);
       if ($field &&
         CoreUtil::getInfoItem($field['entity'], 'label_field') === $field['name'] &&
         !empty(CoreUtil::getInfoItem($field['entity'], 'paths')['view'])

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -22,7 +22,7 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       'api_entity' => 'Contact',
       'api_params' => [
         'version' => 4,
-        'select' => ['first_name', 'last_name', 'contact_sub_type:label', 'gender_id'],
+        'select' => ['first_name', 'display_name', 'contact_sub_type:label', 'gender_id'],
         'where' => [],
       ],
     ];
@@ -37,6 +37,17 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertEquals('fa-table', $display['type:icon']);
     $this->assertEquals('Contact', $display['saved_search_id.api_entity']);
     $this->assertEquals('Contacts', $display['saved_search_id.api_entity:label']);
+
+    // Default sort order should have been added
+    $this->assertEquals([['sort_name', 'ASC']], $display['settings']['sort']);
+
+    // `display_name` column should have a link
+    $this->assertEquals('Contact', $display['settings']['columns'][1]['link']['entity']);
+    $this->assertEquals('view', $display['settings']['columns'][1]['link']['action']);
+    $this->assertEmpty($display['settings']['columns'][1]['link']['join']);
+
+    // `first_name` column should not have a link
+    $this->assertArrayNotHasKey('link', $display['settings']['columns'][0]);
   }
 
   public function testGetDefaultNoEntity() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a SearchKit regresion where links disappeared. This is an unreleased regression in 5.55.

Before
----------------------------------------
1. Go to SearchKit and click "New Search" (for contacts).
2. Click the search button.
3. The display name column no longer has a clickable link for each contact.

After
----------------------------------------
Fixed. Added test.
