### PR TITLE
PHP 8.1 compatibility when enabling logging

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -743,7 +743,7 @@ WHERE  table_schema IN ('{$this->db}', '{$civiDB}')";
           }
           elseif (
             $civiTableSpecs[$col]['COLUMN_DEFAULT'] != ($logTableSpecs[$col]['COLUMN_DEFAULT'] ?? NULL)
-            && !stristr($civiTableSpecs[$col]['COLUMN_DEFAULT'], 'timestamp')
+            && !stristr(($civiTableSpecs[$col]['COLUMN_DEFAULT'] ?? ''), 'timestamp')
             && !($civiTableSpecs[$col]['COLUMN_DEFAULT'] === NULL && ($logTableSpecs[$col]['COLUMN_DEFAULT'] ?? NULL) === 'NULL')
           ) {
             // if default property is different, and its not about a timestamp column, consider it


### PR DESCRIPTION
Overview
----------------------------------------
When enabling logging via `/civicrm/admin/setting/misc?reset=1` on a PHP 8.1+ system:
`Deprecated function: stristr(): Passing null to parameter #1 ($haystack) of type string is deprecated in CRM_Logging_Schema->columnsWithDiffSpecs() (line 746 of /.../civicrm/CRM/Logging/Schema.php).`

Before
----------------------------------------
- First parameter can be `NULL`, which stistr doesn't like

After
----------------------------------------
- NULL coalesced to empty string
- Columns still detected correctly if changes are needed
- No more PHP warnings when enabling logging on PHP 8.1+
