### PR TITLE
{drowning-support-needed} Embed Seach display in summary screen

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -234,4 +234,8 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
       }
     }
   }
+
+  if ($formName === 'CRM_Contact_Import_Form_Summary') {
+    $form->assign('downloadErrorRecordsUrl', '/civicrm/search#/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR');
+  }
 }

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -236,6 +236,9 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
   }
 
   if ($formName === 'CRM_Contact_Import_Form_Summary') {
+    Civi::service('angularjs.loader')->addModules('crmSearchDisplay');
+    Civi::service('angularjs.loader')->addModules('afCore');
+    Civi::service('angularjs.loader')->addModules('af');
     $form->assign('downloadErrorRecordsUrl', '/civicrm/search#/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR');
   }
 }

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -34,7 +34,7 @@
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record has not been imported.{/ts}
         </p>
         <p class="error">
-        {ts 1=$downloadErrorRecordsUrl|smarty:nodefaults}You can <a href='%1'>Download Errors</a>. You may then correct them, and import the new file with the corrected data.{/ts}
+        {ts 1=$downloadErrorRecordsUrl|smarty:nodefaults}You can <a href='%1'>See the errors</a>. You may then correct them, and re-import with the corrected data.{/ts}
         </p>
     {/if}
 
@@ -66,7 +66,7 @@
       <tr class="error"><td class="label crm-grid-cell">{ts}Invalid Rows (skipped){/ts}</td>
         <td class="data">{$invalidRowCount}</td>
         <td class="explanation">{ts}Rows with invalid data in one or more fields (for example, invalid email address formatting). These rows will be skipped (not imported).{/ts}
-          <div class="action-link"><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
+          <div class="action-link"><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}"><i class="crm-i fa-download" aria-hidden="true"></i> {ts}See Errors{/ts}</a></div>
         </td>
       </tr>
     {/if}

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -34,10 +34,21 @@
         {ts count=$invalidRowCount plural='CiviCRM has detected invalid data and/or formatting errors in %count records. These records have not been imported.'}CiviCRM has detected invalid data and/or formatting errors in one record. This record has not been imported.{/ts}
         </p>
         <p class="error">
-        {ts 1=$downloadErrorRecordsUrl|smarty:nodefaults}You can <a href='%1'>See the errors</a>. You may then correct them, and re-import with the corrected data.{/ts}
+        {ts 1=$downloadErrorRecordsUrl|smarty:nodefaults}You can <a href='%1'>see the errors</a>. You may then correct them, and re-import with the corrected data.{/ts}
         </p>
     {/if}
+  I'm here-ere
+  I'm here
+  <crm-angular-js modules="crmSearchDisplay">
+    <af-gui-search display="display"></af-gui-search>
+    <crm-search-display-table search-name="Import_Summary_1" display-name="Import_Summary_1"">
+    </crm-search-display-table>
+    <div af-fieldset="">
+      <crm-search-display-table search-name="Import_Summary_1" display-name="Import_Summary_1"">
+      </crm-search-display-table>
+    </div>
 
+  </crm-angular-js>
     {if $duplicateRowCount}
         <p {if $dupeError}class="error"{/if}>
         {ts count=$duplicateRowCount plural='CiviCRM has detected %count records which are duplicates of existing CiviCRM contact records.'}CiviCRM has detected one record which is a duplicate of existing CiviCRM contact record.{/ts} {$dupeActionString}


### PR DESCRIPTION
@colemanw after meticulously  working through the detailed instructions here https://docs.civicrm.org/dev/en/latest/afform/overview/#embedding  I tried & failed to embed a search display in the summary screen from an import - help

Note that the import creates searches but not an afform - hence I tried with a completely different form (also because the instructions were a bit vague on how I would refer to the one I manually created....)