### PR TITLE
SearchKit - Include html columns in spreadsheet download

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -75,8 +75,15 @@ class Download extends AbstractRunAction {
     $columns = [];
     foreach ($this->display['settings']['columns'] as $index => $col) {
       $col += ['type' => NULL, 'label' => '', 'rewrite' => FALSE];
-      if ($col['type'] === 'field' && !empty($col['key'])) {
+      if (!empty($col['key'])) {
         $columns[$index] = $col;
+      }
+      // Convert html to plain text
+      if ($col['type'] === 'html') {
+        foreach ($rows as $i => $row) {
+          $row['columns'][$index]['val'] = htmlspecialchars_decode(strip_tags($row['columns'][$index]['val']));
+          $rows[$i] = $row;
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds html-type columns to the spreadsheet download, by formatting them as plain text.

Before
----------------------------------------
Html-type columns excluded from spreadsheet (e.g. Activity Subject)

After
----------------------------------------
Included, but converted to plain text
