### PR TITLE
Add tests for importing county (includes adding v4 County api)

### DIFF
--- a/CRM/Core/BAO/County.php
+++ b/CRM/Core/BAO/County.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Core\Event\PostEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * This class contains functions for managing Counties.
+ */
+class CRM_Core_BAO_County extends CRM_Core_DAO_County implements HookInterface {
+
+  /**
+   * Callback for hook_civicrm_post().
+   *
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(PostEvent $event): void {
+    unset(\Civi::$statics['CRM_Core_PseudoConstant']);
+  }
+
+}

--- a/Civi/Api4/County.php
+++ b/Civi/Api4/County.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Country entity.
+ *
+ * @searchable secondary
+ * @since 5.56
+ * @package Civi\Api4
+ */
+class County extends Generic\DAOEntity {
+
+}

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
@@ -1,9 +1,9 @@
 First Name,Last Name,Email,County,Country,State,Custom field state,Custom Field Country,Address Custom Field Country,Address Custom field state,Mum Name,Mum Last name,Mum email,Mum State,Mum Country,Mum County,Address Mum Custom Field Country,Address Mum Custom field state,Mum Custom Field Country,Mum Custom field State,expected,error_value
 Susie,Jones,susie@example.com,,ABC,,,,,,Mum,Jones,mum@example.com,,,,,,,,Invalid,ABC
 Susie,Jones,susie@example.com,,,,,,,,Mum,Jones,mum@example.com,NSW,ABC,,,,,,Invalid,ABC
-Susie,Jones,susie@example.com,,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jones,mum@example.com,NSW,Australia,,Australia,NSW,Australia,NSW,Valid,
-Susie,Jones,susie@example.com,,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,,AU,New South Wales,Australia,New South Wales,Valid,
-Susie,Jones,susie@example.com,,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,,1013,New South Wales,1013,New South Wales,Valid,
-Susie,Jones,susie@example.com,,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,,,,,,Valid,
-Susie,Jones,susie@example.com,,AU,NEW South Wales,NEW South Wales,AU,AU,NEW South Wales,Mum,Jones,mum@example.com,NEW South Wales,AU,,AU,NEW South Wales,Australia,NEW South Wales,Valid,
+Susie,Jones,susie@example.com,farnell,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jones,mum@example.com,NSW,Australia,,Australia,NSW,Australia,NSW,Valid,
+Susie,Jones,susie@example.com,farnell,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,,AU,New South Wales,Australia,New South Wales,Valid,
+Susie,Jones,susie@example.com,FARNELL,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,,1013,New South Wales,1013,New South Wales,Valid,
+Susie,Jones,susie@example.com,Farnell,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,,,,,,Valid,
+Susie,Jones,susie@example.com,Farnell,AU,NEW South Wales,NEW South Wales,AU,AU,NEW South Wales,Mum,Jones,mum@example.com,NEW South Wales,AU,,AU,NEW South Wales,Australia,NEW South Wales,Valid,
 Susie,Jones,susie@example.com,,AU,My own personal fiefdom,My own personal fiefdom,AU,AU,My own personal fiefdom,Mum,Jones,mum@example.com,My own personal fiefdom,AU,,AU,My own personal fiefdom,Australia,My own personal fiefdom,Invalid,rando

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
@@ -1,9 +1,9 @@
 First Name,Last Name,Email,County,Country,State,Custom field state,Custom Field Country,Address Custom Field Country,Address Custom field state,Mum Name,Mum Last name,Mum email,Mum State,Mum Country,Mum County,Address Mum Custom Field Country,Address Mum Custom field state,Mum Custom Field Country,Mum Custom field State,expected,error_value
-Susie,Jones,susie@example.com,,ABC,,,,,,Mum,Jones,mum@example.com,,,,,,,,Invalid,ABC
-Susie,Jones,susie@example.com,,,,,,,,Mum,Jones,mum@example.com,NSW,ABC,,,,,,Invalid,ABC
-Susie,Jones,susie@example.com,farnell,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jones,mum@example.com,NSW,Australia,,Australia,NSW,Australia,NSW,Valid,
-Susie,Jones,susie@example.com,farnell,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,,AU,New South Wales,Australia,New South Wales,Valid,
-Susie,Jones,susie@example.com,FARNELL,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,,1013,New South Wales,1013,New South Wales,Valid,
-Susie,Jones,susie@example.com,Farnell,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,,,,,,Valid,
-Susie,Jones,susie@example.com,Farnell,AU,NEW South Wales,NEW South Wales,AU,AU,NEW South Wales,Mum,Jones,mum@example.com,NEW South Wales,AU,,AU,NEW South Wales,Australia,NEW South Wales,Valid,
-Susie,Jones,susie@example.com,,AU,My own personal fiefdom,My own personal fiefdom,AU,AU,My own personal fiefdom,Mum,Jones,mum@example.com,My own personal fiefdom,AU,,AU,My own personal fiefdom,Australia,My own personal fiefdom,Invalid,rando
+Susie,Jones,susie@example.com,,ABC,,,,,,Mum,Jones,mum@example.com,,,Farnell,,,,,Invalid,ABC
+Susie,Jones,susie@example.com,,,,,,,,Mum,Jones,mum@example.com,NSW,ABC,Farnell,,,,,Invalid,ABC
+Susie,Jones,susie@example.com,farnell,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jones,mum@example.com,NSW,Australia,Farnell,Australia,NSW,Australia,NSW,Valid,
+Susie,Jones,susie@example.com,farnell,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,Farnell,AU,New South Wales,Australia,New South Wales,Valid,
+Susie,Jones,susie@example.com,FARNELL,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,Farnell,1013,New South Wales,1013,New South Wales,Valid,
+Susie,Jones,susie@example.com,Farnell,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,Farnell,,,,,Valid,
+Susie,Jones,susie@example.com,Farnell,AU,NEW South Wales,NEW South Wales,AU,AU,NEW South Wales,Mum,Jones,mum@example.com,NEW South Wales,AU,Farnell,AU,NEW South Wales,Australia,NEW South Wales,Valid,
+Susie,Jones,susie@example.com,,AU,My own personal fiefdom,My own personal fiefdom,AU,AU,My own personal fiefdom,Mum,Jones,mum@example.com,My own personal fiefdom,AU,Farnell,AU,My own personal fiefdom,Australia,My own personal fiefdom,Invalid,rando

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1292,6 +1292,8 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testImportCountryStateCounty(): void {
+    $sql = "INSERT INTO civicrm_county SET id = 999, name = 'Farnell', abbreviation = '', state_province_id = 1640, is_active = 1";
+    \CRM_Core_DAO::executeQuery($sql);
     $childKey = $this->getRelationships()['Child of']['id'] . '_a_b';
     $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
     $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);
@@ -1338,6 +1340,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->importCSV($csv, $mapper);
     $contacts = $this->getImportedContacts();
     foreach ($contacts as $contact) {
+      $this->assertEquals(999, $contact['address'][0]['county_id']);
       $this->assertEquals(1013, $contact['address'][0]['country_id']);
       $this->assertEquals(1640, $contact['address'][0]['state_province_id']);
     }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -17,6 +17,7 @@
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\ContactType;
+use Civi\Api4\County;
 use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Email;
 use Civi\Api4\Group;
@@ -1292,8 +1293,11 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testImportCountryStateCounty(): void {
-    $sql = "INSERT INTO civicrm_county SET id = 999, name = 'Farnell', abbreviation = '', state_province_id = 1640, is_active = 1";
-    \CRM_Core_DAO::executeQuery($sql);
+    $countyID = County::create()->setValues([
+      'name' => 'Farnell',
+      'abbreviation' => '',
+      'state_province_id' => 1640,
+    ])->execute()->first()['id'];
     $childKey = $this->getRelationships()['Child of']['id'] . '_a_b';
     $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
     $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);
@@ -1340,7 +1344,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->importCSV($csv, $mapper);
     $contacts = $this->getImportedContacts();
     foreach ($contacts as $contact) {
-      $this->assertEquals(999, $contact['address'][0]['county_id']);
+      $this->assertEquals($countyID, $contact['address'][0]['county_id']);
       $this->assertEquals(1013, $contact['address'][0]['country_id']);
       $this->assertEquals(1640, $contact['address'][0]['state_province_id']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
I was attempting to address the issue @jmcclelland is showing here https://github.com/civicrm/civicrm-core/pull/24917 - but I found that the tests passed, once I had addressed 2 issues with it

- Caching - this was the main one - the option values are cached
- The csv - after I fixed ^^ I found the csv checks for the same values on the related contact as the main contact