### PR TITLE
Remove php8-specific coding pattern

### DIFF
--- a/Civi/Payment/PropertyBag.php
+++ b/Civi/Payment/PropertyBag.php
@@ -97,7 +97,7 @@ class PropertyBag implements \ArrayAccess {
    *
    * @var string
    */
-  public string $ignoreDeprecatedWarningsInFunction = '';
+  public $ignoreDeprecatedWarningsInFunction = '';
 
   /**
    * @var bool


### PR DESCRIPTION
I'm gonna self-merge this asap so no-one else hits it - the PR that caused it was only just merged

@artfulrobot - even if you are using php8 your IDE can be told to think of it as php 7.3.... (PhpStorm can anyway)