### PR TITLE
dev/core#4117 Add is_current to UserJob, Search

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/IsCurrentFieldSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/IsCurrentFieldSpecProvider.php
@@ -31,7 +31,7 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
   /**
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
-  public function modifySpec(RequestSpec $spec) {
+  public function modifySpec(RequestSpec $spec): void {
     $field = new FieldSpec('is_current', $spec->getEntity(), 'Boolean');
     $field->setLabel(ts('Is Current'))
       ->setTitle(ts('Current'))
@@ -39,8 +39,22 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
       ->setColumnName('is_current')
       ->setDescription(ts('Is active with a non-past end-date'))
       ->setType('Extra')
-      ->setSqlRenderer([__CLASS__, 'renderIsCurrentSql']);
+      ->setSqlRenderer([__CLASS__, $this->getRenderer($field->getEntity())]);
     $spec->addFieldSpec($field);
+  }
+
+  /**
+   * Get the function to render the sql.
+   *
+   * @param string $entity
+   *
+   * @return string
+   */
+  private function getRenderer(string $entity): string {
+    if (in_array($entity, ['UserJob', 'Search'])) {
+      return 'renderNonExpiredSql';
+    }
+    return 'renderIsCurrentSql';
   }
 
   /**
@@ -49,17 +63,18 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
    *
    * @return bool
    */
-  public function applies($entity, $action) {
+  public function applies($entity, $action): bool {
     if ($action !== 'get') {
       return FALSE;
     }
     // TODO: If we wanted this to not be a hard-coded list, we could always return TRUE here
     // and then in the `modifySpec` function check for the 3 fields `is_active`, `start_date`, and `end_date`
-    return in_array($entity, ['Relationship', 'RelationshipCache', 'Event', 'Campaign'], TRUE);
+    return in_array($entity, ['Relationship', 'RelationshipCache', 'Event', 'Campaign', 'Search', 'UserJob'], TRUE);
   }
 
   /**
    * @param array $field
+   *
    * return string
    */
   public static function renderIsCurrentSql(array $field): string {
@@ -69,6 +84,19 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
     $todayStart = date('Ymd', strtotime('now'));
     $todayEnd = date('Ymd', strtotime('now'));
     return "IF($isActive = 1 AND ($startDate <= '$todayStart' OR $startDate IS NULL) AND ($endDate >= '$todayEnd' OR $endDate IS NULL), '1', '0')";
+  }
+
+  /**
+   * Render the sql clause to filter on expires date.
+   *
+   * @param array $field
+   *
+   * return string
+   */
+  public static function renderNonExpiredSql(array $field): string {
+    $endDate = substr_replace($field['sql_name'], 'expires_date', -11, -1);
+    $todayEnd = date('Ymd');
+    return "IF($endDate >= '$todayEnd' OR $endDate IS NULL, 1, 0)";
   }
 
 }

