### PR TITLE
Stop calling unshipped test classes from `SearchRunWithCustomFieldTest` test

### DIFF
--- a/tests/phpunit/api/v4/Custom/CustomTestBase.php
+++ b/tests/phpunit/api/v4/Custom/CustomTestBase.php
@@ -27,6 +27,9 @@ use Civi\Api4\CustomField;
  * Use this base class for any APIv4 tests which create custom groups/fields,
  * to ensure they get cleaned up properly.
  *
+ * Note that this should be reconciled with The CustomDataTestTrait that is
+ * more widely used in our tests & a stable version put in Civi::test();
+ *
  * Note: The TransactionalInterface won't work with custom fields because of adding/dropping tables.
  * So these tests have to do their own cleanup of any contacts or other entities created.
  * The recommended way is to override the `tearDown` function and calling `parent::tearDown()`.


### PR DESCRIPTION
Overview
----------------------------------------
Stop calling unshipped test classes from SearchRun test

Before
----------------------------------------
`SearchRunWithCustomFieldTest` calls 2 classes that it has to add using a `require_once`

After
----------------------------------------
It now uses the generic `Apiv4TestTrait` and self-contains the `tearDown`

Technical Details
----------------------------------------
Although I realise the intent of the class it used to `require` was to be a building block for more classes we wind up with paralell development of the same functionality in that and the more widely used `CRMTraits_Custom_CustomDataTrait` - I feel like we need to bring a combination into `Civi::test()` that will be generally useful to extension developers but the class this previously extended is less mature than the other trait so my feeling was to just disentangle it for now & then when we have 'done' the `apiTrait` we can start working through the other useful traits

Comments
----------------------------------------
