### PR TITLE
[REF][PHP8.2] Fix Dynamic property payment instrument id on back offi…

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -707,7 +707,7 @@ WHERE  contribution_id = {$id}
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getDefaultPaymentInstrumentId() {
+  protected function getDefaultPaymentInstrumentId(): int {
     $paymentInstrumentID = CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer');
     return (int) ($paymentInstrumentID ?? $this->_paymentProcessor['payment_instrument_id']);
   }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -208,6 +208,14 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
    */
   protected $previousContributionStatus;
 
+
+  /**
+   * Payment Instrument ID
+   *
+   * @var int
+   */
+  public $payment_instrument_id;
+
   /**
    * Explicitly declare the form context.
    */
@@ -590,7 +598,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $paneNames[ts('Premium Information')] = 'Premium';
     }
 
-    $this->payment_instrument_id = CRM_Utils_Array::value('payment_instrument_id', $defaults, $this->getDefaultPaymentInstrumentId());
+    $this->payment_instrument_id = $defaults['payment_instrument_id'] ?? $this->getDefaultPaymentInstrumentId();
     CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->payment_instrument_id);
     if (!empty($this->_recurPaymentProcessors)) {
       $buildRecurBlock = TRUE;


### PR DESCRIPTION
…ce contribution form

Overview
----------------------------------------
This aims to fix dynamic class property payment_insturment_id on the backoffice contribution form and remove a usage of `CRM_Utils_Array::value`

Before
----------------------------------------
CancelTest fails on php8.2

After
----------------------------------------
CancelTest passes on php8.2

ping @eileenmcnaughton @totten @demeritcowboy @braders 