### PR TITLE
[NFC] Fix @method documentation for shouldExitAfterFatal

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -38,7 +38,7 @@
  * @method static array synchronizeUsers() Create CRM contacts for all existing CMS users.
  * @method static void appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
  * @method static void alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
- * @method static exitAfterFatal() Should the current execution exit after a fatal error?
+ * @method static bool shouldExitAfterFatal() Should the current execution exit after a fatal error?
  */
 class CRM_Utils_System {
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a broken docblock from https://github.com/civicrm/civicrm-core/pull/22805.

Before
----------------------------------------
During development of #22805 `shouldExitAfterFatal` was renamed from `exitAfterFatal`. It seems I missed updating the docblock.

After
----------------------------------------
Correct inline documentation comments.
