### PR TITLE
Only allow valid image types to be uploaded to image_URL field on profiles

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1894,6 +1894,9 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       }
     }
     elseif (substr($fieldName, 0, 9) === 'image_URL') {
+      if (!isset($attributes['accept'])) {
+        $attributes['accept'] = 'image/png, image/jpeg, image/gif';
+      }
       $form->add('file', $name, $title, $attributes, $required);
       $form->addUploadElement($name);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Towards the start of the year I opened https://github.com/civicrm/civicrm-core/pull/23147 which restricts images on the contact screen of the CRM to only allow the file types CiviCRM supports (png, jpg, gif). This applies the same change to image fields on profile forms.

Before
----------------------------------------
Any file could be uploaded (although not actually saved, CiviCRM would show the error "Image could not be uploaded due to invalid type extension.")

After
----------------------------------------
The field field has the attribute `accept='image/png, image/jpeg, image/gif'`

Comments
----------------------------------------
As the previous PR was accepted and merged, this hopefully won't be a controversial change.