### PR TITLE
Do not `set` cache in cache-bypass mode, since we are bypassing `get`

### DIFF
--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -36,9 +36,8 @@ class CRM_Afform_AfformScanner {
    * @return array
    *   Ex: ['view-individual' => ['/var/www/foo/afform/view-individual']]
    */
-  public function findFilePaths() {
-    if (!CRM_Core_Config::singleton()->debug) {
-      // FIXME: Use a separate setting. Maybe use the asset-builder cache setting?
+  public function findFilePaths(): array {
+    if ($this->isUseCachedPaths()) {
       $paths = $this->cache->get('afformAllPaths');
       if ($paths !== NULL) {
         return $paths;
@@ -61,8 +60,24 @@ class CRM_Afform_AfformScanner {
 
     $this->appendFilePaths($paths, $this->getSiteLocalPath(), '');
 
-    $this->cache->set('afformAllPaths', $paths);
+    if ($this->isUseCachedPaths()) {
+      $this->cache->set('afformAllPaths', $paths);
+    }
     return $paths;
+  }
+
+  /**
+   * Is the cache to be used.
+   *
+   * Skipping the cache helps developers moving files around & messes with developers
+   * debugging performance. It's a cruel world.
+   *
+   * FIXME: Use a separate setting. Maybe use the asset-builder cache setting?
+   *
+   * @return bool
+   */
+  private function isUseCachedPaths(): bool {
+    return !CRM_Core_Config::singleton()->debug;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When `debug` is enabled the afform scanner does not use the cache to get the forms. However, it still sets them. This is bad for 2 reasons

1) performance - it does a `set` every request because it never does the `get` to find them
2) brain-cell harm - while not caching for `get` spares some grey matter in extension development the process kills some for developers trying to make sense of performance issues. While some brain cell harm is unavoidable when trying to do the `get` part - the `set` part IS avoidable

Before
----------------------------------------
When debug is enabled the cache is never retreived but set repeatedly in the form scanning

After
----------------------------------------
When debug is enabled the cache is not hit for `get` or `set`


Technical Details
----------------------------------------
The code suggests that an alternate setting might make sense - however, the one proposed would be enabled by the debug anyway - so it would be just as confusing. Ultimately we don't need to solve that to reduce the confusion / improve the performance so I just stuck it in it's own function for clarity

Comments
----------------------------------------