### PR TITLE
AssetBuilder - Fix `testInvalid()` failure. Switch to JWT.

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -138,9 +138,14 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
     }
     else {
       return \CRM_Utils_System::url('civicrm/asset/builder', [
+        // The 'an' and 'ad' provide hints for cache lifespan and debugging/inspection.
         'an' => $name,
-        'ap' => $this->encode($params),
         'ad' => $this->digest($name, $params),
+        'aj' => \Civi::service('crypto.jwt')->encode([
+          'asset' => [$name, $params],
+          'exp' => 86400 * (floor(\CRM_Utils_Time::time() / 86400) + 2),
+          // Caching-friendly TTL -- We want the URL to be stable for a decent amount of time.
+        ]),
       ], TRUE, NULL, FALSE);
     }
   }
@@ -281,7 +286,6 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
    * @return string
    */
   protected function digest($name, $params) {
-    // WISHLIST: For secure digest, generate+persist privatekey & call hash_hmac.
     ksort($params);
     $digest = md5(
       $name .
@@ -290,40 +294,6 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
       json_encode($params)
     );
     return $digest;
-  }
-
-  /**
-   * Encode $params in a format that's optimized for shorter URLs.
-   *
-   * @param array $params
-   * @return string
-   */
-  protected function encode($params) {
-    if (empty($params)) {
-      return '';
-    }
-
-    $str = json_encode($params);
-    if (function_exists('gzdeflate')) {
-      $str = gzdeflate($str);
-    }
-    return base64_encode($str);
-  }
-
-  /**
-   * @param string $str
-   * @return array
-   */
-  protected function decode($str) {
-    if ($str === NULL || $str === FALSE || $str === '') {
-      return [];
-    }
-
-    $str = base64_decode($str);
-    if (function_exists('gzdeflate')) {
-      $str = gzinflate($str);
-    }
-    return json_decode($str, TRUE);
   }
 
   /**
@@ -372,16 +342,9 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
       /** @var Assetbuilder $assets */
       $assets = \Civi::service('asset_builder');
 
-      $expectDigest = $assets->digest($get['an'], $assets->decode($get['ap']));
-      if ($expectDigest !== $get['ad']) {
-        return [
-          'statusCode' => 500,
-          'mimeType' => 'text/plain',
-          'content' => 'Invalid digest',
-        ];
-      }
-
-      return $assets->render($get['an'], $assets->decode($get['ap']));
+      $obj = \Civi::service('crypto.jwt')->decode($get['aj']);
+      $arr = json_decode(json_encode($obj), TRUE);
+      return $assets->render($arr['asset'][0], $arr['asset'][1]);
     }
     catch (UnknownAssetException $e) {
       return [

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -145,7 +145,7 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
           'asset' => [$name, $params],
           'exp' => 86400 * (floor(\CRM_Utils_Time::time() / 86400) + 2),
           // Caching-friendly TTL -- We want the URL to be stable for a decent amount of time.
-        ]),
+        ], ['SIGN', 'WEAK_SIGN']),
       ], TRUE, NULL, FALSE);
     }
   }
@@ -342,7 +342,7 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
       /** @var Assetbuilder $assets */
       $assets = \Civi::service('asset_builder');
 
-      $obj = \Civi::service('crypto.jwt')->decode($get['aj']);
+      $obj = \Civi::service('crypto.jwt')->decode($get['aj'], ['SIGN', 'WEAK_SIGN']);
       $arr = json_decode(json_encode($obj), TRUE);
       return $assets->render($arr['asset'][0], $arr['asset'][1]);
     }

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -84,6 +84,31 @@ class CryptoRegistry {
         $registry->addSymmetricKey($registry->parseKey($keyExpr) + $key);
       }
     }
