### PR TITLE
Remove reference to 'dataArray' from text version of contribution_online_receipt

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -29,7 +29,7 @@
 {$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
 ----------------------------------------------------------
 {foreach from=$lineItems item=line}
-{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if !empty($dataArray)}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
+{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
 {/foreach}
 
 {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}


### PR DESCRIPTION

Overview
----------------------------------------
Remove reference to 'dataArray' from text version of contribution_online_receipt

Before
----------------------------------------
`$dataArray` mostly removed from online contribution template - but one holdout in the text version 

The html version was updated to 
```
        {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
                  <td>{$line.unit_price*$line.qty|crmMoney:$currency}</td>
```

But the text version was still ` {if !empty($dataArray)}`

After
----------------------------------------
Text version as per html version (not that we really need text versions - but that is another story)


Technical Details
----------------------------------------
Will do regen once merged - using new magic thingee

Comments
----------------------------------------
