### PR TITLE
Avoid symbol scan errors in oauth-client help text

### DIFF
--- a/ext/oauth-client/ang/oauthClientCreateHelp.aff.html
+++ b/ext/oauth-client/ang/oauthClientCreateHelp.aff.html
@@ -7,7 +7,7 @@
         {{ts('Configure the "Redirect URL":')}}
       </p>
       <pre>{{redirectUrl}}</pre>
-      <div ng-if="redirectUrl.startsWith('http:/') && !redirectUrl.match('//(localhost|127\.0\.0\.1)')">
+      <div ng-if="redirectUrl.startsWith('http:/') &amp;&amp; !redirectUrl.match('//(localhost|127\.0\.0\.1)')">
         <p>
           {{ts('WARNING: Most web-service providers require "https://" URLs. Alternatively, "http://" may be accepted for strictly local URLs ("localhost" or "127.0.0.1").')}}
         </p>
@@ -17,7 +17,7 @@
       </div>
     </li>
 
-    <li ng-if="options.provider.options.scopes.length > 0">
+    <li ng-if="options.provider.options.scopes.length">
       <p>
         {{ts('Configure the scopes:')}}
       </p>


### PR DESCRIPTION
Overview
----------------------------------------
Errors while scanning for symbols.

Before
----------------------------------------
1. Install oauth-client
2. On almost every page you get `User warning: htmlParseEntityRef: no name in Civi\Afform\Symbols::scan() (line 46 of ...\ext\afform\core\Civi\Afform\Symbols.php)`
3. I think it shows up more in-your-face with php 8.1 but it would have been there before too just not as loud.

After
----------------------------------------


Technical Details
----------------------------------------
It doesn't seem to like some unescaped html symbols like `>` and `&`.

I wasn't 100% sure about the first one but it seems to evaluate correctly. You can see the text if you go to Administer - system settings - oauth, and then e.g. click on google and then on the register tab.

Comments
----------------------------------------

