### PR TITLE
ConformanceTest - Remove override, which causes failures in `ConformanceTest`

### DIFF
--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -102,7 +102,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
    * @return array
    */
   public function getEntitiesLotech(): array {
-    $manual['add'] = ['SearchDisplay', 'SearchSegment'];
+    $manual['add'] = [];
     $manual['remove'] = ['CustomValue'];
     $manual['transform'] = ['CiviCase' => 'Case'];
 


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #24739 which removes an override from `ConformanceTest`.

cc @colemanw 

Before
----------------------------------------

The test-matrix shows these failures affect `5.57` and `master`:

* `api\v4\Entity\ConformanceTest.testEntitiesProvider`
* `api\v4\Entity\ConformanceTest.testConformance with data set "SearchDisplay"`
* `api\v4\Entity\ConformanceTest.testConformance with data set "SearchSegment"`

Examples:

* https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=5.57,SUITES=phpunit-api4,label=bknix-tmp/11867/testReport/
* https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=min,CIVIVER=5.57,SUITES=phpunit-api4,label=bknix-tmp/11867/testReport/

These failures are reproducible on my regular `dmaster` -- and on a new/local build. Ex:

```bash
civibuild create tmp --type drupal-clean --civi-ver 5.57
cd ~/bknix/build/tmp//web/sites/all/modules/civicrm
CIVICRM_UF=UnitTests phpunit8 tests/phpunit/api/v4/Entity/ConformanceTest.php
```

(FWIW, all of these _include_ https://github.com/civicrm/civicrm-buildkit/pull/735.)

After
----------------------------------------

Passes on my local

Comments
----------------------------------------

This is a bit confusing - because _PR tests_ seem to be passing on 5.57/master. Moreover, [`$manual['add']` was introduced to fix some test-failures](https://github.com/civicrm/civicrm-core/pull/24739/commits/c1e73b271d54ea6b37c17288eedcc000dfd99e68), though I don't see what.

Marking as draft because I'm not really sure what to expect. Will be interesting to see the test result... maybe it passes? Maybe it fails? Maybe there's a spooky interaction with some other test-suite (which only arises in PR testing)?