### PR TITLE
[REF][PHP8.2] Refactor CRM_Contact_BAO_ContactType_ContactSearchTest to not use dynamic properties

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactSearchTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactSearchTest.php
@@ -6,6 +6,81 @@
  */
 class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
 
+  /**
+   * @var string
+   */
+  private $student;
+
+  /**
+   * @var string
+   */
+  private $parent;
+
+  /**
+   * @var string
+   */
+  private $sponsor;
+
+  /**
+   * @var array
+   */
+  private $individualParams;
+
+  /**
+   * @var string
+   */
+  private $individual;
+
+  /**
+   * @var array
+   */
+  private $individualParentParams;
+
+  /**
+   * @var string
+   */
+  private $individualParent;
+
+  /**
+   * @var array
+   */
+  private $individualStudentParams;
+
+  /**
+   * @var string
+   */
+  private $individualStudent;
+
+  /**
+   * @var array
+   */
+  private $organizationSponsorParams;
+
+  /**
+   * @var string
+   */
+  private $organizationSponsor;
+
+  /**
+   * @var array
+   */
+  private $organizationParams;
+
+  /**
+   * @var string
+   */
+  private $organization;
+
+  /**
+   * @var array
+   */
+  private $householdParams;
+
+  /**
+   * @var string
+   */
+  private $household;
+
   public function setUp(): void {
     parent::setUp();
     $students = 'indivi_student' . substr(sha1(rand()), 0, 7);
@@ -30,10 +105,10 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     CRM_Contact_BAO_ContactType::add($params);
     $this->parent = $params['name'];
 
-    $orgs = 'org_sponsor' . substr(sha1(rand()), 0, 7);
+    $organizations = 'org_sponsor' . substr(sha1(rand()), 0, 7);
     $params = [
-      'label' => $orgs,
-      'name' => $orgs,
+      'label' => $organizations,
+      'name' => $organizations,
       // Organization
       'parent_id' => 3,
       'is_active' => 1,
@@ -41,12 +116,12 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     CRM_Contact_BAO_ContactType::add($params);
     $this->sponsor = $params['name'];
 
-    $this->indiviParams = [
+    $this->individualParams = [
       'first_name' => 'Anne',
       'last_name' => 'Grant',
       'contact_type' => 'Individual',
     ];
-    $this->individual = $this->individualCreate($this->indiviParams);
+    $this->individual = $this->individualCreate($this->individualParams);
 
     $this->individualStudentParams = [
       'first_name' => 'Bill',
@@ -56,13 +131,13 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     ];
     $this->individualStudent = $this->individualCreate($this->individualStudentParams);
 
-    $this->indiviParentParams = [
+    $this->individualParentParams = [
       'first_name' => 'Alen',
       'last_name' => 'Adams',
       'contact_type' => 'Individual',
       'contact_sub_type' => $this->parent,
     ];
-    $this->indiviParent = $this->individualCreate($this->indiviParentParams);
+    $this->individualParent = $this->individualCreate($this->individualParentParams);
 
     $this->organizationParams = [
       'organization_name' => 'Compumentor',
@@ -70,12 +145,12 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     ];
     $this->organization = $this->organizationCreate($this->organizationParams);
 
-    $this->orgSponsorParams = [
+    $this->organizationSponsorParams = [
       'organization_name' => 'Conservation Corp',
       'contact_type' => 'Organization',
       'contact_sub_type' => $this->sponsor,
     ];
-    $this->orgSponsor = $this->organizationCreate($this->orgSponsorParams);
+    $this->organizationSponsor = $this->organizationCreate($this->organizationSponsorParams);
 
     $this->householdParams = [
       'household_name' => "John Doe's home",
@@ -97,12 +172,12 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
 
     $individual = $result['values'][$this->individual];
     $individualStudent = $result['values'][$this->individualStudent];
-    $indiviParent = $result['values'][$this->indiviParent];
+    $individualParent = $result['values'][$this->individualParent];
 
     //asserts for type:Individual
     $this->assertEquals($individual['contact_id'], $this->individual);
-    $this->assertEquals($individual['first_name'], $this->indiviParams['first_name']);
-    $this->assertEquals($individual['contact_type'], $this->indiviParams['contact_type']);
+    $this->assertEquals($individual['first_name'], $this->individualParams['first_name']);
+    $this->assertEquals($individual['contact_type'], $this->individualParams['contact_type']);
     $this->assertNotContains('contact_sub_type', $individual);
 
     //asserts for type:Individual subtype:Student
@@ -112,17 +187,17 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     $this->assertEquals(end($individualStudent['contact_sub_type']), $this->individualStudentParams['contact_sub_type']);
 
     //asserts for type:Individual subtype:Parent
-    $this->assertEquals($indiviParent['contact_id'], $this->indiviParent);
-    $this->assertEquals($indiviParent['first_name'], $this->indiviParentParams['first_name']);
-    $this->assertEquals($indiviParent['contact_type'], $this->indiviParentParams['contact_type']);
-    $this->assertEquals(end($indiviParent['contact_sub_type']), $this->indiviParentParams['contact_sub_type']);
+    $this->assertEquals($individualParent['contact_id'], $this->individualParent);
+    $this->assertEquals($individualParent['first_name'], $this->individualParentParams['first_name']);
+    $this->assertEquals($individualParent['contact_type'], $this->individualParentParams['contact_type']);
+    $this->assertEquals(end($individualParent['contact_sub_type']), $this->individualParentParams['contact_sub_type']);
 
     // for type:Organization
     $params = ['contact_type' => 'Organization', 'version' => 3];
     $result = civicrm_api('contact', 'get', $params);
 
     $organization = $result['values'][$this->organization];
-    $orgSponsor = $result['values'][$this->orgSponsor];
+    $organizationSponsor = $result['values'][$this->organizationSponsor];
 
     //asserts for type:Organization
     $this->assertEquals($organization['contact_id'], $this->organization);
@@ -131,10 +206,10 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     $this->assertNotContains('contact_sub_type', $organization);
 
     //asserts for type:Organization subtype:Sponsor
-    $this->assertEquals($orgSponsor['contact_id'], $this->orgSponsor);
-    $this->assertEquals($orgSponsor['organization_name'], $this->orgSponsorParams['organization_name']);
-    $this->assertEquals($orgSponsor['contact_type'], $this->orgSponsorParams['contact_type']);
-    $this->assertEquals(end($orgSponsor['contact_sub_type']), $this->orgSponsorParams['contact_sub_type']);
+    $this->assertEquals($organizationSponsor['contact_id'], $this->organizationSponsor);
+    $this->assertEquals($organizationSponsor['organization_name'], $this->organizationSponsorParams['organization_name']);
+    $this->assertEquals($organizationSponsor['contact_type'], $this->organizationSponsorParams['contact_type']);
+    $this->assertEquals(end($organizationSponsor['contact_sub_type']), $this->organizationSponsorParams['contact_sub_type']);
 
     // for type:Household
     $params = ['contact_type' => 'Household', 'version' => 3];
@@ -171,28 +246,28 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     //all other contact(rather than subtype:student) should not
     //exists
     $this->assertNotContains($this->individual, $result['values']);
-    $this->assertNotContains($this->indiviParent, $result['values']);
+    $this->assertNotContains($this->individualParent, $result['values']);
     $this->assertNotContains($this->organization, $result['values']);
-    $this->assertNotContains($this->orgSponsor, $result['values']);
+    $this->assertNotContains($this->organizationSponsor, $result['values']);
     $this->assertNotContains($this->household, $result['values']);
 
     // for subtype:Sponsor
     $params = ['contact_sub_type' => $this->sponsor, 'version' => 3];
     $result = civicrm_api('contact', 'get', $params);
 
-    $orgSponsor = $result['values'][$this->orgSponsor];
+    $organizationSponsor = $result['values'][$this->organizationSponsor];
 
     //asserts for type:Organization subtype:Sponsor
-    $this->assertEquals($orgSponsor['contact_id'], $this->orgSponsor);
-    $this->assertEquals($orgSponsor['organization_name'], $this->orgSponsorParams['organization_name']);
-    $this->assertEquals($orgSponsor['contact_type'], $this->orgSponsorParams['contact_type']);
-    $this->assertEquals(end($orgSponsor['contact_sub_type']), $this->orgSponsorParams['contact_sub_type']);
+    $this->assertEquals($organizationSponsor['contact_id'], $this->organizationSponsor);
+    $this->assertEquals($organizationSponsor['organization_name'], $this->organizationSponsorParams['organization_name']);
+    $this->assertEquals($organizationSponsor['contact_type'], $this->organizationSponsorParams['contact_type']);
+    $this->assertEquals(end($organizationSponsor['contact_sub_type']), $this->organizationSponsorParams['contact_sub_type']);
 
     //all other contact(rather than subtype:Sponsor) should not
     //exists
     $this->assertNotContains($this->individual, $result['values']);
     $this->assertNotContains($this->individualStudent, $result['values']);
-    $this->assertNotContains($this->indiviParent, $result['values']);
+    $this->assertNotContains($this->individualParent, $result['values']);
     $this->assertNotContains($this->organization, $result['values']);
     $this->assertNotContains($this->household, $result['values']);
   }
@@ -219,28 +294,28 @@ class CRM_Contact_BAO_ContactType_ContactSearchTest extends CiviUnitTestCase {
     //all other contact(rather than subtype:student) should not
     //exists
     $this->assertNotContains($this->individual, $result['values']);
-    $this->assertNotContains($this->indiviParent, $result['values']);
+    $this->assertNotContains($this->individualParent, $result['values']);
     $this->assertNotContains($this->organization, $result['values']);
-    $this->assertNotContains($this->orgSponsor, $result['values']);
+    $this->assertNotContains($this->organizationSponsor, $result['values']);
     $this->assertNotContains($this->household, $result['values']);
 
     // for type:Organization subtype:Sponsor
     $params = ['contact_sub_type' => $this->sponsor, 'version' => 3];
     $result = civicrm_api('contact', 'get', $params);
 
-    $orgSponsor = $result['values'][$this->orgSponsor];
+    $organizationSponsor = $result['values'][$this->organizationSponsor];
 
     //asserts for type:Organization subtype:Sponsor
-    $this->assertEquals($orgSponsor['contact_id'], $this->orgSponsor);
-    $this->assertEquals($orgSponsor['organization_name'], $this->orgSponsorParams['organization_name']);
-    $this->assertEquals($orgSponsor['contact_type'], $this->orgSponsorParams['contact_type']);
-    $this->assertEquals(end($orgSponsor['contact_sub_type']), $this->orgSponsorParams['contact_sub_type']);
+    $this->assertEquals($organizationSponsor['contact_id'], $this->organizationSponsor);
+    $this->assertEquals($organizationSponsor['organization_name'], $this->organizationSponsorParams['organization_name']);
+    $this->assertEquals($organizationSponsor['contact_type'], $this->organizationSponsorParams['contact_type']);
+    $this->assertEquals(end($organizationSponsor['contact_sub_type']), $this->organizationSponsorParams['contact_sub_type']);
 
     //all other contact(rather than subtype:Sponsor) should not
     //exists
     $this->assertNotContains($this->individual, $result['values']);
     $this->assertNotContains($this->individualStudent, $result['values']);
-    $this->assertNotContains($this->indiviParent, $result['values']);
+    $this->assertNotContains($this->individualParent, $result['values']);
     $this->assertNotContains($this->organization, $result['values']);
     $this->assertNotContains($this->household, $result['values']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Refactor `CRM_Contact_BAO_ContactType_ContactSearchTest` to not use dynamic properties

Before
----------------------------------------
`CRM_Contact_BAO_ContactType_ContactSearchTest` used dyanmic properties which are deprecated in PHP 8.2.

After
----------------------------------------
Properties are declared.

I've also renamed some of them to not use abreviations, for better readability and consistency.
