### PR TITLE
Add 'my imports' to Reports navigation (in civimport extension)

### DIFF
--- a/ext/civiimport/ang/afsearchMyImports.aff.html
+++ b/ext/civiimport/ang/afsearchMyImports.aff.html
@@ -1,0 +1,3 @@
+<div af-fieldset="">
+  <crm-search-display-table search-name="My_imports" display-name=""></crm-search-display-table>
+</div>

--- a/ext/civiimport/ang/afsearchMyImports.aff.json
+++ b/ext/civiimport/ang/afsearchMyImports.aff.json
@@ -1,0 +1,23 @@
+{
+    "type": "search",
+    "requires": [],
+    "entity_type": null,
+    "join_entity": null,
+    "title": "My Imports",
+    "description": "",
+    "is_dashlet": false,
+    "is_public": false,
+    "is_token": false,
+    "contact_summary": null,
+    "summary_contact_type": null,
+    "icon": "fa-list-alt",
+    "server_route": "civicrm/imports/my-listing",
+    "permission": "access CiviCRM",
+    "redirect": null,
+    "create_submission": false,
+    "navigation": {
+        "parent": "Reports",
+        "label": "My Imports",
+        "weight": 15
+    }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add 'my imports' to Reports navigation (in civimport extension)

Before
----------------------------------------
No link to 'My Imports'

After
----------------------------------------
Link is part of Civiimport extension - under 'Reports' in the navigation menu

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw per https://github.com/civicrm/civicrm-core/pull/25072#issuecomment-1331525483