### PR TITLE
Remove unused method in CRM_Contact_Form_Task_PDFLetterCommon

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -110,30 +110,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
   }
 
   /**
-   * Convert from a vague-type/file-extension to mime-type.
-   *
-   * @param string $type
-   * @return string
-   * @throws \CRM_Core_Exception
-   *
-   * @deprecated
-   */
-  private static function getMimeType($type) {
-    $mimeTypes = [
-      'pdf' => 'application/pdf',
-      'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'odt' => 'application/vnd.oasis.opendocument.text',
-      'html' => 'text/html',
-    ];
-    if (isset($mimeTypes[$type])) {
-      return $mimeTypes[$type];
-    }
-    else {
-      throw new \CRM_Core_Exception("Cannot determine mime type");
-    }
-  }
-
-  /**
    * Get the categories required for rendering tokens.
    *
    * @deprecated


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused method in CRM_Contact_Form_Task_PDFLetterCommon.

Before
----------------------------------------
`getMimeType` is unused, and as it's private we can be pretty confident about this.

After
----------------------------------------
The method is removed

Comments
----------------------------------------
The `getMimeType` method was originally used in the `postProcess` method which was removed in https://github.com/civicrm/civicrm-core/commit/f93ca6db532c1ca50177cbb225d6b3c5ae407006