+    else {
+      // If you are upgrading an old site that does not have a signing key, then there is a status-check advising you to fix it.
+      // But apparently the current site hasn't fixed it yet. The UI+AssetBuilder need to work long enough for sysadmin to discover/resolve.
+      // This fallback is sufficient for short-term usage in limited scenarios (AssetBuilder=>OK; AuthX=>No).
+      // In a properly configured system, the WEAK_SIGN key is strictly unavailable - s.t. a normal site never uses WEAK_SIGN.
+      $registry->addSymmetricKey([
+        'tags' => ['WEAK_SIGN'],
+        'suite' => 'jwt-hs256',
+        'key' => hash_hkdf('sha256',
+          json_encode([
+            // DSN's and site-keys should usually be sufficient, but it's not strongly guaranteed,
+            // so we'll toss in more spaghetti. (At a minimum, this should mitigate bots/crawlers.)
+            \CRM_Utils_Constant::value('CIVICRM_DSN'),
+            \CRM_Utils_Constant::value('CIVICRM_UF_DSN'),
+            \CRM_Utils_Constant::value('CIVICRM_SITE_KEY') ?: $GLOBALS['civicrm_root'],
+            \CRM_Utils_Constant::value('CIVICRM_UF_BASEURL'),
+            \CRM_Utils_Constant::value('CIVICRM_DB_CACHE_PASSWORD'),
+            \CRM_Utils_System::getSiteID(),
+            \CRM_Utils_System::version(),
+            \CRM_Core_Config::singleton()->userSystem->getVersion(),
+            $_SERVER['HTTP_HOST'] ?? '',
+          ])
+        ),
+      ]);
+    }
 
     //if (isset($_COOKIE['CIVICRM_FORM_KEY'])) {
     //  $crypto->addSymmetricKey([
@@ -243,14 +268,15 @@ class CryptoRegistry {
   /**
    * Find all the keys that apply to a tag.
    *
-   * @param string $keyTag
+   * @param string|string[] $keyTag
    *
    * @return array
    *   List of keys, indexed by id, ordered by weight.
    */
   public function findKeysByTag($keyTag) {
+    $keyTag = (array) $keyTag;
     $keys = array_filter($this->keys, function ($key) use ($keyTag) {
-      return in_array($keyTag, $key['tags'] ?? []);
+      return !empty(array_intersect($keyTag, $key['tags'] ?? []));
     });
     uasort($keys, function($a, $b) {
       return ($a['weight'] ?? 0) - ($b['weight'] ?? 0);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a test-failure that recently appeared in `AssetBuilder`. Additionally, it switches the parameter-validation to JWT (for better security checks). For sites that lack the JWT pre-requisites (ie `CIVICRM_SIGN_KEYS`), it provides a transitional key.

Before+After
----------------------------------------

Based on the asset parameters, there is a digest-code. The usage of this digest-code evolves as follows:

| When | Description |
| -- | -- | 
| Before<br/> (Circa 5.56.0) | Digests are used for file-names and caching. Parameters (for the on-demand/debug variants of assets) are not validated. |
| Before<br/> (Circa 5.57.0) | Digests are used for file-names, caching, *and* parameter validation.
| After<br/> (This Patch) | Digests are used for file-names and caching. JWT does parameter validation. |

Technical Details: Background
-----------------------------

`AssetBuilder` was recently (5.57.0) updated to validate the digest-code in asset URLs (*for the on-demand/debug variants of assets*). But this led to new failures in `E2E\Core\AssetBuilderTest`.  Why?

The digest code relies on a semi-secret value, the runtime ID.   In this specific test (`E2E\Core\AssetBuilderTest::testInvalid()`), there are two processes. The PHPUnit process generates one digest-code (with one runtime ID) and sends it to the HTTP server -- but the HTTP server expects a different digest-code (with a different runtime ID).

Is it good or bad that phpunit+httpd have different runtime IDs? 🤷 Is it good or bad to use runtime ID here? I think runtime ID is fair as part of the cache identifier. But I don't think it's ideal for validating the origin of parameters. We have another tool (JWT) which is better designed for that.

Technical Details: This Patch
-------------------------------

This patch restores the use of `digest` code (and runtime ID) -- they are only used for purposes of file-names and caching. They no longer influence the validation-check. Instead, we use JWT.

There is one catch about JWT, -- as observed in the discussion around #25285, JWT requires a signing-key, and some upgraded sites may not have the signing-key configured. Given the centrality of asset-builder in the upgrade-workflow (e.g. for `civicrm/a/#/status`), we need a fallback so that site-builders can apply the upgrade and do the configuration. This defines a very limited fallback.