### PR TITLE
Fix `cv` failure on J3.

### DIFF
--- a/CRM/Utils/Hook/Joomla.php
+++ b/CRM/Utils/Hook/Joomla.php
@@ -73,6 +73,9 @@ class CRM_Utils_Hook_Joomla extends CRM_Utils_Hook {
         if (version_compare(JVERSION, '3.0', 'lt')) {
           $app = JCli::getInstance();
         }
+        elseif (version_compare(JVERSION, '4.0', 'lt')) {
+          $app = JApplicationCli::getInstance();
+        }
         else {
           $app = \Joomla\CMS\Factory::getApplication();
         }


### PR DESCRIPTION
Overview
----------------------------------------
`cv` fails on J3 - see [dev/core#4060](https://lab.civicrm.org/dev/core/-/issues/4060)

Before
----------------------------------------
`Failed to start application` error

After
----------------------------------------
No error

Technical Details
----------------------------------------
This code was changed by https://github.com/civicrm/civicrm-core/pull/24796 for J4 compatibility.

This PR simply reverts to the previous command for J3 leaving J4 as is.

