### PR TITLE
(NFC) PrevNextTest - Fix warning about "@group"

### DIFF
--- a/tests/phpunit/E2E/Core/PrevNextTest.php
+++ b/tests/phpunit/E2E/Core/PrevNextTest.php
@@ -8,7 +8,8 @@ namespace E2E\Core;
  * Check that the active prev-next service behaves as expected.
  *
  * @package E2E\Core
- * @group e2e ornery
+ * @group e2e
+ * @group ornery
  */
 class PrevNextTest extends \CiviEndToEndTestCase {
 


### PR DESCRIPTION
Overview
----------------------------------------


When running this test, there are warnings like so:

```
WARNING: Class E2E\Core\PrevNextTest implements EndToEndInterface. It should declare "@group e2e".
```

In PHPUnit docs (https://phpunit.readthedocs.io/en/9.5/annotations.html#group), they encode multiple groups using multiple lines. Following this convention fixes the warning.

Before
----------------------------------------

Warning. Multiple groups in one `@group` annotation.

After
----------------------------------------

No warning. Each group has its own `@group` annotation.
