### PR TITLE
Add CMS User ID to contactFooter.tpl

### DIFF
--- a/templates/CRM/common/contactFooter.tpl
+++ b/templates/CRM/common/contactFooter.tpl
@@ -13,6 +13,7 @@
   <span class="col1">
     {if $external_identifier}{ts}External ID{/ts}:&nbsp;{$external_identifier}{/if}
     {if $action !== 2}&nbsp; &nbsp;{ts}Contact ID{/ts}:&nbsp;{$contactId}{/if}
+    {if $userRecordUrl}&nbsp; &nbsp;{ts}User ID{/ts}:&nbsp;<a title="{ts}View user record{/ts}" class="user-record-link" href="{$userRecordUrl}">{$userRecordId}</a>{/if}
   </span>
   {if $lastModified}
     {ts}Last Change by{/ts}: <a href="{crmURL p='civicrm/contact/view' q="action=view&reset=1&cid=`$lastModified.id`"}">{$lastModified.name}</a> ({$lastModified.date|crmDate}) &nbsp;


### PR DESCRIPTION
Overview
----------------------------------------
This adds the CMS ID next to other IDs in footer of contact summary screen.

Before
----------------------------------------
The CMS User ID link is useful to connect to the CMS profile but is only accessible via the ID, Type and Tags block. If you don't want to use all the elements in that block, you have to customize it. It's also redundant with footer IDs and using valuable screen space in the Contact Summary Screen.

Only available in ID, Type and Tags Block.
![image](https://user-images.githubusercontent.com/18341942/199575728-4f9f9375-8f7f-4631-9d08-06692f64905a.png)

Not shown in footer
![image](https://user-images.githubusercontent.com/18341942/199587968-1d9a74b3-1761-484b-ae49-8fc70fec189e.png)


After
----------------------------------------
The various ID's (Contact ID, External ID, User ID) now live together at the footer of the contact summary screen.

![image](https://user-images.githubusercontent.com/18341942/199575068-68a69a62-fd06-4bfe-aac9-be95b077eb57.png)


Technical Details
----------------------------------------
Used some code from https://lab.civicrm.org/dev/core/-/blob/master/templates/CRM/Contact/Page/Inline/Basic.tpl#L28. 