### PR TITLE
Increase timeout on imap

### DIFF
--- a/CRM/Mailing/MailStore/Imap.php
+++ b/CRM/Mailing/MailStore/Imap.php
@@ -68,6 +68,8 @@ class CRM_Mailing_MailStore_Imap extends CRM_Mailing_MailStore {
       'listLimit' => defined('MAIL_BATCH_SIZE') ? MAIL_BATCH_SIZE : 1000,
       'ssl' => $ssl,
       'uidReferencing' => TRUE,
+      // A timeout of 15 prevents the fetch_bounces job from failing if the response is a bit slow.
+      'timeout' => 15,
     ];
     $this->_transport = new ezcMailImapTransport($host, NULL, $options);
     if ($useXOAUTH2) {


### PR DESCRIPTION

Overview
----------------------------------------
Increase timeout on imap

Before
----------------------------------------
Imap attempts time out after 5 seconds

After
----------------------------------------
Imap attempts time out after 15 seconds

Technical Details
----------------------------------------
About once a day we get an error because the imap server takes longer than the 5 second timeout. This would be largely invisible to most sites as it would cause a run of fetch_bounces to fail quietly & then the next one would probably work. For us the impact is we get notified.

I think the impact of increasing to 15 seconds is small enough we don't need to make it configurable and I doubt that we hit this timeout any more than anyone else (our imap is within our own network which is surely more reliably fast than gmail) so the main impact is that people's fetch_bounces jobs are likely to result in data getting into civi with less failed runs & hence a bit quicker


Comments
----------------------------------------
