### PR TITLE
[REF][PHP8.1] Fix a couple of issues where passing in NULL in string …

### DIFF
--- a/CRM/Report/Page/InstanceList.php
+++ b/CRM/Report/Page/InstanceList.php
@@ -161,7 +161,7 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
         continue;
       }
 
-      if (trim($dao->title)) {
+      if (trim($dao->title ?? '')) {
         if ($this->ovID) {
           $this->title = ts("Report(s) created from the template: %1", [1 => $dao->label]);
         }


### PR DESCRIPTION
…functions is deprecated in PHP8.1

Overview
----------------------------------------
This fixes most of the notice errors reported here https://lab.civicrm.org/dev/core/-/issues/3181#note_84245 

Before
----------------------------------------
Notice errors in some configurations in PHP8.1 

After
----------------------------------------
Less Notice Errors

ping @eileenmcnaughton @demeritcowboy 