### PR TITLE
Remove check from when function was shared

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -492,16 +492,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
     // get price info
     if ($priceSetId) {
-      if ($form->_action & CRM_Core_Action::UPDATE) {
-        $form->_values['line_items'] = CRM_Price_BAO_LineItem::getLineItems($form->_id, 'contribution');
-        $required = FALSE;
-      }
-      else {
-        $required = TRUE;
-      }
-
       $form->_priceSetId = $priceSetId;
-      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, $required);
+      $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId, TRUE);
       $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
       $form->_values['fee'] = $form->_priceSet['fields'] ?? NULL;
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -488,9 +488,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id);
     //check if price set is is_config
     if (is_numeric($priceSetId)) {
-      if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config') && $form->getVar('_name') != 'Participant') {
-        $form->assign('quickConfig', 1);
-      }
+      $form->assign('quickConfig', CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config'));
     }
     // get price info
     if ($priceSetId) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove check from when function was shared

Before
----------------------------------------
This private contribution page function used to be shared & `$form->getVar('_name') != 'Participant'` used to be meaningful - however it is always TRUE now

In addition there is handling from that form for 'upgrade mode' - I wasn't sure at first if this was possible to reach from the contribution form but on checking it takes a parameter of `form->_id` and passes it to a function expecting a contribution id or (at a pinch) a participant id. On this form `$form->_id` is the contribution page id....  

Once that if is removed `$required` is always TRUE - which is the default value for `getSetDetail` so not required (it would make sense when updating an contribution's line items in some cases I think - hence the use in the previously shared function)


After
----------------------------------------
Poof

Technical Details
----------------------------------------

Comments
----------------------------------------
