### PR TITLE
[NFC] Incorrect docblock in CRM_Contribute_PseudoConstant::contributionPage()

### DIFF
--- a/CRM/Contribute/PseudoConstant.php
+++ b/CRM/Contribute/PseudoConstant.php
@@ -173,7 +173,7 @@ class CRM_Contribute_PseudoConstant extends CRM_Core_PseudoConstant {
    *   Do we want all pages or only active pages.
    *
    *
-   * @return array
+   * @return string|array|null
    *   array reference of all contribution pages if any
    */
   public static function &contributionPage($id = NULL, $all = FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/pull/539. The incorrect docblock here appears to have caused a faulty typehint in extended reports causing a regression there.

As noted there, yes this function is deprecated, but the suggested replacement is not valid, so this function is still in use.