### PR TITLE
Queues - Ensure that queue timings work, even with bad tzdata

### DIFF
--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -59,12 +59,12 @@ trait CRM_Queue_Queue_SqlTrait {
     switch ($name) {
       case 'ready':
         return (int) CRM_Core_DAO::singleValueQuery(
-          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1 AND (release_time is null OR release_time <= FROM_UNIXTIME(%2))',
+          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1 AND (release_time is null OR UNIX_TIMESTAMP(release_time) <= %2)',
           [1 => [$this->getName(), 'String'], 2 => [CRM_Utils_Time::time(), 'Int']]);
 
       case 'blocked':
         return (int) CRM_Core_DAO::singleValueQuery(
-          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1 AND release_time > FROM_UNIXTIME(%2)',
+          'SELECT count(*) FROM civicrm_queue_item WHERE queue_name = %1 AND UNIX_TIMESTAMP(release_time) > %2',
           [1 => [$this->getName(), 'String'], 2 => [CRM_Utils_Time::time(), 'Int']]);
 
       case 'total':

--- a/CRM/Utils/Time.php
+++ b/CRM/Utils/Time.php
@@ -75,6 +75,16 @@ class CRM_Utils_Time {
   }
 
   /**
+   * Get the simulation offset.
+   *
+   * @return int
+   *   Seconds between logical time and real time.
+   */
+  public static function delta(): int {
+    return self::$callback === NULL ? 0 : (call_user_func(self::$callback) - time());
+  }
+
+  /**
    * Get the time.
    *
    * @param string $returnFormat


### PR DESCRIPTION
Overview
----------------------------------------

The queue tests have been reporting different results on different hosts -- e.g. they pass on `test-{1,2,3}` and on my laptop, but they fail on the temporary worker nodes. The difference is that `tzdata` does not appear to be loaded on the temp node's copy of `mysqld`.

This updates the queuing queries so that the correctness of `tzdata` does not affect the outcome. 

Before
----------------------------------------

We can see that `tests/phpunit/api/v4/Entity/QueueTest.php` has several failures in this environment.

Note:

After
----------------------------------------

After: It doesn't matter if mysqld has tzdata. The test passes.

Comments
-----------------------------------------

I'm not sure if this reflects a substantive bug for typical runtimes. It might... or it might be that the test-suite requires more unusual situations.