### PR TITLE
[REF] Fix strstr deprecation in CustomDataByType class

### DIFF
--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -48,7 +48,8 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     if (array_key_exists($this->_type, $contactTypes)) {
       $this->assign('contactId', $this->_entityId);
     }
-    if (!is_array($this->_subType) && strstr($this->_subType, CRM_Core_DAO::VALUE_SEPARATOR)) {
+    if (!is_array($this->_subType) && strstr($this->_subType ?? '', CRM_Core_DAO::VALUE_SEPARATOR)) {
+      CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType on civicrm/custom route is deprecated, use a comma-separated string instead.');
       $this->_subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($this->_subType, CRM_Core_DAO::VALUE_SEPARATOR));
     }
     CRM_Custom_Form_CustomData::setGroupTree($this, $this->_subType, $this->_groupID, $this->_onlySubtype);


### PR DESCRIPTION
Overview
----------------------------------------
Fix strstr deprecation in CustomDataByType class.

Before
----------------------------------------
The following error could be logged:

```
[28-Dec-2022 19:55:40 Europe/London] PHP Deprecated:  strstr(): Passing null to parameter #1 ($haystack) of type string is deprecated in .../civicrm/CRM/Custom/Form/CustomDataByType.php on line 51
```

After
----------------------------------------
Ensure value passed to `strstr` is an empty string rather than null, avoiding deprecated functionality.