### PR TITLE
Do not attempt to format custom value of empty string

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1129,6 +1129,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
    * @param int|null $entityId
    *
    * @return string
+   * @throws \Brick\Money\Exception\UnknownCurrencyException
    */
   private static function formatDisplayValue($value, $field, $entityId = NULL) {
 
@@ -1269,19 +1270,21 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         break;
 
       case 'Text':
-        if ($field['data_type'] == 'Money' && isset($value)) {
+        if ($field['data_type'] === 'Money' && isset($value)) {
           // $value can also be an array(while using IN operator from search builder or api).
+          $values = [];
           foreach ((array) $value as $val) {
-            $disp[] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($val);
+            $values[] = $val === '' ? '' : CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($val);
           }
-          $display = implode(', ', $disp);
+          $display = implode(', ', $values);
         }
-        elseif ($field['data_type'] == 'Float' && isset($value)) {
+        elseif ($field['data_type'] === 'Float' && isset($value)) {
           // $value can also be an array(while using IN operator from search builder or api).
+          $values = [];
           foreach ((array) $value as $val) {
-            $disp[] = CRM_Utils_Number::formatLocaleNumeric($val);
+            $values[] = $val === '' ? '' : CRM_Utils_Number::formatLocaleNumeric($val);
           }
-          $display = implode(', ', $disp);
+          $display = implode(', ', $values);
         }
         break;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Do not attempt to format custom value of empty string

Before
----------------------------------------
Empty strings passed to the formatting function by custom field formatting code

After
----------------------------------------
The code does not use the function to not-transform the empty string & does it all by itself

Technical Details
----------------------------------------
I think this is perhaps the more correct fix for https://github.com/civicrm/civicrm-core/pull/25448 (but might miss some scenarios) - & should be done regardless of that one being merged

Comments
----------------------------------------
