### PR TITLE
(dev/core#4028) make CRM_Admin_Form_Setting_UF more CMS agnostic

### DIFF
--- a/CRM/Admin/Form/Setting/UF.php
+++ b/CRM/Admin/Form/Setting/UF.php
@@ -34,62 +34,25 @@ class CRM_Admin_Form_Setting_UF extends CRM_Admin_Form_Setting {
 
     $this->assign('wpBasePageEnabled', FALSE);
     $this->assign('userFrameworkUsersTableNameEnabled', FALSE);
+    $this->assign('viewsIntegration', FALSE);
 
     $this->setTitle(
       ts('Settings - %1 Integration', [1 => $this->_uf])
     );
 
-    if ($this->_uf === 'WordPress') {
+    if ($config->userSystem->canSetBasePage()) {
       $this->_settings['wpBasePage'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
       $this->assign('wpBasePageEnabled', TRUE);
     }
 
-    if ($config->userSystem->is_drupal) {
+    if ($config->userSystem->hasUsersTable()) {
       $this->_settings['userFrameworkUsersTableName'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
       $this->assign('userFrameworkUsersTableNameEnabled', TRUE);
     }
 
-    // find out if drupal has its database prefixed
-    if ($this->_uf === 'Drupal8') {
-      $databases['default'] = Drupal\Core\Database\Database::getConnectionInfo('default');
-    }
-    else {
-      global $databases;
-    }
-
-    $drupal_prefix = '';
-    if (isset($databases['default']['default']['prefix'])) {
-      if (is_array($databases['default']['default']['prefix'])) {
-        $drupal_prefix = $databases['default']['default']['prefix']['default'];
-      }
-      else {
-        $drupal_prefix = $databases['default']['default']['prefix'];
-      }
-    }
-
-    $this->assign('tablePrefixes', FALSE);
-
-    if ($config->userSystem->viewsExists() &&
-      (
-        $config->dsn != $config->userFrameworkDSN || !empty($drupal_prefix)
-      )
-    ) {
-
-      $dsnArray = DB::parseDSN(CRM_Utils_SQL::autoSwitchDSN($config->dsn));
-      $tableNames = CRM_Core_DAO::getTableNames();
-      asort($tableNames);
-      $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= [';
-      if ($config->userFramework === 'Backdrop') {
-        $tablePrefixes = '$database_prefix = [';
-      }
-      // add default prefix: the drupal database prefix
-      $tablePrefixes .= "\n  'default' => '$drupal_prefix',";
-      $prefix = $config->userSystem->getCRMDatabasePrefix();
-      foreach ($tableNames as $tableName) {
-        $tablePrefixes .= "\n  '" . str_pad($tableName . "'", 41) . " => '{$prefix}',";
-      }
-      $tablePrefixes .= "\n];";
-      $this->assign('tablePrefixes', $tablePrefixes);
+    $viewsIntegration = $config->userSystem->viewsIntegration();
+    if ($viewsIntegration) {
+      $this->assign('viewsIntegration', $viewsIntegration);
     }
 
     parent::buildQuickForm();

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1116,4 +1116,45 @@ AND    u.status = 1
     ];
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function viewsIntegration(): string {
+    global $databases;
+    $config = CRM_Core_Config::singleton();
+    $text = '';
+    $backdrop_prefix = '';
+    if (isset($databases['default']['default']['prefix'])) {
+      if (is_array($databases['default']['default']['prefix'])) {
+        $backdrop_prefix = $databases['default']['default']['prefix']['default'];
+      }
+      else {
+        $backdrop_prefix = $databases['default']['default']['prefix'];
+      }
+    }
+
+    if ($this->viewsExists() &&
+      (
+        $config->dsn != $config->userFrameworkDSN || !empty($backdrop_prefix)
+      )
+    ) {
+      $text = '<div>' . ts('To enable CiviCRM Views integration, add or update the following item in the <code>settings.php</code> file:') . '</div>';
+
+      $tableNames = CRM_Core_DAO::getTableNames();
+      asort($tableNames);
+
+      $text .= '<pre>$database_prefix = [';
+
+      // Add default prefix.
+      $text .= "\n  'default' => '$backdrop_prefix',";
+      $prefix = $this->getCRMDatabasePrefix();
+      foreach ($tableNames as $tableName) {
+        $text .= "\n  '" . str_pad($tableName . "'", 41) . " => '{$prefix}',";
+      }
+      $text .= "\n];</pre>";
+    }
+
+    return $text;
+  }
+
 }

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1159,4 +1159,34 @@ abstract class CRM_Utils_System_Base {
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
   }
 
+  /**
+   * Has CMS users table
+   *
+   * @return bool
+   */
+  public function hasUsersTable():bool {
+    return FALSE;
+  }
+
+  /**
+   * CiviCRM Table prefixes
+   *   To display for CMS integration.
+   *
+   * @return string
+   */
+  public function viewsIntegration():string {
+    return '';
+  }
+
+  /**
+   * Can set base page for CiviCRM
+   *   By default, CiviCRM will generate front-facing pages
+   *   using the home page. This allows a different template
+   *   for CiviCRM pages.
+   * @return bool
+   */
+  public function canSetBasePage():bool {
+    return FALSE;
+  }
+
 }

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -852,4 +852,44 @@ AND    u.status = 1
     }
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function viewsIntegration(): string {
+    global $databases;
+    $config = CRM_Core_Config::singleton();
+    $text = '';
+    $drupal_prefix = '';
+    if (isset($databases['default']['default']['prefix'])) {
+      if (is_array($databases['default']['default']['prefix'])) {
+        $drupal_prefix = $databases['default']['default']['prefix']['default'];
+      }
+      else {
+        $drupal_prefix = $databases['default']['default']['prefix'];
+      }
+    }
+
+    if ($this->viewsExists() &&
+      (
+        $config->dsn != $config->userFrameworkDSN || !empty($drupal_prefix)
+      )
+    ) {
+      $text = '<div>' . ts('To enable CiviCRM Views integration, add or update the following item in the <code>settings.php</code> file:') . '</div>';
+
+      $tableNames = CRM_Core_DAO::getTableNames();
+      asort($tableNames);
+      $text .= '<pre>$databases[\'default\'][\'default\'][\'prefix\']= [';
+
+      // Add default prefix.
+      $text .= "\n  'default' => '$drupal_prefix',";
+      $prefix = $this->getCRMDatabasePrefix();
+      foreach ($tableNames as $tableName) {
+        $text .= "\n  '" . str_pad($tableName . "'", 41) . " => '{$prefix}',";
+      }
+      $text .= "\n];</pre>";
+    }
+
+    return $text;
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -908,4 +908,11 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return FALSE;
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function viewsIntegration(): string {
+    return '<p><strong>' . ts('To enable CiviCRM Views integration, install the <a %1>CiviCRM Entity</a> module.', [1 => 'href="https://www.drupal.org/project/civicrm_entity"']) . '</strong></p>';
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -529,6 +529,13 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   }
 
   /**
+   * @inheritdoc
+   */
+  public function hasUsersTable():bool {
+    return TRUE;
+  }
+
+  /**
    * Get an array of user details for a contact, containing at minimum the user ID & name.
    *
    * @param int $contactID

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1624,4 +1624,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function canSetBasePage():bool {
+    return TRUE;
+  }
+
 }

--- a/templates/CRM/Admin/Form/Setting/UF.tpl
+++ b/templates/CRM/Admin/Form/Setting/UF.tpl
@@ -34,12 +34,11 @@
         </table>
             <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 <div class="spacer"></div>
-{if $tablePrefixes}
+{if $viewsIntegration}
 <div class="form-item">
 <fieldset>
     <legend>{ts}Views integration settings{/ts}</legend>
-    <div>{ts}To enable CiviCRM Views integration, add or update the following item in the <code>settings.php</code> file:{/ts}</div>
-    <pre>{$tablePrefixes}</pre>
+    <div>{$viewsIntegration}</div>
 </fieldset>
 </div>
 {/if}


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/4028.

An alternative to https://github.com/civicrm/civicrm-core/pull/25148/files. Uses https://docs.civicrm.org/sysadmin/en/latest/integration/drupal/views/#drupal-9 for Drupal 9 info. I left the `CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME` settings as-is, though I'm not sure why someone would ever change the users table name for a CMS, for instance. Could just hardcode it in the userSystem class.