### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Core_I18n_Form

### DIFF
--- a/CRM/Core/I18n/Form.php
+++ b/CRM/Core/I18n/Form.php
@@ -16,6 +16,22 @@
  */
 class CRM_Core_I18n_Form extends CRM_Core_Form {
 
+  /**
+   * List of available locales
+   *
+   * @var array
+   * @internal
+   */
+  public $_locales = [];
+
+  /**
+   * Database structure of translatable columns
+   *
+   * @var array
+   * @internal
+   */
+  public $_structure = [];
+
   public function buildQuickForm() {
     $config = CRM_Core_Config::singleton();
     $tsLocale = CRM_Core_I18n::getLocale();


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in CRM_Core_I18n_Form.

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
The properties are defined upfront, and are not dynamic.

Technical Details
----------------------------------------
These should probably be `private`, but given the number of dynamic properties across the codebase if we take that approach everywhere we're bound to break some extensions. For now I've marked the properties as `internal` to hopefully discourage usage by extensions, and the visibility can be revisited in future.