### PR TITLE
CMS Database Integration - do not display table prefixes on Drupal8 intregration screen

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -76,12 +76,12 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
         $db = Drupal\Core\Database\Database::getConnectionInfo('default')['default'];
         $tablePrefixes = "# Drupal 9 : Per-table prefixes are no longer supported\n";
         $tablePrefixes .= '$databases[\'civicrm\'][\'default\'] = [' . "\n";
-        $tablePrefixes .= "\t" . '\'database\' => \'' . $db['database'] .'\',' . "\n";
-        $tablePrefixes .= "\t" . '\'username\' => \'' . $db['username'] .'\',' . "\n";
-        $tablePrefixes .= "\t" . '\'password\' => \'' . 'set your db password' .'\',' . "\n";
-        $tablePrefixes .= "\t" . '\'host\' => \'' . $db['host'] .'\',' . "\n";
-        $tablePrefixes .= "\t" . '\'port\' => \'' . $db['port'] .'\',' . "\n";
-        $tablePrefixes .= "\t" . '\'driver\' => \'' . $db['driver'] .'\',' . "\n";
+        $tablePrefixes .= "\t" . '\'database\' => \'' . $db['database'] . '\',' . "\n";
+        $tablePrefixes .= "\t" . '\'username\' => \'' . $db['username'] . '\',' . "\n";
+        $tablePrefixes .= "\t" . '\'password\' => \'' . 'set your db password' . '\',' . "\n";
+        $tablePrefixes .= "\t" . '\'host\' => \'' . $db['host'] . '\',' . "\n";
+        $tablePrefixes .= "\t" . '\'port\' => \'' . $db['port'] . '\',' . "\n";
+        $tablePrefixes .= "\t" . '\'driver\' => \'' . $db['driver'] . '\',' . "\n";
         $tablePrefixes .= "\t" . '\'prefix\' => \'\',' . "\n";
         $tablePrefixes .= "\t" . '\'namespace\' => \'Drupal\\Core\\Database\\Driver\\mysql\',' . "\n";
         $tablePrefixes .= "\t" . '\'collation\' => \'utf8mb4_general_ci\',' . "\n";

--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -71,7 +71,7 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
 
     if ($config->userSystem->viewsExists() &&
       ($config->dsn != $config->userFrameworkDSN || !empty($drupal_prefix))) {
-      if (($config->userSystem->is_drupal) && (explode('.', \DRUPAL::VERSION) >=9)) {
+      if (($config->userSystem->is_drupal) && (explode('.', \DRUPAL::VERSION) >= 9)) {
         # Per-table prefixes are no longer supported
         $db = Drupal\Core\Database\Database::getConnectionInfo('default')['default'];
         $tablePrefixes = "# Drupal 9 : Per-table prefixes are no longer supported\n";


### PR DESCRIPTION
CMS Database Integration - Per-table prefixes are no longer supported, as described in issue #4028 https://lab.civicrm.org/dev/core/-/issues/4028

Overview
----------------------------------------
Since Drupal 8.2 per-table prefixes are no longer supported, so **System Settings / CMS Database Integaration** menu should no longer display the 'Drypal 7' mapping table

Before
----------------------------------------
$databases\['default'\]\['default'\]\['prefix'\]= \[
 'default' => 'drupal\_', 'civicrm_acl' => '',
 'civicrm_acl_cache' => '',
 'civicrm_acl_contact_cache' => '', 
'civicrm_acl_entity_role' => '', 
'civicrm_action_log' => '', 
'civicrm_action_mapping' => '', 
'civicrm_action_schedule' => '', 
'civicrm_activity' => '', 
'civicrm_activity_contact' => '',
 ....

After
----------------------------------------
$databases['civicrm']['default'] = [
	'database' => 'famhxrns_dev9_mcm65',
	'username' => 'famhxrns_dev9_mcm65',
	'password' => 'set your db password',
	'host' => '127.0.0.1',
	'port' => '',
	'driver' => 'mysql',
	'prefix' => '',
	'namespace' => 'Drupal\Core\Database\Driver\mysql',
	'collation' => 'utf8mb4_general_ci',
];


