### PR TITLE
avoid fatal error in PHP 8 in BAO/Navigation.php

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -320,7 +320,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       if (!isset($b['attributes']['weight'])) {
         $b['attributes']['weight'] = 1000;
       }
-      return $a['attributes']['weight'] - $b['attributes']['weight'];
+      return (int) $a['attributes']['weight'] - (int) $b['attributes']['weight'];
     });
 
     // If any of the $navigations have children, recurse


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/3968 for details.

Overview
----------------------------------------
Trying to upgrade a test instance of Wordpress+CiviCRM to PHP 8 I found that this line can throw a fatal error. Not sure whether this is the best way to fix it, that’s for core developers to decide.

Before
----------------------------------------
The CiviCRM menu does not show after an upgrade to PHP 8, due to this line throwing a fatal error “Unsupported operand types: string - string”

After
----------------------------------------
The menu is back :-)
