### PR TITLE
APIv4 Autocomplete - Support searching by ID, customize some entities

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -315,8 +315,9 @@ trait SavedSearchInspectorTrait {
    * Search a string for all square bracket tokens and return their contents (without the brackets)
    *
    * @param string $str
+   * @return array
    */
-  protected function getTokens($str) {
+  protected function getTokens(string $str): array {
     $tokens = [];
     preg_match_all('/\\[([^]]+)\\]/', $str, $tokens);
     return array_unique($tokens[1]);

--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -81,13 +81,17 @@ class SqlEquation extends SqlExpression {
    */
   public function render(Api4SelectQuery $query): string {
     $output = [];
-    foreach ($this->args as $arg) {
+    foreach ($this->args as $i => $arg) {
       // Just an operator
-      if (is_string($arg)) {
+      if ($this->getOperatorType($arg)) {
         $output[] = $arg;
       }
-      // Surround fields with COALESCE to handle null values
-      elseif (is_a($arg, SqlField::class)) {
+      // Surround fields with COALESCE to prevent null values when using arithmetic operators
+      elseif (is_a($arg, SqlField::class) && (
+          $this->getOperatorType($this->args[$i - 1] ?? NULL) === 'arithmetic' ||
+          $this->getOperatorType($this->args[$i + 1] ?? NULL) === 'arithmetic'
+        )
+      ) {
         $output[] = 'COALESCE(' . $arg->render($query) . ', 0)';
       }
       else {
@@ -104,6 +108,25 @@ class SqlEquation extends SqlExpression {
    */
   public function getAlias(): string {
     return $this->alias ?? \CRM_Utils_String::munge(trim($this->expr, ' ()'), '_', 256);
+  }
+
+  /**
+   * Check if an item is an operator and if so what category it belongs to
+   *
+   * @param $item
+   * @return string|null
+   */
+  protected function getOperatorType($item): ?string {
+    if (!is_string($item)) {
+      return NULL;
+    }
+    if (in_array($item, self::$arithmeticOperators, TRUE)) {
+      return 'arithmetic';
+    }
+    if (in_array($item, self::$comparisonOperators, TRUE)) {
+      return 'comparison';
+    }
+    return NULL;
   }
 
   /**

--- a/Civi/Api4/Service/Autocomplete/ActivityAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ActivityAutocompleteProvider.php
@@ -19,15 +19,15 @@ use Civi\Core\HookInterface;
  * @service
  * @internal
  */
-class CaseAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+class ActivityAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
 
   /**
-   * Provide default SavedSearch for Case autocompletes
+   * Provide default SavedSearch for Activity autocompletes
    *
    * @param \Civi\Core\Event\GenericHookEvent $e
    */
   public static function on_civi_search_autocompleteDefault(GenericHookEvent $e) {
-    if (!is_array($e->savedSearch) || $e->savedSearch['api_entity'] !== 'Case') {
+    if (!is_array($e->savedSearch) || $e->savedSearch['api_entity'] !== 'Activity') {
       return;
     }
     $e->savedSearch['api_params'] = [
@@ -35,20 +35,20 @@ class CaseAutocompleteProvider extends \Civi\Core\Service\AutoService implements
       'select' => [
         'id',
         'subject',
-        'Case_CaseContact_Contact_01.display_name',
-        'case_type_id:label',
-        'status_id:label',
-        'start_date',
+        'activity_date_time',
+        'Activity_ActivityContact_Contact_01.display_name',
+        'activity_type_id:label',
       ],
       'orderBy' => [],
       'where' => [],
       'groupBy' => [],
       'join' => [
         [
-          'Contact AS Case_CaseContact_Contact_01',
+          'Contact AS Activity_ActivityContact_Contact_01',
           'LEFT',
-          'CaseContact',
-          ['id', '=', 'Case_CaseContact_Contact_01.case_id'],
+          'ActivityContact',
+          ['id', '=', 'Activity_ActivityContact_Contact_01.activity_id'],
+          ['Activity_ActivityContact_Contact_01.record_type_id:name', '=', '"Activity Targets"'],
         ],
       ],
       'having' => [],
@@ -56,12 +56,12 @@ class CaseAutocompleteProvider extends \Civi\Core\Service\AutoService implements
   }
 
   /**
-   * Provide default SearchDisplay for Case autocompletes
+   * Provide default SearchDisplay for Activity autocompletes
    *
    * @param \Civi\Core\Event\GenericHookEvent $e
    */
   public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
-    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Case') {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Activity') {
       return;
     }
     // Basic settings with no join
@@ -76,16 +76,19 @@ class CaseAutocompleteProvider extends \Civi\Core\Service\AutoService implements
           'type' => 'field',
           'key' => 'subject',
           'empty_value' => '(' . ts('no subject') . ')',
+          'icons' => [
+            ['field' => 'activity_type_id:icon'],
+          ],
         ],
         [
           'type' => 'field',
           'key' => 'id',
-          'rewrite' => '#[id]: [case_type_id:label]',
+          'rewrite' => '#[id] [activity_type_id:label]',
         ],
         [
           'type' => 'field',
           'key' => 'status_id:label',
-          'rewrite' => '[status_id:label] (' . ts('Started %1', [1 => '[start_date]']) . ')',
+          'rewrite' => '[status_id:label] - [activity_date_time]',
         ],
       ],
     ];
@@ -98,6 +101,20 @@ class CaseAutocompleteProvider extends \Civi\Core\Service\AutoService implements
         $e->display['settings']['columns'][0]['empty_value'] = "[$contactAlias.display_name] (" . ts('no subject') . ')';
         break;
       }
+    }
+    // If CiviCampaign is enabled
+    if (\CRM_Core_Component::isEnabled('CiviCampaign')) {
+      $e->display['settings']['columns'][] = [
+        'type' => 'field',
+        'key' => 'campaign_id.title',
+      ];
+    }
+    // If CiviCase is enabled
+    if (\CRM_Core_Component::isEnabled('CiviCase')) {
+      $e->display['settings']['columns'][] = [
+        'type' => 'field',
+        'key' => 'case_id.subject',
+      ];
     }
   }
 

--- a/Civi/Api4/Service/Autocomplete/AddressAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/AddressAutocompleteProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class AddressAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for Address autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Address') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['street_address', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'street_address',
+          'rewrite' => '[street_address], [city]',
+          'empty_value' => '[city]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'state_province_id.name',
+          'rewrite' => '[state_province_id.name], [country_id.name]',
+          'empty_value' => '[country_id.name]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'id',
+          'rewrite' => '#[id]',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for Contact autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Contact') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['sort_name', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'display_name',
+          'icons' => [
+            ['field' => 'contact_sub_type:icon'],
+            ['field' => 'contact_type:icon'],
+          ],
+        ],
+        [
+          'type' => 'field',
+          'key' => 'contact_sub_type:label',
+          'rewrite' => '#[id] [contact_sub_type:label]',
+          'empty_value' => '#[id] [contact_type:label]',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/Service/Autocomplete/ParticipantAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ParticipantAutocompleteProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class ParticipantAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for Participant autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Participant') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['contact_id.sort_name', 'ASC'],
+        ['event_id.title', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'contact_id.display_name',
+          'rewrite' => '[contact_id.display_name] - [event_id.title]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'role_id:label',
+          'rewrite' => '#[id] [role_id:label]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'status_id:label',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/Service/Autocomplete/RelationshipAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/RelationshipAutocompleteProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class RelationshipAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for Relationship autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Relationship') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['contact_id_a.sort_name', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'relationship_type_id.label_a_b',
+          'rewrite' => '[contact_id_a.display_name] [relationship_type_id.label_a_b] [contact_id_b.display_name]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'description',
+          'rewrite' => '#[id] [description]',
+          'empty_value' => '#[id]',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/Service/Autocomplete/StateProvinceAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/StateProvinceAutocompleteProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class StateProvinceAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for StateProvince autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'StateProvince') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['name', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'name',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'country_id.name',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
@@ -1,6 +1,4 @@
-<div class="help-block">
 
-</div>
 <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
 
 <fieldset class="crm-search-admin-edit-columns-wrapper">
@@ -8,6 +6,10 @@
     {{:: ts('Fields') }}
     <div ng-if="$ctrl.parent.hiddenColumns.length" ng-include="'~/crmSearchAdmin/displays/common/addColMenu.html'" class="btn-group btn-group-xs"></div>
   </legend>
+  <p class="help-block">
+    {{:: ts("The top-most line will be shown as the searchable title (combine multiple fields using rewrite + tokens).") }}
+    {{:: ts("Other lines will be shown below in smaller text, and will not be searchable (except for ID which is always searchable).") }}
+  </p>
   <div class="crm-search-admin-edit-columns" ng-model="$ctrl.display.settings.columns" ui-sortable="$ctrl.parent.sortableOptions">
     <fieldset ng-repeat="col in $ctrl.display.settings.columns" class="crm-draggable">
       <legend>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/UtilsTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/UtilsTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace api\v4\SearchDisplay;
+
+use Civi\Api4\Contact;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class UtilsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function tokenExamples(): array {
+    return [
+      [
+        '',
+        [],
+      ],
+      [
+        'Hello :]',
+        [],
+      ],
+      [
+        '[whatever:',
+        [],
+      ],
+      [
+        '#[id] [participant_id.role_id:label] [id]',
+        ['id', 'participant_id.role_id:label'],
+      ],
+      [
+        '[contact_id.display_name] - [event_id.title]',
+        ['contact_id.display_name', 'event_id.title'],
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider tokenExamples
+   */
+  public function testGetTokens($input, $expected) {
+    $method = new \ReflectionMethod('\Civi\Api4\Generic\AutocompleteAction', 'getTokens');
+    $method->setAccessible(TRUE);
+
+    $action = Contact::autocomplete();
+    $this->assertEquals($expected, $method->invoke($action, $input));
+  }
+
+}

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -159,6 +159,15 @@ class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
   }
 
   /**
+   * Generate some random lowercase letters
+   * @param int $len
+   * @return string
+   */
+  public function randomLetters(int $len = 10) {
+    return \CRM_Utils_String::createRandom($len, implode('', range('a', 'z')));
+  }
+
+  /**
    * Get the required fields for the api entity + action.
    *
    * @param string $entity
@@ -352,10 +361,10 @@ class Api4TestBase extends \PHPUnit\Framework\TestCase implements HeadlessInterf
         return random_int(1, 2000);
 
       case 'String':
-        return \CRM_Utils_String::createRandom(10, implode('', range('a', 'z')));
+        return $this->randomLetters();
 
       case 'Text':
-        return \CRM_Utils_String::createRandom(100, implode('', range('a', 'z')));
+        return $this->randomLetters(100);
 
       case 'Money':
         return sprintf('%d.%2d', rand(0, 2000), rand(10, 99));


### PR DESCRIPTION
Overview
----------------------------------------
This brings the new APIv4 Autocomplete widget up to the level of the v3 EntityRef, and in several ways surpasses it.

Before
----------------------------------------
Not able to search by id, some entities not supported.

After
----------------------------------------
Gives parity with the v3-based widget which would search either by id or label and place the exact match at the top if found.

Also gives parity with the customized output of some v3 entities, plus a few like Relationship that v3 never was able to handle.

Technical Details
----------------------------------------
This new Autocomplete widget is powered by SearchKit, and can be customized via a SavedSearch (for filtering) and a Search Display (to format the output).