### PR TITLE
(REF) Remove unused setup from AdhocMailingTest

### DIFF
--- a/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
@@ -15,21 +15,6 @@
 class CRM_Mailing_Form_Task_AdhocMailingTest extends CiviUnitTestCase {
 
   /**
-   * @throws \Exception
-   */
-  protected function setUp(): void {
-    parent::setUp();
-    $this->_contactIds = [
-      $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']),
-      $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']),
-    ];
-    $this->_optionValue = $this->callAPISuccess('optionValue', 'create', [
-      'label' => '"Seamus Lee" <seamus@example.com>',
-      'option_group_id' => 'from_email_address',
-    ]);
-  }
-
-  /**
    * Test creating a hidden smart group from a search builder search.
    *
    * A hidden smart group is a group used for sending emails.


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused setup from `CRM_Mailing_Form_Task_AdhocMailingTest`. 

Before
----------------------------------------
`CRM_Mailing_Form_Task_AdhocMailingTest` created 2 individuals, and an option value in `setUp`. However, this logic was not used.

Whilst not specifically a PHP 8.2 fix, this does improve PHP 8.2 compatiability by removing a couple more dynamic properties.

After
----------------------------------------
Unused setup code removed.

Comments
----------------------------------------
The `setUp` function exactly matched that found in `CRM_Contact_Form_Task_EmailTest` which strongly suggests a copy-paste mistake when `CRM_Mailing_Form_Task_AdhocMailingTest` was created.
 