### PR TITLE
[REF] Afform - Use autoservice for event subscribers

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactDedupe.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactDedupe.php
@@ -1,5 +1,5 @@
 <?php
-namespace Civi\Afform\behavior;
+namespace Civi\Afform\Behavior;
 
 use Civi\Afform\AbstractBehavior;
 use Civi\Afform\Event\AfformSubmitEvent;

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Api4\Subscriber;
 
+use Civi\Core\Service\AutoService;
 use Civi\Afform\FormDataModel;
 use Civi\API\Events;
 use Civi\Api4\Afform;
@@ -18,8 +19,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Preprocess api autocomplete requests
+ * @service
+ * @internal
  */
-class AutocompleteSubscriber implements EventSubscriberInterface {
+class AfformAutocompleteSubscriber extends AutoService implements EventSubscriberInterface {
 
   /**
    * @return array
@@ -34,7 +37,7 @@ class AutocompleteSubscriber implements EventSubscriberInterface {
    * @param \Civi\API\Event\PrepareEvent $event
    *   API preparation event.
    */
-  public function onApiPrepare(\Civi\API\Event\PrepareEvent $event) {
+  public function onApiPrepare(\Civi\API\Event\PrepareEvent $event): void {
     $apiRequest = $event->getApiRequest();
     if (is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
       $formName = $apiRequest->getFormName();

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -57,9 +57,6 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);
   $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\Afform\Get', 'getCustomGroupBlocks']);
-  $dispatcher->addSubscriber(new \Civi\Api4\Subscriber\AutocompleteSubscriber());
-  $dispatcher->addSubscriber(new \Civi\Afform\Behavior\ContactAutofill());
-  $dispatcher->addSubscriber(new \Civi\Afform\Behavior\ContactDedupe());
 
   // Register support for email tokens
   if (CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes 3 hard-coded subscriber registrations in favor of the new `AutoService` approach.

Notes
----------------
Only one class had to be modified to extend `AutoService`. The other two were already doing so (via their parent class) so those registrations were redundant.