### PR TITLE
Cast membership object as array before passing to getMembershipStatusByDate()

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2647,7 +2647,7 @@ WHERE {$whereClause}";
             'now',
             FALSE,
             $newMembershipId,
-            $newMembership
+            (array) $newMembership
           );
 
           if (!empty($status['id']) and $status['id'] != $newMembership->status_id) {


### PR DESCRIPTION
Overview
----------------------------------------
The documented $membership param for getMembershipStatusByDate() is an array, but currently this passes a membership object. Casting, as is done in CRM_Contribute_BAO_Contribution transitionComponents() fixes this.

   * @param array $membership
   *   Membership params as available to calling function - not used directly but passed to the hook.

Before
----------------------------------------
Errors when hook code expects an array and receives an object.

After
----------------------------------------
Hook code will receive a membership array as expected.