### PR TITLE
Remove isset from membership receipts

### DIFF
--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -78,7 +78,7 @@
        </th>
       </tr>
 
-      {if !$useForMember and isset($membership_amount) and !empty($is_quick_config)}
+      {if !$useForMember and $membership_amount and !empty($is_quick_config)}
 
        <tr>
         <td {$labelStyle}>
@@ -242,14 +242,14 @@
          {ts}Amount{/ts}
         </td>
         <td {$valueStyle}>
-         {$amount|crmMoney} {if isset($amount_level)} - {$amount_level}{/if}
+         {$amount|crmMoney} {if $amount_level} - {$amount_level}{/if}
         </td>
        </tr>
 
       {/if}
 
 
-     {elseif isset($membership_amount)}
+     {elseif $membership_amount}
 
 
       <tr>

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -26,7 +26,7 @@
 {ts}Membership Fee{/ts}
 
 ===========================================================
-{if !$useForMember && isset($membership_amount) && !empty($is_quick_config)}
+{if !$useForMember && $membership_amount && !empty($is_quick_config)}
 {ts 1=$membership_name}%1 Membership{/ts}: {$membership_amount|crmMoney}
 {if $amount && !$is_separate_payment }
 {ts}Contribution Amount{/ts}: {$amount|crmMoney}
@@ -87,9 +87,9 @@
 {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
 {/if}
 
-{ts}Amount{/ts}: {$amount|crmMoney} {if isset($amount_level) } - {$amount_level} {/if}
+{ts}Amount{/ts}: {$amount|crmMoney} {if $amount_level } - {$amount_level} {/if}
 {/if}
-{elseif isset($membership_amount)}
+{elseif $membership_amount}
 ===========================================================
 {ts}Membership Fee{/ts}
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove `isset` from membership receipts

These cause fatal errors when smarty is escaping by default


Before
----------------------------------------
Membership receipts result in fatal errors with smarty strictness enabled

After
----------------------------------------
e-notices instead

Technical Details
----------------------------------------
the e-notices will cause test fails but I'm working through that...

I'm working through the UI to find the valid variants here 



I have 

- membership configured by block (quickConfig price set)
- membership configured by price set
- membership block + contribution block (both = quick config) - single payment
- membership block + contribution block (both = quick config) - 2 payments
- membership block + contribution block (both = quick config) - 2 payments - auto-renew

In ALL cases `useForMember` is set in `Main.php` based on the price set a) existing & b) extending the membership entity

Note that the membership block & contribution block does not permit either to have non-quick-config price sets
![image](https://user-images.githubusercontent.com/336308/207994230-c796275d-2ee9-49a0-8a81-27e109705c51.png)

![image](https://user-images.githubusercontent.com/336308/207994059-46133c10-0641-42cf-97a6-a2ed87f28121.png)



Comments
----------------------------------------
