### PR TITLE
dev/translation#76 Allow extension gettext mo files to live in the I18N resource dir

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -565,19 +565,25 @@ class CRM_Core_I18n {
     // It's only necessary to find/bind once
     if (!isset($this->_extensioncache[$key])) {
       try {
+        $path = CRM_Core_I18n::getResourceDir();
         $mapper = CRM_Extension_System::singleton()->getMapper();
-        $path = $mapper->keyToBasePath($key);
         $info = $mapper->keyToInfo($key);
         $domain = $info->file;
 
+        // Support extension .mo files outside the CiviCRM codebase (relates to dev/translation#52)
+        if (!file_exists(CRM_Core_I18n::getResourceDir() . $this->locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . $domain . '.mo')) {
+          // Extensions that are not on Transifed might have their .po/mo files in their git repo
+          $path = $mapper->keyToBasePath($key) . DIRECTORY_SEPARATOR . 'l10n' . DIRECTORY_SEPARATOR;
+        }
+
         if ($this->_nativegettext) {
-          bindtextdomain($domain, $path . DIRECTORY_SEPARATOR . 'l10n');
+          bindtextdomain($domain, $path);
           bind_textdomain_codeset($domain, 'UTF-8');
           $this->_extensioncache[$key] = $domain;
         }
         else {
           // phpgettext
-          $mo_file = $path . DIRECTORY_SEPARATOR . 'l10n' . DIRECTORY_SEPARATOR . $this->locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . $domain . '.mo';
+          $mo_file = $path . $this->locale . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR . $domain . '.mo';
           $streamer = new FileReader($mo_file);
           $this->_extensioncache[$key] = $streamer->length() ? new gettext_reader($streamer) : NULL;
         }


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM core already supports having the civicrm.mo files in a custom directory, defined by the CIVICRM_L10N_BASEDIR constant, or `\Civi::paths()->getPath('[civicrm.private]/l10n')`. With this patch, it will also be possible to have the 'mo' files from extensions in that directory.

It will be assumed that if an extension is called "foo" then the mo file will be foo.mo and in the same directory as civicrm.mo.

Ex: `/path/to/l10n/fr_CA/LC_MESSAGES/foo.mo`

This aims to simplify automatic updates of translation files, including those for core extensions (ex: search kit). Currently l10nupdate assumes that the web-user can write in all sorts of places, ex: https://github.com/cividesk/com.cividesk.l10n.update/blob/master/l10nupdate.php#L156

I forked that extension to a new one: https://lab.civicrm.org/extensions/uplang  - so with this PR, and the uplang extension, we can easily do things like download translations for `search_kit`.

Before
----------------------------------------

Extension translations had to be in the directory of the extension.

After
----------------------------------------

Extension translations can be either in the `CIVICRM_L10N_BASEDIR` directory, or in the directory of the extension (searched in that order).

Comment
-----------------

Discussion on the translation channel: https://chat.civicrm.org/civicrm/pl/9moyk8uwab8sxxjxm833dqdfke

https://lab.civicrm.org/dev/translation/-/issues/76