### PR TITLE
Add noisy deprecation to `replaceHookTokens`

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -683,6 +683,7 @@ class CRM_Utils_Token {
     $html = FALSE,
     $escapeSmarty = FALSE
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     if (!$categories) {
       $categories = self::getTokenCategories();
     }


### PR DESCRIPTION

Overview
----------------------------------------
Add noisy deprecation to `replaceHookTokens`


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/216915193-b629c37b-05cd-4a46-bebe-51dda58a453b.png)

After
----------------------------------------
Will issue deprecation warnings on dev sites (and production sites if they misconfigure their php warning level)

Technical Details
----------------------------------------
This was code-comment deprecated around 15 months ago  - ie 5.44 so, 3 ESRs have been out since then - and some extensions have updated to stop calling it so it seems OK to make the deprecation a bit noisier now since the TokenProcessor has been settled & stable for some time now

Comments
----------------------------------------
Where extensions do call this they generally also call `getTokenDetails` which was noisily deprecated a year ago