### PR TITLE
[REF][PHP8.2] Declare missing property on CRM_Utils_HookTest

### DIFF
--- a/tests/phpunit/CRM/Utils/HookTest.php
+++ b/tests/phpunit/CRM/Utils/HookTest.php
@@ -6,11 +6,25 @@
  */
 class CRM_Utils_HookTest extends CiviUnitTestCase {
 
+  /**
+   * @var object|null
+   */
   public static $activeTest = NULL;
 
+  /**
+   * @var array
+   */
   public $fakeModules;
 
+  /**
+   * @var array
+   */
   public $log;
+
+  /**
+   * @var CRM_Utils_Hook_UnitTests
+   */
+  public $hook;
 
   public function setUp(): void {
     $this->useTransaction();


### PR DESCRIPTION
Overview
----------------------------------------
Declare previously dynamic property `$hook` and add some docblock comments.

Before
----------------------------------------
`$hook` was a dyanmic property. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
PHP 8.2. friendly. Some extra docblock annotations added.