### PR TITLE
dev/core#3962 Add 'boolean' as a filter for tokens

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -494,6 +494,10 @@ class TokenProcessor {
       case 'lower':
         return mb_strtolower($value);
 
+      case 'boolean':
+        // Cast to 0 or 1 for use in text.
+        return (int) ((bool) $value);
+
       case 'crmDate':
         if ($value instanceof \DateTime) {
           // @todo cludgey.
@@ -505,7 +509,7 @@ class TokenProcessor {
         }
 
       default:
-        throw new \CRM_Core_Exception("Invalid token filter: " . json_encode($filter, JSON_UNESCAPED_SLASHES));
+        throw new \CRM_Core_Exception('Invalid token filter: ' . json_encode($filter, JSON_UNESCAPED_SLASHES));
     }
   }
 

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -341,14 +341,18 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     $this->assertEquals(1, $this->counts['onEvalTokens']);
   }
 
-  public function testFilter() {
+  public function testFilter(): void {
     $exampleTokens['foo_bar']['whiz_bang'] = 'Some Text';
+    $exampleTokens['foo_bar']['whiz_bop'] = '';
     $exampleMessages = [
       'This is {foo_bar.whiz_bang}.' => 'This is Some Text.',
       'This is {foo_bar.whiz_bang|lower}...' => 'This is some text...',
       'This is {foo_bar.whiz_bang|upper}!' => 'This is SOME TEXT!',
+      'This is {foo_bar.whiz_bang|boolean}!' => 'This is 1!',
+      'This is {foo_bar.whiz_bop|boolean}!' => 'This is 0!',
     ];
-    $expectExampleCount = /* {#msgs} x {smarty:on,off} */ 6;
+    // We expect 5 messages to be parsed 2 times each - ie 10 times.
+    $expectExampleCount = 10;
     $actualExampleCount = 0;
 
     foreach ($exampleMessages as $inputMessage => $expectOutput) {


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#3962 Add 'boolean' as a filter for tokens

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/3962 it is very difficult to combine smarty with tokens in `text/plain` messages as appostrophes break our existing work-around of using `{if '{contact.first_name}'}{/if}'

After
----------------------------------------
New modifier added `|boolean` e.g `{if '{contact.first_name|boolean}'}{/if}'

Technical Details
----------------------------------------
I was originally going to use the shorter 'bool' on the basis `bool` is a well established shortening of `boolean` within code. But of course not everyone reading it is familiar with that, or English speaking. I decided that as usual the marginal benefits of using an abbreviation don't stack up compared with the advantage of using an actual word that most people will understand (even if they don't understand the syntax)

Comments
----------------------------------------
The PR is mostly tests :-)