### PR TITLE
CaseActivityTest - Fix quiet regressions

### DIFF
--- a/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
+++ b/tests/phpunit/CRM/Case/WorkflowMessage/CaseActivityTest.php
@@ -71,7 +71,7 @@ class CRM_Case_WorkflowMessage_CaseActivityTest extends CiviUnitTestCase {
       ->execute()
       ->single();
     $this->assertEquals($name, $get['name']);
-    $this->assertEquals(100, $get['data']['modelProps']['contact']['id']);
+    $this->assertEquals(0, $get['data']['modelProps']['contact']['id']);
     $this->assertEquals('myrole', $get['data']['modelProps']['contact']['role']);
   }
 

--- a/tests/phpunit/CiviTest/bootstrap.php
+++ b/tests/phpunit/CiviTest/bootstrap.php
@@ -17,8 +17,9 @@ $GLOBALS['CIVICRM_FORCE_MODULES'][] = 'civitest';
 function civitest_civicrm_scanClasses(array &$classes): void {
   $phpunit = \Civi::paths()->getPath('[civicrm.root]/tests/phpunit');
   if (strpos(get_include_path(), $phpunit) !== FALSE) {
-    \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'CRM/*/WorkflowMessage', '_');
-    \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'Civi/*/WorkflowMessage', '\\');
+    \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'CRM/*/WorkflowMessage', '_', '/Test$/');
+    \Civi\Core\ClassScanner::scanFolders($classes, $phpunit, 'Civi/*/WorkflowMessage', '\\', '/Test$/');
+    // Exclude all `*Test.php` files - if we load them, then phpunit gets confused.
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------

After eb92dd792c07e0b11ee1561cf00930402345e8b3, `CaseActivityTest` stopped running reliably. After 98e528a20637e880863371a1277f13a887e37eb5, one of the assertions started failing.

Depends: #25415

Before
----------------------------------------

Test does not run consistently.

After
----------------------------------------

Test runs and passes.

Comments
----------------------------------------

More details in commit notes