### PR TITLE
[REF][PHP8.2] Avoid dynamic property in ReportTest

### DIFF
--- a/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
@@ -7,6 +7,11 @@ require_once 'CiviTest/CiviCaseTestCase.php';
  */
 class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
 
+  /**
+   * @var CRM_Case_XMLProcessor_Report
+   */
+  private $report;
+
   public function setUp(): void {
     parent::setUp();
 


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic property in class `CRM_Case_XMLProcessor_ReportTest`

Before
----------------------------------------
`$report` was a dynamic property, deprecated in PHP8.2.

After
----------------------------------------
The property is declared, PHP8.2 compatiable.

