### PR TITLE
[REF] Use Token Processor to generate sort name and display name for …

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/IndividualTest.php
@@ -114,4 +114,47 @@ class CRM_Contact_BAO_IndividualTest extends CiviUnitTestCase {
 
   }
 
+  /**
+   * Display Format cases
+   */
+  public static function displayFormatCases(): array {
+    return [
+      'Nick name with tilde' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', TRUE, FALSE],
+      'Empty nick name' => ['{contact.first_name}{ }{contact.last_name}{ ~ }{contact.nick_name}', FALSE, FALSE],
+      'No Nick Name but Prefix' => ['{contact.individual_prefix}{ }{contact.first_name}{ }{contact.middle_name}{ }{contact.last_name}{ }{contact.individual_suffix}{ ~ }{contact.nick_name}', FALSE, TRUE],
+    ];
+  }
+
+  /**
+   * @dataProvider DisplayFormatCases
+   */
+  public function testGenerateDisplayNameCustomFormats(string $displayNameFormat, bool $includeNickName, bool $includePrefix): void {
+    $params = [
+      'contact_type' => 'Individual',
+      'first_name' => 'Michael',
+      'last_name' => 'Jackson',
+      'individual_prefix' => 'Mr.',
+      'individual_suffix' => 'Jr.',
+    ];
+    if ($includeNickName) {
+      $params['nick_name'] = 'Mick';
+    }
+    \Civi::settings()->set('display_name_format', $displayNameFormat);
+    $contact = new CRM_Contact_DAO_Contact();
+
+    CRM_Contact_BAO_Individual::format($params, $contact);
+    if ($includeNickName) {
+      $this->assertEquals('Michael Jackson ~ Mick', $contact->display_name);
+    }
+    else {
+      if ($includePrefix) {
+        $this->assertEquals('Mr. Michael Jackson Jr.', $contact->display_name);
+      }
+      else {
+        $this->assertEquals('Michael Jackson', $contact->display_name);
+      }
+    }
+    \Civi::settings()->set('display_name_format', \Civi::settings()->getDefault('display_name_format'));
+  }
+
 }


### PR DESCRIPTION
…individuals

Overview
----------------------------------------
This switches the production of the Individual contact record's sort name and display name to use the TokenProcessor rather than having an odd ball CRM_Utils_Address::format function used

Before
----------------------------------------
Odd ball function used

After
----------------------------------------
TokenProcessor used

ping @johntwyman @eileenmcnaughton