### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Extension_Container_Static

### DIFF
--- a/CRM/Extension/Container/Static.php
+++ b/CRM/Extension/Container/Static.php
@@ -21,6 +21,11 @@
 class CRM_Extension_Container_Static implements CRM_Extension_Container_Interface {
 
   /**
+   * @var array
+   */
+  protected $exts = [];
+
+  /**
    * @param array $exts
    *   Array(string $key => array $spec) List of extensions.
    */


### PR DESCRIPTION
Overview
----------------------------------------
[REF][PHP8.2] Avoid dynamic properties in CRM_Extension_Container_Static

Before
----------------------------------------
`exts` set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
PHP 8.2 compatiability.

Full disclosure, I don't really understand how this class is used or what it's for. But it's being used in some tests, `exts` is only being referenced within this class, and I suspect it's unlikely third-parties are using the `exts` propery directly (it's unlikely any extensions are using `CRM_Extension_Container_Static` at all. 