### PR TITLE
Allow matching on external_identifier for source/target contacts on Activity import

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -64,6 +64,10 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
     try {
       $params = $this->getMappedRow($values);
 
+      if (!empty($params['source_contact_external_identifier'])) {
+        $params['source_contact_id'] = $this->lookupExternalIdentifier($params['source_contact_external_identifier'], $this->getContactType(), $params['contact_id'] ?? NULL);
+      }
+
       if (empty($params['external_identifier']) && empty($params['target_contact_id'])) {
 
         // Retrieve contact id using contact dedupe rule.
@@ -169,7 +173,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
       }
       if ($mappedField['name']) {
         $fieldName = $this->getFieldMetadata($mappedField['name'])['name'];
-        if (in_array($mappedField['name'], ['target_contact_id', 'source_contact_id'])) {
+        if (in_array($mappedField['name'], ['target_contact_id', 'source_contact_id', 'source_contact_external_identifier'])) {
           $fieldName = $mappedField['name'];
         }
         $params[$fieldName] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
@@ -217,7 +221,10 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         }
       }
       $tmpContactField['external_identifier'] = $contactFields['external_identifier'];
-      $tmpContactField['external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (match to contact)';
+      $tmpContactField['external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (target contact)' . ' (match to contact)';
+      $tmpContactField['source_contact_external_identifier'] = $contactFields['external_identifier'];
+      $tmpContactField['source_contact_external_identifier']['title'] = $contactFields['external_identifier']['title'] . ' (source contact)' . ' (match to contact)';
+
       $fields = array_merge($fields, $tmpContactField);
       $fields = array_merge($fields, $tmpFields);
       $fields = array_merge($fields, CRM_Core_BAO_CustomField::getFieldsForImport('Activity'));

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -744,7 +744,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
       // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
       $name = str_replace('_.', '~~', $name);
       $name = str_replace('.', '__', $name);
-      $return[$name] = $field['html']['label'] ?? $field['title'];
+      $return[$name] = $field['title'];
     }
     return $return;
   }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -208,7 +208,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @return string
    */
   protected function getContactType(): string {
-    return $this->getSubmittedValue('contactType') ?: $this->getContactTypeForEntity('Contact');
+    return $this->getSubmittedValue('contactType') ?: $this->getContactTypeForEntity('Contact') ?? '';
   }
 
   /**

--- a/tests/phpunit/CRM/Activity/Import/Parser/data/activityexternalidentifier.csv
+++ b/tests/phpunit/CRM/Activity/Import/Parser/data/activityexternalidentifier.csv
@@ -1,0 +1,2 @@
+Activity Date,Activity Status,Email (match to contact),Activity Type,Details,Duration,Priority,Location,Subject,Blah,source,target
+2022-12-07 07:55:56,Completed,mum@example.com,Email,Some stuff,77,Urgent,Phoned up,Long chat,ignore,individual1,individual2


### PR DESCRIPTION
Overview
----------------------------------------
Allow matching on external_identifier for source/target contacts on Activity import.

Before
----------------------------------------
You can only match on source/target contact ID.

After
----------------------------------------
You can match source/target contacts using external_identifier.

Technical Details
----------------------------------------
Adds handling for source/target via external_indentifier in the same way that support for contact matching via external_identifier is handled.

Comments
----------------------------------------
