### PR TITLE
afform/oauth-client - don't call stat on null

### DIFF
--- a/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
+++ b/ext/afform/core/Civi/Afform/AngularDependencyMapper.php
@@ -53,7 +53,7 @@ class AngularDependencyMapper {
         \Civi::log()->warning("Missing html file for Afform: '$jFile'");
         continue;
       }
-      $jStat = stat($jFile);
+      $jStat = $jFile ? stat($jFile) : FALSE;
       $hStat = stat($hFile);
 
       if ($cacheLine === NULL) {


### PR DESCRIPTION
Overview
----------------------------------------
Calling stat() on null

Before
----------------------------------------
`Deprecated function: stat(): Passing null to parameter #1 ($filename) of type string is deprecated in Civi\Afform\AngularDependencyMapper::autoReq() (line 56`

After
----------------------------------------


Technical Details
----------------------------------------
oauth-client has a bunch of .html files that don't have a corresponding .json file. This causes the errors in the above code. I assume it's perfectly fine that you can have .html without .json, since it doesn't seem to affect any functioning.

Comments
----------------------------------------

