### PR TITLE
Follow up on EntityFinancialAccount delete

### DIFF
--- a/CRM/Financial/BAO/EntityFinancialAccount.php
+++ b/CRM/Financial/BAO/EntityFinancialAccount.php
@@ -81,6 +81,7 @@ class CRM_Financial_BAO_EntityFinancialAccount extends CRM_Financial_DAO_EntityF
    * @deprecated
    */
   public static function del($financialTypeAccountId, $accountId = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     static::deleteRecord(['id' => $financialTypeAccountId]);
   }
 

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\EntityFinancialAccount;
+
 /**
  * This class generates form components for Financial Type Account
  */
@@ -270,20 +272,19 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
   /**
    * Process the form submission.
    */
-  public function postProcess() {
+  public function postProcess(): void {
     if ($this->_action & CRM_Core_Action::DELETE) {
       try {
-        CRM_Financial_BAO_FinancialTypeAccount::del($this->_id);
-        CRM_Financial_BAO_EntityFinancialAccount::del($this->_id);
+        EntityFinancialAccount::delete()->addWhere('id', '=', $this->_id)->execute();
       }
       catch (CRM_Core_Exception $e) {
-        CRM_Core_Session::setStatus($e->message);
-        return CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/financial/financialType/accounts', "reset=1&action=browse&aid={$this->_aid}"));
+        CRM_Core_Session::setStatus($e->getMessage());
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/financial/financialType/accounts', "reset=1&action=browse&aid={$this->_aid}"));
       }
       CRM_Core_Session::setStatus(ts('Selected financial type account has been deleted.'));
     }
     else {
-      $params = $ids = [];
+      $ids = [];
       // store the submitted values in an array
       $params = $this->exportValues();
 

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
@@ -39,21 +39,6 @@ class CRM_Financial_BAO_FinancialTypeAccountTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check method del()
-   */
-  public function testDel() {
-    list($financialAccount, $financialType, $financialAccountType) = $this->createFinancialAccount(
-      'Expenses',
-      'Expense Account is'
-    );
-
-    CRM_Financial_BAO_EntityFinancialAccount::del($financialAccountType->id);
-    $params = ['id' => $financialAccountType->id];
-    $result = CRM_Financial_BAO_FinancialType::retrieve($params, $defaults);
-    $this->assertEquals(empty($result), TRUE, 'Verify financial types record deletion.');
-  }
-
-  /**
    * Check method retrieve()
    */
   public function testRetrieve() {


### PR DESCRIPTION


Overview
----------------------------------------
Follow up on EntityFinancialAccount delete

Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/25026/ updated the form to call 2 aliases of the same delete

After
----------------------------------------
APi called, noisy deprecation added to delete

Technical Details
----------------------------------------
This was really confusing as the test implied related entities were being deleted - but as I worked through it I realised the entities & ids were being mixed up & hence checking the wrong id with the wrong entity & meaningless, other than as a duplicat e of syntact conformance test


Comments
----------------------------------------
@aydun 