### PR TITLE
Early return when the cart is not enabled in event cart extension

### DIFF
--- a/ext/eventcart/eventcart.php
+++ b/ext/eventcart/eventcart.php
@@ -11,15 +11,12 @@ use CRM_Eventcart_ExtensionUtil as E;
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
  */
 function eventcart_civicrm_config(&$config) {
-  if (isset(Civi::$statics[__FUNCTION__])) {
+  // Since as a hidden extension it's always enabled, until this is a "real" extension you can turn off we need to check the legacy setting.
+  if (isset(Civi::$statics[__FUNCTION__]) || !Civi::settings()->get('enable_cart')) {
     return;
   }
   Civi::$statics[__FUNCTION__] = 1;
-  // Since as a hidden extension it's always enabled, until this is a "real" extension you can turn off we need to check the legacy setting.
-  if ((bool) Civi::settings()->get('enable_cart')) {
-    Civi::dispatcher()->addListener('hook_civicrm_pageRun', 'CRM_Event_Cart_PageCallback::run');
-  }
-
+  Civi::dispatcher()->addListener('hook_civicrm_pageRun', 'CRM_Event_Cart_PageCallback::run');
   _eventcart_civix_civicrm_config($config);
 }
 


### PR DESCRIPTION


Overview
----------------------------------------
Early return when the cart is not enabled in event cart extension

Before
----------------------------------------
Extension template directory added to list of directories to scan, even if the setting means the extension is actually not enabled

After
----------------------------------------
Directory only added if the extension is 'on' via the setting

Technical Details
----------------------------------------
This just saves 1 directory from being added to the scan. I did duplicate the statics setting - as it seemed there might be some very marginal performance improvement

Comments
----------------------------------------
