### PR TITLE
DebugSubscriber - Fix activation check

### DIFF
--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -37,7 +37,8 @@ class DebugSubscriber implements EventSubscriberInterface {
         break;
 
       case '3.':
-        $xdebugMode = explode(',', ini_get('xdebug.mode'));
+        $xdebugMode = version_compare($version, '3.1', '>=')
+          ? xdebug_info('mode') : explode(',', ini_get('xdebug.mode'));
         $this->enableStats = in_array('develop', $xdebugMode);
         break;
 


### PR DESCRIPTION
Backport https://github.com/civicrm/civicrm-core/pull/24554 (circa 5.54+) to 5.45. This should make it is easier to test civix with prior ESR and current build-environment.