### PR TITLE
remove unused template vars from Profile Form

### DIFF
--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -44,9 +44,6 @@
     {include file="CRM/Form/body.tpl"}
   {/if}
   {strip}
-    {if $help_pre && $action neq 4}
-      <div class="messages help">{$help_pre}</div>
-    {/if}
 
     {include file="CRM/common/CMSUser.tpl"}
 
@@ -215,7 +212,6 @@
         {/if}
       </div>
     {/if}
-    {if $help_post && $action neq 4}<br /><div class="messages help">{$help_post}</div>{/if}
   {/strip}
 
 </div> {* end crm-container div *}


### PR DESCRIPTION
Overview
----------------------------------------
Removing unused template vars to cut down on PHP 8 noise.

Before
----------------------------------------
Unused template vars.

After
----------------------------------------
None.

Technical Details
----------------------------------------
This is probably a decade-old copy/paste error.  This seems intended to capture the `help_pre` and help_post` of the profile itself.  But aside from it being in the wrong place (on the far side of the submit buttons), this functionality is already present.

Comments
----------------------------------------
You can test that this doesn't change the output by adding help_pre and help_post on both the profile and profile field levels and confirming it's still present.