### PR TITLE
dev/core#4039 - Restore ability to have fractional quantity for text price fields

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -302,7 +302,7 @@ WHERE li.contribution_id = %1";
     }
 
     foreach ($params["price_{$fid}"] as $oid => $qty) {
-      $qty = (int) $qty;
+      $qty = (float) $qty;
       $price = (float) ($amount_override === NULL ? $options[$oid]['amount'] : $amount_override);
 
       $participantsPerField = (int) CRM_Utils_Array::value('count', $options[$oid], 0);


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4039
Used to be able to enter a fractional quantity for text price fields.

Before
----------------------------------------
It rounds down since it `(int)`'s it, which was added because strings don't like to be multiplied in php 8.

After
----------------------------------------
Can enter fractional quantities again.

Technical Details
----------------------------------------


Comments
----------------------------------------

