### PR TITLE
PHP8.1 - prices must be numbers, not strings for arithmetic

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -302,9 +302,10 @@ WHERE li.contribution_id = %1";
     }
 
     foreach ($params["price_{$fid}"] as $oid => $qty) {
-      $price = $amount_override === NULL ? $options[$oid]['amount'] : $amount_override;
+      $qty = (int) $qty;
+      $price = (float) ($amount_override === NULL ? $options[$oid]['amount'] : $amount_override);
 
-      $participantsPerField = CRM_Utils_Array::value('count', $options[$oid], 0);
+      $participantsPerField = (int) CRM_Utils_Array::value('count', $options[$oid], 0);
 
       $values[$oid] = [
         'price_field_id' => $fid,


### PR DESCRIPTION
Overview
----------------------------------------
Someone making an online donation can in some circumstances get the following error:

```
NOTICE: PHP message: TypeError: Unsupported operand types: string * string in /var/www/mysite/vendor/civicrm/civicrm-core/CRM/Price/BAO/LineItem.php on line 317 #0 /var/www/mysite/vendor/civicrm/civicrm-core/CRM/Price/BAO/PriceSet.php(1603): CRM_Price_BAO_LineItem::format()
```

This affects online donations, and Drupal 9 is giving out PHP warnings if you're still on 7.4, so I'm putting this against the RC.

Before
----------------------------------------
Error on online donations.

After
----------------------------------------
Type casting.