### PR TITLE
PHP8 fix - always define locations in event info template

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -178,8 +178,8 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $this->assign('action', CRM_Core_Action::VIEW);
     //To show the event location on maps directly on event info page
     $locations = CRM_Event_BAO_Event::getMapInfo($this->_id);
+    $this->assign('locations', $locations);
     if (!empty($locations) && !empty($values['event']['is_map'])) {
-      $this->assign('locations', $locations);
       $this->assign('mapProvider', $config->mapProvider);
       $this->assign('mapKey', $config->mapAPIKey);
       $sumLat = $sumLng = 0;


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/3974

Overview
----------------------------------------
If you try to view an event info page when mapping is enabled, OpenStreetMap is your Mapping Provider, PHP 8, and no geocode on your address, you get a fatal error.

Before
----------------------------------------
WSOD

After
----------------------------------------
Works.

Comments
----------------------------------------
Comments are [on Gitlab](https://lab.civicrm.org/dev/core/-/issues/3974).  This ensures we don't pass a `NULL` value to `count()` which always expects an array.
