### PR TITLE
Turn 'From' dropdown in 'Send Email' into a searchable select2

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -231,7 +231,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
 
     $this->add('text', 'subject', ts('Subject'), ['size' => 50, 'maxlength' => 254], TRUE);
 
-    $this->add('select', 'from_email_address', ts('From'), $this->getFromEmails(), TRUE);
+    $this->add('select', 'from_email_address', ts('From'), $this->getFromEmails(), TRUE, ['class' => 'crm-select2 huge']);
 
     CRM_Mailing_BAO_Mailing::commonCompose($this);
 


### PR DESCRIPTION
Overview
----------------------------------------
Turn the 'From' dropdown in the standard 'Send Email' screen into a searchable select2.

Before
----------------------------------------
Standard select dropdown. This can get very large and unwieldly.

![image](https://user-images.githubusercontent.com/28389118/201347208-b01d477d-2b85-4517-bb15-68134e3ca54d.png)

After
----------------------------------------
Lovely searchable list.

![image](https://user-images.githubusercontent.com/28389118/201347104-ac416477-e275-493e-858e-1fb436386e12.png)
