### PR TITLE
SpecScanner - Fix installation error ('Class XyzSpecProvider does not…

### DIFF
--- a/CRM/Api4/Services.php
+++ b/CRM/Api4/Services.php
@@ -62,6 +62,9 @@ class CRM_Api4_Services {
           $matches = [];
           preg_match('/(\w*)\.php$/', $file, $matches);
           $serviceName = $namespace . array_pop($matches);
+          if (!class_exists($serviceName)) {
+            continue;
+          }
           $serviceClass = new \ReflectionClass($serviceName);
           if ($serviceClass->isInstantiable()) {
             $definition = $container->register(str_replace('\\', '_', $serviceName), $serviceName);

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -11,7 +11,6 @@ use CRM_Search_ExtensionUtil as E;
 function search_kit_civicrm_config(&$config) {
   _search_kit_civix_civicrm_config($config);
   Civi::dispatcher()->addListener('hook_civicrm_alterAngular', ['\Civi\Search\AfformSearchMetadataInjector', 'preprocess'], 1000);
-  Civi::dispatcher()->addSubscriber(new Civi\Api4\Event\Subscriber\SearchKitSubscriber());
 }
 
 /**


### PR DESCRIPTION
port https://github.com/civicrm/civicrm-core/pull/24874

This might never get released - but it de-risks this branch if it ever does for any reason

Note I tested locally disabling & enabling the 2 extensions involved