### PR TITLE
Use IP address helper method consistently

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -29,7 +29,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       ];
       Civi::log()->debug("SECURITY ALERT: Ajax requests can only be issued by javascript clients, eg. CRM.api4().",
         [
-          'IP' => $_SERVER['REMOTE_ADDR'],
+          'IP' => CRM_Utils_System::ipAddress(),
           'level' => 'security',
           'referer' => $_SERVER['HTTP_REFERER'],
           'reason' => 'CSRF suspected',
@@ -48,7 +48,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       ];
       Civi::log()->debug("SECURITY: All requests that modify the database must be http POST, not GET.",
         [
-          'IP' => $_SERVER['REMOTE_ADDR'],
+          'IP' => CRM_Utils_System::ipAddress(),
           'level' => 'security',
           'referer' => $_SERVER['HTTP_REFERER'],
           'reason' => 'Destructive HTTP GET',

--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -233,7 +233,7 @@ class CRM_Core_IDS {
    */
   private function log($result, $reaction = 0) {
     // Include X_FORWARD_FOR ip address if set as per IDS patten.
-    $ip = $_SERVER['REMOTE_ADDR'] . (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? ' (' . $_SERVER['HTTP_X_FORWARDED_FOR'] . ')' : '');
+    $ip = CRM_Utils_System::ipAddress() . (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? ' (' . $_SERVER['HTTP_X_FORWARDED_FOR'] . ')' : '');
 
     $data = [];
     $session = CRM_Core_Session::singleton();
@@ -285,7 +285,7 @@ class CRM_Core_IDS {
       $error = civicrm_api3_create_error(
         $msg,
         [
-          'IP' => $_SERVER['REMOTE_ADDR'],
+          'IP' => CRM_Utils_System::ipAddress(),
           'error_code' => 'IDS_KICK',
           'level' => 'security',
           'referer' => $_SERVER['HTTP_REFERER'],

--- a/CRM/Core/Page/AJAX/Attachment.php
+++ b/CRM/Core/Page/AJAX/Attachment.php
@@ -54,7 +54,7 @@ class CRM_Core_Page_AJAX_Attachment {
         require_once 'api/v3/utils.php';
         $results[$key] = civicrm_api3_create_error("SECURITY ALERT: Attaching files via AJAX requires a recent, valid token.",
           [
-            'IP' => $server['REMOTE_ADDR'],
+            'IP' => CRM_Utils_System::ipAddress(),
             'level' => 'security',
             'referer' => $server['HTTP_REFERER'],
             'reason' => 'CSRF suspected',

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -277,7 +277,7 @@ class CRM_Utils_REST {
       require_once 'api/v3/utils.php';
       return civicrm_api3_create_error("SECURITY: All requests that modify the database must be http POST, not GET.",
         [
-          'IP' => $_SERVER['REMOTE_ADDR'],
+          'IP' => CRM_Utils_System::ipAddress(),
           'level' => 'security',
           'referer' => $_SERVER['HTTP_REFERER'],
           'reason' => 'Destructive HTTP GET',
@@ -430,7 +430,7 @@ class CRM_Utils_REST {
     if (!$config->debug && !self::isWebServiceRequest()) {
       $error = civicrm_api3_create_error("SECURITY ALERT: Ajax requests can only be issued by javascript clients, eg. CRM.api3().",
         [
-          'IP' => $_SERVER['REMOTE_ADDR'],
+          'IP' => CRM_Utils_System::ipAddress(),
           'level' => 'security',
           'referer' => $_SERVER['HTTP_REFERER'],
           'reason' => 'CSRF suspected',
@@ -492,7 +492,7 @@ class CRM_Utils_REST {
       require_once 'api/v3/utils.php';
       $error = civicrm_api3_create_error("SECURITY ALERT: Ajax requests can only be issued by javascript clients, eg. CRM.api3().",
         [
-          'IP' => $_SERVER['REMOTE_ADDR'],
+          'IP' => CRM_Utils_System::ipAddress(),
           'level' => 'security',
           'referer' => $_SERVER['HTTP_REFERER'],
           'reason' => 'CSRF suspected',

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1272,7 +1272,7 @@ class CRM_Utils_System {
   }
 
   /**
-   * Get logged in user's IP address.
+   * Get the client's IP address.
    *
    * Get IP address from HTTP REMOTE_ADDR header. If the CMS is Drupal then use
    * the Drupal function as this also handles reverse proxies (based on proper

--- a/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
+++ b/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
@@ -215,7 +215,7 @@ class CRM_Utils_ReCAPTCHA {
     require_once E::path('lib/recaptcha/recaptchalib.php');
 
     $resp = recaptcha_check_answer(CRM_Core_Config::singleton()->recaptchaPrivateKey,
-      $_SERVER['REMOTE_ADDR'],
+      CRM_Utils_System::ipAddress(),
       $response
     );
     return $resp->is_valid;


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM has a helper method for getting the client's IP address. In Drupal installs, this uses Drupal's built-in function, which can correctly support setups involving remote proxies.

Not everywhere in the CiviCRM codebase is using this function, instead directly accessing `$_SERVER['REMOTE_ADDR']` which might be misleading.

This is part of preparation to fix CiviCRM's ipAddress method to correctly detect IP address regardless of CMS.

Before
----------------------------------------
 `$_SERVER['REMOTE_ADDR']` is used

After
----------------------------------------
`CRM_Utils_System::ipAddress()` is used

