### PR TITLE
[NFC] Remove broken test

### DIFF
--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -2,29 +2,8 @@
 
 /**
  *  File for the Participant import class
- *
- *  (PHP 5)
- *
- * @package   CiviCRM
- *
- *   This file is part of CiviCRM
- *
- *   CiviCRM is free software; you can redistribute it and/or
- *   modify it under the terms of the GNU Affero General Public License
- *   as published by the Free Software Foundation; either version 3 of
- *   the License, or (at your option) any later version.
- *
- *   CiviCRM is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU Affero General Public License for more details.
- *
- *   You should have received a copy of the GNU Affero General Public
- *   License along with this program.  If not, see
- *   <http://www.gnu.org/licenses/>.
  */
 
-use Civi\Api4\Mapping;
 use Civi\Api4\UserJob;
 
 /**
@@ -32,7 +11,7 @@ use Civi\Api4\UserJob;
  * @group headless
  * @group import
  */
-class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
+class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
 
   use CRMTraits_Custom_CustomDataTrait;
 
@@ -130,49 +109,6 @@ class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test the full form-flow import.
-   *
-   * @dataProvider importData
-   */
-  public function testImportCSV($csv, $mapper) :void {
-    $this->campaignCreate(['name' => 'Soccer cup']);
-    $this->eventCreate(['title' => 'Rain-forest Cup Youth Soccer Tournament']);
-    $this->individualCreate(['email' => 'mum@example.com']);
-    $this->importCSV($csv, $mapper);
-    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
-    $row = $dataSource->getRow();
-    $this->assertEquals('IMPORTED', $row['_status']);
-    $this->callAPISuccessGetSingle('Participant', ['campaign_id' => 'Soccer Cup']);
-    $mapping = Mapping::get()->addWhere('mapping_type_id:name', '=', 'Import Participant')->execute()->first();
-    $this->assertEquals('my mapping', $mapping['name']);
-    $this->assertEquals('new mapping', $mapping['description']);
-  }
-
-  /**
-   * Data provider for importCSV.
-   */
-  public function importData(): array {
-    $defaultMapper = [
-      ['name' => 'event_id'],
-      ['name' => 'campaign_id'],
-      ['name' => 'email'],
-      ['name' => 'fee_amount'],
-      ['name' => 'fee_currency'],
-      ['name' => 'fee_level'],
-      ['name' => 'is_pay_later'],
-      ['name' => 'role_id'],
-      ['name' => 'source'],
-      ['name' => 'status_id'],
-      ['name' => 'register_date'],
-      ['name' => 'do_not_import'],
-    ];
-    return [
-      ['csv' => 'participant.csv', 'mapper' => $defaultMapper],
-      ['csv' => 'participant_with_event_id.csv', 'mapper' => $defaultMapper],
-    ];
-  }
-
-  /**
    * Test that an external id will not match to a deleted contact..
    */
   public function testImportWithExternalID() :void {
@@ -201,7 +137,6 @@ class CRM_Participant_Import_Parser_ParticipantTest extends CiviUnitTestCase {
    * @param array $submittedValues
    *
    * @return int
-   * @noinspection PhpDocMissingThrowsInspection
    */
   protected function getUserJobID(array $submittedValues = []): int {
     $userJobID = UserJob::create()->setValues([


### PR DESCRIPTION
Overview
----------------------------------------
This test is broken in a number of ways which I'm not interested in taking on fixing at this time:

* It doesn't even run when the suite is run because the class name is different than the file. (This is a trick you can use to get all your tests to pass!) So it's not doing anything at the moment anyway.
* It tries to look for a file tests/phpunit/CRM/Event/Import/Parser/data/participant_with_event_id.csv which does not exist so it fails even when it does run.
* If you remove that item from the dataprovider it still fails so either the test is wrong or the actual import code is wrong. I dunno.