### PR TITLE
CRM_Utils_System_WordPress - Drop unused variable

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -291,14 +291,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function mapConfigToSSL() {
-    global $base_url;
-    $base_url = str_replace('http://', 'https://', $base_url);
-  }
-
-  /**
-   * @inheritDoc
-   */
   public function url(
     $path = NULL,
     $query = NULL,


### PR DESCRIPTION
Overview
----------------------------------------

This is an off-shoot from #24911 to address a PHP warning.

Before
------

`WordPress` implements the method `mapConfigToSSL()`, but it doesn't _really_ do anything -- because `$base_url` is a Drupal thing.

To see this, you can search for 'base_url' across the entire-source of a Civi-WP installation. Specifically, I used

```
grep -lri 'global.*base_url'
```

The references appeared unrelated -- some references to Drupal/Backdrop adapters, and some references to minified JS files. But I couldn't see anything that would in PHP on WP.

After
-----

Don't bother implementing the method. Might as well inherit the base method (which is empty).
