### PR TITLE
dev/core#4097 Fix empty string $amount error

### DIFF
--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -117,6 +117,10 @@ class CRM_Utils_Number {
    * @throws \Brick\Money\Exception\UnknownCurrencyException
    */
   public static function formatLocaleNumeric(string $amount, $locale = NULL): string {
+    if ($amount === "") {
+      return $amount;
+    }
+
     $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);
     $formatter->setSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryDecimalPoint);
     $formatter->setSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryThousandSeparator);


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Utils_Number::formatLocaleNumeric() method throws fatal error due to empty string paramater.

Before
----------------------------------------
Any call to CRM_Utils_Number::formatLocaleNumeric() with an empty string fails with error: "Fatal error: Uncaught Error: NumberFormatter::format(): Argument #1 ($num) must be of type int|float, string given
in /path/to/civicrm/civicrm/CRM/Utils/Number.php on line 123"

After
----------------------------------------
Method does not throw fatal error if empty string submitted.

Technical Details
----------------------------------------
Added lines to return early with an empty string if empty string submitted as $amount parameter.

Comments
----------------------------------------
Initially this was discussed in closed PR https://github.com/civicrm/civicrm-core/pull/25436. 

Fix for issue: https://lab.civicrm.org/dev/core/-/issues/4097

I closed that PR and opened this one to get around git branch mess. Sorry.
