### PR TITLE
(dev/core#3918) Revert "Add missing country=>billingCountry to PropertyBag mapping"

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -43,7 +43,6 @@ class PropertyBag implements \ArrayAccess {
     'billing_state_province'      => 'billingStateProvince',
     'state_province'              => 'billingStateProvince',
     'billingCountry'              => TRUE,
-    'country'                     => 'billingCountry',
     'contactID'                   => TRUE,
     'contact_id'                  => 'contactID',
     'contributionID'              => TRUE,


### PR DESCRIPTION
This reverts commit 99d7dc7bd17b81e7041c7d85d72b0e70210201d8

Per https://lab.civicrm.org/dev/core/-/issues/3918 this has caused a regression

@mattwire I think we have to revert this in the first instance both because it's our normal approach (quick revert & re-fix in a more timely manner) and because the regression appears to be more serious than the original problem.

Unfortunately I'm only just really getting caught up on the regressions so hadn't looked at it properly until now (we just went through them on the CT meeting).

Separately I guess the issue is the data being passed in as 'country' is inconsistent - which means we should either

- make it not inconsistent or
- handle the inconsistency with a custom setter method in propertyBag or
- both