### PR TITLE
SearchKit - Fix display count when updating items on the last page

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -156,7 +156,8 @@
           ctrl.editing = ctrl.loading = false;
           // Update rowCount if running for the first time or during an update op
           if (!ctrl.rowCount || editedRow) {
-            if (!ctrl.limit || ctrl.results.length < ctrl.limit) {
+            // No need to fetch count if on page 1 and result count is under the limit
+            if (!ctrl.limit || (ctrl.results.length < ctrl.limit && ctrl.page === 1)) {
               ctrl.rowCount = ctrl.results.length;
             } else if (ctrl.settings.pager || ctrl.settings.headerCount) {
               var params = ctrl.getApiParams('row_count');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3975](https://lab.civicrm.org/dev/core/-/issues/3975)

Before
----------------------------------------
Deleting an item from the last page would result in an incorrect count.

After
----------------------------------------
All better.
