### PR TITLE
Do not double check ACLs on scheduled reminders

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -196,6 +196,7 @@ FROM civicrm_action_schedule cas
    * @deprecated
    */
   public static function retrieve($params, &$defaults) {
+    CRM_Core_Error::deprecatedFunctionWarning('api');
     if (empty($params)) {
       return NULL;
     }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -307,14 +307,15 @@ WHERE  ( civicrm_event.is_template IS NULL OR civicrm_event.is_template = 0 )";
 
     $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
+      $eventID = (int) $dao->id;
       if ((!$checkPermission ||
-          CRM_Event_BAO_Event::checkPermission($dao->id)
+          CRM_Event_BAO_Event::checkPermission($eventID)
         ) &&
         $dao->title
       ) {
-        $events[$dao->id] = $dao->title;
+        $events[$eventID] = $dao->title;
         if (!$titleOnly) {
-          $events[$dao->id] .= ' - ' . CRM_Utils_Date::customFormat($dao->start_date);
+          $events[$eventID] .= ' - ' . CRM_Utils_Date::customFormat($dao->start_date);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Do not double check ACLs on scheduled reminders

Before
----------------------------------------
The code gets a list of events from ` $events = \CRM_Event_BAO_Event::getEvents();` and passes it through the `\CRM_ACL_API::group(\CRM_Core_Permission::EDIT, NULL, 'civicrm_event', $events);` function to filter to those permitted by ACL. However, ` $events = \CRM_Event_BAO_Event::getEvents();` itself has a `checkPermissions = TRUE` in this scenario.

That parameter leads to `CRM_Event_BAO_Event::checkPermission($eventID)` which does the same ACL check internally here 

https://github.com/civicrm/civicrm-core/blob/db3bae353ad1823d36f5bba6b8553b331d820e3d/CRM/Event/BAO/Event.php#L2072

After
----------------------------------------
I'm just relying on the permission check from ` $events = \CRM_Event_BAO_Event::getEvents();`

Technical Details
----------------------------------------
This started off with me trying to answer @artfulrobot's question about how the paramters for the function that is now no longer called here are used, and then I wound up seeing @colemanw's hated `retrieveValue` and now both are gone - and I have to find other usages to answer @artfulrobot  :-)

Comments
----------------------------------------
