### PR TITLE
Ensure useful exception thrown for all Smarty errors from user strings

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -19,6 +19,9 @@
  * Fix for bug CRM-392. Not sure if this is the best fix or it will impact
  * other similar PEAR packages. doubt it
  */
+
+use Civi\Core\Event\SmartyErrorEvent;
+
 if (!class_exists('Smarty')) {
   require_once 'Smarty/Smarty.class.php';
 }
@@ -194,6 +197,21 @@ class CRM_Core_Smarty extends Smarty {
       }
     }
     return $output;
+  }
+
+  /**
+   * Handle smarty error in one off string.
+   *
+   * @param int $errorNumber
+   * @param string $errorMessage
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function handleSmartyError(int $errorNumber, string $errorMessage): void {
+    $event = new SmartyErrorEvent($errorNumber, $errorMessage);
+    \Civi::dispatcher()->dispatch('civi.smarty.error', $event);
+    restore_error_handler();
+    throw new \CRM_Core_Exception('Message was not parsed due to invalid smarty syntax : ' . $errorMessage);
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FiveFiftyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyNine.php
@@ -21,13 +21,22 @@
  */
 class CRM_Upgrade_Incremental_php_FiveFiftyNine extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
+    if ($rev === '5.59.alpha1') {
+      if (empty(CRM_Core_Config::singleton()->userSystem->is_wordpress)) {
+        $preUpgradeMessage .= '<p>' . ts('The handling of invalid smarty template code in mailings, reminders and other automated messages has changed . For details, see <a %1>upgrade notes</a>.',
+            [1 => 'href="https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/#civicrm-559" target="_blank"']) . '</p>';
+      }
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *
    * @param string $rev
    *   The version number matching this function name
    */
-  public function upgrade_5_59_alpha1($rev): void {
+  public function upgrade_5_59_alpha1(string $rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Drop column civicrm_custom_field.mask', 'dropColumn', 'civicrm_custom_field', 'mask');
   }

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1026,6 +1026,10 @@ class CRM_Utils_String {
    * @param string $templateString
    *
    * @return string
+   *
+   * @noinspection PhpDocRedundantThrowsInspection
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function parseOneOffStringThroughSmarty($templateString) {
     if (!CRM_Utils_String::stringContainsTokens($templateString)) {
@@ -1034,13 +1038,15 @@ class CRM_Utils_String {
     }
     $smarty = CRM_Core_Smarty::singleton();
     $cachingValue = $smarty->caching;
+    set_error_handler([$smarty, 'handleSmartyError'], E_USER_ERROR);
     $smarty->caching = 0;
     $smarty->assign('smartySingleUseString', $templateString);
     // Do not escape the smartySingleUseString as that is our smarty template
     // and is likely to contain html.
     $templateString = (string) $smarty->fetch('string:{eval var=$smartySingleUseString|smarty:nodefaults}');
     $smarty->caching = $cachingValue;
-    $smarty->assign('smartySingleUseString', NULL);
+    $smarty->assign('smartySingleUseString');
+    restore_error_handler();
     return $templateString;
   }
 

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -442,4 +442,18 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     $this->assertFalse(CRM_Utils_String::unserialize($str));
   }
 
+  /**
+   * Test that we get a meaningful error if Smarty syntax is wrong.
+   */
+  public function testSmartyExceptionHandling(): void {
+    try {
+      CRM_Utils_String::parseOneOffStringThroughSmarty('{if}');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringStartsWith('Message was not parsed due to invalid smarty syntax', $e->getMessage());
+      return;
+    }
+    $this->fail('Exception expected');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This brings back https://github.com/civicrm/civicrm-core/pull/21122 in a mergeable state (with test). It basically ensures that all user strings in core will throw `CRM_Core_Exceptions` AND call the dispatcher if there is a Smarty error. All emails, scheduled reminders, pdf letters, greetings, badges, token processor usages in core have consistently been going through this code path for some time. The last hold out was the one raised as an objection - the legacy BAO civimail method - but with that finally gone this should be able to be merged & ideally we can remove the existing hack to core.

I don't think it really makes sense for us to do any special handling for Smarty at the form level or to guess at how extensions might use it - the key thing is that anything the user enters must be converted to an exception

Before
----------------------------------------
Inconsistent exception thrown, none in Wordpress usually

After
----------------------------------------
Consistently, tested `CRM_Core_Exception`

Technical Details
----------------------------------------
This issue was raised a couple of years ago & we haven't had a lot of reports of concern over it - I mostly brought it back to life cos I'm digging deep into Smarty AND the ways in which we have hacked it in order to try to get my head around an obscure performance issue. In theory the issue is 'new' since I last analysed it some years back - but I might have gotten that wrong. 

I'm investigating a paralel track of upgrading Smarty in an extension - (currently pending merge on https://github.com/civicrm/civicrm-core/pull/25249 and https://github.com/civicrm/civicrm-core/pull/25248 )

Comments
----------------------------------------

