### PR TITLE
Some renames missing from #24982

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -20,9 +20,9 @@ use Civi\Token\TokenProcessor;
 require_once 'Mail/mime.php';
 
 /**
- * Class CRM_Mailing_Event_BAO_Resubscribe
+ * Class CRM_Mailing_Event_BAO_MailingEventResubscribe
  */
-class CRM_Mailing_Event_BAO_Resubscribe {
+class CRM_Mailing_Event_BAO_MailingEventResubscribe {
 
   /**
    * Resubscribe a contact to the groups, he/she was unsubscribed from.

--- a/CRM/Mailing/Page/Common.php
+++ b/CRM/Mailing/Page/Common.php
@@ -77,9 +77,9 @@ class CRM_Mailing_Page_Common extends CRM_Core_Page {
         }
       }
       elseif ($this->_type == 'resubscribe') {
-        $groups = CRM_Mailing_Event_BAO_Resubscribe::resub_to_mailing($job_id, $queue_id, $hash);
+        $groups = CRM_Mailing_Event_BAO_MailingEventResubscribe::resub_to_mailing($job_id, $queue_id, $hash);
         if (count($groups)) {
-          CRM_Mailing_Event_BAO_Resubscribe::send_resub_response($queue_id, $groups, $job_id);
+          CRM_Mailing_Event_BAO_MailingEventResubscribe::send_resub_response($queue_id, $groups, $job_id);
         }
         else {
           // should we indicate an error, or just ignore?

--- a/api/v3/MailingEventResubscribe.php
+++ b/api/v3/MailingEventResubscribe.php
@@ -26,14 +26,14 @@
  */
 function civicrm_api3_mailing_event_resubscribe_create($params) {
 
-  $groups = CRM_Mailing_Event_BAO_Resubscribe::resub_to_mailing(
+  $groups = CRM_Mailing_Event_BAO_MailingEventResubscribe::resub_to_mailing(
     $params['job_id'],
     $params['event_queue_id'],
     $params['hash']
   );
 
   if (count($groups)) {
-    CRM_Mailing_Event_BAO_Resubscribe::send_resub_response(
+    CRM_Mailing_Event_BAO_MailingEventResubscribe::send_resub_response(
       $params['event_queue_id'],
       $groups,
       $params['job_id']


### PR DESCRIPTION
Overview
----------------------------------------
CRM_Mailing_Event_BAO_MailingEventResubscribe missing from #24982 

The file was renamed but not the class declaration, so I figure that confused whatever method was used to refactor.