### PR TITLE
Allow OAuth redirect URI to be overridden in client or provider config

### DIFF
--- a/ext/oauth-client/Civi/OAuth/OAuthLeagueFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthLeagueFacade.php
@@ -36,13 +36,12 @@ class OAuthLeagueFacade {
     $localOptions['clientId'] = $clientDef['guid'];
     $localOptions['tenant'] = !empty($clientDef['tenant']) ? $clientDef['tenant'] : '';
     $localOptions['clientSecret'] = $clientDef['secret'];
-    // NOTE: If we ever have frontend users, this may need to change.
-    $localOptions['redirectUri'] = \CRM_OAuth_BAO_OAuthClient::getRedirectUri();
     $options = array_merge(
       $providerDef['options'] ?? [],
       $clientDef['options'] ?? [],
       $localOptions
     );
+    $options['redirectUri'] = $options['redirectUri'] ?? \CRM_OAuth_BAO_OAuthClient::getRedirectUri();
 
     return [$class, $options];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes we may want to specify the Redirect URI for a particular OAuth flow -- e.g. we may want some flows to be completed on the "public" side of the website (by users who aren't logged into Civi). This small PR makes the oauth-client extension respect whatever Redirect URI is set in the "client" or "provider" configuration.

Before
----------------------------------------
In all OAuth flows, the Redirect URI was always the backend version of `civicrm/oauth-client/return`, or whatever was specified site-wide in the setting `oauthClientRedirectUrl`. Individual Providers or Clients could not have their own Redirect URI.

After
----------------------------------------
In any given OAuth flow, the extension will look for the Redirect URI first in the Client definition, then in the Provider definition, then in the site-wide setting. If none of these are found, it will generate the default redirect URI.

Comments
----------------------------------------
This adds some flexibility after #24383 (@mattwire) made Redirect URIs backend-only.