### PR TITLE
dev/core#4088 Superficial cleanup on Api4testBase

### DIFF
--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformContactSummaryTest.php
@@ -5,6 +5,7 @@ namespace Civi\Afform;
 require_once __DIR__ . '/../../../../../../../tests/phpunit/api/v4/Api4TestBase.php';
 
 use Civi\Api4\Afform;
+use Civi\Test\CiviEnvBuilder;
 
 /**
  * @group headless
@@ -19,7 +20,7 @@ class AfformContactSummaryTest extends \api\v4\Api4TestBase {
     'contact_summary_test5',
   ];
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()->installMe(__DIR__)->install('org.civicrm.search_kit')->apply();
   }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -14,6 +14,7 @@ use Civi\Api4\Phone;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\SearchDisplay;
 use Civi\Api4\UFMatch;
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -22,7 +23,7 @@ use Civi\Test\TransactionalInterface;
 class SearchRunTest extends Api4TestBase implements TransactionalInterface {
   use \Civi\Test\ACLPermissionTrait;
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
     // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
     return \Civi\Test::headless()

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -10,13 +10,14 @@ use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
+use Civi\Test\CiviEnvBuilder;
 
 /**
  * @group headless
  */
 class SearchRunWithCustomFieldTest extends CustomTestBase {
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
       ->apply();

--- a/tests/phpunit/CRM/Report/Form/ContactSummaryTest.php
+++ b/tests/phpunit/CRM/Report/Form/ContactSummaryTest.php
@@ -30,7 +30,7 @@ class CRM_Report_Form_ContactSummaryTest extends CiviReportTestCase {
   /**
    * Ensure the new Odd/Event street number sort column works correctly
    */
-  public function testOddEvenStreetNumber() {
+  public function testOddEvenStreetNumber(): void {
     $customLocationType = $this->callAPISuccess('LocationType', 'create', [
       'name' => 'Custom Location Type',
       'display_name' => 'CiviTest Custom Location Type',
@@ -195,9 +195,9 @@ class CRM_Report_Form_ContactSummaryTest extends CiviReportTestCase {
   }
 
   /**
-   * Test that Loation Type prints out a sensible piece of data
+   * Test that Location Type prints out a sensible piece of data
    */
-  public function testLocationTypeIdHandling() {
+  public function testLocationTypeIdHandling(): void {
     $customLocationType = $this->callAPISuccess('LocationType', 'create', [
       'name' => 'Custom Location Type',
       'display_name' => 'CiviTest Custom Location Type',

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -25,6 +25,7 @@ use Civi\Api4\Contact;
 use Civi\Api4\MockBasicEntity;
 use Civi\Api4\SavedSearch;
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
@@ -54,7 +55,7 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     }
   }
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     // TODO: search_kit should probably be part of the 'headless()' baseline.
     return \Civi\Test::headless()->install(['org.civicrm.search_kit'])->apply();
   }

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -23,6 +23,7 @@ use api\v4\Api4TestBase;
 use Civi\Api4\MockBasicEntity;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
@@ -40,7 +41,7 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
     $e->entities['MockBasicEntity'] = MockBasicEntity::getInfo();
   }
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     // Ensure MockBasicEntity gets added via above listener
     \Civi::cache('metadata')->clear();
     return parent::setUpHeadless();

--- a/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
+++ b/tests/phpunit/api/v4/Action/ContactIsDeletedTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -27,7 +28,7 @@ use Civi\Test\TransactionalInterface;
  */
 class ContactIsDeletedTest extends Api4TestBase implements TransactionalInterface {
 
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     $relatedTables = [
       'civicrm_address',
       'civicrm_email',


### PR DESCRIPTION
Mostly tighting hints & docblocks & using single quotes where possible (more quote consistency = more greppable & also makes it clearer when there IS a reason for double quotes)