### PR TITLE
APIv4 - Show actions as deprecated in the Explorer

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -93,7 +93,7 @@ class GetActions extends BasicGetAction {
               if (strpos($method->getDocComment(), '@inheritDoc') !== FALSE && !empty($methodDocs['comment']) && !empty($actionDocs['comment'])) {
                 $methodDocs['comment'] .= "\n\n" . $actionDocs['comment'];
               }
-              $actionDocs = array_filter($methodDocs) + $actionDocs;
+              $actionDocs = array_filter($methodDocs) + $actionDocs + ['deprecated' => FALSE];
             }
             $this->_actions[$actionName] += $actionDocs;
           }
@@ -130,6 +130,10 @@ class GetActions extends BasicGetAction {
         'name' => 'params',
         'description' => 'List of all accepted parameters',
         'data_type' => 'Array',
+      ],
+      [
+        'name' => 'deprecated',
+        'data_type' => 'Boolean',
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Similar to deprecated entities, the API explorer now displays deprecated actions with a strikethrough effect.

Before
----------------------------------------
No visual cue that actions are deprecated.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/213886139-ea4ab081-c154-41af-9a11-ab692d317f03.png)

Technical Details
-------------
All this does is include that piece of metadata in `getActions` output, and magically it appears on the Explorer!