### PR TITLE
Add noisy deprecation to deprecated contribution token functions

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4606,6 +4606,7 @@ LIMIT 1;";
     $messageToken,
     $escapeSmarty
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('use the TokenProcessor');
     if (empty($contributionIds)) {
       return [];
     }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1419,6 +1419,7 @@ class CRM_Utils_Token {
    * in CRM_Contribute_Form_Task_PDFLetter.
    */
   protected static function _buildContributionTokens() {
+    CRM_Core_Error::deprecatedFunctionWarning('use the token processor');
     $key = 'contribution';
 
     if (!isset(Civi::$statics[__CLASS__][__FUNCTION__][$key])) {
@@ -1569,6 +1570,7 @@ class CRM_Utils_Token {
    * @return mixed
    */
   public static function replaceContributionTokens($str, &$contribution, $html = FALSE, $knownTokens = NULL, $escapeSmarty = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('use the token processor');
     $key = 'contribution';
     if (!$knownTokens || empty($knownTokens[$key])) {
       //early return
@@ -1716,6 +1718,7 @@ class CRM_Utils_Token {
    * @throws \CRM_Core_Exception
    */
   public static function getContributionTokenReplacement($token, $contribution, $html = FALSE, $escapeSmarty = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('use the token processor');
     self::_buildContributionTokens();
 
     switch ($token) {

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -366,42 +366,6 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       }
     }
 
-    $messageToken = CRM_Utils_Token::getTokens($this->schedule->body_text);
-
-    $contributionDetails = CRM_Contribute_BAO_Contribution::replaceContributionTokens(
-      [$this->ids['Contribution']['alice']],
-      $this->schedule->body_text,
-      $messageToken,
-      $this->schedule->body_text,
-      $this->schedule->body_text,
-      $messageToken,
-      TRUE
-    );
-    $expected = [
-      'receive_date = February 1st, 2015',
-      'new style status = Completed',
-      'contribution status id = 1',
-      'id ' . $this->ids['Contribution']['alice'],
-      'contribution_id ' . $this->ids['Contribution']['alice'],
-      'financial type id = 1',
-      'financial type name = Donation',
-      'financial type label = Donation',
-      'payment instrument id = 4',
-      'payment instrument name = Check',
-      'payment instrument label = Check',
-      'legacy source SSF',
-      'source SSF',
-      'non_deductible_amount = € 10.00',
-      'total_amount = € 100.00',
-      'net_amount = € 95.00',
-      'fee_amount = € 5.00',
-      'campaign_id = 1',
-      'campaign name = big_campaign',
-      'campaign label = Campaign',
-    ];
-    foreach ($expected as $string) {
-      $this->assertStringContainsString($string, $contributionDetails[$this->contacts['alice']['id']]['html']);
-    }
     $tokens = [
       'id',
       'payment_instrument_id:label',

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -1233,79 +1233,9 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
   }
 
   /**
-   * Test for replaceContributionTokens.
-   *
-   * This function tests whether the contribution tokens are replaced with
-   * values from contribution.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function testReplaceContributionTokens(): void {
-    $customGroup = $this->customGroupCreate(['extends' => 'Contribution', 'title' => 'contribution stuff']);
-    $customField = $this->customFieldOptionValueCreate($customGroup, 'myCustomField');
-    $contactId1 = $this->individualCreate();
-    $params = [
-      'contact_id' => $contactId1,
-      'receive_date' => '20120511',
-      'total_amount' => 100.00,
-      'financial_type_id' => 1,
-      'trxn_id' => 12345,
-      'invoice_id' => 67890,
-      'source' => 'SSF',
-      'contribution_status_id' => 2,
-      "custom_{$customField['id']}" => 'value1',
-      'currency' => 'EUR',
-    ];
-    $contribution1 = $this->contributionCreate($params);
-    $contactId2 = $this->individualCreate();
-    $params = [
-      'contact_id' => $contactId2,
-      'receive_date' => '20150511',
-      'total_amount' => 200.00,
-      'financial_type_id' => 1,
-      'trxn_id' => 6789,
-      'invoice_id' => 12345,
-      'source' => 'ABC',
-      'contribution_status_id' => 1,
-      "custom_{$customField['id']}" => 'value2',
-    ];
-    $contribution2 = $this->contributionCreate($params);
-    $ids = [$contribution1, $contribution2];
-
-    $subject = 'This is a test for contribution ID: {contribution.contribution_id}';
-    $text = 'Contribution Amount: {contribution.total_amount}';
-    $html = "<p>Contribution Source: {contribution.contribution_source}</p></br>
-      <p>Contribution Invoice ID: {contribution.invoice_id}</p></br>
-      <p>Contribution Receive Date: {contribution.receive_date}</p></br>
-      <p>Contribution Custom Field: {contribution.custom_{$customField['id']}}</p></br>
-      {contribution.contribution_status_id:name}";
-
-    $subjectToken = CRM_Utils_Token::getTokens($subject);
-    $messageToken = CRM_Utils_Token::getTokens($text);
-    $messageToken = array_merge($messageToken, CRM_Utils_Token::getTokens($html));
-
-    $contributionDetails = CRM_Contribute_BAO_Contribution::replaceContributionTokens(
-      $ids,
-      $subject,
-      $subjectToken,
-      $text,
-      $html,
-      $messageToken,
-      TRUE
-    );
-
-    $this->assertEquals('Contribution Amount: € 100.00', $contributionDetails[$contactId1]['text'], 'The text does not match');
-    $this->assertEquals('<p>Contribution Source: ABC</p></br>
-      <p>Contribution Invoice ID: 12345</p></br>
-      <p>Contribution Receive Date: May 11th, 2015 12:00 AM</p></br>
-      <p>Contribution Custom Field: Label2</p></br>
-      Completed', $contributionDetails[$contactId2]['html'], 'The html does not match');
-  }
-
-  /**
    * Test for contribution with deferred revenue.
    */
-  public function testContributionWithDeferredRevenue() {
+  public function testContributionWithDeferredRevenue(): void {
     $contactId = $this->individualCreate();
     Civi::settings()->set('deferred_revenue_enabled', TRUE);
     $params = [


### PR DESCRIPTION
Overview
----------------------------------------
Add noisy deprecation to deprecated contribution token functions

Before
----------------------------------------
Within core the functions are only called from tests, mumbly deprecation

After
----------------------------------------
Noisy deprecation

Technical Details
----------------------------------------
Although this looks like a reduction in test cover the replace functions (the token processor) and the form functions (eg. create pdf letter) have their own tests that cover the functionality used by core - these were mostly parity tests - ie to ensure we didn't lose parity while adding the processor

Comments
----------------------------------------