### PR TITLE
APIv4 Explorer - autocomplete cleanup

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1226,7 +1226,7 @@
             $el.crmDatepicker('destroy');
           }
           if ($el.is('.select2-container + input')) {
-            $el.crmEntityRef('destroy');
+            $el.crmAutocomplete('destroy');
           }
           $(element).removeData().removeAttr('type').removeAttr('placeholder').show();
         }
@@ -1447,7 +1447,7 @@
     if (field && suffix) {
       field.pseudoconstant = suffix;
     }
-    // When joining to a 'name' field, value fields should render an appropriate entityRef
+    // When joining to a 'name' field, value fields should render an appropriate autocomplete
     if (field && field.type === 'Field' && field.name === 'name' && _.includes(fieldName, '.')) {
       field.fk_entity = field.entity;
       field.id_field = 'name';

--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -24,7 +24,7 @@
             inputType = field.input_type,
             dataType = field.data_type;
           multi = field.serialize || dataType === 'Array';
-          $el.crmSelect2('destroy').crmDatepicker('destroy');
+          $el.crmAutocomplete('destroy').crmDatepicker('destroy');
           // Allow input_type to override dataType
           if (inputType) {
             multi = (dataType !== 'Boolean' &&

--- a/js/Common.js
+++ b/js/Common.js
@@ -554,6 +554,9 @@ if (!CRM.vars) CRM.vars = {};
 
   // Autocomplete based on APIv4 and Select2.
   $.fn.crmAutocomplete = function(entityName, apiParams, select2Options) {
+    if (entityName === 'destroy') {
+      return $(this).off('.crmEntity').crmSelect2('destroy');
+    }
     select2Options = select2Options || {};
     return $(this).each(function() {
       var $el = $(this).off('.crmEntity'),


### PR DESCRIPTION
Overview
----------------------------------------
Removes some references to the old EntityRef widget, and ensures the widget is thoroughly cleaned up when destroyed.