### PR TITLE
[REF][PHP8.2] Declare processor property in CRM_Case_XMLProcessorTest

### DIFF
--- a/tests/phpunit/CRM/Case/XMLProcessorTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessorTest.php
@@ -7,6 +7,11 @@ require_once 'CiviTest/CiviCaseTestCase.php';
  */
 class CRM_Case_XMLProcessorTest extends CiviCaseTestCase {
 
+  /**
+   * @var CRM_Case_XMLProcessor
+   */
+  private $processor;
+
   public function setUp(): void {
     parent::setUp();
 


### PR DESCRIPTION
Overview
----------------------------------------
Declare processor property in CRM_Case_XMLProcessorTest

Before
----------------------------------------
`$this->processor` was defined and used as a dynamic property, deprecated in PHP 8.2.

After
----------------------------------------
Declared property, PHP 8.2 compatiable.