### PR TITLE
[PHP 8.1 compat] Afform - Fix display of search filter fields

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -62,7 +62,8 @@ class AfformMetadataInjector {
           // If this fieldset is standalone (not linked to an af-entity) it is for get rather than create
           if ($apiEntities) {
             $action = 'get';
-            $entityType = self::getFieldEntityType($afField->getAttribute('name'), \CRM_Utils_JS::decode($apiEntities));
+            $entityList = \CRM_Utils_JS::decode(htmlspecialchars_decode($apiEntities));
+            $entityType = self::getFieldEntityType($afField->getAttribute('name'), $entityList);
           }
           else {
             $entityName = pq($fieldset)->attr('af-fieldset');
@@ -156,7 +157,7 @@ class AfformMetadataInjector {
         $fieldDefn[$name] = \CRM_Utils_JS::encode($prop);
       }
     }
-    pq($afField)->attr('defn', htmlspecialchars(\CRM_Utils_JS::writeObject($fieldDefn)));
+    pq($afField)->attr('defn', htmlspecialchars(\CRM_Utils_JS::writeObject($fieldDefn), ENT_COMPAT));
   }
 
   /**

--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -49,10 +49,10 @@ class AfformSearchMetadataInjector {
                 ->addSelect('settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
                 ->execute()->first();
               if ($display) {
-                pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? [])));
-                pq($component)->attr('api-entity', htmlspecialchars($display['saved_search_id.api_entity']));
-                pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName)));
-                pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName)));
+                pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
+                pq($component)->attr('api-entity', htmlspecialchars($display['saved_search_id.api_entity'], ENT_COMPAT));
+                pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT));
+                pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName), ENT_COMPAT));
 
                 // Add entity names to the fieldset so that afform can populate field metadata
                 $fieldset = pq($component)->parents('[af-fieldset]');
@@ -64,7 +64,7 @@ class AfformSearchMetadataInjector {
                       $entityList[] = $join[2] . ' AS ' . (explode(' AS ', $join[0])[1]);
                     }
                   }
-                  $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList)));
+                  $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList), ENT_COMPAT));
                   // Add field metadata for aggregate fields because they are not in the schema.
                   // Normal entity fields will be handled by AfformMetadataInjector
                   foreach (Meta::getCalcFields($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']) as $fieldInfo) {


### PR DESCRIPTION
Overview
----------------------------------------
In PHP 8.1 Afform search fields stopped working. This is due to an encoding change which broke the parser.

Before
---------------
With PHP 8.1, try creating a search form. Any fields you add will not show up on the form and you'll see an error in the console.

After
------------
Works on all PHP versions

Technical Details
---------------

According to [the changelog](https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog), PHP 8.1 changed the default mode for `htmlspecialchars`, the impact of which is to escape straight quotes instead of leaving them alone.

This ensures the function works the same on all PHP versions by explicitly setting the mode.
