### PR TITLE
dev/core#4068 Prevent adding in addSelectWhereClause for civicrm_group when filtering by a group as unneded for reports

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3770,14 +3770,18 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     }
 
     CRM_Contact_BAO_GroupContactCache::check($smartGroups);
-
+    $aclFilter = NULL;
+    $selectWhereClauses = array_filter(CRM_Contact_BAO_Group::getSelectWhereClause('group'));
+    $aclFilter = implode(' AND ', $selectWhereClauses);
+    $aclFilter = !empty($aclFilter) ? ' AND ' . $aclFilter : '';
     $smartGroupQuery = '';
     if (!empty($smartGroups)) {
       $smartGroups = implode(',', $smartGroups);
       $smartGroupQuery = " UNION DISTINCT
                   SELECT DISTINCT smartgroup_contact.contact_id
                   FROM civicrm_group_contact_cache smartgroup_contact
-                  WHERE smartgroup_contact.group_id IN ({$smartGroups}) ";
+                  INNER JOIN civicrm_group group ON group.id = smartgroup_contact.group_id
+                  WHERE smartgroup_contact.group_id IN ({$smartGroups}) {$aclFilter}";
     }
 
     $sqlOp = $this->getSQLOperator($op);
@@ -3796,7 +3800,8 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     return " {$contactAlias}.id {$sqlOp} (
                           SELECT DISTINCT {$this->_aliases['civicrm_group']}.contact_id
                           FROM civicrm_group_contact {$this->_aliases['civicrm_group']}
-                          WHERE {$clause} AND {$this->_aliases['civicrm_group']}.status = 'Added'
+                          INNER JOIN civicrm_group group ON group.id = smartgroup_contact.group_id
+                          WHERE {$clause} AND {$this->_aliases['civicrm_group']}.status = 'Added' {$aclFilter}
                           {$smartGroupQuery} ) ";
   }
 
@@ -3950,6 +3955,10 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     $ret = [];
     foreach ($this->selectedTables() as $tableName) {
       $baoName = str_replace('_DAO_', '_BAO_', (CRM_Core_DAO_AllCoreTables::getClassForTable($tableName) ?? ''));
+      // Do not include CiviCRM group add Select Where clause because we don't necessarily join here for reports with optimisedGroupFilters
+      if ($baoName === 'CRM_Contact_BAO_Group') {
+        continue;
+      }
       if ($baoName && class_exists($baoName) && !empty($this->_columns[$tableName]['alias'])) {
         $tableAlias = $this->_columns[$tableName]['alias'];
         $clauses = array_filter($baoName::getSelectWhereClause($tableAlias));

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3780,7 +3780,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
       $smartGroupQuery = " UNION DISTINCT
                   SELECT DISTINCT smartgroup_contact.contact_id
                   FROM civicrm_group_contact_cache smartgroup_contact
-                  INNER JOIN civicrm_group group ON group.id = smartgroup_contact.group_id
+                  INNER JOIN `civicrm_group` AS `group` ON `group`.id = smartgroup_contact.group_id
                   WHERE smartgroup_contact.group_id IN ({$smartGroups}) {$aclFilter}";
     }
 
@@ -3800,7 +3800,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
     return " {$contactAlias}.id {$sqlOp} (
                           SELECT DISTINCT {$this->_aliases['civicrm_group']}.contact_id
                           FROM civicrm_group_contact {$this->_aliases['civicrm_group']}
-                          INNER JOIN civicrm_group group ON group.id = smartgroup_contact.group_id
+                          INNER JOIN `civicrm_group` AS `group` ON `group`.id = {$this->_aliases['civicrm_group']}.group_id
                           WHERE {$clause} AND {$this->_aliases['civicrm_group']}.status = 'Added' {$aclFilter}
                           {$smartGroupQuery} ) ";
   }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -24,6 +24,8 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
   protected $contactIDs = [];
 
