### PR TITLE
Status Check - Raise severity of the check for signing keys

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -210,11 +210,11 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
     if (!$found) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Some components and extensions may need to generate cryptographic signatures. Please configure <a %1>CIVICRM_SIGN_KEYS</a>. ',
+        ts('The system requires a cryptographic signing key. Please configure <a %1>CIVICRM_SIGN_KEYS</a>. ',
           [1 => 'href="https://docs.civicrm.org/sysadmin/en/latest/setup/secret-keys/" target="_blank"']
         ),
-        ts('Signing Key Recommended'),
-        \Psr\Log\LogLevel::NOTICE,
+        ts('Signing Key Required'),
+        \Psr\Log\LogLevel::ERROR,
         'fa-lock'
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------

The `CIVICRM_SIGN_KEYS` was introduced as an optional feature. It's becoming important as more components (like `afform`) rely on JWTs.

Before
----------------------------------------

If `CIVICRM_SIGN_KEYS` is missing, then it gives a `NOTICE`.

After
----------------------------------------

If `CIVICRM_SIGN_KEYS` is missing, then it gives ~~a `WARNING`~~ an `ERROR`.
