### PR TITLE
Add Imports search

### DIFF
--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -1,21 +1,7 @@
 <?php
 
-use Civi\Api4\Entity;
 use Civi\BAO\Import;
 use CRM_Civiimport_ExtensionUtil as E;
-
-// Check if SearchKit is enabled before adding SavedSearches.
-try {
-  if (!Entity::get(FALSE)
-    ->addWhere('name', '=', 'SearchDisplay')
-    ->selectRowCount()
-    ->execute()->count()) {
-    return [];
-  }
-}
-catch (CRM_Core_Exception $e) {
-  return [];
-}
 
 $managedEntities = [];
 $importEntities = Import::getImportTables();

--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -1,0 +1,50 @@
+<?php
+
+use CRM_Civiimport_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_My_imports',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'My_imports',
+        'label' => E::ts('My imports'),
+        'form_values' => NULL,
+        'mapping_id' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'UserJob',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'created_date',
+            'status_id:label',
+            'job_type:label',
+          ],
+          'orderBy' => [],
+          'where' => [
+            [
+              'created_id',
+              '=',
+              'user_contact_id',
+            ],
+            [
+              'is_template',
+              '=',
+              FALSE,
+            ],
+          ],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+        'expires_date' => NULL,
+        'description' => NULL,
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION

Overview
----------------------------------------
Add Imports search

This allows an over-view of a user's searches

Before
----------------------------------------
User can't review their imports

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/204654139-ff471b22-4b86-48d4-bf3d-42700ba981d9.png)

![image](https://user-images.githubusercontent.com/336308/204654189-4dbdf6e1-3fc9-4a31-a3e9-3830e17cc501.png)


Technical Details
----------------------------------------
The best place in the navigation menu I can think of is under 'reports' (not in this PR but a follow up)

Comments
----------------------------------------
