### PR TITLE
Reduce unneeded DNS queries during OAuth flow

### DIFF
--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
@@ -91,20 +91,19 @@ class AuthorizationCode extends AbstractGrantAction {
     parent::validate();
     if ($this->landingUrl) {
       $landingUrlParsed = parse_url($this->landingUrl);
-      $landingUrlIp = gethostbyname($landingUrlParsed['host']);
+      $landingUrlIp = gethostbyname($landingUrlParsed['host'] . '.');
       $allowedBases = [
         \Civi::paths()->getVariable('cms.root', 'url'),
         \Civi::paths()->getVariable('civicrm.root', 'url'),
       ];
-      $ok = max(array_map(function($allowed) use ($landingUrlParsed, $landingUrlIp) {
+      foreach ($allowedBases as $allowed) {
         $allowedParsed = parse_url($allowed);
-        $allowedIp = gethostbyname($allowedParsed['host']);
-        $ok = $landingUrlIp === $allowedIp && $landingUrlParsed['scheme'] == $allowedParsed['scheme'];
-        return (int) $ok;
-      }, $allowedBases));
-      if (!$ok) {
-        throw new OAuthException("Cannot initiate OAuth. Unsupported landing URL.");
+        $allowedIp = gethostbyname($allowedParsed['host'] . '.');
+        if ($landingUrlIp === $allowedIp && $landingUrlParsed['scheme'] == $allowedParsed['scheme']) {
+          return;
+        }
       }
+      throw new OAuthException("Cannot initiate OAuth. Unsupported landing URL.");
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Make code more efficient (at least one less DNS query) and easier to read.

Before
----------------------------------------
This function might take, e.g., 3 seconds

After
----------------------------------------
Function takes 2 seconds

Comments
----------------------------------------
This won't make a big impact in most situations, but I came across a case in development where the DNS queries were very slow, which brought this to my attention