### PR TITLE
Allow Joinables to be added to tables without specifying a base column

### DIFF
--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -104,13 +104,15 @@ class Joinable {
    */
   public function getConditionsForJoin(string $baseTableAlias, string $targetTableAlias) {
     $conditions = [];
-    $conditions[] = sprintf(
-      '`%s`.`%s` =  `%s`.`%s`',
-      $baseTableAlias,
-      $this->baseColumn,
-      $targetTableAlias,
-      $this->targetColumn
-    );
+    if ($this->baseColumn && $this->targetColumn) {
+      $conditions[] = sprintf(
+        '`%s`.`%s` =  `%s`.`%s`',
+        $baseTableAlias,
+        $this->baseColumn,
+        $targetTableAlias,
+        $this->targetColumn
+      );
+    }
     $this->addExtraJoinConditions($conditions, $baseTableAlias, $targetTableAlias);
     return $conditions;
   }


### PR DESCRIPTION
Overview
----------------------------------------
When using APIv4 Calculated Fields, it is sometimes necessary to add a Joinable to a table without specifying a base column using `$table->addTableLink(NULL, $joinable)`


Before
----------------------------------------
This results in an invalid and unneeded join condition resulting a MySQL error.

After
----------------------------------------
No errors, correct join.

Technical Details
----------------------------------------


Comments
----------------------------------------
As discussed here: https://chat.civicrm.org/civicrm/pl/bkguwjgiyjndzefye954w8pn9y
