### PR TITLE
SearchKit - Descriptions for search displays

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -112,6 +112,7 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
       return;
     }
     $e->display['settings'] += [
+      'description' => $e->savedSearch['description'] ?? NULL,
       'sort' => [],
       'limit' => \Civi::settings()->get('default_pager_size'),
       'pager' => [

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
@@ -15,6 +15,9 @@
       {{:: ts('Anyone who can view this display will be able to see all results, regardless of their permission level.') }}
     </div>
   </div>
+  <div>
+    <textarea class="form-control" placeholder="{{:: ts('Description (shown above)') }}" ng-model="$ctrl.display.settings.description"></textarea>
+  </div>
 </fieldset>
 <div class="form-group crm-search-admin-right" ng-if="$ctrl.display.id">
   <a ng-href="{{ $ctrl.parent.crmSearchAdmin.searchDisplayPath + '#/display/' + $ctrl.parent.savedSearch.name + '/' + $ctrl.display.name }}" target="_blank" class="btn btn-primary-outline" title="{{:: ts('View search display on its own page') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -1,5 +1,5 @@
 <li>
-  <textarea placeholder="{{:: ts('Enter description (only shown to admins)') }}" ng-model="$ctrl.savedSearch.description"></textarea>
+  <textarea class="form-control" placeholder="{{:: ts('Description (shown above default display)') }}" ng-model="$ctrl.savedSearch.description"></textarea>
 </li>
 <li>
   <crm-search-admin-tags tag-ids="$ctrl.savedSearch.tag_id" class="btn-group btn-group-sm"></crm-search-admin-tags>

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -1,4 +1,5 @@
 <div class="crm-search-display crm-search-display-grid">
+  <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -1,4 +1,5 @@
 <div class="crm-search-display crm-search-display-list">
+  <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -1,4 +1,5 @@
 <div class="crm-search-display crm-search-display-table">
+  <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>
   <div class="form-inline">
     <div class="btn-group" ng-include="'~/crmSearchDisplay/SearchButton.html'" ng-if="$ctrl.settings.button"></div>
     <crm-search-tasks ng-if="$ctrl.settings.actions" entity="$ctrl.apiEntity" ids="$ctrl.selectedRows" search="$ctrl.search" display="$ctrl.display" display-controller="$ctrl" refresh="$ctrl.refreshAfterTask()"></crm-search-tasks>


### PR DESCRIPTION
Overview
----------------------------------------
This shows the savedSearch description on the default display, and allows each custom display to have its own description which shows at the top. It also fixes the alignment issue for the desription textarea noted in [dev/core#3980](https://lab.civicrm.org/dev/core/-/issues/3980).

![image](https://user-images.githubusercontent.com/2874912/202298046-d2055848-cb32-4df4-be36-ba45fa3329cf.png)

![image](https://user-images.githubusercontent.com/2874912/202298255-ccff8712-3150-4c83-a10c-dd1741d90bef.png)
