### PR TITLE
[REF] [merge custom fields function] Stop returning unaltered cFields parameter (good unit test cover)

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1783,7 +1783,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       $submitted = [];
     }
     foreach ($submitted as $key => $value) {
-      [$cFields, $submitted] = self::processCustomFields($mainId, $key, $cFields, $submitted, $value);
+      $submitted = self::processCustomFields($mainId, $key, $cFields, $submitted, $value);
     }
 
     // move view only custom fields CRM-5362
@@ -2206,7 +2206,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     if (substr($key, 0, 7) === 'custom_') {
       $fid = (int) substr($key, 7);
       if (empty($cFields[$fid])) {
-        return [$cFields, $submitted];
+        return $submitted;
       }
       $htmlType = $cFields[$fid]['attributes']['html_type'];
       $isSerialized = CRM_Core_BAO_CustomField::isSerialized($cFields[$fid]['attributes']);
@@ -2277,7 +2277,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         }
       }
     }
-    return [$cFields, $submitted];
+    return $submitted;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Stop returning unaltered cFields parameter

Before
----------------------------------------
The cryptically named `$cFields` (parameter is returned unchanged from the function

After
----------------------------------------
The function does not return the unchanged variable & the calling code uses the value it already had

Technical Details
----------------------------------------
FWIW the 'c' stands for '$custom` - I will try to ensure we don't have this 'guess what I mean' variables by the end.

Comments
----------------------------------------
