### PR TITLE
Remove always-NULL `$singleRecord` variable

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1944,7 +1944,7 @@ ORDER BY civicrm_custom_group.weight,
     // add info to groupTree
 
     if (isset($groupTree['info']) && !empty($groupTree['info']) &&
-      !empty($groupTree['info']['tables']) && $singleRecord != 'new'
+      !empty($groupTree['info']['tables'])
     ) {
       $select = $from = $where = [];
       $groupTree['info']['where'] = NULL;
@@ -1978,7 +1978,7 @@ ORDER BY civicrm_custom_group.weight,
       }
       $multipleFieldTablesWithEntityData = array_keys($entityMultipleSelectClauses);
       if (!empty($multipleFieldTablesWithEntityData)) {
-        CRM_Core_BAO_CustomGroup::buildEntityTreeMultipleFields($groupTree, $entityID, $entityMultipleSelectClauses, $multipleFieldTablesWithEntityData, $singleRecord);
+        CRM_Core_BAO_CustomGroup::buildEntityTreeMultipleFields($groupTree, $entityID, $entityMultipleSelectClauses, $multipleFieldTablesWithEntityData);
       }
 
     }


### PR DESCRIPTION
Overview
----------------------------------------
Remove always-NULL `$singleRecord` variable

Before
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/25517  `$singleRecord` is always `NULL` so

1) the removed condition renders to `NULL != 'new` & is always TRUE
2) the value passed to the second function is always NULL, which is the default for the parameter so we don't pass it

After
----------------------------------------
extraneous usage removed

Technical Details
----------------------------------------
This can be merged separately from https://github.com/civicrm/civicrm-core/pull/25517  as that PR 'makes the case' but is not required for this to be TRUE. There is other follow on cleanup to do on other parameters so the variables will get flushed out then if need be

Comments
----------------------------------------
