### PR TITLE
Fix Undefined index: name Notice in civicrm_api3_message_template_send

### DIFF
--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -102,7 +102,7 @@ function civicrm_api3_message_template_send($params) {
     // the 'wrong' BAO ones. It works, it's tested &
     // we can do better in apiv4 once we get a suitable
     // api there.
-    if ($spec['name'] !== 'workflow' && isset($spec['api.aliases']) && array_key_exists($field, $params)) {
+    if (($spec['name'] ?? '') !== 'workflow' && isset($spec['api.aliases']) && array_key_exists($field, $params)) {
       $params[CRM_Utils_Array::first($spec['api.aliases'])] = $params[$field];
       unset($params[$field]);
     }


### PR DESCRIPTION
The code assumed that each item of the spec had a 'name' key, but this not so.

(I think this PR is the fix. I do wonder why you need 'name' though here - could use `$field`?)

Tagging @eileenmcnaughton as came in in this commit: cac79b26627