### PR TITLE
Add noisy deprecation to `getContactTokenReplacement`

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -586,6 +586,7 @@ class CRM_Utils_Token {
     $returnBlankToken = FALSE,
     $escapeSmarty = FALSE
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     if (self::$_tokens['contact'] == NULL) {
       /* This should come from UF */
 


### PR DESCRIPTION
Overview
----------------------------------------
Add noisy deprecation to `getContactTokenReplacement`

Before
----------------------------------------
Function only called in core from places that already have their own noisy deprecation

![image](https://user-images.githubusercontent.com/336308/204442517-299cf3d1-8823-4e1a-81c5-4c85e7e57be5.png)

After
----------------------------------------
Noisy deprecation added - full removal to be done later

Technical Details
----------------------------------------

Comments
----------------------------------------
