### PR TITLE
Api3 Order.create: default status to Pending, but do not force it

### DIFF
--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -84,7 +84,9 @@ function civicrm_api3_order_create(array $params): array {
     }
     $params['skipCleanMoney'] = TRUE;
   }
-  $params['contribution_status_id'] = 'Pending';
+  if (empty($params['id']) && empty($params['contribution_status_id'])) {
+    $params['contribution_status_id'] = 'Pending';
+  }
   $order = new CRM_Financial_BAO_Order();
   $order->setDefaultFinancialTypeID($params['financial_type_id'] ?? NULL);
 


### PR DESCRIPTION
Makes it possible to update the status of an order, or to update an existing order that is not in Pending status.

Overview
----------------------------------------

The api3 `Order.create` API assumes that the order being created/updated is always in Pending status.

However, it works fine if we want to update an existing contribution (and change the line items) even if the contribution is Completed, for example. It also makes it possible to change the status of the contribution to Cancelled.

While I understand that I could also just use `Contribution.create` to update the status, this makes it easier in my code to just throw everything (including Line Items) to the Order API and it works fine.

Before
----------------------------------------

Calling `order.create` on a Completed or Cancelled order would result in "You cannot change the status from Completed to Pending" (even if I was not trying to set it to Pending).

After
----------------------------------------

Works as expected.
