### PR TITLE
(dev/core#3979) Localization - Assign a locale for UF during negotiation

### DIFF
--- a/Civi/Core/Locale.php
+++ b/Civi/Core/Locale.php
@@ -203,6 +203,14 @@ class Locale {
       $validDbLocales = \Civi::settings()->get('languageLimit');
       $locale->db = static::pickFirstLocale(array_keys($validDbLocales), $fallbacks) ?: $systemDefault;
     }
+
+    // Determine locale for UF APIs: This next bit is a little bit wrong.
+    // We should have something like `$validUfLanguages` and pick the closest match.
+    // Or perhaps each `CRM_Utils_System_{$UF}` should have a `negotiate()` helper.
+    // But it's a academic... D7/D8/BD are the only UF's which implement `setUFLocale`/`getUFLocale`,
+    // and they drop the country-code - which basically addresses the goal (falling back to a more generic locale).
+    $locale->uf = $locale->ts;
+
     return $locale;
   }
 

--- a/tests/phpunit/E2E/Api4/LocaleTest.php
+++ b/tests/phpunit/E2E/Api4/LocaleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace E2E\Api4;
+
+/**
+ * Class LocaleTest
+ * @package E2E\Api4
+ * @group e2e
+ */
+class LocaleTest extends \CiviEndToEndTestCase {
+
+  /**
+   * Ensure that
+   */
+  public function testSetLanguage() {
+    $contacts = civicrm_api4('Contact', 'get', [
+      'limit' => 25,
+      'language' => 'en_US',
+    ]);
+    $this->assertTrue(count($contacts) > 0);
+  }
+
+}

