### PR TITLE
[REF][PHP8.2] Declare properties in CRM_Contact_BAO_ContactType_ContactTest

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactType/ContactTest.php
@@ -6,6 +6,26 @@
  */
 class CRM_Contact_BAO_ContactType_ContactTest extends CiviUnitTestCase {
 
+  /**
+   * @var string
+   */
+  protected $student;
+
+  /**
+   * @var string
+   */
+  protected $parent;
+
+  /**
+   * @var string
+   */
+  protected $sponsor;
+
+  /**
+   * @var string
+   */
+  protected $team;
+
   public function setUp(): void {
     parent::setUp();
 
@@ -16,7 +36,7 @@ class CRM_Contact_BAO_ContactType_ContactTest extends CiviUnitTestCase {
       'parent_id' => 1,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->student = $params['name'];
 
     $params = [
@@ -26,7 +46,7 @@ class CRM_Contact_BAO_ContactType_ContactTest extends CiviUnitTestCase {
       'parent_id' => 1,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->parent = $params['name'];
 
     $params = [
@@ -36,7 +56,7 @@ class CRM_Contact_BAO_ContactType_ContactTest extends CiviUnitTestCase {
       'parent_id' => 3,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->sponsor = $params['name'];
 
     $params = [
@@ -46,7 +66,7 @@ class CRM_Contact_BAO_ContactType_ContactTest extends CiviUnitTestCase {
       'parent_id' => 3,
       'is_active' => 1,
     ];
-    $result = CRM_Contact_BAO_ContactType::add($params);
+    CRM_Contact_BAO_ContactType::add($params);
     $this->team = $params['name'];
   }
 
@@ -74,7 +94,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($contact->first_name, 'Anne');
     $this->assertEquals($contact->contact_type, 'Individual');
@@ -88,7 +108,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($contact->organization_name, 'Compumentor');
     $this->assertEquals($contact->contact_type, 'Organization');
@@ -102,7 +122,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($contact->household_name, 'John Does home');
     $this->assertEquals($contact->contact_type, 'Household');
@@ -118,7 +138,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($contact->first_name, 'Bill');
     $this->assertEquals($contact->contact_type, 'Individual');
@@ -134,7 +154,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($contact->organization_name, 'Conservation Corp');
     $this->assertEquals($contact->contact_type, 'Organization');
@@ -156,7 +176,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $updateParams = [
       'contact_sub_type' => $this->student,
@@ -166,7 +186,7 @@ DELETE FROM civicrm_contact_type
     try {
       $updatedContact = CRM_Contact_BAO_Contact::add($updateParams);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Individual');
@@ -180,7 +200,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
 
     $updateParams = [
@@ -191,7 +211,7 @@ DELETE FROM civicrm_contact_type
     try {
       $updatedContact = CRM_Contact_BAO_Contact::add($updateParams);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Organization');
@@ -213,7 +233,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
 
     $updateParams = [
@@ -224,7 +244,7 @@ DELETE FROM civicrm_contact_type
     try {
       $updatedContact = CRM_Contact_BAO_Contact::add($updateParams);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
     $this->assertEquals($updatedContact->id, $contact->id);
     $this->assertEquals($updatedContact->contact_type, 'Individual');
@@ -239,7 +259,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
 
     $updateParams = [
@@ -250,7 +270,7 @@ DELETE FROM civicrm_contact_type
     try {
       $updatedContact = CRM_Contact_BAO_Contact::add($updateParams);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
 
     $this->assertEquals($updatedContact->id, $contact->id);
@@ -267,7 +287,7 @@ DELETE FROM civicrm_contact_type
     try {
       $contact = CRM_Contact_BAO_Contact::add($params);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
 
     $updateParams = [
@@ -278,7 +298,7 @@ DELETE FROM civicrm_contact_type
     try {
       $updatedContact = CRM_Contact_BAO_Contact::add($updateParams);
     }
-    catch (Exception$expected) {
+    catch (Exception $expected) {
     }
 
     $this->assertEquals($updatedContact->id, $contact->id);


### PR DESCRIPTION
Overview
----------------------------------------
Dynamic properties are deprecated in PHP 8.2. Declare properties in CRM_Contact_BAO_ContactType_ContactTest.

Before
----------------------------------------
Use of dynamic properties in `CRM_Contact_BAO_ContactType_ContactTest`, meaning tests are failing on PHP 8.2.

There were also some variables which were not used, and some missing spaces in the `catch` syntax which I've tidied up.

After
----------------------------------------
PHP 8.2 compatiable, and cleaner code.