### PR TITLE
Divide & conquer, `initSet` no longer shared as much code is not

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -361,7 +361,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       // get price info
       // CRM-5095
       $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id);
-      CRM_Price_BAO_PriceSet::initSet($this, 'civicrm_contribution_page', FALSE, $priceSetId);
+      $this->initSet($this, 'civicrm_contribution_page', FALSE, $priceSetId);
 
       // this avoids getting E_NOTICE errors in php
       $setNullFields = [
@@ -499,6 +499,106 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     if (!empty($this->_values['is_pay_later'])) {
       $this->_isBillingAddressRequiredForPayLater = $this->_values['is_billing_required'] ?? NULL;
       $this->assign('isBillingAddressRequiredForPayLater', $this->_isBillingAddressRequiredForPayLater);
+    }
+  }
+
+  /**
+   * Initiate price set such that various non-BAO things are set on the form.
+   *
+   * This function is not really a BAO function so the location is misleading.
+   *
+   * @param CRM_Core_Form $form
+   *   Form entity id.
+   * @param string $entityTable
+   * @param bool $doNotIncludeExpiredFields
+   * @param int $priceSetId
+   *   Price Set ID
+   *
+   * @todo - removed unneeded code from previously-shared function
+   */
+  private function initSet(&$form, $entityTable = 'civicrm_event', $doNotIncludeExpiredFields = FALSE, $priceSetId = NULL) {
+
+    //check if price set is is_config
+    if (is_numeric($priceSetId)) {
+      if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config') && $form->getVar('_name') != 'Participant') {
+        $form->assign('quickConfig', 1);
+      }
+    }
+    // get price info
+    if ($priceSetId) {
+      if ($form->_action & CRM_Core_Action::UPDATE) {
+        $entityId = $entity = NULL;
+
+        switch ($entityTable) {
+          case 'civicrm_event':
+            $entity = 'participant';
+            if (in_array(CRM_Utils_System::getClassName($form), ['CRM_Event_Form_Participant', 'CRM_Event_Form_Task_Register'])) {
+              $entityId = $form->_id;
+            }
+            else {
+              $entityId = $form->_participantId;
+            }
+            break;
+
+          case 'civicrm_contribution_page':
+          case 'civicrm_contribution':
+            $entity = 'contribution';
+            $entityId = $form->_id;
+            break;
+        }
+
+        if ($entityId && $entity) {
+          $form->_values['line_items'] = CRM_Price_BAO_LineItem::getLineItems($entityId, $entity);
+        }
+        $required = FALSE;
+      }
+      else {
+        $required = TRUE;
+      }
+
+      $form->_priceSetId = $priceSetId;
+      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, $required, $doNotIncludeExpiredFields);
+      $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
+      $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
+
+      //get the price set fields participant count.
+      if ($entityTable == 'civicrm_event') {
+        //get option count info.
+        $form->_priceSet['optionsCountTotal'] = CRM_Price_BAO_PriceSet::getPricesetCount($priceSetId);
+        if ($form->_priceSet['optionsCountTotal']) {
+          $optionsCountDetails = [];
+          if (!empty($form->_priceSet['fields'])) {
+            foreach ($form->_priceSet['fields'] as $field) {
+              foreach ($field['options'] as $option) {
+                $count = CRM_Utils_Array::value('count', $option, 0);
+                $optionsCountDetails['fields'][$field['id']]['options'][$option['id']] = $count;
+              }
+            }
+          }
+          $form->_priceSet['optionsCountDetails'] = $optionsCountDetails;
+        }
+
+        //get option max value info.
+        $optionsMaxValueTotal = 0;
+        $optionsMaxValueDetails = [];
+
+        if (!empty($form->_priceSet['fields'])) {
+          foreach ($form->_priceSet['fields'] as $field) {
+            foreach ($field['options'] as $option) {
+              $maxVal = CRM_Utils_Array::value('max_value', $option, 0);
+              $optionsMaxValueDetails['fields'][$field['id']]['options'][$option['id']] = $maxVal;
+              $optionsMaxValueTotal += $maxVal;
+            }
+          }
+        }
+
+        $form->_priceSet['optionsMaxValueTotal'] = $optionsMaxValueTotal;
+        if ($optionsMaxValueTotal) {
+          $form->_priceSet['optionsMaxValueDetails'] = $optionsMaxValueDetails;
+        }
+      }
+      $form->set('priceSetId', $form->_priceSetId);
+      $form->set('priceSet', $form->_priceSet);
     }
   }
 

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -555,7 +555,7 @@ WHERE  id = %1";
    *   Price Set ID
    */
   public static function initSet(&$form, $entityTable = 'civicrm_event', $doNotIncludeExpiredFields = FALSE, $priceSetId = NULL) {
-
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     //check if price set is is_config
     if (is_numeric($priceSetId)) {
       if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config') && $form->getVar('_name') != 'Participant') {


### PR DESCRIPTION
Overview
----------------------------------------
Divide & conquer, `initSet` no longer shared as much code is not

Before
----------------------------------------
`BAO_PriceSet::initSet` called by 2 functions, much of the code is specific to the different calling functions

After
----------------------------------------
Function copied to it's callers & deprecated

Technical Details
----------------------------------------
Follow up tidy up can strip out the code that is not relevant to each place

Comments
----------------------------------------
