### PR TITLE
dev/drupal#153 include name when fetching UFGroups so validation can use it

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1672,7 +1672,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    *   array of ufgroups for a module
    */
   public static function getModuleUFGroup($moduleName = NULL, $count = 0, $skipPermission = TRUE, $op = CRM_Core_Permission::VIEW, $returnFields = NULL) {
-    $selectFields = ['id', 'title', 'created_id', 'is_active', 'is_reserved', 'group_type', 'description'];
+    $selectFields = ['id', 'name', 'title', 'created_id', 'is_active', 'is_reserved', 'group_type', 'description'];
 
     if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_uf_group', 'frontend_title')) {
       $selectFields[] = 'frontend_title';


### PR DESCRIPTION
https://lab.civicrm.org/dev/drupal/-/issues/153 - includes the UFGroup name as one of the return fields by default. The validation method in this class looks up the UFGroup by name so it would be nice to just have it available. This MR is in addition to a PR to the civicrm-drupal-8 project.