### PR TITLE
SearchKit - Add clone button for search displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -187,6 +187,15 @@
         }
       };
 
+      this.cloneDisplay = function(display) {
+        var newDisplay = angular.copy(display);
+        delete newDisplay.name;
+        delete newDisplay.id;
+        newDisplay.label += ts(' (copy)');
+        ctrl.savedSearch.displays.push(newDisplay);
+        $scope.selectTab('display_' + (ctrl.savedSearch.displays.length - 1));
+      };
+
       this.addGroup = function() {
         ctrl.savedSearch.groups.push({
           title: '',

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -12,7 +12,7 @@
     <i class="crm-i fa-users"></i>
     {{:: ts('Smart Group') }} {{ $ctrl.savedSearch.groups[0].title }}
   </a>
-  <button type="button" class="btn-xs btn-danger-outline crm-search-delete-display" ng-click="$ctrl.removeGroup()" title="{{ $ctrl.groupExists ? ts('Delete') : ts('Undelete') }}">
+  <button type="button" class="btn-xs btn-danger-outline crm-search-display-control" ng-click="$ctrl.removeGroup()" title="{{ $ctrl.groupExists ? ts('Delete') : ts('Undelete') }}">
     <i class="crm-i fa-{{ $ctrl.groupExists ? 'trash' : 'undo' }}"></i>
   </button>
 </li>
@@ -21,8 +21,11 @@
     <i class="crm-i {{ $ctrl.displayTypes[display.type].icon }}"></i>
     {{ display.label || ts('Untitled') }}
   </a>
-  <button type="button" class="btn-xs btn-danger-outline crm-search-delete-display" ng-click="$ctrl.removeDisplay($index)" title="{{ display.trashed ? ts('Undelete') : ts('Delete') }}">
+  <button type="button" class="btn btn-xs btn-danger-outline crm-search-display-control" ng-click="$ctrl.removeDisplay($index)" title="{{ display.trashed ? ts('Undelete') : ts('Delete') }}">
     <i class="crm-i fa-{{ display.trashed ? 'undo' : 'trash' }}"></i>
+  </button>
+  <button type="button" class="btn btn-xs btn-primary-outline crm-search-display-control" ng-if="!display.trashed" ng-click="$ctrl.cloneDisplay(display)" title="{{:: ts('Clone display') }}">
+    <i class="crm-i fa-copy"></i>
   </button>
 </li>
 <li role="presentation">

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -167,10 +167,13 @@
   height: 36px;
 }
 
-#bootstrap-theme .crm-search-delete-display {
+#bootstrap-theme .crm-search-display-control {
   position: absolute;
   right: 0;
   top: 0;
+}
+#bootstrap-theme .crm-search-display-control+.crm-search-display-control {
+  right: 20px;
 }
 
 #bootstrap-theme .crm-search-admin-edit-columns {


### PR DESCRIPTION
Overview
----------------------------------------
Adds a clone button to easily make a copy of a search display.

Before
----------------------------------------
No easy way to clone search displays.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/199863508-99ed8e9d-5f2a-4dd5-9a3d-ced4f6812c6f.png)

