### PR TITLE
(REF) Tidy up properties in CRM_Core_ResourcesTest

### DIFF
--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -40,7 +40,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
   public function setUp(): void {
     parent::setUp();
 
-    list ($this->basedir, $this->container, $this->mapper) = $this->_createMapper();
+    $this->mapper = $this->createMapper();
     $cache = new CRM_Utils_Cache_Arraycache([]);
     $this->res = new CRM_Core_Resources($this->mapper, new CRM_Core_Resources_Strings($cache), NULL);
     $this->res->setCacheCode('resTest');
@@ -427,22 +427,18 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
   }
 
   /**
-   * @param CRM_Utils_Cache_Interface $cache
-   * @param string $cacheKey
-   *
-   * @return array
-   *   [string $basedir, CRM_Extension_Container_Interface, CRM_Extension_Mapper]
+   * @return CRM_Extension_Mapper
    */
-  public function _createMapper(CRM_Utils_Cache_Interface $cache = NULL, $cacheKey = NULL) {
+  private function createMapper() {
     $basedir = rtrim($this->createTempDir('ext-'), '/');
     mkdir("$basedir/com.example.ext");
     mkdir("$basedir/com.example.ext/js");
     file_put_contents("$basedir/com.example.ext/info.xml", "<extension key='com.example.ext' type='report'><file>oddball</file></extension>");
     file_put_contents("$basedir/com.example.ext/js/example.js", "alert('Boo!');");
     // not needed for now // file_put_contents("$basedir/weird/bar/oddball.php", "<?php\n");
-    $c = new CRM_Extension_Container_Basic($basedir, 'http://ext-dir', $cache, $cacheKey);
+    $c = new CRM_Extension_Container_Basic($basedir, 'http://ext-dir', NULL, NULL);
     $mapper = new CRM_Extension_Mapper($c, NULL, NULL, '/pathto/civicrm', 'http://core-app');
-    return [$basedir, $c, $mapper];
+    return $mapper;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This is a general tidy up of ` CRM_Core_ResourcesTest`. The driving motivation is removing dynamic properties for PHP8.2 support, but in this case the refactoring goes slightly further.

Before
----------------------------------------
1. `basedir` and `container` existed as dynamic properties. Aside from dynamic properties being deprecated, these properties were not used.
2. `_createMapper` took `$cache` and `$cacheKey` arguments, but nothing that called `_createMapper` ever passed in a value.
3. I think many people would argue that the use of `list` was unnecessary here, and harmed readability.

After
----------------------------------------
Refactored so that the unneccessary dynamic properties are not created, and tidied up the `createMapper` function.


Comments
----------------------------------------
As this is a test there should be no backwards-compat risk to changing `createMapper`.

`$this->mapper` is only actually referenced in commented out code. I almost went a step further and made `$mapper` a local variable, not a property, but I was not sure if it was appropriate to delete the commented out test that referenced `$this->mapper`, or leave the commented out code pointing to a property that no longer exists.
