### PR TITLE
5.57.0 quotes typo: security 2x double quotes to 1x double quotes

### DIFF
--- a/release-notes/5.57.0.md
+++ b/release-notes/5.57.0.md
@@ -23,7 +23,7 @@ Released January 4, 2023
 | **Fix bugs?**                                                   | **yes** |
 | **Fix security vulnerabilities?**                               | **yes** |
 
-## <a name=""security""></a>Security advisories
+## <a name="security"></a>Security advisories
 
 * **[CIVI-SA-2023-01](https://civicrm.org/advisory/civi-sa-2023-01-help-subsystem-rce): RCE via Help Subsystem**
 * **[CIVI-SA-2023-02](https://civicrm.org/advisory/civi-sa-2023-02-civievent-xss): XSS via CiviEvent**


### PR DESCRIPTION
Previously broken headline: 
https://github.com/civicrm/civicrm-core/blob/master/release-notes/5.57.0.md#a-namesecuritysecurity-advisories