### PR TITLE
Smarty {ts} - For extensions, use fallback similar to E::ts() and JS ts()

### DIFF
--- a/CRM/Core/Smarty/plugins/block.ts.php
+++ b/CRM/Core/Smarty/plugins/block.ts.php
@@ -34,8 +34,8 @@
  *   the string, translated by gettext
  */
 function smarty_block_ts($params, $text, &$smarty) {
-  if (!isset($params['domain'])) {
-    $params['domain'] = $smarty->get_template_vars('extensionKey');
+  if (!isset($params['domain']) && $extensionKey = $smarty->get_template_vars('extensionKey')) {
+    $params['domain'] = is_array($extensionKey) ? $extensionKey : [$extensionKey, NULL];
   }
   return ts($text, $params);
 }


### PR DESCRIPTION
Overview
----------------------------------------

When using `ts` to translate strings in an extension, there is often some kind of fallback mechanism. This patch resolves an incongruity to make the fallback behavior more consistent.

ping @jmcclelland @mlutfy 

Technical Details
----------------------------------------

Recall how extensions are supposed to use translated strings.

PHP:

```php
use CRM_Myext_ExtensionUtil as E;
echo E::ts('Continue');
```

JS:

```php
Civi::resources()->addScriptFile('myext', 'hello.js');
```
```javascript
console.log(ts('Continue'));
```

Smarty:

```smarty
{crmScope extensionKey='myext'}
  {ts}Continue{/ts}
{/crmScope}
```

Each of these examples includes a hint that the active extension is `myext`, and each one has some notion of fallback. Strings may come from`l10n/xx_XX/LC_MESSAGES/myext.mo` or `l10n/xx_XX/LC_MESSAGES/civicrm.mo`.

The Before+After will describe the subtle way they differ.

Before
----------------------------------------

* When using PHP or JS, the fallback _effectively merges_ the translations from `myext.mo` and `civicrm.mo`.
    * This is useful for providing common strings `OK` and `Continue` across a range of extensions and locales.
    * Technically, it does an ordered search -- for string `$x`, first look in `myext.mo` and then look in `civicrm.mo`. The overall effect is to merge the translation lists.
* When using Smarty, the fallback is strictly either/or (check `myext.mo` xor `civicrm.mo`):
    * If the active locale has `myext.mo`, it uses that -- without any further fallback.
    * If the active locale does not have `myext.mo`, then it uses `civicrm.mo`.

After
----------------------------------------

* PHP, JS, and Smarty all use the _merged_ translations from `myext.mo` and `civicrm.mo`.

Comments
----------------------------------------

This is an off-shoot from discussing https://lab.civicrm.org/dev/core/-/issues/4043, but it may be distinct from the original issue.

It's fairly tricky to write a unit-test to reproduce this. I had to use [a mock extension + l10n + Smarty snippets](https://github.com/totten/issue-4043/blob/master/use-smarty.php).

