### PR TITLE
(REF) Remove _tagElement dynamic property

### DIFF
--- a/CRM/Activity/Form/Task/AddToTag.php
+++ b/CRM/Activity/Form/Task/AddToTag.php
@@ -48,7 +48,7 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
     $this->_tags = CRM_Core_BAO_Tag::getTags('civicrm_activity');
 
     foreach ($this->_tags as $tagID => $tagName) {
-      $this->_tagElement = &$this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
+      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
     }
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_activity');

--- a/CRM/Activity/Form/Task/RemoveFromTag.php
+++ b/CRM/Activity/Form/Task/RemoveFromTag.php
@@ -46,7 +46,7 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
     // add select for tag
     $this->_tags = CRM_Core_BAO_Tag::getTags('civicrm_activity');
     foreach ($this->_tags as $tagID => $tagName) {
-      $this->_tagElement = &$this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
+      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
     }
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_activity');

--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -78,7 +78,6 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
    * @var array
    */
   public $_tag;
-  public $_tagElement;
 
   /**
    * The params used for search.

--- a/CRM/Contact/Form/Task/AddToTag.php
+++ b/CRM/Contact/Form/Task/AddToTag.php
@@ -46,7 +46,7 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
     $this->_tags = CRM_Core_BAO_Tag::getTags();
 
     foreach ($this->_tags as $tagID => $tagName) {
-      $this->_tagElement = &$this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
+      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
     }
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');

--- a/CRM/Contact/Form/Task/RemoveFromTag.php
+++ b/CRM/Contact/Form/Task/RemoveFromTag.php
@@ -41,7 +41,7 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
     // add select for tag
     $this->_tags = CRM_Core_BAO_Tag::getTags();
     foreach ($this->_tags as $tagID => $tagName) {
-      $this->_tagElement = &$this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
+      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
     }
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');


### PR DESCRIPTION
Overview
----------------------------------------
The `$_tagElement` property was a bit odd. Look at how it was used:

```
foreach ($this->_tags as $tagID => $tagName) {
  $this->_tagElement = &$this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
}
```

Issues with this code:

1. The `_tagElement` is being re-written on each iteration of the loop. So `$this->_tagElement` will point to the last element of the loop. I can't see how that is useful for anyone? If it was `$this->_tagElement[] = ...` then maybe; but it's not
2. The `&$this` shows how old this code is. If I understand correctly this was required in PHP4 when objects were not passed as reference by default. I checked the hisory of one file and the property was added when the functionality was first developed, not as part of a later ticket.
3. `$this->_tagElement` is a dynamic property, which is deprecated in PHP 8.2.
4. `_tagElement` is written, but never read or used in core.

We could add a `@deprecated` annotation to `$_tagElement` first, but based on the above I think it's unlikely third-parties are using `_tagElement` and I suspect it's safe to just remove.

`CRM/Contact/Form/Search.php` did specify `$_tagElement` explicitly, but as the task classes don't extend `CRM_Contact_Form_Search` that doesn't make any sense...  

With this change no references to `_tagElement` remain in core.
