### PR TITLE
Remove code deprecated in 2019

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5298,10 +5298,6 @@ civicrm_relationship.start_date > {$today}
   ) {
     // @todo - remove dateFormat - pretty sure it's never passed in...
     [$name, $op, $value, $grouping, $wildcard] = $values;
-    if ($name !== $fieldName && $name !== "{$fieldName}_low" && $name !== "{$fieldName}_high") {
-      CRM_Core_Error::deprecatedFunctionWarning('Date query builder called unexpectedly');
-      return;
-    }
     if ($tableName === 'civicrm_contact') {
       // Special handling for contact table as it has a known alias in advanced search.
       $tableName = 'contact_a';

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6747,8 +6747,6 @@ AND   displayRelType.is_active = 1
    * @param string $additionalFromClause
    *   Should be clause with proper joins, effective to reduce where clause load.
    *
-   * @param bool $skipOrderAndLimit
-   *
    * @return string
    *
    * @throws \CRM_Core_Exception
@@ -6758,23 +6756,10 @@ AND   displayRelType.is_active = 1
     $count = FALSE, $includeContactIds = FALSE,
     $sortByChar = FALSE, $groupContacts = FALSE,
     $additionalWhereClause = NULL, $sortOrder = NULL,
-    $additionalFromClause = NULL, $skipOrderAndLimit = FALSE) {
+    $additionalFromClause = NULL) {
 
     $sqlParts = $this->getSearchSQLParts($offset, $rowCount, $sort, $count, $includeContactIds, $sortByChar, $groupContacts, $additionalWhereClause, $sortOrder, $additionalFromClause);
-
-    if ($sortByChar) {
-      CRM_Core_Error::deprecatedFunctionWarning('sort by char is deprecated - use alphabetQuery method');
-      $sqlParts['order_by'] = 'ORDER BY sort_name asc';
-    }
-
-    if ($skipOrderAndLimit) {
-      CRM_Core_Error::deprecatedFunctionWarning('skipOrderAndLimit is deprected - call getSearchSQLParts & construct it in the calling function');
-      $query = "{$sqlParts['select']} {$sqlParts['from']} {$sqlParts['where']} {$sqlParts['having']} {$sqlParts['group_by']}";
-    }
-    else {
-      $query = "{$sqlParts['select']} {$sqlParts['from']} {$sqlParts['where']} {$sqlParts['having']} {$sqlParts['group_by']} {$sqlParts['order_by']} {$sqlParts['limit']}";
-    }
-    return $query;
+    return "{$sqlParts['select']} {$sqlParts['from']} {$sqlParts['where']} {$sqlParts['having']} {$sqlParts['group_by']} {$sqlParts['order_by']} {$sqlParts['limit']}";
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove code deprecated in 2019

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/210197584-e294ea23-153c-469f-a830-4e4efdc22600.png)

![image](https://user-images.githubusercontent.com/336308/210197698-00665863-4f1c-4a36-a2e6-690100b13ec0.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
This dates back to our datepicker conversion & the second part relates to a re-write on the `sort-by-char` / `alphabetQuery` mostly driven by @mattwire 

Comments
----------------------------------------