### PR TITLE
php8 - don't pass null as string

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2219,6 +2219,9 @@ SELECT contact_id
    * @return string
    */
   public static function escapeString($string) {
+    if ($string === NULL) {
+      return '';
+    }
     static $_dao = NULL;
     if (!$_dao) {
       // If this is an atypical case (e.g. preparing .sql file before CiviCRM

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -465,7 +465,9 @@ class CRM_Utils_Type {
     }
 
     if ($abort) {
-      $data = htmlentities($data);
+      // Note the string 'NULL' is just for display purposes here and to avoid
+      // passing real null to htmlentities - it's not for database queries.
+      $data = htmlentities($data ?? 'NULL');
       throw new CRM_Core_Exception("$name (value: $data) is not of the type $type");
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Some deprecations

Before
----------------------------------------
* `htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated`
* `mysqli_real_escape_string(): Passing null to parameter #2 ($string) of type string is deprecated`

After
----------------------------------------


Technical Details
----------------------------------------
These should be coming up during tests/phpunit/CRM/Core/DAOTest.php, but the mysqli one gets hidden by the `@` in pear/db/myqli, and the other one I dunno what's hiding it. When I run it in a different test environment they show up as deprecations (not fails, but listed separately as deprecations). It think it's phpunit-bridge that shows it.

Comments
----------------------------------------

