### PR TITLE
Remove unused property - not used since import code refactor `_lineCount`

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -38,13 +38,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
    */
   protected $_newContacts = [];
 
-  /**
-   * Line count id.
-   *
-   * @var int
-   */
-  protected $_lineCount;
-
   protected $_tableName;
 
   /**
@@ -525,6 +518,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         throw new CRM_Core_Exception($errorMessage);
       }
       //otherwise, count it and move on
+      // @todo - lineCount is always 0
       $this->_allExternalIdentifiers[$externalID] = $this->_lineCount;
     }
 

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -69,12 +69,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   protected $_separator;
 
   /**
-   * Total number of lines in file
-   * @var int
-   */
-  protected $_lineCount;
-
-  /**
    * Running total number of valid soft credit rows
    * @var int
    */

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -46,13 +46,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
   protected $_separator;
 
   /**
-   * Total number of lines in file.
-   *
-   * @var int
-   */
-  protected $_lineCount;
-
-  /**
    * Whether the file has a column header or not
    *
    * @var bool

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -49,12 +49,6 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
   protected $_separator;
 
   /**
-   * Total number of lines in file
-   * @var int
-   */
-  protected $_lineCount;
-
-  /**
    * Get information about the provided job.
    *  - name
    *  - id (generally the same as name)


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused property - not used since import code refactor `_lineCount`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/215622771-2a6cf6f2-f89a-4fb6-8265-bed98efd7272.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
There is one 'get' on it - that is clearly broken -  I commented that to make it clear for whoever next visits it, There is also one in a deprecated function.

UPDATE - I have a follow on patch that fixes the broken  - not sure whether to push in here or if that would complicate.

Comments
----------------------------------------

