### PR TITLE
Remove conditionals that rely on NULL not being NULL

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -594,24 +594,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         }
         foreach ($membershipTypeIds as $value) {
           $memType = $membershipTypeValues[$value];
-          if ($selectedMembershipTypeID != NULL) {
-            if ($memType['id'] == $selectedMembershipTypeID) {
-              $this->assign('minimum_fee', $memType['minimum_fee'] ?? NULL);
-              $this->assign('membership_name', $memType['name']);
-              if ($cid) {
-                $membership = new CRM_Member_DAO_Membership();
-                $membership->contact_id = $cid;
-                $membership->membership_type_id = $memType['id'];
-                if ($membership->find(TRUE)) {
-                  $this->assign('renewal_mode', TRUE);
-                  $memType['current_membership'] = $membership->end_date;
-                  $this->_currentMemberships[$membership->membership_type_id] = $membership->membership_type_id;
-                }
-              }
-              $membershipTypes[] = $memType;
-            }
-          }
-          elseif ($memType['is_active']) {
+          if ($memType['is_active']) {
 
             if ($allowAutoRenewOpt) {
               $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
@@ -679,14 +662,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
       // Assign autorenew option (0:hide,1:optional,2:required) so we can use it in confirmation etc.
       $autoRenewOption = CRM_Price_BAO_PriceSet::checkAutoRenewForPriceSet($this->_priceSetId);
-      //$selectedMembershipTypeID is retrieved as an array for membership priceset if multiple
-      //options for different organisation is selected on the contribution page.
-      if (is_numeric($selectedMembershipTypeID) && isset($membershipTypeValues[$selectedMembershipTypeID]['auto_renew'])) {
-        $this->assign('autoRenewOption', $membershipTypeValues[$selectedMembershipTypeID]['auto_renew']);
-      }
-      else {
-        $this->assign('autoRenewOption', $autoRenewOption);
-      }
+      $this->assign('autoRenewOption', $autoRenewOption);
 
       if (!$membershipPriceset) {
         if (!$this->_membershipBlock['is_required']) {


### PR DESCRIPTION
Overview
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/25182/files#diff-9319a4134599e85c273c3be5706ffb5d642b7659904fd644dd4273791467384aR526 - 

`  $selectedMembershipTypeID`

is always NULL hence

`    if ($selectedMembershipTypeID != NULL) {`

 is always FALSE as is `if (is_numeric($selectedMembershipTypeID)`

--- This is a previously shared function