### PR TITLE
(dev/backdrop#77) Fix fatal error with password validation

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -198,10 +198,16 @@ class CRM_Core_BAO_CMSUser {
         $params = [
           'name' => $fields['cms_name'],
           'mail' => $fields[$emailName],
+          'pass' => $fields['cms_pass'],
         ];
       }
 
       $config->userSystem->checkUserNameEmailExists($params, $errors, $emailName);
+
+      // Verify the password.
+      if ($config->userSystem->isPasswordUserGenerated()) {
+        $config->userSystem->verifyPassword($params, $errors);
+      }
     }
     return (!empty($errors)) ? $errors : TRUE;
   }

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -33,8 +33,13 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
     ];
 
     $admin = user_access('administer users');
+    $user_register_conf = config_get('system.core', 'user_register');
+    if (!$admin && $user_register_conf == 'admin_only') {
+      return FALSE;
+    }
+
     if (!config_get('system.core', 'user_email_verification') || $admin) {
-      $form_state['input']['pass'] = ['pass1' => $params['cms_pass'], 'pass2' => $params['cms_pass']];
+      $form_state['input']['pass'] = $params['cms_pass'];
     }
 
     if (!empty($params['notify'])) {
@@ -417,6 +422,44 @@ AND    u.status = 1
       return FALSE;
     }
     return TRUE;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function verifyPassword($params, &$errors) {
+    $errors = form_get_errors();
+    if ($errors) {
+      // unset Backdrop messages to avoid twice display of errors
+      unset($_SESSION['messages']);
+    }
+
+    $password = trim($params['pass']);
+    $username = $params['name'];
+    $email = $params['mail'];
+
+    module_load_include('password.inc', 'user', 'user');
+    $reject_weak = user_password_reject_weak($username);
+    if (!$reject_weak) {
+      return;
+    }
+
+    $strength = _user_password_evaluate_strength($password, $username, $email);
+
+    if ($strength < config('system.core')->get('user_password_strength_threshold')) {
+      $password_errors[] = ts('The password is too weak. Please consider making your password longer or more complex: that it contains a number of lower- and uppercase letters, digits and punctuation.');
+    }
+
+    if (backdrop_strtolower($password) == backdrop_strtolower($username)) {
+      $password_errors[] = ts('The password cannot be the same as the username.');
+    }
+    if (backdrop_strtolower($password) == backdrop_strtolower($email)) {
+      $password_errors[] = ts('The password cannot be the same as the email.');
+    }
+
+    if (!empty($password_errors)) {
+      $errors['cms_pass'] = ts('Weak passwords are rejected. Please note the following issues: %1', [1 => implode(' ', $password_errors)]);
+    }
   }
 
   /**

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -102,10 +102,10 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
    *   Field label for the 'email'.
    */
   public static function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
-    $errors = form_get_errors();
-    if ($errors) {
+    if ($backdrop_errors = form_get_errors()) {
       // unset Backdrop messages to avoid twice display of errors
       unset($_SESSION['messages']);
+      $errors = array_merge($errors, $backdrop_errors);
     }
 
     if (!empty($params['name'])) {
@@ -428,10 +428,10 @@ AND    u.status = 1
    * @inheritdoc
    */
   public function verifyPassword($params, &$errors) {
-    $errors = form_get_errors();
-    if ($errors) {
+    if ($backdrop_errors = form_get_errors()) {
       // unset Backdrop messages to avoid twice display of errors
       unset($_SESSION['messages']);
+      $errors = array_merge($errors, $backdrop_errors);
     }
 
     $password = trim($params['pass']);

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -459,6 +459,17 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Verify password
+   *
+   * @param array $params
+   *   Array of name, mail and password values.
+   * @param array $errors
+   *   Array of errors.
+   */
+  public function verifyPassword($params, &$errors) {
+  }
+
+  /**
    * Is a front end page being accessed.
    *
    * Generally this would be a contribution form or other public page as opposed to a backoffice page (like contact edit).


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/backdrop/-/issues/77

It ensures that Backdrop's password validation (if enabled) will get the password field it expects: a string not an array.

And it also adds the ability for Backdrop (and other CMSes) to validate the password field if it appears on a CiviCRM profile form. (Otherwise CMS validation happens too late).