### PR TITLE
(NFC) Reference classes with correct case

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -752,7 +752,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    *   True if used for search else false.
    * @param string $label
    *   Label for custom field.
-   * @return \HTML_QuickForm_Element|null
+   * @return \HTML_QuickForm_element|null
    * @throws \CRM_Core_Exception
    */
   public static function addQuickFormElement(

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -416,7 +416,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   For datepicker elements this is consistent with the data
    *   from CRM_Utils_Date::getDatePickerExtra
    *
-   * @return HTML_QuickForm_Element
+   * @return HTML_QuickForm_element
    *   Could be an error object
    *
    * @throws \CRM_Core_Exception
@@ -1598,7 +1598,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   - context - @see CRM_Core_DAO::buildOptionsContext
    * @param bool $required
    * @throws CRM_Core_Exception
-   * @return HTML_QuickForm_Element
+   * @return HTML_QuickForm_element
    */
   public function addSelect($name, $props = [], $required = FALSE) {
     if (!isset($props['entity'])) {
@@ -1713,7 +1713,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @throws \CRM_Core_Exception
    * @throws \Exception
    * @return mixed
-   *   HTML_QuickForm_Element
+   *   HTML_QuickForm_element
    *   void
    */
   public function addField($name, $props = [], $required = FALSE, $legacyDate = TRUE) {
@@ -2138,7 +2138,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param string $defaultCurrency
    * @param bool $freezeCurrency
    *
-   * @return \HTML_QuickForm_Element
+   * @return HTML_QuickForm_element
    */
   public function addMoney(
     $name,
@@ -2222,7 +2222,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   - class, etc. - other html properties
    * @param bool $required
    *
-   * @return HTML_QuickForm_Element
+   * @return HTML_QuickForm_element
    */
   public function addEntityRef($name, $label = '', $props = [], $required = FALSE) {
     // Default properties
@@ -2538,7 +2538,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param string $elementName
    * @param array $settings
    *
-   * @return HTML_QuickForm_Element
+   * @return HTML_QuickForm_element
    */
   public function addChainSelect($elementName, $settings = []) {
     $required = $settings['required'] ?? FALSE;

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -722,13 +722,13 @@ WHERE civicrm_address.geo_code_1 IS NOT NULL
   /**
    * Get the complete information for one or more events.
    *
-   * @param date $start
+   * @param Date $start
    *   Get events with start date >= this date.
    * @param int $type Get events on the a specific event type (by event_type_id).
    *   Get events on the a specific event type (by event_type_id).
    * @param int $eventId Return a single event - by event id.
    *   Return a single event - by event id.
-   * @param date $end
+   * @param Date $end
    *   Also get events with end date >= this date.
    * @param bool $onlyPublic Include public events only, default TRUE.
    *   Include public events only, default TRUE.

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -187,7 +187,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       if (empty($params['contact_id'])) {
         $error = $this->checkContactDuplicate($formatValues);
 
-        if (CRM_Core_Error::isAPIError($error, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
+        if (CRM_Core_Error::isAPIError($error, CRM_Core_Error::DUPLICATE_CONTACT)) {
           $matchedIDs = (array) $error['error_message']['params'];
           if (count($matchedIDs) >= 1) {
             foreach ($matchedIDs as $contactId) {

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -73,7 +73,7 @@ class CRM_Extension_Downloader {
   /**
    * Determine whether downloading is supported.
    *
-   * @param \CRM_EXtension_Info $extensionInfo Optional info for (updated) extension
+   * @param \CRM_Extension_Info $extensionInfo Optional info for (updated) extension
    *
    * @return array
    *   list of error messages; empty if OK

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -204,7 +204,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
       if (empty($formatValues['id']) && empty($formatValues['contact_id'])) {
         $error = $this->checkContactDuplicate($formatValues);
 
-        if (CRM_Core_Error::isAPIError($error, CRM_Core_ERROR::DUPLICATE_CONTACT)) {
+        if (CRM_Core_Error::isAPIError($error, CRM_Core_Error::DUPLICATE_CONTACT)) {
           $matchedIDs = (array) $error['error_message']['params'];
           if (count($matchedIDs) > 1) {
             throw new CRM_Core_Exception('Multiple matching contact records detected for this row. The membership was not imported', CRM_Import_Parser::ERROR);

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2695,7 +2695,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     $communicationMethods = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method');
 
     // Explode padded values.
-    $values = CRM_utils_array::explodePadded($value);
+    $values = CRM_Utils_Array::explodePadded($value);
     // Flip values, compute intersection with $communicationMethods, and implode with commas.
     $value = implode(', ', array_intersect_key($communicationMethods, array_flip($values)));
     return $value;

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -850,9 +850,9 @@ class CRM_Utils_Date {
    * Find whether today's date lies in
    * the given range
    *
-   * @param date $startDate
+   * @param Date $startDate
    *   Start date for the range.
-   * @param date $endDate
+   * @param Date $endDate
    *   End date for the range.
    *
    * @return bool
@@ -915,9 +915,9 @@ class CRM_Utils_Date {
   /**
    * Calculate Age in Years if greater than one year else in months.
    *
-   * @param date $birthDate
+   * @param Date $birthDate
    *   Birth Date.
-   * @param date $targetDate
+   * @param Date $targetDate
    *   Target Date. (show age on specific date)
    *
    * @return array

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -63,7 +63,7 @@ class CRM_Utils_Mail_Incoming {
       return self::formatMailRfc822Digest($part, $attachments);
     }
 
-    if ($part instanceof ezcMailMultiPart) {
+    if ($part instanceof ezcMailMultipart) {
       return self::formatMailMultipart($part, $attachments);
     }
 
@@ -86,19 +86,19 @@ class CRM_Utils_Mail_Incoming {
    * @throws Exception
    */
   public static function formatMailMultipart($part, &$attachments) {
-    if ($part instanceof ezcMailMultiPartAlternative) {
+    if ($part instanceof ezcMailMultipartAlternative) {
       return self::formatMailMultipartAlternative($part, $attachments);
     }
 
-    if ($part instanceof ezcMailMultiPartDigest) {
+    if ($part instanceof ezcMailMultipartDigest) {
       return self::formatMailMultipartDigest($part, $attachments);
     }
 
-    if ($part instanceof ezcMailMultiPartRelated) {
+    if ($part instanceof ezcMailMultipartRelated) {
       return self::formatMailMultipartRelated($part, $attachments);
     }
 
-    if ($part instanceof ezcMailMultiPartMixed) {
+    if ($part instanceof ezcMailMultipartMixed) {
       return self::formatMailMultipartMixed($part, $attachments);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Reference classes with correct case.

Before
----------------------------------------
Whilst cases (and other tokens) are case-insensitive in PHP, it's considered best practice to declare them in the same case as was used when the token is defined. IDE's and static analysis tools will sometimes complain if the incorrect case is used.

After
----------------------------------------
Correct case is used.

Comments
----------------------------------------
This is a really inconsequential change, but I figured it wouldn't hurt. For some context, I've been using phpstan to help track down dynamic properties, and this will reduce some of the _noise_ that the tool is reporting on.
