### PR TITLE
[REF][PHP8.2] Declare $file property in CRM_Utils_ZipTest

### DIFF
--- a/tests/phpunit/CRM/Utils/ZipTest.php
+++ b/tests/phpunit/CRM/Utils/ZipTest.php
@@ -15,6 +15,12 @@
  */
 class CRM_Utils_ZipTest extends CiviUnitTestCase {
 
+  /**
+   * Reference to filename, to allow cleanup in tearDown
+   * @var string|false
+   */
+  private $file = FALSE;
+
   public function setUp(): void {
     parent::setUp();
     $this->file = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Declare $file property in CRM_Utils_ZipTest

Before
----------------------------------------
`$file` was not declared; i.e. was a dynamic property. 

After
----------------------------------------
Test runs cleanly on PHP8.2

Comments
----------------------------------------
It's a test so backwards compatiability risk is very low.
