### PR TITLE
CiviEvent - Fix missing default values for required fields in event registration setup

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -116,8 +116,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
           $defaults["custom_post_id_multiple[$key]"] = $value;
         }
       }
-
-      $this->assign('profilePostMultiple', CRM_Utils_Array::value('custom_post', $defaults));
+      $this->assign('profilePostMultiple', $defaults['custom_post'] ?? NULL);
 
       // CRM-17745: Make max additional participants configurable
       if (empty($defaults['max_additional_participants'])) {
@@ -149,7 +148,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
             $defaults["additional_custom_post_id_multiple[$key]"] = $value;
           }
         }
-        $this->assign('profilePostMultipleAdd', CRM_Utils_Array::value('additional_custom_post', $defaults, []));
+        $this->assign('profilePostMultipleAdd', $defaults['additional_custom_post'] ?? []);
       }
       else {
         // Avoid PHP notices in the template
@@ -161,10 +160,10 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     }
 
     // provide defaults for required fields if empty (and as a 'hint' for approval message field)
-    $defaults['registration_link_text'] = CRM_Utils_Array::value('registration_link_text', $defaults, ts('Register Now'));
-    $defaults['confirm_title'] = CRM_Utils_Array::value('confirm_title', $defaults, ts('Confirm Your Registration Information'));
-    $defaults['thankyou_title'] = CRM_Utils_Array::value('thankyou_title', $defaults, ts('Thank You for Registering'));
-    $defaults['approval_req_text'] = CRM_Utils_Array::value('approval_req_text', $defaults, ts('Participation in this event requires approval. Submit your registration request here. Once approved, you will receive an email with a link to a web page where you can complete the registration process.'));
+    $defaults['registration_link_text'] = $defaults['registration_link_text'] ?? ts('Register Now');
+    $defaults['confirm_title'] = $defaults['confirm_title'] ?? ts('Confirm Your Registration Information');
+    $defaults['thankyou_title'] = $defaults['thankyou_title'] ?? ts('Thank You for Registering');
+    $defaults['approval_req_text'] = $defaults['approval_req_text'] ?? ts('Participation in this event requires approval. Submit your registration request here. Once approved, you will receive an email with a link to a web page where you can complete the registration process.');
 
     return $defaults;
   }
@@ -442,6 +441,9 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
   public static function formRule($values, $files, $form) {
     if (!empty($values['is_online_registration'])) {
 
+      if (!$values['registration_link_text']) {
+        $errorMsg['registration_link_text'] = ts('Please enter Registration Link Text');
+      }
       if (!$values['confirm_title']) {
         $errorMsg['confirm_title'] = ts('Please enter a Title for the registration Confirmation Page');
       }

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -441,13 +441,13 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
   public static function formRule($values, $files, $form) {
     if (!empty($values['is_online_registration'])) {
 
-      if (!$values['registration_link_text']) {
+      if (($values['registration_link_text'] ?? '') === '') {
         $errorMsg['registration_link_text'] = ts('Please enter Registration Link Text');
       }
-      if (!$values['confirm_title']) {
+      if (($values['confirm_title'] ?? '') === '') {
         $errorMsg['confirm_title'] = ts('Please enter a Title for the registration Confirmation Page');
       }
-      if (!$values['thankyou_title']) {
+      if (($values['thankyou_title'] ?? '') === '') {
         $errorMsg['thankyou_title'] = ts('Please enter a Title for the registration Thank-you Page');
       }
       if ($values['is_email_confirm']) {

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -50,7 +50,7 @@
 
   <tr class="crm-event-manage-registration-form-block-registration_link_text">
     <td scope="row" class="label"
-        width="20%">{$form.registration_link_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='registration_link_text' id=$eventID}{/if}</td>
+        width="20%">{$form.registration_link_text.label} <span class="crm-marker">*</span>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='registration_link_text' id=$eventID}{/if}</td>
     <td>{$form.registration_link_text.html} {help id="id-link_text"}</td>
   </tr>
   {if !$isTemplate}

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/RegistrationTest.php
@@ -16,6 +16,7 @@ class CRM_Event_Form_ManageEvent_RegistrationTest extends CiviUnitTestCase {
       'is_email_confirm' => 0,
       'confirm_title' => 'Confirm your registration',
       'thankyou_title' => 'Thank you for your registration',
+      'registration_link_text' => 'Register Now',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
#24863 caused a regression so that the default values were no longer set for the required fields on the Online Registration tab when configuring an event (as [noted on Stack Exchange](https://civicrm.stackexchange.com/questions/43319/why-am-i-forced-to-enter-a-title-for-the-registration-confirmation-page-even-if)). The cause was that the default values were being set to null from API4 whereas previously the array keys did not exist.

I replaced all uses of Civi_Util_Array:value with ?? in this function. I also made the Registration Link Text required, which seems to be the original intent (if you don't enter a value, the default is used anyways). If this wasn't changed, there would be odd behaviour if the field was set to nothing, resulting in it being re-filled with the default.

Before
----------------------------------------
No default values, which is annoying because you are still forced to enter a title for the confirmation screen even if it is disabled.

After
----------------------------------------
Default values loaded as before.