### PR TITLE
Add html for default field to schema

### DIFF
--- a/xml/schema/Campaign/Survey.xml
+++ b/xml/schema/Campaign/Survey.xml
@@ -160,6 +160,10 @@
     <type>boolean</type>
     <default>0</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>Is this default survey?</comment>
     <add>3.3</add>
   </field>

--- a/xml/schema/Core/LocationType.xml
+++ b/xml/schema/Core/LocationType.xml
@@ -83,6 +83,10 @@
     <name>is_default</name>
     <title>Default Location Type?</title>
     <type>boolean</type>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>Is this location type the default?</comment>
     <add>1.1</add>
   </field>

--- a/xml/schema/Core/MailSettings.xml
+++ b/xml/schema/Core/MailSettings.xml
@@ -56,6 +56,10 @@
     <type>boolean</type>
     <default>0</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>whether this is the default set of settings for this domain</comment>
     <add>2.2</add>
   </field>

--- a/xml/schema/Core/MessageTemplate.xml
+++ b/xml/schema/Core/MessageTemplate.xml
@@ -95,6 +95,10 @@
     <type>boolean</type>
     <default>1</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>is this the default message template for the workflow referenced by workflow_id?</comment>
     <add>3.1</add>
   </field>

--- a/xml/schema/Core/OptionValue.xml
+++ b/xml/schema/Core/OptionValue.xml
@@ -99,6 +99,10 @@
     <title>Option is Default?</title>
     <type>boolean</type>
     <default>0</default>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>Is this the default option for the group?</comment>
     <add>1.5</add>
   </field>

--- a/xml/schema/Core/PrintLabel.xml
+++ b/xml/schema/Core/PrintLabel.xml
@@ -88,6 +88,10 @@
     <type>boolean</type>
     <default>1</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>Is this default?</comment>
     <add>4.4</add>
   </field>

--- a/xml/schema/Financial/FinancialAccount.xml
+++ b/xml/schema/Financial/FinancialAccount.xml
@@ -175,6 +175,10 @@
     <comment>Is this account the default one (or default tax one) for its financial_account_type?</comment>
     <default>0</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <add>4.3</add>
   </field>
   <index>

--- a/xml/schema/Financial/PaymentProcessor.xml
+++ b/xml/schema/Financial/PaymentProcessor.xml
@@ -121,10 +121,14 @@
     <name>is_default</name>
     <title>Processor Is Default?</title>
     <type>boolean</type>
-    <comment>Is this processor the default?</comment>
-    <add>1.8</add>
     <default>0</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
+    <comment>Is this processor the default?</comment>
+    <add>1.8</add>
   </field>
   <field>
     <name>is_test</name>

--- a/xml/schema/Financial/PaymentProcessorType.xml
+++ b/xml/schema/Financial/PaymentProcessorType.xml
@@ -66,6 +66,10 @@
     <type>boolean</type>
     <default>0</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>Is this processor the default?</comment>
     <add>1.8</add>
   </field>

--- a/xml/schema/Mailing/Component.xml
+++ b/xml/schema/Mailing/Component.xml
@@ -75,6 +75,10 @@
     <type>boolean</type>
     <default>0</default>
     <required>true</required>
+    <html>
+      <type>CheckBox</type>
+      <label>Default</label>
+    </html>
     <comment>Is this the default component for this component_type?</comment>
   </field>
   <field>

--- a/xml/schema/Member/MembershipStatus.xml
+++ b/xml/schema/Member/MembershipStatus.xml
@@ -156,6 +156,7 @@
     <required>true</required>
     <html>
       <type>CheckBox</type>
+      <label>Default</label>
     </html>
     <comment>Assign this status to a membership record if no other status match is found.</comment>
     <add>1.5</add>

--- a/xml/schema/Price/PriceFieldValue.xml
+++ b/xml/schema/Price/PriceFieldValue.xml
@@ -188,10 +188,11 @@
     <comment>Is this default price field option</comment>
     <default>0</default>
     <required>true</required>
-    <add>3.3</add>
     <html>
       <type>CheckBox</type>
+      <label>Default</label>
     </html>
+    <add>3.3</add>
   </field>
   <field>
     <name>is_active</name>

--- a/xml/schema/SMS/Provider.xml
+++ b/xml/schema/SMS/Provider.xml
@@ -100,10 +100,11 @@
     <type>boolean</type>
     <default>0</default>
     <required>true</required>
-    <add>4.2</add>
     <html>
       <type>CheckBox</type>
+      <label>Default</label>
     </html>
+    <add>4.2</add>
   </field>
   <field>
     <name>is_active</name>


### PR DESCRIPTION
Overview
----------------------------------------
Add html for default field to schema

Before
----------------------------------------
`<html>` tag for is_reserved fields inconsistent

After
----------------------------------------
`html` tag exists across schema, with consistent name

Technical Details
----------------------------------------
Note in the process I found that OptionValue.is_default is not required and LocationType.is_default is not required and does not have a default

Comments
----------------------------------------
@colemanw this is similar to the `is_default` PRs I did fixing the same field on multiple enitites. For the `is_reserved` - should that one be consistently `readonly` as well?

(started from this PR https://github.com/civicrm/civicrm-core/pull/24953)