### PR TITLE
E_WARNING on bulk email activity view

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -87,6 +87,8 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     $values['mailingId'] = $values['mailingId'] ?? NULL;
     $values['campaign'] = $values['campaign'] ?? NULL;
     $values['engagement_level'] = $values['engagement_level'] ?? NULL;
+    // also this which doesn't get set for bulk emails
+    $values['target_contact_value'] = $values['target_contact_value'] ?? NULL;
 
     // Get the campaign.
     if ($campaignId = CRM_Utils_Array::value('campaign_id', $defaults)) {


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
1. Send a bulk mailing. You can also for the purposes of just seeing the warning create a draft mailing, then use api explorer to update the source_record_id of any existing activity to the mailing id, and the activity type to bulk email.
2. Turn off popups or opening in a new tab, view a bulk email activity from the mailing.
3. `Warning: Undefined array key "target_contact_value" in include() (line 15 of .../templates_c/en_US/%%B2/B2A/B2A9FAF3%%ActivityView.tpl.php).`

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/25169
