### PR TITLE
Add fastArray caching to `mixinBoot` & `mixinScan` caches

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -181,6 +181,8 @@ class Container {
       'fields' => 'contact fields',
       'contactTypes' => 'contactTypes',
       'metadata' => 'metadata',
+      'mixinBoot' => 'mixinBoot',
+      'mixinScan' => 'mixinScan',
     ];
     $verSuffixCaches = ['metadata'];
     $verSuffix = '_' . preg_replace(';[^0-9a-z_];', '_', \CRM_Utils_System::version());
@@ -192,7 +194,7 @@ class Container {
       // For Caches that we don't really care about the ttl for and/or maybe accessed
       // fairly often we use the fastArrayDecorator which improves reads and writes, these
       // caches should also not have concurrency risk.
-      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields', 'contactTypes', 'metadata', 'js_strings'];
+      $fastArrayCaches = ['groups', 'navigation', 'customData', 'fields', 'contactTypes', 'metadata', 'js_strings', 'mixinBoot', 'mixinScan'];
       if (in_array($cacheSvc, $fastArrayCaches)) {
         $definitionParams['withArray'] = 'fast';
       }


### PR DESCRIPTION


Overview
----------------------------------------
Add fastArray caching to `mixinBoot` & `mixinScan` caches

Before
----------------------------------------
In monitoring I found this was hitting Redis many times per request - since they hold an array that is going to hit serialisation performance impacts.

After
----------------------------------------
FastArray cache used - this is a cache that does not change often so it makes sense to use it.

Technical Details
----------------------------------------
@totten 

Comments
----------------------------------------
Note I don't address this here as this PR should not make it better or worse - but we should be flushing these at the same time we flush the metadata cache during extension enable & disable.
