### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in CRM_Event_BAO_ParticipantTest

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -16,6 +16,16 @@
  */
 class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
 
+  /**
+   * @var int
+   */
+  private $_contactId;
+
+  /**
+   * @var int
+   */
+  private $_eventId;
+
   public function setUp(): void {
     parent::setUp();
     $this->_contactId = $this->individualCreate();


### PR DESCRIPTION
Overview
----------------------------------------
Declares properties `_contactId` and `_eventId` which were previously dynamic.

Before
----------------------------------------
Dynamic properties are deprecated in PHP 8.2. Tests fail.

After
----------------------------------------
Tests in `CRM_Event_BAO_ParticipantTest` class pass on PHP 8.2