### PR TITLE
Add noisy deprecation to unused functions `replaceContactTokens`, `replaceCaseTokens`

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -619,6 +619,7 @@ class CRM_Utils_Token {
     $returnBlankToken = FALSE,
     $escapeSmarty = FALSE
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     // Refresh contact tokens in case they have changed. There is heavy caching
     // in exportable fields so there is no benefit in doing this conditionally.
     self::$_tokens['contact'] = array_merge(
@@ -1598,6 +1599,7 @@ class CRM_Utils_Token {
    * @throws \CRM_Core_Exception
    */
   public static function replaceCaseTokens($caseId, $str, $knownTokens = NULL, $escapeSmarty = FALSE): string {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     if (strpos($str, '{case.') === FALSE) {
       return $str;
     }

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1565,29 +1565,6 @@ $text
     }
   }
 
-  public function testCaseTokens() {
-    $caseTest = new CiviCaseTestCase();
-    $caseTest->setUp();
-    // Create a contact and contactDetails array.
-    $contactId = $this->individualCreate();
-
-    // create a case for this user
-    $result = $this->callAPISuccess('Case', 'create', [
-      'contact_id' => $contactId,
-      'case_type_id' => '1',
-      'subject' => "my case",
-      'status_id' => "Open",
-    ]);
-
-    $caseId = $result['id'];
-    $html_message = "<p>This is a test case with id: {case.id} and subject: {case.subject}</p>";
-    $html_message = CRM_Utils_Token::replaceCaseTokens($caseId, $html_message);
-
-    $this->assertTrue(strpos($html_message, 'id: ' . $caseId) !== 0);
-    $this->assertTrue(strpos($html_message, 'subject: my case') !== 0);
-    $caseTest->tearDown();
-  }
-
   public function testSendEmailWithCaseId() {
     $caseTest = new CiviCaseTestCase();
     $caseTest->setUp();

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -58,8 +58,6 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
 
   /**
    * Test that case tokens are consistently rendered.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCaseTokenConsistency(): void {
     $this->createLoggedInUser();
@@ -67,17 +65,7 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
     $this->createCustomGroupWithFieldOfType(['extends' => 'Case']);
     $tokens = CRM_Core_SelectValues::caseTokens();
     $this->assertEquals($this->getCaseTokens(), $tokens);
-    $caseID = $this->getCaseID();
     $tokenString = $this->getTokenString(array_keys($this->getCaseTokens()));
-    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, $tokenString, ['case' => $this->getCaseTokenKeys()]);
-    $this->assertEquals($this->getExpectedCaseTokenOutput(), $tokenHtml);
-    // Now do the same without passing in 'knownTokens'
-    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, $tokenString);
-    $this->assertEquals($this->getExpectedCaseTokenOutput(), $tokenHtml);
-
-    // And check our deprecated tokens still work.
-    $tokenHtml = CRM_Utils_Token::replaceCaseTokens($caseID, '{case.case_type_id} {case.status_id}');
-    $this->assertEquals('Housing Support Ongoing', $tokenHtml);
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
       'controller' => __CLASS__,
       'smarty' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Add noisy deprecation to unused functions

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/200667435-bf3e9063-ed88-4cd9-831a-0e4f9194ce34.png)

![image](https://user-images.githubusercontent.com/336308/200667529-3bfbf8f4-7db8-46d0-84ee-8e6d47aeda21.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
Note the test cover for the token processor tokens is still there - so we haven't lost test coverage here

Comments
----------------------------------------

