### PR TITLE
Duplicate `Activity::importableFields` to upgrader & increase deprecation

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1434,6 +1434,7 @@ WHERE entity_id =%1 AND entity_table = %2";
    *   array of importable Fields
    */
   public static function &importableFields($status = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     if (empty(Civi::$statics[__CLASS__][__FUNCTION__])) {
       Civi::$statics[__CLASS__][__FUNCTION__] = [];
       if (!$status) {


### PR DESCRIPTION
Overview
----------------------------------------
Duplicate `Activity::importableFields` to upgrader & increase deprecation

Before
----------------------------------------
`CRM_Activity_BAO_Activity::importableFields()` only called from upgrade

After
----------------------------------------
`CRM_Activity_BAO_Activity::importableFields()` copied to upgrade & deprecated

Technical Details
----------------------------------------
This is inline with what we did for other `importableFields` functions. There are 2 reasons for this
1) so we can add noisy deprecation to the main function
2) to fix it in time  - the upgrade should do 'what that function does at this moment in time' - not any changes that happen to it later

Comments
----------------------------------------

