### PR TITLE
CRM_Utils_Date - Get month names from IntlDateFormatter. Ignore timezones.

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -232,21 +232,16 @@ class CRM_Utils_Date {
   public static function &getAbbrMonthNames($month = FALSE) {
     $key = 'abbrMonthNames_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
-      $intl_formatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, NULL, IntlDateFormatter::GREGORIAN, 'MMM');
-      \Civi::$statics[__CLASS__][$key] = [
-        1 => $intl_formatter->format(strtotime('1 January')),
-        2 => $intl_formatter->format(strtotime('1 February')),
-        3 => $intl_formatter->format(strtotime('1 March')),
-        4 => $intl_formatter->format(strtotime('1 April')),
-        5 => $intl_formatter->format(strtotime('1 May')),
-        6 => $intl_formatter->format(strtotime('1 June')),
-        7 => $intl_formatter->format(strtotime('1 July')),
-        8 => $intl_formatter->format(strtotime('1 August')),
-        9 => $intl_formatter->format(strtotime('1 September')),
-        10 => $intl_formatter->format(strtotime('1 October')),
-        11 => $intl_formatter->format(strtotime('1 November')),
-        12 => $intl_formatter->format(strtotime('1 December')),
-      ];
+      // Note: IntlDateFormatter provides even more strings than `strftime()` or `l10n/*/civicrm.mo`.
+      // Note: Consistently use UTC for all requests in resolving these names. Avoid edge-cases where TZ support is inconsistent.
+      $intlFormatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, 'UTC', IntlDateFormatter::GREGORIAN, 'MMM');
+      $monthNums = range(1, 12);
+      \Civi::$statics[__CLASS__][$key] = array_combine($monthNums, array_map(
+        function(int $monthNum) use ($intlFormatter) {
+          return $intlFormatter->format(gmmktime(0, 0, 0, $monthNum, 1));
+        },
+        $monthNums
+      ));
     }
     if ($month) {
       return \Civi::$statics[__CLASS__][$key][$month];
@@ -264,23 +259,16 @@ class CRM_Utils_Date {
   public static function &getFullMonthNames() {
     $key = 'fullMonthNames_' . \CRM_Core_I18n::getLocale();
     if (empty(\Civi::$statics[__CLASS__][$key])) {
-      // Not relying on strftime because it depends on the operating system
-      // and most people will not have a non-US locale configured out of the box
-      // Ignoring other date names for now, since less visible by default
-      \Civi::$statics[__CLASS__][$key] = [
-        1 => ts('January'),
-        2 => ts('February'),
-        3 => ts('March'),
-        4 => ts('April'),
-        5 => ts('May'),
-        6 => ts('June'),
-        7 => ts('July'),
-        8 => ts('August'),
-        9 => ts('September'),
-        10 => ts('October'),
-        11 => ts('November'),
-        12 => ts('December'),
-      ];
+      // Note: IntlDateFormatter provides even more strings than `strftime()` or `l10n/*/civicrm.mo`.
+      // Note: Consistently use UTC for all requests in resolving these names. Avoid edge-cases where TZ support is inconsistent.
+      $intlFormatter = IntlDateFormatter::create(CRM_Core_I18n::getLocale(), IntlDateFormatter::MEDIUM, IntlDateFormatter::MEDIUM, 'UTC', IntlDateFormatter::GREGORIAN, 'MMMM');
+      $monthNums = range(1, 12);
+      \Civi::$statics[__CLASS__][$key] = array_combine($monthNums, array_map(
+        function(int $monthNum) use ($intlFormatter) {
+          return $intlFormatter->format(gmmktime(0, 0, 0, $monthNum, 1));
+        },
+        $monthNums
+      ));
     }
 
     return \Civi::$statics[__CLASS__][$key];

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -2617,7 +2617,7 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
   public function testLocalizeConsts() {
     $expect['en_US'] = ['Jan', 'Tue', 'March', 'Thursday'];
     $expect['fr_FR'] = ['janv.', 'mar.', 'mars', 'jeudi'];
-    $expect['es_MX'] = ['ene.', 'mar.', 'Marzo', 'jueves'];
+    $expect['es_MX'] = ['ene.', 'mar.', 'marzo', 'jueves'];
 
     foreach ($expect as $lang => $expectNames) {
       $useLocale = CRM_Utils_AutoClean::swapLocale($lang);

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -212,7 +212,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     $expectText = [
       'Yes No April',
       'Oui Non avril',
-      'Sí No Abril',
+      'Sí No abril',
     ];
 
     $rowCount = 0;


### PR DESCRIPTION
Overview
----------------------------------------

Alternative to #25066. Not tested. Let's see what CI says...

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
