### PR TITLE
Remove a couple of legacy uses of `contributeMode`

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -207,9 +207,7 @@
     </div>
   {/if}
 
-  {if ( $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) ) or $email }
-    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) }
-      {if $billingName or $address}
+    {if $billingName or $address}
         <div class="crm-group billing_name_address-group">
           <div class="header-dark">
             {ts}Billing Name and Address{/ts}
@@ -224,8 +222,7 @@
           </div>
         </div>
       {/if}
-    {/if}
-    {if !$emailExists}
+    {if $email && !$emailExists}
       <div class="crm-group contributor_email-group">
         <div class="header-dark">
           {ts}Your Email{/ts}
@@ -236,19 +233,17 @@
         </div>
       </div>
     {/if}
-  {/if}
 
   {* Show credit or debit card section for 'direct' mode, except for PayPal Express (detected because credit card number is empty) *}
-  {if $contributeMode eq 'direct' and ! $is_pay_later and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 )}
     {crmRegion name="contribution-confirm-billing-block"}
-    {if ($credit_card_number or $bank_account_number)}
+    {if in_array('credit_card_number', $form) || in_array('bank_account_number', $form)}
       <div class="crm-group credit_card-group">
         {if $paymentFieldsetLabel}
           <div class="header-dark">
             {$paymentFieldsetLabel}
           </div>
         {/if}
-        {if $paymentProcessor.payment_type == 2}
+        {if in_array('bank_account_number', $form)}
           <div class="display-block">
             {ts}Account Holder{/ts}: {$account_holder}<br/>
             {ts}Bank Account Number{/ts}: {$bank_account_number}<br/>
@@ -265,7 +260,8 @@
               </div>
             </div>
           {/if}
-        {else}
+        {/if}
+        {if in_array('credit_card_number', $form)}
           <div class="crm-section no-label credit_card_details-section">
             <div class="content">{$credit_card_type}</div>
             <div class="content">{$credit_card_number}</div>
@@ -276,7 +272,6 @@
       </div>
     {/if}
     {/crmRegion}
-  {/if}
 
   {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="confirmContribution"}
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove a couple of legacy uses of `contributeMode`

Before
----------------------------------------
Value in deprecated varaible `contributeMode` used to determine whether to show billing address block & card block

After
----------------------------------------
Presence of relevant paramters used to decide whether to show the above blocks

Technical Details
----------------------------------------
These changes were made a long time back to the message templates. I thought we might be able to finally get rid of `contributeMode` but still 2 uses in this tpl I don't quite have an answer for:
```
          {if $contributeMode eq 'direct'}
            <div class="crm-group debit_agreement-group">
              <div class="header-dark">
                {ts}Agreement{/ts}
              </div>
              <div class="display-block">
                {ts}Your account data will be used to charge your bank account via direct debit. While submitting this form you agree to the charging of your bank account via direct debit.{/ts}
              </div>
            </div>
          {/if}
```

```
  {if $contributeMode NEQ 'notify' and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) } {* In 'notify mode, contributor is taken to processor payment forms next *}
    <div class="messages status continue_instructions-section">
      <p>
        {if $is_pay_later OR $amount LE 0.0}
          {ts 1=$button}Your transaction will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
        {else}
          {ts 1=$button}Your contribution will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
        {/if}
      </p>
    </div>
  {/if}
```
Comments
----------------------------------------
I didn't alter whitespace for legibility