### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Case_XMLProcessor_ProcessTest

### DIFF
--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -7,10 +7,43 @@ require_once 'CiviTest/CiviCaseTestCase.php';
  */
 class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
 
+  /**
+   * @var array
+   */
+  private $defaultAssigneeOptionsValues = [];
+
+  /**
+   * @var array
+   */
+  private $contacts = [];
+
+  /**
+   * @var array
+   */
+  private $relationships = [];
+
+  /**
+   * @var array
+   */
+  private $moreRelationshipTypes = [];
+
+  /**
+   * @var SimpleXMLElement
+   */
+  private $activityTypeXml;
+
+  /**
+   * @var array
+   */
+  private $activityParams = [];
+
+  /**
+   * @var CRM_Case_XMLProcessor_Process
+   */
+  private $process;
+
   public function setUp(): void {
     parent::setUp();
-
-    $this->defaultAssigneeOptionsValues = [];
 
     $this->setupContacts();
     $this->setupDefaultAssigneeOptions();


### PR DESCRIPTION
Overview
----------------------------------------
Stop using properties as dynamic properties in CRM_Case_XMLProcessor_ProcessTest. This is a test, so the properties can safely be private. The properties are set in `setUp` and used as part of the tests.

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
A step closer to PHP 8.2 compat.