### PR TITLE
dev/core#4055 Remove OPCache risk in the extension class loader

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -178,7 +178,7 @@ class CRM_Extension_ClassLoader {
    */
   protected function getCacheFile() {
     $envId = \CRM_Core_Config_Runtime::getId();
-    $file = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+    $file = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php.meta");
     return $file;
   }
 

--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -78,14 +78,12 @@ class CRM_Extension_ClassLoader {
 
     $file = $this->getCacheFile();
     if (file_exists($file)) {
-      $this->loader = require $file;
+      $this->loader = unserialize(file_get_contents($file, LOCK_EX));
     }
     else {
       $this->loader = $this->buildClassLoader();
       $ser = serialize($this->loader);
-      file_put_contents($file,
-        sprintf("<?php\nreturn unserialize(%s);", var_export($ser, 1))
-      );
+      file_put_contents($file, $ser, LOCK_EX);
     }
     return $this->loader->register();
   }


### PR DESCRIPTION
Overview
----------------------------------------
It is a code thing. The extension class loader used `require` to load configuration. When OPCache is enabled, this adds the risk that outdated configuration is used, specially when extensions are installed. A use case can be found at https://lab.civicrm.org/dev/core/-/issues/4055

Before
----------------------------------------
* Use file_put_contents to write class loader configuration.
* Use require to read it.

After
----------------------------------------
* Use file_put_contents to write class loader configuration.
* Use file_get_contents to read it.
* Lock the configuration file as an extra safety measure.

Technical Details
----------------------------------------
* With some luck this prevents a number of bugs that only show themselves in production situations (because on developer laptops the OP cache is often disabled.).

Comments
----------------------------------------
Updating this code directly causes a nasty error because the configuration format is changed. Using `cv flush` solves this, because it removes the cache files.
