### PR TITLE
Deprecate `CRM_Contact_BAO_Relationship::del()` in favour of `deleteRecord()`

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -509,6 +509,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    */
   private function deleteAction($id) {
     CRM_Contact_BAO_Relationship::del($id);
+    CRM_Core_Session::setStatus(ts('Selected relationship has been deleted successfully.'), ts('Record Deleted'), 'success');
 
     // reload all blocks to reflect this change on the user interface.
     $this->ajaxResponse['reloadBlocks'] = ['#crm-contactinfo-content'];

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -181,6 +181,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
 
       // delete relationship
       CRM_Contact_BAO_Relationship::del($this->getEntityId());
+      CRM_Core_Session::setStatus(ts('Selected relationship has been deleted successfully.'), ts('Record Deleted'), 'success');
 
       CRM_Utils_System::redirect($url);
     }
@@ -239,6 +240,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
   public function delete() {
     // calls a function to delete relationship
     CRM_Contact_BAO_Relationship::del($this->getEntityId());
+    CRM_Core_Session::setStatus(ts('Selected relationship has been deleted successfully.'), ts('Record Deleted'), 'success');
   }
 
   /**


### PR DESCRIPTION
Another `del()` deprecation

Move status message out of business-layer

