### PR TITLE
Fix test class not to use discouraged function

### DIFF
--- a/CRM/Core/DomainTokens.php
+++ b/CRM/Core/DomainTokens.php
@@ -88,6 +88,7 @@ class CRM_Core_DomainTokens extends AbstractTokenSubscriber {
    * @throws \CRM_Core_Exception
    * @internal
    *
+   * @todo - make this non-static & protected. Remove last deprecated fn that calls it.
    */
   public static function getDomainTokenValues(?int $domainID = NULL, bool $html = TRUE): array {
     if (!$domainID) {

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -158,6 +158,9 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
     ], 1);
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function testMailingReplyAutoRespond(): void {
     // Because our parent class marks the _groupID as private, we can't use that :-(
     $group_1 = $this->groupCreate([
@@ -165,14 +168,15 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
       'title' => 'Test Group Mailing Reply',
     ]);
     $this->createContactsInGroup(1, $group_1);
+    $this->callAPISuccess('Address', 'create', ['street_address' => 'Sesame Street', 'contact_id' => 1]);
 
     // Also _mut is private to the parent, so we have to make our own:
     $mut = new CiviMailUtils($this, TRUE);
 
-    $replyComponent = civicrm_api3('MailingComponent', 'get', ['id' => CRM_Mailing_PseudoConstant::defaultComponent('Reply', ''), 'sequential' => 1])['values'][0];
-    $replyComponent['body_html'] = $replyComponent['body_html'] . ' {domain.address} ';
-    $replyComponent['body_txt'] = $replyComponent['body_txt'] . ' {domain.address} ';
-    civicrm_api3('MailingComponent', 'create', $replyComponent);
+    $replyComponent = $this->callAPISuccess('MailingComponent', 'get', ['id' => CRM_Mailing_PseudoConstant::defaultComponent('Reply', ''), 'sequential' => 1])['values'][0];
+    $replyComponent['body_html'] .= ' {domain.address} ';
+    $replyComponent['body_txt'] .= ' {domain.address} ';
+    $this->callAPISuccess('MailingComponent', 'create', $replyComponent);
 
     // Create initial mailing to the group.
     $mailingParams = [
@@ -187,16 +191,16 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
     ];
 
     // The following code is exactly the same as runMailingSuccess() except that we store the ID of the mailing.
-    $mailing_1 = $this->callAPISuccess('mailing', 'create', $mailingParams);
+    $mailing_1 = $this->callAPISuccess('Mailing', 'create', $mailingParams);
     $mut->assertRecipients(array());
     $this->callAPISuccess('job', 'process_mailing', array('runInNonProductionEnvironment' => TRUE));
 
     $allMessages = $mut->getAllMessages('ezc');
-    $this->assertEquals(1, count($allMessages));
+    $this->assertCount(1, $allMessages);
 
     // So far so good.
     $message = end($allMessages);
-    $this->assertTrue($message->body instanceof ezcMailText);
+    $this->assertInstanceOf(ezcMailText::class, $message->body);
     $this->assertEquals('plain', $message->body->subType);
     $this->assertEquals(1, preg_match(
       '@mailing/unsubscribe.*jid=(\d+)&qid=(\d+)&h=([0-9a-z]+)@',
@@ -213,7 +217,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
     );
     $mut->checkMailLog([
       'Please Send Inquiries to Our Contact Email Address',
-      CRM_Core_DomainTokens::getDomainTokenValues(NULL, FALSE)['address'],
+      'Sesame Street',
       'do-not-reply@chaos.org',
       'info@EXAMPLE.ORG',
       'mail1@nul.example.com',


### PR DESCRIPTION
Overview
----------------------------------------
Fix test class not to use deprecated function

Before
----------------------------------------
@seamuslee001 added `testMailingReplyAutoRespond` in https://github.com/civicrm/civicrm-core/pull/24453 - I went to use the test to help me revist getting rid of some old token calls and found the test itself contained one (well actually not a deprecated function - a call to an internal function that has been marked as being made protected in the near future). 


After
----------------------------------------
I removed the deprecated function call from the test & replaced it with the expected output of the function. 
In addition the call was returing nothing, as the domain had no address - so I added an address 

Technical Details
----------------------------------------


Comments
----------------------------------------

