### PR TITLE
[REF][PHP8.2] Fix Deprecated Dynamic class properties in Legacy custo…

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
@@ -68,6 +68,60 @@ class CRM_Contact_Form_Search_Custom_Group extends CRM_Contact_Form_Search_Custo
   protected $_aclWhere = NULL;
 
   /**
+   * Include Groups
+   * @var array
+   */
+  protected $_includeGroups;
+
+  /**
+   * Exclude Groups
+   * @var array
+   */
+  protected $_excludeGroups;
+
+  /**
+   * Include Tags
+   * @var array
+   */
+  protected $_includeTags;
+
+  /**
+   * Exclude Tags
+   * @var array
+   */
+  protected $_excludeTags;
+
+  /**
+   * All Search
+   * @var bool
+   */
+  protected $_allSearch;
+
+  /**
+   * Does this search use groups
+   * @var bool
+   */
+  protected $_groups;
+
+  /**
+   * Does this search use tags
+   * @var bool
+   */
+  protected $_tags;
+
+  /**
+   * Is this search And or OR search
+   * @var string
+   */
+  protected $_andOr;
+
+  /**
+   * Search Columns
+   * @var array
+   */
+  protected $_columns;
+
+  /**
    * Class constructor.
    *
    * @param array $formValues

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
@@ -29,6 +29,12 @@ use PHPUnit\Framework\TestCase;
  */
 class FullTextTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
+  /**
+   * Entity ids created as part of test
+   * @var array
+   */
+  protected $ids;
+
   use Test\ContactTestTrait;
   use Test\Api3TestTrait;
 


### PR DESCRIPTION
…m searches extension

Overview
----------------------------------------
This fixes PHP8.2 deprecations in the legacy custom search extension

Before
----------------------------------------
PHP8.2 deprecations triggered when tests are run

After
----------------------------------------
PHP8.2 deprecations fixed

@eileenmcnaughton @totten @demeritcowboy @braders 