--- a/tests/phpunit/E2E/Api4/LocaleTest.php
+++ b/tests/phpunit/E2E/Api4/LocaleTest.php
@@ -15,21 +15,37 @@ class LocaleTest extends \CiviEndToEndTestCase {
   public function getLanguageExamples(): array {
     $results = [];
     switch (CIVICRM_UF) {
-      case 'Drupal':
-      case 'Drupal8':
       case 'Backdrop':
-        $results[] = ['de_DE', 'de_CH', 't', 'Yes', 'Ja'];
-        // That's weird -- you install Drupal's "de", and you do `setUFLocale('de_DE')`, and
-        // the result is... to report back as 'de_DE'. Weird. But the actual string is OK...
+        // FIXME: In buildkit.git:app/config/backdrop-*, it downloads the *.po files, but it lacks drush support for activating them.
+        $results[] = ['*SKIP*', NULL, NULL, NULL, NULL];
         break;
 
-      case 'WordPress':
-        $results[] = ['de_DE', 'de_DE', '__', 'Yes', 'Ja'];
+      case 'Drupal':
+        $results[] = ['de_DE', 'de_CH', 't', 'Yes', 'Ja'];
+        // That's weird... If you install Drupal's "de", and if you do `setUFLocale('de_DE')`, if
+        // you lookup `getUFLocale()`... then it reports back as 'de_CH'. Feels arbitrary.
+        // OTOH, D7 doesn't appear to distinguish national dialects, so `de_DE` and `de_CH` are the same thing...
+        break;
+
+      case 'Drupal8':
+        // FIXME: In buildkit.git:app/config/drupal8-*, it downloads the *.po files, but it lacks drush support for activating them.
+        $results[] = ['*SKIP*', NULL, NULL, NULL, NULL];
         break;
 
       case 'Joomla':
+        // FIXME: In CRM_Utils_System_Joomla, the setUFLocale and getUFLocale are not fully implemented.
+        // FIXME: In buildkit.git:app/config/joomla-*, it does not enable any languages.
+        $results[] = ['*SKIP*', NULL, NULL, NULL, NULL];
+        break;
+
+      case 'WordPress':
+        // FIXME: In CRM_Utils_System_WordPress, the setUFLocale and getUFLocale are not fully implemented.
+        // FIXME: In buildkit.git:app/config/wp-*, it does not enable any languages.
+        $results[] = ['*SKIP*', NULL, NULL, NULL, NULL];
+        // $results[] = ['de_DE', 'de_DE', '__', 'Yes', 'Ja'];
+        break;
+
       default:
-        $this->fail('Test not implemented for ' . CIVICRM_UF);
     }
     return $results;
   }
@@ -56,6 +72,10 @@ class LocaleTest extends \CiviEndToEndTestCase {
    * @dataProvider getLanguageExamples
    */
   public function testSetLanguage($civiLocale, $expectUfLocale, $translator, $inputString, $expectString) {
+    if ($civiLocale === '*SKIP*') {
+      $this->markTestIncomplete('Current environment does not support testing of UF locale.');
+    }
+
     $actualStrings = [];
     $actualLocales = [];
     \Civi::dispatcher()->addListener('civi.api.respond', function (RespondEvent $e) use (&$actualStrings, &$actualLocales, $translator, $inputString, $civiLocale) {

--- a/tests/phpunit/E2E/Api4/LocaleTest.php
+++ b/tests/phpunit/E2E/Api4/LocaleTest.php
@@ -2,22 +2,78 @@
 
 namespace E2E\Api4;
 
+use Civi\API\Event\RespondEvent;
+
 /**
  * Class LocaleTest
+ *
  * @package E2E\Api4
  * @group e2e
  */
 class LocaleTest extends \CiviEndToEndTestCase {
 
+  public function getLanguageExamples(): array {
+    $results = [];
+    switch (CIVICRM_UF) {
+      case 'Drupal':
+      case 'Drupal8':
+      case 'Backdrop':
+        $results[] = ['de_DE', 'de_CH', 't', 'Yes', 'Ja'];
+        // That's weird -- you install Drupal's "de", and you do `setUFLocale('de_DE')`, and
+        // the result is... to report back as 'de_DE'. Weird. But the actual string is OK...
+        break;
+
+      case 'WordPress':
+        $results[] = ['de_DE', 'de_DE', '__', 'Yes', 'Ja'];
+        break;
+
+      case 'Joomla':
+      default:
+        $this->fail('Test not implemented for ' . CIVICRM_UF);
+    }
+    return $results;
+  }
+
   /**
-   * Ensure that
+   * APIv4 allows you to request that operations be processed in a specific language.
+   *
+   * @param string $civiLocale
+   *   The locale to specify in Civi. (eg Civi\Api4\Foo::bar()->setLanguage($civiLocale))
+   *   Ex: 'de_DE'
+   * @param string $expectUfLocale
+   *   The corresponding locale in the UF.
+   *   Ex: 'de'
+   * @param string|array $translator
+   *   The user-framework's translation method.
+   *   Ex: 't' (Drupal) or '__' (WordPress)
+   * @param string $inputString
+   *   The string to translate.
+   *   Ex: 'Yes', 'Login', 'Continue'
+   * @param string $expectString
+   *   The string that should be returned.
+   *   Ex: 'Ja', 'Anmeldung', 'Fortsetzen'
+   *
+   * @dataProvider getLanguageExamples
    */
-  public function testSetLanguage() {
+  public function testSetLanguage($civiLocale, $expectUfLocale, $translator, $inputString, $expectString) {
+    $actualStrings = [];
+    $actualLocales = [];
+    \Civi::dispatcher()->addListener('civi.api.respond', function (RespondEvent $e) use (&$actualStrings, &$actualLocales, $translator, $inputString, $civiLocale) {
+      $isTranslatedRequest = ($e->getApiRequest()->getLanguage() === $civiLocale);
+      if ($isTranslatedRequest) {
+        $actualLocales[] = \CRM_Utils_System::getUFLocale();
+        $actualStrings[] = call_user_func($translator, $inputString);
+      }
+    }, -100);
     $contacts = civicrm_api4('Contact', 'get', [
       'limit' => 25,
-      'language' => 'en_US',
+      'language' => $civiLocale,
     ]);
-    $this->assertTrue(count($contacts) > 0);
+    $this->assertTrue(count($contacts) > 0, 'The API call should return successfully.');
+    $this->assertEquals(1, count($actualLocales), 'We should observed one UF locale.');
+    $this->assertEquals(1, count($actualStrings), 'We should observed one UF translation.');
+    $this->assertEquals($expectUfLocale . ':' . $expectString, $actualLocales[0] . ':' . $actualStrings[0],
+      "Expected UF to report locale as '$expectUfLocale:$expectString'.");
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

For: https://lab.civicrm.org/dev/core/-/issues/3979
Related: https://lab.civicrm.org/dev/translation/-/issues/78

Before
----------------------------------------

If you make an APIv4 call with `setLanguage('en_NZ')`, it negotiates an active locale for various layers (Civi's `tsLocale` and `dbLocale`, the currency-formatter, and so on). However, it neglects to choose a locale for the UF.

Consequently, it calls `CRM_Utils_System::setUFLocale(NULL)` which produces PHP warnings in some environments (eg PHP 8.1 and D9(?)).

After
----------------------------------------

If you make an APIv4 call with `setLanguage('en_NZ')`, it negotiates an active locale. It now chooses the UF locale as well.

Consequently, it calls `CRM_Utils_System::setUFLocale('en_NZ')` which does not produce those PHP warnings.

Comments
----------------------------------------

The implementation is a bit wrong, but I suspect it's not consequential. Want to figure out testing before we geeking out on that.

The test will probably fail because the test sites don't have localization data for UFs. @demeritcowboy, is there some magic `drush` incantation to get the localization data for a couple example locales? (*Some Civi tests use `de_DE` and `fr_FR`, so `de` and `fr` might be handy...*)