### PR TITLE
Improve formatting for recurring contributions in user dashboard

### DIFF
--- a/templates/CRM/Contribute/Page/UserDashboard.tpl
+++ b/templates/CRM/Contribute/Page/UserDashboard.tpl
@@ -120,7 +120,7 @@
                 <div><label>{ts}Recurring Contribution(s){/ts}</label></div>
                 <table class="selector">
                     <tr class="columnheader">
-                        <th>{ts}Terms:{/ts}</th>
+                        <th>{ts}Terms{/ts}</th>
                         <th>{ts}Status{/ts}</th>
                         <th>{ts}Installments{/ts}</th>
                         <th>{ts}Created{/ts}</th>
@@ -129,13 +129,18 @@
                     {foreach from=$recurRows item=row key=id}
                         <tr class="{cycle values="odd-row,even-row"}">
                             <td><label>{$recurRows.$id.amount|crmMoney}</label>
-                                every {$recurRows.$id.frequency_interval} {$recurRows.$id.frequency_unit}
-                                for {$recurRows.$id.installments} installments
+                                {ts 1=$recurRows.$id.frequency_interval 2=$recurRows.$id.frequency_unit} every %1 %2{/ts}
+                                {if !empty($recurRows.$id.installments)}
+                                    {ts 1=$recurRows.$id.installments} for %1 installments{/ts}
+                                {/if}
                             </td>
                             <td>{$recurRows.$id.recur_status}</td>
                             <td>{if $recurRows.$id.completed}<a href="{$recurRows.$id.link}">{$recurRows.$id.completed}
-                                    /{$recurRows.$id.installments}</a>
-                                {else}0/{$recurRows.$id.installments} {/if}</td>
+                                    {if !empty($recurRows.$id.installments)}/{$recurRows.$id.installments}{/if}</a>
+                                {else}0
+                                    {if !empty($recurRows.$id.installments)}/{$recurRows.$id.installments}{/if}
+                                {/if}
+                            </td>
                             <td>{$recurRows.$id.create_date|crmDate}</td>
                             <td>{$recurRows.$id.action|replace:'xx':$recurRows.id}</td>
                         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a few minor issues in the formatting of recurring contribution information on the user dashboard. Intended to close https://lab.civicrm.org/dev/core/-/issues/4005.

Before
----------------------------------------
Some specific and minor issues with the display of recurring contributions on the user dashboard:

1. No handling for if (installments == 0), i.e. the recurring contribution is open-ended. Just leaves a blank string which is confusing to users.
2. No spacing between clauses in 'Terms' - makes difficult to read. Also untranslated strings.
3. Unnecessary colon after 'Terms' in table header (doesn't match other header cells).

Screenshot below shows issues.

![image](https://user-images.githubusercontent.com/72983627/205190951-4db837e1-85df-4e38-a8b4-77ab1550a44b.png)
![image](https://user-images.githubusercontent.com/72983627/205190481-e8d642a5-9956-4fc3-a0d2-51f16187dca1.png)

After
----------------------------------------
The above issues resolved.

1. "for X instalments" omitted from 'Terms' and "/X" omitted from instalments counter if open-ended (X is blank).
2. spacing corrected by use of `{ts}...{/ts}` in Smarty template.
3. colon removed from table header cell.

Screenshot below shows example.

![image](https://user-images.githubusercontent.com/72983627/206880046-58e8af11-df92-4f7b-9f98-68142a337f8b.png)

Technical Details
----------------------------------------
Minor tweaks to Smarty file to implement these improvements.

Comments
----------------------------------------
Tested on CiviCRM 5.55.2.
