### PR TITLE
dev/core#4095 - update log schema of civicrm_option_group before adding values

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyEight.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyEight.php
@@ -34,6 +34,8 @@ class CRM_Upgrade_Incremental_php_FiveFiftyEight extends CRM_Upgrade_Incremental
 
   public static function addOptionGroupDescriptions($ctx): bool {
     CRM_Upgrade_Incremental_Base::alterColumn($ctx, 'civicrm_option_group', 'description', "TEXT COMMENT 'Option group description.'", TRUE);
+    $schema = new CRM_Logging_Schema();
+    $schema->fixSchemaDifferences();
     $values = [
       [
         'group' => 'gender',


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/4095

Overview
----------------------------------------
Fix upgrading to 5.58 when logging is enabled.

Before
----------------------------------------
If logging is enabled, the upgrade to 5.58 fails on the step that inserts description values to `civicrm_option_group`

After
----------------------------------------
No failure on upgrade


