### PR TITLE
Afform: Fix dedupe rules for anonymous users

### DIFF
--- a/Civi/Api4/Action/Contact/GetDuplicates.php
+++ b/Civi/Api4/Action/Contact/GetDuplicates.php
@@ -144,6 +144,7 @@ class GetDuplicates extends \Civi\Api4\Generic\DAOCreateAction {
     $ignore = ['id', 'contact_id', 'is_primary', 'on_hold', 'location_type_id', 'phone_type_id'];
     foreach (['Contact', 'Email', 'Phone', 'Address', 'IM'] as $entity) {
       $entityFields = (array) civicrm_api4($entity, 'getFields', [
+        'checkPermissions' => FALSE,
         'action' => 'create',
         'loadOptions' => $action->getLoadOptions(),
         'where' => [['name', 'NOT IN', $ignore], ['type', 'IN', ['Field', 'Custom']]],


### PR DESCRIPTION
Overview
----------------------------------------
Configuring a formbuilder form per https://github.com/civicrm/civicrm-core/pull/24552 and selecting a dedupe rule triggers a 403 forbidden for anonymous users.

Before
----------------------------------------
Selecting a dedupe rule on formbuilder triggers a 403 forbidden for anonymous users.

After
----------------------------------------
Selecting a dedupe rule on formbuilder works for anonymous users.

Technical Details
----------------------------------------
API4 `Contact.getDuplicates()` calls `{entity}->getFields()` but does not disable permissions checks so it fails for anonymous users. We have already done the permissions check to get to this bit of the code..

Comments
----------------------------------------
@colemanw 
