### PR TITLE
AdminUI - POC option groups/values page

### DIFF
--- a/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Page/AdminOptionValues.php
+++ b/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Page/AdminOptionValues.php
@@ -1,0 +1,84 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+class CRM_CivicrmAdminUi_Page_AdminOptionValues extends CRM_Core_Page {
+
+  public function run() {
+    $groupName = $this->urlPath[3] ?? NULL;
+    $filters = [];
+
+    // Browse all groups
+    if (!$groupName) {
+      $display = $this->getSearchDisplay('Administer_Option_Groups', 'Administer_Option_Groups_Display');
+      CRM_Utils_System::setTitle(ts('Option Groups'));
+    }
+    // Browse options in specified group
+    else {
+      $group = \Civi\Api4\OptionGroup::get(FALSE)
+        ->addWhere('name', '=', $groupName)
+        ->execute()->single();
+
+      CRM_Utils_System::setTitle(ts('%1 Options', [1 => $group['title']]));
+
+      $display = $this->getSearchDisplay('Administer_Option_Values', 'Administer_Option_Values_Display');
+
+      $optionValueFields = \Civi\Api4\OptionGroup::getFields(FALSE)
+        ->addWhere('name', '=', 'option_value_fields')
+        ->setLoadOptions(TRUE)
+        ->execute()->single()['options'];
+
+      // Adjust table columns according to the fields used by this option group
+      foreach ($optionValueFields as $fieldName) {
+        if (!in_array($fieldName, $group['option_value_fields'], TRUE)) {
+          foreach ($display['settings']['columns'] as $idx => $column) {
+            if ($fieldName === ($column['key'] ?? NULL)) {
+              unset($display['settings']['columns'][$idx]);
+            }
+          }
+        }
+      }
+
+      if (!empty($group['is_locked'])) {
+        unset($display['settings']['addButton']);
+      }
+
+      $display['settings']['description'] = $group['description'] ?: ts('The existing option choices for %1 group are listed below. You can add, edit or delete them from this screen.', [1 => $group['title']]);
+      $filters = ['option_group_id' => $group['id']];
+    }
+
+    $this->outputSearchDisplay($display, $filters);
+
+    parent::run();
+  }
+
+  /**
+   * @param string $searchName
+   * @param string $displayName
+   * @return array
+   */
+  private function getSearchDisplay(string $searchName, string $displayName): array {
+    return \Civi\Api4\SearchDisplay::get(FALSE)
+      ->addWhere('name', '=', $displayName)
+      ->addWhere('saved_search_id.name', '=', $searchName)
+      ->addSelect('name', 'settings', 'saved_search_id.name', 'saved_search_id.api_entity')
+      ->execute()->single();
+  }
+
+  /**
+   * Outputs smarty variables and js to render search display
+   *
+   * @param array $display
+   * @param array $filters
+   */
+  private function outputSearchDisplay(array $display, array $filters): void {
+    $this->assign('apiEntity', $display['saved_search_id.api_entity']);
+    $this->assign('filters', htmlspecialchars(\CRM_Utils_JS::encode($filters), ENT_COMPAT));
+    $this->assign('searchName', $display['saved_search_id.name']);
+    $this->assign('displayName', $display['name']);
+    $this->assign('searchSettings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings']), ENT_COMPAT));
+
+    Civi::service('angularjs.loader')
+      ->addModules('crmSearchDisplayTable');
+  }
+
+}

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -36,5 +36,6 @@
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
+    <mixin>menu-xml@1.0.0</mixin>
   </mixins>
 </extension>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Option_Groups.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Option_Groups.mgd.php
