### PR TITLE
[REF] Fix E2E_Core_ErrorTest on wordpress-clean builds

### DIFF
--- a/tests/phpunit/E2E/Core/ErrorTest.php
+++ b/tests/phpunit/E2E/Core/ErrorTest.php
@@ -99,7 +99,7 @@ class ErrorTest extends \CiviEndToEndTestCase {
       'Backdrop' => '/href=.*user\/(login|register)/',
       'Drupal' => '/href=.*user\/register/',
       'Drupal8' => '/href=.*user\/(login|register)/',
-      'WordPress' => '/( role=.navigation.| class=.site-header.)/',
+      'WordPress' => '/( role=.navigation.| class=.site-header.| class=.page-template-default.)/',
     ];
     if (!isset($patterns[CIVICRM_UF])) {
       $this->markTestIncomplete('testErrorChrome() cannot check for chrome on ' . CIVICRM_UF);


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the test failures shown here https://test.civicrm.org/job/CiviCRM-E2E-Edge/BLDTYPE=wp-clean,CIVIVER=master,label=bknix-tmp-edge/lastCompletedBuild/testReport/

Before
----------------------------------------
Test failures due to different HTML markup

After
----------------------------------------
Tests pass

ping @demeritcowboy @eileenmcnaughton @totten 