### PR TITLE
Petition ThankYou.tpl: fix strong typo

### DIFF
--- a/templates/CRM/Campaign/Page/Petition/ThankYou.tpl
+++ b/templates/CRM/Campaign/Page/Petition/ThankYou.tpl
@@ -20,7 +20,7 @@
 {/if}
 
 {if $status_id eq 4}
-  <p>{ts}You have already signed this petition but we<strong>need to confirm your email address</strong>.{/ts}</p>
+  <p><strong>{ts}You have already signed this petition but we need to confirm your email address.{/ts}</strong></p>
   <b>{ts}IMPORTANT{/ts}</b>
   : {ts}Before we can add your signature, you must validate your email address by clicking on the activation link in the confirmation e-mail. Sometimes our confirmation emails get flagged as spam and are moved to your spam folder.{/ts}
   <br/>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a typo in a confirmation message, but also changes how the message is bolded.

Edit: it says "survey" here because of word-replacements on my test site.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/210447001-f819e957-9453-49fe-b50e-7df5e19f503a.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/210446916-550a36cf-62b1-4f8f-ad92-53978c25f9bc.png)