@@ -1,0 +1,151 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Administer_Option_Groups',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Administer_Option_Groups',
+        'label' => E::ts('Administer Option Groups'),
+        'form_values' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'OptionGroup',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'name',
+            'title',
+            'description',
+            'is_active',
+            'is_reserved',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+        'expires_date' => NULL,
+        'description' => NULL,
+        'mapping_id' => NULL,
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Administer_Option_Groups_SearchDisplay_Table',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Administer_Option_Groups_Display',
+        'label' => E::ts('Option Groups'),
+        'saved_search_id.name' => 'Administer_Option_Groups',
+        'type' => 'table',
+        'settings' => [
+          'actions' => FALSE,
+          'limit' => 50,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'pager' => [
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+          ],
+          'sort' => [],
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'title',
+              'dataType' => 'String',
+              'label' => E::ts('Title'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'description',
+              'dataType' => 'String',
+              'label' => E::ts('Description'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_reserved',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Reserved'),
+              'sortable' => TRUE,
+              'icons' => [
+                [
+                  'icon' => 'fa-lock',
+                  'side' => 'left',
+                  'if' => [
+                    'is_reserved',
+                    'IS NOT EMPTY',
+                  ],
+                ],
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_active',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Enabled'),
+              'sortable' => TRUE,
+              'editable' => TRUE,
+            ],
+            [
+              'size' => 'btn-xs',
+              'links' => [
+                [
+                  'path' => '',
+                  'icon' => 'fa-pencil',
+                  'text' => E::ts('Settings'),
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => 'OptionGroup',
+                  'action' => 'update',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                ],
+                [
+                  'entity' => 'OptionGroup',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-list',
+                  'text' => E::ts('Edit Options'),
+                  'style' => 'primary',
+                  'path' => 'civicrm/admin/option/[name]',
+                  'condition' => ['is_locked', '=', FALSE],
+                ],
+              ],
+              'type' => 'buttons',
+              'alignment' => 'text-right',
+            ],
+          ],
+          'cssRules' => [
+            [
+              'disabled',
+              'is_active',
+              '=',
+              FALSE,
+            ],
+          ],
+          'addButton' => [
+            'path' => 'civicrm/admin/options?reset=1&action=add&gid=[option_group_id]',
+            'text' => E::ts('Add Option'),
+            'icon' => 'fa-plus',
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ],
+    ],
+  ],
+];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Option_Values.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Option_Values.mgd.php
@@ -1,0 +1,194 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Administer_Option_Values',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Administer_Option_Values',
+        'label' => E::ts('Administer Option Values'),
+        'form_values' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'OptionValue',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'name',
+            'label',
+            'value',
+            'description',
+            'is_active',
+            'is_reserved',
+            'is_default',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+        'expires_date' => NULL,
+        'description' => NULL,
+        'mapping_id' => NULL,
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Administer_Option_Values_SearchDisplay_Table',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Administer_Option_Values_Display',
+        'label' => E::ts('Option Values'),
+        'saved_search_id.name' => 'Administer_Option_Values',
+        'type' => 'table',
+        'settings' => [
+          'actions' => FALSE,
+          'limit' => 50,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'pager' => [
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+          ],
+          'sort' => [],
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'name',
+              'dataType' => 'String',
+              'label' => E::ts('Name'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'label',
+              'dataType' => 'String',
+              'label' => E::ts('Label'),
+              'sortable' => TRUE,
+              'editable' => TRUE,
+              'icons' => [
+                [
+                  'field' => 'icon',
+                  'side' => 'left',
+                ],
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'value',
+              'dataType' => 'String',
+              'label' => E::ts('Value'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'html',
+              'key' => 'description',
+              'dataType' => 'String',
+              'label' => E::ts('Description'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_default',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Default'),
+              'sortable' => TRUE,
+              'editable' => TRUE,
+              'icons' => [
+                [
+                  'icon' => 'fa-check',
+                  'side' => 'left',
+                  'if' => [
+                    'is_default',
+                    'IS NOT EMPTY',
+                  ],
+                ],
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_reserved',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Reserved'),
+              'sortable' => TRUE,
+              'icons' => [
+                [
+                  'icon' => 'fa-lock',
+                  'side' => 'left',
+                  'if' => [
+                    'is_reserved',
+                    'IS NOT EMPTY',
+                  ],
+                ],
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'is_active',
+              'dataType' => 'Boolean',
+              'label' => E::ts('Enabled'),
+              'sortable' => TRUE,
+              'editable' => TRUE,
+            ],
+            [
+              'size' => 'btn-xs',
+              'links' => [
+                [
+                  'path' => '',
+                  'icon' => 'fa-pencil',
+                  'text' => E::ts('Edit'),
+                  'style' => 'default',
+                  'condition' => [],
+                  'entity' => 'OptionValue',
+                  'action' => 'update',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                ],
+                [
+                  'entity' => 'OptionValue',
+                  'action' => 'delete',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-trash',
+                  'text' => E::ts('Delete'),
+                  'style' => 'danger',
+                  'path' => '',
+                  'condition' => [],
+                ],
+              ],
+              'type' => 'buttons',
+              'alignment' => 'text-right',
+            ],
+          ],
+          'draggable' => 'weight',
+          'cssRules' => [
+            [
+              'disabled',
+              'is_active',
+              '=',
+              FALSE,
+            ],
+          ],
+          'addButton' => [
+            'path' => 'civicrm/admin/options?reset=1&action=add&gid=[option_group_id]',
+            'text' => E::ts('Add Option'),
+            'icon' => 'fa-plus',
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ],
+    ],
+  ],
+];

