### PR TITLE
Hide deprecated fields from SearchKit & Afform

### DIFF
--- a/CRM/Activity/DAO/Activity.php
+++ b/CRM/Activity/DAO/Activity.php
@@ -497,6 +497,7 @@ class CRM_Activity_DAO_Activity extends CRM_Core_DAO {
           'bao' => 'CRM_Activity_BAO_Activity',
           'localizable' => 0,
           'FKClassName' => 'CRM_Core_DAO_Phone',
+          'deprecated' => TRUE,
           'html' => [
             'type' => 'EntityRef',
             'label' => ts("Phone (called)"),
@@ -515,6 +516,7 @@ class CRM_Activity_DAO_Activity extends CRM_Core_DAO {
           'entity' => 'Activity',
           'bao' => 'CRM_Activity_BAO_Activity',
           'localizable' => 0,
+          'deprecated' => TRUE,
           'html' => [
             'type' => 'Text',
           ],
@@ -662,6 +664,7 @@ class CRM_Activity_DAO_Activity extends CRM_Core_DAO {
           'bao' => 'CRM_Activity_BAO_Activity',
           'localizable' => 0,
           'FKClassName' => 'CRM_Contact_DAO_Relationship',
+          'deprecated' => TRUE,
           'html' => [
             'label' => ts("Relationship"),
           ],
@@ -679,6 +682,7 @@ class CRM_Activity_DAO_Activity extends CRM_Core_DAO {
           'entity' => 'Activity',
           'bao' => 'CRM_Activity_BAO_Activity',
           'localizable' => 0,
+          'deprecated' => TRUE,
           'add' => '2.2',
         ],
         'original_id' => [
@@ -692,6 +696,7 @@ class CRM_Activity_DAO_Activity extends CRM_Core_DAO {
           'bao' => 'CRM_Activity_BAO_Activity',
           'localizable' => 0,
           'FKClassName' => 'CRM_Activity_DAO_Activity',
+          'deprecated' => TRUE,
           'html' => [
             'label' => ts("Original Activity"),
           ],

--- a/CRM/Contact/DAO/Contact.php
+++ b/CRM/Contact/DAO/Contact.php
@@ -973,6 +973,7 @@ class CRM_Contact_DAO_Contact extends CRM_Core_DAO {
           'entity' => 'Contact',
           'bao' => 'CRM_Contact_BAO_Contact',
           'localizable' => 0,
+          'deprecated' => TRUE,
           'html' => [
             'type' => 'Select',
             'label' => ts("Preferred Mail Format"),
@@ -1582,6 +1583,7 @@ class CRM_Contact_DAO_Contact extends CRM_Core_DAO {
           'entity' => 'Contact',
           'bao' => 'CRM_Contact_BAO_Contact',
           'localizable' => 0,
+          'deprecated' => TRUE,
           'html' => [
             'type' => 'Text',
           ],

--- a/CRM/Core/DAO/Address.php
+++ b/CRM/Core/DAO/Address.php
@@ -763,6 +763,7 @@ class CRM_Core_DAO_Address extends CRM_Core_DAO {
           'entity' => 'Address',
           'bao' => 'CRM_Core_BAO_Address',
           'localizable' => 0,
+          'deprecated' => TRUE,
           'add' => '1.1',
         ],
         'country_id' => [

--- a/CRM/Core/DAO/Phone.php
+++ b/CRM/Core/DAO/Phone.php
@@ -271,6 +271,7 @@ class CRM_Core_DAO_Phone extends CRM_Core_DAO {
           'entity' => 'Phone',
           'bao' => 'CRM_Core_BAO_Phone',
           'localizable' => 0,
+          'deprecated' => TRUE,
           'add' => '1.1',
         ],
         'phone' => [

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -392,6 +392,11 @@ class BasicGetFieldsAction extends BasicGetAction {
         'default_value' => FALSE,
       ],
       [
+        'name' => 'deprecated',
+        'data_type' => 'Boolean',
+        'default_value' => FALSE,
+      ],
+      [
         'name' => 'output_formatters',
         'data_type' => 'Array',
         '@internal' => TRUE,

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -81,6 +81,11 @@ class FieldSpec {
   public $readonly = FALSE;
 
   /**
+   * @var bool
+   */
+  public $deprecated = FALSE;
+
+  /**
    * @var callable[]
    */
   public $outputFormatters;
@@ -241,6 +246,16 @@ class FieldSpec {
    */
   public function setReadonly($readonly) {
     $this->readonly = (bool) $readonly;
+
+    return $this;
+  }
+
+  /**
+   * @param bool $deprecated
+   * @return $this
+   */
+  public function setDeprecated($deprecated) {
+    $this->deprecated = (bool) $deprecated;
 
     return $this;
   }

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -87,6 +87,7 @@ class SpecFormatter {
     $field->setSerialize($data['serialize'] ?? NULL);
     $field->setDefaultValue($data['default'] ?? NULL);
     $field->setDescription($data['description'] ?? NULL);
+    $field->setDeprecated($data['deprecated'] ?? FALSE);
     self::setInputTypeAndAttrs($field, $data, $dataTypeName);
 
     $field->setPermission($data['permission'] ?? NULL);

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -89,7 +89,7 @@ class AfformAdminMeta {
       'loadOptions' => ['id', 'label'],
       'action' => 'create',
       'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly'],
-      'where' => [['input_type', 'IS NOT NULL']],
+      'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],
     ];
     if (in_array($entityName, \CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE)) {
       $params['values']['contact_type'] = $entityName;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -29,7 +29,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       ->addSelect('name', 'title_plural')
       ->setChain([
         'actions' => ['$name', 'getActions', ['where' => [['name', 'IN', ['update', 'delete']]]], 'name'],
-        'fields' => ['$name', 'getFields', ['where' => [['type', '=', 'Field']]], 'name'],
+        'fields' => ['$name', 'getFields', ['where' => [['deprecated', '=', FALSE], ['type', '=', 'Field']]], 'name'],
       ])
       ->execute()->first();
 

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -143,7 +143,7 @@ class Admin {
         }
         $getFields = civicrm_api4($entity['name'], 'getFields', [
           'select' => ['name', 'title', 'label', 'description', 'type', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'entity', 'fk_entity', 'readonly', 'operators', 'suffixes', 'nullable'],
-          'where' => [['name', 'NOT IN', ['api_key', 'hash']]],
+          'where' => [['deprecated', '=', FALSE], ['name', 'NOT IN', ['api_key', 'hash']]],
           'orderBy' => ['label'],
         ]);
         foreach ($getFields as $field) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -15,7 +15,7 @@
       action: 'update',
       select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable'],
       loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
-      where: [["readonly", "=", false]],
+      where: [['deprecated', '=', FALSE], ["readonly", "=", false]],
     }).then(function(fields) {
         ctrl.fields = fields;
       });

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -101,7 +101,7 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(['name', 'label'], $fields['campaign_id']['suffixes']);
   }
 
-  public function testRequiredAndNullable() {
+  public function testRequiredAndNullableAndDeprecated() {
     $actFields = Activity::getFields(FALSE)
       ->setAction('create')
       ->execute()->indexBy('name');
@@ -111,6 +111,8 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertFalse($actFields['activity_type_id']['nullable']);
     $this->assertFalse($actFields['subject']['required']);
     $this->assertTrue($actFields['subject']['nullable']);
+    $this->assertFalse($actFields['subject']['deprecated']);
+    $this->assertTrue($actFields['phone_id']['deprecated']);
   }
 
   public function testGetSuffixes() {

--- a/xml/templates/dao.tpl
+++ b/xml/templates/dao.tpl
@@ -226,6 +226,9 @@ class {$table.className} extends CRM_Core_DAO {ldelim}
 {if $field.uniqueTitle}
   'unique_title' => {$tsFunctionName}('{$field.uniqueTitle}'),
 {/if}
+{if $field.deprecated}
+  'deprecated' => TRUE,
+{/if}
 {if $field.html}
   'html' => array(
   {foreach from=$field.html item=val key=key}


### PR DESCRIPTION
Overview
----------------------------------------
Hides any fields marked `@deprecated` from the SK & Afform UI. Follow-up to #25112.

Before
----------------------------------------
Now you see them.

After
----------------------------------------
Now you don't.

Technical Details
----------------------------------------
This builds on #24248 and #25112 and more recently #25112 by exposing the 'deprecated' attribute to APIv4 `getfields` and then filtering them out in SK & Afform.