+  protected $aclGroupId = NULL;
+
   /**
    * Our group reports use an alter so transaction cleanup won't work.
    *
@@ -33,6 +35,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_group', 'civicrm_saved_search', 'civicrm_group_contact', 'civicrm_group_contact_cache', 'civicrm_group'], TRUE);
     (new CRM_Logging_Schema())->dropAllLogTables();
+    CRM_Utils_Hook::singleton()->reset();
+    $config = CRM_Core_Config::singleton();
+    unset($config->userPermissionClass->permissions);
     parent::tearDown();
   }
 
@@ -678,6 +683,33 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     $rows = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,
       'gid_value' => [$groupID],
+      'gid_op' => 'in',
+      'options' => ['metadata' => ['sql']],
+    ]);
+    $this->assertNumberOfContactsInResult(1, $rows, $template);
+  }
+
+  /**
+   * Test the group filter works on various reports when ACLed user is in play
+   *
+   * @dataProvider getMembershipAndContributionReportTemplatesForGroupTests
+   *
+   * @param string $template
+   *   Report template unique identifier.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testReportsWithNonSmartGroupFilterWithACL($template) {
+    $this->aclGroupId = $this->setUpPopulatedGroup();
+    $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+    $this->callAPISuccessGetCount('Group', ['check_permissions' => 1], 0);
+    $this->hookClass->setHook('civicrm_aclGroup', [$this, 'aclGroupOnly']);
+    $this->hookClass->setHook('civicrm_aclWhereClause', [$this, 'aclGroupContactsOnly']);
+    unset(Civi::$statics['CRM_ACL_API']['group_permission']);
+    $rows = $this->callAPISuccess('report_template', 'getrows', [
+      'report_id' => $template,
+      'gid_value' => [$this->aclGroupId],
       'gid_op' => 'in',
       'options' => ['metadata' => ['sql']],
     ]);
@@ -1772,6 +1804,35 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     // every trigger.
     CRM_Core_Config::singleton(TRUE, TRUE);
     \Civi::service('sql_triggers')->rebuild(NULL, TRUE);
+  }
+
+  /**
+   * Implement hook to restrict to test group 1.
+   *
+   * @param string $type
+   * @param int $contactID
+   * @param string $tableName
+   * @param array $allGroups
+   * @param array $ids
+   */
+  public function aclGroupOnly($type, $contactID, $tableName, $allGroups, &$ids) {
+    $ids = [$this->aclGroupId];
+  }
+
+  /**
+   * Implements hook to limit to contacts only in the aclGroup
+   *
+   * @param string $type
+   * @param array $tables
+   * @param array $whereTables
+   * @param int|null $contactID
+   * @param string $where
+   */
+  public function aclGroupContactsOnly($type, &$tables, &$whereTables, &$contactID, &$where) {
+    if (!empty($where)) {
+      $where .= ' AND ';
+    }
+    $where .= 'contact_a.id IN (SELECT contact_id FROM civicrm_group_contact WHERE status = \'Added\' AND group_id = ' . $this->aclGroupId . ')';
   }
 
 }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -24,7 +24,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
   protected $contactIDs = [];
 
-  protected $aclGroupId = NULL;
+  protected $aclGroupID = NULL;
 
   /**
    * Our group reports use an alter so transaction cleanup won't work.
@@ -440,6 +440,11 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     return $templates;
   }
 
+  public static function getConactMenbershipAndContributionReportTemplatesForACLGroupTests(): array {
+    $templates = array_merge([['contact/summary']], self::getMembershipAndContributionReportTemplatesForGroupTests());
+    return $templates;
+  }
+
   /**
    * Test Lybunt report to check basic inclusion of a contact who gave in the year before the chosen year.
    *
@@ -692,15 +697,15 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   /**
    * Test the group filter works on various reports when ACLed user is in play
    *
-   * @dataProvider getMembershipAndContributionReportTemplatesForGroupTests
+   * @dataProvider getConactMenbershipAndContributionReportTemplatesForACLGroupTests
    *
    * @param string $template
    *   Report template unique identifier.
    *
    * @throws \CRM_Core_Exception
    */
-  public function testReportsWithNonSmartGroupFilterWithACL($template) {
-    $this->aclGroupId = $this->setUpPopulatedGroup();
+  public function testReportsWithNonSmartGroupFilterWithACL($template): void {
+    $this->aclGroupID = $this->setUpPopulatedGroup();
     $this->createLoggedInUser();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $this->callAPISuccessGetCount('Group', ['check_permissions' => 1], 0);
@@ -709,7 +714,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     unset(Civi::$statics['CRM_ACL_API']['group_permission']);
     $rows = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,
-      'gid_value' => [$this->aclGroupId],
+      'gid_value' => [$this->aclGroupID],
       'gid_op' => 'in',
       'options' => ['metadata' => ['sql']],
     ]);
@@ -1816,7 +1821,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @param array $ids
    */
   public function aclGroupOnly($type, $contactID, $tableName, $allGroups, &$ids) {
-    $ids = [$this->aclGroupId];
+    $ids = [$this->aclGroupID];
   }
 
   /**
@@ -1832,7 +1837,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     if (!empty($where)) {
       $where .= ' AND ';
     }
-    $where .= 'contact_a.id IN (SELECT contact_id FROM civicrm_group_contact WHERE status = \'Added\' AND group_id = ' . $this->aclGroupId . ')';
+    $where .= 'contact_a.id IN (SELECT contact_id FROM civicrm_group_contact WHERE status = \'Added\' AND group_id = ' . $this->aclGroupID . ')';
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This removes the adding of the selectWhereClauses from CRM_Contact_BAO_Group when running a report by an ACLed user with filtering by a group

Before
----------------------------------------
DB error about unknown field

After
----------------------------------------
No DB Error and Test

Technical Details
----------------------------------------
The problem was that when adding in the addSelectWhereClauses for civicrm_group table it was expecting that the civicrm_group table was already joined which for most reports would not be the case. If the reports have had their group filter optimised then only a temporary table is joined and that uses  group.get call to filter the groups used https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/GroupContactCache.php#L664 For the non optimised reports I have added additional filters onto the SQL to handle this situation and added a unit test to cover