### PR TITLE
(dev/core#4074) Make CRM_Core_BAO_CMSUser CMS agnostic

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -144,71 +144,47 @@ class CRM_Core_BAO_CMSUser {
 
     $config = CRM_Core_Config::singleton();
 
-    $isDrupal = $config->userSystem->is_drupal;
-    $isJoomla = ucfirst($config->userFramework) == 'Joomla';
-    $isWordPress = $config->userFramework == 'WordPress';
-
     $errors = [];
-    if ($isDrupal || $isJoomla || $isWordPress) {
-      $emailName = NULL;
-      if (!empty($form->_bltID) && array_key_exists("email-{$form->_bltID}", $fields)) {
-        // this is a transaction related page
-        $emailName = 'email-' . $form->_bltID;
-      }
-      else {
-        // find the email field in a profile page
-        foreach ($fields as $name => $dontCare) {
-          if (substr($name, 0, 5) == 'email') {
-            $emailName = $name;
-            break;
-          }
-        }
-      }
 
-      if ($emailName == NULL) {
-        $errors['_qf_default'] = ts('Could not find an email address.');
-        return $errors;
+    $emailName = $config->userSystem->getEmailFieldName($form, $fields);
+
+    $params = [
+      'name' => $fields['cms_name'],
+      'mail' => isset($fields[$emailName]) ? $fields[$emailName] : '',
+      'pass' => isset($fields['cms_pass']) ? $fields['cms_pass'] : '',
+    ];
+
+    // Verify the password.
+    if ($config->userSystem->isPasswordUserGenerated()) {
+      $config->userSystem->verifyPassword($params, $errors);
+    }
+
+    // Set generic errors messages.
+    if ($emailName == '') {
+      $errors['_qf_default'] = ts('Could not find an email address.');
+    }
+
+    if (empty($params['name'])) {
+      $errors['cms_name'] = ts('Please specify a username.');
+    }
+
+    if (empty($params['mail'])) {
+      $errors[$emailName] = ts('Please specify a valid email address.');
+    }
+
+    if ($config->userSystem->isPasswordUserGenerated()) {
+      if (empty($fields['cms_pass']) ||
+        empty($fields['cms_confirm_pass'])
+      ) {
+        $errors['cms_pass'] = ts('Please enter a password.');
       }
-
-      if (empty($fields['cms_name'])) {
-        $errors['cms_name'] = ts('Please specify a username.');
-      }
-
-      if (empty($fields[$emailName])) {
-        $errors[$emailName] = ts('Please specify a valid email address.');
-      }
-
-      if ($config->userSystem->isPasswordUserGenerated()) {
-        if (empty($fields['cms_pass']) ||
-          empty($fields['cms_confirm_pass'])
-        ) {
-          $errors['cms_pass'] = ts('Please enter a password.');
-        }
-        if ($fields['cms_pass'] != $fields['cms_confirm_pass']) {
-          $errors['cms_pass'] = ts('Password and Confirm Password values are not the same.');
-        }
-      }
-
-      if (!empty($errors)) {
-        return $errors;
-      }
-
-      // now check that the cms db does not have the user name and/or email
-      if ($isDrupal or $isJoomla or $isWordPress) {
-        $params = [
-          'name' => $fields['cms_name'],
-          'mail' => $fields[$emailName],
-          'pass' => $fields['cms_pass'],
-        ];
-      }
-
-      $config->userSystem->checkUserNameEmailExists($params, $errors, $emailName);
-
-      // Verify the password.
-      if ($config->userSystem->isPasswordUserGenerated()) {
-        $config->userSystem->verifyPassword($params, $errors);
+      if ($fields['cms_pass'] != $fields['cms_confirm_pass']) {
+        $errors['cms_pass'] = ts('Password and Confirm Password values are not the same.');
       }
     }
+
+    $config->userSystem->checkUserNameEmailExists($params, $errors, $emailName);
+
     return (!empty($errors)) ? $errors : TRUE;
   }
 

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -92,16 +92,9 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
   }
 
   /**
-   * Check if username and email exists in the Backdrop db.
-   *
-   * @param array $params
-   *   Array of name and mail values.
-   * @param array $errors
-   *   Array of errors.
-   * @param string $emailName
-   *   Field label for the 'email'.
+   * @inheritdoc
    */
-  public static function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
+  public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
     if ($backdrop_errors = form_get_errors()) {
       // unset Backdrop messages to avoid twice display of errors
       unset($_SESSION['messages']);

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1134,4 +1134,29 @@ abstract class CRM_Utils_System_Base {
     return FALSE;
   }
 
+  /**
+   * Get email field name from form values
+   *
+   * @param CRM_Core_Form $form
+   * @param array $fields
+   *
+   * @return string
+   */
+  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
+    return 'email';
+  }
+
+  /**
+   * Check if username and email exists in the CMS.
+   *
+   * @param array $params
+   *   Array of name and mail values.
+   * @param array $errors
+   *   Array of errors.
+   * @param string $emailName
+   *   Field label for the 'email'.
+   */
+  public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
+  }
+
 }

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -100,25 +100,13 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
   }
 
   /**
-   * Check if username and email exists in the drupal db.
-   *
-   * @param array $params
-   *   Array of name and mail values.
-   * @param array $errors
-   *   Array of errors.
-   * @param string $emailName
-   *   Field label for the 'email'.
+   * @inheritdoc
    */
