### PR TITLE
[dev/backdrop#76] The control buttons in crm pop ups are all X's

### DIFF
--- a/css/backdrop.css
+++ b/css/backdrop.css
@@ -34,3 +34,26 @@
   background: transparent url(../i/logo_sm.png) 5% center no-repeat;
   background-size: 16px;
 }
+
+/* Fix title bar icons in crm-popups*/
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-print::before,
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-print::after,
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-compress::before,
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-compress::after,
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-expand::before,
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-expand::after {
+  transform: none;
+  background: none;
+}
+
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-expand::before {
+  content: "\f065";
+}
+
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-print::before {
+  content: "\f02f";
+}
+
+.crm-container.ui-dialog .ui-dialog-titlebar-close .ui-icon.fa-compress::before {
+  content: "\f066";
+}


### PR DESCRIPTION
Overview
----------------------------------------
fixes the icons in the title bar in crm popups more details here: https://lab.civicrm.org/dev/backdrop/-/issues/76

Before
------------
![allexes](https://user-images.githubusercontent.com/11323624/200653312-47b08d23-24d6-402f-b378-530d7a92fa0e.png)

After
--------------
![popupicons](https://user-images.githubusercontent.com/11323624/200653286-d3f863d6-37c0-4d4f-8e97-f16990168701.png)
