### PR TITLE
Add search/display details to searchKitTasks hook - allows for eg. filtering actions by search display

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\SearchDisplay;
 
+use Civi\Api4\Generic\Traits\SavedSearchInspectorTrait;
 use CRM_Search_ExtensionUtil as E;
 use Civi\Api4\Entity;
 
@@ -11,6 +12,14 @@ use Civi\Api4\Entity;
  * @package Civi\Api4\Action\SearchDisplay
  */
 class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
+
+  use SavedSearchInspectorTrait;
+
+  /**
+   * An array containing the searchDisplay definition
+   * @var array
+   */
+  protected $display;
 
   /**
    * Name of entity
@@ -36,6 +45,10 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
     if (!$entity) {
       return;
     }
+
+    $this->loadSavedSearch();
+    $this->loadSearchDisplay();
+
     $tasks = [$entity['name'] => []];
 
     if (array_key_exists($entity['name'], \CRM_Export_BAO_Export::getComponents())) {
@@ -199,9 +212,9 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
     $null = NULL;
     $checkPermissions = $this->checkPermissions;
     $userId = $this->checkPermissions ? \CRM_Core_Session::getLoggedInContactID() : NULL;
-    \CRM_Utils_Hook::singleton()->invoke(['tasks', 'checkPermissions', 'userId'],
+    \CRM_Utils_Hook::singleton()->invoke(['tasks', 'checkPermissions', 'userId', 'search', 'display'],
       $tasks, $checkPermissions, $userId,
-      $null, $null, $null, 'civicrm_searchKitTasks'
+      $this->savedSearch, $this->display, $null, 'civicrm_searchKitTasks'
     );
 
     foreach ($tasks[$entity['name']] as $name => &$task) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
@@ -31,7 +31,7 @@
         initialized = true;
         crmApi4({
           entityInfo: ['Entity', 'get', {select: ['name', 'title', 'title_plural', 'primary_key'], where: [['name', '=', ctrl.entity]]}, 0],
-          tasks: ['SearchDisplay', 'getSearchTasks', {entity: ctrl.entity}]
+          tasks: ['SearchDisplay', 'getSearchTasks', {entity: ctrl.entity, savedSearch: ctrl.search, display: ctrl.display}]
         }).then(function(result) {
           ctrl.entityInfo = result.entityInfo;
           ctrl.tasks = result.tasks;

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -70,7 +70,7 @@ function search_kit_civicrm_angularModules(&$angularModules) {
   $tasks = [];
   $null = NULL;
   $checkPermissions = FALSE;
-  \CRM_Utils_Hook::singleton()->invoke(['tasks', 'checkPermissions', 'userId'],
+  \CRM_Utils_Hook::singleton()->invoke(['tasks', 'checkPermissions', 'userId', 'search', 'display'],
     $tasks, $checkPermissions, $null,
     $null, $null, $null, 'civicrm_searchKitTasks'
   );


### PR DESCRIPTION
Overview
----------------------------------------
You can't currently identify the search display when adding/removing tasks in the searchKitTasks hook. This means you can only provide actions per entity / user and not by search display.
Example:
In the AccountSync extension we have a display for errors which is showing AccountContact entities and provides a set of actions to handle those errors. But I want another display which shows all AccountContact entries that are NOT matched to CiviCRM contacts and offer actions to not sync / create / match. Each of these sets of actions make no sense on the other display.

Before
----------------------------------------
Can't identify search display

After
----------------------------------------
Can identify search display.

Technical Details
----------------------------------------
Pass extra params to the GetSearchTasks API call to include the name of the display.

I tried getting from ctrl.search and ctrl.display but `ctrl.search` seems to contain the display name and `ctrl.display` seems to be null?

Comments
----------------------------------------
@colemanw Does this seem like a sensible approach - do you know why `ctrl.display`/`ctrl.search` don't seem to contain what I expected?
