### PR TITLE
Don't show email receipt option for on hold emails when adding contribution and selecting contact

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -386,11 +386,11 @@
             var data = $("#contact_id", $form).select2('data');
             if (data && data.extra && data.extra.email && data.extra.email.length) {
               CRM.api4('Email', 'get', {
-                select: ["on_hold"],
-                where: [["contact_id", "=", data.id], ["is_primary", "=", true]],
-                chain: {"contact_do_not_email":["Contact", "get", {"where":[["id", "=", data.id]], "select":["do_not_email"]}]}
+                select: ["on_hold", "contact.do_not_email"],
+                join: [["Contact AS contact", "LEFT", ["contact_id", "=", "contact.id"]]],
+                where: [["contact_id", "=", data.id], ["is_primary", "=", true]]
               }).then(function(emails) {
-                if (!emails[0]['on_hold'] && !emails[0]['contact_do_not_email'][0]['do_not_email']) {
+                if (!emails[0]['on_hold'] && !emails[0]['contact.do_not_email']) {
                   $("#email-receipt", $form).show();
                   $("#email-address", $form).html(data.extra.email);
                 }
@@ -399,8 +399,8 @@
                   $("#email-receipt", $form).hide();
                 }
               }, function(failure) {
-                   $("#email-receipt", $form).show();
-                   $("#email-address", $form).html(data.extra.email);
+                $("#email-receipt", $form).show();
+                $("#email-address", $form).html(data.extra.email);
               });
             }
             else {


### PR DESCRIPTION
Overview
----------------------------------------
This resolves the one half of [Issue 4604](https://lab.civicrm.org/dev/core/-/issues/4064), which @briennekordis has fixed the other half of in #25368.

Before
----------------------------------------
When a user goes to New Contribution, selects a contact whose primary email is on hold, and selects the Send Receipt? option, the email is sent to the on hold address - or select a contact who is set do not email and the email is also sent.

The user is not aware that the contributor's email address is bad and doesn't realize they won't actually receive the receipt, which creates a potential for unintentional bad donor stewardship (maybe they should have sent a receipt in the mail) - or if the contact is do not email, the user just sent an email to a contact they shouldn't have.

After
----------------------------------------
If a contact with an on hold primary email or do not email set is selected, an alert informs the user and the Send Receipt? option is not shown. I think the alert is necessary because the contact's email address is shown in the select2 (unless I'm missing something, there is no way to limit the select2 to not show emails that are on hold).

<img width="361" alt="image" src="https://user-images.githubusercontent.com/25517556/233751488-24df8920-9cc5-46d8-b5f4-9e90b54be73b.png">