### PR TITLE
Remove never-true IF

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1898,10 +1898,6 @@ WHERE civicrm_custom_group.is_active = 1
         );
     }
 
-    if ($showPublicOnly && $is_public_version) {
-      $strWhere .= "AND civicrm_custom_group.is_public = 1";
-    }
-
     $orderBy = "
 ORDER BY civicrm_custom_group.weight,
          civicrm_custom_group.title,


### PR DESCRIPTION
Per https://github.com/civicrm/civicrm-core/pull/25517  `$showPublicOnly` is always FALSE so this IF is never true