-  public static function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
-    $config = CRM_Core_Config::singleton();
-
-    $dao = new CRM_Core_DAO();
-    $name = $dao->escape(CRM_Utils_Array::value('name', $params));
-    $email = $dao->escape(CRM_Utils_Array::value('mail', $params));
-    $errors = form_get_errors();
-    if ($errors) {
-      // unset drupal messages to avoid twice display of errors
+  public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
+    if ($drupal_errors = form_get_errors()) {
+      // unset Drupal messages to avoid twice display of errors
       unset($_SESSION['messages']);
+      $errors = array_merge($errors, $drupal_errors);
     }
 
     if (!empty($params['name'])) {

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -124,16 +124,9 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
-   * Check if username and email exists in the drupal db.
-   *
-   * @param array $params
-   *   Array of name and mail values.
-   * @param array $errors
-   *   Errors.
-   * @param string $emailName
-   *   Field label for the 'email'.
+   * @inheritdoc
    */
-  public static function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
+  public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
     // If we are given a name, let's check to see if it already exists.
     if (!empty($params['name'])) {
       $name = $params['name'];

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -733,4 +733,27 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return FALSE;
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
+    $emailName = '';
+
+    if (!empty($form->_bltID) && array_key_exists("email-{$form->_bltID}", $fields)) {
+      // this is a transaction related page
+      $emailName = 'email-' . $form->_bltID;
+    }
+    else {
+      // find the email field in a profile page
+      foreach ($fields as $name => $dontCare) {
+        if (substr($name, 0, 5) == 'email') {
+          $emailName = $name;
+          break;
+        }
+      }
+    }
+
+    return $emailName;
+  }
+
 }

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -100,14 +100,30 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   }
 
   /**
-   * Check if username and email exists in the Joomla db.
-   *
-   * @param array $params
-   *   Array of name and mail values.
-   * @param array $errors
-   *   Array of errors.
-   * @param string $emailName
-   *   Field label for the 'email'.
+   * @inheritdoc
+   */
+  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
+    $emailName = '';
+
+    if (!empty($form->_bltID) && array_key_exists("email-{$form->_bltID}", $fields)) {
+      // this is a transaction related page
+      $emailName = 'email-' . $form->_bltID;
+    }
+    else {
+      // find the email field in a profile page
+      foreach ($fields as $name => $dontCare) {
+        if (substr($name, 0, 5) == 'email') {
+          $emailName = $name;
+          break;
+        }
+      }
+    }
+
+    return $emailName;
+  }
+
+  /**
+   * @inheritdoc
    */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
     $config = CRM_Core_Config::singleton();

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -972,17 +972,32 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
-   * @param array $params
-   * @param array $errors
-   * @param string $emailName
+   * @inheritdoc
+   */
+  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
+    $emailName = '';
+
+    if (!empty($form->_bltID) && array_key_exists("email-{$form->_bltID}", $fields)) {
+      // this is a transaction related page
+      $emailName = 'email-' . $form->_bltID;
+    }
+    else {
+      // find the email field in a profile page
+      foreach ($fields as $name => $dontCare) {
+        if (substr($name, 0, 5) == 'email') {
+          $emailName = $name;
+          break;
+        }
+      }
+    }
+
+    return $emailName;
+  }
+
+  /**
+   * @inheritdoc
    */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
-    $config = CRM_Core_Config::singleton();
-
-    $dao = new CRM_Core_DAO();
-    $name = $dao->escape(CRM_Utils_Array::value('name', $params));
-    $email = $dao->escape(CRM_Utils_Array::value('mail', $params));
-
     if (!empty($params['name'])) {
       if (!validate_username($params['name'])) {
         $errors['cms_name'] = ts("Your username contains invalid characters");


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/4074. Splits up the logic into each CMS in the userSystem. This functionality is used when using  a profile to create a user account.

I've tested it with creating a user account and also checking the username which happens via ajax on the profile (on Drupal 9). Both still work.