### PR TITLE
Don't crash ContributionView when participant fields are null

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -126,14 +126,14 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
       $participantLineItems = [];
     }
 
-    $associatedParticipants = FALSE;
+    $associatedParticipants = empty($participantLineItems) ? FALSE : [];
     foreach ($participantLineItems as $participant) {
       $associatedParticipants[] = [
         'participantLink' => CRM_Utils_System::url('civicrm/contact/view/participant',
           "action=view&reset=1&id={$participant['entity_id']}&cid={$participant['participant.contact_id']}&context=home"
         ),
         'participantName' => $participant['contact.display_name'],
-        'fee' => implode(', ', $participant['participant.fee_level']),
+        'fee' => implode(', ', $participant['participant.fee_level'] ?? []),
         'role' => implode(', ', $participant['participant.role_id:label']),
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Don't crash ContributionView when participant fields are null.

Before
----------------------------------------
In some cases a participant may have no `fee_level` set. One example this can happen is when creating a contribution using the recomended instructions at https://docs.civicrm.org/dev/en/latest/financial/orderAPI/. (As an aside, updating the example in the documentation to show saving a `fee_amount` and `fee_level` could be a sensible idea).

On PHP8, viewing a contribution with associated participants that have no fee_level will result in the following critical error:

```
implode(): Argument #1 ($pieces) must be of type array, string given
```

On PHP 7.x I don't think the error would be critical (stop execuction).

After
----------------------------------------
No errors occur.

Comments
----------------------------------------
I've only seen problems with `fee_level` being null, but adding a  check on the `role_id` felt like it wouldn't hurt.
