### PR TITLE
getStatus() should be returning a string

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -431,13 +431,13 @@ class CRM_Core_Session {
    * @param bool $reset
    *   Should we reset the status variable?.
    *
-   * @return string
+   * @return array
    *   the status message if any
    */
-  public function getStatus($reset = FALSE) {
+  public function getStatus($reset = FALSE) : array {
     $this->initialize();
 
-    $status = NULL;
+    $status = [];
     if (array_key_exists('status', $this->_session[$this->_key])) {
       $status = $this->_session[$this->_key]['status'];
     }


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Session::getStatus()` has a docblock that says it returns an array.  However, it can also return `NULL`.  This fixes that.

Before
----------------------------------------
`$status` initialized to `NULL`.

After
----------------------------------------
`$status` initialized to a blank string.  Return type specified.

Comments
----------------------------------------
When a return type is specified, should we remove the `@return` from the docblock?
