### PR TITLE
APIv3 - Use the Exception rather than the rule

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmAPI.php
+++ b/CRM/Core/Smarty/plugins/function.crmAPI.php
@@ -26,22 +26,17 @@ function smarty_function_crmAPI($params, &$smarty) {
     $smarty->trigger_error("assign: missing 'entity' parameter");
     return "crmAPI: missing 'entity' parameter";
   }
-  $errorScope = CRM_Core_TemporaryErrorScope::create(['CRM_Utils_REST', 'fatal']);
   $entity = $params['entity'];
   $action = CRM_Utils_Array::value('action', $params, 'get');
   $params['sequential'] = CRM_Utils_Array::value('sequential', $params, 1);
   $var = $params['var'] ?? NULL;
   CRM_Utils_Array::remove($params, 'entity', 'action', 'var');
-  $params['version'] = 3;
-  require_once 'api/api.php';
-  $result = civicrm_api($entity, $action, $params);
-  unset($errorScope);
-  if ($result === FALSE) {
-    $smarty->trigger_error("Unknown error");
+  try {
+    $result = civicrm_api3($entity, $action, $params);
   }
-
-  if (!empty($result['is_error'])) {
-    $smarty->trigger_error("{crmAPI} " . $result["error_message"]);
+  catch (Exception $e) {
+    $smarty->trigger_error('{crmAPI} ' . $e->getMessage());
+    return NULL;
   }
 
   if (!$var) {

--- a/CRM/Core/Smarty/plugins/function.crmSetting.php
+++ b/CRM/Core/Smarty/plugins/function.crmSetting.php
@@ -25,18 +25,14 @@
  * @return int|string|null
  */
 function smarty_function_crmSetting($params, &$smarty) {
-
-  $errorScope = CRM_Core_TemporaryErrorScope::create(['CRM_Utils_REST', 'fatal']);
   unset($params['method']);
   unset($params['assign']);
-  $params['version'] = 3;
 
-  require_once 'api/api.php';
-  $result = civicrm_api('setting', 'getvalue', $params);
-  unset($errorScope);
-  // Core-688 FALSE is returned by Boolean settings, thus giving false errors.
-  if ($result === NULL) {
-    $smarty->trigger_error("Unknown error");
+  try {
+    $result = civicrm_api3('setting', 'getvalue', $params);
+  }
+  catch (Exception $e) {
+    $smarty->trigger_error('{crmAPI} ' . $e->getMessage());
     return NULL;
   }
 

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -270,13 +270,6 @@ class CRM_Utils_REST {
       $params['version'] = 3;
     }
 
-    if ($params['version'] == 2) {
-      $result['is_error'] = 1;
-      $result['error_message'] = "FATAL: API v2 not accessible from ajax/REST";
-      $result['deprecated'] = "Please upgrade to API v3";
-      return $result;
-    }
-
     if ($_SERVER['REQUEST_METHOD'] == 'GET' &&
       strtolower(substr($args[2], 0, 3)) != 'get' &&
       strtolower($args[2] != 'check')) {
@@ -293,12 +286,12 @@ class CRM_Utils_REST {
     }
 
     // trap all fatal errors
-    $errorScope = CRM_Core_TemporaryErrorScope::create([
-      'CRM_Utils_REST',
-      'fatal',
-    ]);
-    $result = civicrm_api($args[1], $args[2], $params);
-    unset($errorScope);
+    try {
+      $result = civicrm_api($args[1], $args[2], $params);
+    }
+    catch (Exception $e) {
+      return self::error($e->getMessage());
+    }
 
     if ($result === FALSE) {
       return self::error('Unknown error.');
@@ -346,7 +339,9 @@ class CRM_Utils_REST {
   }
 
   /**
-   * @param $pearError
+   * Unused function from the dark ages before PHP Exceptions
+   * @deprecated
+   * @param PEAR_Error $pearError
    */
   public static function fatal($pearError) {
     CRM_Utils_System::setHttpHeader('Content-Type', 'text/xml');
@@ -462,7 +457,6 @@ class CRM_Utils_REST {
     }
 
     $params['check_permissions'] = TRUE;
-    $params['version'] = 3;
     // $requestParams is local-only; this line seems pointless unless there's a side-effect influencing other functions
     $_GET['json'] = $requestParams['json'] = 1;
     if (!$params['sequential']) {
@@ -470,12 +464,12 @@ class CRM_Utils_REST {
     }
 
     // trap all fatal errors
-    $errorScope = CRM_Core_TemporaryErrorScope::create([
-      'CRM_Utils_REST',
-      'fatal',
-    ]);
-    $result = civicrm_api($entity, $action, $params);
-    unset($errorScope);
+    try {
+      $result = civicrm_api3($entity, $action, $params);
+    }
+    catch (Exception $e) {
+      $result = self::error($e->getMessage());
+    }
 
     echo self::output($result);
 


### PR DESCRIPTION
Overview
----------------------------------------
Following up on #19323 this converts APIv3 in Smarty and Ajax to use exceptions instead of `CRM_Core_TemporaryErrorScope` which is self-described as ["An evil, evil work-around"](https://github.com/civicrm/civicrm-core/blob/0b882a86fa186d488c622a76becabb67ff202ae6/CRM/Core/TemporaryErrorScope.php#L4), so I'm gonna say we're better off not using it.

Before
----------------------------------------
The "evil, evil work-around" was causing problems like this:

1. Disable the SearchKit extension
2. In your browser console run `CRM.api3('Extension', 'install', {key: 'org.civicrm.search_kit'});`
3. Fails with a bunch of uncaught errors.

After
----------------------------------------
SearchKit can be installed via ajax without errors, and there's generally less evil in the world.

Technical Details
----------------------------------------
Now that PEAR throws exceptions there is no need to override the PEAR error handler and it was interfering with `try/catch` handlers within the api call.