### PR TITLE
APIv4 - Support autocompletes of the Entity entity

### DIFF
--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -15,6 +15,8 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Generic\AbstractEntity
  *
+ * @primaryKey name
+ * @labelField title_plural
  * @searchable none
  * @since 5.19
  * @package Civi\Api4
@@ -145,6 +147,15 @@ class Entity extends Generic\AbstractEntity {
     return (new Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function(Generic\BasicGetFieldsAction $getFields) {
       return Entity::$entityFields;
     }))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\AutocompleteAction
+   */
+  public static function autocomplete($checkPermissions = TRUE) {
+    return (new Generic\AutocompleteAction('Entity', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -178,7 +178,8 @@ trait ArrayQueryActionTrait {
           return in_array($expected, $value);
         }
         elseif (is_string($value) || is_numeric($value)) {
-          return strpos((string) $value, (string) $expected) !== FALSE;
+          // Lowercase check if string contains string
+          return strpos(strtolower((string) $value), strtolower((string) $expected)) !== FALSE;
         }
         return $value == $expected;
 

--- a/Civi/Api4/Service/Autocomplete/EntityAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/EntityAutocompleteProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class EntityAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for ContactType autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Entity') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['title_plural', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'title_plural',
+          'icons' => [
+            ['field' => 'icon'],
+          ],
+        ],
+        [
+          'type' => 'field',
+          'key' => 'description',
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds missing metadata to allow browsing API entities with the APIv4 autocomplete select.

Before
----------------------------------------
- Insufficient metadata to create autocomplete widget for the APIv4 Entity Entity.
- Autocomplete for non-dao apis was case-sensitive (incongruous with the majority of apis).

After
----------------------------------------
Search now works as expected.