### PR TITLE
Enable settings to use select2

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -451,7 +451,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $type = 'text';
       $options = $attributes;
       $attributes = ($extra ? $extra : []) + ['class' => ''];
-      $attributes['class'] = ltrim($attributes['class'] . " crm-select2 crm-form-select2");
+      $attributes['class'] = ltrim($attributes['class'] . ' crm-select2 crm-form-select2');
       $attributes['data-select-params'] = json_encode(['data' => $options, 'multiple' => !empty($attributes['multiple'])]);
       unset($attributes['multiple']);
       $extra = NULL;

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1081,11 +1081,9 @@ class CRM_Core_SelectValues {
    * @return array
    *   Dashboard entries options - in practice [-1 => 'Show All', 10 => 10, 20 => 20, ... 100 => 100].
    */
-  public static function getDashboardEntriesCount() {
-    $optionValues = [];
-    $optionValues[-1] = ts('show all');
+  public static function getDashboardEntriesCount(): array {
     for ($i = 10; $i <= 100; $i += 10) {
-      $optionValues[$i] = $i;
+      $optionValues[] = ['id' => $i, 'name' => $i, 'label' => $i];
     }
     return $optionValues;
   }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -394,7 +394,7 @@ WHERE      civicrm_event.is_active = 1 AND
       $event_summary_limit = "LIMIT      0, $show_max_events";
     }
     else {
-      $event_summary_limit = "";
+      $event_summary_limit = '';
     }
 
     $query = "

--- a/settings/Event.setting.php
+++ b/settings/Event.setting.php
@@ -34,6 +34,7 @@ return [
     'is_contact' => 0,
     'description' => ts('Configure how many events should be shown on the dashboard. This overrides the default value of 10 entries.'),
     'help_text' => NULL,
+    'html_attributes' => ['class' => 'crm-select2', 'required' => FALSE, 'placeholder' => ts('Show All')],
     'pseudoconstant' => ['callback' => 'CRM_Core_SelectValues::getDashboardEntriesCount'],
   ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
The goal here is to make it possible to declare options for settngs in select2 style arrays (since it's silly to be writing new arrays in the flat style when the keyed arrays are the new styles). I picked on a setting that is already using the generic for - `show_events` and tried to convert it to use the new style. I checked & an empty value is quite heavily handled when the setting is used so the likely change in that from `-1` to `''` won't break anything

@colemanw this is not actually working & I'm a bit stuck on why.

I'm getting the select2 box - but not my options

$props['html_attributes']['multiple'] 

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
