### PR TITLE
Remove empty param declarations in docblocks

### DIFF
--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -244,12 +244,10 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
   /**
    * Returns total number of rows for the query.
    *
-   * @param
-   *
    * @return int
    *   Total number of rows
    */
-  public function getTotalCount($action) {
+  public function getTotalCount() {
     return $this->_query->searchQuery(0, 0, NULL,
       TRUE, FALSE,
       FALSE, FALSE,

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -348,8 +348,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
    * The processing consists of using a Selector / Controller framework for getting the
    * search results.
    *
-   * @param
-   *
    * @return void
    * @throws \CRM_Core_Exception
    */

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -43,8 +43,6 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    *
-   * @param
-   *
    * @return void
    */
   public function preProcess() {

--- a/CRM/Event/Form/Task/Badge.php
+++ b/CRM/Event/Form/Task/Badge.php
@@ -37,8 +37,6 @@ class CRM_Event_Form_Task_Badge extends CRM_Event_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    *
-   * @param
-   *
    * @return void
    */
   public function preProcess() {

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -64,8 +64,6 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    *
-   * @param
-   *
    * @return void
    */
   public function preProcess() {

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2153,8 +2153,6 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   /**
    * Get the count of mailings.
    *
-   * @param
-   *
    * @return int
    *   Count
    */

--- a/CRM/Mailing/Event/BAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/BAO/MailingEventQueue.php
@@ -231,9 +231,7 @@ class CRM_Mailing_Event_BAO_MailingEventQueue extends CRM_Mailing_Event_DAO_Mail
   /**
    * Get the mailing object for this queue event instance.
    *
-   * @param
-   *
-   * @return object
+   * @return CRM_Mailing_BAO_Mailing
    *   Mailing BAO
    */
   public function &getMailing() {

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -33,8 +33,6 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    *
-   * @param
-   *
    * @return void
    * @throws \CRM_Core_Exception
    */

--- a/CRM/Profile/Form/Dynamic.php
+++ b/CRM/Profile/Form/Dynamic.php
@@ -28,8 +28,6 @@ class CRM_Profile_Form_Dynamic extends CRM_Profile_Form {
   /**
    * Pre processing work done here.
    *
-   * @param
-   *
    */
   public function preProcess(): void {
     if ($this->get('register')) {

--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -35,8 +35,6 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
   /**
    * Pre processing work done here.
    *
-   * @param
-   *
    */
   public function preProcess() {
     $this->_mode = CRM_Profile_Form::MODE_CREATE;

--- a/CRM/UF/Form/Inline/PreviewById.php
+++ b/CRM/UF/Form/Inline/PreviewById.php
@@ -27,8 +27,6 @@ class CRM_UF_Form_Inline_PreviewById extends CRM_UF_Form_AbstractPreview {
    *
    * gets session variables for group or field id
    *
-   * @param
-   *
    * @return void
    * @throws \CRM_Core_Exception
    */

--- a/CRM/UF/Form/Preview.php
+++ b/CRM/UF/Form/Preview.php
@@ -27,8 +27,6 @@ class CRM_UF_Form_Preview extends CRM_UF_Form_AbstractPreview {
    *
    * gets session variables for group or field id
    *
-   * @param
-   *
    * @return void
    */
   public function preProcess() {

--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -35,8 +35,6 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
   /**
    * Get the action links for this page.
    *
-   * @param
-   *
    * @return array
    */
   public static function &actionLinks() {
@@ -286,11 +284,9 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
   /**
    * Browse all uf data groups.
    *
-   * @param
-   *
    * @return void
    */
-  public function browse($action = NULL) {
+  public function browse() {
     $ufGroup = [];
     $allUFGroups = CRM_Core_BAO_UFGroup::getModuleUFGroup();
     if (empty($allUFGroups)) {

--- a/ext/civigrant/CRM/Grant/Form/Task.php
+++ b/ext/civigrant/CRM/Grant/Form/Task.php
@@ -25,8 +25,6 @@ class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    *
-   * @param
-   *
    * @return void
    */
   public function preProcess() {


### PR DESCRIPTION
Overview
----------------------------------------
Get's rid of cases where `@param` is used incorrectly on it's own, with functions that don't take arguments.

Also returns an unused argument `$action` from `getTotalCount`, and fixes the documented return type on `getMailing`.