### PR TITLE
php8 - don't pass null to htmlspecialchars on profile admin page

### DIFF
--- a/CRM/UF/Page/Group.php
+++ b/CRM/UF/Page/Group.php
@@ -303,7 +303,7 @@ class CRM_UF_Page_Group extends CRM_Core_Page {
       $ufGroup[$id]['frontend_title'] = $value['frontend_title'];
       $ufGroup[$id]['created_id'] = $value['created_id'];
       $ufGroup[$id]['created_by'] = CRM_Contact_BAO_Contact::displayName($value['created_id']);
-      $ufGroup[$id]['description'] = $value['description'];
+      $ufGroup[$id]['description'] = $value['description'] ?? '';
       $ufGroup[$id]['is_active'] = $value['is_active'];
       $ufGroup[$id]['group_type'] = $value['group_type'];
       $ufGroup[$id]['is_reserved'] = $value['is_reserved'];


### PR DESCRIPTION
Overview
----------------------------------------
htmlspecialchars doesn't like null

Before
----------------------------------------
1. Visit 
2. Screen fills with `Deprecated function: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in smarty_modifier_escape()`

After
----------------------------------------


Technical Details
----------------------------------------
If you leave the description field blank it gets stored as null. When passed to smarty modifier escape it gets upset.

Comments
----------------------------------------
There isn't any semantic difference for the description field between "blank description" and "no value". If there were, I would probably address this in the tpl instead.