### PR TITLE
Log API Authorization failed errors

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -144,7 +144,16 @@ class Kernel {
     $this->boot($apiRequest);
 
     [$apiProvider, $apiRequest] = $this->resolve($apiRequest);
-    $this->authorize($apiProvider, $apiRequest);
+
+    try {
+      $this->authorize($apiProvider, $apiRequest);
+    }
+    catch (\Civi\API\Exception\UnauthorizedException $e) {
+      // We catch and re-throw to log for visibility
+      \CRM_Core_Error::backtrace('API Request Authorization failed', TRUE);
+      throw $e;
+    }
+
     [$apiProvider, $apiRequest] = $this->prepare($apiProvider, $apiRequest);
     $result = $apiProvider->invoke($apiRequest);
 


### PR DESCRIPTION
Overview
----------------------------------------

Related to #25025, it would be nice to have more visibility about "Authorization failed" errors, both for stats/logging, and to make it easier to debug when those errors happen.

To be honest I have done very limited testing. I'll try to deploy to production in some places, to see how noizy it can be.