### PR TITLE
Deprecate meaningless parameter

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Base.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Base.php
@@ -69,10 +69,14 @@ class CRM_Contact_Form_Search_Custom_Base {
    * @param int $rowcount
    * @param null $sort
    * @param bool $returnSQL
+   *   Deprecated parameter
    *
    * @return string
    */
   public function contactIDs($offset = 0, $rowcount = 0, $sort = NULL, $returnSQL = FALSE) {
+    if ($returnSQL) {
+      CRM_Core_Error::deprecatedWarning('do not pass returnSQL');
+    }
     $sql = $this->sql(
       'contact_a.id as contact_id',
       $offset,
@@ -80,12 +84,7 @@ class CRM_Contact_Form_Search_Custom_Base {
       $sort
     );
     $this->validateUserSQL($sql);
-
-    if ($returnSQL) {
-      return $sql;
-    }
-
-    return CRM_Core_DAO::composeQuery($sql);
+    return $sql;
   }
 
   /**

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -449,13 +449,7 @@ WHERE      t.table_name = 'Activity' AND
    */
   public function contactIDs($offset = 0, $rowcount = 0, $sort = NULL, $returnSQL = FALSE) {
     $this->initialize();
-
-    if ($returnSQL) {
-      return $this->all($offset, $rowcount, $sort, FALSE, TRUE);
-    }
-    else {
-      return CRM_Core_DAO::singleValueQuery("SELECT contact_id FROM {$this->tableName}");
-    }
+    return $this->all($offset, $rowcount, $sort, FALSE, TRUE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate meaningless parameter

Before
----------------------------------------
If `$returnSQL` is passed in then the resulting sql is returned via `CRM_Core_DAO::composeQuery($sql);` - However, this function leaves the sql unchanged if it is the only input parameter (it kicks into gear if `$params` is passed in as well)

After
----------------------------------------
simplifed


Technical Details
----------------------------------------
A universe search suggests only one search has been implemented that overrides this function to use the variable - the full text search

I tried to make sense of the full text search - this function is called from 2 places
- filling the group contact cache
- filling the prevnext cache

In the latter case the function would return an integer (a contact ID) - this possibly works because if makes invalid sql which gets caught by the try-catch (which would probably still be true). @lcdservices can maybe help here?

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4056
