### PR TITLE
Speed up SearchKit results loading by 800ms

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -9,7 +9,7 @@
         boundary-links="true"
         total-items="$ctrl.rowCount"
         ng-model="$ctrl.page"
-        ng-change="$ctrl.getResults()"
+        ng-change="$ctrl.getResultsPronto()"
         items-per-page="$ctrl.limit"
         max-size="6"
         force-ellipses="true"

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -74,7 +74,7 @@
           ctrl.page = 1;
           // Only refresh if search has already been run
           if (ctrl.results) {
-            ctrl.getResultsPronto();
+            ctrl.getResultsSoon();
           }
         }
 

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -27,8 +27,14 @@
           this.placeholders.push({});
         }
 
-        // _.debounce used here to trigger the initial search immediately but prevent subsequent launches within 800ms
-        this.getResults = _.debounce(ctrl.runSearch, 800, {leading: true, trailing: false});
+        // _.debounce used here to trigger the initial search immediately but prevent subsequent launches within 300ms
+        this.getResultsPronto = _.debounce(ctrl.runSearch, 300, {leading: true, trailing: false});
+        // _.debounce used here to schedule a search if nothing else happens for 600ms: useful for auto-searching on typing
+        this.getResultsSoon = _.debounce(function() {
+          $scope.$apply(function() {
+            ctrl.runSearch();
+          });
+        }, 600);
 
         // Update totalCount variable if used.
         // Integrations can pass in `total-count="somevar" to keep track of the number of results returned
@@ -50,7 +56,7 @@
         // Popup forms in this display or surrounding Afform trigger a refresh
         $element.closest('form').on('crmPopupFormSuccess', function() {
           ctrl.rowCount = null;
-          ctrl.getResults();
+          ctrl.getResultsPronto();
         });
 
         function onChangeFilters() {
@@ -60,7 +66,7 @@
             callback.call(ctrl);
           });
           if (!ctrl.settings.button) {
-            ctrl.getResults();
+            ctrl.getResultsSoon();
           }
         }
 
@@ -68,7 +74,7 @@
           ctrl.page = 1;
           // Only refresh if search has already been run
           if (ctrl.results) {
-            ctrl.getResults();
+            ctrl.getResultsPronto();
           }
         }
 
@@ -128,7 +134,7 @@
       onClickSearchButton: function() {
         this.rowCount = null;
         this.page = 1;
-        this.getResults();
+        this.getResultsPronto();
       },
 
       // Call SearchDisplay.run and update ctrl.results and ctrl.rowCount

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -27,11 +27,8 @@
           this.placeholders.push({});
         }
 
-        this.getResults = _.debounce(function() {
-          $scope.$apply(function() {
-            ctrl.runSearch();
-          });
-        }, 800);
+        // _.debounce used here to trigger the initial search immediately but prevent subsequent launches within 800ms
+        this.getResults = _.debounce(ctrl.runSearch, 800, {leading: true, trailing: false});
 
         // Update totalCount variable if used.
         // Integrations can pass in `total-count="somevar" to keep track of the number of results returned

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplaySortableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplaySortableTrait.service.js
@@ -37,7 +37,7 @@
           this.sort.push([col.key, dir]);
         }
         if (this.results || !this.settings.button) {
-          this.getResults();
+          this.getResultsPronto();
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------

I always found searchkit laggy, and it turned out to be a deliberate 800ms delay before the query is even sent.


Before
----------------------------------------

Lodash's [debounce function](https://lodash.com/docs/3.10.1#debounce) called with (default) triggering on trailling event.

Click once → **Wait** → Click twice within 800ms → **Wait another 800ms** → submit request → display loading animation → results


After
----------------------------------------

Click once → **submit request** → display loading animation → results → Clicks again within 800ms are ignored.


Technical Details
----------------------------------------

Apart from the obvious, I had to remove the `$apply()` wrapper as angular was already digesting after the change. This is tidier anyway; and I *think* it's an ok change- I haven't noticed any prolems so far. I think that the old way ended up using a setTimeout (thanks to lodash.debounce) and *that* required `$apply()`. When processing on the *leading* edge, angular notices that changes are needed and starts digesting on its own. So I have a reasonable confidence in this change.


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
