### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Contact_Page_DedupeException

### DIFF
--- a/CRM/Contact/Page/DedupeException.php
+++ b/CRM/Contact/Page/DedupeException.php
@@ -21,6 +21,12 @@
 class CRM_Contact_Page_DedupeException extends CRM_Core_Page {
 
   /**
+   * @var CRM_Utils_Pager
+   * @internal
+   */
+  public $_pager;
+
+  /**
    * the main function that is called when the page loads,
    * it decides the which action has to be taken for the page.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Hopefully a straightforward one:  Avoid dynamic properties in CRM_Contact_Page_DedupeException

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
`_pager` is dynamic no longer.

Comments
----------------------------------------
As the value is only set in `run`, I thought about defaulting `_pager` to be null, and adding null to the `@var`. But TBH I think the meaning is clearer like this, and it should avoid tools (IDEs etc) complaining that we're calling `getOffsetAndRowCount` on null in `getExceptions`
