### PR TITLE
APIv4 - Always allow anonymous autocomplete action access

### DIFF
--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -49,6 +49,10 @@ function search_kit_civicrm_alterApiRoutePermissions(&$permissions, $entity, $ac
       $permissions = CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION;
     }
   }
+  // An autocomplete is a type of search dislay and should always be allowed
+  if ($action === 'autocomplete') {
+    $permissions = CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION;
+  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
An API anonymous access allowance (and an amazing alliteration).

Before
----------------------------------------
Aww

After
----------------------------------------
Access

Technical Details
----------------------------------------
This is a safe change because this api action simply wraps around `SearchDisplay::run`, which already allows anonymous access. Permissions are always enforced by this action, this just prevents the outer gatekeeper from getting in the way.