### PR TITLE
CiviUnitTestCase - More aggressive simplifications

### DIFF
--- a/ext/civigrant/tests/phpunit/api/v3/GrantTest.php
+++ b/ext/civigrant/tests/phpunit/api/v3/GrantTest.php
@@ -25,8 +25,6 @@ class api_v3_GrantTest extends \PHPUnit\Framework\TestCase implements \Civi\Test
   protected $ids = [];
   protected $_entity = 'Grant';
 
-  public $DBResetRequired = FALSE;
-
   public function setUpHeadless() {
     return \Civi\Test::headless()
       ->install(['org.civicrm.afform', 'org.civicrm.search_kit'])

--- a/tests/phpunit/CRM/Core/Page/HookTest.php
+++ b/tests/phpunit/CRM/Core/Page/HookTest.php
@@ -4,7 +4,6 @@
  * Test that page hooks only get invoked once per page run.
  */
 class CRM_Core_Page_HookTest extends CiviUnitTestCase {
-  public $DBResetRequired = TRUE;
 
   /**
    * The list of classes extending CRM_Core_Page_Basic: the ones to try the

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -54,7 +54,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    * @var int
    */
   protected $_membershipStatusID;
-  public $DBResetRequired = FALSE;
 
   /**
    * Setup function.

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -27,7 +27,6 @@
 abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
 
-  public $DBResetRequired = FALSE;
   public $defaultParams = [];
   private $_groupID;
 

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -264,6 +264,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   final public static function buildEnvironment(): \Civi\Test\CiviEnvBuilder {
     // Ideally: return Civi\Test::headless();
     $b = new \Civi\Test\CiviEnvBuilder();
+    $b->callback(function () {
+      fprintf(STDERR, "\nInstalling %s database\n", \Civi\Test::dsn('database'));
+    });
     $b->callback([\Civi\Test::data(), 'populate']);
     return $b;
   }
@@ -297,7 +300,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     }
 
     if (!self::$dbInit) {
-      fprintf(STDERR, "\nInstalling %s database\n", \Civi\Test::dsn('database'));
       \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
       self::$dbInit = TRUE;
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -79,13 +79,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   use \Civi\Test\LocaleTestTrait;
 
   /**
-   *  Database has been initialized.
-   *
-   * @var bool
-   */
-  private static $dbInit = FALSE;
-
-  /**
    * API version in use.
    *
    * @var int
@@ -287,11 +280,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     if ($GLOBALS['stdin'] === FALSE) {
       echo "Couldn't open temporary file\n";
       exit(1);
-    }
-
-    if (!self::$dbInit) {
-      \Civi\Test::asPreInstall([static::CLASS, 'buildEnvironment'])->apply(TRUE);
-      self::$dbInit = TRUE;
     }
 
     // "initialize" CiviCRM to avoid problems when running single tests

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -106,16 +106,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected $tempDirs;
 
   /**
-   * DBResetRequired allows skipping DB reset
-   * in specific test case. If you still need
-   * to reset single test (method) of such case, call
-   * $this->cleanDB() in the first line of this
-   * test (method).
-   * @var bool
-   */
-  public $DBResetRequired = TRUE;
-
-  /**
    * @var CRM_Core_Transaction|null
    */
   private $tx = NULL;

--- a/tests/phpunit/api/v3/ACLCachingTest.php
+++ b/tests/phpunit/api/v3/ACLCachingTest.php
@@ -19,8 +19,6 @@
 class api_v3_ACLCachingTest extends CiviUnitTestCase {
   protected $_params;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
   }

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -35,7 +35,6 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    */
   protected $isValidateFinancialsOnPostAssert = FALSE;
 
-  public $DBResetRequired = FALSE;
   protected $_entity;
 
   /**

--- a/tests/phpunit/api/v3/APITest.php
+++ b/tests/phpunit/api/v3/APITest.php
@@ -16,7 +16,6 @@
  * @group headless
  */
 class api_v3_APITest extends CiviUnitTestCase {
-  public $DBResetRequired = FALSE;
 
   protected $_apiversion = 3;
 

--- a/tests/phpunit/api/v3/APIWrapperTest.php
+++ b/tests/phpunit/api/v3/APIWrapperTest.php
@@ -18,8 +18,6 @@ require_once 'api/Wrapper.php';
  * @group headless
  */
 class api_v3_APIWrapperTest extends CiviUnitTestCase {
-  public $DBResetRequired = FALSE;
-
 
   protected $_apiversion = 3;
 

--- a/tests/phpunit/api/v3/CampaignTest.php
+++ b/tests/phpunit/api/v3/CampaignTest.php
@@ -17,8 +17,6 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
   protected $params;
   protected $id;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     $this->params = [
       'title' => "campaign title",

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -42,8 +42,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
   use CRMTraits_Custom_CustomDataTrait;
 
-  public $DBResetRequired = FALSE;
-
   protected $_entity;
 
   protected $_params;

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -20,8 +20,6 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
   protected $params;
   protected $_entity = 'ContributionRecur';
 
-  public $DBResetRequired = FALSE;
-
   /**
    * @throws \CRM_Core_Exception
    */

--- a/tests/phpunit/api/v3/CustomValueTest.php
+++ b/tests/phpunit/api/v3/CustomValueTest.php
@@ -19,8 +19,6 @@ class api_v3_CustomValueTest extends CiviUnitTestCase {
 
   protected $optionGroup;
 
-  public $DBResetRequired = FALSE;
-
   /**
    * @throws \CRM_Core_Exception
    */

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -18,13 +18,6 @@
  */
 class api_v3_DomainTest extends CiviUnitTestCase {
 
-  /**
-   * This test case doesn't require DB reset - apart from
-   * where cleanDB() is called.
-   * @var bool
-   */
-  public $DBResetRequired = FALSE;
-
   protected $params;
 
   /**

--- a/tests/phpunit/api/v3/EntityBatchTest.php
+++ b/tests/phpunit/api/v3/EntityBatchTest.php
@@ -19,8 +19,6 @@ class api_v3_EntityBatchTest extends CiviUnitTestCase {
   protected $id;
   protected $_entity;
 
-  public $DBResetRequired = FALSE;
-
   /**
    * @throws \CRM_Core_Exception
    */

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -21,8 +21,6 @@ class api_v3_ImTest extends CiviUnitTestCase {
   protected $id;
   protected $_entity;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -27,7 +27,6 @@
 class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
 
-  public $DBResetRequired = FALSE;
   public $_entity = 'Job';
   public $_params = [];
   private $_groupID;

--- a/tests/phpunit/api/v3/JobProcessMembershipTest.php
+++ b/tests/phpunit/api/v3/JobProcessMembershipTest.php
@@ -26,7 +26,6 @@
 class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
 
-  public $DBResetRequired = FALSE;
   public $_entity = 'Job';
 
   /**

--- a/tests/phpunit/api/v3/MailSettingsTest.php
+++ b/tests/phpunit/api/v3/MailSettingsTest.php
@@ -22,8 +22,6 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
 
   protected $id;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     $this->params = [
       'domain_id' => 1,

--- a/tests/phpunit/api/v3/MappingFieldTest.php
+++ b/tests/phpunit/api/v3/MappingFieldTest.php
@@ -23,8 +23,6 @@ class api_v3_MappingFieldTest extends CiviUnitTestCase {
   protected $id;
   protected $_entity;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);

--- a/tests/phpunit/api/v3/MappingTest.php
+++ b/tests/phpunit/api/v3/MappingTest.php
@@ -23,8 +23,6 @@ class api_v3_MappingTest extends CiviUnitTestCase {
   protected $id;
   protected $_entity;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);

--- a/tests/phpunit/api/v3/MultilingualTest.php
+++ b/tests/phpunit/api/v3/MultilingualTest.php
@@ -18,7 +18,6 @@
  */
 class api_v3_MultilingualTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $DBResetRequired = FALSE;
 
   /**
    * Sets up the fixture, for example, opens a network connection.

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -29,8 +29,6 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
   protected $id;
   protected $_entity;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction();

--- a/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
+++ b/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
@@ -18,8 +18,6 @@ class api_v3_ParticipantStatusTypeTest extends CiviUnitTestCase {
   protected $params;
   protected $id;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     $this->_apiversion = 3;
     $this->params = [

--- a/tests/phpunit/api/v3/PaymentTokenTest.php
+++ b/tests/phpunit/api/v3/PaymentTokenTest.php
@@ -17,8 +17,6 @@ class api_v3_PaymentTokenTest extends CiviUnitTestCase {
   protected $params;
   protected $id;
 
-  public $DBResetRequired = FALSE;
-
   /**
    * Setup for class.
    *

--- a/tests/phpunit/api/v3/PcpTest.php
+++ b/tests/phpunit/api/v3/PcpTest.php
@@ -31,7 +31,6 @@
 class api_v3_PcpTest extends CiviUnitTestCase {
   protected $params;
   protected $entity = 'Pcp';
-  public $DBResetRequired = TRUE;
 
   public function setUp(): void {
     $this->params = [

--- a/tests/phpunit/api/v3/PriceFieldValueTest.php
+++ b/tests/phpunit/api/v3/PriceFieldValueTest.php
@@ -20,8 +20,6 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
   protected $priceSetID = 0;
   protected $_entity = 'price_field_value';
 
-  public $DBResetRequired = TRUE;
-
   /**
    * @var int
    */

--- a/tests/phpunit/api/v3/PriceSetTest.php
+++ b/tests/phpunit/api/v3/PriceSetTest.php
@@ -20,8 +20,6 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
   protected $contactIds = [];
   protected $_entity = 'price_set';
 
-  public $DBResetRequired = TRUE;
-
   /**
    * Set up for class.
    */

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -37,7 +37,6 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   protected $params;
   protected $id;
   protected $_entity;
-  public $DBResetRequired = FALSE;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v3/SurveyTest.php
+++ b/tests/phpunit/api/v3/SurveyTest.php
@@ -31,7 +31,6 @@
 class api_v3_SurveyTest extends CiviUnitTestCase {
   protected $params;
   protected $entity = 'survey';
-  public $DBResetRequired = FALSE;
 
   public function setUp(): void {
     $phoneBankActivityTypeID = $this->callAPISuccessGetValue('Option_value', [

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -40,12 +40,6 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
    */
   protected $deletableTestObjects;
 
-  /**
-   * This test case doesn't require DB reset.
-   * @var bool
-   */
-  public $DBResetRequired = FALSE;
-
   protected $_entity;
 
   /**

--- a/tests/phpunit/api/v3/UserTest.php
+++ b/tests/phpunit/api/v3/UserTest.php
@@ -22,8 +22,6 @@ class api_v3_UserTest extends CiviUnitTestCase {
   protected $_entity = 'User';
   protected $contactID;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
     $this->contactID = $this->createLoggedInUser();

--- a/tests/phpunit/api/v3/UtilsTest.php
+++ b/tests/phpunit/api/v3/UtilsTest.php
@@ -17,7 +17,6 @@
  */
 class api_v3_UtilsTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  public $DBResetRequired = FALSE;
 
   public $_contactID = 1;
 

--- a/tests/phpunit/api/v3/WebsiteTest.php
+++ b/tests/phpunit/api/v3/WebsiteTest.php
@@ -22,8 +22,6 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
   protected $id;
   protected $_entity;
 
-  public $DBResetRequired = FALSE;
-
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction();


### PR DESCRIPTION
Overview
----------------------------------------

This depends on #25178 and does even more aggressive simplifications:

* There is a policy change which removes one (extraneous) reset.
* It drops a bit of metadata that hasn't been used for `$whoKnowsHowLong`.
