### PR TITLE
Fully deprecate `CRM_Utils_Token::getMembershipTokenDetails`, `CRM_Utils_Token::replaceEntityTokens`

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1197,6 +1197,7 @@ class CRM_Utils_Token {
    * @deprecated
    */
   public static function getMembershipTokenDetails($membershipIDs) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     $memberships = civicrm_api3('membership', 'get', [
       'options' => ['limit' => 0],
       'membership_id' => ['IN' => (array) $membershipIDs],
@@ -1389,6 +1390,7 @@ class CRM_Utils_Token {
    *   string with replacements made
    */
   public static function replaceEntityTokens($entity, $entityArray, $str, $knownTokens = [], $escapeSmarty = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     if (!$knownTokens || empty($knownTokens[$entity])) {
       return $str;
     }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -467,20 +467,17 @@ contribution_recur.payment_instrument_id:name :Check
     $this->restoreMembershipTypes();
     $this->createCustomGroupWithFieldOfType(['extends' => 'Membership']);
     $expectedTokens = $this->getMembershipTokens();
+    // This get also creates...
+    $this->getMembershipID();
     $newStyleTokens = "\n{membership.status_id:label}\n{membership.membership_type_id:label}\n";
     $tokenString = $newStyleTokens . implode("\n", array_keys($this->getMembershipTokens()));
-
-    $memberships = CRM_Utils_Token::getMembershipTokenDetails([$this->getMembershipID()]);
-    $messageToken = CRM_Utils_Token::getTokens($tokenString);
-    $tokenHtml = CRM_Utils_Token::replaceEntityTokens('membership', $memberships[$this->getMembershipID()], $tokenString, $messageToken);
-    $this->assertEquals($this->getExpectedMembershipTokenOutput(), $tokenHtml);
 
     // Custom fields work in the processor so test it....
     $tokenString .= "\n{membership." . $this->getCustomFieldName('text') . '}';
     // Now compare with scheduled reminder
     $mut = new CiviMailUtils($this);
     CRM_Utils_Time::setTime('2007-01-22 15:00:00');
-    $this->callAPISuccess('action_schedule', 'create', [
+    $this->callAPISuccess('ActionSchedule', 'create', [
       'title' => 'job',
       'subject' => 'job',
       'entity_value' => 1,
@@ -491,7 +488,7 @@ contribution_recur.payment_instrument_id:name :Check
       'start_action_unit' => 'day',
       'body_html' => $tokenString,
     ]);
-    $this->callAPISuccess('job', 'send_reminder', []);
+    $this->callAPISuccess('Job', 'send_reminder', []);
     $expected = $this->getExpectedMembershipTokenOutput();
     // Unlike the legacy method custom fields are resolved by the processor.
     $expected .= "\nmy field";


### PR DESCRIPTION
Overview
----------------------------------------
Fully deprecate `CRM_Utils_Token::getMembershipTokenDetails`, `CRM_Utils_Token::replaceEntityTokens`

Before
----------------------------------------
Function `getMembershipTokenDetails` only called from Unit test
![image](https://user-images.githubusercontent.com/336308/216906446-7e7c563b-6cf5-4b4e-b441-638fb416ea41.png)

`CRM_Utils_Token::replaceEntityTokens` called from unit test and from a function which already has noisy deprecation
![image](https://user-images.githubusercontent.com/336308/216906697-bf832c0d-cbc5-4489-9675-6984bf778059.png)



After
----------------------------------------
Fully deprecated, test calls removed

Technical Details
----------------------------------------
Test cover remains for the token processor functions

Comments
----------------------------------------
