### PR TITLE
Fix Import summary to differentiate between 'valid' and 'imported'

### DIFF
--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -63,7 +63,8 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
     $this->assign('outputUnavailable', FALSE);
     try {
       $this->assign('totalRowCount', $this->getRowCount());
-      $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID) + $this->getRowCount(CRM_Import_Parser::UNPARSED_ADDRESS_WARNING));
+      $this->assign('unprocessedRowCount', $this->getRowCount() - $this->getRowCount('imported') - $this->getRowCount(CRM_Import_Parser::ERROR) - $this->getRowCount(CRM_Import_Parser::DUPLICATE));
+      $this->assign('importedRowCount', $this->getRowCount('imported'));
       $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
       $this->assign('duplicateRowCount', $this->getRowCount(CRM_Import_Parser::DUPLICATE));
       $this->assign('unMatchCount', $this->getRowCount(CRM_Import_Parser::NO_MATCH));
@@ -100,6 +101,7 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
       }
       $this->assign('dupeActionString', $dupeActionString);
     }
+    // @todo - remove this - it is never thrown.
     catch (CRM_Import_Exception_ImportTableUnavailable $e) {
       $this->assign('outputUnavailable', TRUE);
     }

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -639,6 +639,7 @@ abstract class CRM_Import_DataSource {
       CRM_Contribute_Import_Parser_Contribution::PLEDGE_PAYMENT_ERROR => ['pledge_payment_error'],
       'new' => ['new', 'valid'],
       'valid' => ['valid'],
+      'imported' => ['imported', 'soft_credit_imported', 'pledge_payment_imported', 'warning_unparsed_address'],
     ];
   }
 

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -14,11 +14,14 @@
 
  {* WizardHeader.tpl provides visual display of steps thru the wizard as well as title for current step *}
  {include file="CRM/common/WizardHeader.tpl"}
-<div class="help">
-    <p>
-      <strong>{ts}Import has completed successfully.{/ts}</strong>
-    {if $outputUnavailable}{ts}Detailed information is no longer available.{/ts}{else}{ts}The information below summarizes the results.{/ts}{/if}
-    </p>
+ <div class="help">
+   <p>
+     {if $unprocessedRowCount}
+       <strong>{ts}The import is still processing.{/ts}</strong>
+     {else}
+       <strong>{ts}Import has completed successfully.{/ts}</strong>
+     {/if}
+   </p>
 
    {if $unMatchCount}
         <p class="error">
@@ -61,6 +64,12 @@
       <td class="data">{$totalRowCount}</td>
       <td class="explanation">{ts}Total number of rows in the imported data.{/ts}</td>
     </tr>
+    {if $unprocessedRowCount}
+      <tr><td class="label crm-grid-cell">{ts}Rows Still processing{/ts}</td>
+        <td class="data">{$unprocessedRowCount}</td>
+        <td class="explanation">{ts}Rows still being processed.{/ts}</td>
+      </tr>
+    {/if}
 
     {if $invalidRowCount}
       <tr class="error"><td class="label crm-grid-cell">{ts}Invalid Rows (skipped){/ts}</td>
@@ -91,7 +100,7 @@
 
     <tr>
       <td class="label crm-grid-cell">{ts}Total Rows Imported{/ts}</td>
-      <td class="data">{$validRowCount}</td>
+      <td class="data">{$importedRowCount}</td>
       <td class="explanation">{ts}Total number of primary records created or modified during the import.{/ts}</td>
     </tr>
     {foreach from=$trackingSummary item="summaryRow"}


### PR DESCRIPTION
Overview
----------------------------------------
Fix Import summary to differentiate between 'valid' and 'imported'

Before
----------------------------------------
The contact summary page assumes that

1) the import has completed
2) all rows not marked error or invalid succeeded

event when, as in this case, the import has not actually started running

![image](https://user-images.githubusercontent.com/336308/203682735-a04e3bd8-a86a-46be-8ef2-96d8aa30f6b5.png)


After
----------------------------------------
The screen differentiates between the two

![image](https://user-images.githubusercontent.com/336308/203682594-2aa2ea18-5785-4d7f-a5c3-a14cf594dd6f.png)


Technical Details
----------------------------------------
This form used to be only accessible as part of the QuickForm wizard flow - but now it is standalone and relects the current state of the job. Hence the assumptions need updating

Comments
----------------------------------------
The `$outputUnavailable` smarty var looks like a good intention I had during the refactor that is now always FALSE - I removed just the part that wouldn't cause a big whitespace diff for this PR

