### PR TITLE
E_NOTICES on activity view

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -83,6 +83,11 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
       }
     }
 
+    // ensure these are set so that they get assigned to the template
+    $values['mailingId'] = $values['mailingId'] ?? NULL;
+    $values['campaign'] = $values['campaign'] ?? NULL;
+    $values['engagement_level'] = $values['engagement_level'] ?? NULL;
+
     // Get the campaign.
     if ($campaignId = CRM_Utils_Array::value('campaign_id', $defaults)) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);

--- a/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityViewTest.php
@@ -73,6 +73,9 @@ class CRM_Activity_Form_ActivityViewTest extends CiviUnitTestCase {
       'modified_date' => $activityMoreInfo['modified_date'],
       'activity_modified_date' => $activityMoreInfo['modified_date'],
       'attachment' => NULL,
+      'mailingId' => NULL,
+      'campaign' => NULL,
+      'engagement_level' => NULL,
     ];
 
     $this->assertEquals($expected, $templateVar);


### PR DESCRIPTION
Overview
----------------------------------------
I have some unit tests I'm working on and these are coming up.

Before
----------------------------------------
1. Send an email from civi.
2. View the email activity.
3.
  ```
  Warning: Undefined array key "mailingId" in include() (line 21 of ...ActivityView.tpl.php).
  Warning: Undefined array key "campaign" in include() (line 32 of ...ActivityView.tpl.php).
  Warning: Undefined array key "engagement_level" in include() (line 39 of ...ActivityView.tpl.php).
  ```

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

