### PR TITLE
Fix api handling of OptionValue defaults

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/OptionValueTest.php
+++ b/tests/phpunit/CRM/Core/BAO/OptionValueTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\OptionValue;
+
 /**
  * Class CRM_Core_BAO_SchemaHandlerTest.
  *
@@ -23,13 +25,58 @@ class CRM_Core_BAO_OptionValueTest extends CiviUnitTestCase {
    */
   public function setUp(): void {
     parent::setUp();
-    $this->useTransaction(TRUE);
+    $this->useTransaction();
+  }
+
+  /**
+   * Test that option values that support more than one default maintain them.
+   *
+   * There is code to support updating default = 0 for other options
+   * when an option value is set to 1. However, some option groups (eg.
+   * email_greeting) support multiple option values.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testHandlingForMultiDefaultOptions(): void {
+    foreach (['email_greeting', 'postal_greeting', 'addressee'] as $optionGroupName) {
+      $options = $this->getDefaultOptions($optionGroupName);
+      $existing = count($options);
+      OptionValue::update()->addWhere('id', 'IN', array_keys($options))
+        ->setValues(['description', '=', 'updated', 'is_default' => TRUE])
+        ->execute();
+      $options = $this->getDefaultOptions($optionGroupName);
+      $this->assertCount($existing, $options, 'There should be no change in the number of default options');
+    }
+  }
+
+  /**
+   * Test that option values that support more than one default maintain them.
+   *
+   * The from_email_address supports a single default per domain.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testDefaultHandlingForFromEmailAddress(): void {
+    $options = $this->getDefaultOptions('from_email_address');
+    $this->assertCount(2, $options);
+    OptionValue::create()
+      ->setValues([
+        'option_group_id:name' => 'from_email_address',
+        'is_default' => TRUE,
+        'label' => 'email@example.com',
+        'name' => 'email@example.com',
+        'value' => 3,
+      ])
+      ->execute();
+
+    $options = $this->getDefaultOptions('from_email_address');
+    $this->assertCount(2, $options, 'There should be one default per domain');
   }
 
   /**
    * Ensure only one option value exists after calling ensureOptionValueExists.
    */
-  public function testEnsureOptionValueExistsExistingValue() {
+  public function testEnsureOptionValueExistsExistingValue(): void {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists(['name' => 'Completed', 'option_group_id' => 'contribution_status']);
     $this->callAPISuccessGetSingle('OptionValue', ['name' => 'Completed', 'option_group_id' => 'contribution_status']);
   }
@@ -37,11 +84,11 @@ class CRM_Core_BAO_OptionValueTest extends CiviUnitTestCase {
   /**
    * Ensure only one option value exists adds a new value.
    */
-  public function testEnsureOptionValueExistsNewValue() {
+  public function testEnsureOptionValueExistsNewValue(): void {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists(['name' => 'Bombed', 'option_group_id' => 'contribution_status']);
     $optionValues = $this->callAPISuccess('OptionValue', 'get', ['option_group_id' => 'contribution_status']);
     foreach ($optionValues['values'] as $value) {
-      if ($value['name'] == 'Bombed') {
+      if ($value['name'] === 'Bombed') {
         return;
       }
     }
@@ -54,7 +101,7 @@ class CRM_Core_BAO_OptionValueTest extends CiviUnitTestCase {
    * (Our expectation is no change - ie. currently we are respecting 'someone's
    * decision to disable it & leaving it in that state.
    */
-  public function testEnsureOptionValueExistsDisabled() {
+  public function testEnsureOptionValueExistsDisabled(): void {
     $optionValue = CRM_Core_BAO_OptionValue::ensureOptionValueExists(['name' => 'Crashed', 'option_group_id' => 'contribution_status', 'is_active' => 0]);
     $value = $this->callAPISuccessGetSingle('OptionValue', ['name' => 'Crashed', 'option_group_id' => 'contribution_status']);
     $this->assertEquals(0, $value['is_active']);
@@ -64,6 +111,21 @@ class CRM_Core_BAO_OptionValueTest extends CiviUnitTestCase {
     $value = $this->callAPISuccessGetSingle('OptionValue', ['name' => 'Crashed', 'option_group_id' => 'contribution_status']);
     $this->assertEquals(0, $value['is_active']);
     $this->assertEquals($value['id'], $optionValue['id']);
+  }
+
+  /**
+   * @param string $optionGroupName
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected function getDefaultOptions(string $optionGroupName): array {
+    $options = (array) OptionValue::get()
+      ->addWhere('option_group_id:name', '=', $optionGroupName)
+      ->addWhere('is_default', '=', TRUE)
+      ->execute()->indexBy('id');
+    return $options;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix api handling of OptionValue defaults

Before
----------------------------------------
Some option values (greetings, from_email_address) have more than one default. For from_email_address it is per domain and for the others it is per 'filter' (aka contact_type).

The special handling for greetings relies on the form layer - updating a greeting for 'Individual' and passing 'is_default' will unset 'is_default' for Household greetings.

For from_email_address the form layer magic-param is set but ultimately has no bearing as there is duplicate handling in the bao layer

After
----------------------------------------
The default handling is done in the BAO layer & removed from the form layer

Technical Details
----------------------------------------
I moved the handling to after-update because values are more guarantee there. I did this by excluding the id from the update query (also prevents flappy updates). I didn't move all the way to the post hook because I wasn't sure about the interaction with cache flushing etc (that already happen after save in create) but that could be considered.

