### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in api_v3_GroupOrganizationTest

### DIFF
--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -19,6 +19,16 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
   protected $_apiversion;
 
   /**
+   * @var int
+   */
+  private $_groupID;
+
+  /**
+   * @var int
+   */
+  private $_orgID;
+
+  /**
    * Sets up the fixture, for example, opens a network connection.
    * This method is called before a test is executed.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in api_v3_GroupOrganizationTest

Before
----------------------------------------
`_groupID` and `_orgID` were dynamic properties.

After
----------------------------------------
These properties are declared, which is the right way to do things in PHP 8.2.

See https://lab.civicrm.org/dev/core/-/issues/3833 for additional context.