### PR TITLE
Fix 'cannot determine default entity' error on New Batch page

### DIFF
--- a/CRM/Batch/Form/Batch.php
+++ b/CRM/Batch/Form/Batch.php
@@ -19,6 +19,13 @@ class CRM_Batch_Form_Batch extends CRM_Admin_Form {
   protected $submittableMoneyFields = ['total'];
 
   /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'Batch';
+  }
+
+  /**
    * PreProcess function.
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4036

"New Batch" no longer loads.  When you try, you get an error.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/1796012/208126202-31a1f6b1-e007-44c1-99d8-bf6ecb890922.png)

After
----------------------------------------
No error.

Technical Details
----------------------------------------
The error describes things pretty well.