### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in api_v3_ContactTypeTest

### DIFF
--- a/tests/phpunit/api/v3/ContactTypeTest.php
+++ b/tests/phpunit/api/v3/ContactTypeTest.php
@@ -16,6 +16,21 @@
 class api_v3_ContactTypeTest extends CiviUnitTestCase {
   protected $_apiversion;
 
+  /**
+   * @var string
+   */
+  protected $subTypeIndividual;
+
+  /**
+   * @var string
+   */
+  protected $subTypeOrganization;
+
+  /**
+   * @var string
+   */
+  protected $subTypeHousehold;
+
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);
@@ -26,7 +41,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'parent_id' => 1,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->subTypeIndividual = $params['name'];
 
     $params = [
@@ -36,7 +51,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'parent_id' => 3,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->subTypeOrganization = $params['name'];
 
     $params = [
@@ -46,7 +61,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'parent_id' => 2,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->subTypeHousehold = $params['name'];
   }
 
@@ -111,7 +126,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
       'contact_sub_type' => $this->subTypeHousehold,
     ];
-    $contact = $this->callAPIFailure('contact', 'create', $contactParams);
+    $this->callAPIFailure('contact', 'create', $contactParams);
 
     // check for Type:Organization Subtype:sub_individual
     $contactParams = [
@@ -119,7 +134,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'contact_type' => 'Organization',
       'contact_sub_type' => $this->subTypeIndividual,
     ];
-    $contact = $this->callAPIFailure('contact', 'create', $contactParams);
+    $this->callAPIFailure('contact', 'create', $contactParams);
   }
 
   /**
@@ -214,7 +229,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
       'contact_sub_type' => $this->subTypeHousehold,
     ];
-    $updateContact = $this->callAPIFailure('contact', 'create', $updateParams);
+    $this->callAPIFailure('contact', 'create', $updateParams);
     $params = [
       'contact_id' => $contact['id'],
     ];
@@ -233,7 +248,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'contact_type' => 'Organization',
       'contact_sub_type' => $this->subTypeIndividual,
     ];
-    $updateContact = $this->callAPIFailure('contact', 'create', $updateParams);
+    $this->callAPIFailure('contact', 'create', $updateParams);
     $params = [
       'contact_id' => $contact['id'],
     ];
@@ -256,7 +271,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'parent_id' => 1,
       'is_active' => 1,
     ];
-    $getSubtype = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $subtype = $params['name'];
 
     // check for Type:Individual subype:sub_individual
@@ -299,7 +314,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'parent_id' => 3,
       'is_active' => 1,
     ];
-    $getSubtype = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $subtype = $params['name'];
 
     // check for Type:Organization subype:sub_organization
@@ -357,7 +372,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
       'contact_sub_type' => $this->subTypeHousehold,
     ];
-    $updateContact = $this->callAPIFailure('contact', 'create', $updateParams);
+    $this->callAPIFailure('contact', 'create', $updateParams);
     $params = [
       'contact_id' => $contact['id'],
     ];
@@ -376,7 +391,7 @@ class api_v3_ContactTypeTest extends CiviUnitTestCase {
       'contact_id' => $contact['id'],
       'contact_sub_type' => $this->subTypeIndividual,
     ];
-    $updateContact = $this->callAPIFailure('contact', 'create', $updateParams);
+    $this->callAPIFailure('contact', 'create', $updateParams);
     $params = [
       'contact_id' => $contact['id'],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in api_v3_ContactTypeTest

Before
----------------------------------------
Several properties set and retreived dynamically, which is deprecated in PHP 8.2. See https://lab.civicrm.org/dev/core/-/issues/3833 for context.

After
----------------------------------------
Correctly declare properties for `api_v3_ContactTypeTest`

Comments
----------------------------------------
`_apiversion` seems a bit pointlessly declared on line 17, as it's also declared in the parent, but I wasn't sure if there was a reason I'm missing so I've left it.

I've also tidied up some variables which were being set but not used.
