### PR TITLE
Fix Contact import e-notice on preview screen

### DIFF
--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -26,7 +26,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->addElement('text', 'newGroupName', ts('Name for new group'), CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Group', 'title'));
     $this->addElement('text', 'newGroupDesc', ts('Description of new group'));
     $groupTypes = CRM_Core_OptionGroup::values('group_type', TRUE);
@@ -38,11 +38,11 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       );
     }
 
-    $groups = CRM_Core_PseudoConstant::nestedGroup();;
+    $groups = CRM_Core_PseudoConstant::nestedGroup();
 
     if (!empty($groups)) {
       $this->addElement('select', 'groups', ts('Add imported records to existing group(s)'), $groups, [
-        'multiple' => "multiple",
+        'multiple' => 'multiple',
         'class' => 'crm-select2',
       ]);
     }
@@ -70,47 +70,31 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
    * @param array $fields
    *   Posted values of the form.
    *
-   * @param $files
-   * @param self $self
-   *
    * @return array|bool
    *   list of errors to be posted back to the form
    */
-  public static function formRule($fields, $files, $self) {
+  public static function formRule(array $fields) {
     $errors = [];
-    $invalidTagName = $invalidGroupName = FALSE;
-
-    if (!empty($fields['newTagName'])) {
-      if (!CRM_Utils_Rule::objectExists(trim($fields['newTagName']),
-        ['CRM_Core_DAO_Tag']
-      )
-      ) {
-        $errors['newTagName'] = ts('Tag \'%1\' already exists.',
-          [1 => $fields['newTagName']]
-        );
-        $invalidTagName = TRUE;
-      }
+    if (!empty($fields['newTagName'])
+      && !CRM_Utils_Rule::objectExists(trim($fields['newTagName']), ['CRM_Core_DAO_Tag'])
+    ) {
+      $errors['newTagName'] = ts('Tag \'%1\' already exists.', [1 => $fields['newTagName']]);
     }
 
     if (!empty($fields['newGroupName'])) {
       $title = trim($fields['newGroupName']);
       $name = CRM_Utils_String::titleToVar($title);
       $query = 'SELECT COUNT(*) FROM civicrm_group WHERE name LIKE %1 OR title LIKE %2';
-      $grpCnt = CRM_Core_DAO::singleValueQuery(
+      if (CRM_Core_DAO::singleValueQuery(
         $query,
         [
           1 => [$name, 'String'],
           2 => [$title, 'String'],
         ]
-      );
-      if ($grpCnt) {
-        $invalidGroupName = TRUE;
+      )) {
         $errors['newGroupName'] = ts('Group \'%1\' already exists.', [1 => $fields['newGroupName']]);
       }
     }
-
-    $self->assign('invalidTagName', $invalidTagName);
-    $self->assign('invalidGroupName', $invalidGroupName);
 
     return empty($errors) ? TRUE : $errors;
   }

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -143,13 +143,13 @@
 {literal}
 <script type="text/javascript">
 
-{/literal}{if $invalidGroupName}{literal}
-cj("#new-group.collapsed").crmAccordionToggle();
-{/literal}{/if}{literal}
+if (cj("#newGroupName").val()) {
+  cj("#new-group.collapsed").crmAccordionToggle();
+}
 
-{/literal}{if $invalidTagName}{literal}
-cj("#new-tag.collapsed").crmAccordionToggle();
-{/literal}{/if}{literal}
+if (cj("#newTagName").val()) {
+  cj("#new-tag.collapsed").crmAccordionToggle();
+}
 
 </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Fix Contact import e-notice on preview screen

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/211423522-f634e479-5342-4505-8274-b9c4ae8a524b.png)


After
----------------------------------------
I did an r-run to confirm the notices no longer appear but the accordians load open if not empty - this is a slight change of behaviour (ie they used to be closed if not empty & no error but I think it is better behaviour as well as cleaner code)

![image](https://user-images.githubusercontent.com/336308/211426677-4066a928-ad19-4b59-8604-6e5a9c525f3a.png)


Technical Details
----------------------------------------
These notices occur because it tries to ensure that if you try to create a group in the new group section

![image](https://user-images.githubusercontent.com/336308/211423640-8c2476aa-5c78-4aa7-9b98-0372dcdc3b71.png)


the accordian is open if there is an error on reload

![image](https://user-images.githubusercontent.com/336308/211423939-cd4b61cd-adaa-4906-85e6-e23f894123bc.png)

I figured we could simplify by opening the according if the field has a value & get away from all the dark magic...

Comments
----------------------------------------
