### PR TITLE
Fix dev/core#3960 in a second location

### DIFF
--- a/templates/CRM/Financial/Form/Search.tpl
+++ b/templates/CRM/Financial/Form/Search.tpl
@@ -218,7 +218,7 @@ CRM.$(function($) {
   function saveRecords(records, op) {
     var postUrl = CRM.url('civicrm/ajax/rest', 'className=CRM_Financial_Page_AJAX&fnName=assignRemove');
     //post request and get response
-    $.post(postUrl, {records: records, recordBAO: 'CRM_Batch_BAO_Batch', op: op, key: {/literal}"{crmKey name='civicrm/ajax/ar'}"{literal}},
+    $.post(postUrl, {records: records, recordBAO: 'CRM_Batch_BAO_Batch', op: op},
       function(response) {
         //this is custom status set when record update success.
         if (response.status == 'record-updated-success') {


### PR DESCRIPTION
Overview
----------------------------------------
This is the same bug ([core#3960](https://lab.civicrm.org/dev/core/-/issues/3960)) fixed by #24895 but in a second location.

Before
----------------------------------------
The original fix dealt with pressing "Close Batch" while viewing the batch transactions (screenshot 1).  This is the same fix for the "Close [Batch]" link while viewing open batches (screenshot 2).

After
----------------------------------------
No more "FATAL: Invalid Credential".

![Selection_1701](https://user-images.githubusercontent.com/1796012/206297272-ba477047-f2dd-4459-a87e-ac8312b4c7fc.png)

![Selection_1702](https://user-images.githubusercontent.com/1796012/206297320-8c3c79ff-228e-4770-92fd-1cecf2d003ef.png)

