### PR TITLE
Php layer consolidation on Import DataSource form

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -43,39 +43,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   }
 
   /**
-   * Set variables up before form is built.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function preProcess() {
-    $results = [];
-    $config = CRM_Core_Config::singleton();
-    $handler = opendir($config->uploadDir);
-    $errorFiles = ['sqlImport.errors', 'sqlImport.conflicts', 'sqlImport.duplicates', 'sqlImport.mismatch'];
-
-    // check for post max size avoid when called twice
-    $snippet = $_GET['snippet'] ?? 0;
-    if (empty($snippet)) {
-      CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
-    }
-
-    while ($file = readdir($handler)) {
-      if ($file !== '.' && $file !== '..' &&
-        in_array($file, $errorFiles) && !is_writable($config->uploadDir . $file)
-      ) {
-        $results[] = $file;
-      }
-    }
-    closedir($handler);
-    if (!empty($results)) {
-      $this->invalidConfig(ts('<b>%1</b> file(s) in %2 directory are not writable. Listed file(s) might be used during the import to log the errors occurred during Import process. Contact your site administrator for assistance.', [
-        1 => implode(', ', $results),
-        2 => $config->uploadDir,
-      ]));
-    }
-  }
-
-  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -164,4 +164,34 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
     return array_values($types);
   }
 
+  /**
+   * Get user job type.
+   *
+   * @param string $type
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function getType(string $type): array {
+    foreach (self::getTypes() as $importType) {
+      if ($importType['id'] === $type) {
+        return $importType;
+      }
+    }
+    throw new CRM_Core_Exception($type . 'not found');
+  }
+
+  /**
+   * Get the specified value for the import job type.
+   *
+   * @param string $type
+   * @param string $key
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  public static function getTypeValue(string $type, string $key) {
+    return self::getType($type)[$key];
+  }
+
 }

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -14,6 +14,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Base class for upload-only import forms (all but Contact import).
  */
@@ -22,7 +24,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
   /**
    * Set variables up before form is built.
    */
-  public function preProcess() {
+  public function preProcess(): void {
     // check for post max size
     CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     $this->assign('importEntity', $this->getTranslatedEntity());
@@ -37,7 +39,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    * @return string
    */
   protected function getTranslatedEntity(): string {
-    return (string) Civi\Api4\Utils\CoreUtil::getInfoItem($this::IMPORT_ENTITY, 'title');
+    return (string) CoreUtil::getInfoItem($this->getBaseEntity(), 'title');
   }
 
   /**
@@ -48,7 +50,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    * @return string
    */
   protected function getTranslatedEntities(): string {
-    return (string) Civi\Api4\Utils\CoreUtil::getInfoItem($this::IMPORT_ENTITY, 'title_plural');
+    return (string) CoreUtil::getInfoItem($this->getBaseEntity(), 'title_plural');
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -761,10 +761,15 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * Get the base entity for the import.
    *
    * @return string
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function getBaseEntity(): string {
-    $info = $this->getParser()->getUserJobInfo();
-    return reset($info)['entity'];
+    if ($this->getUserJobID()) {
+      $info = $this->getParser()->getUserJobInfo();
+      return reset($info)['entity'];
+    }
+    return CRM_Core_BAO_UserJob::getTypeValue($this->getUserJobType(), 'entity');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Php layer consolidation on Import DataSource form

Before
----------------------------------------
Contact import dataSource form `preProcess` has a whole lot of code to set up error files that are no longer used. The download is direct from db & the function that used to deliver them is deprecated

![image](https://user-images.githubusercontent.com/336308/206610888-a277e5cf-d713-4804-a15c-fa42bd003530.png)


After
----------------------------------------
`preProcess` removed from `CRM_Contact_Import_Form_Datasource` - this caused it to need the other functions in the `preProcess` to work - which needed me to either declare the constant or stop using it. I did the latter because the constant was already duplicated by another function `getBaseEntity` - although that function didn't fallback well pre-job creation so I fixed that

Technical Details
----------------------------------------

Comments
----------------------------------------
Also takes https://github.com/civicrm/civicrm-core/pull/25141 forwards a bit (the consolidation) 