### PR TITLE
[REF] Unused vars in the State Machine

### DIFF
--- a/CRM/Core/StateMachine.php
+++ b/CRM/Core/StateMachine.php
@@ -257,14 +257,9 @@ class CRM_Core_StateMachine {
     }
 
     $i = 0;
-    foreach ($pages as $tempName => $value) {
+    foreach ($pages as $dontCareWeJustNeededToCalculatePageNamesFirst) {
       $name = $this->_pageNames[$i];
 
-      $className = CRM_Utils_Array::value('className',
-        $value,
-        $tempName
-      );
-      $classPath = str_replace('_', '/', $className) . '.php';
       if ($numPages == 1) {
         $prev = $next = NULL;
         $type = CRM_Core_State::START | CRM_Core_State::FINISH;


### PR DESCRIPTION
Overview
----------------------------------------
Unused vars. Borderline bonkers.

Before
----------------------------------------
Same

After
----------------------------------------
Same

Technical Details
----------------------------------------
Get on up, like a state machine, get on up.

Comments
----------------------------------------
This is the first part of many of the problems in https://github.com/civicrm/civicrm-core/pull/24896

Die CRM_Utils_Array::value, die.
