### PR TITLE
(REF) CiviUnitTestCase - Cleanup and simplify the DB-reset mechanism

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -91,13 +91,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected $_dbconn;
 
   /**
-   * The database name.
-   *
-   * @var string
-   */
-  static protected $_dbName;
-
-  /**
    * API version in use.
    *
    * @var int
@@ -240,8 +233,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
 
     // we need full error reporting
     error_reporting(E_ALL & ~E_NOTICE);
-
-    self::$_dbName = self::getDBName();
 
     // also load the class loader
     require_once 'CRM/Core/ClassLoader.php';

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -84,13 +84,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   private static $dbInit = FALSE;
 
   /**
-   *  Database connection.
-   *
-   * @var PHPUnit_Extensions_Database_DB_IDatabaseConnection
-   */
-  protected $_dbconn;
-
-  /**
    * API version in use.
    *
    * @var int
@@ -339,7 +332,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     }
 
     //  Get and save a connection to the database
-    $this->_dbconn = $this->getConnection();
+    $this->getConnection(); /* NOTE: Side-effects! */
 
     // reload database before each test
     //        $this->_populateDB();

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -262,13 +262,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * @return bool
-   */
-  public function requireDBReset() {
-    return $this->DBResetRequired;
-  }
-
-  /**
    * @return string
    */
   public static function getDBName() {
@@ -318,7 +311,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       $dbreset = TRUE;
     }
     else {
-      $dbreset = $object->requireDBReset();
+      $dbreset = $object->DBResetRequired;
     }
 
     if (self::$populateOnce || !$dbreset) {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -241,20 +241,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * @return string
-   */
-  public static function getDBName() {
-    static $dbName = NULL;
-    if ($dbName === NULL) {
-      require_once "DB.php";
-      $dsn = CRM_Utils_SQL::autoSwitchDSN(CIVICRM_DSN);
-      $dsninfo = DB::parseDSN($dsn);
-      $dbName = $dsninfo['database'];
-    }
-    return $dbName;
-  }
-
-  /**
    * Declare the environment that we wish to run in.
    *
    * TODO: The hope is to get this to align with `Civi\Test::headless()` and perhaps
@@ -301,9 +287,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     }
 
     if (!self::$dbInit) {
-      $dbName = self::getDBName();
-      // install test database
-      echo PHP_EOL . "Installing {$dbName} database" . PHP_EOL;
+      fprintf(STDERR, "\nInstalling %s database\n", \Civi\Test::dsn('database'));
       \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
       self::$dbInit = TRUE;
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -262,10 +262,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *   TRUE if the populate logic runs; FALSE if it is skipped
    */
   protected static function _populateDB($perClass = FALSE, &$object = NULL) {
-    if (CIVICRM_UF !== 'UnitTests') {
-      throw new \RuntimeException("_populateDB requires CIVICRM_UF=UnitTests");
-    }
-
     if ($perClass || $object == NULL) {
       $dbreset = TRUE;
     }
@@ -287,6 +283,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   public static function setUpBeforeClass(): void {
+    if (CIVICRM_UF !== 'UnitTests') {
+      throw new \RuntimeException("CiviUnitTestCase requires CIVICRM_UF=UnitTests");
+    }
+
     static::_populateDB(TRUE);
 
     // also set this global hack

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -312,12 +312,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   *  Required implementation of abstract method.
-   */
-  protected function getDataSet() {
-  }
-
-  /**
    * @param bool $perClass
    * @param null $object
    *

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -255,26 +255,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   *  Create database connection for this instance.
-   *
-   *  Initialize the test database if it hasn't been initialized
-   *
-   */
-  protected function getConnection() {
-    if (!self::$dbInit) {
-      $dbName = self::getDBName();
-
-      //  install test database
-      echo PHP_EOL . "Installing {$dbName} database" . PHP_EOL;
-
-      static::_populateDB(FALSE, $this);
-
-      self::$dbInit = TRUE;
-    }
-
-  }
-
-  /**
    * @param bool $perClass
    * @param null $object
    *
@@ -331,11 +311,13 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       exit(1);
     }
 
-    //  Get and save a connection to the database
-    $this->getConnection(); /* NOTE: Side-effects! */
-
-    // reload database before each test
-    //        $this->_populateDB();
+    if (!self::$dbInit) {
+      $dbName = self::getDBName();
+      // install test database
+      echo PHP_EOL . "Installing {$dbName} database" . PHP_EOL;
+      static::_populateDB(FALSE, $this);
+      self::$dbInit = TRUE;
+    }
 
     // "initialize" CiviCRM to avoid problems when running single tests
     // FIXME: look at it closer in second stage

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -273,13 +273,25 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       return FALSE;
     }
 
-    Civi\Test::data()->populate();
-
-    // `CiviUnitTestCase` has replaced the baseline DB configuration. To coexist with other
-    // tests based on `CiviEnvBuilder`, we need to store a signature marking the current DB configuration.
-    (new \Civi\Test\CiviEnvBuilder())->callback(function(){}, 'CiviUnitTestCase')->apply(TRUE);
-
+    \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
     return TRUE;
+  }
+
+  /**
+   * Declare the environment that we wish to run in.
+   *
+   * TODO: The hope is to get this to align with `Civi\Test::headless()` and perhaps
+   * assimilate other steps from 'setUp()'. The method is reserved while we look
+   * for the right split. However, when we're a little further along on that, this
+   * should be made overrideable.
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   */
+  final public static function buildEnvironment(): \Civi\Test\CiviEnvBuilder {
+    // Ideally: return Civi\Test::headless();
+    $b = new \Civi\Test\CiviEnvBuilder();
+    $b->callback([\Civi\Test::data(), 'populate']);
+    return $b;
   }
 
   public static function setUpBeforeClass(): void {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -255,29 +255,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * @param bool $perClass
-   * @param null $object
-   *
-   * @return bool
-   *   TRUE if the populate logic runs; FALSE if it is skipped
-   */
-  protected static function _populateDB($perClass = FALSE, &$object = NULL) {
-    if ($perClass || $object == NULL) {
-      $dbreset = TRUE;
-    }
-    else {
-      $dbreset = $object->DBResetRequired;
-    }
-
-    if (!$dbreset) {
-      return FALSE;
-    }
-
-    \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
-    return TRUE;
-  }
-
-  /**
    * Declare the environment that we wish to run in.
    *
    * TODO: The hope is to get this to align with `Civi\Test::headless()` and perhaps
@@ -299,7 +276,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       throw new \RuntimeException("CiviUnitTestCase requires CIVICRM_UF=UnitTests");
     }
 
-    static::_populateDB(TRUE);
+    \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
 
     // also set this global hack
     $GLOBALS['_PEAR_ERRORSTACK_OVERRIDE_CALLBACK'] = [];
@@ -327,7 +304,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       $dbName = self::getDBName();
       // install test database
       echo PHP_EOL . "Installing {$dbName} database" . PHP_EOL;
-      static::_populateDB(FALSE, $this);
+      \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
       self::$dbInit = TRUE;
     }
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -111,20 +111,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected $tempDirs;
 
   /**
-   * @var bool
-   * populateOnce allows to skip db resets in setUp
-   *
-   *  WARNING! USE WITH CAUTION - IT'LL RENDER DATA DEPENDENCIES
-   *  BETWEEN TESTS WHEN RUN IN SUITE. SUITABLE FOR LOCAL, LIMITED
-   *  "CHECK RUNS" ONLY!
-   *
-   *  IF POSSIBLE, USE $this->DBResetRequired = FALSE IN YOUR TEST CASE!
-   *
-   * @see http://forum.civicrm.org/index.php/topic,18065.0.html
-   */
-  public static $populateOnce = FALSE;
-
-  /**
    * DBResetRequired allows skipping DB reset
    * in specific test case. If you still need
    * to reset single test (method) of such case, call
@@ -314,10 +300,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       $dbreset = $object->DBResetRequired;
     }
 
-    if (self::$populateOnce || !$dbreset) {
+    if (!$dbreset) {
       return FALSE;
     }
-    self::$populateOnce = NULL;
 
     Civi\Test::data()->populate();
 


### PR DESCRIPTION
Overview
----------------------------------------

Simplify the code which handles data-setup in `CiviUnitTestCase`. This removes several properties and functions which are not really used. Instead, call`CiviEnvBuilder` (which includes similar/better helpers -- and which is shared by `Civi\Test::headless()`, `Civi\Test::e2e()`, `Api4TestBase`, and most civix testing templates).

Before
----------------------------------------

Primarily, the functionality here is that `setUpBeforeClass()` and `setUp()` call `_populateDB()`,

There is a series of inter-related properties and functions which reference each other - but they are not used externally. These are:

```php
class CiviUnitTestCase {
  protected $_dbconn;
  protected static $_dbName;
  public static $populateOnce;
  public function requireDBreset(): bool;
  public static function getDBName(): string;
  public function getConnection(): WhoKnowsWhat;
  protected function getDataSet(): WhoKnowsWhat;
  protected static function _populateDB(): bool;
}
```

After
----------------------------------------

Primarily, the functionality here is that `setUpBeforeClass()` and `setUp()` call `buildEnvironment()->apply(TRUE)`,

All the "Before" methods are removed. Instead, there is one new, short method:

```php
class CiviUnitTestCase ... {
  public static function buildEnvironment(): CiviEnvBuilder
}
```

Comments
----------------------------------------

The existing policy in `CiviUnitTestCase` have a very strong tendency to do DB resets. The PR preserves this policy.

Most of the commits are fairly basic: search for "XX", find "XX" is only used 0-1 times, and remove "XX".

The most interesting commit is probably 8cfba744faab400d5cf72cc2fad328f787127214 -- that's where it becomes apparent that the funny conditionals in `_populateDB()` don't serve a purpose, and that `$DBResetRequired` is inert  (even though ~30 test-classes mention it).

This file has a huge amount of implicit test-coverage by way of `./tests/phpunit/` --  `CiviUnitTestCase` is extended by 450+ test-classes.