### PR TITLE
[REF][PHP8.2] Declare system property in tests

### DIFF
--- a/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Extension_Manager_PaymentTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Extension_System
+   */
+  private $system;
+
   public function setUp(): void {
     parent::setUp();
     if (class_exists('test_extension_manager_paymenttest')) {

--- a/tests/phpunit/CRM/Extension/Manager/ReportTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/ReportTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Extension_Manager_ReportTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Extension_System
+   */
+  private $system;
+
   public function setUp(): void {
     parent::setUp();
     //if (class_exists('test_extension_manager_reporttest')) {

--- a/tests/phpunit/CRM/Extension/Manager/SearchTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/SearchTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Extension_Manager_SearchTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Extension_System
+   */
+  private $system;
+
   public function setUp(): void {
     parent::setUp();
     //if (class_exists('test_extension_manager_searchtest')) {


### PR DESCRIPTION
Overview
----------------------------------------
Declare system property in tests.

Before
----------------------------------------
3 tests were declaring `$this->system` as a dynamic property, which is deprecated in PHP8.2

After
----------------------------------------
Propery is decalared on the affected classes, PHP 8.2 compatiable.

These are tests so there should hopefully be no backwards compatability impact.