### PR TITLE
(dev/core#4055) ClassLoader - Use separate cache IDs for different configurations of modules

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -179,7 +179,12 @@ class CRM_Extension_ClassLoader {
    * @return string
    */
   protected function getCacheFile() {
-    $envId = \CRM_Core_Config_Runtime::getId();
+    $envId = md5(implode(',', array_merge(
+      [\CRM_Core_Config_Runtime::getId()],
+      array_column($this->mapper->getActiveModuleFiles(), 'prefix')
+      // dev/core#4055 - When toggling ext's on systems with opcode caching, you may get stale reads for a moment.
+      // New cache key ensures new data-set.
+    )));
     $file = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
     return $file;
   }


### PR DESCRIPTION
Overview
----------------------------------------

Possible alternative to #25235. It aims to address https://lab.civicrm.org/dev/core/-/issues/4055, although I don't know that my local system is suitable for testing.

Before
----------------------------------------

When you enable or disable an extension:

1. It deletes the `CachedExtLoader.{$envId}.php`, then
2. It creates a new version of `CachedExtLoader.{$envId}.php`, and finally 
3. It loads the new version of `CachedExtLoader.{$envId}.php`.

But in some environments, step (3) is reported to read stale data because the opcode cache has momentarily retained the old data.

After
----------------------------------------

When you enable or disable an extension, it changes the `{$envId}` used for the filename `CachedExtLoader.{$envId}.php`.

Since the `{$envId}` is different, it doesn't matter whether the opcode cache retains the old data -- because it's retained under the old name. The new name should be clean.

Comments
----------------------------------------

I haven't specifically tried to reproduce the scenario in 4055. Putting this up to see if the test-suite likes it.

ping @kainuk 