### PR TITLE
Fix WP Clean Pages check when components are disabled

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1531,7 +1531,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     }
     if ($clean == 1) {
       //cleanURLs are enabled in CiviCRM, let's make sure the wordpress permalink settings and cache are actually correct by checking the first active contribution page
-      $contributionPages = \Civi\Api4\ContributionPage::get(FALSE)
+      $contributionPages = !CRM_Core_Component::isEnabled('CiviContribute') ? [] : \Civi\Api4\ContributionPage::get(FALSE)
         ->addSelect('id')
         ->addWhere('is_active', '=', TRUE)
         ->setLimit(1)
@@ -1544,7 +1544,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       }
       else {
         //no active contribution pages, we can check an event page. This probably won't ever happen.
-        $eventPages = \Civi\Api4\Event::get(FALSE)
+        $eventPages = !CRM_Core_Component::isEnabled('CiviEvent') ? [] : \Civi\Api4\Event::get(FALSE)
           ->addSelect('id')
           ->addWhere('is_active', '=', TRUE)
           ->setLimit(1)


### PR DESCRIPTION
Overview
----------------------------------------
In CiviCRM 5.55.1, the Clean URLs check fails on WordPress with CiviContribute disabled with the error `ContributionPage API is not available because CiviContribute component is disabled`. This doesn't happen on 5.54.1.

Before
----------------------------------------
Error.

After
----------------------------------------
No error.

Technical Details
----------------------------------------
Previously I suppose the APIs were available even if the component was enabled - but now it's not, so we check first.