### PR TITLE
Move form specific code to the form

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -87,18 +87,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $entity;
 
   /**
-   * The id of the premium that we are proceessing.
-   *
-   * @var int
-   */
-  public $_premiumID = NULL;
-
-  /**
-   * @var CRM_Contribute_DAO_ContributionProduct
-   */
-  public $_productDAO = NULL;
-
-  /**
    * The id of the note
    *
    * @var int
@@ -349,23 +337,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, 1, $type, $entityId);
     CRM_Custom_Form_CustomData::buildQuickForm($this);
     CRM_Custom_Form_CustomData::setDefaultValues($this);
-  }
-
-  /**
-   * @param int $id
-   * @todo - this function is a long way, non standard of saying $dao = new CRM_Contribute_DAO_ContributionProduct(); $dao->id = $id; $dao->find();
-   */
-  public function assignPremiumProduct($id) {
-    $sql = "
-SELECT *
-FROM   civicrm_contribution_product
-WHERE  contribution_id = {$id}
-";
-    $dao = CRM_Core_DAO::executeQuery($sql);
-    if ($dao->fetch()) {
-      $this->_premiumID = $dao->id;
-      $this->_productDAO = $dao;
-    }
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -2134,4 +2134,21 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     return $this->getSubmittedValue('price_set_id');
   }
 
+  /**
+   * @param int $id
+   * @todo - this function is a long way, non standard of saying $dao = new CRM_Contribute_DAO_ContributionProduct(); $dao->id = $id; $dao->find();
+   */
+  private function assignPremiumProduct($id): void {
+    $sql = "
+SELECT *
+FROM   civicrm_contribution_product
+WHERE  contribution_id = {$id}
+";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    if ($dao->fetch()) {
+      $this->_premiumID = $dao->id;
+      $this->_productDAO = $dao;
+    }
+  }
+
 }


### PR DESCRIPTION
This function is only called from the one form & the properties are likewise only touched by the form
so they 'belong' to that form & should be private
for clarity

Images show the 'after' searches

![image](https://user-images.githubusercontent.com/336308/215361355-742f009c-0783-46de-a431-fc9ffcf3735f.png)

![image](https://user-images.githubusercontent.com/336308/215361377-07c5a0f8-a56c-4274-991a-eeeff75098c1.png)


![image](https://user-images.githubusercontent.com/336308/215361443-6405dc1f-bb4f-4746-9f83-176830f54c43.png)
