### PR TITLE
ensure counties are properly imported even if ambiguous

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -204,12 +204,17 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
 
     // add county id if county is set
     // CRM-7837
-    if ((!isset($params['county_id']) || !is_numeric($params['county_id']))
-      && isset($params['county']) && !empty($params['county'])
+    if (
+      (isset($params['county_id']) && !is_numeric($params['county_id'])) ||
+      (!isset($params['county_id']) && isset($params['county']) && !empty($params['county']))
     ) {
       $county = new CRM_Core_DAO_County();
-      $county->name = $params['county'];
 
+      $search = $params['county'] ?? NULL;
+      if (empty($search)) {
+        $search = $params['county_id'];
+      }
+      $county->name = $search;
       if (isset($params['state_province_id'])) {
         $county->state_province_id = $params['state_province_id'];
       }

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1298,6 +1298,13 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
       'abbreviation' => '',
       'state_province_id' => 1640,
     ])->execute()->first()['id'];
+    // What if there are two counties with the same name?
+    $dupeCountyID = County::create()->setValues([
+      'name' => 'Farnell',
+      'abbreviation' => '',
+      'state_province_id' => 1641,
+    ])->execute()->first()['id'];
+
     $childKey = $this->getRelationships()['Child of']['id'] . '_a_b';
     $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
     $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);


### PR DESCRIPTION
Overview
----------------------------------------
If a county has a unique name, you can import it by name.

But, if there is one or more counties with the same name, the county is not properly converted to an id, and we get a foreign constraint error and/or a invalid value error.

Before
----------------------------------------
Setup:

 1. Ensure you have your `civicrm_county`  table populated with two different counties in different state/provinces that share the same name
 2. Import a record with the county field set to that non-unique name.
 3. Get a foreign constraint error or a invalid value error (depending on your version of CiviCRM)

After
----------------------------------------
The record is properly imported and the county is properly assigned.

Technical Details
----------------------------------------

When importing, there are two chances to transform the county name into an id. The first one just checks the name against the county table. If there is more than one match it bails. The second one takes into account the state province id, which should weed out such non-unique name values. But, that code was not properly firing.

Comments
----------------------------------------
@eileenmcnaughton if this sounds familiar, it's because I finally tracked down what was really going on for me in https://github.com/civicrm/civicrm-core/pull/24917#issuecomment-1307403134 - it turns out my problem is that the county I was importing was not a unique county name.
