### PR TITLE
dev/core#4097 Type fix for formatLocaleNumeric method

### DIFF
--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -117,6 +117,10 @@ class CRM_Utils_Number {
    * @throws \Brick\Money\Exception\UnknownCurrencyException
    */
   public static function formatLocaleNumeric(string $amount, $locale = NULL): string {
+    if ($amount === "") {
+      return $amount;
+    }
+
     $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);
     $formatter->setSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryDecimalPoint);
     $formatter->setSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryThousandSeparator);

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -15,6 +15,8 @@ namespace Civi\Api4;
  *
  * @see \Civi\Api4\Generic\AbstractEntity
  *
+ * @primaryKey name
+ * @labelField title_plural
  * @searchable none
  * @since 5.19
  * @package Civi\Api4
@@ -145,6 +147,15 @@ class Entity extends Generic\AbstractEntity {
     return (new Generic\BasicGetFieldsAction('Entity', __FUNCTION__, function(Generic\BasicGetFieldsAction $getFields) {
       return Entity::$entityFields;
     }))->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\AutocompleteAction
+   */
+  public static function autocomplete($checkPermissions = TRUE) {
+    return (new Generic\AutocompleteAction('Entity', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
+++ b/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php
@@ -178,7 +178,8 @@ trait ArrayQueryActionTrait {
           return in_array($expected, $value);
         }
         elseif (is_string($value) || is_numeric($value)) {
-          return strpos((string) $value, (string) $expected) !== FALSE;
+          // Lowercase check if string contains string
+          return strpos(strtolower((string) $value), strtolower((string) $expected)) !== FALSE;
         }
         return $value == $expected;
 

--- a/Civi/Api4/Service/Autocomplete/EntityAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/EntityAutocompleteProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class EntityAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for ContactType autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Entity') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['title_plural', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'title_plural',
+          'icons' => [
+            ['field' => 'icon'],
+          ],
+        ],
+        [
+          'type' => 'field',
+          'key' => 'description',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/tests/phpunit/CRM/Activity/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Activity/Page/AJAXTest.php
@@ -5,6 +5,16 @@
  */
 class CRM_Activity_Page_AJAXTest extends CiviUnitTestCase {
 
+  /**
+   * @var int
+   */
+  private $loggedInUser;
+
+  /**
+   * @var int
+   */
+  private $target;
+
   public function setUp(): void {
     parent::setUp();
 

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -6,28 +6,28 @@
  */
 class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
 
+  const TABLES_TO_TRUNCATE = [
+    'civicrm_activity',
+    'civicrm_group_contact',
+    'civicrm_contact',
+    'civicrm_custom_group',
+    'civicrm_custom_field',
+    'civicrm_case',
+    'civicrm_case_contact',
+    'civicrm_case_activity',
+    'civicrm_case_type',
+    'civicrm_file',
+    'civicrm_entity_file',
+    'civicrm_activity_contact',
+    'civicrm_managed',
+    'civicrm_relationship',
+    'civicrm_relationship_type',
+  ];
+
   public function setUp(): void {
     parent::setUp();
 
-    $this->tablesToTruncate = [
-      'civicrm_activity',
-      'civicrm_group_contact',
-      'civicrm_contact',
-      'civicrm_custom_group',
-      'civicrm_custom_field',
-      'civicrm_case',
-      'civicrm_case_contact',
-      'civicrm_case_activity',
-      'civicrm_case_type',
-      'civicrm_file',
-      'civicrm_entity_file',
-      'civicrm_activity_contact',
-      'civicrm_managed',
-      'civicrm_relationship',
-      'civicrm_relationship_type',
-    ];
-
-    $this->quickCleanup($this->tablesToTruncate);
+    $this->quickCleanup(self::TABLES_TO_TRUNCATE);
 
     $this->loadAllFixtures();
 
@@ -60,7 +60,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
   }
 
   protected function tearDown(): void {
-    $this->quickCleanup($this->tablesToTruncate, TRUE);
+    $this->quickCleanup(self::TABLES_TO_TRUNCATE, TRUE);
     parent::tearDown();
   }
 

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Extension_InfoTest extends CiviUnitTestCase {
 
+  /**
+   * @var string|null
+   */
+  private $file;
+
   public function setUp(): void {
     parent::setUp();
     $this->file = NULL;

--- a/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/PaymentTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Extension_Manager_PaymentTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Extension_System
+   */
+  private $system;
+
   public function setUp(): void {
     parent::setUp();
     if (class_exists('test_extension_manager_paymenttest')) {

--- a/tests/phpunit/CRM/Extension/Manager/ReportTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/ReportTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Extension_Manager_ReportTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Extension_System
+   */
+  private $system;
+
   public function setUp(): void {
     parent::setUp();
     //if (class_exists('test_extension_manager_reporttest')) {

--- a/tests/phpunit/CRM/Extension/Manager/SearchTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/SearchTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Extension_Manager_SearchTest extends CiviUnitTestCase {
 
+  /**
+   * @var CRM_Extension_System
+   */
+  private $system;
+
   public function setUp(): void {
     parent::setUp();
     //if (class_exists('test_extension_manager_searchtest')) {

--- a/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
@@ -12,6 +12,7 @@ class CRM_Utils_API_MatchOptionTest extends CiviUnitTestCase {
   public $noise;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     $this->assertDBQuery(0, "SELECT count(*) FROM civicrm_contact WHERE first_name='Jeffrey' and last_name='Lebowski'");
 

--- a/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
@@ -12,6 +12,7 @@
 class CRM_Utils_API_ReloadOptionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_post', [$this, 'onPost']);
   }

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -6,6 +6,14 @@
  */
 class CRM_Utils_ArrayTest extends CiviUnitTestCase {
 
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testAsColumns() {
     $rowsNum = [
       ['a' => 10, 'b' => 11],

--- a/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
@@ -8,6 +8,11 @@
  */
 class CRM_Utils_Check_Component_EnvTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * File check test should fail if reached maximum timeout.
    * @throws \GuzzleHttp\Exception\GuzzleException

--- a/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
@@ -8,6 +8,11 @@
  */
 class CRM_Utils_Check_Component_OptionGroupsTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testCheckOptionGroupValues() {
     $optionGroup = $this->callAPISuccess('OptionGroup', 'create', [
       'name' => 'testGroup',

--- a/tests/phpunit/CRM/Utils/ColorTest.php
+++ b/tests/phpunit/CRM/Utils/ColorTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_ColorTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @dataProvider contrastExamples
    */

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -27,6 +27,14 @@
 class CRM_Utils_DateTest extends CiviUnitTestCase {
 
   /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
    * Used by testGetFromTo
    */
   private function fromToData() {

--- a/tests/phpunit/CRM/Utils/GlobalStackTest.php
+++ b/tests/phpunit/CRM/Utils/GlobalStackTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_GlobalStackTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Temporarily override global variables and ensure that the variable data.
    * is set as expected (before/during/after the override).

--- a/tests/phpunit/CRM/Utils/HTMLTest.php
+++ b/tests/phpunit/CRM/Utils/HTMLTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Utils_HTMLTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/HookTest.php
+++ b/tests/phpunit/CRM/Utils/HookTest.php
@@ -13,6 +13,7 @@ class CRM_Utils_HookTest extends CiviUnitTestCase {
   public $log;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     $this->fakeModules = [
       'hooktesta',

--- a/tests/phpunit/CRM/Utils/HtmlToTextTest.php
+++ b/tests/phpunit/CRM/Utils/HtmlToTextTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_HtmlToTextTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -25,6 +25,7 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
   protected $client;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
 
     $this->tmpFile = $this->createTempDir() . '/example.txt';

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -16,6 +16,14 @@
 class CRM_Utils_JSTest extends CiviUnitTestCase {
 
   /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
    * @return array
    */
   public function translateExamples() {

--- a/tests/phpunit/CRM/Utils/LazyArrayTest.php
+++ b/tests/phpunit/CRM/Utils/LazyArrayTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_LazyArrayTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testAssoc() {
     $l = $this->createFruitBasket();
     $this->assertFalse($l->isLoaded());

--- a/tests/phpunit/CRM/Utils/Mail/FilteredPearMailerTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/FilteredPearMailerTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_Mail_FilteredPearMailerTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testFilter() {
     $mock = new class() extends \Mail {
       public $buf = [];

--- a/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
@@ -32,6 +32,7 @@ class CRM_Utils_Mail_IncomingTest extends CiviUnitTestCase {
   protected $name;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
 
     $rand = rand(0, 1000);

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_MailTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Test case for add( )
    * test with empty params.

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Utils_MoneyTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @dataProvider subtractCurrenciesDataProvider
    * @param string $leftOp

--- a/tests/phpunit/CRM/Utils/NumberTest.php
+++ b/tests/phpunit/CRM/Utils/NumberTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_NumberTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/PDF/UtilsTest.php
+++ b/tests/phpunit/CRM/Utils/PDF/UtilsTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_PDF_UtilsTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Test user-supplied settings for DOMPDF
    */

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -7,6 +7,14 @@
 class CRM_Utils_RuleTest extends CiviUnitTestCase {
 
   /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
    * @dataProvider integerDataProvider
    * @param $inputData
    * @param $expectedResult

--- a/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQL_DeleteTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testGetDefault() {
     $del = CRM_Utils_SQL_Delete::from('foo');
     $this->assertLike('DELETE FROM foo', $del->toSQL());

--- a/tests/phpunit/CRM/Utils/SQL/InsertTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/InsertTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQL_InsertTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testRow_twice() {
     $insert = CRM_Utils_SQL_Insert::into('foo')
       ->row(['first' => '1', 'second' => '2'])

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testGetDefault() {
     $select = CRM_Utils_SQL_Select::from('foo bar');
     $this->assertLike('SELECT * FROM foo bar', $select->toSQL());

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQLTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testInterpolate() {
     // This function is a thin wrapper for `CRM_Utils_SQL_BaseParamQuery::interpolate()`, which already has
     // lots of coverage in other test classes. This test just checks the basic wiring.

--- a/tests/phpunit/CRM/Utils/SignerTest.php
+++ b/tests/phpunit/CRM/Utils/SignerTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Utils_SignerTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testSignValidate() {
     $cases = [];
     $cases[] = [

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -6,6 +6,14 @@
  */
 class CRM_Utils_StringTest extends CiviUnitTestCase {
 
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testBase64Url(): void {
     $examples = [
       'a' => 'YQ',

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Utils_SystemTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testUrlQueryString() {
     $config = CRM_Core_Config::singleton();
     $this->assertTrue($config->userSystem instanceof CRM_Utils_System_UnitTests);

--- a/tests/phpunit/CRM/Utils/TimeTest.php
+++ b/tests/phpunit/CRM/Utils/TimeTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_TimeTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Equal cases.
    *

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -8,6 +8,11 @@ use Civi\Token\TokenProcessor;
  */
 class CRM_Utils_TokenTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Test for replaceGreetingTokens.
    *

--- a/tests/phpunit/CRM/Utils/ZipTest.php
+++ b/tests/phpunit/CRM/Utils/ZipTest.php
@@ -22,6 +22,7 @@ class CRM_Utils_ZipTest extends CiviUnitTestCase {
   private $file = FALSE;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     $this->file = FALSE;
   }

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -8,6 +8,11 @@ use Civi\Test\Invasive;
  */
 class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @var array
    */


### PR DESCRIPTION
Overview
----------------------------------------

CRM_Utils_Number::formatLocaleNumeric() method throws fatal error due to string paramater.

Before
----------------------------------------
Any call to CRM_Utils_Number::formatLocaleNumeric() fails with error: "Fatal error: Uncaught Error: NumberFormatter::format(): Argument #1 ($num) must be of type int|float, string given
in /path/to/civicrm/civicrm/CRM/Utils/Number.php on line 123"

After
----------------------------------------
Method returns correctly formatted $amount variable, as intended.

Technical Details
----------------------------------------
Added lines to test if string $amount can be converted to an int or float. Integer strings converted to proper ints, float strings to floats.

Comments
----------------------------------------
I wasn't able to find an existing built-in CiviCRM utility to parse strings to numeric values in this way, but it may exist, in which case it should probably be used instead.
