### PR TITLE
fixes core#4027 - don't crash when a contribution has no line items

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -838,7 +838,10 @@ class CRM_Financial_BAO_Order {
       // Set the price set ID from the first line item (we need to set this here
       // to prevent a loop later when we retrieve the price field metadata to
       // set the 'title' (as accessed from workflow message templates).
-      $this->setPriceSetID($lineItems[0]['price_field_id.price_set_id']);
+      // Contributions *should* all have line items, but historically, imports did not create them.
+      if ($lineItems) {
+        $this->setPriceSetID($lineItems[0]['price_field_id.price_set_id']);
+      }
     }
     else {
       foreach ($this->getPriceOptions() as $fieldID => $valueID) {


### PR DESCRIPTION
Overview
----------------------------------------
Full details are on https://lab.civicrm.org/dev/core/-/issues/4027.

Before
----------------------------------------
Crash when viewing a contact's contribution tab if a recurring contribution is present and its "template" contribution has no line items.

After
----------------------------------------
Displays normally.

Comments
----------------------------------------
This is a regression from 5.53 - which seems close enough to put against the RC.
