### PR TITLE
Add Membership entity to formbuilder

### DIFF
--- a/ext/afform/admin/afformEntities/Membership.php
+++ b/ext/afform/admin/afformEntities/Membership.php
@@ -1,0 +1,8 @@
+<?php
+return [
+  'type' => 'primary',
+  'defaults' => "{
+    actions: {create: true, update: true}
+  }",
+  'boilerplate' => [],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Based on https://github.com/civicrm/civicrm-core/pull/24991

Before
----------------------------------------
Membership entity not available in formbuilder.

After
----------------------------------------
Membership entity available in formbuilder.

Technical Details
----------------------------------------
Add entity definition file.

Comments
----------------------------------------
@kurund @colemanw 
