### PR TITLE
(dev/core#3136) Incorporate the domain id in the log file nomenclatur…

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -689,7 +689,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       else {
         $hash = '';
       }
-      $fileName = $config->configAndLogDir . 'CiviCRM.' . $prefixString . $hash . 'log';
+      $fileName = $config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '_' . $prefixString . $hash . 'log';
 
       // Roll log file monthly or if greater than our threshold.
       // Size-based rotation introduced in response to filesize limits on

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -100,7 +100,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     $log->log('Little lamb');
     $config = CRM_Core_Config::singleton();
     $fileContents = file_get_contents($log->_filename);
-    $this->assertEquals($config->configAndLogDir . 'CiviCRM.' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log', $log->_filename);
+    $this->assertEquals($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '_' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log', $log->_filename);
     // The 5 here is a bit arbitrary - on my local the date part is 15 chars (Mar 29 05:29:16) - but we are just checking that
     // there are chars for the date at the start.
     $this->assertTrue(strpos($fileContents, '[info] Mary had a little lamb') > 10);


### PR DESCRIPTION
…e to help locate the file easily.


Overview
----------------------------------------
If you have loads of domains, it gets harder to locate the correct log file. Incorporating the domain id in the log file name will make it simpler.

Before
----------------------------------------
Harder to locate the domain specific file.

After
----------------------------------------
Nomenclature reflects the domain id making it easier to locate.