### PR TITLE
fix numfmt error when pager limit is set in Civi settings

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -114,7 +114,7 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
     $e->display['settings'] += [
       'description' => $e->savedSearch['description'] ?? NULL,
       'sort' => [],
-      'limit' => \Civi::settings()->get('default_pager_size'),
+      'limit' => (int) \Civi::settings()->get('default_pager_size'),
       'pager' => [
         'show_count' => TRUE,
         'expose_limit' => TRUE,

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -44,7 +44,7 @@ class Admin {
       'functions' => self::getSqlFunctions(),
       'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon']),
       'styles' => \CRM_Utils_Array::makeNonAssociative(self::getStyles()),
-      'defaultPagerSize' => \Civi::settings()->get('default_pager_size'),
+      'defaultPagerSize' => (int) \Civi::settings()->get('default_pager_size'),
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),
       'modules' => $extensions,
       'defaultContactType' => \CRM_Contact_BAO_ContactType::basicTypeInfo()['Individual']['name'] ?? NULL,


### PR DESCRIPTION
Overview
----------------------------------------
If you set a default pager limit in the **Search Preferences** screen, SearchKit will display this error in console when selecting contacts to take an action on:

```
Error: [ngModel:numfmt] http://errors.angularjs.org/1.8.2/ngModel/numfmt?p0=44
```

Before
----------------------------------------
Error.

After
----------------------------------------
No error.
