### PR TITLE
Remove error suppression operator from test

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -195,7 +195,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $object->set('rgid', $dao->id);
     $object->set('action', CRM_Core_Action::UPDATE);
     $object->setEmbedded(TRUE);
-    @$object->run();
+    $object->run();
 
     // Retrieve pairs from prev next cache table
     $select = ['pn.is_selected' => 'is_selected'];
@@ -265,7 +265,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     $object->set('rgid', $dao->id);
     $object->set('action', CRM_Core_Action::UPDATE);
     $object->setEmbedded(TRUE);
-    @$object->run();
+    $object->run();
 
     // Retrieve pairs from prev next cache table
     $select = ['pn.is_selected' => 'is_selected'];


### PR DESCRIPTION
Overview
----------------------------------------
Remove error suppression operator from test.

This error is bad practice, and could be hiding real problems.

I wouldn't be surprised if this test fails - if it does we should fix the underlying cause rather than keeping the error suppression. 