### PR TITLE
SearchKit - Fix crashy-ness when an Afform contains a deleted search

### DIFF
--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -45,32 +45,35 @@ class AfformSearchMetadataInjector {
                 $searchDisplayGet = \Civi\Api4\SearchDisplay::getDefault(FALSE)
                   ->setSavedSearch($searchName);
               }
-              $display = $searchDisplayGet
-                ->addSelect('settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
-                ->execute()->first();
-              if ($display) {
-                pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
-                pq($component)->attr('api-entity', htmlspecialchars($display['saved_search_id.api_entity'], ENT_COMPAT));
-                pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT));
-                pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName), ENT_COMPAT));
+              try {
+                $display = $searchDisplayGet
+                  ->addSelect('settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
+                  ->execute()->single();
+              }
+              catch (\CRM_Core_Exception $e) {
+                return;
+              }
+              pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
+              pq($component)->attr('api-entity', htmlspecialchars($display['saved_search_id.api_entity'], ENT_COMPAT));
+              pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT));
+              pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName), ENT_COMPAT));
 
-                // Add entity names to the fieldset so that afform can populate field metadata
-                $fieldset = pq($component)->parents('[af-fieldset]');
-                if ($fieldset->length) {
-                  $entityList = [$display['saved_search_id.api_entity']];
-                  foreach ($display['saved_search_id.api_params']['join'] ?? [] as $join) {
-                    $entityList[] = $join[0];
-                    if (is_string($join[2] ?? NULL)) {
-                      $entityList[] = $join[2] . ' AS ' . (explode(' AS ', $join[0])[1]);
-                    }
+              // Add entity names to the fieldset so that afform can populate field metadata
+              $fieldset = pq($component)->parents('[af-fieldset]');
+              if ($fieldset->length) {
+                $entityList = [$display['saved_search_id.api_entity']];
+                foreach ($display['saved_search_id.api_params']['join'] ?? [] as $join) {
+                  $entityList[] = $join[0];
+                  if (is_string($join[2] ?? NULL)) {
+                    $entityList[] = $join[2] . ' AS ' . (explode(' AS ', $join[0])[1]);
                   }
-                  $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList), ENT_COMPAT));
-                  // Add field metadata for aggregate fields because they are not in the schema.
-                  // Normal entity fields will be handled by AfformMetadataInjector
-                  foreach (Meta::getCalcFields($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']) as $fieldInfo) {
-                    foreach (pq("af-field[name='{$fieldInfo['name']}']", $doc) as $afField) {
-                      \Civi\Afform\AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
-                    }
+                }
+                $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList), ENT_COMPAT));
+                // Add field metadata for aggregate fields because they are not in the schema.
+                // Normal entity fields will be handled by AfformMetadataInjector
+                foreach (Meta::getCalcFields($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']) as $fieldInfo) {
+                  foreach (pq("af-field[name='{$fieldInfo['name']}']", $doc) as $afField) {
+                    \Civi\Afform\AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
                   }
                 }
               }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes crash when trying to load an Afform that contains a SavedSearch which has been deleted.

Before
----------------------------------------
Hard crash if a SavedSearch embedded in an Afform cannot be found. I tested this by embedding a Search in a form (using the default table display), then deleting it without deleting the form. Caused random system crashes even on non-afform pages.

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
Lots of whitespace changes but the only functional difference is to add try/catch.
