### PR TITLE
Add new Config function to register templates

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -589,7 +589,10 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       return;
     }
     if (($templateDirectory['type'] ?? 'Smarty') === 'Smarty') {
-      CRM_Core_Smarty::singleton()->addTemplateDir($templateDirectory['path']);
+      \Civi::$statics['CRM_Core_Smarty']['PATHS'][] = $templateDirectory['path'];
+      if (CRM_Core_Smarty::$_singleton !== NULL) {
+        CRM_Core_Smarty::singleton()->addTemplateDir($templateDirectory['path']);
+      }
       return;
     }
     throw new CRM_Core_Exception('Only Smarty supported currently');

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -573,4 +573,26 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     CRM_Core_Config::singleton()->doNotResetCache = $enabled ? 0 : 1;
   }
 
+  /**
+   * Register a template directory with the template engine.
+   *
+   * @param array $templateDirectory Array describing the template directory with
+   *  - path Full file path
+   *  - type Currently always 'Smarty'
+   *  - version Currently always 2 - ie Smarty v2, currently ignored.
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function registerTemplateDirectory(array $templateDirectory): void {
+    if (!file_exists($templateDirectory['path'])) {
+      return;
+    }
+    if (($templateDirectory['type'] ?? 'Smarty') === 'Smarty') {
+      CRM_Core_Smarty::singleton()->addTemplateDir($templateDirectory['path']);
+      return;
+    }
+    throw new CRM_Core_Exception('Only Smarty supported currently');
+  }
+
 }

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -314,7 +314,7 @@ class CRM_Core_Smarty extends Smarty {
       // More recent versions of Smarty have this method.
       return parent::addTemplateDir($template_dir, $key, $isConfig);
     }
-    if (is_array($this->template_dir)) {
+    if (is_array($this->template_dir) && !in_array($template_dir, $this->template_dir, TRUE)) {
       array_unshift($this->template_dir, $template_dir);
     }
     else {

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -55,7 +55,7 @@ class CRM_Core_Smarty extends Smarty {
    *
    * @var object
    */
-  static private $_singleton = NULL;
+  static public $_singleton = NULL;
 
   /**
    * Backup frames.
@@ -69,14 +69,14 @@ class CRM_Core_Smarty extends Smarty {
   private function initialize() {
     $config = CRM_Core_Config::singleton();
 
+    $this->template_dir = $config->templateDir;
     if (isset($config->customTemplateDir) && $config->customTemplateDir) {
-      $this->template_dir = array_merge([$config->customTemplateDir],
-        $config->templateDir
-      );
+      $this->addTemplateDir($config->customTemplateDir);
     }
-    else {
-      $this->template_dir = $config->templateDir;
+    foreach (\Civi::$statics['CRM_Core_Smarty']['PATHS'] ?? [] as $dir) {
+      $this->addTemplateDir($dir);
     }
+
     $this->compile_dir = CRM_Utils_File::addTrailingSlash(CRM_Utils_File::addTrailingSlash($config->templateCompileDir) . $this->getLocale());
     CRM_Utils_File::createDir($this->compile_dir);
     CRM_Utils_File::restrictAccess($this->compile_dir);

--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -301,16 +301,26 @@ class CRM_Core_Smarty extends Smarty {
   }
 
   /**
-   * @param $path
+   * Add template directory(s).
+   *
+   * @param string|array $template_dir directory(s) of template sources
+   * @param string $key (Smarty3+) of the array element to assign the template dir to
+   * @param bool $isConfig (Smarty3+) true for config_dir
+   *
+   * @return Smarty          current Smarty instance for chaining
    */
-  public function addTemplateDir($path) {
+  public function addTemplateDir($template_dir, $key = NULL, $isConfig = FALSE) {
+    if (method_exists('parent', 'addTemplateDir')) {
+      // More recent versions of Smarty have this method.
+      return parent::addTemplateDir($template_dir, $key, $isConfig);
+    }
     if (is_array($this->template_dir)) {
-      array_unshift($this->template_dir, $path);
+      array_unshift($this->template_dir, $template_dir);
     }
     else {
-      $this->template_dir = [$path, $this->template_dir];
+      $this->template_dir = [$template_dir, $this->template_dir];
     }
-
+    return $this;
   }
 
   /**

--- a/mixin/smarty-v2@1/mixin.php
+++ b/mixin/smarty-v2@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty-v2
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.1.0
  * @since 5.59
  *
  * @param CRM_Extension_MixInfo $mixInfo
@@ -19,14 +19,11 @@ return function ($mixInfo, $bootCache) {
   }
 
   $register = function() use ($dir) {
-    // This implementation is useful for older versions of CiviCRM. It can be replaced/updated going forward (v1.1+).
-    $smarty = CRM_Core_Smarty::singleton();
-    if (!is_array($smarty->template_dir)) {
-      $this->template_dir = [$smarty->template_dir];
-    }
-    if (!in_array($dir, $smarty->template_dir)) {
-      array_unshift($smarty->template_dir, $dir);
-    }
+    \CRM_Core_Config::singleton()->registerTemplateDirectory([
+      'path' => $dir,
+      'type' => 'Smarty',
+      'version' => 2,
+    ]);
   };
 
   // Let's figure out what environment we're in -- so that we know the best way to call $register().

--- a/tools/mixin/bin/mixer
+++ b/tools/mixin/bin/mixer
@@ -273,7 +273,7 @@ function main($args) {
     }
   }
 
-  if (function_exists($task)) {
+  if ($task && function_exists($task)) {
     call_user_func($task, $newOptions, ...$newArgs);
   }
   else {


### PR DESCRIPTION
I had been upgrading some of the extensions civix to use the addTemplateDir method (this is already merged to civix and replaces the more cludgey way that fails post Smarty2).

However, it struck me that we are still calling a
class that extends the Smarty class - which means we have fewer options than if we call a separate class, with no Smarty dependency.

The specific challenge currently is that
loading version 3 from an extension 'works' but I have to directly hack the require_once in the file because the CRM_Core_Smarty file is loaded by the first class that attempts to run it's stock civix config. In theory if the classes didn't do this then the extension's auto-loader would kick in and we could do a class_exists check first. I'm sure it's more difficult than that but
I think not involving the Smarty class directly
in our config functions we have more options
to evolve it.

I made the signature an array since that felt more flexible although only type=Smarty is a thing and
the version is ignored at this stage

Note this would also require a civix update & the goal is to start phasing this in in preparation for a future option to use Smarty3

Related https://github.com/civicrm/civicrm-core/pull/25248

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
