### PR TITLE
 totten/civix#257 Fix Civix not correctly loading Mixinx

### DIFF
--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -92,8 +92,8 @@ return function ($longName, $shortName, $basePath) {
   }
   foreach ($mixins as $mixin) {
     // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
-    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
-      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+    if (!isset(\Civi::$statics[$longName][$mixin])) {
+      \Civi::$statics[$longName][$mixin] = 1;
       $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
       $func($mixInfo, $bootCache);
     }


### PR DESCRIPTION
Overview
----------------------------------------

This is basically a fix for Civix. Civix had a mistake in the generated boilerplate causing to run the mixin only for the first installed extension.

Before
----------------------------------------

Mixin functions where only called once. So when a CiviCRM installation has multiple extensions the mixin functions where only called for one. Resulting in breaking functionality, such as not loading the xml/Menu/*.xml files.

After
----------------------------------------

The mixin functions are called for every extension. It loads it only once for each extension.


Comments
----------------------------------------

This is a fix to the boiler template used by Civix.

See as well: https://github.com/totten/civix/issues/257
