### PR TITLE
Update Smarty addTemplateDir function signature to future smarty

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -283,16 +283,26 @@ class CRM_Core_Smarty extends Smarty {
   }
 
   /**
-   * @param $path
+   * Add template directory(s).
+   *
+   * @param string|array $template_dir directory(s) of template sources
+   * @param string $key (Smarty3+) of the array element to assign the template dir to
+   * @param bool $isConfig (Smarty3+) true for config_dir
+   *
+   * @return Smarty          current Smarty instance for chaining
    */
-  public function addTemplateDir($path) {
+  public function addTemplateDir($template_dir, $key = NULL, $isConfig = FALSE) {
+    if (method_exists('parent', 'addTemplateDir')) {
+      // More recent versions of Smarty have this method.
+      return parent::addTemplateDir($template_dir, $key, $isConfig);
+    }
     if (is_array($this->template_dir)) {
-      array_unshift($this->template_dir, $path);
+      array_unshift($this->template_dir, $template_dir);
     }
     else {
-      $this->template_dir = [$path, $this->template_dir];
+      $this->template_dir = [$template_dir, $this->template_dir];
     }
-
+    return $this;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The `addTemplateDir` function is not in Smartyv2. However, it is added in Smarty v3 with the signature below (which is the same in v4), This updates our functions signature to the signature that will someday be on the parent class, calling the parent class if it is there.

```
/**
     * Add template directory(s)
     *
     * @param string|array $template_dir directory(s) of template sources
     * @param string       $key          of the array element to assign the template dir to
     * @param bool         $isConfig     true for config_dir
     *
     * @return Smarty          current Smarty instance for chaining
     */
    public function addTemplateDir($template_dir, $key = null, $isConfig = false)
   ``` 

Before
----------------------------------------
Function signature does not match future parent

After
----------------------------------------
Now it does

Technical Details
----------------------------------------
We may never upgrade smarty ... but this seems like sensible future proofing

Comments
----------------------------------------
