### PR TITLE
always define showCMS

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -71,12 +71,9 @@ class CRM_Core_BAO_CMSUser {
     $config = CRM_Core_Config::singleton();
     $showCMS = FALSE;
 
-    $isDrupal = $config->userSystem->is_drupal;
-    $isJoomla = ucfirst($config->userFramework) == 'Joomla';
-    $isWordPress = $config->userFramework == 'WordPress';
-
     if (!$config->userSystem->isUserRegistrationPermitted()) {
       // Do not build form if CMS is not configured to allow creating users.
+      $form->assign('showCMS', $showCMS);
       return FALSE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
`showCMS` isn't defined if we return early from deciding if we want to allow user reg on a profile.

Before
----------------------------------------
Undefined property warning on the Smarty template.

After
----------------------------------------
Less noise.

Comments
----------------------------------------
I also removed three unused variables.
