### PR TITLE
Unconditionally assign `registerClosed` on event info page

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -280,10 +280,8 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
           $this->assign('registerURL', $url);
         }
       }
-      elseif (CRM_Core_Permission::check('register for events')) {
-        $this->assign('registerClosed', TRUE);
-      }
     }
+    $this->assign('registerClosed', !empty($values['event']['is_online_registration']) && !$isEventOpenForRegistration);
 
     $this->assign('allowRegistration', $allowRegistration);
 


### PR DESCRIPTION
Overview
----------------------------------------
Unconditionally assign `registerClosed` on event info page

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/210161383-232840c2-13a1-4e76-8af3-5d49c9593a8a.png)

After
----------------------------------------
First notice is gone

Technical Details
----------------------------------------
I changed the logic slightly in that it used to only show `registerClosed` ie 
![image](https://user-images.githubusercontent.com/336308/210161409-4511a007-60ec-45d4-8de7-5288127338c1.png)


if the user had register event permission. This felt a bit overloaded & confusing to me & there didn't seem to be any harm in showing the text even if they couldn't register


Comments
----------------------------------------