### PR TITLE
Create MVP UI for imports when background queue processing is taking place

### DIFF
--- a/ext/civiimport/templates/CRM/Import/Monitor.tpl
+++ b/ext/civiimport/templates/CRM/Import/Monitor.tpl
@@ -1,0 +1,19 @@
+<div id='crm-import-progress'></div>
+{literal}
+  <script>
+    CRM.$(function($) {
+      var target = '#crm-import-progress';
+      var url = CRM.vars.civiimport.url;
+      // Load the snippet into the container
+      CRM.loadPage(url, {
+        target: target,
+        block: false
+      })
+      window.setInterval(function () {
+        if (document.hasFocus()) {
+          CRM.$(target).crmSnippet('refresh');
+        }
+      }, 1000);
+    });
+  </script>
+{/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Create acceptable UI for imports when background queue processing is taking place 

BackGround queue processing requires three things

1) enable civi-import core extension 

2) the setting to be enabled - eg.
``` drush @dmaster cvapi Setting.create enableBackgroundQueue=1```

3) a job to run in the background processing the queue. In build-kit environments running `coworker run` from the site directory will generally work

The result of this is that the Import will run in the background and the user does not have to keep the browser tab open

Before
----------------------------------------
There is a placeholder screen

![image](https://user-images.githubusercontent.com/336308/203692988-e1b5463b-40f4-4941-b3bb-243797412c2d.png)


After
----------------------------------------
![import](https://user-images.githubusercontent.com/336308/203694293-4fa03fb7-4b7c-412f-aa30-545e13f6d776.gif)


Technical Details
----------------------------------------
I decided to do an import-specific version of this in the import extension to avoid having to figure out larger issues around this & also to provide a space where the experience could be tailored to imports. This approach made removing this last blocker more manageable.

I think there is a lot of scope to improve wording but I left that out of scope for this commit. The main thing we probably want to communicate is that they can close the browser, bookmark the page & come back



Comments
----------------------------------------
The csv I used for testing is in this ext - https://github.com/eileenmcnaughton/testdata/tree/master/csvs
