### PR TITLE
Fold `processGreetingTemplate` function only called from one place into caller, deprecate

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -1009,7 +1009,8 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
         }
       }
 
-      self::processGreetingTemplate($greetingString, [], $contactID, 'CRM_UpdateGreeting');
+      CRM_Utils_Token::replaceGreetingTokens($greetingString, [], $contactID, 'CRM_UpdateGreeting', TRUE);
+      $greetingString = CRM_Utils_String::parseOneOffStringThroughSmarty($greetingString);
       $greetingString = CRM_Core_DAO::escapeString($greetingString);
       $cacheFieldQuery .= " WHEN {$contactID} THEN '{$greetingString}' ";
 
@@ -1115,11 +1116,14 @@ WHERE id IN (" . implode(',', $contactIds) . ")";
    * @param string $templateString
    *   The greeting template string with contact tokens + Smarty syntax.
    *
+   * @deprecated
+   *
    * @param array $contactDetails
    * @param int $contactID
    * @param string $className
    */
   public static function processGreetingTemplate(&$templateString, $contactDetails, $contactID, $className) {
+    CRM_Core_Error::deprecatedFunctionWarning('no replacement');
     CRM_Utils_Token::replaceGreetingTokens($templateString, $contactDetails, $contactID, $className, TRUE);
     $templateString = CRM_Utils_String::parseOneOffStringThroughSmarty($templateString);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fold `processGreetingTemplate` function only called from one place into caller, deprecate

(Covered by test in api_v3_JobTest::testCallUpdateGreetingSuccess)

Before
----------------------------------------
2 line function only called from one place, can no longer justify it's existance

After
----------------------------------------
Folded back in, deprecated

![image](https://user-images.githubusercontent.com/336308/200496383-d2648f5b-7b74-4c35-b52d-667eecb4c1b0.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
