### PR TITLE
ajax batchSave() method should be static, php8 compatibility

### DIFF
--- a/CRM/Batch/Page/AJAX.php
+++ b/CRM/Batch/Page/AJAX.php
@@ -23,7 +23,7 @@ class CRM_Batch_Page_AJAX {
   /**
    * Save record.
    */
-  public function batchSave() {
+  public static function batchSave() {
     // save the entered information in 'data' column
     $batchId = CRM_Utils_Type::escape($_POST['batch_id'], 'Positive');
 


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/22895 in php8 the batchSave() method gives errors when used as an AJAX callback without being marked as static.