### PR TITLE
Api4 Activity.Get: add virtual fields for source/target/assignee contacts, and magic joins through them (Api3 parity)

### DIFF
--- a/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
@@ -72,7 +72,7 @@ class ActivitySchemaMapSubscriber extends \Civi\Core\Service\AutoService impleme
         $fieldName))
         ->setBaseTable('civicrm_activity')
         ->setJoinType(Joinable::JOIN_TYPE_ONE_TO_MANY)
-        ->addCondition('`{target_table}`.`id` = '
+        ->addCondition('`{target_table}`.`id` IN '
           . '(SELECT `civicrm_activity_contact`.`contact_id` '
           . 'FROM `civicrm_activity_contact` '
           . 'WHERE `civicrm_activity_contact`.`activity_id` = `{base_table}`.`id` '

--- a/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
@@ -29,12 +29,56 @@ class ActivitySchemaMapSubscriber extends \Civi\Core\Service\AutoService impleme
     $schema = $event->getSchemaMap();
     $table = $schema->getTableByName('civicrm_activity');
 
-    $link = (new ExtraJoinable('civicrm_case', 'id', 'case_id'))
+    $caseLink = (new ExtraJoinable('civicrm_case', 'id', 'case_id'))
       ->setBaseTable('civicrm_activity')
       ->setJoinType(Joinable::JOIN_TYPE_MANY_TO_ONE)
-      ->addCondition('`{target_table}`.`id` = (SELECT `civicrm_case_activity`.`case_id` FROM `civicrm_case_activity` WHERE `civicrm_case_activity`.`activity_id` = `{base_table}`.`id` LIMIT 1)');
-    $table->addTableLink('id', $link);
+      ->addCondition('`{target_table}`.`id` = '
+        . '(SELECT `civicrm_case_activity`.`case_id` '
+        . 'FROM `civicrm_case_activity` '
+        . 'WHERE `civicrm_case_activity`.`activity_id` = `{base_table}`.`id` '
+        . 'LIMIT 1)');
+    $table->addTableLink('id', $caseLink);
 
+    $contactLinkTypes = [
+      'source_contact_id' => 'Activity Source',
+      'target_contact_id' => 'Activity Targets',
+      'assignee_contact_id' => 'Activity Assignees',
+    ];
+    foreach ($contactLinkTypes as $fieldName => $typeName) {
+      $contactLinkTypes[$fieldName] = \CRM_Core_PseudoConstant::getKey(
+        'CRM_Activity_BAO_ActivityContact',
+        'record_type_id',
+        $typeName);
+    }
+
+    $sourceContactLink = (new ExtraJoinable(
+      'civicrm_contact',
+      'id',
+      'source_contact_id'))
+      ->setBaseTable('civicrm_activity')
+      ->setJoinType(Joinable::JOIN_TYPE_ONE_TO_ONE)
+      ->addCondition('`{target_table}`.`id` = '
+        . '(SELECT `civicrm_activity_contact`.`contact_id` '
+        . 'FROM `civicrm_activity_contact` '
+        . 'WHERE `civicrm_activity_contact`.`activity_id` = `{base_table}`.`id` '
+        . 'AND record_type_id = ' . $contactLinkTypes['source_contact_id']
+        . ' LIMIT 1)');
+    $table->addTableLink('id', $sourceContactLink);
+
+    foreach (['target_contact_id', 'assignee_contact_id'] as $fieldName) {
+      $otherContactLink = (new ExtraJoinable(
+        'civicrm_contact',
+        'id',
+        $fieldName))
+        ->setBaseTable('civicrm_activity')
+        ->setJoinType(Joinable::JOIN_TYPE_ONE_TO_MANY)
+        ->addCondition('`{target_table}`.`id` = '
+          . '(SELECT `civicrm_activity_contact`.`contact_id` '
+          . 'FROM `civicrm_activity_contact` '
+          . 'WHERE `civicrm_activity_contact`.`activity_id` = `{base_table}`.`id` '
+          . 'AND record_type_id = ' . $contactLinkTypes[$fieldName] . ')');
+      $table->addTableLink('id', $otherContactLink);
+    }
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -45,7 +45,9 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $spec->getFieldByName('activity_type_id')
         ->setDefaultValue(NULL)
         ->setRequired($action === 'create');
+    }
 
+    if (in_array($action, ['get', 'create', 'update'], TRUE)) {
       $field = new FieldSpec('source_contact_id', 'Activity', 'Integer');
       $field->setTitle(ts('Source Contact'));
       $field->setLabel(ts('Added by'));
@@ -53,6 +55,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setRequired($action === 'create');
       $field->setFkEntity('Contact');
       $field->setInputType('EntityRef');
+      $field->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
       $spec->addFieldSpec($field);
 
       $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
@@ -62,6 +65,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setFkEntity('Contact');
       $field->setInputType('EntityRef');
       $field->setInputAttrs(['multiple' => TRUE]);
+      $field->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
       $spec->addFieldSpec($field);
 
       $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
@@ -71,6 +75,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setFkEntity('Contact');
       $field->setInputType('EntityRef');
       $field->setInputAttrs(['multiple' => TRUE]);
+      $field->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
       $spec->addFieldSpec($field);
     }
   }

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
@@ -91,20 +91,19 @@ class AuthorizationCode extends AbstractGrantAction {
     parent::validate();
     if ($this->landingUrl) {
       $landingUrlParsed = parse_url($this->landingUrl);
-      $landingUrlIp = gethostbyname($landingUrlParsed['host']);
+      $landingUrlIp = gethostbyname($landingUrlParsed['host'] . '.');
       $allowedBases = [
         \Civi::paths()->getVariable('cms.root', 'url'),
         \Civi::paths()->getVariable('civicrm.root', 'url'),
       ];
-      $ok = max(array_map(function($allowed) use ($landingUrlParsed, $landingUrlIp) {
+      foreach ($allowedBases as $allowed) {
         $allowedParsed = parse_url($allowed);
-        $allowedIp = gethostbyname($allowedParsed['host']);
-        $ok = $landingUrlIp === $allowedIp && $landingUrlParsed['scheme'] == $allowedParsed['scheme'];
-        return (int) $ok;
-      }, $allowedBases));
-      if (!$ok) {
-        throw new OAuthException("Cannot initiate OAuth. Unsupported landing URL.");
+        $allowedIp = gethostbyname($allowedParsed['host'] . '.');
+        if ($landingUrlIp === $allowedIp && $landingUrlParsed['scheme'] == $allowedParsed['scheme']) {
+          return;
+        }
       }
+      throw new OAuthException("Cannot initiate OAuth. Unsupported landing URL.");
     }
   }
 

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
@@ -24,11 +24,13 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
   public function testCreateDocumentBasicTokens(): void {
     CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $this->enableCiviCampaign();
-    $case = $this->createCase($this->individualCreate());
+    $sourceContactId = $this->individualCreate();
+    $case = $this->createCase($sourceContactId);
 
     $activity = $this->activityCreate([
       'campaign_id' => $this->campaignCreate(),
       'case_id' => $case->id,
+      'source_contact_id' => $sourceContactId,
     ]);
     $data = [
       ['Subject: {activity.subject}', 'Subject: Discussion on warm beer'],
@@ -45,6 +47,9 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
       ['(legacy) Activity ID: {activity.activity_id}', '(legacy) Activity ID: ' . $activity['id']],
       ['Activity ID: {activity.id}', 'Activity ID: ' . $activity['id']],
       ['(APIv4 virtual field) Case ID: {activity.case_id}', '(APIv4 virtual field) Case ID: ' . $case->id],
+      ['(APIv4 virtual field) Source Contact ID: {activity.source_contact_id}', '(APIv4 virtual field) Source Contact ID: ' . $sourceContactId],
+      ['(APIv4 virtual field) Target Contact ID: {activity.target_contact_id}', '(APIv4 virtual field) Target Contact ID: ' . $activity['target_contact_id']],
+      ['(APIv4 virtual field) Assignee Contact ID: {activity.assignee_contact_id}', '(APIv4 virtual field) Assignee Contact ID: ' . $activity['assignee_contact_id']],
     ];
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['activityId']]);
 
