### PR TITLE
Afform - Fix multivalue entityRef fields

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -721,14 +721,14 @@
         bindToController: {
           crmAutocomplete: '<',
           crmAutocompleteParams: '<',
-          multiple: '<',
+          multi: '<',
           autoOpen: '<'
         },
         controller: function($element, $timeout) {
           var ctrl = this;
           $timeout(function() {
             $element.crmAutocomplete(ctrl.crmAutocomplete, ctrl.crmAutocompleteParams, {
-              multiple: ctrl.multiple,
+              multiple: ctrl.multi,
               minimumInputLength: ctrl.autoOpen ? 0 : 1
             });
             // Ensure widget is updated when model changes

--- a/ext/afform/admin/ang/afGuiEditor/inputType/EntityRef.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/EntityRef.html
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <div class="input-group">
-    <input autocomplete="off" type="text" class="form-control" placeholder="{{:: ts('Select %1', {1: $ctrl.getFkEntity().label}) }}" title="{{:: ts('Click to add placeholder text') }}" ng-model="getSet('input_attrs.placeholder')" ng-model-options="$ctrl.editor.debounceWithGetterSetter">
+    <input autocomplete="off" type="text" class="form-control" placeholder="{{:: ts('Select %1', {1: $ctrl.getFkEntity().label || $ctrl.getDefn().label }) }}" title="{{:: ts('Click to add placeholder text') }}" ng-model="getSet('input_attrs.placeholder')" ng-model-options="$ctrl.editor.debounceWithGetterSetter">
     <div class="input-group-btn">
       <button type="button" class="btn btn-default" disabled><i class="crm-i fa-search"></i></button>
     </div>

--- a/ext/afform/core/ang/af/fields/EntityRef.html
+++ b/ext/afform/core/ang/af/fields/EntityRef.html
@@ -6,7 +6,7 @@
        ng-model-options="{getterSetter: true}"
        crm-autocomplete="$ctrl.defn.fk_entity"
        crm-autocomplete-params="{formName: 'afform:' + $ctrl.afFieldset.getFormName(), fieldName: $ctrl.afFieldset.modelName + ':' + $ctrl.fieldName}"
-       multiple="$ctrl.defn.input_attrs.multiple"
+       multi="$ctrl.defn.input_attrs.multiple"
        auto-open="$ctrl.defn.input_attrs.autoOpen"
        placeholder="{{:: $ctrl.defn.input_attrs.placeholder }}"
        ng-change="$ctrl.onSelectEntity()" >


### PR DESCRIPTION
Overview
----------------------------------------
Followup fixes from #24832 

Before
----------------------------------------
To reproduce (master branch):

1. Create a search for contributions
2. Make a form for the search
3. Add "Campaign" as a filter field
4. Notice the label displays wrong in the editor, and setting it to "Multiple" doesn't actually work.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Apparently 'multiple' is a reserved word and wasn't working as an angular param, switching it to 'multi' fixes the issue.

The label wasn't right because Campaign is not yet a supported Afform entity so its metadata was missing. Working around that for now, as it will likely be added as an entity in the near future.