### PR TITLE
Don't allow selection of deleted contacts as email recipients

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -371,7 +371,7 @@ class CRM_Contact_Page_AJAX {
 SELECT sort_name name, ce.email, cc.id
 FROM   civicrm_email ce INNER JOIN civicrm_contact cc ON cc.id = ce.contact_id
        {$aclFrom}
-WHERE  ce.on_hold = 0 AND cc.is_deceased = 0 AND cc.do_not_email = 0 AND {$queryString}
+WHERE  ce.on_hold = 0 AND cc.is_deceased = 0 AND cc.do_not_email = 0 AND cc.is_deleted = 0 AND {$queryString}
        {$aclWhere}
 LIMIT {$rowCount}
 )";


### PR DESCRIPTION
Overview
----------------------------------------
Users should not be able to select deleted contacts as recipients of emails (in the Email - Send now to 50 or less sense). Turns out that not only could deleted contacts be selected, emails were sent to those deleted contacts.

Before
----------------------------------------
Can select a deleted contact.

After
----------------------------------------
Cannot select a deleted contact.

Technical Details
----------------------------------------
getContactEmail doesn't appear to be used anywhere else in universe except in the invoicehelper extension, which I'm sure isn't looking to [send invoices to deleted contacts](https://lab.civicrm.org/extensions/invoicehelper/-/blob/master/templates/CRM/Invoicehelper/Contribute/Form/Task/Invoice.tpl) either. Pinging @mlutfy just in case.
