### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in api_v3_EventTest

### DIFF
--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -18,6 +18,16 @@ class api_v3_EventTest extends CiviUnitTestCase {
   protected $_apiversion;
   protected $_entity;
 
+  /**
+   * @var int[]
+   */
+  protected $_eventIds = [];
+
+  /**
+   * @var array
+   */
+  protected $_events = [];
+
   public function setUp(): void {
     parent::setUp();
     $this->_apiversion = 3;
@@ -72,8 +82,8 @@ class api_v3_EventTest extends CiviUnitTestCase {
       ],
     ];
 
-    $this->events = [];
-    $this->eventIds = [];
+    $this->_events = [];
+    $this->_eventIds = [];
     foreach ($params as $event) {
       $result = $this->callAPISuccess('Event', 'Create', $event);
       $this->_events[] = $result;
@@ -82,9 +92,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
   }
 
   public function tearDown(): void {
-    foreach ($this->eventIds as $eventId) {
-      $this->eventDelete($eventId);
-    }
     $tablesToTruncate = [
       'civicrm_participant',
       'civicrm_event',


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in api_v3_EventTest, as dynamic properties are deprecated in PHP8.2

Before
----------------------------------------
This class was a bit of a mess. `_events` and `_eventIds` were being used with a mixture of leading underscore and no leading underscore, and neither version was explicitely declared. Whilst the tests were actually working correctly, it meant some of the code was not running quite as originally expected.

After
----------------------------------------
`_events` and `_eventIds` are explicitely declared, no longer dynamic.

I've stuck with the leading underscore (even though I'm not the fan) as these were the params in most frequent use throughout the class.

