### PR TITLE
[NFC] Remove line that does nothing

### DIFF
--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -152,7 +152,6 @@ class CRM_Activity_BAO_Query {
         if ($query->_mode == CRM_Contact_BAO_Query::MODE_CONTACTS) {
           $query->_useDistinct = TRUE;
         }
-        $query->_params[$id][3];
         self::whereClauseSingle($query->_params[$id], $query);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Remove line that does nothing!


Technical Details
----------------------------------------
`$query->_params[$id][3];` used to be `$grouping = $query->_params[$id][3];`. The first part of the line was removed with the commit message, ["remove some unused variables"](https://github.com/civicrm/civicrm-core/commit/56bf86688cb313e0da2c92056971c43b5b9a0ad7), it seems quite clear that the entire line was intended to be deleted.

Simply calling `$query->_params[$id][3];` on it's own does nothing...