### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in mailstores

### DIFF
--- a/CRM/Mailing/MailStore.php
+++ b/CRM/Mailing/MailStore.php
@@ -16,10 +16,18 @@
  */
 class CRM_Mailing_MailStore {
   /**
-   * flag to decide whether to print debug messages
+   * Flag to decide whether to print debug messages
+   *
    * @var bool
    */
   public $_debug = FALSE;
+
+  /**
+   * Holds the underlying mailbox transport implementation
+   *
+   * @var ezcMailImapTransport|ezcMailMboxTransport|ezcMailPop3Transport|null
+   */
+  protected $_transport;
 
   /**
    * Return the proper mail store implementation, based on config settings.

--- a/CRM/Mailing/MailStore/Imap.php
+++ b/CRM/Mailing/MailStore/Imap.php
@@ -21,6 +21,20 @@
 class CRM_Mailing_MailStore_Imap extends CRM_Mailing_MailStore {
 
   /**
+   * Path to a IMAP directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_ignored;
+
+  /**
+   * Path to a IMAP directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_processed;
+
+  /**
    * Connect to the supplied IMAP server and make sure the two mailboxes exist.
    *
    * @param string $host

--- a/CRM/Mailing/MailStore/Localdir.php
+++ b/CRM/Mailing/MailStore/Localdir.php
@@ -21,10 +21,31 @@
 class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
 
   /**
+   * Directory to operate upon.
+   *
+   * @var string
+   */
+  private $_dir;
+
+  /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_ignored;
+
+  /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_processed;
+
+  /**
    * Connect to the supplied dir and make sure the two mail dirs exist.
    *
    * @param string $dir
-   *   Dir to operate upon.
+   *   Directory to operate upon.
    *
    * @return \CRM_Mailing_MailStore_Localdir
    */

--- a/CRM/Mailing/MailStore/Maildir.php
+++ b/CRM/Mailing/MailStore/Maildir.php
@@ -21,10 +21,31 @@
 class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
 
   /**
+   * Directory to operate upon.
+   *
+   * @var string
+   */
+  private $_dir;
+
+  /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_ignored;
+
+  /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_processed;
+
+  /**
    * Connect to the supplied dir and make sure the two mail dirs exist.
    *
    * @param string $dir
-   *   Dir to operate upon.
+   *   Directory to operate upon.
    *
    * @return \CRM_Mailing_MailStore_Maildir
    */

--- a/CRM/Mailing/MailStore/Mbox.php
+++ b/CRM/Mailing/MailStore/Mbox.php
@@ -21,6 +21,27 @@
 class CRM_Mailing_MailStore_Mbox extends CRM_Mailing_MailStore {
 
   /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_ignored;
+
+  /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_processed;
+
+  /**
+   * Count of messages left to process
+   *
+   * @var int
+   */
+  private $_leftToProcess;
+
+  /**
    * Connect to and lock the supplied file and make sure the two mail dirs exist.
    *
    * @param string $file

--- a/CRM/Mailing/MailStore/Pop3.php
+++ b/CRM/Mailing/MailStore/Pop3.php
@@ -21,6 +21,20 @@
 class CRM_Mailing_MailStore_Pop3 extends CRM_Mailing_MailStore {
 
   /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_ignored;
+
+  /**
+   * Path to a local directory to store ignored emails
+   *
+   * @var string
+   */
+  private $_processed;
+
+  /**
    * Connect to the supplied POP3 server and make sure the two mail dirs exist
    *
    * @param string $host


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in mailstores. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

Before
----------------------------------------
`_mailbox`, `_ignored`, `_processed`, `_dir` and `_leftToProcess` were declared dynamically, which will be deprecated in PHP 8.2.

After
----------------------------------------
The properties are explicitly declared.

Comments
----------------------------------------
I've declared the properties as private/protected. It's possible that something is trying to read one of the above properties in an extension, but I think it's unlikely - the mailer object is not passed into any hooks, which means any extension would struggle to get a refrerence to the mailer object in order to read it's properties.

That said, happy to change the properties to public if it would make people feel more comfortable with merging this.
