### PR TITLE
Allows multiple Free Text fields to be added to form layout

### DIFF
--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -363,6 +363,7 @@
       });
       this.each(function(ufFieldModel){
         const length = ufFieldModelsByKey[ufFieldModel.getSignature()].length > 1;
+        // Allow multiple free html fields, but note this would only work on an English install, and only if the field label hasn't been changed.
         const label = ufFieldModelsByKey[ufFieldModel.getSignature()][0].attributes.label !== 'Free HTML';
         const is_duplicate = length && label;
         if (is_duplicate !== ufFieldModel.get('is_duplicate')) {

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -358,12 +358,14 @@
      *
      */
     markDuplicates: function() {
-      var ufFieldModelsByKey = this.groupBy(function(ufFieldModel) {
+      const ufFieldModelsByKey = this.groupBy(function(ufFieldModel) {
         return ufFieldModel.getSignature();
       });
       this.each(function(ufFieldModel){
-        var is_duplicate = ufFieldModelsByKey[ufFieldModel.getSignature()].length > 1;
-        if (is_duplicate != ufFieldModel.get('is_duplicate')) {
+        const length = ufFieldModelsByKey[ufFieldModel.getSignature()].length > 1;
+        const label = ufFieldModelsByKey[ufFieldModel.getSignature()][0].attributes.label !== 'Free HTML';
+        const is_duplicate = length && label;
+        if (is_duplicate !== ufFieldModel.get('is_duplicate')) {
           ufFieldModel.set('is_duplicate', is_duplicate);
         }
       });


### PR DESCRIPTION
Overview
----------------------------------------
When building a conribution form, or altering the profile for a form, the Javascript rightly detects duplciate fields and prevents saving. Would like to make an exception for Free HTML fields (could be expanded to anything from the Formatting section if that section should expand)

Before
----------------------------------------
Work around is to save after each change. The form allows another Free HTML element to be added

After
----------------------------------------
Change alters the markDuplicates() method so that is_duplicate class is only applied when the ufFieldModel does not have the label 'Free HTML'. This will allow multiple Free HTML fields for formatting forms

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

