### PR TITLE
Undefined `accessKey` on case activity view

### DIFF
--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -622,6 +622,8 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'url' => 'civicrm/case/activity/view',
           'qs' => 'reset=1&cid=%%cid%%&caseid=%%caseid%%&aid=%%aid%%',
           'title' => ts('View'),
+          'accessKey' => '',
+          'ref' => 'View',
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
@@ -629,6 +631,8 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'qs' => 'reset=1&cid=%%cid%%&caseid=%%caseid%%&id=%%aid%%&action=update%%cxt%%',
           'title' => ts('Edit'),
           'icon' => 'fa-pencil',
+          'accessKey' => '',
+          'ref' => 'Edit',
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
@@ -636,6 +640,8 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'qs' => 'reset=1&cid=%%cid%%&caseid=%%caseid%%&id=%%aid%%&action=delete%%cxt%%',
           'title' => ts('Delete'),
           'icon' => 'fa-trash',
+          'accessKey' => '',
+          'ref' => 'Delete',
         ],
         CRM_Core_Action::RENEW => [
           'name' => ts('Restore'),
@@ -643,6 +649,8 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'qs' => 'reset=1&cid=%%cid%%&caseid=%%caseid%%&id=%%aid%%&action=renew%%cxt%%',
           'title' => ts('Restore'),
           'icon' => 'fa-undo',
+          'accessKey' => '',
+          'ref' => 'Restore',
         ],
         CRM_Core_Action::DETACH => [
           'name' => ts('Move To Case'),
@@ -650,6 +658,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'title' => ts('Move To Case'),
           'extra' => 'onclick = "Javascript:fileOnCase( \'move\', %%aid%%, %%caseid%%, this ); return false;"',
           'icon' => 'fa-clipboard',
+          'accessKey' => '',
         ],
         CRM_Core_Action::COPY => [
           'name' => ts('Copy To Case'),
@@ -657,6 +666,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'title' => ts('Copy To Case'),
           'extra' => 'onclick = "Javascript:fileOnCase( \'copy\', %%aid%%, %%caseid%%, this ); return false;"',
           'icon' => 'fa-files-o',
+          'accessKey' => '',
         ],
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
This isn't even php 8 I'm writing a unit test and these are coming up.

Before
----------------------------------------
1. Create a case.
2. Turn on debugging at Administer - System Settings - debugging.
3. Turn off popups at Administer - Customize - Display prefs, or in step 4 open in a new tab.
4. View a case activity.
5. Red box with smarty notices.

After
----------------------------------------


Technical Details
----------------------------------------
For the `ref`, note that when it's missing it [sets the name html attribute](https://github.com/civicrm/civicrm-core/blob/41a42395e26a30755d45500351075876d2af9e74/templates/CRM/common/formButtons.tpl#L23-L27) to the `name` value instead, so I'm doing almost same thing but not the ts'd word since that seems more appropriate for an html attribute value. It's questionable whether the use of ts() on `name` makes sense, but I've left the array element `name` as-is.

Comments
----------------------------------------

