### PR TITLE
Standardise method of getting entity in imports

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -55,6 +55,8 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
 
   /**
    * Common form elements.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     $this->assign('errorMessage', $this->getErrorMessage());
@@ -67,7 +69,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       ['onchange' => 'buildDataSourceFormBlock(this.value);']
     );
 
-    $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . static::IMPORT_ENTITY);
+    $mappingArray = CRM_Core_BAO_Mapping::getCreateMappingValues('Import ' . $this->getBaseEntity());
     $this->add('select', 'savedMapping', ts('Saved Field Mapping'), ['' => ts('- select -')] + $mappingArray);
 
     if ($loadedMapping = $this->get('loadedMapping')) {


### PR DESCRIPTION
Overview
----------------------------------------
Standardise method of getting entity in imports

Before
----------------------------------------
Most places that check the entity for imports call `getBaseEntity` , one checks the CONST

After
----------------------------------------
ALL places that check the entity for imports call `getBaseEntity

Technical Details
----------------------------------------
The consts can go - I am just conscious it would make https://github.com/civicrm/civicrm-core/pull/25171 stale / be hard to co-ordinate with changes to that PR so they can be removed in that PR or after it is merged

Comments
----------------------------------------
