### PR TITLE
Autocomplete fields: display data loaded from model

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -753,7 +753,7 @@
           if (ctrl.ngModel) {
             // Ensure widget is updated when model changes
             ctrl.ngModel.$render = function() {
-              element.val(ctrl.ngModel.$viewValue || '');
+              element.val(ctrl.ngModel.$viewValue || '').change();
             };
 
             // Copied from ng-list


### PR DESCRIPTION
Overview
----------------------------------------
Part of the fix for [dev/core#4110](https://lab.civicrm.org/dev/core/-/issues/4110). At least on some angular forms, autocomplete fields weren't showing their stored values. This gives them a little kick in the pants so they do.

Before
----------------------------------------
<img width="320" alt="Screenshot 2023-01-30 at 13 27 49" src="https://user-images.githubusercontent.com/385812/215599998-ad531918-6b2f-48d9-afb6-066d6c83ce6c.png">

After
----------------------------------------
<img width="324" alt="Screenshot 2023-01-30 at 13 32 26" src="https://user-images.githubusercontent.com/385812/215600047-d6910bbc-08a2-46b6-9f9a-fc1fde394203.png">

You can try this out yourself with the afform shown above: [afformDemoAutofillFix.aff.zip](https://github.com/civicrm/civicrm-core/files/10540204/afformDemoAutofillFix.aff.zip)
