### PR TITLE
dev/core#4008 - alternate to 24998 - Avoid symbol scan errors

### DIFF
--- a/ext/afform/core/Civi/Afform/Symbols.php
+++ b/ext/afform/core/Civi/Afform/Symbols.php
@@ -37,15 +37,12 @@ class Symbols {
     $symbols = new static();
     $oldErrorStatus = libxml_use_internal_errors(TRUE);
     $doc = new \DOMDocumentWrapper($html, 'text/html');
-    foreach (libxml_get_errors() as $error) {
-      if (substr($error->message, 0, 3) === 'Tag' && substr(trim($error->message), -7, 7) === 'invalid') {
-        // ignore? libxml treats e.g. af-field tags as invalid html
-      }
-      else {
-        // This is similar to when use_internal_errors is false.
-        trigger_error($error->message, E_USER_WARNING);
-      }
-    }
+    // Angular isn't fussy about technically invalid html, such as unescaped
+    // `>` in ng-if statements. But php/libxml is. Since this is all for
+    // angular, let's also be less fussy. This will mean silly typos which
+    // might be otherwise quickly noticed via the error will be more hidden,
+    // but that's the same as before, and it's not worth flooding logs with
+    // known issues.
     libxml_clear_errors();
     libxml_use_internal_errors($oldErrorStatus);
     $symbols->scanNode($doc->root);


### PR DESCRIPTION
Overview
----------------------------------------
Errors while scanning for symbols. Alternate to https://github.com/civicrm/civicrm-core/pull/24998

Before
----------------------------------------
1. Install oauth-client
2. On almost every page you get `User warning: htmlParseEntityRef: no name in Civi\Afform\Symbols::scan() (line 46 of ...\ext\afform\core\Civi\Afform\Symbols.php)`
3. I think it shows up more in-your-face with php 8.1 but it would have been there before too just not as loud.

After
----------------------------------------


Technical Details
----------------------------------------
It doesn't seem to like some unescaped html symbols like `>` and `&`.


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
