### PR TITLE
Add new Organization Example contact (The Daily Bugle)

### DIFF
--- a/Civi/Test/EntityExample.php
+++ b/Civi/Test/EntityExample.php
@@ -24,6 +24,15 @@ abstract class EntityExample implements ExampleDataInterface {
    */
   protected $exName;
 
+  /**
+   * Get the name of the example.
+   *
+   * @return string
+   */
+  protected function getExampleName(): string {
+    return $this->exName;
+  }
+
   public function __construct() {
     if (!preg_match(';^(.*)[_\\\]([a-zA-Z0-9]+)[_\\\]([a-zA-Z0-9]+)$;', static::class, $m)) {
       throw new \RuntimeException("Failed to parse class: " . static::class);

--- a/Civi/Test/ExampleData/Contact/TheDailyBugle.php
+++ b/Civi/Test/ExampleData/Contact/TheDailyBugle.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Civi\Test\ExampleData\Contact;
+
+use Civi\Test\EntityExample;
+
+class TheDailyBugle extends EntityExample {
+
+  public function getExamples(): iterable {
+    yield [
+      'name' => "entity/{$this->entityName}/" . $this->getExampleName(),
+    ];
+  }
+
+  public function build(array &$example): void {
+    $example['data'] = [
+      'contact_id' => 102,
+      'contact_type' => 'Organization',
+      'organization_name' => 'The Daily Bugle',
+      'sort_name' => 'Daily Bugle',
+      'display_name' => 'The Daily Bugle',
+      'do_not_email' => 1,
+      'do_not_phone' => 1,
+      'do_not_mail' => 0,
+      'do_not_sms' => 0,
+      'do_not_trade' => 0,
+      'is_opt_out' => 0,
+      'legal_name' => 'The Daily Bugle',
+      'sic_code' => NULL,
+      'contact_is_deleted' => '0',
+      'email_primary.email' => 'clark@example.com',
+      'address_primary.street_address' => 'Goodman Building',
+      'address_primary.supplemental_address' => 'Cnr 39th Street and Second Avenue',
+      'address_primary.city' => 'New York',
+      'email_greeting_id' => 1,
+      'email_greeting_display' => 'Dear Bugle Reporters',
+      'postal_greeting_id' => 1,
+      'postal_greeting_display' => 'Dear Bugle Reporters',
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add new Organization Example contact (The Daily Bugle)

Before
----------------------------------------
Examples are only individuals

After
---------------------------------------
We have an organization

Technical Details
----------------------------------------
This is not used as of this PR - but it sits alongside 'Alex' & 'Barb' as available

Comments
----------------------------------------
Examples are used in Message Templates & the hope is to also use some of them in UnitTests
