### PR TITLE
Fix Authorization failed on Event Registration - 5.56 RC regression

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -1074,7 +1074,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $profiles[] = $form->_values[$topProfile];
     }
     if (!empty($profiles)) {
-      $uFGroups = \Civi\Api4\UFGroup::get()
+      $uFGroups = \Civi\Api4\UFGroup::get(FALSE)
         ->addSelect('add_to_group_id')
         ->addWhere('id', 'IN', $profiles)
         ->execute();


### PR DESCRIPTION
Overview
----------------------------------------

To reproduce:

- as an anonymous user, register for an event that uses profiles (nothing special, I think)
- after the confirmation step, CiviCRM throws a generic "Authorization failed" error.

Technical Details
----------------------------------------

We had a few CiviCRM Spark users report the issue. They had fairly standard configurations, including providing anonymous users with "access ajax api".

Side-note: these errors can be difficult to debug without a debugger? I tend to add:

```
die(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), 1));
```

in `Civi/API/Kernel.php` function `authorize` (before the `throw`). Enabling debugging does not display more information. Is there a debug/log call we could add by default in that function, so that something is logged? (and ideally trace displayed on screen if debugging is enabled)