### PR TITLE
[REF][PHP8.2] Fix PHP8.2 creation of dynamic properties in the elavon…

### DIFF
--- a/ext/elavon/CRM/Core/Payment/Elavon.php
+++ b/ext/elavon/CRM/Core/Payment/Elavon.php
@@ -28,6 +28,13 @@ use Civi\Payment\Exception\PaymentProcessorException;
 class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
 
   /**
+   * Payment Processor Mode
+   *   either test or live
+   * @var string
+   */
+  protected $_mode;
+
+  /**
    * Constructor.
    *
    * @param string $mode

--- a/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
+++ b/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
@@ -26,6 +26,18 @@ class CRM_Core_Payment_ElavonTest extends \PHPUnit\Framework\TestCase implements
   use \Civi\Test\Api3TestTrait;
 
   /**
+   * Instance of CRM_Core_Payment_Elavon|null
+   * @var CRM_Core_Payment_Elavon
+   */
+  protected $processor;
+
+  /**
+   * Created Object Ids
+   * @var array
+   */
+  public $ids;
+
+  /**
    * Setup used when HeadlessInterface is implemented.
    *
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().


### PR DESCRIPTION
… tests and Payment Processor class

Overview
----------------------------------------
This fixes the creation of dynamic properties in class in the elavon extension

Before
----------------------------------------
Elavon tests fail in PHP8.2

After
----------------------------------------
Tests pass on php8.2

ping @eileenmcnaughton @demeritcowboy @braders 