### PR TITLE
CRM_Utils_FileTest - Fix compatibility with private data folders

### DIFF
--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -319,7 +319,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
    */
   public function testIsDirWithOpenBasedir(?string $input, bool $expected) {
     // This might not always be under cms root, but let's see how it goes.
-    $a_dir = \Civi::paths()->getPath('[civicrm.compile]/');
+    $a_dir = \Civi::paths()->getPath('[civicrm.compile]/.');
 
     if (file_exists("{$a_dir}/isDirTest/ok/ok.txt")) {
       unlink("{$a_dir}/isDirTest/ok/ok.txt");
@@ -339,10 +339,13 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
     // where this file is:
     $cms_root = realpath(__DIR__ . '/../../../../../../../..');
 
+    // NOTE: The `[civicrm.compile]` does not necessarily live under the public `[cms.root] -- e.g. if you have a private data-folder.
+    $open_base_dirs = implode(PATH_SEPARATOR, [$cms_root, dirname($a_dir)]);
+
     // This test requires tightening `open_basedir` settings, which is a one-way change.
     // Therefore, we have to do that part of the test in a sub-process.
     // If you run directly in the same-process, then (eg) `phpunit` will have trouble writing error-data to JUnit XML files.
-    [$exitCode, $stdout, $stderr] = $this->runStaticMethodAsScript(__CLASS__, 'doIsDirWithOpenBasedir', [$a_dir, $cms_root, $input, $expected]);
+    [$exitCode, $stdout, $stderr] = $this->runStaticMethodAsScript(__CLASS__, 'doIsDirWithOpenBasedir', [$a_dir, $open_base_dirs, $input, $expected]);
     $this->assertEquals('"OK"', trim($stdout), 'doIsDirWithOpenBasedir() should return OK');
     $this->assertEquals('', trim($stderr), 'doIsDirWithOpenBasedir() should not generate warnings');
     $this->assertEquals(0, $exitCode, 'doIsDirWithOpenBasedir() should exit normally');
@@ -354,22 +357,22 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
 
   /**
    * @param string $a_dir
-   * @param string $cms_root
+   * @param string $open_base_dirs
    * @param string|null $input
    * @param bool $expected
    * @return string
    * @throws \ErrorException
    */
-  public static function doIsDirWithOpenBasedir(string $a_dir, string $cms_root, ?string $input, bool $expected): string {
+  public static function doIsDirWithOpenBasedir(string $a_dir, string $open_base_dirs, ?string $input, bool $expected): string {
     // We also need temp dir because phpunit creates files in there as it does stuff before we can reset basedir.
-    ini_set('open_basedir', $cms_root . PATH_SEPARATOR . sys_get_temp_dir());
+    ini_set('open_basedir', $open_base_dirs . PATH_SEPARATOR . sys_get_temp_dir());
 
     if (!mkdir("{$a_dir}/isDirTest")) {
-      return 'Failed to make isDirTest';
+      return "Failed to make isDirTest";
     }
 
     if (!mkdir("{$a_dir}/isDirTest/ok")) {
-      return 'Failed to make isDirTest/ok';
+      return "Failed to make isDirTest/ok";
     }
 
     file_put_contents("{$a_dir}/isDirTest/ok/ok.txt", 'Hello World!');


### PR DESCRIPTION
Overview
----------------------------------------

Update `FileTest` so that it runs successfully in more environments.

cc @demeritcowboy 

Before
----------------------------------------

We've been seeing fairly persistent failures for `CRM_Utils_FileTest` in the test-matrix, eg

https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=min,CIVIVER=5.57,SUITES=phpunit-crm,label=bknix-tmp/11867/testReport/

After
----------------------------------------

Should be fixed. (It's fixed on my local, which was reproducing the failure from the test-matrix.)

Technical Details
----------------------------------------

A typical test build has a web-root like this:

```
$BUILDKIT/build/dmaster/web
```

The `templates_c` (aka `[civicrm.compile]`) is often stored at


```
$BUILDKIT/build/dmaster/web/sites/default/files/civicrm/templates_c
```

However, if the Drupal site supports private folders, then may actually be at:

```
$BUILDKIT/build/dmaster/.civibuild/private/default/civicrm/templates_c
```

It seems that the test is setting `open_basedir` to something like `$BUILDKIT/build/dmaster/web`, but the `private` folder doesn't live under there. Hence the failure. The adds another item to `open_basedir` to ensure that it works in this configuration.

