### PR TITLE
Make MessageTemplate.master_id fully joinable

### DIFF
--- a/Civi/Api4/Event/Subscriber/MessageTemplateSchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/MessageTemplateSchemaMapSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Api4\Event\Events;
+use Civi\Api4\Event\SchemaMapBuildEvent;
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service civi.api4.messagetemplateSchema
+ */
+class MessageTemplateSchemaMapSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      Events::SCHEMA_MAP_BUILD => 'onSchemaBuild',
+    ];
+  }
+
+  /**
+   * This creates a joinable which gets exposed and rendered by:
+   *
+   * @see \Civi\Api4\Service\Spec\Provider\MessageTemplateGetSpecProvider
+   *
+   * @param \Civi\Api4\Event\SchemaMapBuildEvent $event
+   *
+   * Condition based on CRM_Admin_Page_MessageTemplates::__construct()
+   */
+  public function onSchemaBuild(SchemaMapBuildEvent $event) {
+    $schema = $event->getSchemaMap();
+    $table = $schema->getTableByName('civicrm_msg_template');
+
+    $link = new Joinable("civicrm_msg_template", 'id', "master_id");
+    $link->setBaseTable('civicrm_msg_template');
+    $link->setJoinType(Joinable::JOIN_TYPE_ONE_TO_ONE);
+    $link->addCondition("`{target_table}`.`id` =
+      (SELECT `id` FROM `civicrm_msg_template` `orig`
+        WHERE `{base_table}`.`workflow_name` = `orig`.`workflow_name` AND `orig`.`is_reserved` = 1 AND
+          ( `{base_table}`.`msg_subject` != `orig`.`msg_subject` OR
+            `{base_table}`.`msg_text`    != `orig`.`msg_text`    OR
+            `{base_table}`.`msg_html`    != `orig`.`msg_html`
+          ))"
+    );
+    $table->addTableLink(NULL, $link);
+  }
+
+}

--- a/Civi/Api4/Service/Spec/Provider/MessageTemplateGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/MessageTemplateGetSpecProvider.php
@@ -23,7 +23,7 @@ class MessageTemplateGetSpecProvider extends \Civi\Core\Service\AutoService impl
       ->setInputType('Select')
       ->setReadonly(TRUE)
       ->setFkEntity('MessageTemplate')
-      ->setSqlRenderer([__CLASS__, 'revertible']);
+      ->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
     $spec->addFieldSpec($field);
   }
 