--- a/tests/phpunit/api/v4/Action/CurrentFilterTest.php
+++ b/tests/phpunit/api/v4/Action/CurrentFilterTest.php
@@ -22,6 +22,7 @@ namespace api\v4\Action;
 use Civi\Api4\Relationship;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Api4\UserJob;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -29,37 +30,42 @@ use Civi\Test\TransactionalInterface;
  */
 class CurrentFilterTest extends Api4TestBase implements TransactionalInterface {
 
-  public function testCurrentRelationship() {
-    $cid1 = Contact::create()->addValue('first_name', 'Bob1')->execute()->first()['id'];
-    $cid2 = Contact::create()->addValue('first_name', 'Bob2')->execute()->first()['id'];
+  /**
+   * Test relationship is_current checks start, end, active.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCurrentRelationship(): void {
+    $contactID1 = Contact::create()->addValue('first_name', 'Bob1')->execute()->first()['id'];
+    $contactID2 = Contact::create()->addValue('first_name', 'Bob2')->execute()->first()['id'];
 
     $current = Relationship::create()->setValues([
       'relationship_type_id' => 1,
-      'contact_id_a' => $cid1,
-      'contact_id_b' => $cid2,
+      'contact_id_a' => $contactID1,
+      'contact_id_b' => $contactID2,
       'end_date' => 'now + 1 week',
     ])->execute()->first();
     $indefinite = Relationship::create()->setValues([
       'relationship_type_id' => 2,
-      'contact_id_a' => $cid1,
-      'contact_id_b' => $cid2,
+      'contact_id_a' => $contactID1,
+      'contact_id_b' => $contactID2,
     ])->execute()->first();
     $expiring = Relationship::create()->setValues([
       'relationship_type_id' => 3,
-      'contact_id_a' => $cid1,
-      'contact_id_b' => $cid2,
+      'contact_id_a' => $contactID1,
+      'contact_id_b' => $contactID2,
       'end_date' => 'now',
     ])->execute()->first();
     $past = Relationship::create()->setValues([
       'relationship_type_id' => 3,
-      'contact_id_a' => $cid1,
-      'contact_id_b' => $cid2,
+      'contact_id_a' => $contactID1,
+      'contact_id_b' => $contactID2,
       'end_date' => 'now - 1 week',
     ])->execute()->first();
     $inactive = Relationship::create()->setValues([
       'relationship_type_id' => 4,
-      'contact_id_a' => $cid1,
-      'contact_id_b' => $cid2,
+      'contact_id_a' => $contactID1,
+      'contact_id_b' => $contactID2,
       'is_active' => 0,
     ])->execute()->first();
 
@@ -90,6 +96,39 @@ class CurrentFilterTest extends Api4TestBase implements TransactionalInterface {
     $this->assertArrayNotHasKey('is_current', $defaultGet);
     $starGet = Relationship::get()->addSelect('*')->setLimit(1)->execute()->single();
     $this->assertArrayNotHasKey('is_current', $starGet);
+  }
+
+  /**
+   * Test UserJob checks expires.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCurrentUserJob(): void {
+    $current = UserJob::create()->setValues([
+      'expires_date' => '+ 1 week',
+      'status_id:name' => 'draft',
+      'job_type:name' => 'contact_import',
+    ])->execute()->first();
+    $indefinite = UserJob::create()->setValues([
+      'status_id:name' => 'draft',
+      'job_type:name' => 'contact_import',
+    ])->execute()->first();
+    $expired = UserJob::create()->setValues([
+      'expires_date' => '-1 week',
+      'status_id:name' => 'draft',
+      'job_type:name' => 'contact_import',
+    ])->execute()->first();
+
+    $getCurrent = (array) UserJob::get()->addWhere('is_current', '=', TRUE)->execute()->indexBy('id');
+    $notCurrent = (array) UserJob::get()->addWhere('is_current', '=', FALSE)->execute()->indexBy('id');
+    $getAll = (array) UserJob::get()->addSelect('is_current')->execute()->indexBy('id');
+
+    $this->assertTrue($getAll[$current['id']]['is_current']);
+    $this->assertTrue($getAll[$indefinite['id']]['is_current']);
+    $this->assertFALSE($getAll[$expired['id']]['is_current']);
+
+    $this->assertEquals([$current['id'], $indefinite['id']], array_keys($getCurrent));
+    $this->assertEquals([$expired['id']], array_keys($notCurrent));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4117 Add is_current to UserJob, Search

Before
----------------------------------------
I hit an issue where I've filled in the `expires_date` on searches - but they still show. Filtering in the js layer is a little painful & it also feels like `is_current` should be an api filter

After
----------------------------------------
Can filter the entities on `is_current`

Technical Details
----------------------------------------
The difficulty here is the SpecProvider (or whatever it is) chooses which entities to apply to & while it seems OK to extend the hack in place for `UserJob`, `Search` lives in an extension. An earlier approach would have allowed me to include  a trait - but that seems deprecated, along with the thing that replaced it

Comments
----------------------------------------
@colemanw I could do what the code already suggested & detect 'expires_date` - it feels like this is almost something that should be part of the schema - eg a key at the table level specifying the fields that make up 'current-ness'