### PR TITLE
Pass correct variable type to the hook

### DIFF
--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -146,7 +146,8 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
   public function browse() {
     // do nothing :) we are using datatable for rendering relationship selectors
     $columnHeaders = CRM_Contact_BAO_Relationship::getColumnHeaders();
-    $contactRelationships = $selector = NULL;
+    $selector = NULL;
+    $contactRelationships = [];
     CRM_Utils_Hook::searchColumns('relationship.columns', $columnHeaders, $contactRelationships, $selector);
     $this->assign('columnHeaders', $columnHeaders);
   }


### PR DESCRIPTION
The variable type for 'rows' is an array, not null. Fix to pass an empty array.

I renamed it to 'rows' since that is what the hook calls it & it is just a dummy variable from the page's point of view

`selector` is an object - so I didn't touch that one

https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_searchColumns/
