### PR TITLE
dev/core#4000 Fix (old) regression - ensure only template contribution updates update recur

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -16,6 +16,7 @@ use Civi\Api4\ContributionRecur;
 use Civi\Api4\LineItem;
 use Civi\Api4\ContributionSoft;
 use Civi\Api4\PaymentProcessor;
+use Civi\Core\Event\PostEvent;
 
 /**
  *
@@ -603,9 +604,12 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
   /**
    * Event fired after modifying a contribution.
+   *
    * @param \Civi\Core\Event\PostEvent $event
+   *
+   * @throws \CRM_Core_Exception
    */
-  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+  public static function self_hook_civicrm_post(PostEvent $event): void {
     if ($event->action === 'edit') {
       CRM_Contribute_BAO_ContributionRecur::updateOnTemplateUpdated($event->object);
     }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4000 Fix (old) regression - ensure only template contribution updates update recur

https://github.com/civicrm/civicrm-core/pull/21473 moved the updating of the `ContributionRecur` from updates to the template contribution from the form layer to the BAO (good) but did not add sufficient filtering - with the result that we are seeing updates to non-template contributions update the contribution recur total and currency.


Before
----------------------------------------
Updating the amount or currency on ANY contribution linked to a recurring contribution updates the amount & currency on the contribution_recur record

After
----------------------------------------
Only updates to the contributions with `is_template = TRUE` will update details on the contribution recur record. 

Technical Details
----------------------------------------
It's worth noting that template contributions are only created when a recurring is edited so by moving the queries around a bit I was able to return quicker with less queries too.

Note only creating template contributions when needed is a good thing as it reduces database bloat. We have 22 contribution records with `is_template` = 1  in our database - which iis several zeros less than the number of recurring contributions we have.


Comments
----------------------------------------
@mattwire  - I think this was just an over-sight after digging into it
