### PR TITLE
Remove broken method CRM_Utils_File::isHtml()

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -49,36 +49,6 @@ class CRM_Utils_File {
   }
 
   /**
-   * Given a file name, determine if the file contents make it an html file
-   *
-   * @param string $name
-   *   Name of file.
-   *
-   * @return bool
-   *   true if file is html
-   */
-  public static function isHtml($name) {
-    $fd = fopen($name, "r");
-    if (!$fd) {
-      return FALSE;
-    }
-
-    $html = FALSE;
-    $lineCount = 0;
-    while (!feof($fd) & $lineCount <= 5) {
-      $lineCount++;
-      $line = fgets($fd, 8192);
-      if (!CRM_Utils_String::isHtml($line)) {
-        $html = TRUE;
-        break;
-      }
-    }
-
-    fclose($fd);
-    return $html;
-  }
-
-  /**
    * Create a directory given a path name, creates parent directories
    * if needed
    *


### PR DESCRIPTION
Overview
----------------------------------------
Remove broken method CRM_Utils_File::isHtml()

Before
----------------------------------------
The method `CRM_Utils_File::isHtml()` referenced `CRM_Utils_String::isHtml($line)` which does not exist (and has not existed for at least 10 years, and maybe never). Therefore `CRM_Utils_File::isHtml()` won't work as expected.

After
----------------------------------------
The method is gone.

Comments
----------------------------------------
Usually when removing a method, the correct thing to do would be to initially deprecated it. However, given how broken the method appears, I thought it was probably ok to just remove it. That said, it might be worth someone doing a check on [universe](https://docs.civicrm.org/dev/en/latest/tools/universe/) (I don't have it setup myself).
