### PR TITLE
dev/core#4016 Fix label for `_entity_id` to be the correct entity

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -146,7 +146,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
    * @return array
    */
   public static function getTypes(): array {
-    $types = Civi::cache()->get('UserJobTypes');
+    $types = Civi::cache('metadata')->get('UserJobTypes');
     if ($types === NULL) {
       $types = [];
       $classes = ClassScanner::get(['interface' => UserJobInterface::class]);
@@ -158,10 +158,27 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
         }
         $types = array_merge($types, $declaredTypes);
       }
-      Civi::cache()->set('UserJobTypes', $types);
+      Civi::cache('metadata')->set('UserJobTypes', $types);
     }
     // Rekey to numeric to prevent https://lab.civicrm.org/dev/core/-/issues/3719
     return array_values($types);
+  }
+
+  /**
+   * Get the data about the user job type.
+   *
+   * @param string $jobType
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function getType(string $jobType): array {
+    foreach (CRM_Core_BAO_UserJob::getTypes() as $userJobType) {
+      if ($jobType === $userJobType['id']) {
+        return $userJobType;
+      }
+    }
+    throw new CRM_Core_Exception('type not found');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
In the import table the created entity has a field - but it is not well labeled, This adds the label

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/204956430-5e63c458-14c0-41a8-8095-586821072bca.png)


After
----------------------------------------
See the contribution id column on the right (as this was a contribution import)

![image](https://user-images.githubusercontent.com/336308/204956080-bc44e798-f1f8-42c0-8bde-084f5ee03661.png)


Technical Details
----------------------------------------
@colemanw I was trying to figure out why the 'View Contribution' link fails when I add it - it turns out the reason is the join fields are being determined using a function that is not aware enough to use in a dynamic entity - I thought maybe the 'fields_callback' key would help - but I couldn't quite get there with it (the entities are registered in 'civiimport.php'

https://github.com/civicrm/civicrm-core/blob/15ee25102e114e54f159e4c0082b870062ed562d/Civi/Api4/Service/Schema/SchemaMapBuilder.php#L69-L71

Comments
----------------------------------------
