### PR TITLE
(REF) Fix field name when doing DAO find in MergerTest

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -170,7 +170,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $dao = new CRM_Dedupe_DAO_DedupeRuleGroup();
     $dao->contact_type = 'Individual';
     $dao->name = 'IndividualSupervised';
-    $dao->is_default = 1;
+    $dao->is_reserved = 1;
     $dao->find(TRUE);
 
     $foundDupes = CRM_Dedupe_Finder::dupesInGroup($dao->id, $this->_groupId);
@@ -240,7 +240,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $dao = new CRM_Dedupe_DAO_DedupeRuleGroup();
     $dao->contact_type = 'Individual';
     $dao->name = 'IndividualSupervised';
-    $dao->is_default = 1;
+    $dao->is_reserved = 1;
     $dao->find(TRUE);
 
     $foundDupes = CRM_Dedupe_Finder::dupesInGroup($dao->id, $this->_groupId);


### PR DESCRIPTION
Overview
----------------------------------------
This is broadly related to the PHP8.2 deprecated properties work, but this was also wrong in it's own right. 

Before
----------------------------------------
DedupeRuleGroup's don't have a `is_default` field. Therefore the `is_default` field was being marked as a deprecated dynamic property, and ignored for the purposes of the search.

After
----------------------------------------
Is default changed to `is_reserved`. I almost just removed the `is_default` lines, but I've taken a guess that the original purpose was to test that the `IndividualSupervised` rule remains reserved in new installs, which makes sense.

Comments
----------------------------------------
It only affects tests, and wasn't breaking anything, but even so this might be the first unintended behaviour found as part of the deprecation of dyanmic properties. I suspect we'll come across more like this.
