### PR TITLE
dev/core#4063 fix lack of count info on soft credit listing

### DIFF
--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -409,7 +409,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
     ];
 
     $contributionSofts = ContributionSoft::get()
-      ->addSelect('*', 'contribution_id.receive_date', 'contribution_id.contact_id', 'contribution_id.contact_id.display_name', 'soft_credit_type_id:label', 'contribution_id.contribution_status_id:label', 'contribution_id.financial_type_id:label', 'pcp_id.title')
+      ->addSelect('*', 'contribution_id.receive_date', 'contribution_id.contact_id', 'contribution_id.contact_id.display_name', 'soft_credit_type_id:label', 'contribution_id.contribution_status_id:label', 'contribution_id.financial_type_id:label', 'pcp_id.title', 'row_count')
       ->addWhere('contact_id', '=', $contact_id)
       ->addWhere('contribution_id.is_test', '=', $isTest);
 

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/ContributionSoftTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/ContributionSoftTest.php
@@ -73,7 +73,9 @@ class ContributionSoftTest extends BaseTestClass {
         'sct_label' => NULL,
       ],
     ];
-    $list = CRM_Contribute_BAO_ContributionSoft::getSoftContributionList($this->ids['Contact']['credited']);
+    $dataTableParameters = [];
+    $list = CRM_Contribute_BAO_ContributionSoft::getSoftContributionList($this->ids['Contact']['credited'], NULL, 0, $dataTableParameters);
+    $this->assertEquals(2, $dataTableParameters['total']);
     foreach ($expectedCredits[1] as $key => $value) {
       $this->assertEquals($value, $list[1][$key], $key);
     }


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#4063 fix lack of count info on soft credit listing

Per https://lab.civicrm.org/dev/core/-/issues/4063 the rowCount was not being set as a result of a regression in https://github.com/civicrm/civicrm-core/pull/22504

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4063

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/215389432-db033dca-f954-4e82-9597-ecf4300397d7.png)


Technical Details
----------------------------------------
The api required `record_count` to be specifed in the return (fyi @MegaphoneJon  - I wasn't clear on this either)

Comments
----------------------------------------
Thanks to @larssandergreen for identifying this - @larssandergreen I believe this ports broke in 5.54 & will apply to any version in between but would like your feedback