### PR TITLE
Regression fix - fieldSeparator lost in 5.58 import screens

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -93,8 +93,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       $this->addElement('checkbox', 'doGeocodeAddress', ts('Geocode addresses during import?'));
     }
 
-    $this->addElement('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2]);
-
     if (Civi::settings()->get('address_standardization_provider') === 'USPS') {
       $this->addElement('checkbox', 'disableUSPS', ts('Disable USPS address validation during import?'));
     }

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -367,7 +367,7 @@ abstract class CRM_Import_DataSource {
   }
 
   /**
-   * Get the table name for the datajob.
+   * Get the table name for the import job.
    *
    * @return string|null
    *
@@ -416,8 +416,6 @@ abstract class CRM_Import_DataSource {
 
   /**
    * Initialize the datasource, based on the submitted values stored in the user job.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function initialize(): void {
 
@@ -462,7 +460,7 @@ abstract class CRM_Import_DataSource {
    *   If the dataSource is being updated to another variant of the same
    *   class (eg. the csv upload was set to no column headers and they
    *   have resubmitted WITH skipColumnHeader (first row is a header) then
-   *   the dataSource is still CSV and the params for the new intance
+   *   the dataSource is still CSV and the params for the new instance
    *   are passed in. When changing from csv to SQL (for example) newParams is
    *   empty.
    *

--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -41,7 +41,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    * It should add all fields necessary to get the data
    * uploaded to the temporary table in the DB.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Contact_Import_Form_DataSource|\CRM_Import_Form_DataSourceConfig $form
    *
    * @throws \CRM_Core_Exception
    */
@@ -56,6 +56,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
     $form->assign('uploadSize', $uploadSize);
     $form->add('File', 'uploadFile', ts('Import Data File'), NULL, TRUE);
+    $form->addElement('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2]);
     $form->setMaxFileSize($uploadFileSize);
     $form->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', [
       1 => $uploadSize,
@@ -63,7 +64,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     ]), 'maxfilesize', $uploadFileSize);
     $form->addRule('uploadFile', ts('Input file must be in CSV format'), 'utf8File');
     $form->addRule('uploadFile', ts('A valid file must be uploaded.'), 'uploadedfile');
-
+    $form->setDataSourceDefaults($this->getDefaultValues());
     $form->addElement('checkbox', 'skipColumnHeader', ts('First row contains column headers'));
   }
 
@@ -258,6 +259,19 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
       $string = mb_convert_encoding($string, 'UTF-8', [$encoding]);
     }
     return preg_replace("/^(\u{a0})+|(\u{a0})+$/", '', $string);
+  }
+
+  /**
+   * Get default values for csv dataSource fields.
+   *
+   * @return array
+   */
+  public function getDefaultValues(): array {
+    return [
+      'fieldSeparator' => CRM_Core_Config::singleton()->fieldSeparator,
+      'skipColumnHeader' => 1,
+    ];
+
   }
 
 }

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -96,11 +96,10 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
   }
 
   public function setDefaultValues() {
-    return [
+    return array_merge($this->dataSourceDefaults, [
       'dataSource' => $this->getDefaultDataSource(),
       'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-      'fieldSeparator' => CRM_Core_Config::singleton()->fieldSeparator,
-    ];
+    ]);
 
   }
 
@@ -189,6 +188,25 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    */
   private function instantiateDataSource(): void {
     $this->getDataSourceObject()->initialize();
+  }
+
+  /**
+   * Default values for datasource fields.
+   *
+   * @var array
+   */
+  protected $dataSourceDefaults = [];
+
+  /**
+   * Set dataSource default values.
+   *
+   * @param array $dataSourceDefaults
+   *
+   * @return self
+   */
+  public function setDataSourceDefaults(array $dataSourceDefaults): self {
+    $this->dataSourceDefaults = $dataSourceDefaults;
+    return $this;
   }
 
 }

--- a/CRM/Import/Form/DataSourceConfig.php
+++ b/CRM/Import/Form/DataSourceConfig.php
@@ -21,6 +21,25 @@
 class CRM_Import_Form_DataSourceConfig extends CRM_Import_Forms {
 
   /**
+   * Default values for datasource fields.
+   *
+   * @var array
+   */
+  protected $dataSourceDefaults = [];
+
+  /**
+   * Set dataSource default values.
+   *
+   * @param array $dataSourceDefaults
+   *
+   * @return CRM_Import_Form_DataSourceConfig
+   */
+  public function setDataSourceDefaults(array $dataSourceDefaults): CRM_Import_Form_DataSourceConfig {
+    $this->dataSourceDefaults = $dataSourceDefaults;
+    return $this;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception
@@ -56,6 +75,9 @@ class CRM_Import_Form_DataSourceConfig extends CRM_Import_Forms {
       foreach ($this->getDataSourceFields() as $fieldName) {
         $defaults[$fieldName] = $this->getSubmittedValue($fieldName);
       }
+    }
+    else {
+      $defaults = array_merge($this->dataSourceDefaults, $defaults);
     }
     return $defaults;
   }

--- a/templates/CRM/Contact/Import/Form/CSV.tpl
+++ b/templates/CRM/Contact/Import/Form/CSV.tpl
@@ -22,5 +22,9 @@
             <div class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'First Name','Last Name','Email'){/ts}</div>
         </td>
     </tr>
+    <tr class="crm-import-datasource-form-block-fieldSeparator">
+      <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
+      <td>{$form.fieldSeparator.html}</td>
+    </tr>
   </table>
 

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -61,10 +61,6 @@
           <td><span>{$form.multipleCustomData.html}</span> </td>
         </tr>
       {/if}
-        <tr class="crm-import-datasource-form-block-fieldSeparator">
-          <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
-          <td>{$form.fieldSeparator.html}</td>
-        </tr>
        <tr class="crm-import-uploadfile-form-block-date">{include file="CRM/Core/Date.tpl"}</tr>
        {if array_key_exists('savedMapping', $form)}
          <tr class="crm-import-uploadfile-form-block-savedMapping">


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow on from the work @mattwire did to standardise the handling of the `DataSource` screen. the `fieldSeparator` element got lost on the contribution screen, resulting in notices. This only affects 5.58.


Before
----------------------------------------
enotices & missing data separator field
![image](https://user-images.githubusercontent.com/336308/214721605-c2005e80-5a4f-4d0f-ac19-0083b96be3b1.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/214728017-ad2da0d3-c29c-49e7-88bc-14fac736bf02.png)

Technical Details
----------------------------------------
In addition to fixing the field/ notice I leveraged the work @mattwire did to allow us to move the csv-data-source-relevant `skipColumnHeader` field to the csv class / tpl and to give it a default of TRUE. This has been requested before by a few people, with only soft dissent at most

Comments
----------------------------------------
