### PR TITLE
[REF][PHP8.2] Declare dynamic property in two SMS tests

### DIFF
--- a/tests/phpunit/CRM/SMS/BAO/ProviderTest.php
+++ b/tests/phpunit/CRM/SMS/BAO/ProviderTest.php
@@ -19,12 +19,19 @@
 class CRM_SMS_BAO_ProviderTest extends CiviUnitTestCase {
 
   /**
+   * Reference to option value in sms_provider_name group.
+   *
+   * @var int
+   */
+  private $optionValueID;
+
+  /**
    * Set Up Funtion
    */
   public function setUp(): void {
     parent::setUp();
     $option = $this->callAPISuccess('option_value', 'create', ['option_group_id' => 'sms_provider_name', 'name' => 'test_provider_name', 'label' => 'test_provider_name', 'value' => 1]);
-    $this->option_value = $option['id'];
+    $this->optionValueID = $option['id'];
   }
 
   /**
@@ -32,7 +39,7 @@ class CRM_SMS_BAO_ProviderTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     parent::tearDown();
-    $this->callAPISuccess('option_value', 'delete', ['id' => $this->option_value]);
+    $this->callAPISuccess('option_value', 'delete', ['id' => $this->optionValueID]);
   }
 
   /**

--- a/tests/phpunit/CRM/SMS/PreviewTest.php
+++ b/tests/phpunit/CRM/SMS/PreviewTest.php
@@ -8,12 +8,19 @@
 class CRM_SMS_PreviewTest extends CiviUnitTestCase {
 
   /**
+   * Reference to option value in sms_provider_name group.
+   *
+   * @var int
+   */
+  private $optionValueID;
+
+  /**
    * Set Up Function
    */
   public function setUp(): void {
     parent::setUp();
     $option = $this->callAPISuccess('option_value', 'create', ['option_group_id' => 'sms_provider_name', 'name' => 'test_provider_name', 'label' => 'Test Provider Label', 'value' => 1]);
-    $this->option_value = $option['id'];
+    $this->optionValueID = $option['id'];
   }
 
   /**
@@ -21,7 +28,7 @@ class CRM_SMS_PreviewTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     parent::tearDown();
-    $this->callAPISuccess('option_value', 'delete', ['id' => $this->option_value]);
+    $this->callAPISuccess('option_value', 'delete', ['id' => $this->optionValueID]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Declare dyanmic property in `CRM_SMS_BAO_ProviderTest` and `CRM_SMS_PreviewTest`.

Before
----------------------------------------
Dynamic property used, not PHP 8.2. compatiable. Also snakecase was used, which is not very in keeping with the CiviCRM style.

After
----------------------------------------
Properties renamed and declared.

Comments
----------------------------------------
This is esentially the same setup code used in two different test classes.
