### PR TITLE
TabHeader: remove redundant history.replaceState

### DIFF
--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -20,7 +20,7 @@
         var tabId = ui.newTab.attr('id');
         if (tabId && tabId.length) {
           tabId = tabId.slice(4); // Remove leading 'tab_'
-          history.replaceState(null, '', updateUrlParameter('selectedChild', tabId));
+          updateUrlParameter('selectedChild', tabId);
         }
       })
       .on('tabsbeforeload', function(e, ui) {


### PR DESCRIPTION
@braders I was having a look at something unrelated for the TabHeaders, and wondering if `history.replaceState` is called twice on purpose, or if it's a typo?

i.e. the `updateUrlParameter` function ends with: `window.history.replaceState("", "", newUrl);` and does not return anything.

(I very much enjoy this feature, by the way!)

Original PR: #22316