### PR TITLE
SearchKit - Configurable action menu tasks per-search-display

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -206,13 +206,15 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       }
     }
 
-    // Call `hook_civicrm_searchKitTasks`.
-    // Note - this hook serves 2 purposes, both to augment this list of tasks AND to
-    // get a full list of Angular modules which provide tasks. That's why this hook needs
-    // the base-level array and not just the array of tasks for `$this->entity`.
-    // Although it may seem wasteful to have extensions add tasks for all possible entities and then
-    // discard most of it (all but the ones relevant to `$this->entity`), it's necessary to do it this way
-    // so that they can be declared as angular dependencies - see search_kit_civicrm_angularModules().
+    // Call `hook_civicrm_searchKitTasks` which serves 3 purposes:
+    // 1. For extensions to augment this list of tasks
+    // 2. To allow tasks to be added/removed per search display
+    //    Note: Use Events::W_LATE to do so after the tasks are filtered per search-display settings.
+    // 3. To get a full list of Angular modules which provide tasks.
+    //    Note: That's why this hook needs the base-level array and not just the array of tasks for `$this->entity`.
+    //    Although it may seem wasteful to have extensions add tasks for all possible entities and then
+    //    discard most of it (all but the ones relevant to `$this->entity`), it's necessary to do it this way
+    //    so that they can be declared as angular dependencies - see search_kit_civicrm_angularModules().
     $null = NULL;
     $checkPermissions = $this->checkPermissions;
     $userId = $this->checkPermissions ? \CRM_Core_Session::getLoggedInContactID() : NULL;
@@ -234,7 +236,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
     $result->exchangeArray($tasks[$entity['name']]);
   }
 
-  public static function fields() {
+  public static function fields(): array {
     return [
       [
         'name' => 'name',

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Core\Event\GenericHookEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber to filter search display tasks
+ * @service
+ * @internal
+ */
+class SearchDisplayTasksSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+
+  /**
+   * Filter tasks with a priority of -50, which allows W_MIDDLE & W_EARLY to go first, but W_LATE to go after.
+   *
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'hook_civicrm_searchKitTasks' => [
+        ['filterTasksForDisplay', -50],
+      ],
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public function filterTasksForDisplay(GenericHookEvent $event): void {
+    $enabledActions = $event->display['settings']['actions'] ?? NULL;
+    $entityName = $event->search['api_entity'] ?? NULL;
+    if ($entityName && is_array($enabledActions)) {
+      $event->tasks[$entityName] = array_intersect_key($event->tasks[$entityName], array_flip($enabledActions));
+    }
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminTasksConfig.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminTasksConfig.component.js
@@ -1,0 +1,58 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('searchAdminTasksConfig', {
+    bindings: {
+      display: '<',
+      apiEntity: '<',
+      apiParams: '<'
+    },
+    templateUrl: '~/crmSearchAdmin/displays/common/searchAdminTasksConfig.html',
+    controller: function($scope, crmApi4, $timeout) {
+      var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.$onInit = function() {
+        crmApi4('SearchDisplay', 'getSearchTasks', {
+          entity: ctrl.apiEntity,
+          savedSearch: {api_entity: ctrl.apiEntity, api_params: ctrl.apiParams}
+        }).then(function(tasks) {
+          ctrl.allTasks = tasks;
+        });
+      };
+
+      this.toggleActions = function() {
+        this.display.settings.actions = !this.display.settings.actions;
+        ctrl.menuOpen = false;
+      };
+
+      this.toggleTask = function(name) {
+        // Timeout waits for checkbox state to change, otherwise checkbox 'checked' property gets out-of-sync with angular model
+        $timeout(function() {
+          // Disabling one when all enabled, convert to array
+          if (typeof ctrl.display.settings.actions === 'boolean') {
+            ctrl.display.settings.actions = _.map(ctrl.allTasks, 'name');
+          }
+          // Remove enabled task
+          if (ctrl.display.settings.actions.includes(name)) {
+            _.pull(ctrl.display.settings.actions, name);
+          }
+          // Add disabled task
+          else {
+            ctrl.display.settings.actions.push(name);
+          }
+          // All enabled, convert to boolean
+          if (ctrl.display.settings.actions.length === ctrl.allTasks.length) {
+            ctrl.display.settings.actions = true;
+          }
+        });
+      };
+
+      this.isEnabled = function(name) {
+        return (typeof this.display.settings.actions === 'boolean') || this.display.settings.actions.includes(name);
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminTasksConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminTasksConfig.html
@@ -1,0 +1,26 @@
+<div class="checkbox-inline form-control">
+  <label>
+    <input type="checkbox" ng-checked="$ctrl.display.settings.actions" ng-click="$ctrl.toggleActions()">
+    <span>{{:: ts('Actions Menu') }}</span>
+  </label>
+</div>
+<div class="input-group" ng-if="$ctrl.display.settings.actions">
+  <div class="input-group-btn">
+    <button type="button" ng-click="$ctrl.menuOpen = true" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <span ng-if="$ctrl.display.settings.actions === true">{{:: ts('All Enabled') }}</span>
+      <span ng-if="$ctrl.display.settings.actions !== true">{{ ts('%1 Enabled', {1: $ctrl.display.settings.actions.length}) }}</span>
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" ng-if="$ctrl.menuOpen">
+      <li ng-if="!$ctrl.allTasks" class="disabled">
+        <a href><i class="crm-i fa-spinner fa-spin"></i></a>
+      </li>
+      <li ng-repeat="task in $ctrl.allTasks">
+        <a href ng-click="$ctrl.toggleTask(task.name); $event.stopPropagation()">
+          <input type="checkbox" ng-checked="$ctrl.isEnabled(task.name)">
+          {{:: task.title }}
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -10,12 +10,9 @@
     </div>
   </div>
   <div class="form-inline">
-    <div class="checkbox-inline form-control">
-      <label>
-        <input type="checkbox" ng-model="$ctrl.display.settings.actions">
-        <span>{{:: ts('Enable Actions') }}</span>
-      </label>
-    </div>
+    <search-admin-tasks-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-tasks-config>
+  </div>
+  <div class="form-inline">
     <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
   </div>
   <div class="form-inline">


### PR DESCRIPTION
Overview
----------------------------------------
Allows the admin to limit the available choices of bulk actions (tasks) in a Search Display.
See https://lab.civicrm.org/dev/core/-/issues/4118

Before
----------------------------------------
Actions menu can be influenced by hook but not in the UI.

After
----------------------------------------
**Selecting only certain tasks:**
![image](https://user-images.githubusercontent.com/2874912/217389815-42fb025d-0936-4433-a49b-89e15731dc5d.png)

**Results in limited choices:**
![image](https://user-images.githubusercontent.com/2874912/217389935-92f36676-f92c-4ef0-abf7-d9177b473d16.png)



Technical Details
----------------------------------------
This utilizes the hook from @mattwire's [25123](https://github.com/civicrm/civicrm-core/pull/25123). The filtering happens before W_LATE but after W_MIDDLE so that the filtering happens after extensions add to the tasks list. If you want to alter the list of tasks _after_ the filtering, implement your hook at W_LATE to have the final say about which tasks are available (e.g. to add disabled tasks back in on a per-user-role basis).