### PR TITLE
Fix Scheduled reminders form to use tokenProcessor to get token list

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Token\TokenProcessor;
+
 /**
  * This class generates form components for Scheduling Reminders.
  */
@@ -696,19 +698,13 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
    *
    * @return array
    */
-  public function listTokens() {
-    $tokenProcessor = new \Civi\Token\TokenProcessor(\Civi::dispatcher(), [
-      'controller' => get_class(),
+  public function listTokens(): array {
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => __CLASS__,
       'smarty' => FALSE,
-      'schema' => ['activityId', 'participantId'],
+      'schema' => ['activityId', 'participantId', 'membershipId', 'contactId', 'eventId', 'contributionId'],
     ]);
-    $tokens = $tokenProcessor->listTokens();
-
-    $tokens = array_merge(CRM_Core_SelectValues::contactTokens(), $tokens);
-    $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
-    $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
-    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
-    return $tokens;
+    return $tokenProcessor->listTokens();
   }
 
 }

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -540,6 +540,8 @@ class CRM_Core_SelectValues {
   /**
    * Different type of Membership Tokens.
    *
+   * @deprecated
+   *
    * @return array
    */
   public static function membershipTokens(): array {


### PR DESCRIPTION


Overview
----------------------------------------
Fix Scheduled reminders form to use tokenProcessor to get token list

This is the last place outside of tests that calls some of these functions so I will check in on them

Before
----------------------------------------
call to `listTokens` supplemented by a bunch of legacy function calls

```
 $tokens = $tokenProcessor->listTokens();

    $tokens = array_merge(CRM_Core_SelectValues::contactTokens(), $tokens);
    $tokens = array_merge(CRM_Core_SelectValues::eventTokens(), $tokens);
    $tokens = array_merge(CRM_Core_SelectValues::membershipTokens(), $tokens);
    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
    return $tokens;
```


After
----------------------------------------
Correct schema declared so `listTokens` does all the work

Technical Details
----------------------------------------


Comments
----------------------------------------
