### PR TITLE
Sentence runs together since period is inside the if block

### DIFF
--- a/templates/CRM/common/CMSUser.tpl
+++ b/templates/CRM/common/CMSUser.tpl
@@ -12,7 +12,7 @@
       <legend>{ts}Account{/ts}</legend>
       <div class="messages help cms_user_help-section">
    {if !$isCMS}
-      {ts}If you would like to create an account on this site, check the box below and enter a Username{/ts}{if !empty($form.cms_pass)} {ts}and a password{/ts}.{/if}
+      {ts}If you would like to create an account on this site, check the box below and enter a Username{/ts}{if !empty($form.cms_pass)} {ts}and a password{/ts}{/if}.
    {else}
       {ts}Please enter a Username to create an account.{/ts}
    {/if}


### PR DESCRIPTION
Overview
----------------------------------------
It should be outside the `if`.

Before
----------------------------------------
1. Add a profile to a contribution page that allows user signup (in the advanced profile settings - under account creation).
2. Visit the contribution page. Depending on the cms config, the `if` block will show or not. If it doesn't show, then there's no period and the first sentence runs right into the next one: `If you would like to create an account on this site, check the box below and enter a Username If you already have an account please login before completing this form.`
  

After
----------------------------------------
Better

Technical Details
----------------------------------------


Comments
----------------------------------------
Came up during review of https://github.com/civicrm/civicrm-core/pull/25002
