### PR TITLE
Fix miscoordination between CiviUnitTestCase/CiviEnvBuilder. Fix flaky ConformanceTest.

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -110,7 +110,7 @@ class Test {
    */
   public static function headless() {
     $civiRoot = dirname(__DIR__);
-    $builder = new \Civi\Test\CiviEnvBuilder('CiviEnvBuilder');
+    $builder = new \Civi\Test\CiviEnvBuilder();
     $builder
       ->callback(function ($ctx) {
         if (CIVICRM_UF !== 'UnitTests') {
@@ -139,7 +139,7 @@ class Test {
    * @return \Civi\Test\CiviEnvBuilder
    */
   public static function e2e() {
-    $builder = new \Civi\Test\CiviEnvBuilder('CiviEnvBuilder');
+    $builder = new \Civi\Test\CiviEnvBuilder();
     $builder
       ->callback(function ($ctx) {
         if (CIVICRM_UF === 'UnitTests') {

--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -28,7 +28,7 @@ class CiviEnvBuilder {
    */
   private $targetSignature = NULL;
 
-  public function __construct($name) {
+  public function __construct(string $name = 'CiviEnvBuilder') {
     $this->name = $name;
   }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -343,6 +343,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
     Civi\Test::data()->populate();
 
+    // `CiviUnitTestCase` has replaced the baseline DB configuration. To coexist with other
+    // tests based on `CiviEnvBuilder`, we need to store a signature marking the current DB configuration.
+    (new \Civi\Test\CiviEnvBuilder())->callback(function(){}, 'CiviUnitTestCase')->apply(TRUE);
+
     return TRUE;
   }
 

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -54,6 +54,11 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     }
   }
 
+  public function setUpHeadless() {
+    // TODO: search_kit should probably be part of the 'headless()' baseline.
+    return \Civi\Test::headless()->install(['org.civicrm.search_kit'])->apply();
+  }
+
   public function setUp(): void {
     $this->hookCallback = NULL;
     // Ensure MockBasicEntity gets added via above listener

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -102,7 +102,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
    * @return array
    */
   public function getEntitiesLotech(): array {
-    $manual['add'] = ['SearchDisplay', 'SearchSegment'];
+    $manual['add'] = [];
     $manual['remove'] = ['CustomValue'];
     $manual['transform'] = ['CiviCase' => 'Case'];
 


### PR DESCRIPTION
Overview
----------------------------------------

(Replaces #25159. Follow-up to #24739.)

This fixes a subtle and general leak in how `CiviUnitTestCase` and `CiviEnvBuilder` coordinate the use of the headless DB. It was discovered while investigating a flaky test-result that stems from 5.57's #24739 -- specifically, [there is a spooky interaction between `CRM_Contribute_Import_Parser_ContributionTest` and  `api\v4\Entity\ConformanceTest`](https://gist.github.com/totten/38b73c12505c770c6862cde5967ab25f) -- where the outcome of `ConformanceTest` appears to change arbitrarily.

After fixing the general leak, the spooky-interaction goes away, and the tests behave reliably. However, the reliable behavior is to complain. So I also update `ConformanceTest` -- resolving the complaint, removing an adhoc override, and getting it to pass.

(I suspect that developers have been locally+intermittently bitten by this spooky interaction in the past -- just not in a way that was visible to CI. So I'm including a bit more of write-up to explain what was fixed.)

General: Background
----------

Recall that `CiviUnitTestCase` and `CiviEnvBuilder` provide two different implementations of a similar concept.

* __Basic Concept__: When running tests, you need to setup the DB. You should do it regularly and reproducibly, but you shouldn't do it for every test-method (because it's slow/expensive). You should have some rules to decide (a) how to setup the DB and (b) when to reset it.

* `CiviUnitTestCase`: The older implementation.  Tightly coupled.  Only allows one specific baseline.  Mingled with a lot of unrelated functionality in`CiviUnitTestCase`.

* `CiviEnvBuilder`: The newer implementation.  Loosely coupled.  Allows different baselines.  Can be mixed into any plain-old `TestCase`.  Used by `Civi\Test::headless()` and `Civi\Test::e2e()`.
    * When you first call`CiviEnvBuilder`, it resets the DB and stores a flag (`civitests_rev`) that says "Here is how I setup the DB." Each time you call again, it checks that flag and decides whether the current environment is good enough. (If not, then it resets.)

The problem arises when you interleave test-runs that are based on the two systems. This could be a structural thing (one large test-suite with heterogeneous tests), or it could be circumstantial -- where a developer or testbot happens to run tests in a disagreeable order.

General: Before
---------

When running interleaved tests, it misses some resets.

1. Run some tests based on `CiviEnvBuilder`
    * This resets the DB and also stores a DB signature. ("Here is how we setup the DB...")
2. Run some tests based on `CiviUnitTestCase`
    * This resets the DB, but leaves the old DB signature in place.
3. Run some tests based on `CiviEnvBuilder`
    * This sees the _old DB signature_ and wrongly concludes that we still have the DB from step (1). It does not reset.

General: After
--------

1. Run some tests based on `CiviEnvBuilder`
    * This resets the DB and also stores a DB signature. ("Here is how we setup the DB...")
2. Run some tests based on `CiviUnitTestCase`
    * This resets the DB and also stores a DB signature. ("Here is how we setup the DB...")
3. Run some tests based on `CiviEnvBuilder`
    * This resets the DB and also stores a DB signature. ("Here is how we setup the DB...")

Specific: Before
--------------------

`CRM_Contribute_Import_Parser_ContributionTest` (based on `CiviUnitTestCase`) enables a series of several extensions, including `search_kit`. Prior to #24739, it cleaned up after itself (disabling+uninstalling each extension -- returning to CiviUnitTestCase's baseline environment). However, #24739 made it impossible to directly disable `search_kit`. Thus, `ContributionTest` left SK active.

`ConformanceTest` (based on `CiviEnvBuilder`) sometimes runs after `ContributionTest` (as in `CiviCRM-Core-PR`) -- which means SK is sometimes active. But it sometimes runs independently (as in `CiviCRM-Core-Matrix`) -- which means that SK is sometimes inactive.

There is an override in `ConformanceTest`. If you keep it, then `CiviCRM-Core-Matrix` fails. If you remove it, then `CiviCRM-Core-PR` fails.

Specifics: After
--------------------

It doesn't matter if you run `ConformanceTest` via `CiviCRM-Core-PR` or `CiviCRM-Core-Matrix` -- they both start from the same baseline (ie SK disabled).

The override can be removed.

Specifics: Future
-----------------------

Given that policy has changed (`search_kit` is becoming mandatory), it may be appealing to change the test-baselines -- so that `CiviUnitTestCase` and `CiviEnvBuilder` both include it. Right now, I'm mostly concerned about getting a stable signal from the tests. Changes to baseline should be pursued as a separate exercise.