--- a/ext/civicrm_admin_ui/templates/CRM/CivicrmAdminUi/Page/AdminOptionValues.tpl
+++ b/ext/civicrm_admin_ui/templates/CRM/CivicrmAdminUi/Page/AdminOptionValues.tpl
@@ -1,0 +1,17 @@
+<form id="bootstrap-theme">
+  {if $searchName eq 'Administer_Option_Groups'}
+    <div class="alert alert-info">
+      {ts}CiviCRM stores configurable choices for various drop-down fields as 'option groups'. You can click <strong>Options</strong> to view the available choices.{/ts}
+      <p><i class="crm-i fa-exclamation-triangle" aria-hidden="true"></i> {ts}WARNING: Many option groups are used programatically and values should be added or modified with caution.{/ts}</p>
+    </div>
+  {/if}
+  <crm-angular-js modules="crmSearchDisplayTable">
+    <crm-search-display-table
+      api-entity="{$apiEntity}"
+      settings="{$searchSettings|smarty:nodefaults}"
+      search="'{$searchName}'"
+      display="'{$displayName}'"
+      filters="{$filters|smarty:nodefaults}"
+    ></crm-search-display-table>
+  </crm-angular-js>
+</form>

--- a/ext/civicrm_admin_ui/xml/Menu/civicrm_admin_ui.xml
+++ b/ext/civicrm_admin_ui/xml/Menu/civicrm_admin_ui.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/admin/option</path>
+    <page_callback>CRM_CivicrmAdminUi_Page_AdminOptionValues</page_callback>
+    <title>AdminOptionValues</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
Overview
----------------------------------------
POC replacement for option group administration pages, for discussion (because we haven't had enough of *that* on this subject yet!)

Before
----------------------------------------
Heavily overloaded path `civicrm/admin/options` is used to:

1. Browse all option groups
2. Browse the options in a group
3. Create a new option group
4. Edit an option group
5. Create a new option in a group
6. Edit an option
7. Delete an option

After
----------------------------------------
(will update description as this changes)

Currently, this PR adds a new path: `civicrm/admin/option` (for POC purposes it's subtly different than the one in core) which is used to:
1. Browse all option groups
2. Browse the options in a group

I thought it could become a drop-in replacement for the currently overloaded path simply by adding the letter `s` when we're ready to flip that switch (provided we change items 3-7 to go through different paths). Now I'm wondering if we oughtn't just create an entirely new url structure because the old one really is bad.

How about this new url structure (similar to that of custom groups/fields):

1. Browse all option groups: `civicrm/admin/option/group`
2. Browse the options in a group `civicrm/admin/option/group/values`
3. Create a new option group: `civicrm/admin/option/group/add`
4. Edit an option group: `civicrm/admin/option/group/update`
5. Create a new option in a group: `civicrm/admin/option/group/values/add`
6. Edit an option: `civicrm/admin/option/group/values/update`
7. Delete an option: `civicrm/admin/option/group/values/delete`

Ping @aydun 