### PR TITLE
Fully deprecate `CRM_Core_SelectValues::eventTokens()`

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -564,6 +564,7 @@ class CRM_Core_SelectValues {
    * @return array
    */
   public static function eventTokens(): array {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['eventId']]);
     $allTokens = $tokenProcessor->listTokens();
     foreach (array_keys($allTokens) as $token) {

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -811,8 +811,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $mut = new CiviMailUtils($this);
     $this->setupParticipantScheduledReminder();
 
-    $tokens = CRM_Core_SelectValues::eventTokens();
-    $this->assertEquals(array_merge($this->getEventTokens()), $tokens);
+    $tokens = array_merge($this->getEventTokens());
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
       'controller' => __CLASS__,
       'smarty' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Fully deprecate `CRM_Core_SelectValues::eventTokens()`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/216907862-d3e775e3-28a9-4860-8f81-03b249b01aad.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------
Test cover remains for preferred token processor functions

Comments
----------------------------------------
