### PR TITLE
Fix CiviCRM Home/Hide/Logout translation

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -898,7 +898,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
         $item['child'] = [
           [
             'attributes' => [
-              'label' => 'CiviCRM Home',
+              'label' => ts('CiviCRM Home'),
               'name' => 'CiviCRM Home',
               'url' => 'civicrm/dashboard?reset=1',
               'weight' => 1,
@@ -906,7 +906,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
           ],
           [
             'attributes' => [
-              'label' => 'Hide Menu',
+              'label' => ts('Hide Menu'),
               'name' => 'Hide Menu',
               'url' => '#hidemenu',
               'weight' => 2,
@@ -914,7 +914,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
           ],
           [
             'attributes' => [
-              'label' => 'Log out',
+              'label' => ts('Log out'),
               'name' => 'Log out',
               'url' => 'civicrm/logout?reset=1',
               'weight' => 3,


### PR DESCRIPTION
Overview
----------------------------------------

Some CiviCRM menu items were not translatable.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/202782668-605dddb8-9704-49d6-8cc8-414eed15d241.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/202782806-58e1a6c3-d2c4-4a53-b358-bd6d843625d3.png)


Technical Details
----------------------------------------

Just the usual missing `ts()`


Assumes that the translation files are up to date (it will require updating Transifex for two of the strings). In this case, I updated my `fr_CA/LC_MESSAGES/civicrm.mo` file manually.