### PR TITLE
PaymentProcessor - Use ajax refresh

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -217,8 +217,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       'payment_processor_type_id',
       ts('Payment Processor Type'),
       CRM_Financial_BAO_PaymentProcessor::buildOptions('payment_processor_type_id'),
-      TRUE,
-      ['onchange' => "reload(true)"]
+      TRUE
     );
 
     // Financial Account of account type asset CRM-11515

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -145,12 +145,15 @@
 {if $action eq 1  or $action eq 2}
   <script type="text/javascript">
   {literal}
-    function reload(refresh) {
-      var paymentProcessorType = cj("#payment_processor_type_id");
-      var url = {/literal}"{$refreshURL}"{literal} + "&pp=" + paymentProcessorType.val();
-      paymentProcessorType.closest('form').attr('data-warn-changes', 'false');
-      window.location.href = url;
-    }
+    CRM.$(function($) {
+      $('#payment_processor_type_id').change(function() {
+        var url = {/literal}"{$refreshURL}"{literal} + "&pp=" + $(this).val();
+        $(this).closest('form').attr('data-warn-changes', 'false')
+          // Ajax refresh (works in a popup or full-screen)
+          .closest('.crm-ajax-container, #crm-main-content-wrapper')
+          .crmSnippet({url: url}).crmSnippet('refresh');
+      });
+    });
   {/literal}
   </script>
 


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #25340 - makes page refresh a bit nicer when changing payment processor types on the admin form.

Before
----------------------------------------
Popup turns into a full-page when you change processor type.

After
----------------------------------------
Popup stays a popup, full-page stays full-page but refreshes faster using ajax.

Technical Details
----------------------------------------
This same pattern is used elsewhere, so this isn't groundbreaking or anything.