### PR TITLE
Make dedupe exceptions searchable in SearchKit

### DIFF
--- a/Civi/Api4/DedupeException.php
+++ b/Civi/Api4/DedupeException.php
@@ -15,7 +15,7 @@ namespace Civi\Api4;
  *
  * This api exposes CiviCRM (dedupe) exceptions.
  *
- * @searchable none
+ * @searchable secondary
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/
  * @since 5.39
  * @package Civi\Api4


### PR DESCRIPTION
I do kinda wonder if primary & secondary is nuanced enough - but this might not be the use case to split that open...


This is a good candidate for AdminUI as the existing screen is a bit hurty