### PR TITLE
Closes dev/core#4013: remove 'sortable' from quicksearch_options array

### DIFF
--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -216,7 +216,6 @@ return [
     'type' => 'String',
     'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND,
     'html_type' => 'checkboxes',
-    'sortable' => TRUE,
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::quicksearchOptions',
     ],


### PR DESCRIPTION
Overview
----------------------------------------
This PR resolves the [issue 4013](https://lab.civicrm.org/dev/core/-/issues/4013), which noted an unreleased regression of an error when editing **Search Preferences**. It is also related to/resolves [issue 4022](https://lab.civicrm.org/dev/core/-/issues/4022): "PHP 7.4, 8+ TypeError: array_flip(): Argument [#1](https://lab.civicrm.org/dev/core/-/issues/1) ($array) must be of type array, string given".

Before
----------------------------------------
When a user tried to change the default pager limit and save those changes on the **Search Preferences** page, they encountered an error with the below messages:

```
Warning: array_flip() expects parameter 1 to be array, string given in CRM_Admin_Form_Setting::reorderSortableOptions() (line 380 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Admin/Form/SettingTrait.php).
    Warning: array_merge(): Expected parameter 1 to be an array, null given in CRM_Admin_Form_Setting::reorderSortableOptions() (line 380 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Admin/Form/SettingTrait.php).
    Warning: array_flip() expects parameter 1 to be array, null given in CRM_Admin_Form_Setting->addFieldsDefinedInSettingsMetadata() (line 224 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Admin/Form/SettingTrait.php).
    Warning: Invalid argument supplied for foreach() in CRM_Core_Form->addCheckBox() (line 1418 of /srv/buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Form.php).
```
**Replication steps**
1. Go to **Administer » Customize Data and Screens » Search Preferences**.
1. Change the default pager limit to different integer and save.
1. Visit the **Search Preferences** page again.

After
----------------------------------------
By removing the `'sortable' => TRUE` option from the `'quicksearch_options'` settings array in `civicrm/settings/Search.setting.php` (and then clearing cache)- which was recommended by @demeritcowboy in the comments of the issue linked above- the user no longer encounters an error when they try to change the default pager limit.

Technical Details
----------------------------------------
As @demeritcowboy notes within the issue's comments, `'quicksearch_ooptions'` is the only field that uses this (currently unreliable) sortable option.