### PR TITLE
(NFC) Speed up random tests by 55-60%

### DIFF
--- a/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
@@ -12,6 +12,7 @@ class CRM_Utils_API_MatchOptionTest extends CiviUnitTestCase {
   public $noise;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     $this->assertDBQuery(0, "SELECT count(*) FROM civicrm_contact WHERE first_name='Jeffrey' and last_name='Lebowski'");
 

--- a/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
@@ -12,6 +12,7 @@
 class CRM_Utils_API_ReloadOptionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_post', [$this, 'onPost']);
   }

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -6,6 +6,14 @@
  */
 class CRM_Utils_ArrayTest extends CiviUnitTestCase {
 
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testAsColumns() {
     $rowsNum = [
       ['a' => 10, 'b' => 11],

--- a/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
@@ -8,6 +8,11 @@
  */
 class CRM_Utils_Check_Component_EnvTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * File check test should fail if reached maximum timeout.
    * @throws \GuzzleHttp\Exception\GuzzleException

--- a/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
@@ -8,6 +8,11 @@
  */
 class CRM_Utils_Check_Component_OptionGroupsTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testCheckOptionGroupValues() {
     $optionGroup = $this->callAPISuccess('OptionGroup', 'create', [
       'name' => 'testGroup',

--- a/tests/phpunit/CRM/Utils/ColorTest.php
+++ b/tests/phpunit/CRM/Utils/ColorTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_ColorTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @dataProvider contrastExamples
    */

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -27,6 +27,14 @@
 class CRM_Utils_DateTest extends CiviUnitTestCase {
 
   /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
    * Used by testGetFromTo
    */
   private function fromToData() {

--- a/tests/phpunit/CRM/Utils/GlobalStackTest.php
+++ b/tests/phpunit/CRM/Utils/GlobalStackTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_GlobalStackTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Temporarily override global variables and ensure that the variable data.
    * is set as expected (before/during/after the override).

--- a/tests/phpunit/CRM/Utils/HTMLTest.php
+++ b/tests/phpunit/CRM/Utils/HTMLTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Utils_HTMLTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/HookTest.php
+++ b/tests/phpunit/CRM/Utils/HookTest.php
@@ -13,6 +13,7 @@ class CRM_Utils_HookTest extends CiviUnitTestCase {
   public $log;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     $this->fakeModules = [
       'hooktesta',

--- a/tests/phpunit/CRM/Utils/HtmlToTextTest.php
+++ b/tests/phpunit/CRM/Utils/HtmlToTextTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_HtmlToTextTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -25,6 +25,7 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
   protected $client;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
 
     $this->tmpFile = $this->createTempDir() . '/example.txt';

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -16,6 +16,14 @@
 class CRM_Utils_JSTest extends CiviUnitTestCase {
 
   /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
    * @return array
    */
   public function translateExamples() {

--- a/tests/phpunit/CRM/Utils/LazyArrayTest.php
+++ b/tests/phpunit/CRM/Utils/LazyArrayTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_LazyArrayTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testAssoc() {
     $l = $this->createFruitBasket();
     $this->assertFalse($l->isLoaded());

--- a/tests/phpunit/CRM/Utils/Mail/FilteredPearMailerTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/FilteredPearMailerTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_Mail_FilteredPearMailerTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testFilter() {
     $mock = new class() extends \Mail {
       public $buf = [];

--- a/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
@@ -32,6 +32,7 @@ class CRM_Utils_Mail_IncomingTest extends CiviUnitTestCase {
   protected $name;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
 
     $rand = rand(0, 1000);

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_MailTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Test case for add( )
    * test with empty params.

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Utils_MoneyTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @dataProvider subtractCurrenciesDataProvider
    * @param string $leftOp

--- a/tests/phpunit/CRM/Utils/NumberTest.php
+++ b/tests/phpunit/CRM/Utils/NumberTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_NumberTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @return array
    */

--- a/tests/phpunit/CRM/Utils/PDF/UtilsTest.php
+++ b/tests/phpunit/CRM/Utils/PDF/UtilsTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_PDF_UtilsTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Test user-supplied settings for DOMPDF
    */

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -7,6 +7,14 @@
 class CRM_Utils_RuleTest extends CiviUnitTestCase {
 
   /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  /**
    * @dataProvider integerDataProvider
    * @param $inputData
    * @param $expectedResult

--- a/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQL_DeleteTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testGetDefault() {
     $del = CRM_Utils_SQL_Delete::from('foo');
     $this->assertLike('DELETE FROM foo', $del->toSQL());

--- a/tests/phpunit/CRM/Utils/SQL/InsertTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/InsertTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQL_InsertTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testRow_twice() {
     $insert = CRM_Utils_SQL_Insert::into('foo')
       ->row(['first' => '1', 'second' => '2'])

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testGetDefault() {
     $select = CRM_Utils_SQL_Select::from('foo bar');
     $this->assertLike('SELECT * FROM foo bar', $select->toSQL());

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_SQLTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testInterpolate() {
     // This function is a thin wrapper for `CRM_Utils_SQL_BaseParamQuery::interpolate()`, which already has
     // lots of coverage in other test classes. This test just checks the basic wiring.

--- a/tests/phpunit/CRM/Utils/SignerTest.php
+++ b/tests/phpunit/CRM/Utils/SignerTest.php
@@ -15,6 +15,11 @@
  */
 class CRM_Utils_SignerTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testSignValidate() {
     $cases = [];
     $cases[] = [

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -6,6 +6,14 @@
  */
 class CRM_Utils_StringTest extends CiviUnitTestCase {
 
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testBase64Url(): void {
     $examples = [
       'a' => 'YQ',

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -7,6 +7,11 @@
  */
 class CRM_Utils_SystemTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   public function testUrlQueryString() {
     $config = CRM_Core_Config::singleton();
     $this->assertTrue($config->userSystem instanceof CRM_Utils_System_UnitTests);

--- a/tests/phpunit/CRM/Utils/TimeTest.php
+++ b/tests/phpunit/CRM/Utils/TimeTest.php
@@ -6,6 +6,11 @@
  */
 class CRM_Utils_TimeTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Equal cases.
    *

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -8,6 +8,11 @@ use Civi\Token\TokenProcessor;
  */
 class CRM_Utils_TokenTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * Test for replaceGreetingTokens.
    *

--- a/tests/phpunit/CRM/Utils/ZipTest.php
+++ b/tests/phpunit/CRM/Utils/ZipTest.php
@@ -22,6 +22,7 @@ class CRM_Utils_ZipTest extends CiviUnitTestCase {
   private $file = FALSE;
 
   public function setUp(): void {
+    $this->useTransaction();
     parent::setUp();
     $this->file = FALSE;
   }

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -8,6 +8,11 @@ use Civi\Test\Invasive;
  */
 class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
   /**
    * @var array
    */


### PR DESCRIPTION
Before
----------------------------------------

Slower

After
----------------------------------------

Faster

Technical Details
----------------------------------------

`useTransaction()`

Comments
----------------------------------------

I noticed that the CRM suite is particularly slow, so I skimmed the recent results. While there are a few particularly expensive tests (>1min ea), they don't actually account for a huge percentage of the suite. The overhead is more diffuse - there's a huge number of tests, all with a chunk of overhead. This kind of thing reduces that overhead.