@@ -82,6 +87,9 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
       '{activity.status_id:label}' => 'Activity Status',
       '{activity.campaign_id:label}' => 'Campaign',
       '{activity.case_id}' => 'Case ID',
+      '{activity.source_contact_id}' => 'Source Contact',
+      '{activity.target_contact_id}' => 'Target Contacts',
+      '{activity.assignee_contact_id}' => 'Assignee Contacts',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Part of the fix for [dev/core#4110](https://lab.civicrm.org/dev/core/-/issues/4110). Also relevant to [dev/core#2486](https://lab.civicrm.org/dev/core/-/issues/2486). When getting Activities through Api4, you can now access source/target/assignee contacts without explicitly setting up the ActivityContact bridge. This also means more joy in FormBuilder.

Before
----------------------------------------
To "get" contacts connected with an activity, you had to add a join to your request.

After
----------------------------------------
You can select pseudofields `source_contact_id`, `target_contact_id`, and `assignee_contact_id`, as well as things like `target_contact_id.display_name`.

These activity contacts will now also be autofilled in FormBuilder Activity submission forms.

Technical Details
----------------------------------------
If you only need to get the contact ids of activity contacts, it's still more performant to join onto the ActivityContact; using one of these pseudofields adds an additional join onto Contact whether you want contact fields or not.