### PR TITLE
Avoid 5.57 upgrade taking hours on large activity tables

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftySeven.php
@@ -21,10 +21,23 @@
  */
 class CRM_Upgrade_Incremental_php_FiveFiftySeven extends CRM_Upgrade_Incremental_Base {
 
+  /**
+   * How many activities before the queries used here are slow. Guessing.
+   */
+  const ACTIVITY_THRESHOLD = 1000000;
+
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
     if ($rev === '5.57.alpha1') {
-      if (CRM_Core_DAO::singleValueQuery('SELECT COUNT(id) FROM civicrm_activity WHERE is_current_revision = 0')) {
+      // The query on is_current_revision is slow if there's a lot of activities. So limit when it gets run.
+      $activityCount = CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_activity');
+      if ($activityCount < self::ACTIVITY_THRESHOLD && CRM_Core_DAO::singleValueQuery('SELECT COUNT(id) FROM civicrm_activity WHERE is_current_revision = 0')) {
         $preUpgradeMessage .= '<p>' . ts('Your database contains CiviCase activity revisions which are deprecated and will begin to appear as duplicates in SearchKit/api4/etc.<ul><li>For further instructions see this <a %1>Lab Snippet</a>.</li></ul>', [1 => 'target="_blank" href="https://lab.civicrm.org/-/snippets/85"']) . '</p>';
+      }
+      // Similarly the original_id ON DELETE drop+recreate is slow, so if we
+      // don't add the task farther down below, then tell people what to do at
+      // their convenience.
+      elseif ($activityCount >= self::ACTIVITY_THRESHOLD) {
+        $preUpgradeMessage .= '<p>' . ts('Your database contains too many activities to efficiently run a query needed to check for deprecated case activity revisions and to fix a bad foreign key constraint and it may take hours to run. You can run these queries manually at your convenience:<ul><li>SELECT COUNT(id) FROM `civicrm_activity` WHERE `is_current_revision` = 0;</li><li>ALTER TABLE `civicrm_activity` DROP FOREIGN KEY `FK_civicrm_activity_original_id`;</li><li>ALTER TABLE `civicrm_activity` ADD CONSTRAINT `FK_civicrm_activity_original_id` FOREIGN KEY (`original_id`) REFERENCES `civicrm_activity` (`id`) ON DELETE SET NULL;</li><li>For more information see this <a %1>Lab Snippet</a>.</li></ul>', [1 => 'target="_blank" href="https://lab.civicrm.org/-/snippets/85"']) . '</p>';
       }
     }
   }
@@ -37,7 +50,9 @@ class CRM_Upgrade_Incremental_php_FiveFiftySeven extends CRM_Upgrade_Incremental
    */
   public function upgrade_5_57_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
-    $this->addTask('Fix dangerous delete cascade', 'fixDeleteCascade');
+    if (CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_activity') < self::ACTIVITY_THRESHOLD) {
+      $this->addTask('Fix dangerous delete cascade', 'fixDeleteCascade');
+    }
     $this->addExtensionTask('Enable SearchKit extension', ['org.civicrm.search_kit'], 1100);
     $this->addExtensionTask('Enable Flexmailer extension', ['org.civicrm.flexmailer']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
As discussed in [chat](https://chat.civicrm.org/civicrm/pl/pog4xm4re7n5z8s8utoutgd5we), the queries on is_current_revision and original_id perform badly on large activity tables. This only runs them if you don't have a lot of activities. If it can't run the queries then it points you to the lab snippet which also contains the queries you can run manually.

Before
----------------------------------------
Slow

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

