### PR TITLE
dev/core#3960 Remove legacy ar key

### DIFF
--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -142,7 +142,7 @@ function saveRecord(recordID, op, recordBAO, entityID) {
   }
   var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_Financial_Page_AJAX&fnName=assignRemove'}"{literal};
   //post request and get response
-  CRM.$.post( postUrl, { records: [recordID], recordBAO: recordBAO, op:op, entityID:entityID, key: {/literal}"{crmKey name='civicrm/ajax/ar'}"{literal}  }, function( html ){
+  CRM.$.post( postUrl, { records: [recordID], recordBAO: recordBAO, op:op, entityID:entityID }, function( html ){
     //this is custom status set when record update success.
     if (html.status == 'record-updated-success') {
        if (op == 'close') {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3960 Remove legacy ar key

 https://lab.civicrm.org/dev/core/-/issues/3960

Before
----------------------------------------
js error

After
----------------------------------------
seems to work

Technical Details
----------------------------------------
I can't see anything using the `key` so I think it is obsolete. This form is one of our earlier attempts at using ajax so I think that might just be something that we evolved away from

Comments
----------------------------------------
Can probably also close https://lab.civicrm.org/dev/core/-/issues/3050 with this merged