### PR TITLE
dev/core#4014 add ext-fileinto php extension to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,8 @@
     "symfony/polyfill-php81": "^1.0",
     "symfony/polyfill-php82": "^1.0",
     "html2text/html2text": "^4.3.1",
-    "psr/container": "~1.0"
+    "psr/container": "~1.0",
+    "ext-fileinfo": "*"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11f1e08bb3ad215b65446c4edfc8c7be",
+    "content-hash": "ea291fe135ab61b48ff4ca909c2d85de",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5740,7 +5740,8 @@
         "php": "~7.2.5 || ~7.3 || ~8",
         "composer-runtime-api": "~2.0",
         "ext-intl": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-fileinfo": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Overview
----------------------------------------
In 5.44 (released in Nov 2021) we added a requirement for php extension fileinfo without 'noticing' via a composer package. This was not in our docs/ release notes or explicitly in composer

Before
----------------------------------------
Extension not listed in our composer

After
----------------------------------------
Added to composer.json & to docs here
https://lab.civicrm.org/documentation/docs/installation/-/commit/d9e2f188ddd33108958921be78a87df7ff698faa

Technical Details
----------------------------------------

Comments
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4014 @jensschuppe suggests docs & release notes (and that we should have included it when we added it) - this has flown under the radar for a year so is obviously not affecting many people so I have updated docs but not so sure about retrospective release notes fixes
