### PR TITLE
Add html definition to schema for is_active (part 1)

### DIFF
--- a/ext/oauth-client/xml/schema/CRM/OAuth/OAuthClient.xml
+++ b/ext/oauth-client/xml/schema/CRM/OAuth/OAuthClient.xml
@@ -80,6 +80,10 @@
     <type>boolean</type>
     <default>1</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
     <comment>Is the client currently enabled?</comment>
     <add>5.32</add>
   </field>

--- a/xml/schema/ACL/ACL.xml
+++ b/xml/schema/ACL/ACL.xml
@@ -123,6 +123,7 @@
     <add>1.6</add>
     <html>
       <type>CheckBox</type>
+      <label>Enabled</label>
     </html>
   </field>
 </table>

--- a/xml/schema/ACL/ACLEntityRole.xml
+++ b/xml/schema/ACL/ACLEntityRole.xml
@@ -64,6 +64,10 @@
     <comment>Is this property active?</comment>
     <default>1</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
     <add>1.6</add>
   </field>
   <index>

--- a/xml/schema/Campaign/Campaign.xml
+++ b/xml/schema/Campaign/Campaign.xml
@@ -197,6 +197,7 @@
     <add>3.3</add>
     <html>
       <type>CheckBox</type>
+      <label>Enabled</label>
     </html>
   </field>
 

--- a/xml/schema/Campaign/Survey.xml
+++ b/xml/schema/Campaign/Survey.xml
@@ -146,6 +146,10 @@
     <type>boolean</type>
     <default>1</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
     <comment>Is this survey enabled or disabled/cancelled?</comment>
     <add>3.3</add>
   </field>

--- a/xml/schema/Case/CaseType.xml
+++ b/xml/schema/Case/CaseType.xml
@@ -72,6 +72,7 @@
     <comment>Is this case type enabled?</comment>
     <html>
       <type>CheckBox</type>
+      <label>Enabled</label>
     </html>
     <default>1</default>
     <required>true</required>

--- a/xml/schema/Contact/ContactType.xml
+++ b/xml/schema/Contact/ContactType.xml
@@ -110,6 +110,10 @@
     <type>boolean</type>
     <default>1</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
     <comment>Is this entry active?</comment>
     <add>3.1</add>
   </field>

--- a/xml/schema/Contact/DashboardContact.xml
+++ b/xml/schema/Contact/DashboardContact.xml
@@ -99,6 +99,10 @@
     <title>Dashlet is Active?</title>
     <comment>Is this widget active?</comment>
     <default>0</default>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
     <add>3.1</add>
   </field>
   <field>

--- a/xml/schema/Contact/Group.xml
+++ b/xml/schema/Contact/Group.xml
@@ -93,7 +93,11 @@
     <default>1</default>
     <required>true</required>
     <title>Group Enabled</title>
-    <comment>Is this entry active?</comment>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
+    <comment>Is this group active?</comment>
     <add>1.1</add>
   </field>
   <field>

--- a/xml/schema/Contact/Relationship.xml
+++ b/xml/schema/Contact/Relationship.xml
@@ -125,6 +125,7 @@
     <add>1.1</add>
     <html>
       <type>CheckBox</type>
+      <label>Enabled</label>
     </html>
   </field>
   <field>

--- a/xml/schema/Contact/RelationshipCache.xml
+++ b/xml/schema/Contact/RelationshipCache.xml
@@ -201,6 +201,7 @@
     <add>5.29</add>
     <html>
       <type>CheckBox</type>
+      <label>Enabled</label>
     </html>
     <readonly>true</readonly>
   </field>

--- a/xml/schema/Contact/RelationshipType.xml
+++ b/xml/schema/Contact/RelationshipType.xml
@@ -169,6 +169,7 @@
     <comment>Is this relationship type currently active (i.e. can be used when creating or editing relationships)?</comment>
     <html>
       <type>CheckBox</type>
+      <label>Enabled</label>
     </html>
     <add>1.1</add>
   </field>

--- a/xml/schema/Contribute/ContributionPage.xml
+++ b/xml/schema/Contribute/ContributionPage.xml
@@ -363,7 +363,11 @@
     <type>boolean</type>
     <default>1</default>
     <required>true</required>
-    <comment>Is this property active?</comment>
+    <html>
+      <type>CheckBox</type>
+      <label>Enabled</label>
+    </html>
+    <comment>Is this page active?</comment>
     <add>1.3</add>
   </field>
   <field>


### PR DESCRIPTION
Overview
----------------------------------------
Add html definition to schema for is_active (part 1)

Before
----------------------------------------
Many `is_active` field missing `html` schema definition

After
----------------------------------------
I'm making sure they all have
```
   <html>
      <type>CheckBox</type>
      <label>Enabled</label>
    </html>
```

Per discussion on https://github.com/civicrm/civicrm-core/pull/24953


Technical Details
----------------------------------------
@colemanw since there is some `GenCode` challenge on  https://github.com/civicrm/civicrm-core/pull/24953 I thought I might standardise the handling of `is_active` first. Since the `DAO` is stale-y & there are more to do I figure I'll do the schema first on these

Comments
----------------------------------------

