### PR TITLE
Fix failure when changing processor type on add Payment Processor screen

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -114,13 +114,13 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
     $this->assign('ppTypeName', $this->_paymentProcessorDAO->name);
 
     if ($this->_id) {
-      $refreshURL = CRM_Utils_System::url('civicrm/admin/paymentProcessor',
+      $refreshURL = CRM_Utils_System::url('civicrm/admin/paymentProcessor/edit',
         "reset=1&action=update&id={$this->_id}",
         FALSE, NULL, FALSE
       );
     }
     else {
-      $refreshURL = CRM_Utils_System::url('civicrm/admin/paymentProcessor',
+      $refreshURL = CRM_Utils_System::url('civicrm/admin/paymentProcessor/edit',
         "reset=1&action=add",
         FALSE, NULL, FALSE
       );


### PR DESCRIPTION
Overview
----------------------------------------
With AdminUI enabled, trying to add a payment processor fails when the processor is changed from the default.

See https://chat.civicrm.org/civicrm/pl/ax16thpgujfx3k7xdz7oarygyc

Before
----------------------------------------
Changing the Payment Processor reloads the configuration page correctly when AdminUI is not enabled, but fails when it is enabled.

After
----------------------------------------
Changing the Payment Processor reloads the configuration page correctly with and without AdminUI enabled.

Technical Details
----------------------------------------
The editing path was changed to `civicrm/admin/paymentProcessor/edit` but the URL used by the javascript `reload()` function was not updated.

Comments
----------------------------------------
The experience is a little odd when AdminUI is enabled as the initial configuration page is displayed as a pop-up, then when the processor type is changed, the reload is done on the base page, not the pop-up window.  But it works.

We need an option in SearchKit to make 'Add new' reload in the page rather than a pop-up.  When that is added, AdminUI can be updated to use that.

@colemanw 
