### PR TITLE
luxembourg-provices added missing provices, updated outdated ISO code…

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.59.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.59.alpha1.mysql.tpl
@@ -1,1 +1,16 @@
-{* file to handle db changes in 5.59.alpha1 during upgrade *}
+-- Add missing provinces for Luxembourg
+SELECT @country_id := id from civicrm_country where name = 'Luxembourg' AND iso_code = 'LU';
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'CA', 'Capellen');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'CL', 'Clervaux');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'EC', 'Echternach');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'ES', 'Esch-sur-Alzette');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'GR', 'Grevenmacher');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'ME', 'Mersch');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'RD', 'Redange-sur-Attert');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'RM', 'Remich');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'VD', 'Vianden');
+INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'WI', 'Wiltz');
+UPDATE `civicrm_state_province` SET abbreviation = 'LU' WHERE name = 'Luxembourg';
+UPDATE `civicrm_state_province` SET abbreviation = 'DI' WHERE name = 'Diekirch';
+UPDATE `civicrm_state_province` SET name = 'Grevenmacher' WHERE name = 'GreveNmacher';
+UPDATE `civicrm_state_province` SET abbreviation = 'GR' WHERE name = 'Grevenmacher';

--- a/CRM/Upgrade/Incremental/sql/5.59.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.59.alpha1.mysql.tpl
@@ -10,7 +10,7 @@ INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name
 INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'RM', 'Remich');
 INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'VD', 'Vianden');
 INSERT IGNORE INTO `civicrm_state_province` (`country_id`, `abbreviation`, `name`) VALUES (@country_id, 'WI', 'Wiltz');
-UPDATE `civicrm_state_province` SET abbreviation = 'LU' WHERE name = 'Luxembourg';
-UPDATE `civicrm_state_province` SET abbreviation = 'DI' WHERE name = 'Diekirch';
-UPDATE `civicrm_state_province` SET name = 'Grevenmacher' WHERE name = 'GreveNmacher';
-UPDATE `civicrm_state_province` SET abbreviation = 'GR' WHERE name = 'Grevenmacher';
+UPDATE `civicrm_state_province` SET abbreviation = 'LU' WHERE name = 'Luxembourg' AND country_id = @country_id;
+UPDATE `civicrm_state_province` SET abbreviation = 'DI' WHERE name = 'Diekirch' AND country_id = @country_id;
+UPDATE `civicrm_state_province` SET name = 'Grevenmacher' WHERE name = 'GreveNmacher' AND country_id = @country_id;
+UPDATE `civicrm_state_province` SET abbreviation = 'GR' WHERE name = 'Grevenmacher' AND country_id = @country_id;

--- a/xml/templates/civicrm_state_province.tpl
+++ b/xml/templates/civicrm_state_province.tpl
@@ -4166,4 +4166,18 @@ INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 (NULL, 1101, "LA", "Ladākh")
 
  -- end of statement:
+
+-- Add missing provinces for Luxembourg
+(NULL, 1020, 'CA', 'Capellen'),
+(NULL, 1020, 'CL', 'Clervaux'),
+(NULL, 1020, 'EC', 'Echternach'),
+(NULL, 1020, 'ES', 'Esch-sur-Alzette'),
+(NULL, 1020, 'GR', 'Grevenmacher'),
+(NULL, 1020, 'ME', 'Mersch'),
+(NULL, 1020, 'RD', 'Redange-sur-Attert'),
+(NULL, 1020, 'RM', 'Remich'),
+(NULL, 1020, 'VD', 'Vianden'),
+(NULL, 1020, 'WI', 'Wiltz'),
+
+-- end of statement:
  ;

--- a/xml/templates/civicrm_state_province.tpl
+++ b/xml/templates/civicrm_state_province.tpl
@@ -4163,7 +4163,7 @@ INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 -- Add in missing Indian State provinces
 
 (NULL, 1101, "DH", "Dādra and Nagar Haveli and Damān and Diu"),
-(NULL, 1101, "LA", "Ladākh")
+(NULL, 1101, "LA", "Ladākh"),
 
  -- end of statement:
 
@@ -4177,7 +4177,7 @@ INSERT INTO civicrm_state_province (id, country_id, abbreviation, name) VALUES
 (NULL, 1020, 'RD', 'Redange-sur-Attert'),
 (NULL, 1020, 'RM', 'Remich'),
 (NULL, 1020, 'VD', 'Vianden'),
-(NULL, 1020, 'WI', 'Wiltz'),
+(NULL, 1020, 'WI', 'Wiltz')
 
 -- end of statement:
  ;


### PR DESCRIPTION
Added missing provinces for luxembourg, updated 3 outdated ISO codes for Diekirch, Grevenmacher and Luxembourg provices because after 2015 they were changed and also changed GreveNmacher name to Grevenmacher


