### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in civicrm_api3 class

### DIFF
--- a/api/class.api.php
+++ b/api/class.api.php
@@ -90,6 +90,89 @@
 class civicrm_api3 {
 
   /**
+   * Are we performing a local or remote API call?
+   *
+   * @var bool
+   */
+  public $local = TRUE;
+
+  /**
+   * Array of inputs to pass to `call`, if param not passed directly
+   *
+   * @var array
+   * @internal
+   */
+  public $input = [];
+
+  /**
+   * Holds the result of the last API request.
+   * If the request has not yet run, lastResult will be empty.
+   *
+   * @var \stdClass
+   * @internal
+   */
+  public $lastResult;
+
+  /**
+   * When making a remote API request,
+   * $uri will be the path to the remote server's API endpoint
+   *
+   * @var string|null
+   * @internal
+   */
+  public $uri = NULL;
+
+  /**
+   * When making a remote API request,
+   * $key will be sent as part of the request
+   *
+   * @var string|null
+   * @internal
+   */
+  public $key = NULL;
+
+  /**
+   * When making a remote API request,
+   * $api_key will be sent as part of the request
+   *
+   * @var string|null
+   * @internal
+   */
+  public $api_key = NULL;
+
+  /**
+   * When making a remote API request,
+   * $referer holds the Referer header value to be sent as part of the request
+   *
+   * @var string|null
+   * @internal
+   */
+  public $referer = NULL;
+
+  /**
+   * When making a remote API request,
+   * $useragent holds the User-Agent header value to be sent as part of the request
+   *
+   * @var string|null
+   * @internal
+   */
+  public $useragent = NULL;
+
+  /**
+   * Reference to the CRM_Core_Config singleton
+   *
+   * @var CRM_Core_Config
+   */
+  protected $cfg;
+
+  /**
+   * The current entity, which actions should be performed against
+   *
+   * @var string|null
+   */
+  protected $currentEntity = NULL;
+
+  /**
    * Class constructor.
    *
    * @param array $config API configuration.
@@ -97,7 +180,7 @@ class civicrm_api3 {
   public function __construct($config = NULL) {
     $this->local      = TRUE;
     $this->input      = [];
-    $this->lastResult = [];
+    $this->lastResult = new stdClass();
     if (!empty($config) && !empty($config['server'])) {
       // we are calling a remote server via REST
       $this->local = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in civicrm_api3 class.

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
The properties are defined upfront, and are not dynamic.

Technical Details
----------------------------------------
 - I made `local` public. It felt like there could be use-cases for third-party code to be able to see whether an API3 object is local or not. Furthermore, the property needs to be public as it is used in tests.
 - `input`, `lastResult`, `uri`, `key`, `api_key`, `referer` and `useragent` are also public. Some of these are also used by tests, but I also gathered that given how widely used `civicrm_api3` is in the ecosystem there may well be use-cases where these are being read. That said, I'm not sure we really want to be advertisting these as part of the public API, and so I have marked them as `@internal`.
 - `cfg` and `currentEntity` felt very implementation specific and so have been made protected.

I've also changed the initial value of `lastResult` set in the constructor, to match the type it has elsewhere in the class (once the request has been made)

Happy to hear arguments for why any of these should change.

Comments
----------------------------------------
Reading through the code I couldn't really understand what `$this->input` is doing, and I suspect it's a bit buggy. Given everything is moving to APIv4 it probably doesn't warrant too much time spent looking into it, and for this PR I just wanted to get the dynamic properties righted out.