### PR TITLE
Use search display to view errors when using Civi-import extension

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -234,4 +234,8 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
       }
     }
   }
+
+  if ($formName === 'CRM_Contact_Import_Form_Summary') {
+    $form->assign('downloadErrorRecordsUrl', '/civicrm/search#/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR');
+  }
 }

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -34,7 +34,7 @@
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record has not been imported.{/ts}
         </p>
         <p class="error">
-        {ts 1=$downloadErrorRecordsUrl|smarty:nodefaults}You can <a href='%1'>Download Errors</a>. You may then correct them, and import the new file with the corrected data.{/ts}
+        {ts 1=$downloadErrorRecordsUrl|smarty:nodefaults}You can <a href='%1'>See the errors</a>. You may then correct them, and re-import with the corrected data.{/ts}
         </p>
     {/if}
 
@@ -66,7 +66,7 @@
       <tr class="error"><td class="label crm-grid-cell">{ts}Invalid Rows (skipped){/ts}</td>
         <td class="data">{$invalidRowCount}</td>
         <td class="explanation">{ts}Rows with invalid data in one or more fields (for example, invalid email address formatting). These rows will be skipped (not imported).{/ts}
-          <div class="action-link"><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
+          <div class="action-link"><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}See Errors{/ts}</a></div>
         </td>
       </tr>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Use search display to view errors when using Civi-import extension

This replaces the link to download the csv with a link to view the search display if civiimport is enabled, allowing re-doing within the UI


Before
----------------------------------------
After importing there is a link to download the errors
![image](https://user-images.githubusercontent.com/336308/203667179-8e9711f5-fc1d-46b8-b066-b9d3a1faa039.png)


After
----------------------------------------
The link is renamed to 'See Errors'

![image](https://user-images.githubusercontent.com/336308/203667279-1704e9c1-1e8c-4efa-bcee-93c6987bc7e3.png)

IF the civiimport extension is enabled the link goes to the relevant search display - at which point the import data can be optionally edited without having to wrangle a csv

![image](https://user-images.githubusercontent.com/336308/203667353-439264f0-06a4-495f-8687-e94edb08711c.png)

After which rows can be re-attempted one by one or en mass

![image](https://user-images.githubusercontent.com/336308/203667461-f3a07762-ad87-4217-b7cb-c5a976c8cd7a.png)


Technical Details
----------------------------------------
This is pretty straight forward really :-)

Comments
----------------------------------------
@colemanw - this is what we discussed at the airport :-) It's possible I'll switch to an afform - but I think that is not-blocking as it can happen as evolves
