### PR TITLE
API4: Allow save() to match on null values

### DIFF
--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -128,7 +128,7 @@ abstract class AbstractSaveAction extends AbstractAction {
     if (empty($record[$primaryKey]) && !empty($this->match)) {
       $where = [];
       foreach ($record as $key => $val) {
-        if (isset($val) && in_array($key, $this->match, TRUE)) {
+        if (in_array($key, $this->match, TRUE)) {
           if ($val === '' || is_null($val)) {
             // If we want to match empty string we have to match on NULL/''
             $where[] = [$key, 'IS EMPTY'];

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -127,7 +127,6 @@ abstract class AbstractSaveAction extends AbstractAction {
     $primaryKey = CoreUtil::getIdFieldName($this->getEntityName());
     if (empty($record[$primaryKey]) && !empty($this->match)) {
       $where = [];
-      $hasNonEmptyMatchValue = FALSE;
       foreach ($record as $key => $val) {
         if (in_array($key, $this->match, TRUE)) {
           if ($val === '' || is_null($val)) {
@@ -136,11 +135,10 @@ abstract class AbstractSaveAction extends AbstractAction {
           }
           else {
             $where[] = [$key, '=', $val];
-            $hasNonEmptyMatchValue = TRUE;
           }
         }
       }
-      if ((count($where) === count($this->match)) && $hasNonEmptyMatchValue) {
+      if (count($where) === count($this->match)) {
         $existing = civicrm_api4($this->getEntityName(), 'get', [
           'select' => [$primaryKey],
           'where' => $where,

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -127,6 +127,7 @@ abstract class AbstractSaveAction extends AbstractAction {
     $primaryKey = CoreUtil::getIdFieldName($this->getEntityName());
     if (empty($record[$primaryKey]) && !empty($this->match)) {
       $where = [];
+      $hasNonEmptyMatchValue = FALSE;
       foreach ($record as $key => $val) {
         if (in_array($key, $this->match, TRUE)) {
           if ($val === '' || is_null($val)) {
@@ -135,10 +136,11 @@ abstract class AbstractSaveAction extends AbstractAction {
           }
           else {
             $where[] = [$key, '=', $val];
+            $hasNonEmptyMatchValue = TRUE;
           }
         }
       }
-      if (count($where) === count($this->match)) {
+      if ((count($where) === count($this->match)) && $hasNonEmptyMatchValue) {
         $existing = civicrm_api4($this->getEntityName(), 'get', [
           'select' => [$primaryKey],
           'where' => $where,

--- a/tests/phpunit/api/v4/Action/SaveTest.php
+++ b/tests/phpunit/api/v4/Action/SaveTest.php
@@ -55,7 +55,7 @@ class SaveTest extends Api4TestBase implements TransactionalInterface {
         ->execute()->single()['id'];
 
       // This modified version of Zak will match with the existing Zak
-      // (external id and first name both match)
+      // (nickname and first name both match)
 
       $sameZakWithChangedLastName = [
         'nick_name' => $zakOriginal['nick_name'],
@@ -71,7 +71,7 @@ class SaveTest extends Api4TestBase implements TransactionalInterface {
       self::assertEquals($zakOriginal['id'], $sameZakWithChangedLastName['id']);
 
       // This new Bob will not match the existing Bob
-      // (first name matches, but external id is different)
+      // (first name matches, but nickname is different)
 
       self::assertNotEquals($bobOriginal['nick_name'], $testValue);
 

--- a/tests/phpunit/api/v4/Action/SaveTest.php
+++ b/tests/phpunit/api/v4/Action/SaveTest.php
@@ -101,6 +101,26 @@ class SaveTest extends Api4TestBase implements TransactionalInterface {
         ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'ghi'],
       ],
     ];
+    // Test that we get a match on NULL (eg. external_identifier => NULL)
+    $data[] = [
+      ['first_name', 'last_name', 'external_identifier'],
+      [
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => NULL],
+      ],
+      [
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'ghi'],
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => NULL],
+      ],
+      [
+        // Original insert
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'abc'],
+        // Match+update
+        ['first_name' => 'Two', 'last_name' => 'Test', 'external_identifier' => NULL],
+        // Subsequent insert
+        ['first_name' => 'One', 'last_name' => 'Test', 'external_identifier' => 'ghi'],
+      ],
+    ];
     return $data;
   }
 


### PR DESCRIPTION
Before
----------------------------------------
Code was trying to allow save() to match on null values, but was shooting itself in the foot.

After
----------------------------------------
Matching on fields works even when their value is null.