### PR TITLE
(dev/core#4433) WordPress::url() - By default, choose frontend or backend based on route

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -281,6 +281,33 @@ class CRM_Core_Menu {
   }
 
   /**
+   * Determine whether a route should canonically use a frontend or backend UI.
+   *
+   * @param string $path
+   *   Ex: 'civicrm/contribute/transact'
+   * @return bool
+   *   TRUE if the route is marked with 'is_public=1'.
+   */
+  public static function isPublicRoute(string $path): bool {
+    // A page-view may include hundreds of links - so don't hit DB for every link. Use cache.
+    // In default+demo builds, the list of public routes is much smaller than the list of
+    // private routes (roughly 1:10; ~50 entries vs ~450 entries). Cache the smaller list.
+    $cache = Civi::cache('long');
+    $index = $cache->get('PublicRouteIndex');
+    if ($index === NULL) {
+      $routes = CRM_Core_DAO::executeQuery('SELECT id, path FROM civicrm_menu WHERE is_public = 1')
+        ->fetchMap('id', 'path');
+      if (empty($routes)) {
+        Civi::log()->warning('isPublicRoute() should not be called before the menu has been built.');
+        return FALSE;
+      }
+      $index = array_fill_keys(array_values($routes), TRUE);
+      $cache->set('PublicRouteIndex', $index);
+    }
+    return isset($index[$path]);
+  }
+
+  /**
    * This function recomputes menu from xml and populates civicrm_menu.
    *
    * @param bool $truncate
@@ -291,6 +318,7 @@ class CRM_Core_Menu {
       $query = 'TRUNCATE civicrm_menu';
       CRM_Core_DAO::executeQuery($query);
     }
+    Civi::cache('long')->delete('PublicRouteIndex');
     $menuArray = self::items($truncate);
 
     self::build($menuArray);

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -129,6 +129,7 @@
     <path>civicrm/asset/builder</path>
     <page_callback>\Civi\Core\AssetBuilder::pageRun</page_callback>
     <access_arguments>*always allow*</access_arguments>
+    <is_public>1</is_public>
   </item>
   <item>
      <path>civicrm/contribute/ajax/tableview</path>

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -111,6 +111,10 @@ abstract class CRM_Utils_System_Base {
   /**
    * Generate the url string to a CiviCRM path.
    *
+   * Note: The options `$frontend` and `$forceBackend` are opposites. If you use exactly one (and not
+   * the other), then the URL will follow your request. If you leave the default values, or if you
+   * give incompatible values, then we will use the route's preferred default (from `civicrm_menu.is_public`).
+   *
    * @param string $path
    *   The path being linked to, such as "civicrm/add".
    * @param string $query

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -313,6 +313,17 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       $this->loadBootStrap();
     }
 
+    // If caller didn't express a clear preference for frontend xor backend, then use default.
+    // Aside: I definitely find it confusing that this decision is spread across two variables.
+    if ($frontend === $forceBackend) {
+      if (CRM_Core_Menu::isPublicRoute($path)) {
+        $frontend = TRUE;
+      }
+      else {
+        $forceBackend = TRUE;
+      }
+    }
+
     // When on the front-end.
     if ($config->userFrameworkFrontend) {
 

--- a/tests/phpunit/CRM/Core/MenuTest.php
+++ b/tests/phpunit/CRM/Core/MenuTest.php
@@ -135,4 +135,9 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
     $this->assertEquals($expectedArray, $actual);
   }
 
+  public function testIsPublicRoute(): void {
+    $this->assertEquals(FALSE, \CRM_Core_Menu::isPublicRoute('civicrm/contribute'));
+    $this->assertEquals(TRUE, \CRM_Core_Menu::isPublicRoute('civicrm/contribute/transact'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

(*See also: https://lab.civicrm.org/dev/core/-/issues/4433*)

The method `CRM_Utils_System::url($path, ...)` is used to construct the full URL for a route. On WordPress, it is important to determine whether the route is intended for frontend/public usage or backend/private usage. URLs may look like:

```
## Backend / Private
http://wpmaster.bknix:8001/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fcontribute&reset=1

## Frontend / Public - With Clean URLs
http://wpmaster.bknix:8001/civicrm/contribute/transact/?reset=1&id=1

## Frontend / Public - Without Clean URLs
http://wpmaster.bknix:8001/civicrm?civiwp=CiviCRM&q=civicrm%2Fcontribute%2Ftransact&reset=1
```

We recently started to see failures in [`E2E\Core\PathUrlTest::testGetUrl_WpAdmin()`](https://github.com/civicrm/civicrm-core/blob/8e0dabd20bebe55d5dd725f3015c41019cb8dbed/tests/phpunit/E2E/Core/PathUrlTest.php#L94-L117), which asserts that a particular URL is backend/private.

* [Example failure 1](https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=max,BLDTYPE=wp-demo,CIVIVER=5.57,label=bknix-tmp/5752/testReport/(root)/E2E_Core_PathUrlTest/testGetUrl_WpAdmin/)
* [Example failure 2](https://test.civicrm.org/job/CiviCRM-E2E-Matrix/BKPROF=min,BLDTYPE=wp-demo,CIVIVER=5.57,label=bknix-tmp/5752/testReport/(root)/E2E_Core_PathUrlTest/testGetUrl_WpAdmin/)

The proximate cause is that [`cv url` changed to mirror the default from `CRM_Utils_System::url()`](https://github.com/civicrm/cv/pull/141/commits/c0e770daa2b065662c8e8f0f52bf323065a71eb6). IMHO, the root-cause is that the contract for `CRM_Utils_System::url()` is confusing. This patch tries to make the contract easier.

Of course, the fact that I am confused by the contract means that I may not fully understand. Hopefully @christianwach or @kcristiano understand WP URLs' better and can give some feedback.

Before
----------------------------------------

`CRM_Utils_System::url()` accepts two optional parameters, `bool $frontend=FALSE` and `bool $forceBackend=FALSE`.

Conceptually, the choice is binary - you either have a frontend URL or a backend URL. But the contract allows four choices (`FALSE,FALSE` and `TRUE,FALSE` and `FALSE,TRUE` and `TRUE,TRUE`). It seems clear enough when you have `TRUE,FALSE` or `FALSE,TRUE` -- but the meaning of `FALSE,FALSE` and `TRUE,TRUE` seems ambiguous.

Additionally, this seems related to -- but different from -- the property `civicrm_menu.is_public`. I can understand the cases where either:

* Route declares `is_public=1` and `url()` is called with `$frontend=TRUE`
* Route declares `is_public=0` and `url()` is called with `$forceBackend=TRUE`

But the other possibilities (`is_public=1` with `$forceBackend=TRUE`) seem confusing to me.

After
----------------------------------------

`CRM_Utils_System::url()` still accepts two optional parameters, `bool $frontend=FALSE` and `bool $forceBackend=FALSE`. (You can't remove them without a hard break.)

In the default case (`FALSE,FALSE`) and in the other ambiguous case (`TRUE,TRUE`), it will lookup the value of `is_public` and use that. For example:

* `CRM_Utils_System::url('civicrm/contribute/transact', 'reset'=1)` ==> Use the frontend URL (because the route specifies `is_public=1` and the caller hasn't indicated a clear preference).
* `CRM_Utils_System::url('civicrm/contribute', 'reset'=1)` ==> Use the backend URL (because the route specifies `is_public=0`  and the caller hasn't indicated a clear preference)

But if the caller does have a specific request (`TRUE,FALSE` or `FALSE,TRUE`), then that is respected.

On my local, this appears to fix `testGetUrl_WpAdmin()`.

Comments
----------------------------------------

I don't understand everything in WP URL's, so hopefully folks with experience there.

I was concerned about possibility of performance impact -- e.g. you don't want `SELECT is_public FROM civicrm_menu` every time the system renders a `url()`. The approach in here should only require 1 moderate-sized cache-item (1-2 kb).

There are some routes like `civicrm/ajax/api4/*` which are sort of fundamentally ambiguous -- they're headless, so calling them "frontend" or "backend" is sort of meaningless. Maybe that needs some kind of `r-run` to ensure that API4 REST calls work in both UIs?

If this is all too aggressive, I could do a narrower fix in cv-only -- e.g. we retain the current contract for `CRM_Utils_System::url()`, and then update `cv url` to pick its default convention based on `is_public`.