### PR TITLE
Make unshared `getTree` function private, remove never passed params

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1699,9 +1699,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *   api - through which it is properly tested - so can be refactored with some comfort.)
    * @param bool|int $checkPermission
    *   Either a CRM_Core_Permission constant or FALSE to disable checks
-   * @param string|int $singleRecord
-   *   holds 'new' or id if view/edit/copy form for a single record is being loaded.
-   * @param bool $showPublicOnly
    *
    * @return array
    *   Custom field 'tree'.
@@ -1717,7 +1714,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getTree(
+  private static function getTree(
     $entityType,
     $toReturn = [],
     $entityID = NULL,
@@ -1727,10 +1724,10 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $fromCache = TRUE,
     $onlySubType = NULL,
     $returnAll = FALSE,
-    $checkPermission = CRM_Core_Permission::EDIT,
-    $singleRecord = NULL,
-    $showPublicOnly = FALSE
+    $checkPermission = CRM_Core_Permission::EDIT
   ) {
+    $singleRecord = NULL;
+    $showPublicOnly = FALSE;
     if ($checkPermission === TRUE) {
       CRM_Core_Error::deprecatedWarning('Unexpected TRUE passed to CustomGroup::getTree $checkPermission param.');
       $checkPermission = CRM_Core_Permission::EDIT;


### PR DESCRIPTION

Overview
----------------------------------------
Make unshared `getTree` function private, remove never passed params

Before
----------------------------------------
Function called from 2 places - last passed parameter is checkPermissions

![image](https://user-images.githubusercontent.com/336308/217126036-54fae086-e3fb-4a9c-b42c-4fcbd395ecf5.png)


After
----------------------------------------
Function private, un-passed parameters gone from signature 

Technical Details
----------------------------------------
This function is a recent split from a complex function. It is called from 2 places, within this file so this
1) makes it private
2) removes never-passed parameters
https://github.com/civicrm/civicrm-core/commit/1090db413680855d449671b841af8185f0baeb1f#diff-fe60c89ebe94bbd40114d135459371cc53708db1f2952ade6c0ce9b3468c4dabR1720


Comments
----------------------------------------

