### PR TITLE
Extra deprecation for clarity on token function `convertPseudoConstantsUsingMetadata`

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1720,12 +1720,15 @@ class CRM_Utils_Token {
   }
 
   /**
+   * @deprecated
+   *
    * @param $value
    * @param $token
    *
    * @return bool|int|mixed|string|null
    */
   protected static function convertPseudoConstantsUsingMetadata($value, $token) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     // Convert pseudoconstants using metadata
     if ($value && is_numeric($value)) {
       $allFields = CRM_Contact_BAO_Contact::exportableFields('All');


### PR DESCRIPTION
Overview
----------------------------------------
Extra deprecation for clarity on token function

Before
----------------------------------------
The only function this is called from is, itself, noisily deprecated. However, you have to do a search to find out this is deprecated

![image](https://user-images.githubusercontent.com/336308/216916484-361acfa2-88c2-4d68-a70f-f879b186d0cb.png)

After
----------------------------------------
Deprecation is more obvious, not much change for anything that hits this path as there is already a warning

Technical Details
----------------------------------------

Comments
----------------------------------------
