### PR TITLE
Php8.2 Contact import Map Field screen - remove undefined property usage (mutliple)

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -41,7 +41,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @return string
    */
-  public function defaultFromColumnName($columnName) {
+  public function defaultFromColumnName(string $columnName): string {
 
     if (!preg_match('/^[a-z0-9 ]$/i', $columnName)) {
       if ($columnKey = array_search($columnName, $this->getFieldTitles())) {
@@ -70,7 +70,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function preProcess() {
+  public function preProcess(): void {
     $this->_mapperFields = $this->getAvailableFields();
     $this->_contactSubType = $this->getSubmittedValue('contactSubType');
     //format custom field names, CRM-2676
@@ -109,7 +109,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->addSavedMappingFields();
 
     $this->addFormRule(['CRM_Contact_Import_Form_MapField', 'formRule']);
@@ -334,7 +334,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public static function formRule(array $fields) {
     if (!empty($fields['saveMapping'])) {
-      // todo - this is non-sensical - sane js is better. PR to fix got stale but
+      // todo - this is nonsensical - sane js is better. PR to fix got stale but
       // is here https://github.com/civicrm/civicrm-core/pull/23950
       CRM_Core_Smarty::singleton()->assign('isCheked', TRUE);
     }
@@ -343,8 +343,10 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
    * Process the mapped fields and map it into the uploaded file.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function postProcess() {
+  public function postProcess(): void {
     $params = $this->controller->exportValues('MapField');
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $this->submit($params);
@@ -359,7 +361,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @return array
    */
-  public function formatCustomFieldName($fields) {
+  public function formatCustomFieldName(array $fields): array {
     //CRM-2676, replacing the conflict for same custom field name from different custom group.
     $fieldIds = $formattedFieldNames = [];
     foreach ($fields as $key => $value) {
@@ -388,12 +390,11 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * Extracted to add testing & start refactoring.
    *
-   * @param $params
-   * @param $mapperKeys
+   * @param array $params
    *
    * @throws \CRM_Core_Exception
    */
-  public function submit($params) {
+  public function submit(array $params): void {
     $this->set('columnNames', $this->_columnNames);
 
     // store mapping Id to display it in the preview page
@@ -431,7 +432,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * Did the user specify duplicates matching should not be attempted.
    *
    * @return bool
-   * @throws \CRM_Core_Exception
    */
   private function isIgnoreDuplicates(): bool {
     return ((int) $this->getSubmittedValue('onDuplicate')) === CRM_Import_Parser::DUPLICATE_NOCHECK;
@@ -473,9 +473,11 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * e.g ['first_name' => FALSE, 'email' => TRUE, 'street_address' => TRUE']
    *
+   * @param bool $name
+   *
    * @return bool
    */
-  private function isLocationTypeRequired($name): bool {
+  private function isLocationTypeRequired(bool $name): bool {
     if (!isset(Civi::$statics[__CLASS__]['location_fields'])) {
       Civi::$statics[__CLASS__]['location_fields'] = (new CRM_Contact_Import_Parser_Contact())->setUserJobID($this->getUserJobID())->getFieldsWhichSupportLocationTypes();
     }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -72,7 +72,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function preProcess(): void {
     $this->_mapperFields = $this->getAvailableFields();
-    $this->_contactSubType = $this->getSubmittedValue('contactSubType');
     //format custom field names, CRM-2676
     $contactType = $this->getContactType();
 

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -117,7 +117,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $defaults = [];
     $mapperKeys = array_keys($this->_mapperFields);
-    $hasColumnNames = !empty($this->_columnNames);
+    $hasColumnNames = $this->getSubmittedValue('skipColumnHeader');
+
 
     $this->_location_types = ['Primary' => ts('Primary')] + CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
@@ -292,7 +293,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       else {
         if ($hasColumnNames) {
           // do array search first to see if has mapped key
-          $columnKey = array_search($this->_columnNames[$i], $this->getFieldTitles());
+          $columnKey = array_search($columnHeader, $this->getFieldTitles(), TRUE);
           if (isset($this->_fieldUsed[$columnKey])) {
             $defaults["mapper[$i]"] = [$columnKey];
             $this->_fieldUsed[$key] = TRUE;
@@ -300,7 +301,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           else {
             // Infer the default from the column names if we have them
             $defaults["mapper[$i]"] = [
-              $this->defaultFromColumnName($this->_columnNames[$i]),
+              $this->defaultFromColumnName($columnHeader),
             ];
           }
         }
@@ -394,8 +395,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   public function submit(array $params): void {
-    $this->set('columnNames', $this->_columnNames);
-
     // store mapping Id to display it in the preview page
     $this->set('loadMappingId', CRM_Utils_Array::value('mappingId', $params));
 

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -277,9 +277,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $processor->setContactSubType($this->getSubmittedValue('contactSubType'));
     $mapper = $this->getSubmittedValue('mapper');
 
-    for ($i = 0; $i < $this->_columnCount; $i++) {
+    foreach ($this->getColumnHeaders() as $i => $columnHeader) {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
-      $last_key = 0;
 
       // Don't set any defaults if we are going to the next page.
       // ... or coming back.

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -120,10 +120,10 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $hasColumnNames = $this->getSubmittedValue('skipColumnHeader');
 
 
-    $this->_location_types = ['Primary' => ts('Primary')] + CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $this->getLocationTypes();
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
     $this->assign('defaultLocationType', $defaultLocationType->id);
-    $this->assign('defaultLocationTypeLabel', $this->_location_types[$defaultLocationType->id]);
+    $this->assign('defaultLocationTypeLabel', $this->getLocationTypeLabel($defaultLocationType->id));
 
     /* Initialize all field usages to false */
     foreach ($mapperKeys as $key) {
@@ -137,7 +137,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $imProviders = CRM_Core_PseudoConstant::get('CRM_Core_DAO_IM', 'provider_id');
     $websiteTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Website', 'website_type_id');
 
-    foreach ($this->_location_types as $key => $value) {
+    foreach ($this->getLocationTypes() as $key => $value) {
       $sel3['phone'][$key] = &$phoneTypes;
       $sel3['phone_ext'][$key] = &$phoneTypes;
       //build array for IM service provider type for contact
@@ -192,7 +192,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         foreach ($relatedFields as $name => $field) {
           $values[$name] = $field['title'];
           if ($this->isLocationTypeRequired($name)) {
-            $sel3[$key][$name] = $this->_location_types;
+            $sel3[$key][$name] = $this->getLocationTypes();
           }
           elseif ($name === 'url') {
             $sel3[$key][$name] = $websiteTypes;
@@ -246,7 +246,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           }
         }
 
-        foreach ($this->_location_types as $k => $value) {
+        foreach ($this->getLocationTypes() as $k => $value) {
           $sel4[$key]['phone'][$k] = &$phoneTypes;
           $sel4[$key]['phone_ext'][$k] = &$phoneTypes;
           //build array of IM service provider for related contact
@@ -256,7 +256,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       else {
         $options = NULL;
         if ($this->isLocationTypeRequired($key)) {
-          $options = $this->_location_types;
+          $options = $this->getLocationTypes();
         }
         elseif ($key === 'url') {
           $options = $websiteTypes;
@@ -489,6 +489,25 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $parser = new CRM_Contact_Import_Parser_Contact();
     $parser->setUserJobID($this->getUserJobID());
     return $parser;
+  }
+
+  /**
+   * Get the location types for import, including the pseudo-type 'Primary'.
+   *
+   * @return array
+   */
+  protected function getLocationTypes(): array {
+    return ['Primary' => ts('Primary')] + CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+  }
+
+  /**
+   * Get the location types for import, including the pseudo-type 'Primary'.
+   * @param int|string $type
+   *   Location Type ID or 'Primary'.
+   * @return string
+   */
+  protected function getLocationTypeLabel($type): string {
+    return $this->getLocationTypes()[$type];
   }
 
 }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -173,12 +173,12 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         $id = $first = $second = NULL;
       }
       if (($first === 'a' && $second === 'b') || ($first === 'b' && $second === 'a')) {
-        $cType = $contactRelationCache[$id]["contact_type_{$second}"];
+        $cType = $contactRelationCache[$id]["contact_type_$second"];
 
-        //CRM-5125 for contact subtype specific relationshiptypes
+        //CRM-5125 for contact subtype specific RelationshipTypes
         $cSubType = NULL;
-        if (!empty($contactRelationCache[$id]["contact_sub_type_{$second}"])) {
-          $cSubType = $contactRelationCache[$id]["contact_sub_type_{$second}"];
+        if (!empty($contactRelationCache[$id]["contact_sub_type_$second"])) {
+          $cSubType = $contactRelationCache[$id]["contact_sub_type_$second"];
         }
 
         if (!$cType) {
@@ -328,10 +328,10 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @param array $fields
    *   Posted values of the form.
    *
-   * @return array|bool
+   * @return bool
    *   list of errors to be posted back to the form
    */
-  public static function formRule(array $fields) {
+  public static function formRule(array $fields): bool {
     if (!empty($fields['saveMapping'])) {
       // todo - this is nonsensical - sane js is better. PR to fix got stale but
       // is here https://github.com/civicrm/civicrm-core/pull/23950
@@ -374,7 +374,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
       if (!empty($groupTitles)) {
         foreach ($groupTitles as $fId => $values) {
-          $key = "custom_{$fId}";
+          $key = "custom_$fId";
           $groupTitle = $values['groupTitle'];
           $formattedFieldNames[$key] = $fields[$key] . ' :: ' . $groupTitle;
         }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -473,11 +473,11 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * e.g ['first_name' => FALSE, 'email' => TRUE, 'street_address' => TRUE']
    *
-   * @param bool $name
+   * @param string $name
    *
    * @return bool
    */
-  private function isLocationTypeRequired(bool $name): bool {
+  private function isLocationTypeRequired(string $name): bool {
     if (!isset(Civi::$statics[__CLASS__]['location_fields'])) {
       Civi::$statics[__CLASS__]['location_fields'] = (new CRM_Contact_Import_Parser_Contact())->setUserJobID($this->getUserJobID())->getFieldsWhichSupportLocationTypes();
     }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -75,8 +75,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     //format custom field names, CRM-2676
     $contactType = $this->getContactType();
 
-    $this->_contactType = $contactType;
-
     if ($this->isIgnoreDuplicates()) {
       //Mark Dedupe Rule Fields as required, since it's used in matching contact
       foreach (CRM_Contact_BAO_ContactType::basicTypes() as $cType) {
@@ -117,8 +115,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $defaults = [];
     $mapperKeys = array_keys($this->_mapperFields);
-    $hasColumnNames = $this->getSubmittedValue('skipColumnHeader');
-
+    $hasColumnNames = !empty($this->getDataSourceObject()->getColumnHeaders());
 
     $this->getLocationTypes();
     $defaultLocationType = CRM_Core_BAO_LocationType::getDefault();
@@ -203,7 +200,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         }
 
         //fix to append custom group name to field name, CRM-2676
-        if (empty($this->_formattedFieldNames[$cType]) || $cType == $this->_contactType) {
+        if (empty($this->_formattedFieldNames[$cType]) || $cType === $this->getContactType()) {
           $this->_formattedFieldNames[$cType] = $this->formatCustomFieldName($values);
         }
 
@@ -215,7 +212,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           is_array($this->_dedupeFields[$cType])
         ) {
           static $cTypeArray = [];
-          if ($cType != $this->_contactType && !in_array($cType, $cTypeArray)) {
+          if ($cType !== $this->getContactType() && !in_array($cType, $cTypeArray)) {
             foreach ($this->_dedupeFields[$cType] as $val) {
               if ($valTitle = CRM_Utils_Array::value($val, $this->_formattedFieldNames[$cType])) {
                 $this->_formattedFieldNames[$cType][$val] = $valTitle . ' (match to contact)';
@@ -226,7 +223,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
         }
 
         foreach ($highlightedFields as $k => $v) {
-          if ($v == $cType || $v === 'All') {
+          if ($v === $cType || $v === 'All') {
             $highlightedRelFields[$key][] = $k;
           }
         }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -25,13 +25,6 @@ use Civi\Api4\MappingField;
 abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
 
   /**
-   * Cache of preview data values
-   *
-   * @var array
-   */
-  protected $_dataValues;
-
-  /**
    * Mapper fields
    *
    * @var array
@@ -132,46 +125,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       }
     }
     return '';
-  }
-
-  /**
-   * Guess at the field names given the data and patterns from the schema.
-   *
-   * @param array $patterns
-   * @param string $index
-   *
-   * @return string
-   */
-  public function defaultFromData($patterns, $index) {
-    $best = '';
-    $bestHits = 0;
-    $n = count($this->_dataValues);
-
-    foreach ($patterns as $key => $re) {
-      // Skip empty key/patterns
-      if (!$key || !$re || strlen("$re") < 5) {
-        continue;
-      }
-
-      /* Take a vote over the preview data set */
-      $hits = 0;
-      for ($i = 0; $i < $n; $i++) {
-        if (isset($this->_dataValues[$i][$index])) {
-          if (preg_match($re, $this->_dataValues[$i][$index])) {
-            $hits++;
-          }
-        }
-      }
-      if ($hits > $bestHits) {
-        $bestHits = $hits;
-        $best = $key;
-      }
-    }
-
-    if ($best != '') {
-      $this->_fieldUsed[$best] = TRUE;
-    }
-    return $best;
   }
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -39,13 +39,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   protected $_mapperFields;
 
   /**
-   * Number of columns in import file
-   *
-   * @var int
-   */
-  protected $_columnCount;
-
-  /**
    * Column headers, if we have them
    *
    * @var array

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -684,7 +684,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $this->assign('columnNames', $this->getColumnHeaders());
     $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');
     $this->assign('highlightedFields', $this->getHighlightedFields());
-    $this->assign('columnCount', $this->_columnCount);
     $this->assign('dataValues', $this->_dataValues);
   }
 

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -678,7 +678,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function assignMapFieldVariables(): void {
     $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
-    $this->_columnCount = $this->getNumberOfColumns();
     $this->_columnNames = $this->getColumnHeaders();
     $this->_dataValues = array_values($this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -678,11 +678,10 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function assignMapFieldVariables(): void {
     $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
-    $this->_dataValues = array_values($this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());
     $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');
     $this->assign('highlightedFields', $this->getHighlightedFields());
-    $this->assign('dataValues', $this->_dataValues);
+    $this->assign('dataValues', array_values($this->getDataRows([], 2)));
   }
 
   /**

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -678,7 +678,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
    */
   protected function assignMapFieldVariables(): void {
     $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
-    $this->_columnNames = $this->getColumnHeaders();
     $this->_dataValues = array_values($this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());
     $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');


### PR DESCRIPTION
Overview
----------------------------------------

Removes rather than declares `_columnCount` (https://github.com/civicrm/civicrm-core/pull/25296/files#diff-4f0a1c0d1f7a02c448ebe273bd5b951a1811dd14949b11b9c8914b2c198fceba was going with declare

This is a legacy property 

Before
----------------------------------------
We can see the assign is never used (only in search related forms)
![image](https://user-images.githubusercontent.com/336308/211389824-cd88d8f7-6456-4e9a-9c23-d435d9dc5d37.png)

We can see that `_columnCount` is only still used in the Contact MapField form - the others simply loop through the headers (rather than counting them & the using that number in a for loop)
https://github.com/civicrm/civicrm-core/blob/76b53f28710d30e1e4c6cd0793abadee72253288/CRM/Activity/Import/Form/MapField.php#L86

Unused variable
![image](https://user-images.githubusercontent.com/336308/211390983-9acc1705-e84a-4143-adfa-5210ab110037.png)

`_dataValues` is only used for an unused function

![image](https://user-images.githubusercontent.com/336308/211403979-1415042d-ef41-4f97-a6c0-19738bf42147.png)


After
----------------------------------------
Note there are still 7 rows - that is what the `columnCount` was used to display

![image](https://user-images.githubusercontent.com/336308/211391294-81baae7a-f997-424b-943f-5db720093483.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
