### PR TITLE
(NFC) Fix documented return type on getByClass method

### DIFF
--- a/Civi/Payment/System.php
+++ b/Civi/Payment/System.php
@@ -156,7 +156,7 @@ class System {
    *
    * @param string $className
    *
-   * @return \Civi\Payment\CRM_Core_Payment|NULL
+   * @return \CRM_Core_Payment|NULL
    * @throws \CRM_Core_Exception
    */
   public function getByClass($className) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix documented return type on getByClass method.

Before
----------------------------------------
`Civi\Payment\System->getByClass` documented as returning `Civi\Payment\CRM_Core_Payment`, which does not exist. Furthermore `getByProcessor` is documented as returning simply `CRM_Core_Payment`.

After
----------------------------------------
`@return` annotation correct.