### PR TITLE
[REF] Use civi::statics to get activityinfos in case activity view

### DIFF
--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -199,7 +199,6 @@ AND    ac.case_id = %1
    * @return mixed
    */
   public function &getActivityInfo($clientID, $activityID, $anyActivity = FALSE, $redact = 0) {
-    static $activityInfos = [];
     if ($redact) {
       $this->_isRedact = 1;
       $this->getRedactionRules();
@@ -211,8 +210,8 @@ AND    ac.case_id = %1
       $index = $index . '_' . $clientID;
     }
 
-    if (!array_key_exists($index, $activityInfos)) {
-      $activityInfos[$index] = [];
+    if (!array_key_exists($index, \Civi::$statics[__CLASS__][__FUNCTION__]['activityInfos'] ?? [])) {
+      \Civi::$statics[__CLASS__][__FUNCTION__]['activityInfos'][$index] = [];
       $selectCaseActivity = "";
       $joinCaseActivity = "";
 
@@ -249,12 +248,12 @@ WHERE      a.id = %1
           $activityTypeInfo = $activityTypes[$dao->activity_type_id];
         }
         if ($activityTypeInfo) {
-          $activityInfos[$index] = $this->getActivity($clientID, $dao, $activityTypeInfo);
+          \Civi::$statics[__CLASS__][__FUNCTION__]['activityInfos'][$index] = $this->getActivity($clientID, $dao, $activityTypeInfo);
         }
       }
     }
 
-    return $activityInfos[$index];
+    return \Civi::$statics[__CLASS__][__FUNCTION__]['activityInfos'][$index];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
It uses php static

After
----------------------------------------
Uses Civi::$statics

Technical Details
----------------------------------------
I was confused why a unit test I'm writing kept returning the same (wrong) output for each variation of the inputs. In a unit test static clings for the entire test suite run, but Civi::$statics gets reset each test.

Comments
----------------------------------------

