### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Activity_Page_AJAXTest

### DIFF
--- a/tests/phpunit/CRM/Activity/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Activity/Page/AJAXTest.php
@@ -5,6 +5,16 @@
  */
 class CRM_Activity_Page_AJAXTest extends CiviUnitTestCase {
 
+  /**
+   * @var int
+   */
+  private $loggedInUser;
+
+  /**
+   * @var int
+   */
+  private $target;
+
   public function setUp(): void {
     parent::setUp();
 


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties in CRM_Activity_Page_AJAXTest

Before
----------------------------------------
Dynamic properties were used, which are deprecated in PHP 8.2. Tests failed on PHP 8.2.

After
----------------------------------------
Properties declared.