### PR TITLE
[REF][PHP8.2] Use const instead of dynamic property: CRM_Contribute_BAO_ContributionPageTest

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionPageTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionPageTest.php
@@ -15,9 +15,10 @@
  */
 class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
 
+  const FINANCIAL_TYPE_ID = 1;
+
   public function setUp(): void {
     parent::setUp();
-    $this->_financialTypeID = 1;
   }
 
   /**
@@ -28,7 +29,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
     $params = [
       'qfkey' => '9a3ef3c08879ad4c8c109b21c583400e',
       'title' => 'Test Contribution Page',
-      'financial_type_id' => $this->_financialTypeID,
+      'financial_type_id' => self::FINANCIAL_TYPE_ID,
       'intro_text' => '',
       'footer_text' => 'Thanks',
       'is_for_organization' => 0,
@@ -58,7 +59,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
 
     $params = [
       'title' => 'Test Contribution Page',
-      'financial_type_id' => $this->_financialTypeID,
+      'financial_type_id' => self::FINANCIAL_TYPE_ID,
       'is_active' => 1,
     ];
 
@@ -77,7 +78,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
 
     $params = [
       'title' => 'Test Contribution Page',
-      'financial_type_id' => $this->_financialTypeID,
+      'financial_type_id' => self::FINANCIAL_TYPE_ID,
       'is_active' => 1,
     ];
 
@@ -88,7 +89,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
     CRM_Contribute_BAO_ContributionPage::setValues($id, $values);
 
     $this->assertEquals($params['title'], $values['title'], 'Verify contribution title.');
-    $this->assertEquals($this->_financialTypeID, $values['financial_type_id'], 'Verify financial types id.');
+    $this->assertEquals(self::FINANCIAL_TYPE_ID, $values['financial_type_id'], 'Verify financial types id.');
     $this->assertEquals(1, $values['is_active'], 'Verify contribution is_active value.');
     $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionPage->id]);
   }
@@ -100,7 +101,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
     $params = [
       'qfkey' => '9a3ef3c08879ad4c8c109b21c583400e',
       'title' => 'Test Contribution Page',
-      'financial_type_id' => $this->_financialTypeID,
+      'financial_type_id' => self::FINANCIAL_TYPE_ID,
       'intro_text' => '',
       'footer_text' => 'Thanks',
       'is_for_organization' => 0,
@@ -118,7 +119,7 @@ class CRM_Contribute_BAO_ContributionPageTest extends CiviUnitTestCase {
 
     $contributionPage = CRM_Contribute_BAO_ContributionPage::create($params);
     $copyContributionPage = CRM_Contribute_BAO_ContributionPage::copy($contributionPage->id);
-    $this->assertEquals($copyContributionPage->financial_type_id, $this->_financialTypeID, 'Check for Financial type id.');
+    $this->assertEquals($copyContributionPage->financial_type_id, self::FINANCIAL_TYPE_ID, 'Check for Financial type id.');
     $this->assertEquals($copyContributionPage->goal_amount, 400, 'Check for goal amount.');
     $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionPage->id]);
     $this->callAPISuccess('ContributionPage', 'delete', ['id' => $copyContributionPage->id]);


### PR DESCRIPTION
Overview
----------------------------------------
Use const instead of dynamic property in CRM_Contribute_BAO_ContributionPageTest

Before
----------------------------------------
A dynamic property was being used to ensure a consistent ID was used across tests. Dynamic properties are deprecated in PHP8.2 The value was hardcoded and never changed.

After
----------------------------------------
Use a `const` instead, this text will run cleanly on PHP 8.2

Comments
----------------------------------------
It's a test so backwards compatiability risk is very low.
