### PR TITLE
Fully deprecate legacy contributionTokens

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -582,6 +582,7 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function contributionTokens(): array {
+    CRM_Core_Error::deprecatedFunctionWarning('use the token processor');
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contributionId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -366,20 +366,6 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       }
     }
 
-    $tokens = [
-      'id',
-      'payment_instrument_id:label',
-      'financial_type_id:label',
-      'contribution_status_id:label',
-    ];
-    $legacyTokens = [];
-    $realLegacyTokens = [];
-    foreach (CRM_Core_SelectValues::contributionTokens() as $token => $label) {
-      $legacyTokens[substr($token, 14, -1)] = $label;
-      if (strpos($token, ':') === FALSE) {
-        $realLegacyTokens[substr($token, 14, -1)] = $label;
-      }
-    }
     $fields = (array) Contribution::getFields()->addSelect('name', 'title')->execute()->indexBy('name');
     $allFields = [];
     foreach ($fields as $field) {
@@ -389,7 +375,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
     }
     // contact ID is skipped.
     unset($allFields['contact_id']);
-    $this->assertEquals($allFields, $realLegacyTokens);
+
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
       'controller' => __CLASS__,
       'smarty' => FALSE,
@@ -403,10 +389,42 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
       }
       $comparison[substr($token, 14, -1)] = $label;
     }
-    $this->assertEquals($legacyTokens, $comparison);
-    foreach ($tokens as $token) {
-      $this->assertEquals(CRM_Core_SelectValues::contributionTokens()['{contribution.' . $token . '}'], $comparison[$token]);
-    }
+    $this->assertEquals(
+      [
+        'id' => 'Contribution ID',
+        'financial_type_id:label' => 'Financial Type',
+        'contribution_page_id:label' => 'Contribution Page',
+        'payment_instrument_id:label' => 'Payment Method',
+        'receive_date' => 'Date Received',
+        'non_deductible_amount' => 'Non-deductible Amount',
+        'total_amount' => 'Total Amount',
+        'fee_amount' => 'Fee Amount',
+        'net_amount' => 'Net Amount',
+        'trxn_id' => 'Transaction ID',
+        'invoice_id' => 'Invoice Reference',
+        'invoice_number' => 'Invoice Number',
+        'currency' => 'Currency',
+        'cancel_date' => 'Cancelled / Refunded Date',
+        'cancel_reason' => 'Cancellation / Refund Reason',
+        'receipt_date' => 'Receipt Date',
+        'thankyou_date' => 'Thank-you Date',
+        'source' => 'Contribution Source',
+        'amount_level' => 'Amount Label',
+        'contribution_recur_id' => 'Recurring Contribution ID',
+        'is_test:label' => 'Test',
+        'is_pay_later:label' => 'Is Pay Later',
+        'contribution_status_id:label' => 'Contribution Status',
+        'address_id' => 'Address ID',
+        'check_number' => 'Check Number',
+        'campaign_id:label' => 'Campaign',
+        'creditnote_id' => 'Credit Note ID',
+        'tax_amount' => 'Tax Amount',
+        'revenue_recognition_date' => 'Revenue Recognition Date',
+        'is_template:label' => 'Is a Template Contribution',
+        'paid_amount' => 'Amount Paid',
+        'balance_amount' => 'Balance',
+        'tax_exclusive_amount' => 'Tax Exclusive Amount',
+      ], $comparison);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fully deprecate legacy `CRM_Core_SelectValues::contributionTokens`

Before
----------------------------------------
`CRM_Core_SelectValues::contributionTokens()` only called from unit tests now https://github.com/civicrm/civicrm-core/pull/25052 is merged - this was good to get parity while working on the `TokenProcessor` - but now we just want to noisily deprecate & remove


![image](https://user-images.githubusercontent.com/336308/216902524-2f895ea4-5a1f-4221-8500-2d42a5284eb9.png)

After
----------------------------------------
Noisy deprection, code slated for removal no longer tested

Technical Details
----------------------------------------
3 more functions involved in https://github.com/civicrm/civicrm-core/pull/25052/files#diff-44a4a11ca99ca3a9414ca43afd6a90936e15a19c7cf4f32fa6723e3fc15c75c3L707-L709 on the todo

Comments
----------------------------------------

