### PR TITLE
(REF) Remove _prefElement dynamic property

### DIFF
--- a/CRM/Contact/Form/Task/AlterPreferences.php
+++ b/CRM/Contact/Form/Task/AlterPreferences.php
@@ -34,7 +34,7 @@ class CRM_Contact_Form_Task_AlterPreferences extends CRM_Contact_Form_Task {
     $privacyOptions = CRM_Core_SelectValues::privacy();
 
     foreach ($privacyOptions as $prefID => $prefName) {
-      $this->_prefElement = &$this->addElement('checkbox', "pref[$prefID]", NULL, $prefName);
+      $this->addElement('checkbox', "pref[$prefID]", NULL, $prefName);
     }
 
     $this->addDefaultButtons(ts('Set Privacy Options'));


### PR DESCRIPTION
Overview
----------------------------------------
Remove _prefElement dynamic property. Esentially the same issue as in https://github.com/civicrm/civicrm-core/pull/25265, which was merged last week (and this description is basically a copy...)

The `$_prefElement` property was a bit odd. Look at how it was used:

```
foreach ($privacyOptions as $prefID => $prefName) {
  $this->_prefElement = &$this->addElement('checkbox', "pref[$prefID]", NULL, $prefName);
}
```

Issues with this code:

1. The `_prefElement` is being re-written on each iteration of the loop. So `$this->_prefElement` will point to the last element of the loop. I can't see how that is useful for anyone? If it was `$this->_prefElement[] = ...` then maybe; but it's not
2. The `&$this` shows how old this code is. If I understand correctly this was required in PHP4 when objects were not passed as reference by default. This code dates back to the SVN days.
3. `$this->_prefElement` is a dynamic property, which is deprecated in PHP 8.2.
4. `_prefElement` is written, but never read or used in core.

We could add a `@deprecated` annotation to `$_prefElement` first, but based on the above I think it's unlikely third-parties are using `_prefElement` and I suspect it's safe to just remove.
