### PR TITLE
(NFC) When using @var annotations, ensure type comes first

### DIFF
--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -112,7 +112,7 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
   public function getReferenceCounts($dao) {
     $result = [];
     if ($dao instanceof CRM_Core_DAO_OptionValue) {
-      /** @var $dao CRM_Core_DAO_OptionValue */
+      /** @var CRM_Core_DAO_OptionValue $dao */
       $activity_type_gid = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'activity_type', 'id', 'name');
       if ($activity_type_gid == $dao->option_group_id) {
         $count = CRM_Case_XMLRepository::singleton()
@@ -127,7 +127,7 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
       }
     }
     elseif ($dao instanceof CRM_Contact_DAO_RelationshipType) {
-      /** @var $dao CRM_Contact_DAO_RelationshipType */
+      /** @var CRM_Contact_DAO_RelationshipType $dao  */
 
       // Need to look both directions, but no need to translate case role
       // direction from XML perspective to client-based perspective

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -763,15 +763,15 @@ HEREDOC;
   /**
    * Get a reference to the file-search service (if one is available).
    *
-   * @return CRM_Core_FileSearchInterface|NULL
+   * @return CRM_Core_FileSearchInterface|null
    */
   public static function getSearchService() {
     $fileSearches = [];
     CRM_Utils_Hook::fileSearches($fileSearches);
 
     // use the first available search
+    /** @var CRM_Core_FileSearchInterface $fileSearch */
     foreach ($fileSearches as $fileSearch) {
-      /** @var $fileSearch CRM_Core_FileSearchInterface */
       return $fileSearch;
     }
     return NULL;

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -355,8 +355,8 @@ class CRM_Extension_Mapper {
     // TODO optimization/caching
     $urls = [];
     $urls['civicrm'] = $this->keyToUrl('civicrm');
+    /** @var CRM_Core_Module $module */
     foreach ($this->getModules() as $module) {
-      /** @var $module CRM_Core_Module */
       if ($module->is_active) {
         try {
           $urls[$module->name] = $this->keyToUrl($module->name);

--- a/CRM/Extension/MixinLoader.php
+++ b/CRM/Extension/MixinLoader.php
@@ -64,8 +64,8 @@ class CRM_Extension_MixinLoader {
       }
     }
 
+    /** @var \CRM_Extension_MixInfo $ext */
     foreach ($mixInfos as $ext) {
-      /** @var \CRM_Extension_MixInfo $ext */
       foreach ($ext->mixins as $verExpr) {
         $doneId = $ext->longName . '::' . $verExpr;
         if (isset($this->done[$doneId])) {

--- a/Civi/CCase/Events.php
+++ b/Civi/CCase/Events.php
@@ -96,8 +96,8 @@ class Events {
   public static function delegateToXmlListeners(\Civi\CCase\Event\CaseChangeEvent $event) {
     $p = new \CRM_Case_XMLProcessor_Process();
     $listeners = $p->getListeners($event->analyzer->getCaseType());
+    /** @var \Civi\CCase\CaseChangeListener $listener */
     foreach ($listeners as $listener) {
-      /** @var $listener \Civi\CCase\CaseChangeListener */
       $listener->onCaseChange($event);
     }
   }

--- a/Civi/Test/CiviEnvBuilder/SqlFileStep.php
+++ b/Civi/Test/CiviEnvBuilder/SqlFileStep.php
@@ -24,8 +24,11 @@ class SqlFileStep implements StepInterface {
     return is_file($this->file) && is_readable($this->file);
   }
 
+  /**
+   * @param \CiviEnvBuilder $ctx
+   * @throws \RuntimeException
+   */
   public function run($ctx) {
-    /** @var $ctx \CiviEnvBuilder */
     if (\Civi\Test::execute(@file_get_contents($this->file)) === FALSE) {
       throw new \RuntimeException("Cannot load {$this->file}. Aborting.");
     }

--- a/Civi/Test/CiviEnvBuilder/SqlStep.php
+++ b/Civi/Test/CiviEnvBuilder/SqlStep.php
@@ -20,8 +20,11 @@ class SqlStep implements StepInterface {
     return TRUE;
   }
 
+  /**
+   * @param \CiviEnvBuilder $ctx
+   * @throws \RuntimeException
+   */
   public function run($ctx) {
-    /** @var $ctx \CiviEnvBuilder */
     if (\Civi\Test::execute($this->sql) === FALSE) {
       throw new \RuntimeException("Cannot execute: {$this->sql}");
     }

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -231,8 +231,8 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
   }
 
   public function fillTable() {
+    /** @var CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery $partialQuery */
     foreach ($this->_partialQueries as $partialQuery) {
-      /** @var $partialQuery CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery */
       if (!$this->_table || $this->_table == $partialQuery->getName()) {
         if ($partialQuery->isActive()) {
           $result = $partialQuery->fillTempTable($this->_text, $this->_entityIDTableName, $this->_tableName, $this->_limitClause, $this->_limitDetailClause);
@@ -301,8 +301,8 @@ WHERE      t.table_name = 'Activity' AND
 
     // also add a select box to allow the search to be constrained
     $tables = ['' => ts('All tables')];
+    /** @var CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery $partialQuery */
     foreach ($this->_partialQueries as $partialQuery) {
-      /** @var $partialQuery CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery */
       if ($partialQuery->isActive()) {
         $tables[$partialQuery->getName()] = $partialQuery->getLabel();
       }
@@ -360,8 +360,8 @@ WHERE      t.table_name = 'Activity' AND
     $this->initialize();
 
     $summary = [];
+    /** @var CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery $partialQuery */
     foreach ($this->_partialQueries as $partialQuery) {
-      /** @var $partialQuery CRM_Contact_Form_Search_Custom_FullText_AbstractPartialQuery */
       $summary[$partialQuery->getName()] = [];
     }
 

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -205,7 +205,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       ];
 
       $contributionId = $this->createContribution();
-      /** @var $form CRM_Contribute_Form_Task_PDFLetter */
+      /** @var CRM_Contribute_Form_Task_PDFLetter $form */
       $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
       $form->setContributionIds([$contributionId]);
       $format = Civi::settings()->get('dateformatFull');
@@ -244,7 +244,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       'html_message' => '{contact.display_name}',
       'document_type' => 'pdf',
     ];
-    /** @var $form CRM_Contribute_Form_Task_PDFLetter */
+    /** @var CRM_Contribute_Form_Task_PDFLetter $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
     $form->setContributionIds([$this->createContribution()]);
     try {
@@ -277,7 +277,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
       $formValues['html_message'] .= "$token : {contribution.$token}\n";
     }
     $formValues['html_message'] .= '{emoji.favourite_emoticon}';
-    /** @var $form CRM_Contribute_Form_Task_PDFLetter */
+    /** @var CRM_Contribute_Form_Task_PDFLetter $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter', $formValues);
     $form->setContributionIds([$this->createContribution(array_merge(['campaign_id' => $tokens['campaign_id:label']], $tokens))]);
     try {

--- a/tests/phpunit/CiviTest/CiviCaseTestCase.php
+++ b/tests/phpunit/CiviTest/CiviCaseTestCase.php
@@ -96,7 +96,7 @@ class CiviCaseTestCase extends CiviUnitTestCase {
     $enableResult = CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $this->assertTrue($enableResult, 'Cannot enable CiviCase in line ' . __LINE__);
 
-    /** @var $hooks \CRM_Utils_Hook_UnitTests */
+    /** @var \CRM_Utils_Hook_UnitTests $hooks  */
     $hooks = \CRM_Utils_Hook::singleton();
     $hooks->setHook('civicrm_caseTypes', array($this, 'hook_caseTypes'));
     \CRM_Case_XMLRepository::singleton(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
When using `@var` annotations, ensure type comes first.

See https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/var.html#var for details:

1. The type should come first,
2. When used with foreach blocks, it's more common to put the `@var` annotation outside the loop.

These changes will help IDEs use the information sensibly.
