### PR TITLE
Enotice fixes, consolidation on Import datasource forms

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -98,8 +98,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     ]);
 
     $mappingArray = CRM_Core_BAO_Mapping::getMappings('Import Contact');
-
-    $this->assign('savedMapping', $mappingArray);
     $this->addElement('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
     $js = ['onClick' => "buildSubTypes();buildDedupeRules();"];
@@ -124,12 +122,9 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
 
-    $geoCode = FALSE;
     if (CRM_Utils_GeocodeProvider::getUsableClassName()) {
-      $geoCode = TRUE;
       $this->addElement('checkbox', 'doGeocodeAddress', ts('Geocode addresses during import?'));
     }
-    $this->assign('geoCode', $geoCode);
 
     $this->addElement('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2]);
 

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -85,8 +85,6 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
     $this->add('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2], TRUE);
     $this->setDefaults(['fieldSeparator' => $config->fieldSeparator]);
     $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . static::IMPORT_ENTITY);
-
-    $this->assign('savedMapping', $mappingArray);
     $this->add('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
     if ($loadedMapping = $this->get('loadedMapping')) {

--- a/templates/CRM/Contact/Import/Form/DataSource.tpl
+++ b/templates/CRM/Contact/Import/Form/DataSource.tpl
@@ -33,20 +33,26 @@
   <div id="common-form-controls" class="form-item">
     <h3>{ts}Import Options{/ts}</h3>
     <table class="form-layout-compressed">
-      <tr class="crm-import-datasource-form-block-contactType">
-        <td class="label">{$form.contactType.label}</td>
-        <td>{$form.contactType.html} {help id='contact-type'}&nbsp;&nbsp;&nbsp;
-          <span id="contact-subtype">{$form.contactSubType.label}&nbsp;&nbsp;&nbsp;{$form.contactSubType.html} {help id='contact-sub-type'}</span>
-        </td>
-      </tr>
-      <tr class="crm-import-datasource-form-block-onDuplicate">
-        <td class="label">{$form.onDuplicate.label}</td>
-        <td>{$form.onDuplicate.html} {help id='dupes'}</td>
-      </tr>
-      <tr class="crm-import-datasource-form-block-dedupe">
-        <td class="label">{$form.dedupe_rule_id.label}</td>
-        <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule'}</td>
-      </tr>
+      {if array_key_exists('contactType', $form)}
+        <tr class="crm-import-datasource-form-block-contactType">
+          <td class="label">{$form.contactType.label}</td>
+          <td>{$form.contactType.html} {help id='contact-type'}{if array_key_exists('contactSubType', $form)}&nbsp;&nbsp;&nbsp;
+            <span id="contact-subtype">{$form.contactSubType.label}&nbsp;&nbsp;&nbsp;{$form.contactSubType.html} {help id='contact-sub-type'}{/if}</span>
+          </td>
+        </tr>
+      {/if}
+      {if array_key_exists('onDuplicate', $form)}
+        <tr class="crm-import-datasource-form-block-onDuplicate">
+          <td class="label">{$form.onDuplicate.label}</td>
+          <td>{$form.onDuplicate.html} {help id='dupes'}</td>
+        </tr>
+      {/if}
+      {if array_key_exists('dedupe_rule_id', $form)}
+        <tr class="crm-import-datasource-form-block-dedupe">
+          <td class="label">{$form.dedupe_rule_id.label}</td>
+          <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule'}</td>
+        </tr>
+      {/if}
       <tr class="crm-import-datasource-form-block-fieldSeparator">
         <td class="label">{$form.fieldSeparator.label}</td>
         <td>{$form.fieldSeparator.html} {help id='id-fieldSeparator'}</td>
@@ -56,7 +62,7 @@
         <td></td><td class="description">{ts}Select the format that is used for date fields in your import data.{/ts}</td>
       </tr>
 
-      {if $geoCode}
+      {if array_key_exists('doGeocodeAddress', $form)}
         <tr class="crm-import-datasource-form-block-doGeocodeAddress">
           <td class="label"></td>
           <td>{$form.doGeocodeAddress.html} {$form.doGeocodeAddress.label}<br />
@@ -68,7 +74,7 @@
         </tr>
       {/if}
 
-      {if $savedMapping}
+      {if array_key_exists('savedMapping', $form)}
         <tr class="crm-import-datasource-form-block-savedMapping">
           <td class="label"><label for="savedMapping">{$form.savedMapping.label}</label></td>
           <td>{$form.savedMapping.html}<br />
@@ -77,7 +83,7 @@
         </tr>
       {/if}
 
-      {if $form.disableUSPS}
+      {if array_key_exists('disableUSPS', $form)}
         <tr class="crm-import-datasource-form-block-disableUSPS">
           <td class="label"></td>
           <td>{$form.disableUSPS.html} <label for="disableUSPS">{$form.disableUSPS.label}</label><br />

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -67,7 +67,7 @@
           <td>{$form.fieldSeparator.html}</td>
         </tr>
        <tr class="crm-import-uploadfile-form-block-date">{include file="CRM/Core/Date.tpl"}</tr>
-       {if $savedMapping}
+       {if array_key_exists('savedMapping', $form)}
          <tr class="crm-import-uploadfile-form-block-savedMapping">
            <td>{$form.savedMapping.label}</td>
            <td>{$form.savedMapping.html}<br />


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fixes, consolidation on Import datasource forms

Before
----------------------------------------
E-notices on dataSource form in some cases, inconsistent across the 2 templates

After
----------------------------------------
Standardised

Technical Details
----------------------------------------
The goal is to consolidate the 2 forms of `DataSource.tpl` such that the 
logic to select csv or sql is in shared code used by Contact import (as is currently the case) and all the other imports (including csvimporter)

This PR simply wraps all fields that might not be in one or both tpls with ` {if array_key_exists('contactType', $form)}` so we can more easily merge them into one.

Note that in addition to the tpl layer stuff the php layer requires these lines that are only in the Contact import at the moment to be accessed by all imports

```   
    $this->buildDataSourceFields();
    $this->assign('urlPath', 'civicrm/import/datasource');
    $this->assign('urlPathVar', 'snippet=4&user_job_id=' . $this->get('user_job_id'));

    $this->add('select', 'dataSource', ts('Data Source'), $this->getDataSources(), TRUE,
      ['onchange' => 'buildDataSourceFormBlock(this.value);']
    );
```

Comments
----------------------------------------
@mattwire once this is done we won't need to add to csvimporter per your PR. However, I hit a couple of gotchas consolidating the tpl - the first 2 I expect just take more fiddling around

1) I couldn't quite seem to get the help text working for the `onDuplicate` field
2) For some reason I didn't get the ` buildDataSourceFormBlock();` to work & hence I backed out for now, scaling this down to consolidation so the tpls can be more easily merged
3) the text around `contactType` doesn't quite work for contacts if we use what is in the shared tpl
```
         <span class="description">
              {ts 1=$importEntities}Select 'Individual' if you are importing %1 made by individual persons.{/ts}
              {ts 1=$importEntities}Select 'Organization' or 'Household' if you are importing %1 to contacts of that type.{/ts}
            </span>
```

Perhaps

```
         <span class="description">
              {ts 1=$importEntities}Select 'Individual' if you are importing to individual persons.{/ts}
              {ts 1=$importEntities}Select 'Organization' or 'Household' to contacts of that type.{/ts}
            </span>
```

would get us past it?

Maybe we could even drop it?
