### PR TITLE
dev/core#1984 fix custom fields sometimes missing from profiles

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -730,8 +730,8 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
       $checkPermission = CRM_Core_Permission::EDIT;
     }
     // Make the cache user specific by adding the ID to the key.
-    $id = CRM_Core_Session::getLoggedInContactID();
-    $cacheKey = 'uf_group_custom_fields_' . $ctype . '_' . $id . '_' . (int) $checkPermission;
+    $contactId = CRM_Core_Session::getLoggedInContactID();
+    $cacheKey = 'uf_group_custom_fields_' . $ctype . '_' . $contactId . '_' . (int) $checkPermission;
     if (!Civi::cache('metadata')->has($cacheKey)) {
       $customFields = CRM_Core_BAO_CustomField::getFieldsForImport($ctype, FALSE, FALSE, FALSE, $checkPermission, TRUE);
 
@@ -922,7 +922,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
         if (!empty($_POST)) {
           $supressForm = CRM_Core_Config::singleton()->userSystem->suppressProfileFormErrors();
           $template->assign('suppressForm', $supressForm);
-          }
+        }
 
         $templateFile = "CRM/Profile/Form/{$profileID}/Dynamic.tpl";
         if (!$template->template_exists($templateFile)) {

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -729,7 +729,9 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
     if ($checkPermission == CRM_Core_Permission::CREATE) {
       $checkPermission = CRM_Core_Permission::EDIT;
     }
-    $cacheKey = 'uf_group_custom_fields_' . $ctype . '_' . (int) $checkPermission;
+    // Make the cache user specific by adding the ID to the key.
+    $id = CRM_Core_Session::getLoggedInContactID();
+    $cacheKey = 'uf_group_custom_fields_' . $ctype . '_' . $id . '_' . (int) $checkPermission;
     if (!Civi::cache('metadata')->has($cacheKey)) {
       $customFields = CRM_Core_BAO_CustomField::getFieldsForImport($ctype, FALSE, FALSE, FALSE, $checkPermission, TRUE);
 
@@ -916,10 +918,11 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
 
         $template = CRM_Core_Smarty::singleton();
 
-        // Hide CRM error messages if they are set by the CMS.
-        if (!empty($_POST)) {
-          $supressForm = CRM_Core_Config::singleton()->userSystem->suppressProfileFormErrors();
-          $template->assign('suppressForm', $supressForm);
+        // Hide CRM error messages if they are displayed using drupal form_set_error.
+        if (!empty($_POST) && CRM_Core_Config::singleton()->userFramework == 'Drupal') {
+          if (arg(0) == 'user' || (arg(0) == 'admin' && arg(1) == 'people')) {
+            $template->assign('suppressForm', TRUE);
+          }
         }
 
         $templateFile = "CRM/Profile/Form/{$profileID}/Dynamic.tpl";

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -918,12 +918,11 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
 
         $template = CRM_Core_Smarty::singleton();
 
-        // Hide CRM error messages if they are displayed using drupal form_set_error.
-        if (!empty($_POST) && CRM_Core_Config::singleton()->userFramework == 'Drupal') {
-          if (arg(0) == 'user' || (arg(0) == 'admin' && arg(1) == 'people')) {
-            $template->assign('suppressForm', TRUE);
+        // Hide CRM error messages if they are set by the CMS.
+        if (!empty($_POST)) {
+          $supressForm = CRM_Core_Config::singleton()->userSystem->suppressProfileFormErrors();
+          $template->assign('suppressForm', $supressForm);
           }
-        }
 
         $templateFile = "CRM/Profile/Form/{$profileID}/Dynamic.tpl";
         if (!$template->template_exists($templateFile)) {


### PR DESCRIPTION
Overview
----------------------------------------
We were finding that custom fields were missing from profiles from time to time. See [Sometimes Custom fields missing on profile](https://lab.civicrm.org/dev/core/-/issues/1984)

Before
----------------------------------------
Profiles would be missing their custom fields even if the user had access to them.

After
----------------------------------------
Profiles are now available to users, even if a less privileged user was the first one to access the profile after a cache refresh.

Technical Details
----------------------------------------
The list of custom fields for a profile is held in a cache created when the profile is first accessed after the cache has expired. Before this change that cache was generic to all users,, so it only held the fields visible to the first user accessing the profile after the cache refresh. If that user did not have access to the fields, they were not in the cache and subsequent users couldn't see them. By adding the user ID to the cache key, it means that each user creates their own cache, so they can see the fields to which they have access.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
It is a very simple change, simply adding the user id to the cache key used to hold the custom field information.