### PR TITLE
Afform - fix empty search filters

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -100,7 +100,7 @@
 
       getAfformFilters: function() {
         return _.pick(this.afFieldset ? this.afFieldset.getFieldData() : {}, function(val) {
-          return val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length);
+          return typeof val !== 'undefined' && val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length);
         });
       },
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3997](https://lab.civicrm.org/dev/core/-/issues/3997)

Before
----------------------------------------
Clearing a filter field breaks the search display

After
----------------------------------------
Fixed
