### PR TITLE
PriceSetTest - Fix test-run on case-insensitive filesystem

### DIFF
--- a/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
+++ b/tests/phpunit/CRM/Price/BAO/PriceSetTest.php
@@ -30,7 +30,7 @@ class CRM_Price_BAO_PriceSetTest extends CiviUnitTestCase {
     $params = ['priceSetId' => $priceSetID, 'price_' . $field['id'] => 1];
     $amountLevel = CRM_Price_BAO_PriceSet::getAmountLevelText($params);
     $this->assertEquals(CRM_Core_DAO::VALUE_SEPARATOR . 'Price Field - 1' . CRM_Core_DAO::VALUE_SEPARATOR, $amountLevel);
-    $priceFieldValue = $this->callAPISuccess('pricefieldvalue', 'getsingle', ['price_field_id' => $field['id']]);
+    $priceFieldValue = $this->callAPISuccess('PriceFieldValue', 'getsingle', ['price_field_id' => $field['id']]);
     $this->callAPISuccess('PriceFieldValue', 'delete', ['id' => $priceFieldValue['id']]);
     $this->callAPISuccess('PriceField', 'delete', ['id' => $field['id']]);
     $this->callAPISuccess('PriceSet', 'delete', ['id' => $priceSetID]);


### PR DESCRIPTION
Before
----------------------------------------

The test internally+arbitrarily inconsistent about `PriceFieldValue` vs `pricefieldvalue`.

On case-insensitive filesystem, this leads to a test failure:

```
$ CIVICRM_UF=UnitTests phpunit8 tests/phpunit/CRM/Price/BAO/
PHPUnit 8.5.27 #StandWithUkraine

.
Installing dmastertest_qmzfj database
...
Fatal error: Cannot redeclare civicrm_api3_price_field_value_create() (previously declared in /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/api/v3/PriceFieldValue.php:31) in /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/api/v3/Pricefieldvalue.php on line 31

```


After
----------------------------------------

The test internally consistent. Test passes.

