### PR TITLE
dev/core#4112 Separate code to handle exporting legacy custom searches into the extension

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -269,56 +269,6 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
   }
 
   /**
-   * @param $customSearchClass
-   * @param $formValues
-   * @param $order
-   */
-  public static function exportCustom($customSearchClass, $formValues, $order) {
-    $ext = CRM_Extension_System::singleton()->getMapper();
-    if (!$ext->isExtensionClass($customSearchClass)) {
-      require_once str_replace('_', DIRECTORY_SEPARATOR, $customSearchClass) . '.php';
-    }
-    else {
-      require_once $ext->classToPath($customSearchClass);
-    }
-    $search = new $customSearchClass($formValues);
-
-    $includeContactIDs = FALSE;
-    if ($formValues['radio_ts'] == 'ts_sel') {
-      $includeContactIDs = TRUE;
-    }
-
-    $sql = $search->all(0, 0, $order, $includeContactIDs);
-
-    $columns = $search->columns();
-
-    $header = array_keys($columns);
-    $fields = array_values($columns);
-
-    $rows = [];
-    $dao = CRM_Core_DAO::executeQuery($sql);
-    $alterRow = FALSE;
-    if (method_exists($search, 'alterRow')) {
-      $alterRow = TRUE;
-    }
-    while ($dao->fetch()) {
-      $row = [];
-
-      foreach ($fields as $field) {
-        $unqualified_field = CRM_Utils_Array::First(array_slice(explode('.', $field), -1));
-        $row[$field] = $dao->$unqualified_field;
-      }
-      if ($alterRow) {
-        $search->alterRow($row);
-      }
-      $rows[] = $row;
-    }
-
-    CRM_Core_Report_Excel::writeCSVFile(ts('CiviCRM Contact Search'), $header, $rows);
-    CRM_Utils_System::civiExit();
-  }
-
-  /**
    * @param \CRM_Export_BAO_ExportProcessor $processor
    * @param $details
    */

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -68,16 +68,6 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
    */
   public function preProcess() {
     $this->preventAjaxSubmit();
-
-    //special case for custom search, directly give option to download csv file
-    $customSearchID = $this->get('customSearchID');
-    if ($customSearchID) {
-      CRM_Export_BAO_Export::exportCustom($this->get('customSearchClass'),
-        $this->get('formValues'),
-        $this->get(CRM_Utils_Sort::SORT_ORDER)
-      );
-    }
-
     $this->_selectAll = FALSE;
     $this->_exportMode = self::CONTACT_EXPORT;
     $this->_componentIds = [];

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Action/Export.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Action/Export.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Contact_Form_Search_Action_Export extends CRM_Core_Form_Task {
+
+  public function preProcess(): void {
+    $this->preventAjaxSubmit();
+    self::exportCustom($this->get('customSearchClass'),
+      $this->get('formValues'),
+      $this->get(CRM_Utils_Sort::SORT_ORDER)
+    );
+  }
+
+  /**
+   * @param $customSearchClass
+   * @param $formValues
+   * @param $order
+   */
+  public static function exportCustom($customSearchClass, $formValues, $order) {
+    $ext = CRM_Extension_System::singleton()->getMapper();
+    if (!$ext->isExtensionClass($customSearchClass)) {
+      require_once str_replace('_', DIRECTORY_SEPARATOR, $customSearchClass) . '.php';
+    }
+    else {
+      require_once $ext->classToPath($customSearchClass);
+    }
+    $search = new $customSearchClass($formValues);
+
+    $includeContactIDs = FALSE;
+    if ($formValues['radio_ts'] == 'ts_sel') {
+      $includeContactIDs = TRUE;
+    }
+
+    $sql = $search->all(0, 0, $order, $includeContactIDs);
+
+    $columns = $search->columns();
+
+    $header = array_keys($columns);
+    $fields = array_values($columns);
+
+    $rows = [];
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    $alterRow = FALSE;
+    if (method_exists($search, 'alterRow')) {
+      $alterRow = TRUE;
+    }
+    while ($dao->fetch()) {
+      $row = [];
+
+      foreach ($fields as $field) {
+        $unqualified_field = CRM_Utils_Array::First(array_slice(explode('.', $field), -1));
+        $row[$field] = $dao->$unqualified_field;
+      }
+      if ($alterRow) {
+        $search->alterRow($row);
+      }
+      $rows[] = $row;
+    }
+
+    CRM_Core_Report_Excel::writeCSVFile(ts('CiviCRM Contact Search'), $header, $rows);
+    CRM_Utils_System::civiExit();
+  }
+
+}

--- a/ext/legacycustomsearches/CRM/Legacycustomsearches/StateMachine/Search.php
+++ b/ext/legacycustomsearches/CRM/Legacycustomsearches/StateMachine/Search.php
@@ -73,7 +73,9 @@ class CRM_Legacycustomsearches_StateMachine_Search extends CRM_Core_StateMachine
       $value = $this->_controller->get('task');
     }
     $this->_controller->set('task', $value);
-
+    if ((int) $value === CRM_Core_Task::TASK_EXPORT) {
+      return ['CRM_Contact_Form_Search_Action_Export', FALSE];
+    }
     $componentMode = $this->_controller->get('component_mode');
     $modeValue = CRM_Contact_Form_Search::getModeValue($componentMode);
     $taskClassName = $modeValue['taskClassName'];


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#4112 Separate code to handle exporting legacy custom searches into the extension

Before
----------------------------------------
Main `Export` class does a call to a custom function for legacy custom searches (which calls `CiviExit` and quietly never returns https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:cust_ex?expand=1#diff-5daa4963e0d6e7e84b8cd46c8ea1968cc88e2cb58ef3fe9abb701fb1dad62417L71

After
----------------------------------------
legacy custom search export function moved to the extension & the Core_Controller directs the code to the use that function

Technical Details
----------------------------------------
Part of separating the legacy custom searches such that we can start to allow them to be disabled - https://lab.civicrm.org/dev/core/-/issues/4112

Comments
----------------------------------------
