### PR TITLE
Support ES6 (2015) in civilint: jshint config update

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,7 @@
 {
   "indent": 2,
   "jasmine": true,
+  "esversion": 6,
   "predef": [
     "angular",
     "inject",


### PR DESCRIPTION
Overview
----------------------------------------

We should support ES6. 

https://chat.civicrm.org/civicrm/pl/h1yzet38jjbxbqn31an1z9gmye

Before
----------------------------------------

jshint configuration file did not specify eslevel; throws errors on ES6 code.


After
----------------------------------------
 
jshint configured with `eslevel: 6`; no errors thrown.


Technical Details / Discussion
----------------------------------------

In the chat link above a few of us, @artfulrobot @colemanw @mattwire [thought](https://chat.civicrm.org/civicrm/pl/mhnp3ryc4ifrx8iybccwqhf3kw) we should now support ES6, a javascript standard that came out in 2015(!) and has been well supported by all the main browsers (except Internet Explorer) since 2017.

Both Microsoft and the web at large has given up on Internet Explorer now, and so this is really not something we want to be supporting.

This change will enable us to use much more concise Javascript, and spare us a lot of dependency on polyfill utility functions in jQuery, and basically the whole of Lodash. 

Nb. 'concise': We should always remember [Kernihan's law](https://github.com/dwmkerr/hacker-laws#kernighans-law) however.


