### PR TITLE
(NFC) dev/core#4008 - Afform - More coverage for symbol-scanner

### DIFF
--- a/ext/afform/core/tests/phpunit/Civi/Afform/SymbolsTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/SymbolsTest.php
@@ -51,6 +51,27 @@ class SymbolsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterfa
       ],
     ];
     $exs[] = [
+      // These are ordinary ng-if's in Angular, but libxml likes to warn about '&&' and '<'. Let's make we're still able to parse them.
+      '<div class="my-parent" ng-if="a<b"><div ng-if="c && d" class="my-child"><img ng-if="e > f" class="special" src="foo.png"/></div></div>',
+      [
+        'e' => ['div' => 2, 'img' => 1, 'body' => 1],
+        'a' => ['class' => 3, 'src' => 1, 'ng-if' => 3],
+        'c' => [
+          'my-parent' => 1,
+          'my-child' => 1,
+          'special' => 1,
+        ],
+      ],
+    ];
+    $exs[] = [
+      '<blink>aw<fulmark&up<img><img><area></amap></blink>',
+      [
+        'e' => ['body' => 1, 'blink' => 1, 'fulmark' => 1, 'img' => 1, 'area' => 1],
+        'a' => [],
+        'c' => [],
+      ],
+    ];
+    $exs[] = [
       '<div class="my-parent foo bar">a<div class="my-child whiz bang {{ghost + stuff}} last">b</div>c</div>',
       [
         'e' => ['div' => 2, 'body' => 1],


### PR DESCRIPTION
Overview
----------------------------------------

Add more test-coverage.  This reproduces the failure-scenario that was addressed by #25067.  (When combined with 25067, it passes.  But before 25067, it fails.)

Before
----------------------------------------

6 tests

After
----------------------------------------

8 tests

