### PR TITLE
PHP8: callback function on GOTV must be static

### DIFF
--- a/CRM/Campaign/Page/AJAX.php
+++ b/CRM/Campaign/Page/AJAX.php
@@ -127,7 +127,7 @@ class CRM_Campaign_Page_AJAX {
     CRM_Utils_JSON::output($result);
   }
 
-  public function voterList() {
+  public static function voterList() {
     //get the search criteria params.
     $searchCriteria = CRM_Utils_Request::retrieve('searchCriteria', 'String', CRM_Core_DAO::$_nullObject, FALSE, NULL, 'POST');
     $searchParams = explode(',', $searchCriteria);


### PR DESCRIPTION
Overview
----------------------------------------
The GOTV search page doesn't work, you get an error when you try to search.

Replication steps:
* Enable CiviCampaign.
* Create at least one Survey.
* Go to **Campaigns menu » GOTV (Voter Tracking)**.
* Press **Search**.

Before
----------------------------------------
Endless spinning triangle, this error in the logs:
```
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, non-static method CRM_Campaign_Page_AJAX::voterList() cannot be called statically in CRM_Utils_REST::process() (line 266 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Utils/REST.php).
```

After
----------------------------------------
Works.

Technical Details
----------------------------------------
callback functions need to be declared as static.

@jmcclelland You probably are interested in this patch.
