### PR TITLE
Only load dedupe rules for the chosen entity

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -483,7 +483,7 @@ LIMIT {$offset}, {$rowCount}
   }
 
   public static function buildDedupeRules() {
-    $contactType = CRM_Utils_Request::retrieve('parentId', 'Positive');
+    $contactType = CRM_Utils_Request::retrieve('parentId', 'String');
     $dedupeRules = CRM_Dedupe_BAO_DedupeRuleGroup::getByType($contactType);
 
     CRM_Utils_JSON::output($dedupeRules);


### PR DESCRIPTION
I'm not sure how long this has been broken??

CRM_Dedupe_BAO_DedupeRuleGroup::getByType() clearly takes a string and will never get one without this change.

Overview
----------------------------------------
The contact import screen asks the user to specify the entity to import. It should then display the dedupe rules for that entity.

Before
----------------------------------------

A list of dedupe rules for all entities is displayed, even after an entity is chosen.

After
----------------------------------------
Only the dedupe rules for the selected entity are displayed.


Technical Details
----------------------------------------
This is a regression, but one that may be very old.

