### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in api_v3_NoteTest

### DIFF
--- a/tests/phpunit/api/v3/NoteTest.php
+++ b/tests/phpunit/api/v3/NoteTest.php
@@ -19,6 +19,7 @@ class api_v3_NoteTest extends CiviUnitTestCase {
   protected $_params;
   protected $_noteID;
   protected $_note;
+  protected $_createdDate;
 
   public function setUp(): void {
 


### PR DESCRIPTION
Overview
----------------------------------------
This is becoming a well-trodden path by now. Avoid dynamic properties in api_v3_NoteTest.

Before
----------------------------------------
`_createdDate` set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
`api_v3_NoteTest` is PHP8.2 friendly.

Usually my inclination is to add `@var` annotations for any properties, but I didn't bother here as it's part of a test, and so less likely to be of relevance to extension authors, and the other properties in this class are not commented.