### PR TITLE
[REF] Fix a couple of errors in PHP8.2

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -156,6 +156,11 @@ class CRM_Extension_Info {
   public $version;
 
   /**
+   * @var array
+   */
+  public $typeInfo;
+
+  /**
    * Load extension info an XML file.
    *
    * @param string $file

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -130,7 +130,7 @@ class CRM_Utils_Request {
       return $method[$name];
     }
     // CRM-18384 - decode incorrect keys generated when &amp; is present in url
-    foreach ($method as $key => $value) {
+    foreach (($method ?? []) as $key => $value) {
       if (strpos($key, 'amp;') !== FALSE) {
         $method[str_replace('amp;', '', $key)] = $method[$key];
         if (isset($method[$name])) {


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the following notice errors on PHP8.2

```
Deprecated: Creation of dynamic property CRM_Extension_Info::$typeInfo is deprecated in /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Extension/Info.php on line 309
Warning: foreach() argument must be of type array|object, null given in /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Utils/Request.php on line 133
```

Before
----------------------------------------
Notice errors

After
----------------------------------------
Less Notice errors

ping @eileenmcnaughton @demeritcowboy @totten 