### PR TITLE
[REF][PHP8.2] Refactor CRM_Case_BAO_CaseTest to use const

### DIFF
--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -6,28 +6,28 @@
  */
 class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
 
+  const TABLES_TO_TRUNCATE = [
+    'civicrm_activity',
+    'civicrm_group_contact',
+    'civicrm_contact',
+    'civicrm_custom_group',
+    'civicrm_custom_field',
+    'civicrm_case',
+    'civicrm_case_contact',
+    'civicrm_case_activity',
+    'civicrm_case_type',
+    'civicrm_file',
+    'civicrm_entity_file',
+    'civicrm_activity_contact',
+    'civicrm_managed',
+    'civicrm_relationship',
+    'civicrm_relationship_type',
+  ];
+
   public function setUp(): void {
     parent::setUp();
 
-    $this->tablesToTruncate = [
-      'civicrm_activity',
-      'civicrm_group_contact',
-      'civicrm_contact',
-      'civicrm_custom_group',
-      'civicrm_custom_field',
-      'civicrm_case',
-      'civicrm_case_contact',
-      'civicrm_case_activity',
-      'civicrm_case_type',
-      'civicrm_file',
-      'civicrm_entity_file',
-      'civicrm_activity_contact',
-      'civicrm_managed',
-      'civicrm_relationship',
-      'civicrm_relationship_type',
-    ];
-
-    $this->quickCleanup($this->tablesToTruncate);
+    $this->quickCleanup(self::TABLES_TO_TRUNCATE);
 
     $this->loadAllFixtures();
 
@@ -60,7 +60,7 @@ class CRM_Case_BAO_CaseTest extends CiviUnitTestCase {
   }
 
   protected function tearDown(): void {
-    $this->quickCleanup($this->tablesToTruncate, TRUE);
+    $this->quickCleanup(self::TABLES_TO_TRUNCATE, TRUE);
     parent::tearDown();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
`tablesToTruncate` was a dynamic property in `CRM_Case_BAO_CaseTest`. As dynamic propertes are deprecated in PHP 8.2, and as the value of `tablesToTruncate` never changes, this refactors to use a `const` instead.

Before
----------------------------------------
Dynamic property, not PHP 8.2 friendly. 

After
----------------------------------------
Dynamic property no more!