### PR TITLE
Afform - Support repeatable relationships

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -344,52 +344,55 @@ class Submit extends AbstractProcessor {
     // Prevent processGenericEntity
     $event->stopPropagation();
     $api4 = $event->getSecureApi4();
-    $relationship = $event->records[0]['fields'] ?? [];
-    if (empty($relationship['contact_id_a']) || empty($relationship['contact_id_b']) || empty($relationship['relationship_type_id'])) {
-      return;
-    }
-    $relationshipType = RelationshipType::get(FALSE)
-      ->addWhere('id', '=', $relationship['relationship_type_id'])
-      ->execute()->single();
-    $isReciprocal = $relationshipType['label_a_b'] == $relationshipType['label_b_a'];
-    $isActive = !isset($relationship['is_active']) || !empty($relationship['is_active']);
-    // Each contact id could be multivalued (e.g. using `af-repeat`)
-    foreach ((array) $relationship['contact_id_a'] as $contact_id_a) {
-      foreach ((array) $relationship['contact_id_b'] as $contact_id_b) {
-        $params = $relationship;
-        $params['contact_id_a'] = $contact_id_a;
-        $params['contact_id_b'] = $contact_id_b;
-        // Check for existing relationships (if allowed)
-        if (!empty($event->getEntity()['actions']['update'])) {
-          $where = [
-            ['is_active', '=', $isActive],
-            ['relationship_type_id', '=', $relationship['relationship_type_id']],
-          ];
-          // Reciprocal relationship types need an extra check
-          if ($isReciprocal) {
-            $where[] = [
-              'OR', [
-                ['AND', [['contact_id_a', '=', $contact_id_a], ['contact_id_b', '=', $contact_id_b]]],
-                ['AND', [['contact_id_a', '=', $contact_id_b], ['contact_id_b', '=', $contact_id_a]]],
-              ],
+    // Iterate through multiple relationships (if using af-repeat)
+    foreach ($event->records as $relationship) {
+      $relationship = $relationship['fields'] ?? [];
+      if (empty($relationship['contact_id_a']) || empty($relationship['contact_id_b']) || empty($relationship['relationship_type_id'])) {
+        return;
+      }
+      $relationshipType = RelationshipType::get(FALSE)
+        ->addWhere('id', '=', $relationship['relationship_type_id'])
+        ->execute()->single();
+      $isReciprocal = $relationshipType['label_a_b'] == $relationshipType['label_b_a'];
+      $isActive = !isset($relationship['is_active']) || !empty($relationship['is_active']);
+      // Each contact id could be multivalued (e.g. using `af-repeat`)
+      foreach ((array) $relationship['contact_id_a'] as $contact_id_a) {
+        foreach ((array) $relationship['contact_id_b'] as $contact_id_b) {
+          $params = $relationship;
+          $params['contact_id_a'] = $contact_id_a;
+          $params['contact_id_b'] = $contact_id_b;
+          // Check for existing relationships (if allowed)
+          if (!empty($event->getEntity()['actions']['update'])) {
+            $where = [
+              ['is_active', '=', $isActive],
+              ['relationship_type_id', '=', $relationship['relationship_type_id']],
             ];
+            // Reciprocal relationship types need an extra check
+            if ($isReciprocal) {
+              $where[] = [
+                'OR', [
+                  ['AND', [['contact_id_a', '=', $contact_id_a], ['contact_id_b', '=', $contact_id_b]]],
+                  ['AND', [['contact_id_a', '=', $contact_id_b], ['contact_id_b', '=', $contact_id_a]]],
+                ],
+              ];
+            }
+            else {
+              $where[] = ['contact_id_a', '=', $contact_id_a];
+              $where[] = ['contact_id_b', '=', $contact_id_b];
+            }
+            $existing = $api4('Relationship', 'get', ['where' => $where])->first();
+            if ($existing) {
+              $params['id'] = $existing['id'];
+              unset($params['contact_id_a'], $params['contact_id_b']);
+              // If this is a flipped reciprocal relationship, also flip the permissions
+              $params['is_permission_a_b'] = $relationship['is_permission_b_a'] ?? NULL;
+              $params['is_permission_b_a'] = $relationship['is_permission_a_b'] ?? NULL;
+            }
           }
-          else {
-            $where[] = ['contact_id_a', '=', $contact_id_a];
-            $where[] = ['contact_id_b', '=', $contact_id_b];
-          }
-          $existing = $api4('Relationship', 'get', ['where' => $where])->first();
-          if ($existing) {
-            $params['id'] = $existing['id'];
-            unset($params['contact_id_a'], $params['contact_id_b']);
-            // If this is a flipped reciprocal relationship, also flip the permissions
-            $params['is_permission_a_b'] = $relationship['is_permission_b_a'] ?? NULL;
-            $params['is_permission_b_a'] = $relationship['is_permission_a_b'] ?? NULL;
-          }
+          $api4('Relationship', 'save', [
+            'records' => [$params],
+          ]);
         }
-        $api4('Relationship', 'save', [
-          'records' => [$params],
-        ]);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Supports creating multiple relationships at once using the "Repeatable" feature in the relationship fields.

See https://chat.civicrm.org/civicrm/pl/r3nw5p4z9jyg9gx61dndp99ipe

Before
----------------------------------------
Relationship blocks could be repeated, but only the first one would save

After
----------------------------------------
All repeated relationships save.

### 1. Create form, add relationship fieldset and make it repeatable

![image](https://user-images.githubusercontent.com/2874912/213223746-a90ecbc4-c0f5-42a5-9312-4bffe28bad3c.png)


### 2. When filling out form, click the "Add" button to add multiple relations

![image](https://user-images.githubusercontent.com/2874912/213222299-aa623fa0-0046-452c-a6ec-8feecc1f8079.png)

### 3. Relationships have been created

![image](https://user-images.githubusercontent.com/2874912/213223246-b3a054b3-4aca-43d1-a1c5-c8bc2d5597f2.png)

