### PR TITLE
fixes financial#203 - false duplicate contribution detection with Authorize.net

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -143,7 +143,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
       $this->_setParam($field, $value);
     }
 
-    if (!empty($params['is_recur']) && !empty($params['contributionRecurID'])) {
+    if (!empty($propertyBag->getIsRecur()) && !empty($propertyBag->getContributionRecurID())) {
       $this->doRecurPayment();
       $params['payment_status_id'] = array_search('Pending', $statuses);
       $params['payment_status'] = 'Pending';
@@ -167,7 +167,8 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
     }
 
     // Authorize.Net will not refuse duplicates, so we should check if the user already submitted this transaction
-    if ($this->checkDupe($authorizeNetFields['x_invoice_num'], $params['contributionID'] ?? NULL)) {
+    $contributionId = $propertyBag->has('contributionID') ? $propertyBag->getContributionID() : NULL;
+    if ($this->checkDupe($authorizeNetFields['x_invoice_num'], $contributionId)) {
       throw new PaymentProcessorException('It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from Authorize.net.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.', 9004);
     }
 


### PR DESCRIPTION
https://lab.civicrm.org/dev/financial/-/issues/203

Overview
----------------------------------------
Description and replication steps are on the ticket, but briefly - this comes up with:
* webform_civicrm, D7, core Auth.net, and contributiontransactlegacy extension;
* or webform_civicrm, D9, core Auth.net.

Before
----------------------------------------
This error:
```
It appears that this transaction is a duplicate.  Have you already submitted the form once?  If so there may have been a connection problem.  Check your email for a receipt from Authorize.net.  If you do not receive a receipt within 2 hours you can try your transaction again.  If you continue to have problems please contact the site administrator.
```

After
----------------------------------------
No error.

Technical Details
----------------------------------------
@twomice and @mattwire deserve the credit here - but basically we need to be using the PropertyBag to deal with inconsistencies in array element names.