### PR TITLE
Standardise Type on `includedGroups` parameter

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -140,7 +140,7 @@ class CRM_ACL_API {
    *
    * @param string $tableName
    * @param array|null $allGroups
-   * @param array|null $includedGroups
+   * @param array $includedGroups
    *
    * @return array
    *   the ids of the groups for which the user has permissions
@@ -150,8 +150,12 @@ class CRM_ACL_API {
     $contactID = NULL,
     $tableName = 'civicrm_saved_search',
     $allGroups = NULL,
-    $includedGroups = NULL
+    $includedGroups = []
   ) {
+    if (!is_array($includedGroups)) {
+      CRM_Core_Error::deprecatedWarning('pass an array for included groups');
+      $includedGroups = (array) $includedGroups;
+    }
     if ($contactID == NULL) {
       $contactID = CRM_Core_Session::getLoggedInContactID();
     }

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -324,7 +324,7 @@ SELECT g.*
    * @param int $contactID
    * @param string $tableName
    * @param array|null $allGroups
-   * @param array|null $includedGroups
+   * @param array $includedGroups
    *
    * @return array
    */
@@ -333,9 +333,13 @@ SELECT g.*
     $contactID = NULL,
     $tableName = 'civicrm_saved_search',
     $allGroups = NULL,
-    $includedGroups = NULL
+    $includedGroups = []
   ) {
-    $userCacheKey = "{$contactID}_{$type}_{$tableName}_" . CRM_Core_Config::domainID() . '_' . md5(implode(',', array_merge((array) $allGroups, (array) $includedGroups)));
+    if (!is_array($includedGroups)) {
+      CRM_Core_Error::deprecatedWarning('pass an array for included groups');
+      $includedGroups = (array) $includedGroups;
+    }
+    $userCacheKey = "{$contactID}_{$type}_{$tableName}_" . CRM_Core_Config::domainID() . '_' . md5(implode(',', array_merge((array) $allGroups, $includedGroups)));
     if (empty(Civi::$statics[__CLASS__]['permissioned_groups'])) {
       Civi::$statics[__CLASS__]['permissioned_groups'] = [];
     }
@@ -363,9 +367,7 @@ SELECT g.*
       }
     }
 
-    if (empty($ids) && !empty($includedGroups) &&
-      is_array($includedGroups)
-    ) {
+    if (empty($ids) && !empty($includedGroups)) {
       // This is pretty alarming - we 'sometimes' include all included groups
       // seems problematic per https://lab.civicrm.org/dev/core/-/issues/1879
       $ids = $includedGroups;

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -598,7 +598,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     // and addCustomDataToColumns() will allow access to all custom groups.
     $permCustomGroupIds = [];
     if (!CRM_Core_Permission::check('access all custom data')) {
-      $permCustomGroupIds = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_custom_group', $allGroups, NULL);
+      $permCustomGroupIds = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_custom_group', $allGroups);
       // do not allow custom data for reports if user doesn't have
       // permission to access custom data.
       if (!empty($this->_customGroupExtends) && empty($permCustomGroupIds)) {


### PR DESCRIPTION
Overview
----------------------------------------
Standardise Type on `includedGroups` parameter

Before
----------------------------------------
I had to read through the function to determine that passing `NULL` or `[]` for `$includedGroups` had the same outcome (because it is only used if `!empty($includedGroups) `

After
----------------------------------------
Parameter standardised as an array, NULL deprecated

Technical Details
----------------------------------------
The deprecation notice might cause some test fails, which I will address if so

Comments
----------------------------------------
