### PR TITLE
[REF][PHP8.2] Declare file property in CRM_Extension_InfoTest

### DIFF
--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Extension_InfoTest extends CiviUnitTestCase {
 
+  /**
+   * @var string|null
+   */
+  private $file;
+
   public function setUp(): void {
     parent::setUp();
     $this->file = NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Declare file property in CRM_Extension_InfoTest

Before
----------------------------------------
`$file` was a dynamic property; dynamic properties are deprecated in PHP8.2.

After
----------------------------------------
No longer a dynamic property.