### PR TITLE
Smarty notice fix on contact search results

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -55,6 +55,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     'geo_code_1',
     'geo_code_2',
     'is_deceased',
+    'is_deleted',
     'email',
     'on_hold',
     'phone',

--- a/templates/CRM/Contact/Form/Selector.tpl
+++ b/templates/CRM/Contact/Form/Selector.tpl
@@ -78,7 +78,7 @@
                 {$row.status}</td>
             {/if}
             <td>{$row.contact_type}</td>
-            <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&key=`$qfKey`&context=`$context`"}">{if !empty($row.is_deleted)}<del>{/if}{$row.sort_name}{if !empty($row.is_deleted)}</del>{/if}</a></td>
+            <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`&key=`$qfKey`&context=`$context`"}">{if $row.is_deleted}<del>{/if}{$row.sort_name}{if $row.is_deleted}</del>{/if}</a></td>
             {if $action eq 512 or $action eq 256}
               {if !empty($columnHeaders.street_address)}
           <td><span title="{$row.street_address|escape}">{$row.street_address|mb_truncate:22:"...":true}{privacyFlag field=do_not_mail condition=$row.do_not_mail}</span></td>


### PR DESCRIPTION
Overview
----------------------------------------
Smarty notice fix on contact search results - with smarty default escaping on you can see this just doing a basic Contact Search with no criteria

Before
----------------------------------------
e-notices when searching with escape-on-output

After
----------------------------------------
empty check removed in favour of making it present - contact who can't see deleted contacts won't get them returned so we should put it in the array regardless of contact permissions

Technical Details
----------------------------------------

Comments
----------------------------------------
