### PR TITLE
Flexmailer: Prevent broken urls containing hyphens when click tracking is enabled for plain text mailings

### DIFF
--- a/ext/flexmailer/src/ClickTracker/TextClickTracker.php
+++ b/ext/flexmailer/src/ClickTracker/TextClickTracker.php
@@ -37,7 +37,7 @@ class TextClickTracker implements ClickTrackerInterface {
     };
     // Find any HTTP(S) URLs in the text.
     // return preg_replace_callback('/\b(?:(?:https?):\/\/|www\.|ftp\.)[-A-Z0-9+&@#\/%=~_|$?!:,.]*[A-Z0-9+&@#\/%=~_|$]/i', $callback, $tex
-    return preg_replace_callback('/\b(?:(?:https?):\/\/)[\w+&@#\/%=~_|$?!:,.{}\[\];]*[\w+&@#\/%=~_|${}\[\];]/iu',
+    return preg_replace_callback('/\b(?:(?:https?):\/\/)[\w+&@#\/%=~_|$?!:,.{}\[\];\-]*[\w+&@#\/%=~_|${}\[\];\-]/iu',
       $callback, $text);
   }
 

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/TextClickTrackerTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ClickTracker/TextClickTrackerTest.php
@@ -69,7 +69,11 @@ class TextClickTrackerTest extends \CiviUnitTestCase {
       '<p><a href="http://example.com/1">First</a><a href="http://example.com/2">Second</a><a href=\'http://example.com/3\'>Third</a><a href="http://example.com/4">Fourth</a></p>',
       '<p><a href="tracking(http://example.com/1)" rel=\'nofollow\'>First</a><a href="tracking(http://example.com/2)" rel=\'nofollow\'>Second</a><a href=\'tracking(http://example.com/3)\' rel=\'nofollow\'>Third</a><a href="tracking(http://example.com/4)" rel=\'nofollow\'>Fourth</a></p>',
     ];
-
+    $exs[] = [
+      // Messy looking URL, including hyphens
+      '<p><a href=\'https://sub.example-url.com/foo-bar.php?whiz=%2Fbang%2F&pie[fruit]=apple-pie\'>Foo</a></p>',
+      '<p><a href=\'tracking(https://sub.example-url.com/foo-bar.php?whiz=%2Fbang%2F&pie[fruit]=apple-pie)\' rel=\'nofollow\'>Foo</a></p>',
+    ];
     return $exs;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Hyphens are allowed in URLs, but the regex for plain text mailings in Flexmailer did not include hyphens. URLs of the form `example.org/wp-content/something` were stored for click tracking as `example.org/wp`, breaking them.

Before
----------------------------------------
Hyphens not included in regex.

After
----------------------------------------
Hyphens included.
