### PR TITLE
Fix typo in upgrade message

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyNine.php
@@ -24,7 +24,7 @@ class CRM_Upgrade_Incremental_php_FiveFiftyNine extends CRM_Upgrade_Incremental_
   public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
     if ($rev === '5.59.alpha1') {
       if (empty(CRM_Core_Config::singleton()->userSystem->is_wordpress)) {
-        $preUpgradeMessage .= '<p>' . ts('The handling of invalid smarty template code in mailings, reminders and other automated messages has changed . For details, see <a %1>upgrade notes</a>.',
+        $preUpgradeMessage .= '<p>' . ts('The handling of invalid smarty template code in mailings, reminders and other automated messages has changed. For details, see <a %1>upgrade notes</a>.',
             [1 => 'href="https://docs.civicrm.org/sysadmin/en/latest/upgrade/version-specific/#civicrm-559" target="_blank"']) . '</p>';
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
This was just merged yesterday in https://github.com/civicrm/civicrm-core/pull/25334.

Extra space before the period.