### PR TITLE
searchkit - fix broken update task in dropdown

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -15,7 +15,7 @@
       action: 'update',
       select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable'],
       loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
-      where: [['deprecated', '=', FALSE], ["readonly", "=", false]],
+      where: [['deprecated', '=', false], ["readonly", "=", false]],
     }).then(function(fields) {
         ctrl.fields = fields;
       });


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
Run a search. From the results choose to Update from the actions dropdown. Nothing happens.

After
----------------------------------------
Better.

Technical Details
----------------------------------------
false !== FALSE in javascript

Comments
----------------------------------------
Broke in 5.57 it looks like.
