### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in module tests

### DIFF
--- a/tests/phpunit/CRM/Extension/Manager/ModuleTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/ModuleTest.php
@@ -6,6 +6,16 @@
  */
 class CRM_Extension_Manager_ModuleTest extends CiviUnitTestCase {
 
+  /**
+   * @var string
+   */
+  protected $basedir;
+
+  /**
+   * @var \CRM_Extension_System
+   */
+  protected $system;
+
   public function setUp():void {
     parent::setUp();
     // $query = "INSERT INTO civicrm_domain ( name, version ) VALUES ( 'domain', 3 )";

--- a/tests/phpunit/CRM/Extension/Manager/ModuleUpgTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/ModuleUpgTest.php
@@ -7,6 +7,11 @@
 class CRM_Extension_Manager_ModuleUpgTest extends CiviUnitTestCase {
 
   /**
+   * @var string
+   */
+  protected $basedir;
+
+  /**
    * @var \CRM_Extension_System
    */
   protected $system;


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in module tests

Before
----------------------------------------
`basedir` and `system` were used as dynamic properties, not declared.

After
----------------------------------------
The properties are declared, we move closer to PHP8.2 support.

See https://lab.civicrm.org/dev/core/-/issues/3833