### PR TITLE
Paypal cancel/notify/return URLs

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1175,11 +1175,11 @@ abstract class CRM_Core_Payment {
    * Get url to return to after cancelled or failed transaction.
    *
    * @param string $qfKey
-   * @param int $participantID
+   * @param int|NULL $participantID
    *
    * @return string cancel url
    */
-  public function getCancelUrl($qfKey, $participantID) {
+  public function getCancelUrl($qfKey, $participantID = NULL) {
     if (isset($this->cancelUrl)) {
       return $this->cancelUrl;
     }

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -255,7 +255,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $args['desc'] = $params['description'] ?? NULL;
     $args['invnum'] = $params['invoiceID'];
     $args['returnURL'] = $this->getReturnSuccessUrl($params['qfKey']);
-    $args['cancelURL'] = $this->getCancelUrl($params['qfKey'], NULL);
+    $args['cancelURL'] = $this->getCancelUrl($params['qfKey'], $params['participantID'] ?? NULL);
     $args['version'] = '56.0';
     $args['SOLUTIONTYPE'] = 'Sole';
 

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -500,11 +500,11 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
 
     if ($this->_paymentProcessor['billing_mode'] == 4) {
-      $this->doPaymentRedirectToPayPal($params, $component);
+      $this->doPaymentRedirectToPayPal($params);
       // redirect calls CiviExit() so execution is stopped
     }
     else {
-      $result = $this->doPaymentPayPalButton($params, $component);
+      $result = $this->doPaymentPayPalButton($params);
       if (is_array($result) && !isset($result['payment_status_id'])) {
         if (!empty($params['is_recur'])) {
           $result = $this->setStatusPaymentPending($result);
@@ -537,12 +537,11 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
    * @param array $params
    *   Assoc array of input parameters for this transaction.
    *
-   * @param string $component
    * @return array
    *   the result in an nice formatted array (or an error object)
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
-  public function doPaymentPayPalButton(&$params, $component = 'contribute') {
+  public function doPaymentPayPalButton(&$params) {
     $args = [];
 
     $result = $this->setStatusPaymentPending([]);
@@ -590,7 +589,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       $args['totalbillingcycles'] = $params['installments'] ?? NULL;
       $args['version'] = 56.0;
       $args['PROFILEREFERENCE'] = "" .
-        "i=" . $params['invoiceID'] . "&m=" . $component .
+        "i=" . $params['invoiceID'] . "&m=" . $this->_component .
         "&c=" . $params['contactID'] . "&r=" . $params['contributionRecurID'] .
         "&b=" . $params['contributionID'] . "&p=" . $params['contributionPageID'];
     }
@@ -915,12 +914,11 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
   /**
    * @param array $params
-   * @param string $component
    *
    * @throws Exception
    */
-  public function doPaymentRedirectToPayPal(&$params, $component = 'contribute') {
-    $notifyParameters = ['module' => $component];
+  public function doPaymentRedirectToPayPal(&$params) {
+    $notifyParameters = ['module' => $this->_component];
     $notifyParameterMap = [
       'contactID' => 'contactID',
       'contributionID' => 'contributionID',
@@ -941,8 +939,8 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $notifyURL = $this->getNotifyUrl();
 
     $config = CRM_Core_Config::singleton();
-    $url = ($component == 'event') ? 'civicrm/event/register' : 'civicrm/contribute/transact';
-    $cancel = ($component == 'event') ? '_qf_Register_display' : '_qf_Main_display';
+    $url = ($this->_component == 'event') ? 'civicrm/event/register' : 'civicrm/contribute/transact';
+    $cancel = ($this->_component == 'event') ? '_qf_Register_display' : '_qf_Main_display';
 
     $cancelUrlString = "$cancel=1&cancel=1&qfKey={$params['qfKey']}";
     if (!empty($params['is_recur'])) {

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -939,7 +939,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     $notifyURL = $this->getNotifyUrl();
 
     $config = CRM_Core_Config::singleton();
-    $url = ($this->_component == 'event') ? 'civicrm/event/register' : 'civicrm/contribute/transact';
+    $url = $this->getBaseReturnUrl();
     $cancel = ($this->_component == 'event') ? '_qf_Register_display' : '_qf_Main_display';
 
     $cancelUrlString = "$cancel=1&cancel=1&qfKey={$params['qfKey']}";

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -936,30 +936,15 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
         $notifyParameters[$notifyName] = $params[$paramsName];
       }
     }
-    $notifyURL = $this->getNotifyUrl();
-
     $config = CRM_Core_Config::singleton();
-    $url = $this->getBaseReturnUrl();
-    $cancel = ($this->_component == 'event') ? '_qf_Register_display' : '_qf_Main_display';
-
-    $cancelUrlString = "$cancel=1&cancel=1&qfKey={$params['qfKey']}";
-    if (!empty($params['is_recur'])) {
-      $cancelUrlString .= "&isRecur=1&recurId={$params['contributionRecurID']}&contribId={$params['contributionID']}";
-    }
-
-    $cancelURL = CRM_Utils_System::url(
-      $url,
-      $cancelUrlString,
-      TRUE, NULL, FALSE
-    );
 
     $paypalParams = [
       'business' => $this->_paymentProcessor['user_name'],
-      'notify_url' => $notifyURL,
+      'notify_url' => $this->getNotifyUrl(),
       'item_name' => $this->getPaymentDescription($params, 127),
       'quantity' => 1,
       'undefined_quantity' => 0,
-      'cancel_return' => $cancelURL,
+      'cancel_return' => $this->getCancelUrl($params['qfKey'], $params['participantID'] ?? NULL),
       'no_note' => 1,
       'no_shipping' => 1,
       'return' => $this->getReturnSuccessUrl($params['qfKey']),


### PR DESCRIPTION
Overview
----------------------------------------
This fixes Paypal standard on Drupal9 Webform and will also work for any other offsite payment processor that uses the standard methods.

Paypal: Stop passing component when it exists on the class

Paypal: Use getBaseReturnUrl() function

`CRM_Core_Payment`: getCancelUrl participant default value of NULL

Paypal (express): Pass participantID to getCancelUrl() if available

Paypal: Use standard functions for cancelUrl / notifyUrl

Before
----------------------------------------
Paypal using it's own code instead of generic code.

After
----------------------------------------
Using generic code to generate cancel/notify links.

Technical Details
----------------------------------------
Historically (a long time ago) these functions didn't exist. Recently (6 years ago) they were updated to allow them to be overridden by eg. webform.

Comments
----------------------------------------

