### PR TITLE
Configure Event Fees tab

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -226,152 +226,145 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
    * Build the form object.
    */
   public function buildQuickForm() {
-    // Check to see if CiviContribute is an enabled component
-    $components = \Civi\Api4\Setting::get()
-      ->addSelect('enable_components')
-      ->execute()['value'];
-    // if Contribute component is active, do below, else run a check to say that this component must be active to use the Fees tab
-    if (in_array('CiviContribute', $components)) {
-      $this->addYesNo('is_monetary',
-        ts('Paid Event'),
-        NULL,
-        NULL,
-        ['onclick' => "return showHideByValue('is_monetary','0','event-fees','block','radio',false);"]
-      );
+    $this->addYesNo('is_monetary',
+      ts('Paid Event'),
+      NULL,
+      NULL,
+      ['onclick' => "return showHideByValue('is_monetary','0','event-fees','block','radio',false);"]
+    );
 
-      //add currency element.
-      $this->addCurrency('currency', ts('Currency'), FALSE);
+    //add currency element.
+    $this->addCurrency('currency', ts('Currency'), FALSE);
 
-      $paymentProcessor = CRM_Core_PseudoConstant::paymentProcessor();
+    $paymentProcessor = CRM_Core_PseudoConstant::paymentProcessor();
 
-      $this->assign('paymentProcessor', $paymentProcessor);
-      $this->addCheckBox('payment_processor', ts('Payment Processor'),
-        array_flip($paymentProcessor),
-        NULL, NULL, NULL, NULL,
-        ['&nbsp;&nbsp;', '&nbsp;&nbsp;', '&nbsp;&nbsp;', '<br/>']
-      );
+    $this->assign('paymentProcessor', $paymentProcessor);
+    $this->addCheckBox('payment_processor', ts('Payment Processor'),
+      array_flip($paymentProcessor),
+      NULL, NULL, NULL, NULL,
+      ['&nbsp;&nbsp;', '&nbsp;&nbsp;', '&nbsp;&nbsp;', '<br/>']
+    );
 
-      // financial type
-      if (!CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() ||
-          (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && CRM_Core_Permission::check('administer CiviCRM Financial Types'))) {
-        $this->addSelect('financial_type_id');
-      }
-      else {
-        CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::ADD);
-        $this->addSelect('financial_type_id', ['context' => 'search', 'options' => $financialTypes]);
-      }
-      // add pay later options
-      $this->addElement('checkbox', 'is_pay_later', ts('Enable Pay Later option?'), NULL,
-        ['onclick' => "return showHideByValue('is_pay_later','','payLaterOptions','block','radio',false);"]
-      );
-      $this->addElement('textarea', 'pay_later_text', ts('Pay Later Label'),
-        CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_text'),
-        FALSE
-      );
-      $this->add('wysiwyg', 'pay_later_receipt', ts('Pay Later Instructions'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_receipt'));
-
-      $this->addElement('checkbox', 'is_billing_required', ts('Billing address required'));
-      $this->add('text', 'fee_label', ts('Fee Label'));
-
-      $price = CRM_Price_BAO_PriceSet::getAssoc(FALSE, 'CiviEvent');
-      if (CRM_Utils_System::isNull($price)) {
-        $this->assign('price', FALSE);
-      }
-      else {
-        $this->assign('price', TRUE);
-      }
-      $this->addField('price_set_id', [
-        'entity' => 'PriceField',
-        'options' => $price,
-        'onchange' => "return showHideByValue('price_set_id', '', 'map-field', 'block', 'select', false);",
-      ]);
-
-      $default = [0 => NULL];
-      $this->add('hidden', 'price_field_id', '', ['id' => 'price_field_id']);
-      for ($i = 1; $i <= self::NUM_OPTION; $i++) {
-        // label
-        $this->add('text', "label[$i]", ts('Label'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'label'));
-        $this->add('hidden', "price_field_value[$i]", '', ['id' => "price_field_value[$i]"]);
-
-        // value
-        $this->add('text', "value[$i]", ts('Value'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'value'));
-        $this->addRule("value[$i]", ts('Please enter a valid money value for this field (e.g. %1).', [1 => CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency('99.99')]), 'money');
-
-        // default
-        $default[$i] = NULL;
-      }
-
-      $this->addRadio('default', '', $default);
-
-      $this->addElement('checkbox', 'is_discount', ts('Discounts by Signup Date?'), NULL,
-        ['onclick' => "warnDiscountDel(); return showHideByValue('is_discount','','discount','block','radio',false);"]
-      );
-      $discountSection = $this->get('discountSection');
-
-      $this->assign('discountSection', $discountSection);
-
-      // form fields of Discount sets
-      $defaultOption = [];
-      $_showHide = new CRM_Core_ShowHideBlocks();
-
-      for ($i = 1; $i <= self::NUM_DISCOUNT; $i++) {
-        //the show hide blocks
-        $showBlocks = 'discount_' . $i;
-        if ($i > 2) {
-          $_showHide->addHide($showBlocks);
-        }
-        else {
-          $_showHide->addShow($showBlocks);
-        }
-
-        //Increment by 1 of start date of previous end date.
-        if (is_array($this->_submitValues) &&
-          !empty($this->_submitValues['discount_name'][$i]) &&
-          !empty($this->_submitValues['discount_name'][$i + 1]) &&
-          isset($this->_submitValues['discount_end_date']) &&
-          isset($this->_submitValues['discount_end_date'][$i]) &&
-          $i < self::NUM_DISCOUNT - 1
-        ) {
-          if (!empty($this->_submitValues['discount_end_date'][$i + 1])
-            && empty($this->_submitValues['discount_start_date'][$i + 1])
-          ) {
-            $this->_submitValues['discount_start_date'][$i + 1] = date('Y-m-d', strtotime("+1 days " . $this->_submitValues['discount_end_date'][$i]));
-          }
-        }
-        //Decrement by 1 of end date from next start date.
-        if ($i > 1 &&
-          is_array($this->_submitValues) &&
-          !empty($this->_submitValues['discount_name'][$i]) &&
-          !empty($this->_submitValues['discount_name'][$i - 1]) &&
-          isset($this->_submitValues['discount_start_date']) &&
-          isset($this->_submitValues['discount_start_date'][$i])
-        ) {
-          if (!empty($this->_submitValues['discount_start_date'][$i])
-            && empty($this->_submitValues['discount_end_date'][$i - 1])
-          ) {
-            list($this->_submitValues['discount_end_date'][$i - 1]) = date('Y-m-d', strtotime("-1 days " . $this->_submitValues['discount_start_date'][$i]));
-          }
-        }
-
-        $this->add('text', 'discount_name[' . $i . ']', ts('Discount Name'),
-          CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceSet', 'title')
-        );
-        $this->add('hidden', "discount_price_set[$i]", '', ['id' => "discount_price_set[$i]"]);
-        $this->add('datepicker', 'discount_start_date[' . $i . ']', ts('Discount Start Date'), [], FALSE, ['time' => FALSE]);
-        $this->add('datepicker', 'discount_end_date[' . $i . ']', ts('Discount End Date'), [], FALSE, ['time' => FALSE]);
-      }
-      $_showHide->addToTemplate();
-      $this->addElement('xbutton', $this->getButtonName('submit'), ts('Add Discount Set to Fee Table'),
-        [
-          'type' => 'submit',
-          'class' => 'crm-form-submit cancel',
-          'value' => 1,
-        ]
-      );
-      $this->assign('deferredFinancialType', Civi::settings()->get('deferred_revenue_enabled') ? array_keys(CRM_Financial_BAO_FinancialAccount::getDeferredFinancialType()) : NULL);
-      $this->buildAmountLabel();
-      parent::buildQuickForm(); 
+    // financial type
+    if (!CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() ||
+        (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus() && CRM_Core_Permission::check('administer CiviCRM Financial Types'))) {
+      $this->addSelect('financial_type_id');
     }
+    else {
+      CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes($financialTypes, CRM_Core_Action::ADD);
+      $this->addSelect('financial_type_id', ['context' => 'search', 'options' => $financialTypes]);
+    }
+    // add pay later options
+    $this->addElement('checkbox', 'is_pay_later', ts('Enable Pay Later option?'), NULL,
+      ['onclick' => "return showHideByValue('is_pay_later','','payLaterOptions','block','radio',false);"]
+    );
+    $this->addElement('textarea', 'pay_later_text', ts('Pay Later Label'),
+      CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_text'),
+      FALSE
+    );
+    $this->add('wysiwyg', 'pay_later_receipt', ts('Pay Later Instructions'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'pay_later_receipt'));
+
+    $this->addElement('checkbox', 'is_billing_required', ts('Billing address required'));
+    $this->add('text', 'fee_label', ts('Fee Label'));
+
+    $price = CRM_Price_BAO_PriceSet::getAssoc(FALSE, 'CiviEvent');
+    if (CRM_Utils_System::isNull($price)) {
+      $this->assign('price', FALSE);
+    }
+    else {
+      $this->assign('price', TRUE);
+    }
+    $this->addField('price_set_id', [
+      'entity' => 'PriceField',
+      'options' => $price,
+      'onchange' => "return showHideByValue('price_set_id', '', 'map-field', 'block', 'select', false);",
+    ]);
+
+    $default = [0 => NULL];
+    $this->add('hidden', 'price_field_id', '', ['id' => 'price_field_id']);
+    for ($i = 1; $i <= self::NUM_OPTION; $i++) {
+      // label
+      $this->add('text', "label[$i]", ts('Label'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'label'));
+      $this->add('hidden', "price_field_value[$i]", '', ['id' => "price_field_value[$i]"]);
+
+      // value
+      $this->add('text', "value[$i]", ts('Value'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_OptionValue', 'value'));
+      $this->addRule("value[$i]", ts('Please enter a valid money value for this field (e.g. %1).', [1 => CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency('99.99')]), 'money');
+
+      // default
+      $default[$i] = NULL;
+    }
+
+    $this->addRadio('default', '', $default);
+
+    $this->addElement('checkbox', 'is_discount', ts('Discounts by Signup Date?'), NULL,
+      ['onclick' => "warnDiscountDel(); return showHideByValue('is_discount','','discount','block','radio',false);"]
+    );
+    $discountSection = $this->get('discountSection');
+
+    $this->assign('discountSection', $discountSection);
+
+    // form fields of Discount sets
+    $defaultOption = [];
+    $_showHide = new CRM_Core_ShowHideBlocks();
+
+    for ($i = 1; $i <= self::NUM_DISCOUNT; $i++) {
+      //the show hide blocks
+      $showBlocks = 'discount_' . $i;
+      if ($i > 2) {
+        $_showHide->addHide($showBlocks);
+      }
+      else {
+        $_showHide->addShow($showBlocks);
+      }
+
+      //Increment by 1 of start date of previous end date.
+      if (is_array($this->_submitValues) &&
+        !empty($this->_submitValues['discount_name'][$i]) &&
+        !empty($this->_submitValues['discount_name'][$i + 1]) &&
+        isset($this->_submitValues['discount_end_date']) &&
+        isset($this->_submitValues['discount_end_date'][$i]) &&
+        $i < self::NUM_DISCOUNT - 1
+      ) {
+        if (!empty($this->_submitValues['discount_end_date'][$i + 1])
+          && empty($this->_submitValues['discount_start_date'][$i + 1])
+        ) {
+          $this->_submitValues['discount_start_date'][$i + 1] = date('Y-m-d', strtotime("+1 days " . $this->_submitValues['discount_end_date'][$i]));
+        }
+      }
+      //Decrement by 1 of end date from next start date.
+      if ($i > 1 &&
+        is_array($this->_submitValues) &&
+        !empty($this->_submitValues['discount_name'][$i]) &&
+        !empty($this->_submitValues['discount_name'][$i - 1]) &&
+        isset($this->_submitValues['discount_start_date']) &&
+        isset($this->_submitValues['discount_start_date'][$i])
+      ) {
+        if (!empty($this->_submitValues['discount_start_date'][$i])
+          && empty($this->_submitValues['discount_end_date'][$i - 1])
+        ) {
+          list($this->_submitValues['discount_end_date'][$i - 1]) = date('Y-m-d', strtotime("-1 days " . $this->_submitValues['discount_start_date'][$i]));
+        }
+      }
+
+      $this->add('text', 'discount_name[' . $i . ']', ts('Discount Name'),
+        CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceSet', 'title')
+      );
+      $this->add('hidden', "discount_price_set[$i]", '', ['id' => "discount_price_set[$i]"]);
+      $this->add('datepicker', 'discount_start_date[' . $i . ']', ts('Discount Start Date'), [], FALSE, ['time' => FALSE]);
+      $this->add('datepicker', 'discount_end_date[' . $i . ']', ts('Discount End Date'), [], FALSE, ['time' => FALSE]);
+    }
+    $_showHide->addToTemplate();
+    $this->addElement('xbutton', $this->getButtonName('submit'), ts('Add Discount Set to Fee Table'),
+      [
+        'type' => 'submit',
+        'class' => 'crm-form-submit cancel',
+        'value' => 1,
+      ]
+    );
+    $this->assign('deferredFinancialType', Civi::settings()->get('deferred_revenue_enabled') ? array_keys(CRM_Financial_BAO_FinancialAccount::getDeferredFinancialType()) : NULL);
+    $this->buildAmountLabel();
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -66,11 +66,11 @@ class CRM_Event_Form_ManageEvent_TabHeader {
     $tabs = [];
     $tabs['settings'] = ['title' => ts('Info and Settings'), 'class' => 'ajaxForm livePage'] + $default;
     $tabs['location'] = ['title' => ts('Event Location')] + $default;
-    // Check to see if CiviContribute is an enabled component
+    // Check to see if CiviContribute is an enabled component.
     $components = \Civi\Api4\Setting::get()
       ->addSelect('enable_components')
       ->execute()[0]['value'];
-    // if Contribute component is active, create the Fees tab
+    // If CiviContribute is active, create the Fees tab.
     if (in_array('CiviContribute', $components)) {
       $tabs['fee'] = ['title' => ts('Fees')] + $default;
     }

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -66,12 +66,8 @@ class CRM_Event_Form_ManageEvent_TabHeader {
     $tabs = [];
     $tabs['settings'] = ['title' => ts('Info and Settings'), 'class' => 'ajaxForm livePage'] + $default;
     $tabs['location'] = ['title' => ts('Event Location')] + $default;
-    // Check to see if CiviContribute is an enabled component.
-    $components = \Civi\Api4\Setting::get()
-      ->addSelect('enable_components')
-      ->execute()[0]['value'];
     // If CiviContribute is active, create the Fees tab.
-    if (in_array('CiviContribute', $components)) {
+    if (CRM_Core_Component::isEnabled('CiviContribute')) {
       $tabs['fee'] = ['title' => ts('Fees')] + $default;
     }
     $tabs['registration'] = ['title' => ts('Online Registration')] + $default;

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -66,7 +66,14 @@ class CRM_Event_Form_ManageEvent_TabHeader {
     $tabs = [];
     $tabs['settings'] = ['title' => ts('Info and Settings'), 'class' => 'ajaxForm livePage'] + $default;
     $tabs['location'] = ['title' => ts('Event Location')] + $default;
-    $tabs['fee'] = ['title' => ts('Fees')] + $default;
+    // Check to see if CiviContribute is an enabled component
+    $components = \Civi\Api4\Setting::get()
+      ->addSelect('enable_components')
+      ->execute()[0]['value'];
+    // if Contribute component is active, create the Fees tab
+    if (in_array('CiviContribute', $components)) {
+      $tabs['fee'] = ['title' => ts('Fees')] + $default;
+    }
     $tabs['registration'] = ['title' => ts('Online Registration')] + $default;
     // @fixme I don't understand the event permissions check here - can we just get rid of it?
     $permissions = CRM_Event_BAO_Event::getAllPermissions();

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -147,12 +147,8 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
           'url' => 'civicrm/event/manage/location',
           'field' => 'loc_block_id',
         ];
-      // Check to see if CiviContribute is an enabled component.
-      $components = \Civi\Api4\Setting::get()
-        ->addSelect('enable_components')
-        ->execute()[0]['value'];
       // If CiviContribute is active, create the Fees dropdown menu item.
-      if (in_array('CiviContribute', $components)) {
+      if (CRM_Core_Component::isEnabled('CiviContribute')) {
         self::$_tabLinks[$cacheKey]['fee']
           = [
             'title' => ts('Fees'),

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -147,13 +147,20 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
           'url' => 'civicrm/event/manage/location',
           'field' => 'loc_block_id',
         ];
+      // Check to see if CiviContribute is an enabled component.
+      $components = \Civi\Api4\Setting::get()
+        ->addSelect('enable_components')
+        ->execute()[0]['value'];
+      // If CiviContribute is active, create the Fees dropdown menu item.
+      if (in_array('CiviContribute', $components)) {
+        self::$_tabLinks[$cacheKey]['fee']
+          = [
+            'title' => ts('Fees'),
+            'url' => 'civicrm/event/manage/fee',
+            'field' => 'is_monetary',
+          ];
+      }
 
-      self::$_tabLinks[$cacheKey]['fee']
-        = [
-          'title' => ts('Fees'),
-          'url' => 'civicrm/event/manage/fee',
-          'field' => 'is_monetary',
-        ];
       self::$_tabLinks[$cacheKey]['registration']
         = [
           'title' => ts('Online Registration'),


### PR DESCRIPTION
Overview
----------------------------------------
This PR makes the Fees tab on the Configure Event page - as well as the link to the Fees page from the **Configure** button on an event - conditionally dependent on whether CiviContribute is enabled. This will prevent users from trying to set up a paid event when the Component that allows payment processing is not active.

Before
----------------------------------------
Previously, if the CiviContribute Component was disabled, the Configure Event page included the Fees tab, which would allow users to try to set up a paid event. However, users would receive an error because without CiviContribute, there are no Financial Types for a user to select from. 

![Selection_156](https://user-images.githubusercontent.com/87245718/206007327-9a6b015a-6d0d-40aa-b9c3-4521e06b4381.png)

![Selection_157](https://user-images.githubusercontent.com/87245718/206007435-4875a90b-f432-45bf-a2c3-ee49ba7a7fb5.png)

![Selection_158](https://user-images.githubusercontent.com/87245718/206010274-dafb90e7-0861-4a85-bf67-fc9800805ecf.png)

After
----------------------------------------
With this PR,  the Fees tab and its corresponding link on the **Configure** menu of an event are not displayed if CiviContribute is disabled. (CiviContribute can be disabled by going to **Administer > System Settings > Components**, unchecking the box next to the component's name, and clicking **Save**.)

![Selection_154](https://user-images.githubusercontent.com/87245718/206007211-14046776-9b20-4e62-9eb5-4c10a7dfb5dc.png)

![Selection_155](https://user-images.githubusercontent.com/87245718/206007284-2ed9b579-b2dd-40a4-98f4-58b8d7d2b7e4.png)


Technical Details
----------------------------------------
While ideally one shouldn't repeat themselves in code, since the code that controls the tab and the link are housed in two different classes,  I made the same changes to both files; wrapping the line(s) of code that generate the Fees tab/link in an `if` block that is only entered if CiviComponent is within the `['value']` array returned by an APIv4 call to the `enable_components` Setting entity.
