### PR TITLE
Undefined array keys on case activity view

### DIFF
--- a/CRM/Case/Form/ActivityView.php
+++ b/CRM/Case/Form/ActivityView.php
@@ -90,6 +90,7 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
       $this->assign('latestRevisionID', $latestRevisionID);
     }
     else {
+      $this->assign('revs', 0);
       if (count($viewPriorActivities) > 1) {
         $this->assign('activityID', $activityID);
       }
@@ -100,9 +101,7 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
     }
 
     $parentID = CRM_Activity_BAO_Activity::getParentActivity($activityID);
-    if ($parentID) {
-      $this->assign('parentID', $parentID);
-    }
+    $this->assign('parentID', $parentID ?? NULL);
 
     //viewing activity should get diplayed in recent list.CRM-4670
     $activityTypeID = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityID, 'activity_type_id');


### PR DESCRIPTION
Overview
----------------------------------------
This isn't even php 8 I'm writing a unit test and these are coming up.

Before
----------------------------------------
1. Create a case.
2. Turn on debugging at Administer - System Settings - debugging.
3. Turn off popups at Administer - Customize - Display prefs, or in step 4 open in a new tab.
4. View a case activity.
5. Red box with smarty notices.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

