### PR TITLE
Fix APIv4 autocompletes for dynamic entities

### DIFF
--- a/Civi/API/Request.php
+++ b/Civi/API/Request.php
@@ -55,6 +55,7 @@ class Request {
         if ($daoName && !$daoName::isComponentEnabled()) {
           throw new \Civi\API\Exception\NotImplementedException("$entity API is not available because " . $daoName::COMPONENT . " component is disabled");
         }
+        // Extra arguments used e.g. by dynamic entities like Multi-Record custom groups & the ECK extension
         $args = (array) CoreUtil::getInfoItem($entity, 'class_args');
         $apiRequest = call_user_func_array($callable, $args);
         foreach ($params as $name => $param) {

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Api4\Event\Subscriber;
 
+use Civi\API\Request;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -66,7 +67,8 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
     // Default sort order
     $e->display['settings']['sort'] = self::getDefaultSort($entityName);
 
-    $fields = CoreUtil::getApiClass($entityName)::get()->entityFields();
+    $apiGet = Request::create($entityName, 'get', ['version' => 4]);
+    $fields = $apiGet->entityFields();
     $columns = [$labelField];
     // Add grouping fields like "event_type_id" in the description
     $grouping = (array) (CoreUtil::getCustomGroupExtends($entityName)['grouping'] ?? []);


### PR DESCRIPTION
Overview
----------------------------------------
Ensures APIv4 autocompletes work with dynamic entities like Multi-Record custom groups & the ECK extension

Before
----------------------------------------
New Autocompletes don't work with custom groups & ECK entities.

After
----------------------------------------
Works with all entities.