### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Utils_Signer

### DIFF
--- a/CRM/Utils/Signer.php
+++ b/CRM/Utils/Signer.php
@@ -40,6 +40,26 @@ class CRM_Utils_Signer {
   const SALT_LEN = 4;
 
   /**
+   * @var string
+   */
+  private $secret;
+
+  /**
+   * @var array
+   */
+  private $paramNames;
+
+  /**
+   * @var string
+   */
+  public $signDelim;
+
+  /**
+   * @var string
+   */
+  private $defaultSalt;
+
+  /**
    * Instantiate a signature-processor
    *
    * @param string $secret


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in CRM_Utils_Signer, which are deprecated in PHP 8.2 https://lab.civicrm.org/dev/core/-/issues/3833

Before
----------------------------------------
Dynamic properties in `CRM_Utils_Signer`

After
----------------------------------------
Properties are no longer dynamic.

Comments
----------------------------------------
I struggled a little on the choice of `public` vs `private` visibility for these props. In the end I figured that the lack of explicit visibility on `secret`, `paramNames`, `defaultSalt` probabaly means they don't form part of any public API, and as such we're free to make them private. A universe check might be sensible all the same.

The only reason for `signDelim` to be a property (rather than say a `const`) is to allow it to be changed. So there is a legitimate use case for this being accessed and for it to be public.