### PR TITLE
Add html_attributes to API4 Setting

### DIFF
--- a/Civi/Api4/Action/Setting/GetFields.php
+++ b/Civi/Api4/Action/Setting/GetFields.php
@@ -80,6 +80,10 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
         'data_type' => 'String',
       ],
       [
+        'name' => 'html_attributes',
+        'data_type' => 'Array',
+      ],
+      [
         'name' => 'add',
         'data_type' => 'String',
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Used to specify eg. size for an HTML element

Before
----------------------------------------
Not available via API.

After
----------------------------------------
Available via API.

Technical Details
----------------------------------------
This is a metadata field specified by the `.settings.php` metadata and does not exist in the database - like `html_type`.

Comments
----------------------------------------
