### PR TITLE
System Status - Add check to ensure that MySQL timezones are operational

### DIFF
--- a/CRM/Utils/Check/Component/Timestamps.php
+++ b/CRM/Utils/Check/Component/Timestamps.php
@@ -19,6 +19,48 @@ class CRM_Utils_Check_Component_Timestamps extends CRM_Utils_Check_Component {
   const DOCTOR_WHEN = 'https://github.com/civicrm/org.civicrm.doctorwhen';
 
   /**
+   * Check that MySQL actually supports timezone operations.
+   *
+   * @return CRM_Utils_Check_Message[]
+   */
+  public function checkTimezoneAPIs() {
+    $messages = [];
+
+    try {
+      $tzCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM mysql.time_zone_name');
+    }
+    catch (\Exception $e) {
+      $tzCount = 0;
+    }
+
+    try {
+      $convertedTime = CRM_Core_DAO::singleValueQuery('SELECT CONVERT_TZ("2001-02-03 04:05:00", "GMT", "America/New_York")');
+    }
+    catch (\Exception $e) {
+      $convertedTime = NULL;
+    }
+    $expectedTime = '2001-02-02 23:05:00';
+
+    if ($tzCount < 5 || $convertedTime !== $expectedTime) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__,
+        ts('The MySQL database does not fully support timezones. Please ask the database administrator to <a %1>load timezone data</a>.', [
+          // If we had a manual page, it would make sense to link to that. Such a page might
+          // (a) point out that the process is similar for MySQL 5.x/8.x and MariaDB,
+          // and (b) talk more about potential impacts (re: current code; extensions; future changes).
+          // We don't have that page. But this link gives the general gist.
+          1 => 'target="_blank" href="https://dev.mysql.com/doc/refman/8.0/en/mysql-tzinfo-to-sql.html"',
+        ]),
+        ts('MySQL Timezone Problem'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-clock-o'
+      );
+    }
+
+    return $messages;
+  }
+
+  /**
    * Check that various columns are TIMESTAMP and not DATETIME. (CRM-9683, etal)
    *
    * @return CRM_Utils_Check_Message[]


### PR DESCRIPTION
Overview
----------------------------------------

Add a status check to ensure that MySQL can consistently handle `TIMESTAMP` data in a timezone-sensitive fashion.

The main issue is that timezone data has to be loaded into MySQL. Many platforms/environments do this automatically, but some don't.

Before
----------------------------------------

No status check. You may have random trouble because MySQL cannot accurately set the timezone.

After
----------------------------------------

If MySQL lacks timezone support, then Civi will display a warning:

<img width="945" alt="Screen Shot 2023-01-16 at 10 52 03 PM" src="https://user-images.githubusercontent.com/1336047/212829558-f620cfc8-6b82-48c8-a126-25825bdcff94.png">

Comments
----------------------------------------

I was ambivalent about whether to target `5.58` or `master`. The branch is based on a shared commit, so it should be easy to switch if appropriate.