### PR TITLE
Fix Contributions listing crash due to getLineItemTitle returning null

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1246,7 +1246,7 @@ class CRM_Financial_BAO_Order {
         $lineItemTitle .= ' ' . CRM_Utils_String::ellipsify($description, 30);
       }
     }
-    return $lineItemTitle;
+    return $lineItemTitle ?? '';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

The function  `CRM_Financial_BAO_Order::getLineItemTitle()` declares it returns a string, but currently returns NULL sometimes.

https://chat.civicrm.org/civicrm/pl/mtdfasnbzpguifqj8nodxejqrw

Before
----------------------------------------

Visiting the Contributions tab of certain contacts' records would crash, due to PHP's assertions on the return type.

After
----------------------------------------

No crash.

Technical Details
----------------------------------------

The schema suggests NULL as a default value, but the PHP doesn't allow that.

https://github.com/civicrm/civicrm-core/blob/ea39ef4337bcdc86e3f8e9c94d6bc52e4a1faf32/xml/schema/Price/LineItem.xml#L94

The function in question is asking for a 'title' - to me this means a string is suitable, so I have chosen to coerce NULL to `''` rather than weaken the type hint.
