### PR TITLE
Creating a new Drupal user with some kinds of CiviCRM custom fields throws an exception.

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -275,7 +275,7 @@ AND    domain_id = %2
           }
         }
 
-        $contactId = civicrm_api3('Contact', 'create', $params)['id'];
+        $contactId = CRM_Contact_BAO_Contact::createProfileContact($params);
         $ufmatch->contact_id = $contactId;
         $ufmatch->uf_name = $uniqId;
       }


### PR DESCRIPTION
To reproduce, add an Alphanumeric Checkbox custom field to the user registration profile with at east one field option. As an admin, create a new user and check one of the options for the custom field and save. An exception like `CRM_Core_Exception: '1' is not a valid option for field custom_1 in civicrm_api3()` is thrown.

I've reproduced this on a clean install of Drupal 7 and CiviCRM 5.57.3. The bug appears to have been introduced in https://lab.civicrm.org/dev/core/-/commit/288eddac95e6cd86578c95f4d28e34fbe4c2ad1a with the change from

`$contactId = CRM_Contact_BAO_Contact::createProfileContact($params);`

to

`$contactId = civicrm_api3('Contact', 'create', $params)['id'];`


It looks like the `$params` passed to `civicrm_api3()` is pretty raw and mainly derived from `$_POST`. `CRM_Contact_BAO_Contact::createProfileContact()` does a bunch of transformation of the `$params` before it goes to `CRM_Contact_BAO_Contact::create()`. Maybe there's an existing utility function to translate the raw `$_POST` values to ones that are API ready, but I haven't been able to find it.

For now, the easiest fix would be to revert that part of the change and use `CRM_Contact_BAO_Contact::createProfileContact()` again.
