### PR TITLE
Fully deprecate `CRM_Core_SelectValues::membershipTokens()`

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -545,6 +545,7 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function membershipTokens(): array {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     return [
       '{membership.id}' => ts('Membership ID'),
       '{membership.status_id:label}' => ts('Status'),

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -466,9 +466,7 @@ contribution_recur.payment_instrument_id:name :Check
     $this->createLoggedInUser();
     $this->restoreMembershipTypes();
     $this->createCustomGroupWithFieldOfType(['extends' => 'Membership']);
-    $tokens = CRM_Core_SelectValues::membershipTokens();
     $expectedTokens = $this->getMembershipTokens();
-    $this->assertEquals($expectedTokens, $tokens);
     $newStyleTokens = "\n{membership.status_id:label}\n{membership.membership_type_id:label}\n";
     $tokenString = $newStyleTokens . implode("\n", array_keys($this->getMembershipTokens()));
 


### PR DESCRIPTION
Overview
----------------------------------------
Fully deprecate `CRM_Core_SelectValues::membershipTokens()`

Before
----------------------------------------
Function now only called from a unit test
![image](https://user-images.githubusercontent.com/336308/216906020-4bec797e-41ff-416b-8801-294b7d52bfb8.png)

After
----------------------------------------
Fully deprecated & slated for removal down the track

Technical Details
----------------------------------------
The test still covers the preferred function 

Comments
----------------------------------------
