### PR TITLE
default token filter

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -508,6 +508,14 @@ class TokenProcessor {
           return $value;
         }
 
+      case 'default':
+        if (!$value) {
+          return $filter[1];
+        }
+        else {
+          return $value;
+        }
+
       default:
         throw new \CRM_Core_Exception('Invalid token filter: ' . json_encode($filter, JSON_UNESCAPED_SLASHES));
     }

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -350,9 +350,11 @@ class TokenProcessorTest extends \CiviUnitTestCase {
       'This is {foo_bar.whiz_bang|upper}!' => 'This is SOME TEXT!',
       'This is {foo_bar.whiz_bang|boolean}!' => 'This is 1!',
       'This is {foo_bar.whiz_bop|boolean}!' => 'This is 0!',
+      'This is {foo_bar.whiz_bang|default:"bang"}.' => 'This is Some Text.',
+      'This is {foo_bar.whiz_bop|default:"bop"}.' => 'This is bop.',
     ];
-    // We expect 5 messages to be parsed 2 times each - ie 10 times.
-    $expectExampleCount = 10;
+    // We expect 7 messages to be parsed 2 times each - ie 14 times.
+    $expectExampleCount = 14;
     $actualExampleCount = 0;
 
     foreach ($exampleMessages as $inputMessage => $expectOutput) {


### PR DESCRIPTION
Overview
----------------------------------------
This adds a token filter of "default", e.g.:
```
Membership Type: {civicrm_membership.name|default:"Not a member"}
```
will return "Not a Member" instead of rendering a blank token.

Before
----------------------------------------
No default filter.

After
----------------------------------------
Default filter.

Comments
----------------------------------------
I don't think *any* token filters besides `crmDate` are documented?  If someone thinks otherwise, show me where.  Either way, this needs documentation.
