### PR TITLE
Afform: Fix for formbuilder autocomplete (prefill) on anonymous forms

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -114,13 +114,22 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     $idField = CoreUtil::getIdFieldName($entity['type']);
     if ($ids && !empty($entity['fields'][$idField]['defn']['saved_search'])) {
       $ids = $this->validateBySavedSearch($entity, $ids);
+      $result = civicrm_api4($entity['type'], 'get', [
+        'checkPermissions' => FALSE,
+        'where' => [['id', 'IN', $ids]],
+        'select' => array_keys($entity['fields']),
+      ])->indexBy($idField);
     }
     if (!$ids) {
       return;
     }
-    $result = $this->apiGet($api4, $entity['type'], $entity['fields'], [
-      'where' => [['id', 'IN', $ids]],
-    ]);
+
+    if (empty($result)) {
+      $result = $this->apiGet($api4, $entity['type'], $entity['fields'], [
+        'where' => [['id', 'IN', $ids]],
+      ]);
+    }
+
     foreach ($ids as $index => $id) {
       $this->_entityIds[$entity['name']][$index] = [
         $idField => isset($result[$id]) ? $id : NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Prefill not working on anonymous forms.

To reproduce:

1. Create a form with an individual and an organisation.
2. Add an existing contact autocomplete for the organisation.
3. Select a savedsearch autocomplete that contains the filter eg. Contact organisations (set permission to "open access").
4. Run the form logged in - you can select and prefill organisations.
5. Run the form as anonymous user - you can select organisation but prefill API returns empty result.

Before
----------------------------------------
Prefill not working on anonymous forms.

After
----------------------------------------
Prefill working on anonymous forms.

Technical Details
----------------------------------------
It seems like there are two issues in the code:
1. The savedsearch definition is nested one level deeper in "defn" key. Is that because it's a savedsearch in an autocomplete?
2. The "secureapi4" doesn't seem to respect the result of validateBySavedSearch. I opted to use the standard `civicrm_api4` and checkPermissions=FALSE once it's been validated by `validateBySavedSearch()` but maybe secureApi4 should instead be made aware of savedsearch?

Comments
----------------------------------------
@colemanw Not sure if this is quite the right fix or if this has any security implications.
