### PR TITLE
getSiteStats - Use consistent report format

### DIFF
--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -203,6 +203,8 @@ class CRM_Utils_VersionCheck {
       'CRM_Pledge_DAO_PledgeBlock' => NULL,
       'CRM_Mailing_Event_DAO_MailingEventDelivered' => NULL,
     ];
+    // Provide continuity in wire format.
+    $compat = ['MailingEventDelivered' => 'Delivered'];
     foreach ($tables as $daoName => $where) {
       if (class_exists($daoName)) {
         /** @var \CRM_Core_DAO $dao */
@@ -212,7 +214,7 @@ class CRM_Utils_VersionCheck {
         }
         $short_name = substr($daoName, strrpos($daoName, '_') + 1);
         $this->stats['entities'][] = [
-          'name' => $short_name,
+          'name' => $compat[$short_name] ?? $short_name,
           'size' => $dao->count(),
         ];
       }

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -216,7 +216,8 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
         'MembershipBlock',
         'Pledge',
         'PledgeBlock',
-        'MailingEventDelivered',
+        'Delivered',
+        // TIP: If an entity is renamed, then update VersionCheck's $compat list.
       ];
       sort($entity_names);
       sort($expected_entity_names);


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #25150. When general usage stats are enabled, the format should be consistent across versions.

* __Before (4.7 - 5.56)__: Report stat as 'Delivered'
* __Before (5.57.beta1)__: Report stat as 'MailingEventDelivered'
* __After (5.57.beta1)__: Report stat as 'Delivered'

Comment
----------------------------------------

It's easier to provide continuity than to administer a breaking change. If the BC served some functional purpose, that would be one thing... but this seems cosmetic...