@@ -35,21 +35,6 @@ class MessageTemplateGetSpecProvider extends \Civi\Core\Service\AutoService impl
    */
   public function applies($entity, $action) {
     return $entity === 'MessageTemplate' && $action === 'get';
-  }
-
-  /**
-   * Callback for finding id of template to revert to
-   * Based on CRM_Admin_Page_MessageTemplates::__construct()
-   *
-   * @return string
-   */
-  public static function revertible(): string {
-    return "(SELECT `id` FROM `civicrm_msg_template` `orig`
-      WHERE `a`.`workflow_name` = `orig`.`workflow_name` AND `orig`.`is_reserved` = 1 AND
-        ( `a`.`msg_subject` != `orig`.`msg_subject` OR
-          `a`.`msg_text`    != `orig`.`msg_text`    OR
-          `a`.`msg_html`    != `orig`.`msg_html`
-        ))";
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -342,45 +342,6 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test APIv4 calculated field master_id
-   */
-  public function testMessageTemplateMasterID() {
-    CRM_Core_Transaction::create(TRUE)->run(function(CRM_Core_Transaction $tx) {
-      $tx->rollback();
-
-      $messageTemplateID = MessageTemplate::get()
-        ->addWhere('is_default', '=', 1)
-        ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
-        ->addSelect('id')
-        ->execute()->first()['id'];
-      $messageTemplateIDReserved = MessageTemplate::get()
-        ->addWhere('is_reserved', '=', 1)
-        ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
-        ->addSelect('id')
-        ->execute()->first()['id'];
-      $master_id = MessageTemplate::get()
-        ->addSelect('master_id')
-        ->addWhere('id', '=', $messageTemplateID)
-        ->execute()->first()['master_id'];
-      $this->assertNull($master_id);
-
-      MessageTemplate::update()
-        ->addWhere('id', '=', $messageTemplateID)
-        ->setValues([
-          'msg_subject' => 'Hello world',
-          'msg_text' => 'Hello world',
-          'msg_html' => '<p>Hello world</p>',
-        ])
-        ->execute();
-      $master_id = MessageTemplate::get()
-        ->addSelect('master_id')
-        ->addWhere('id', '=', $messageTemplateID)
-        ->execute()->first()['master_id'];
-      $this->assertEquals($master_id, $messageTemplateIDReserved);
-    });
-  }
-
-  /**
    * Test rendering of domain tokens.
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
+++ b/tests/phpunit/api/v4/Entity/MessageTemplateTest.php
@@ -22,6 +22,7 @@ use api\v4\Api4TestBase;
 use Civi\Test\DbTestTrait;
 use Civi\Test\GenericAssertionsTrait;
 use Civi\Test\TransactionalInterface;
+use Civi\Api4\MessageTemplate;
 
 /**
  * @group headless
@@ -132,6 +133,56 @@ class MessageTemplateTest extends Api4TestBase implements TransactionalInterface
     $saved = civicrm_api4('MessageTemplate', 'save', ['records' => [array_merge(['id' => NULL, 'is_reserved' => 0], $this->baseTpl)]])->first();
     $this->assertDBQuery('My Template', 'SELECT msg_title FROM civicrm_msg_template WHERE id = %1', [1 => [$saved['id'], 'Int']]);
     $this->assertDBQuery('<p>My body as HTML</p>', 'SELECT msg_html FROM civicrm_msg_template WHERE id = %1', [1 => [$saved['id'], 'Int']]);
+  }
+
+  /**
+   * Test APIv4 calculated field master_id
+   */
+  public function testMessageTemplateMasterID() {
+    \CRM_Core_Transaction::create(TRUE)->run(function(\CRM_Core_Transaction $tx) {
+      $tx->rollback();
+
+      $messageTemplateID = MessageTemplate::get()
+        ->addWhere('is_default', '=', 1)
+        ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
+        ->addSelect('id')
+        ->execute()->first()['id'];
+      $messageTemplateIDReserved = MessageTemplate::get()
+        ->addWhere('is_reserved', '=', 1)
+        ->addWhere('workflow_name', '=', 'contribution_offline_receipt')
+        ->addSelect('id')
+        ->execute()->first()['id'];
+      $msgTpl = MessageTemplate::get()
+        ->addSelect('msg_subject', 'master_id', 'master_id.msg_subject')
+        ->addWhere('id', '=', $messageTemplateID)
+        ->execute()->first();
+      // confirm subject is set
+      $this->assertNotNull($msgTpl['msg_subject']);
+      // message is unchanged from original so both of these should be null
+      $this->assertNull($msgTpl['master_id']);
+      $this->assertNull($msgTpl['master_id.msg_subject']);
+
+      MessageTemplate::update()
+        ->addWhere('id', '=', $messageTemplateID)
+        ->setValues([
+          'msg_subject' => 'Hello world',
+          'msg_text' => 'Hello world',
+          'msg_html' => '<p>Hello world</p>',
+        ])
+        ->execute();
+      $msgTpl = MessageTemplate::get()
+        ->addSelect('msg_subject', 'master_id', 'master_id.msg_subject')
+        ->addWhere('id', '=', $messageTemplateID)
+        ->execute()->first();
+      // confirm subject is set
+      $this->assertNotNull($msgTpl['msg_subject']);
+      // message is changed so both of these should be set
+      $this->assertEquals($msgTpl['master_id'], $messageTemplateIDReserved);
+      $this->assertNotNull($msgTpl['master_id.msg_subject']);
+      // these should be different
+      $this->assertNotEquals($msgTpl['msg_subject'], $msgTpl['master_id.msg_subject']);
+
+    });
   }
 
 }


### PR DESCRIPTION
Update to https://github.com/civicrm/civicrm-core/pull/24992

Overview
----------------------------------------
Make MessageTemplate.master_id fully joinable

Before
----------------------------------------
`MessageTemplate.master_id` returned the id of the master template (ie the core distributed one)
But fields of the master template like `MessageTemplate.master_id.msg_subject` were not returned.

After
----------------------------------------
Fields of the master template like `MessageTemplate.master_id.msg_subject` are returned.

Technical Details
----------------------------------------
Also moves tests out of the BAO class since these fields are not in the BAO.  Enhanced tests

Comments
----------------------------------------

@colemanw 