### PR TITLE
dev/core#3981 Fix Examples to use 0 rather than a possibly-real contact_id

### DIFF
--- a/Civi/Test/ExampleData/Contact/Alex.php
+++ b/Civi/Test/ExampleData/Contact/Alex.php
@@ -2,7 +2,9 @@
 
 namespace Civi\Test\ExampleData\Contact;
 
-class Alex extends \Civi\Test\EntityExample {
+use Civi\Test\EntityExample;
+
+class Alex extends EntityExample {
 
   public function getExamples(): iterable {
     yield [
@@ -12,7 +14,7 @@ class Alex extends \Civi\Test\EntityExample {
 
   public function build(array &$example): void {
     $example['data'] = [
-      'id' => '100',
+      'id' => 0,
       'first_name' => 'Alex',
       'middle_name' => '',
       'last_name' => 'D\u00edaz',

--- a/Civi/Test/ExampleData/Contact/Barb.php
+++ b/Civi/Test/ExampleData/Contact/Barb.php
@@ -2,7 +2,9 @@
 
 namespace Civi\Test\ExampleData\Contact;
 
-class Barb extends \Civi\Test\EntityExample {
+use Civi\Test\EntityExample;
+
+class Barb extends EntityExample {
 
   public function getExamples(): iterable {
     yield [
@@ -12,7 +14,7 @@ class Barb extends \Civi\Test\EntityExample {
 
   public function build(array &$example): void {
     $example['data'] = [
-      'contact_id' => '100',
+      'contact_id' => 0,
       'contact_type' => 'Individual',
       'contact_sub_type' => NULL,
       'sort_name' => 'Johnson, Barbara',

--- a/Civi/Test/ExampleData/Contact/TheDailyBugle.php
+++ b/Civi/Test/ExampleData/Contact/TheDailyBugle.php
@@ -14,7 +14,7 @@ class TheDailyBugle extends EntityExample {
 
   public function build(array &$example): void {
     $example['data'] = [
-      'contact_id' => 102,
+      'contact_id' => 0,
       'contact_type' => 'Organization',
       'organization_name' => 'The Daily Bugle',
       'sort_name' => 'Daily Bugle',

--- a/tests/phpunit/api/v4/Entity/ExampleDataTest.php
+++ b/tests/phpunit/api/v4/Entity/ExampleDataTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\ExampleData;
 
 /**
  * @group headless
@@ -30,15 +31,14 @@ class ExampleDataTest extends Api4TestBase {
    * Basic canary test fetching a specific example.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function testGet() {
+  public function testGet(): void {
     $file = \Civi::paths()->getPath('[civicrm.root]/Civi/WorkflowMessage/GenericWorkflowMessage/Alex.php');
     $name = 'workflow/generic/Alex';
 
-    $this->assertTrue(file_exists($file), "Expect find canary file ($file)");
+    $this->assertFileExists($file, "Expect find canary file ($file)");
 
-    $get = \Civi\Api4\ExampleData::get()
+    $get = ExampleData::get()
       ->addWhere('name', '=', $name)
       ->execute()
       ->single();
@@ -46,7 +46,7 @@ class ExampleDataTest extends Api4TestBase {
     $this->assertTrue(!isset($get['data']), 'Default "get" should not return "data"');
     $this->assertTrue(!isset($get['asserts']), 'Default "get" should not return "asserts"');
 
-    $get = \Civi\Api4\ExampleData::get()
+    $get = ExampleData::get()
       ->addWhere('name', 'LIKE', 'workflow/generic/%')
       ->execute();
     $this->assertTrue($get->count() > 0);
@@ -54,13 +54,13 @@ class ExampleDataTest extends Api4TestBase {
       $this->assertStringStartsWith('workflow/generic/', $gotten['name']);
     }
 
-    $get = \Civi\Api4\ExampleData::get()
+    $get = ExampleData::get()
       ->addWhere('name', '=', $name)
       ->addSelect('workflow', 'data')
       ->execute()
       ->single();
     $this->assertEquals($name, $get['name']);
-    $this->assertEquals(100, $get['data']['modelProps']['contact']['id']);
+    $this->assertEquals(0, $get['data']['modelProps']['contact']['id']);
   }
 
 }


### PR DESCRIPTION
Overview
================================================== 

dev/core#3981 Fix Examples to use 0 rather than a possibly-real contact_id

https://lab.civicrm.org/dev/core/-/issues/3981

Before
==============================================
When using the Message Admin UI and trying out tokens those that are not explicitly defined in the sample data are fetched from the database from the contact whose id has been arbitrarily used. (screenshots in the gitlab https://lab.civicrm.org/dev/core/-/issues/3981) 

After
======================================================================= 
The contact_id is set to 0. As a result nothing is retrievable from the database and undefined parameters stay blank

Technical Details
=======================================================================
 I suspect this was not possible when the example was first written (the token code has matured a bit) & a stand in number seemed intuitive - but I think that is arguable even when there are no negative side effects (for example if a url were in the letter then linking to a random contact from it is kinda confusing) - but really loses it's potency as an argument when there ARE negative side effects

Comments
============================================================================ 
I'm pretty sure there are some tests I need to adjust for this.... but from my UI testing this works fine & removes the leakage

@totten 