### PR TITLE
avoid empty error message when submitting PCP page.

### DIFF
--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -62,17 +62,6 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
     $pcpStatus = CRM_Core_OptionGroup::values("pcp_status");
     $approvedId = CRM_Core_PseudoConstant::getKey('CRM_PCP_BAO_PCP', 'status_id', 'Approved');
 
-    // check if PCP is created by anonymous user
-    $anonymousPCP = CRM_Utils_Request::retrieve('ap', 'Boolean', $this);
-    if ($anonymousPCP) {
-      $loginURL = $config->userSystem->getLoginURL();
-      $anonMessage = ts('Once you\'ve received your new account welcome email, you can <a href=%1>click here</a> to login and promote your campaign page.', [1 => $loginURL]);
-      CRM_Core_Session::setStatus($anonMessage, ts('Success'), 'success');
-    }
-    else {
-      $statusMessage = ts('The personal campaign page you requested is currently unavailable. However you can still support the campaign by making a contribution here.');
-    }
-
     $pcpBlock = new CRM_PCP_DAO_PCPBlock();
     $pcpBlock->entity_table = CRM_PCP_BAO_PCP::getPcpEntityTable($pcpInfo['page_type']);
     $pcpBlock->entity_id = $pcpInfo['page_id'];
@@ -84,6 +73,21 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
     }
     elseif ($pcpInfo['page_type'] == 'event') {
       $urlBase = 'civicrm/event/register';
+    }
+
+    // check if PCP is created by anonymous user
+    $anonymousPCP = CRM_Utils_Request::retrieve('ap', 'Boolean', $this);
+    if ($anonymousPCP) {
+      $loginURL = $config->userSystem->getLoginURL();
+      $anonMessage = ts('Once you\'ve received your new account welcome email, you can <a href=%1>click here</a> to login and promote your campaign page.', [1 => $loginURL]);
+      CRM_Core_Session::setStatus($anonMessage, ts('Success'), 'success');
+      CRM_Utils_System::redirect(CRM_Utils_System::url($urlBase,
+          "reset=1&id=" . $pcpInfo['page_id'],
+          FALSE, NULL, FALSE, TRUE
+      ));
+    }
+    else {
+      $statusMessage = ts('The personal campaign page you requested is currently unavailable. However you can still support the campaign by making a contribution here.');
     }
 
     if ($pcpInfo['status_id'] != $approvedId || !$pcpInfo['is_active']) {


### PR DESCRIPTION
Overview
----------------------------------------

When submitting a PCP as an anonymous user, an empty error message is generated on the last step. It's generated because the PCP page is not yet active. However, that should not create a confusing error.

Before
----------------------------------------
If you:

 * create a contribution page
 * enable Personal Campaign Pages
 * Copy and paste the link to create a PCP page into a browser tab that is not lgged in
 * Follow the steps to create your page
 * On the last step, hit submit
 * You get the following messages:
 
![empty-error](https://user-images.githubusercontent.com/4511942/210603877-480658b3-0a88-4157-987b-67b1f12cdb60.png)

After
----------------------------------------

Instead, you should only get the first two messages:

![fixed-no-error](https://user-images.githubusercontent.com/4511942/210604044-4ae9ded2-f72d-494e-a026-42a1e0c2237e.png)

Technical Details
----------------------------------------

The code checks for anonymous users and generates the right messages, but, instead of redirecting right away, we fall through and get caught in the check that warns people that they are accessing a PCP page that is not yet enabled. By redirecting right away we avoid this problem.

