### PR TITLE
Fix exception type in upgrade snapshot

### DIFF
--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -63,7 +63,7 @@ class CRM_Upgrade_Snapshot {
           // Use select MAX(id) rather than COUNT as COUNT is slow on large databases.
           $max = CRM_Core_DAO::singleValueQuery("SELECT MAX(id) FROM `{$table}`");
         }
-        catch (CRM_Core_Exception $e) {
+        catch (\Exception $e) {
           $max = 0;
         }
         if ($max > $limit) {


### PR DESCRIPTION
Overview
----------------------------------------
This was just merged in https://github.com/civicrm/civicrm-core/pull/25420 but it's not the right type.

Before
----------------------------------------
No exceptions get caught.

After
----------------------------------------
Puts it back like it was before #25420 where exceptions get caught.

Technical Details
----------------------------------------
There's only a handful of things that can go wrong in this query:
1. DB error => PEAR_Exception
2. Aliens arrive and are friendly, in which case will have an advanced version of civi you can use instead.
3. Aliens arrive and are not friendly, in which case you will have more important things to worry about than upgrading civi.

Comments
----------------------------------------

