### PR TITLE
Prevent PHP warnings when no WordPress user is found

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -581,15 +581,15 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   public function loadUser($user) {
     $userdata = get_user_by('login', $user);
-    if (!$userdata->data->ID) {
+    if (empty($userdata->ID)) {
       return FALSE;
     }
 
-    $uid = $userdata->data->ID;
+    $uid = $userdata->ID;
     wp_set_current_user($uid);
     $contactID = CRM_Core_BAO_UFMatch::getContactId($uid);
 
-    // lets store contact id and user id in session
+    // Lets store contact id and user id in session.
     $session = CRM_Core_Session::singleton();
     $session->set('ufID', $uid);
     $session->set('userID', $contactID);
@@ -616,10 +616,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    */
   public function getUfId($username) {
     $userdata = get_user_by('login', $username);
-    if (!$userdata->data->ID) {
+    if (empty($userdata->ID)) {
       return NULL;
     }
-    return $userdata->data->ID;
+    return $userdata->ID;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When no WordPress user is found, PHP warnings are issued:

```
Warning: Attempt to read property "data" on bool
Warning: Attempt to read property "ID" on bool
```

Additionally, the `WP_User` object has magic methods for retrieving the `ID` directly, so there is no need to look in the `data` property.

Before
----------------------------------------
PHP warnings are issued.

After
----------------------------------------
No PHP warnings are issued.

Comments
----------------------------------------
IMO too minor a fix to open an issue on Lab.