### PR TITLE
Simplify removing file extension when using basename function

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -52,7 +52,7 @@ class CRM_Upgrade_Incremental_Base {
     $sqlGlob = implode(DIRECTORY_SEPARATOR, [dirname(__FILE__), 'sql', $this->getMajorMinor() . '.*.mysql.tpl']);
     $sqlFiles = glob($sqlGlob);;
     foreach ($sqlFiles as $file) {
-      $revList[] = str_replace('.mysql.tpl', '', basename($file));
+      $revList[] = basename($file, '.mysql.tpl');
     }
 
     $c = new ReflectionClass(static::class);

--- a/mixin/ang-php@1/mixin.php
+++ b/mixin/ang-php@1/mixin.php
@@ -26,7 +26,7 @@ return function ($mixInfo, $bootCache) {
 
     $files = (array) glob($mixInfo->getPath('ang/*.ang.php'));
     foreach ($files as $file) {
-      $name = preg_replace(':\.ang\.php$:', '', basename($file));
+      $name = basename($file, '.ang.php');
       $module = include $file;
       if (empty($module['ext'])) {
         $module['ext'] = $mixInfo->longName;

--- a/mixin/case-xml@1/mixin.php
+++ b/mixin/case-xml@1/mixin.php
@@ -26,7 +26,7 @@ return function ($mixInfo, $bootCache) {
     }
 
     foreach ((array) glob($mixInfo->getPath('xml/case/*.xml')) as $file) {
-      $name = preg_replace('/\.xml$/', '', basename($file));
+      $name = basename($file, '.xml');
       if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
         $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
         throw new CRM_Core_Exception($errorMessage);

--- a/mixin/theme-php@1/mixin.php
+++ b/mixin/theme-php@1/mixin.php
@@ -27,7 +27,7 @@ return function ($mixInfo, $bootCache) {
     foreach ($files as $file) {
       $themeMeta = include $file;
       if (empty($themeMeta['name'])) {
-        $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+        $themeMeta['name'] = basename($file, '.theme.php');
       }
       if (empty($themeMeta['ext'])) {
         $themeMeta['ext'] = $mixInfo->longName;

--- a/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
+++ b/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.php
@@ -28,7 +28,7 @@ class E2E_Shimmy_LifecycleTest extends \PHPUnit\Framework\TestCase implements \C
     $mixinTestFiles = (array) glob($this->getPath('/tests/mixin/*Test.php'));
     foreach ($mixinTestFiles as $file) {
       require_once $file;
-      $class = '\\Civi\Shimmy\\Mixins\\' . preg_replace(';\.php$;', '', basename($file));
+      $class = '\\Civi\Shimmy\\Mixins\\' . basename($file, '.php');
       $this->mixinTests[] = new $class();
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Code simplification

Technical Details
----------------------------------------
The basename function has a native way of removing file extensions, so the use of str_replace or preg_replace is usually unnecessary.