### PR TITLE
Support DedupeRules as Managed entities

### DIFF
--- a/Civi/Api4/DedupeRule.php
+++ b/Civi/Api4/DedupeRule.php
@@ -21,5 +21,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class DedupeRule extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }

--- a/Civi/Api4/DedupeRuleGroup.php
+++ b/Civi/Api4/DedupeRuleGroup.php
@@ -21,5 +21,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class DedupeRuleGroup extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Support DedupeRules as Managed entities

Before
----------------------------------------
DedupeRuleGroup and DedupeRule entities cannot be managed as apiv4 entities

After
----------------------------------------
tada

Technical Details
----------------------------------------

Comments
----------------------------------------
