### PR TITLE
Add datasource selector to generic import (so it can be used eg. with contribution import)

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -121,13 +121,9 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    *   reference to the array of default values
    */
   public function setDefaultValues() {
-    $defaults = [
-      'dataSource' => $this->getDefaultDataSource(),
-      'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-      'contactType' => 'Individual',
-      'fieldSeparator' => CRM_Core_Config::singleton()->fieldSeparator,
-      'disableUSPS' => TRUE,
-    ];
+    $defaults = parent::setDefaultValues();
+    $defaults['contactType'] = 'Individual';
+    $defaults['disableUSPS'] = TRUE;
 
     if ($this->get('loadedMapping')) {
       $defaults['savedMapping'] = $this->get('loadedMapping');

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -44,8 +44,6 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing contributions'),
     ]);
 
-    $this->setDefaults(['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
-
     $this->addElement('xbutton', 'loadMapping', ts('Load Mapping'), [
       'type' => 'submit',
       'onclick' => 'checkSelect()',

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -99,13 +99,10 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    * @throws \CRM_Core_Exception
    */
   public function setDefaultValues(): array {
-    $config = CRM_Core_Config::singleton();
-    $defaults = [
-      'contactType' => 'Individual',
-      'fieldSeparator' => $config->fieldSeparator,
-      // Perhaps never used, but permits url passing of the group.
-      'multipleCustomData' => CRM_Utils_Request::retrieve('id', 'Positive', $this),
-    ];
+    parent::setDefaultValues();
+    $defaults['contactType'] = 'Individual';
+    // Perhaps never used, but permits url passing of the group.
+    $defaults['multipleCustomData'] = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
     $loadedMapping = $this->get('loadedMapping');
     if ($loadedMapping) {

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -46,7 +46,6 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
       CRM_Import_Parser::DUPLICATE_NOCHECK => ts('No Duplicate Checking'),
     ]);
-    $this->setDefaults(['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 
     $this->addContactTypeSelector();
   }

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -59,33 +59,14 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
   public function buildQuickForm() {
     $this->assign('errorMessage', $this->getErrorMessage());
     $config = CRM_Core_Config::singleton();
-    // When we switch to using the DataSource.tpl used by Contact we can remove this in
-    // favour of the one used by Contact - I was trying to consolidate
-    // first & got stuck on https://github.com/civicrm/civicrm-core/pull/23458
-    $this->add('hidden', 'hidden_dataSource', 'CRM_Import_DataSource_CSV');
-    $uploadFileSize = CRM_Utils_Number::formatUnitSize($config->maxFileSize . 'm', TRUE);
 
-    //Fetch uploadFileSize from php_ini when $config->maxFileSize is set to "no limit".
-    if (empty($uploadFileSize)) {
-      $uploadFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), TRUE);
-    }
-    $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
+    $this->assign('urlPath', 'civicrm/import/datasource');
+    $this->assign('urlPathVar', 'snippet=4&user_job_id=' . $this->get('user_job_id'));
 
-    $this->assign('uploadSize', $uploadSize);
+    $this->add('select', 'dataSource', ts('Data Source'), $this->getDataSources(), TRUE,
+      ['onchange' => 'buildDataSourceFormBlock(this.value);']
+    );
 
-    $this->add('File', 'uploadFile', ts('Import Data File'), NULL, TRUE);
-    $this->setMaxFileSize($uploadFileSize);
-    $this->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', [
-      1 => $uploadSize,
-      2 => $uploadFileSize,
-    ]), 'maxfilesize', $uploadFileSize);
-    $this->addRule('uploadFile', ts('A valid file must be uploaded.'), 'uploadedfile');
-    $this->addRule('uploadFile', ts('Input file must be in CSV format'), 'utf8File');
-
-    $this->addElement('checkbox', 'skipColumnHeader', ts('First row contains column headers'));
-
-    $this->add('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2], TRUE);
-    $this->setDefaults(['fieldSeparator' => $config->fieldSeparator]);
     $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . static::IMPORT_ENTITY);
     $this->add('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
@@ -95,6 +76,8 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
 
     //build date formats
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
+
+    $this->buildDataSourceFields();
 
     $this->addButtons([
         [
@@ -108,6 +91,15 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
           'name' => ts('Cancel'),
         ],
     ]);
+  }
+
+  public function setDefaultValues() {
+    return [
+      'dataSource' => $this->getDefaultDataSource(),
+      'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
+      'fieldSeparator' => CRM_Core_Config::singleton()->fieldSeparator,
+    ];
+
   }
 
   /**

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -45,9 +45,6 @@ class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_SKIP => ts('Insert new Membership'),
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing Membership'),
     ]);
-    $this->setDefaults([
-      'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-    ]);
 
     $this->addContactTypeSelector();
   }

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -24,21 +24,20 @@
   </div>
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-    <table class="form-layout-compressed">
-      <tr class="crm-import-uploadfile-from-block-uploadFile">
-        <td class="label">{$form.uploadFile.label}</td>
-        <td class="html-adjust"> {$form.uploadFile.html}<br />
-          <span class="description">{ts}File format must be comma-separated-values (CSV).{/ts}</span>
-          <br /><span>{ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}</span>
-        </td>
+  <div id="choose-data-source" class="form-item">
+    <h3>{ts}Choose Data Source{/ts}</h3>
+    <table class="form-layout">
+      <tr class="crm-import-datasource-form-block-dataSource">
+        <td class="label">{$form.dataSource.label}</td>
+        <td>{$form.dataSource.html} {help id='data-source-selection'}</td>
       </tr>
-       <tr class="crm-import-uploadfile-from-block-skipColumnHeader">
-         <td class="label"></td><td>{$form.skipColumnHeader.html}{$form.skipColumnHeader.label}<br />
-           <span class="description">
-             {ts}Check this box if the first row of your file consists of field names (Example: 'Contact ID', 'Amount').{/ts}
-           </span>
-         </td>
-       </tr>
+    </table>
+  </div>
+
+    {* Data source form pane is injected here when the data source is selected. *}
+  <div id="data-source-form-block">
+  </div>
+    <table class="form-layout-compressed">
       {if array_key_exists('contactType', $form)}
         <tr class="crm-import-uploadfile-from-block-contactType">
           <td class="label">{$form.contactType.label}</td>
@@ -79,5 +78,30 @@
     <div class="spacer"></div>
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+{literal}
+  <script type="text/javascript">
+    CRM.$(function($) {
+      // build data source form block
+      buildDataSourceFormBlock();
+    });
+
+    function buildDataSourceFormBlock(dataSource) {
+      var dataUrl = {/literal}"{crmURL p=$urlPath h=0 q=$urlPathVar|smarty:nodefaults}"{literal};
+
+      if (!dataSource) {
+        var dataSource = CRM.$("#dataSource").val();
+      }
+
+      if (dataSource) {
+        dataUrl = dataUrl + '&dataSource=' + dataSource;
+      } else {
+        CRM.$("#data-source-form-block").html('');
+        return;
+      }
+
+      CRM.$("#data-source-form-block").load(dataUrl);
+    }
+  </script>
+{/literal}
 </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
So you can use CSV or SQL as datasource on core importers.

Before
----------------------------------------
CSV/SQL available on Contact import.

After
----------------------------------------
CSV/SQL available on Contact/Contribution import.

Technical Details
----------------------------------------
I only tested contact/contribution import. But the others all use the generic import class so should work.

Comments
----------------------------------------
@eileenmcnaughton 
