### PR TITLE
ensure checkbox imports work on contacts

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -420,12 +420,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
               if ((strtolower($v2['label']) == strtolower(trim($v1))) ||
                 (strtolower($v2['value']) == strtolower(trim($v1)))
               ) {
-                if ($htmlType == 'CheckBox') {
-                  $params[$key][$v2['value']] = $formatted[$key][$v2['value']] = 1;
-                }
-                else {
-                  $params[$key][] = $formatted[$key][] = $v2['value'];
-                }
+                $params[$key][] = $formatted[$key][] = $v2['value'];
               }
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------

Ensure checkboxes with string values are imported properly.

See https://lab.civicrm.org/dev/core/-/issues/3850 and the fix in https://github.com/civicrm/civicrm-core/pull/24848

The initial fix was tested, but I think I may have tested when importing the integer values? I'm not sure, but now when I test with string values for checkboxes it fails.

Before
----------------------------------------
When importing a check box custom field using the multiple choice values in the import, the user gets a validation error: "1" is not a valid option for field custom_1. 

After
----------------------------------------

The import is properly recorded in the database.

Technical Details
----------------------------------------
I followed the lead of the early PR and removed code that seems unnecessary now.


