### PR TITLE
Remove code for legacy php versions - `assign_by_ref` with an object

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -117,8 +117,8 @@ class CRM_Core_Smarty extends Smarty {
     // add the session and the config here
     $session = CRM_Core_Session::singleton();
 
-    $this->assign_by_ref('config', $config);
-    $this->assign_by_ref('session', $session);
+    $this->assign('config', $config);
+    $this->assign('session', $session);
 
     $tsLocale = CRM_Core_I18n::getLocale();
     $this->assign('tsLocale', $tsLocale);


### PR DESCRIPTION
Overview
----------------------------------------
Remove code for legacy php versions - `assign_by_ref` with an object

Before
----------------------------------------
Use of assign_by_ref with objects is no different to assign in modern php - I believe this to be left over from our drive to support php4 at one point

After
----------------------------------------
poof

Technical Details
----------------------------------------
I'm tinkering with later smarty - which don't support assign_by_ref at all & none of our usages of it make sense

Comments
----------------------------------------
