### PR TITLE
FieldSpec - Generate better default field titles for DAOs

### DIFF
--- a/CRM/Core/CodeGen/Specification.php
+++ b/CRM/Core/CodeGen/Specification.php
@@ -536,24 +536,23 @@ class CRM_Core_CodeGen_Specification {
    * @return string
    */
   public function composeTitle($name) {
+    $substitutions = [
+      'is_active' => 'Enabled',
+    ];
+    if (isset($substitutions[$name])) {
+      return $substitutions[$name];
+    }
     $names = explode('_', strtolower($name));
-    $title = '';
-    for ($i = 0; $i < count($names); $i++) {
-      if ($names[$i] === 'id' || $names[$i] === 'is') {
-        // id's do not get titles
-        return NULL;
-      }
-
-      if ($names[$i] === 'im') {
-        $names[$i] = 'IM';
+    $allCaps = ['im', 'id'];
+    foreach ($names as $i => $str) {
+      if (in_array($str, $allCaps, TRUE)) {
+        $names[$i] = strtoupper($str);
       }
       else {
-        $names[$i] = ucfirst(trim($names[$i]));
+        $names[$i] = ucfirst(trim($str));
       }
-
-      $title = $title . ' ' . $names[$i];
     }
-    return trim($title);
+    return trim(implode(' ', $names));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Improves autogenerated field titles, beneficial for some extensions.

Before
----------------------------------------
Fields with `id` or `is` in their name don't get a default title; confusing code comment incorrectly asserts that they shouldn't have one.

After
----------------------------------------
Every field gets a title.

Technical Details
----------------------------------------
I stumbled across this when adding metadata to CiviDiscount. Normally when you generate a DAO from the xml, any field without a `<title>` will get an autogenerated one based splitting and uc_words-ing the `<name>`. However, I noticed that some fields were getting autogenerated titles and others weren't... I finally traced it to this function that boldly (but incorrectly) asserts "id's do not get titles". That's not true; every field in the core schema has a title, in fact after making this change and regenerating all core DAOs... nothing changed. So apparently after making a function to deliberately not make titles for those fields, we then spent years diligently working around it by manually adding `<title>` to every field!

So even though this has no apparent impact on core, it's good to have anyway and now fields in Extensions will consistently have titles. With this change I re-ran `civix generate:entity-boilerplate` for CiviDiscount and was rewarded with this: https://lab.civicrm.org/extensions/cividiscount/-/merge_requests/282/diffs