### PR TITLE
[dev/core#3470] Search Kit: Mailing labels don't work

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -139,10 +139,8 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
           }
           $key = \CRM_Core_Key::get(\CRM_Utils_Array::first((array) $task['class']), TRUE);
 
-          //break out mailing labels (and/or others) for redirect instead of crmPopup
+          //break out mailing labels for redirect instead of crmPopup
           if ($task['title'] == 'Mailing labels - print') {
-            //this is questionable see below
-            // $url = $task['url'] . '?qfKey=' . $key;
             $tasks[$entity['name']]['contact.' . $id] = [
               'title' => $task['title'],
               'icon' => $task['icon'] ?? 'fa-gear',

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -140,7 +140,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
           $key = \CRM_Core_Key::get(\CRM_Utils_Array::first((array) $task['class']), TRUE);
 
           //break out mailing labels for redirect instead of crmPopup
-          if ($task['title'] == 'Mailing labels - print') {
+          if ($id == CRM_Core_Task::LABEL_CONTACTS) {
             $tasks[$entity['name']]['contact.' . $id] = [
               'title' => $task['title'],
               'icon' => $task['icon'] ?? 'fa-gear',

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -148,7 +148,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
                 'path' => "'{$task['url']}'",
                 'query' => "{reset: 1}",
                 'data' => "{cids: ids.join(','), qfKey: '$key'}",
-              ]
+              ],
             ];
           }
           else {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -138,15 +138,32 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
             $task['title'] = E::ts('Profile Update');
           }
           $key = \CRM_Core_Key::get(\CRM_Utils_Array::first((array) $task['class']), TRUE);
-          $tasks[$entity['name']]['contact.' . $id] = [
-            'title' => $task['title'],
-            'icon' => $task['icon'] ?? 'fa-gear',
-            'crmPopup' => [
-              'path' => "'{$task['url']}'",
-              'query' => "{reset: 1}",
-              'data' => "{cids: ids.join(','), qfKey: '$key'}",
-            ],
-          ];
+
+          //break out mailing labels (and/or others) for redirect instead of crmPopup
+          if ($task['title'] == 'Mailing labels - print') {
+            //this is questionable see below
+            // $url = $task['url'] . '?qfKey=' . $key;
+            $tasks[$entity['name']]['contact.' . $id] = [
+              'title' => $task['title'],
+              'icon' => $task['icon'] ?? 'fa-gear',
+              'redirect' => [
+                'path' => "'{$task['url']}'",
+                'query' => "{reset: 1}",
+                'data' => "{cids: ids.join(','), qfKey: '$key'}",
+              ]
+            ];
+          }
+          else {
+            $tasks[$entity['name']]['contact.' . $id] = [
+              'title' => $task['title'],
+              'icon' => $task['icon'] ?? 'fa-gear',
+              'crmPopup' => [
+                'path' => "'{$task['url']}'",
+                'query' => "{reset: 1}",
+                'data' => "{cids: ids.join(','), qfKey: '$key'}",
+              ],
+            ];
+          }
         }
       }
       if (!$this->checkPermissions || \CRM_Core_Permission::check(['merge duplicate contacts', 'delete contacts'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -139,29 +139,18 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
           }
           $key = \CRM_Core_Key::get(\CRM_Utils_Array::first((array) $task['class']), TRUE);
 
-          //break out mailing labels for redirect instead of crmPopup
-          if ($id == CRM_Core_Task::LABEL_CONTACTS) {
-            $tasks[$entity['name']]['contact.' . $id] = [
-              'title' => $task['title'],
-              'icon' => $task['icon'] ?? 'fa-gear',
-              'redirect' => [
-                'path' => "'{$task['url']}'",
-                'query' => "{reset: 1}",
-                'data' => "{cids: ids.join(','), qfKey: '$key'}",
-              ],
-            ];
-          }
-          else {
-            $tasks[$entity['name']]['contact.' . $id] = [
-              'title' => $task['title'],
-              'icon' => $task['icon'] ?? 'fa-gear',
-              'crmPopup' => [
-                'path' => "'{$task['url']}'",
-                'query' => "{reset: 1}",
-                'data' => "{cids: ids.join(','), qfKey: '$key'}",
-              ],
-            ];
-          }
+          // Print Labels action does not support popups, open full-screen
+          $actionType = $id == \CRM_Core_Task::LABEL_CONTACTS ? 'redirect' : 'crmPopup';
+
+          $tasks[$entity['name']]['contact.' . $id] = [
+            'title' => $task['title'],
+            'icon' => $task['icon'] ?? 'fa-gear',
+            $actionType => [
+              'path' => "'{$task['url']}'",
+              'query' => "{reset: 1}",
+              'data' => "{cids: ids.join(','), qfKey: '$key'}",
+            ],
+          ];
         }
       }
       if (!$this->checkPermissions || \CRM_Core_Permission::check(['merge duplicate contacts', 'delete contacts'])) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
@@ -11,7 +11,7 @@
       ids: '<'
     },
     templateUrl: '~/crmSearchTasks/crmSearchTasks.html',
-    controller: function($scope, crmApi4, dialogService) {
+    controller: function($scope, crmApi4, dialogService, $window) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         initialized = false,
@@ -71,6 +71,11 @@
             query = action.crmPopup.query && $scope.$eval(action.crmPopup.query, data);
           CRM.loadForm(CRM.url(path, query), {post: action.crmPopup.data && $scope.$eval(action.crmPopup.data, data)})
             .on('crmFormSuccess', ctrl.refresh);
+        }
+        else if (action.redirect) {
+          var path = $scope.$eval(action.redirect.path, data),
+            query = action.redirect.query && $scope.$eval(action.redirect.query, data) && $scope.$eval(action.redirect.data, data);
+          $window.open(CRM.url(path, query), '_blank');
         }
         // If action uses dialogService
         else {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
@@ -73,9 +73,9 @@
             .on('crmFormSuccess', ctrl.refresh);
         }
         else if (action.redirect) {
-          var path = $scope.$eval(action.redirect.path, data),
-            query = action.redirect.query && $scope.$eval(action.redirect.query, data) && $scope.$eval(action.redirect.data, data);
-          $window.open(CRM.url(path, query), '_blank');
+          var redirectPath = $scope.$eval(action.redirect.path, data),
+            redirectQuery = action.redirect.query && $scope.$eval(action.redirect.query, data) && $scope.$eval(action.redirect.data, data);
+          $window.open(CRM.url(redirectPath, redirectQuery), '_blank');
         }
         // If action uses dialogService
         else {


### PR DESCRIPTION
Overview
----------------------------------------
When one creates a SearchKit Search for the "Contacts" entity the Actions dropdown includes an option:  "Mailing labels - Print". This action is broken. This PR fixes it. More details can be found on this issue: https://lab.civicrm.org/dev/core/-/issues/3470. 

Before
----------------------------------------
The Search Kit action "Mailing labels - Print" for contact searches does NOT work.

After
----------------------------------------
The Search Kit action "Mailing labels - Print" for contact searches work.

