### PR TITLE
[NFC] Restore locale properly after test

### DIFF
--- a/tests/phpunit/CRM/Core/I18n/LocaleTest.php
+++ b/tests/phpunit/CRM/Core/I18n/LocaleTest.php
@@ -147,7 +147,7 @@ class CRM_Core_I18n_LocaleTest extends CiviUnitTestCase {
     $dao = new CRM_Core_DAO();
     // When query() uses strtolower this returns NULL instead
     $this->assertEquals(1, $dao->query("INSERT INTO foo VALUES ('Turkish Delight')"));
-    setlocale(LC_ALL, 'en_US');
+    setlocale(LC_ALL, 'en_US.utf8');
     CRM_Core_DAO::executeQuery("DROP TABLE foo");
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This resolves a bizarre quantum entanglement between the turkish upper-case `I` test and a CRM_Core_ResourcesTest fail that then cascades into dedupemerger test fails.

I can't explain why it doesn't happen on the official test nodes, but it happens in another test environment and this fixes it and since this change seems correct regardless, then if this doesn't cause any issues here then I don't see the harm.