### PR TITLE
APIv4, Case API, configure options and suffixes for medium_id field

### DIFF
--- a/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseCreationSpecProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseCreationSpecProvider.php
@@ -14,6 +14,7 @@ namespace Civi\Api4\Service\Spec\Provider;
 
 use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * @service
@@ -51,6 +52,9 @@ class CaseCreationSpecProvider extends \Civi\Core\Service\AutoService implements
     $medium_id = new FieldSpec('medium_id', $spec->getEntity(), 'Integer');
     $medium_id->setTitle(ts('Activity Medium'));
     $medium_id->setDescription('Open Case activity medium.');
+    $medium_id->setOptionsCallback(['Civi\Api4\Service\Spec\SpecFormatter', 'getOptions']);
+    $suffixes = CoreUtil::getOptionValueFields('encounter_medium', 'name');
+    $medium_id->setSuffixes($suffixes);
     $spec->addFieldSpec($medium_id);
 
     $duration = new FieldSpec('duration', $spec->getEntity(), 'Integer');


### PR DESCRIPTION
Overview
----------------------------------------
In `CaseCreationSpecProvider` add necessary configuration to `medium_id` field, to support options and suffixes

Before
----------------------------------------
`medium_id` is a text field; users of the API need to know the corresponding option value ID:

<img width="909" alt="Screenshot 2022-12-27 at 11 39 35" src="https://user-images.githubusercontent.com/1931323/209661615-29829f4b-139f-4588-bb05-04cc4c9e1bb1.png">


After
----------------------------------------
`medium_ud` shows a dropdown of possible options in the explorer, and also supports `medium_id:name`:

<img width="909" alt="Screenshot 2022-12-27 at 11 40 48" src="https://user-images.githubusercontent.com/1931323/209661759-7ff378e3-77bc-48b5-92d0-9d9ce3cdcee2.png">


Technical Details
----------------------------------------
`setOptionsCallback` populates the dropdonw. Usually this would happen automatically for fields, but `Case` is a bit different as `medium_id` doesn't actually live on the case itself, but on an activity created at the moment the case is opened.

`setSuffixes` allows `medium_id` to be used as `medium_id:name`.

`setOptionsCallback` is a public method, but this is the first time it's being used in core outside of the `SpecFormatter` class. Therefore, I'm not sure if test coverage would be deemed necessary here.

Comments
----------------------------------------
An oddity of the Case API is that when creating case records, `medium_id` is always `null` in the returned payload. This is because the `medium_id` actually lives on the case-open `activity`, not the newly created case itself. Arguably this is a bug, and it does make it a bit harder to see at a glance whether this PR is working as expected. That said, it's not a new issue caused by this change, and so not something I have looked at fixing.
