### PR TITLE
Don't crash API4 if pseudoconstant lookups return nothing

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -633,6 +633,10 @@ class Api4SelectQuery {
       return sprintf('%s %s "%s"', $fieldAlias, $operator, \CRM_Core_DAO::escapeString($value));
     }
 
+    if (!$value && ($operator === 'IN' || $operator === 'NOT IN')) {
+      $value[] = FALSE;
+    }
+
     if (is_bool($value)) {
       $value = (int) $value;
     }

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -424,4 +424,17 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount(0, $result);
   }
 
+  public function testInvalidPseudoConstantWithIN(): void {
+    $this->createTestRecord('Contact', [
+      'first_name' => uniqid(),
+      'last_name' => uniqid(),
+      'prefix_id:name' => 'Ms.',
+    ]);
+    $resultCount = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('prefix_id:name', 'IN', ['Msssss.'])
+      ->execute();
+    $this->assertCount(0, $resultCount);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4002.

Before
----------------------------------------
An API call that uses pseudoconstants that don't exist creates an exception.

After
----------------------------------------
An API call that uses pseudoconstants that don't exist returns no records.
