### PR TITLE
Backport use AutoService for Afform AutocompleteSubscriber

### DIFF
--- a/ext/afform/core/Civi/Api4/Subscriber/AutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AutocompleteSubscriber.php
@@ -14,12 +14,15 @@ namespace Civi\Api4\Subscriber;
 use Civi\Afform\FormDataModel;
 use Civi\API\Events;
 use Civi\Api4\Afform;
+use Civi\Core\Service\AutoService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Preprocess api autocomplete requests
+ * @service
+ * @internal
  */
-class AutocompleteSubscriber implements EventSubscriberInterface {
+class AutocompleteSubscriber extends AutoService implements EventSubscriberInterface {
 
   /**
    * @return array

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -56,7 +56,6 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);
   $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\Afform\Get', 'getCustomGroupBlocks']);
-  $dispatcher->addSubscriber(new \Civi\Api4\Subscriber\AutocompleteSubscriber());
 
   // Register support for email tokens
   if (CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -32,5 +32,6 @@
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>mgd-php@1.1.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
 </extension>


### PR DESCRIPTION
Overview
----------------------------------------
Backports #24962 to 5.55 as it fixes a regression - fatal error when enabling the Afform extension.

For details see https://github.com/civicrm/civicrm-core/pull/24132#issuecomment-1312493751