### PR TITLE
dev/core#4026 custom field not saved when changing membership type

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -286,15 +286,18 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     }
     $this->assign('existingContactMemberships', $mems_by_org);
 
-    if (!$this->_memType) {
-      $params = CRM_Utils_Request::exportValues();
-      if (!empty($params['membership_type_id'][1])) {
-        $this->_memType = $params['membership_type_id'][1];
-      }
+    $customFieldMemType = $this->_memType;
+    $params = CRM_Utils_Request::exportValues();
+
+    if (!$this->_memType && !empty($params['membership_type_id'][1])) {
+      $this->_memType = $params['membership_type_id'][1];
     }
 
-    // Add custom data to form
-    CRM_Custom_Form_CustomData::addToForm($this, $this->_memType);
+    if (($this->_action & CRM_Core_Action::UPDATE) && !empty($params['membership_type_id'][1])) {
+      $customFieldMemType = $params['membership_type_id'][1];
+    }
+
+    CRM_Custom_Form_CustomData::addToForm($this, $customFieldMemType);
     $this->setPageTitle(ts('Membership'));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Resolves [#4026](https://lab.civicrm.org/dev/core/-/issues/4026), "custom field not saved when changing membership type".

Before
----------------------------------------
When updating the membership type for a membership, if the custom fields were different for the two membership types, then only custom fields present on the original membership type would be saved.

After
----------------------------------------
Any custom fields present on the membership type that is being switched to are saved.

Technical Details
----------------------------------------
This was a bit of a tricky one to track down!

In `CRM_Member_Form_Membership->preProcess` any fields are registered on the form (i.e. the standard CiviCRM approach for building a form). This included calling `CRM_Custom_Form_CustomData::addToForm($this, $this->_memType);` which adds any custom fields for the current membership type.

When `addToForm` was called,  `$this->_memType` originally corresponded to the membership type that the membership was originally (i.e. before update). `$this->_memType` was set in `setContextVariables` and `setDefaultValues` based on the value stored against the membership before the update saves.

Later in the code at the point of the update actually saving to the database, `HTML_QuickForm->exportValues` is called to get the submitted `$_POST` values. This method only returns values which correspond to fields present in the form. Therefore the bug was caused by this not returning any custom fields associated with the new membership type, as those fields originally were not being registered against the form/page object.

The fix simply ensures that the membership type is based on the submitted type in cases where an update is taking place, allowing the correct form fields to be rendered, and therefore leading to `exportValues` returning an accurate picture of what was submitted.