### PR TITLE
Move part of deprecated function `loadRelatedObjects` to calling functions

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -106,7 +106,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->find(TRUE);
     $contribution->_component = 'contribute';
     $ids = array_merge(CRM_Contribute_BAO_Contribution::getComponentDetails($this->_contributionId), $this->ids);
-    $contribution->loadRelatedObjects($this->input, $ids);
+
+    $contribution->loadRelatedObjects($this->_processorId, $ids);
     $this->assertNotEmpty($contribution->_relatedObjects['membership']);
     $this->assertArrayHasKey($this->_membershipId . '_' . $this->_membershipTypeID, $contribution->_relatedObjects['membership']);
     $this->assertTrue(is_a($contribution->_relatedObjects['membership'][$this->_membershipId . '_' . $this->_membershipTypeID], 'CRM_Member_BAO_Membership'));
@@ -185,7 +186,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpParticipantObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $contribution->loadRelatedObjects($this->input, $this->ids);
+    $contribution->loadRelatedObjects($this->_processorId, $this->ids);
     $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
     $this->assertStringContainsString('registration has been received and your status has been updated to Attended.', $msg['body']);
     $this->assertStringContainsString('Annual CiviCRM meet', $msg['html']);


### PR DESCRIPTION
Overview
----------------------------------------
Move part of deprecated function `loadRelatedObjects` to calling functions

Before
----------------------------------------
It turns out `$input` is only used for the extraction of one value (`$paymentProcessorID`) - so we should pass only that value in

After
----------------------------------------
Only that value is passed in

Technical Details
----------------------------------------
I copied back the code to the calling functions - one of them could be further tidied up but I left that out of scope for this PR to keep it easy to review

Comments
----------------------------------------
This code was the very first function we started refactoring off the form layer with test support - still going... a decade later