### PR TITLE
[NFC] Update testGetSiteStats to match earlier name change

### DIFF
--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -216,7 +216,7 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
         'MembershipBlock',
         'Pledge',
         'PledgeBlock',
-        'Delivered',
+        'MailingEventDelivered',
       ];
       sort($entity_names);
       sort($expected_entity_names);


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://lab.civicrm.org/dev/core/-/issues/3057#note_69324, if the expected entity name has changed this test will fail in betas and releases, but not in alpha versions.

Before
----------------------------------------
test fail

After
----------------------------------------
test not fail

Technical Details
----------------------------------------
Entity short name was changed recently in https://github.com/civicrm/civicrm-core/commit/e45a8e7aba3de4cdb79674d1e377c83899f943c9

Comments
----------------------------------------

