### PR TITLE
dev/core#4081 Ensure that if using the API to update an event templat…

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -95,9 +95,6 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event implements \Civi\Core\Hook
    */
   public static function create(&$params) {
     $transaction = new CRM_Core_Transaction();
-    if (empty($params['is_template'])) {
-      $params['is_template'] = 0;
-    }
     // check if new event, if so set the created_id (if not set)
     // and always set created_date to now
     if (empty($params['id'])) {

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -935,4 +935,28 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $this->assertEquals(1, $result['count']);
   }
 
+  /**
+   * Test that using the API to update an Event template keeps the is_template parameter the same
+   * @dataProvider versionThreeAndFour
+   */
+  public function testUpdateEventTemplate($version): void {
+    $this->_apiversion = $version;
+    $templateParams = [
+      'summary' => 'Sign up now to learn the results of this unit test',
+      'description' => 'This event is created from a template, so all the values should be the same as the original ones.',
+      'event_type_id' => 1,
+      'is_public' => 1,
+      'end_date' => '2018-06-25 17:00:00',
+      'is_online_registration' => 1,
+      'registration_start_date' => '2017-06-25 17:00:00',
+      'registration_end_date' => '2018-06-25 17:00:00',
+      'max_participants' => 100,
+      'event_full_text' => 'Sorry! We are already full',
+    ];
+    $template = $this->callAPISuccess('Event', 'create', ['is_template' => 1, 'template_title' => 'Test tpl'] + $templateParams);
+    $this->callAPISuccess('Event', 'create', ['id' => $template['id'], 'is_public' => 0]);
+    $template = $this->callAPISuccess('Event', 'get', ['id' => $template['id']])['values'][$template['id']];
+    $this->assertEquals(1, $template['is_template']);
+  }
+
 }


### PR DESCRIPTION
…e it is not converted to a non template

Overview
----------------------------------------
When using the API to update an Event template the is_template flag gets reset to be 0

Before
----------------------------------------
is_template flag is reset when updating via api

After
----------------------------------------
is_template flag is not reset 

ping @demeritcowboy @eileenmcnaughton 