### PR TITLE
(dev/core#4088) ClassScanner - Move test registration

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -309,6 +309,10 @@ abstract class CRM_Utils_Hook {
    * @param $moduleList
    */
   public function requireCiviModules(&$moduleList) {
+    foreach ($GLOBALS['CIVICRM_FORCE_MODULES'] ?? [] as $prefix) {
+      $moduleList[$prefix] = $prefix;
+    }
+
     $civiModules = CRM_Core_PseudoConstant::getModuleExtensions();
     foreach ($civiModules as $civiModule) {
       if (!file_exists($civiModule['filePath'] ?? '')) {

--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -143,12 +143,6 @@ class ClassScanner {
     static::scanFolders($classes, $civicrmRoot, 'CRM/*/WorkflowMessage', '_');
     static::scanFolders($classes, $civicrmRoot, 'CRM/*/Import', '_');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
-    if (\CRM_Utils_Constant::value('CIVICRM_UF') === 'UnitTests') {
-      if (strpos(get_include_path(), $civicrmRoot . 'tests/phpunit') !== FALSE) {
-        static::scanFolders($classes, $civicrmRoot . 'tests/phpunit', 'CRM/*/WorkflowMessage', '_');
-        static::scanFolders($classes, $civicrmRoot . 'tests/phpunit', 'Civi/*/WorkflowMessage', '\\');
-      }
-    }
 
     $cache->set($cacheKey, $classes, static::TTL);
     return $classes;

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -12,6 +12,16 @@ if (file_exists('/etc/timezone')) {
   }
 }
 
+$GLOBALS['CIVICRM_FORCE_MODULES'][] = 'civitest';
+
+function civitest_civicrm_scanClasses(array &$classes): void {
+  $phpunit = \Civi::paths()->getPath('[civicrm.root]/tests/phpunit');
+  if (strpos(get_include_path(), $phpunit) !== FALSE) {
+    \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'CRM/*/WorkflowMessage', '_');
+    \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'Civi/*/WorkflowMessage', '\\');
+  }
+}
+
 # Crank up the memory
 ini_set('memory_limit', '2G');
 define('CIVICRM_TEST', 1);


### PR DESCRIPTION
Overview
----------------------------------------

This loosens the interdependence between `Civi\Core\ClassScanner` and `tests/phpunit/CRM/*/WorkflowMessage`.

See also: https://lab.civicrm.org/dev/core/-/issues/4088

Before
----------------------------------------

The `ClassScanner` includes a special  rule to load some mocks/examples from `tests/phpunit/` which are needed for some core tests. But (reportedly) it will load even when running other test-suites.

After
----------------------------------------

The special rule has moved to the `bootstrap.php` for core tests. It should be inert when running other test-suites.

Technical Details
----------------------------------------

I believe the reason why the special rule was originally embedded into `ClassScanner` was that `ClassScanner` has special place in bootstrap/system-lifecycle.  To get around this, the patch adds `CIVICRM_FORCE_MODULES` as a way to pre-register some hook listeners.  (To wit: `civitest` is a "force-enabled module" defined by `bootstrap.php`. It's always-on; it can participate in special/pre-boot hooks; and it doesn't present as a configurable extension. You might also call it a "ghost module"...)
