### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in queue tests

### DIFF
--- a/tests/phpunit/CRM/Queue/Queue/SqlTest.php
+++ b/tests/phpunit/CRM/Queue/Queue/SqlTest.php
@@ -20,6 +20,16 @@ class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
 
   use \Civi\Test\QueueTestTrait;
 
+  /**
+   * @var CRM_Queue_Service
+   */
+  private $queueService;
+
+  /**
+   * @var CRM_Queue_Queue
+   */
+  private $queue;
+
   /* ----------------------- Queue providers ----------------------- */
 
   /* Define a list of queue providers which should be tested */

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -18,6 +18,16 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
 
   use \Civi\Test\QueueTestTrait;
 
+  /**
+   * @var CRM_Queue_Service
+   */
+  private $queueService;
+
+  /**
+   * @var CRM_Queue_Queue
+   */
+  private $queue;
+
   /* ----------------------- Queue providers ----------------------- */
 
   /* Define a list of queue providers which should be tested */

--- a/tests/phpunit/CRM/Queue/RunnerTest.php
+++ b/tests/phpunit/CRM/Queue/RunnerTest.php
@@ -18,6 +18,16 @@ class CRM_Queue_RunnerTest extends CiviUnitTestCase {
 
   use \Civi\Test\QueueTestTrait;
 
+  /**
+   * @var CRM_Queue_Service
+   */
+  private $queueService;
+
+  /**
+   * @var CRM_Queue_Queue
+   */
+  private $queue;
+
   public function setUp(): void {
     parent::setUp();
     $this->queueService = CRM_Queue_Service::singleton(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in queue tests

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
The properties are not declared dynamically, the tests should pass on PHP8.2
