### PR TITLE
Remove unreachable code (since 2020)

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2851,11 +2851,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         'payment_processor_id' => 0,
       ];
     }
-
-    CRM_Contribute_BAO_ContributionPage::sendMail($contactID,
-      $form->_values,
-      $contribution->is_test
-    );
+    throw new CRM_Core_Exception('code is unreachable, exception is for clarity for refactoring');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove unreachable code (since 2020)

Before
----------------------------------------
This function MUST return an array due to the type hint

![image](https://user-images.githubusercontent.com/336308/210280359-8baca4fd-2e96-49a3-9536-db615617516d.png)

The last few lines of the code (after the last return has failed) do not return anything - so they will always cause a fatal error & never work. The earlier code suggests it should be unreachable & 2 years of no reports of this error confirms

![image](https://user-images.githubusercontent.com/336308/210280324-f6ebbd75-ddb6-409f-8373-afff09dddaab.png)


After
----------------------------------------
For clarity the unreachable function call is replaced with an exception

Technical Details
----------------------------------------
`CRM_Contribute_BAO_ContributionPage::sendMail` is toxic so less calls to it = better

Comments
----------------------------------------
