### PR TITLE
[php 8] Update pear/mail to 1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "pear/auth_sasl": "1.1.0",
     "pear/net_smtp": "1.10.*",
     "pear/net_socket": "1.0.*",
-    "pear/mail": "^1.4",
+    "pear/mail": "^1.5",
     "guzzlehttp/guzzle": "^6.3 || ^7.3",
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dffadad8ce192e8891726d033e452ac8",
+    "content-hash": "11f1e08bb3ad215b65446c4edfc8c7be",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2201,16 +2201,16 @@
         },
         {
             "name": "pear/mail",
-            "version": "v1.4.1",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Mail.git",
-                "reference": "9609ed5e42ac5b221dfd9af85de005c59d418ee7"
+                "reference": "c31b7635899a630a8ce681e5ced18cededcc15f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Mail/zipball/9609ed5e42ac5b221dfd9af85de005c59d418ee7",
-                "reference": "9609ed5e42ac5b221dfd9af85de005c59d418ee7",
+                "url": "https://api.github.com/repos/pear/Mail/zipball/c31b7635899a630a8ce681e5ced18cededcc15f3",
+                "reference": "c31b7635899a630a8ce681e5ced18cededcc15f3",
                 "shasum": ""
             },
             "require": {
@@ -2234,12 +2234,17 @@
                 "./"
             ],
             "license": [
-                "BSD-2-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Chuck Hagenbuch",
                     "email": "chuck@horde.org",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Armin Graefe",
+                    "email": "schengawegga@gmail.com",
                     "role": "Lead"
                 },
                 {
@@ -2259,7 +2264,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Mail",
                 "source": "https://github.com/pear/Mail"
             },
-            "time": "2017-04-11T17:27:29+00:00"
+            "time": "2022-11-29T22:04:18+00:00"
         },
         {
             "name": "pear/mail_mime",


### PR DESCRIPTION
Overview
----------------------------------------
Some php 8 warnings. See https://github.com/pear/Mail/commit/368c52f3001c4e4423cd83408040305d12da8c5e

Before
----------------------------------------
preg_replace doesn't like null

After
----------------------------------------
preg_replace ok with `''`, until php decides that's not ok either and then we have to update again.

Technical Details
----------------------------------------
You won't see these in unit tests mostly because the mailer doesn't use smtp. In another environment where tests do, this comes up 1000s of times in the core tests. I couldn't figure out where they were coming from since locally it doesn't use smtp either, and then they magically went away today, and tracked it down to this being released today.

Comments
----------------------------------------
This also includes https://github.com/pear/Mail/commit/66ac6d105e874d416f163b1d2094c1f1c087698d which is the only thing that stood out from: https://github.com/pear/Mail/compare/v1.4.1...v1.5.0, and it looks like @MegaphoneJon liked it. I'll note also that as of today new drupal 9 installs will automatically get 1.5 regardless of the change here.
