### PR TITLE
Turn 'From' dropdown in mailings into a searchable select2

### DIFF
--- a/ang/crmMailing/BlockMailing.html
+++ b/ang/crmMailing/BlockMailing.html
@@ -14,6 +14,7 @@ It could perhaps be thinned by 30-60% by making more directives.
         <select
           crm-ui-id="subform.fromAddress"
           crm-ui-select="{dropdownAutoWidth : true, allowClear: false, placeholder: ts('Email address')}"
+          ui-jq="select2"
           name="fromAddress"
           ng-model="fromPlaceholder.label"
           required>


### PR DESCRIPTION
Overview
----------------------------------------
Turn the 'From' dropdown in mailings into a searchable select2.

Before
----------------------------------------
Standard select dropdown. This can get very large and unwieldly.

After
----------------------------------------
Lovely searchable list.

Technical Details
----------------------------------------
This seems to be a standard way of turning an angular field into a select2. Not all fields seem to do it this way, though, so hopefully it makes sense here.
