### PR TITLE
Use APIv4-based Autocomplete widget throughout SearchKit, Afform & API Explorer

### DIFF
--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Preprocess api autocomplete requests
+ * @service
+ * @internal
+ */
+class AutocompleteFieldSubscriber extends AutoService implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api.prepare' => ['onApiPrepare', -50],
+    ];
+  }
+
+  /**
+   * Apply any filters set in the schema for autocomplete fields
+   *
+   * In order for this to work, the `$fieldName` param needs to be in
+   * the format `EntityName.field_name`. Anything not in that format
+   * will be ignored, with the expectation that any extension making up
+   * its own notation for identifying fields (e.g. Afform) can implement
+   * its own `PrepareEvent` handler to do filtering. If their callback
+   * runs earlier than this one, it can optionally `setFieldName` to the
+   * standard recognized here to get the benefit of both custom filters
+   * and the ones from the schema.
+   * @see \Civi\Api4\Subscriber\AfformAutocompleteSubscriber::processAfformAutocomplete
+   *
+   * @param \Civi\API\Event\PrepareEvent $event
+   */
+  public function onApiPrepare(\Civi\API\Event\PrepareEvent $event): void {
+    $apiRequest = $event->getApiRequest();
+    if (is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
+      [$entityName, $fieldName] = array_pad(explode('.', (string) $apiRequest->getFieldName(), 2), 2, '');
+
+      if (!$fieldName) {
+        return;
+      }
+      try {
+        $fieldSpec = civicrm_api4($entityName, 'getFields', [
+          'checkPermissions' => FALSE,
+          'where' => [['name', '=', $fieldName]],
+        ])->single();
+
+        // Auto-add filters defined in schema
+        foreach ($fieldSpec['input_attrs']['filter'] ?? [] as $key => $value) {
+          $apiRequest->addFilter($key, $value);
+        }
+
+      }
+      catch (\Exception $e) {
+        // Ignore anything else. Extension using their own $fieldName notation can do their own handling.
+      }
+    }
+  }
+
+}

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1259,8 +1259,11 @@
                 $el.removeClass('loading').crmSelect2({data: options, multiple: multi});
               });
             } else if (field.fk_entity) {
-              var apiParams = field.id_field ? {id_field: field.id_field} : {};
-              $el.crmEntityRef({entity: field.fk_entity, api: apiParams, select: {multiple: multi}, static: field.fk_entity === 'Contact' ? ['user_contact_id'] : []});
+              $el.crmAutocomplete(field.fk_entity, {fieldName: field.entity + '.' + field.name, key: field.id_field || null}, {
+                multiple: multi,
+                static: field.fk_entity === 'Contact' ? ['user_contact_id'] : [],
+                minimumInputLength: field.fk_entity === 'Contact' ? 1 : 0
+              });
             } else if (dataType === 'Boolean') {
               $el.attr('placeholder', ts('- select -')).crmSelect2({allowClear: false, multiple: multi, placeholder: ts('- select -'), data: [
                 {id: 'true', text: ts('Yes')},

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -38,7 +38,11 @@
               _.each(ctrl.editor.getEntities({type: field.fk_entity}), function(entity) {
                  options.push({id: entity.name, label: entity.label, icon: afGui.meta.entities[entity.type].icon});
               });
-              $el.crmEntityRef({entity: field.fk_entity, select: {multiple: multi}, static: options});
+              $el.crmAutocomplete(field.fk_entity, {fieldName: field.entity + '.' + field.name}, {
+                multiple: multi,
+                "static": options,
+                minimumInputLength: options.length ? 1 : 0
+              });
             } else if (field.options) {
               options = _.transform(field.options, function(options, val) {
                 options.push({id: val.id, text: val.label});

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -236,16 +236,9 @@
           else if (ctrl.defn.search_range) {
             return ($scope.dataProvider.getFieldData()[ctrl.fieldName]['>='] = val);
           }
-          // A multi-select needs to split string value into an array
-          if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.multiple) {
-            val = val ? val.split(',') : [];
-          }
           return ($scope.dataProvider.getFieldData()[ctrl.fieldName] = val);
         }
         // Getter
-        if (_.isArray(currentVal)) {
-          return currentVal.join(',');
-        }
         if (ctrl.defn.is_date) {
           return _.isPlainObject(currentVal) ? '{}' : currentVal;
         }

--- a/ext/afform/core/ang/af/fields/Select.html
+++ b/ext/afform/core/ang/af/fields/Select.html
@@ -1,5 +1,6 @@
 <div class="{{:: $ctrl.defn.search_range ? 'form-inline' : 'form-group' }}">
-  <input class="form-control" id="{{:: fieldId }}" crm-ui-select="{data: select2Options, multiple: $ctrl.defn.input_attrs.multiple, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
+  <input class="form-control" id="{{:: fieldId }}" ng-if="!$ctrl.defn.input_attrs.multiple" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
+  <input class="form-control" id="{{:: fieldId }}" ng-if="$ctrl.defn.input_attrs.multiple" ng-list crm-ui-select="{data: select2Options, multiple: true, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
   <input class="form-control" ng-if=":: $ctrl.defn.search_range && !$ctrl.defn.is_date" id="{{:: fieldId }}2" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder2 || $ctrl.defn.input_attrs.placeholder}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" >
   <div ng-if="$ctrl.defn.search_range && $ctrl.defn.is_date && getSetSelect() === '{}'" class="form-group" ng-include="'~/af/fields/Date.html'"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -17,7 +17,6 @@
         var rendered = false,
           field = this.field || {};
         ctrl.dateRanges = CRM.crmSearchTasks.dateRanges;
-        ctrl.entity = field.fk_entity || field.entity;
 
         this.ngModel.$render = function() {
           ctrl.value = ctrl.ngModel.$viewValue;
@@ -44,6 +43,19 @@
             ctrl.dateType = 'fixed';
           }
         }
+      };
+
+      this.getFkEntity = function() {
+        return ctrl.field ? ctrl.field.fk_entity || ctrl.field.entity : null;
+      };
+
+      var autocompleteStaticOptions = {
+        Contact: ['user_contact_id'],
+        '': []
+      };
+
+      this.getAutocompleteStaticOptions = function() {
+        return autocompleteStaticOptions[ctrl.getFkEntity() || ''] || autocompleteStaticOptions[''];
       };
 
       this.isMulti = function() {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/entityRef.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/entityRef.html
@@ -1,6 +1,10 @@
-<div class="form-group" ng-if="!$ctrl.isMulti()">
-  <input class="form-control" ng-model="$ctrl.value" crm-entityref="{entity: $ctrl.entity, select:{allowClear: true, placeholder: ts('Select')}, static: $ctrl.entity === 'Contact' ? ['user_contact_id'] : []}">
-</div>
-<div class="form-group" ng-if="$ctrl.isMulti()">
-  <input class="form-control" ng-model="$ctrl.value" crm-entityref="{entity: $ctrl.entity, select: {multiple: true}, static: $ctrl.entity === 'Contact' ? ['user_contact_id'] : []}" ng-list >
-</div>
+<input
+  class="form-control"
+  ng-model="$ctrl.value"
+  crm-autocomplete="$ctrl.getFkEntity()"
+  crm-autocomplete-params="{fieldName: $ctrl.field.entity + '.' + $ctrl.field.name}"
+  auto-open="true"
+  multi="$ctrl.isMulti()"
+  static-options="$ctrl.getAutocompleteStaticOptions()"
+  placeholder="{{:: ts('Select') }}"
+>

--- a/js/Common.js
+++ b/js/Common.js
@@ -478,6 +478,7 @@ if (!CRM.vars) CRM.vars = {};
       }
 
       $el
+        .off('.crmSelect2')
         .on('select2-loaded.crmSelect2', function() {
           // Use description as title for each option
           $('.crm-select2-row-description', '#select2-drop').each(function() {
@@ -523,11 +524,43 @@ if (!CRM.vars) CRM.vars = {};
     });
   };
 
+  function getStaticOptions(staticItems) {
+    var staticPresets = {
+      user_contact_id: {
+        id: 'user_contact_id',
+        label: ts('Select Current User'),
+        icon: 'fa-user-circle-o'
+      }
+    };
+
+    return _.transform(staticItems || [], function(staticItems, option) {
+      staticItems.push(_.isString(option) ? staticPresets[option] : option);
+    });
+  }
+
+  function getStaticOptionMarkup(staticItems) {
+    if (!staticItems.length) {
+      return '';
+    }
+    var markup = '<div class="crm-entityref-links crm-entityref-links-static">';
+    _.each(staticItems, function(link) {
+      markup += ' <a class="crm-hover-button" href="#' + link.id + '">' +
+        '<i class="crm-i ' + link.icon + '" aria-hidden="true"></i> ' +
+        _.escape(link.label) + '</a>';
+    });
+    markup += '</div>';
+    return markup;
+  }
+
   // Autocomplete based on APIv4 and Select2.
   $.fn.crmAutocomplete = function(entityName, apiParams, select2Options) {
     select2Options = select2Options || {};
     return $(this).each(function() {
-      $(this).crmSelect2(_.extend({
+      var $el = $(this).off('.crmEntity'),
+        staticItems = getStaticOptions(select2Options.static),
+        multiple = !!select2Options.multiple;
+
+      $el.crmSelect2(_.extend({
         ajax: {
           quietMillis: 250,
           url: CRM.url('civicrm/ajax/api4/' + entityName + '/autocomplete'),
@@ -549,18 +582,51 @@ if (!CRM.vars) CRM.vars = {};
         formatSelection: formatEntityRefSelection,
         escapeMarkup: _.identity,
         initSelection: function($el, callback) {
-          var
-            multiple = !!select2Options.multiple,
-            val = $el.val();
+          var val = $el.val();
           if (val === '') {
             return;
           }
-          var params = $.extend({}, apiParams || {}, {ids: val.split(',')});
-          CRM.api4(entityName, 'autocomplete', params).then(function(result) {
-            callback(multiple ? result : result[0]);
-          });
+          var idsNeeded = _.difference(val.split(','), _.pluck(staticItems, 'id')),
+            existing = _.filter(staticItems, function(item) {
+              return _.includes(val.split(','), item.id);
+            });
+          // If we already have the data, just return it
+          if (!idsNeeded.length) {
+            callback(multiple ? existing : existing[0]);
+          } else {
+            var params = $.extend({}, apiParams || {}, {ids: idsNeeded});
+            CRM.api4(entityName, 'autocomplete', params).then(function (result) {
+              callback(multiple ? result.concat(existing) : result[0]);
+            });
+          }
+        },
+        formatInputTooShort: function() {
+          var txt = $.fn.select2.defaults.formatInputTooShort.call(this);
+          txt += getStaticOptionMarkup(staticItems);
+          return txt;
         }
       }, select2Options));
+
+      $el.on('select2-open.crmEntity', function() {
+        var $el = $(this);
+        $('#select2-drop')
+          .off('.crmEntity')
+          .on('click.crmEntity', '.crm-entityref-links-static a', function(e) {
+            var id = $(this).attr('href').substr(1),
+              item = _.findWhere(staticItems, {id: id});
+            $el.select2('close');
+            if (multiple) {
+              var selection = $el.select2('data');
+              if (!_.findWhere(selection, {id: id})) {
+                selection.push(item);
+                $el.select2('data', selection, true);
+              }
+            } else {
+              $el.select2('data', item, true);
+            }
+            return false;
+          });
+      });
     });
   };
 
@@ -584,14 +650,7 @@ if (!CRM.vars) CRM.vars = {};
       var
         $el = $(this).off('.crmEntity'),
         entity = options.entity || $el.data('api-entity') || 'Contact',
-        selectParams = {},
-        staticPresets = {
-          user_contact_id: {
-            id: 'user_contact_id',
-            label: ts('Select Current User'),
-            icon: 'fa-user-circle-o'
-          }
-        };
+        selectParams = {};
       // Legacy: fix entity name if passed in as snake case
       if (entity.charAt(0).toUpperCase() !== entity.charAt(0)) {
         entity = _.capitalize(_.camelCase(entity));
@@ -600,26 +659,6 @@ if (!CRM.vars) CRM.vars = {};
       $el.data('select-params', $.extend({}, $el.data('select-params') || {}, options.select));
       $el.data('api-params', $.extend(true, {}, $el.data('api-params') || {}, options.api));
       $el.data('create-links', options.create || $el.data('create-links'));
-      var staticItems = options.static || $el.data('static') || [];
-      _.each(staticItems, function(option, i) {
-        if (_.isString(option)) {
-          staticItems[i] = staticPresets[option];
-        }
-      });
-
-      function staticItemMarkup() {
-        if (!staticItems.length) {
-          return '';
-        }
-        var markup = '<div class="crm-entityref-links crm-entityref-links-static">';
-        _.each(staticItems, function(link) {
-          markup += ' <a class="crm-hover-button" href="#' + link.id + '">' +
-            '<i class="crm-i ' + link.icon + '" aria-hidden="true"></i> ' +
-            _.escape(link.label) + '</a>';
-        });
-        markup += '</div>';
-        return markup;
-      }
 
       $el.addClass('crm-form-entityref crm-' + _.kebabCase(entity) + '-ref');
       var settings = {
@@ -649,7 +688,7 @@ if (!CRM.vars) CRM.vars = {};
           var
             multiple = !!$el.data('select-params').multiple,
             val = $el.val(),
-            stored = ($el.data('entity-value') || []).concat(staticItems);
+            stored = $el.data('entity-value') || [];
           if (val === '') {
             return;
           }
@@ -704,7 +743,7 @@ if (!CRM.vars) CRM.vars = {};
       else {
         selectParams.formatInputTooShort = function() {
           var txt = $el.data('select-params').formatInputTooShort || $.fn.select2.defaults.formatInputTooShort.call(this);
-          txt += entityRefFiltersMarkup($el) + staticItemMarkup() + renderEntityRefCreateLinks($el);
+          txt += entityRefFiltersMarkup($el) + renderEntityRefCreateLinks($el);
           return txt;
         };
         selectParams.formatNoMatches = function() {
@@ -737,21 +776,6 @@ if (!CRM.vars) CRM.vars = {};
                   }
                 }
               });
-              return false;
-            })
-            .on('click.crmEntity', '.crm-entityref-links-static a', function(e) {
-              var id = $(this).attr('href').substr(1),
-                item = _.findWhere(staticItems, {id: id});
-              $el.select2('close');
-              if ($el.select2('container').hasClass('select2-container-multi')) {
-                var selection = $el.select2('data');
-                if (!_.findWhere(selection, {id: id})) {
-                  selection.push(item);
-                  $el.select2('data', selection, true);
-                }
-              } else {
-                $el.select2('data', item, true);
-              }
               return false;
             })
             .on('change.crmEntity', '.crm-entityref-filter-value', function() {


### PR DESCRIPTION
Overview
----------------------------------------
This switches our 3 APIv4-based UIs to consistently use the new Autocomplete widget instead of the old v3-based entityRef

Before
----------------------------------------
v3 widget on v4 screens.

After
----------------------------------------
v4 only

Comments
----------------------------------------
You won't notice much difference in the UI as the widgets look the same. There are some differences in how the results are formatted as some v3 apis have customizations to give more verbose output. I'm working on recreating that in APIv4...