### PR TITLE
(dev/core#3844) Dummy payment processor should be flagged as such on …

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1406,6 +1406,15 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    * Set form variables if contribution ID is found
    */
   public function assignFormVariablesByContributionID() {
+    $dummyTitle = 0;
+    foreach ($this->_paymentProcessors as $pp) {
+      if ($pp['class_name'] == 'Payment_Dummy') {
+        $dummyTitle = $pp['name'];
+        break;
+      }
+    }
+    $this->assign('dummyTitle', $dummyTitle);
+
     if (empty($this->_ccid)) {
       return;
     }

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -46,7 +46,7 @@
   </script>
 {/literal}
 
-  {if $action & 1024}
+  {if ($action & 1024) or $dummyTitle}
     {include file="CRM/Contribute/Form/Contribution/PreviewHeader.tpl"}
   {/if}
 

--- a/templates/CRM/Contribute/Form/Contribution/PreviewHeader.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PreviewHeader.tpl
@@ -8,8 +8,16 @@
  +--------------------------------------------------------------------+
 *}
 {* Displays Test-drive mode header for Contribution pages. *}
-<div class="messages status no-popup">
+{if $action & 1024}
+  <div class="messages status no-popup">
     <i class="crm-i fa-cogs" aria-hidden="true"></i>
     <strong>{ts}Test-drive Your Contribution Page{/ts}</strong>
     <p>{ts}This page is currently running in <strong>test-drive mode</strong>. Transactions will be sent to your payment processor's test server. <strong>No live financial transactions will be submitted. However, a contact record will be created or updated and a test contribution record will be saved to the database. Use obvious test contact names so you can review and delete these records as needed. Test contributions are not visible on the Contributions tab, but can be viewed by searching for 'Test Contributions' in the CiviContribute search form.</strong> Refer to your payment processor's documentation for information on values to use for test credit card number, security code, postal code, etc.{/ts}</p>
-</div>
+  </div>
+{else}
+  <div class="messages status no-popup">
+    <i class="crm-i fa-cogs"></i>
+    <strong>{ts}Test payment processor on Your Contribution Page{/ts}</strong>
+    <p>{ts 1=$dummyTitle|escape}This page is currently configured to use the <strong>%1 payment processor</strong>. <strong>No live financial transactions will be submitted if %1 payment processor is selected. However, a contact record will be created or updated and a live contribution record will be saved to the database with no actual financial transaction. Remove %1 payment processor before going live.</strong>{/ts}</p>
+  </div>
+{/if}


### PR DESCRIPTION
…LIVE page

Overview
----------------------------------------
When dummy payment processor is configured for contribution pages/ event, there is no indication that is NOT a real transaction. This could be confusing and we should flag any LIVE page that is configured with dummy processor.

Before
----------------------------------------
No indication

After
----------------------------------------
![ec](https://user-images.githubusercontent.com/3455173/210722909-8ce1f654-3e16-493f-b9b5-45538894f16b.png)
