### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Case_Form_CaseView

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -26,10 +26,58 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
   private $_mergeCases = FALSE;
 
   /**
+   * Related case view
+   *
+   * @var bool
+   * @internal
+   */
+  public $_showRelatedCases = FALSE;
+
+  /**
+   * Does user have capabilities to access all cases and activities
+   *
+   * @var bool
+   * @internal
+   */
+  public $_hasAccessToAllCases = FALSE;
+
+  /**
+   * ID of contact being viewed
+   *
+   * @var int
+   * @internal
+   */
+  public $_contactID;
+
+  /**
+   * ID of case being viewed
+   *
+   * @var int
+   * @internal
+   */
+  public $_caseID;
+
+  /**
+   * Various case details, for use in the template
+   *
+   * @var array
+   * @internal
+   */
+  public $_caseDetails = [];
+
+  /**
+   * The name of the type associated with the current case
+   *
+   * @var string
+   * @internal
+   */
+  public $_caseType;
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {
-    $this->_showRelatedCases = $_GET['relatedCases'] ?? NULL;
+    $this->_showRelatedCases = (bool) ($_GET['relatedCases'] ?? FALSE);
 
     $xmlProcessorProcess = new CRM_Case_XMLProcessor_Process();
     $isMultiClient = $xmlProcessorProcess->getAllowMultipleCaseClients();
@@ -40,7 +88,6 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     if ($this->_showRelatedCases) {
       $relatedCases = $this->get('relatedCases');
       if (!isset($relatedCases)) {
-        $cId = CRM_Utils_Request::retrieve('cid', 'Integer');
         $caseId = CRM_Utils_Request::retrieve('id', 'Integer');
         $relatedCases = CRM_Case_BAO_Case::getRelatedCases($caseId);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in CRM_Case_Form_CaseView.

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
The properties are defined upfront, and are not dynamic.

I've also ensured `_showRelatedCases` is always a boolean (rather than simply a "truthy" value), which better reflects how it is used.

Also removes an unused `$cId` variable.

Technical Details
----------------------------------------
 Most of these should probably be `private`, but given the number of dynamic properties across the codebase if we take that approach everywhere we're bound to break some extensions. For now I've marked the properties as `internal` to hopefully discourage usage by extensions, and the visibility can be revisited in future.