### PR TITLE
dev/core#3977 Handle dodgier calls to setBillingCountry in property bag.

### DIFF
--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -463,6 +463,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     // Many sorts of nothingness
     foreach ([NULL, 0, FALSE] as $bad) {
       $propertyBag = new PropertyBag();
+      $propertyBag->ignoreDeprecatedWarningsInFunction = 'setBillingCountry';
       $propertyBag->setBillingCountry($bad);
       $this->assertCount(1, $propertyBag->logs);
       $latestLog = end($propertyBag->logs);
@@ -472,6 +473,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
     // '' special case
     $propertyBag = new PropertyBag();
+    $propertyBag->ignoreDeprecatedWarningsInFunction = 'setBillingCountry';
     $propertyBag->setBillingCountry('');
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
@@ -480,6 +482,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
     // Invalid country name
     $propertyBag = new PropertyBag();
+    $propertyBag->ignoreDeprecatedWarningsInFunction = 'setBillingCountry';
     $propertyBag->setBillingCountry('UnitedKing');
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
@@ -488,6 +491,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
     // Valid country name
     $propertyBag = new PropertyBag();
+    $propertyBag->ignoreDeprecatedWarningsInFunction = 'setBillingCountry';
     $propertyBag->setBillingCountry('United Kingdom');
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
@@ -496,6 +500,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
     // Invalid country ID
     $propertyBag = new PropertyBag();
+    $propertyBag->ignoreDeprecatedWarningsInFunction = 'setBillingCountry';
     $propertyBag->setBillingCountry(-1);
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
@@ -504,6 +509,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
 
     // Valid country ID
     $propertyBag = new PropertyBag();
+    $propertyBag->ignoreDeprecatedWarningsInFunction = 'setBillingCountry';
     $propertyBag->setBillingCountry(1154); /* should be New Zealand */
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);


### PR DESCRIPTION
Alternative to https://github.com/civicrm/civicrm-core/pull/24903 

As a solution to https://lab.civicrm.org/dev/core/-/issues/3977 & to getting back the regression in https://lab.civicrm.org/dev/core/-/issues/3918

This does what @mattwire's suggestion does but includes @eileenmcnaughton's suggestion of munging.

TL;DR:

- lots of code calls setBillingCountry incorrectly, some passing country IDs, nulls, empty strings, country names, the time of day - who knows.
- propertyBag thowing errors caused too much pain.
- this PR munges crap input where possible (translating IDs, names to ISO codes) but logs it as a warning.
- anything that can't be munged gets set to `''` (empty string). boo.
- no exceptions thrown
- big test added.

