### PR TITLE
distmaker - Fix 'WordPress' entry in JSON report

### DIFF
--- a/distmaker/utils/repo-report.php
+++ b/distmaker/utils/repo-report.php
@@ -52,7 +52,7 @@ if (getenv('J5PACK')) {
 if (getenv('D5PACK')) {
   $data['tar']['Drupal'] = "civicrm-$DM_VERSION-drupal.tar.gz";
 }
-if (getenv('WPPACK')) {
+if (getenv('WP5PACK')) {
   $data['tar']['WordPress'] = "civicrm-$DM_VERSION-wordpress.zip";
 }
 if (getenv('L10NPACK')) {


### PR DESCRIPTION
Overview
----------------------------------------

When publishing a release, `distmaker` produces is a JSON summary about the inputs and outputs. @christianwach found that the `WordPress` section was missing from the list of outputs.

Before
----------------------------------------

JSON output is missing something important:

```diff
    "rev" : "5.58.beta1-2e2455ba34bb2a02c2a886e107b0e20a",
    "tar" : {
       "Drupal" : "civicrm-5.58.beta1-drupal.tar.gz",
       "Joomla" : "civicrm-5.58.beta1-joomla.zip",
-      "WordPress" : "civicrm-5.58.beta1-wordpress.zip"
        ...
```

After
----------------------------------------

JSON output has something important:

```diff
    "rev" : "5.58.beta1-2e2455ba34bb2a02c2a886e107b0e20a",
    "tar" : {
       "Drupal" : "civicrm-5.58.beta1-drupal.tar.gz",
       "Joomla" : "civicrm-5.58.beta1-joomla.zip",
+      "WordPress" : "civicrm-5.58.beta1-wordpress.zip"
        ...
```

Technical Details
----------------------------------------

`distmaker` has silly variable names. Grep for `WPPACK` and `WP5PACK` to see which is more correct.

Comments
----------------------------------------

This is a little finnicky to test. I did do a local `r-run` with this patch and saw the fixed output , but... it is generally easier to test by merging and letting the autobuild run...