### PR TITLE
Only show File Activity on Case success alert for 10s

### DIFF
--- a/templates/CRM/Case/Form/ActivityToCase.tpl
+++ b/templates/CRM/Case/Form/ActivityToCase.tpl
@@ -73,7 +73,7 @@
             var caseUrl = destUrl + selectedCaseId + '&cid=' + contactId + context;
 
             var statusMsg = {/literal}'{ts escape='js' 1='%1'}Activity has been filed to %1 case.{/ts}'{literal};
-            CRM.alert(ts(statusMsg, {1: '<a href="' + caseUrl + '">' + CRM._.escape(caseTitle) + '</a>'}), '{/literal}{ts escape="js"}Saved{/ts}{literal}', 'success');
+            CRM.alert(ts(statusMsg, {1: '<a href="' + caseUrl + '">' + CRM._.escape(caseTitle) + '</a>'}), '{/literal}{ts escape="js"}Saved{/ts}{literal}', 'success', {expires: 10000});
             CRM.refreshParent(a);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
When using File on Case for an Activity from search results or the Contacts Activities tab, the success alert never expired (because this is the default behaviour for a message with a link in it). This becomes a problem if you file multiple activities on cases because your screen fills up with alerts.

<img width="366" alt="image" src="https://user-images.githubusercontent.com/25517556/200134440-49dfdf00-cd2a-4d73-a159-30044abc8983.png">

Before
----------------------------------------
Alert hangs around forever.

After
----------------------------------------
Alert fades after 10s.