### PR TITLE
Import: Set user context and gracefully handle datasource errors

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -20,7 +20,11 @@
  */
 class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/import/activity';
+  /**
+   * Variable to store redirect path.
+   * @var string
+   */
+  protected $_userContext = 'civicrm/import/activity';
 
   const IMPORT_ENTITY = 'Activity';
 

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -22,7 +22,11 @@ use Civi\Api4\CustomGroup;
  */
 class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/import/custom';
+  /**
+   * Variable to store redirect path.
+   * @var string
+   */
+  protected $_userContext = 'civicrm/import/custom';
 
   const IMPORT_ENTITY = 'Multi value custom data';
 

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -20,7 +20,11 @@
  */
 class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/event/import';
+  /**
+   * Variable to store redirect path.
+   * @var string
+   */
+  protected $_userContext = 'civicrm/event/import';
 
   const IMPORT_ENTITY = 'Participant';
 

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -22,9 +22,17 @@ use Civi\Api4\Utils\CoreUtil;
 abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
 
   /**
+   * Variable to store redirect path.
+   * @var string
+   */
+  protected $_userContext = '';
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess(): void {
+    CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url($this->_userContext, 'reset=1'));
+
     // check for post max size
     CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     $this->assign('importEntity', $this->getTranslatedEntity());
@@ -183,7 +191,12 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       $this->flushDataSource();
       $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     }
-    $this->instantiateDataSource();
+    try {
+      $this->instantiateDataSource();
+    }
+    catch (Exception $e) {
+      CRM_Core_Error::statusBounce('Could not process datasource: ' . $e->getMessage());
+    }
   }
 
   /**

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -20,7 +20,11 @@
  */
 class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/member/import';
+  /**
+   * Variable to store redirect path.
+   * @var string
+   */
+  protected $_userContext = 'civicrm/member/import';
 
   const IMPORT_ENTITY = 'Membership';
 


### PR DESCRIPTION
Overview
----------------------------------------
Applies more to SQL datasource which will throw an exception if the query does not work (eg. database table does not exist).

Before
----------------------------------------
Ugly fatal error screen.

After
----------------------------------------
Bounces back to datasource form and display error as standard notification.

Technical Details
----------------------------------------
I can't see anywhere where `CONST PATH` is used? So I've changed it to a class property to match other forms.

Comments
----------------------------------------
@eileenmcnaughton 
