### PR TITLE
Fix dedupe finder performance issue on looking up table size

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1081,9 +1081,11 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
-   * Scans all the tables using a slow query and table name.
+   * Gets the names of all the tables in the schema.
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function getTableNames(): array {
     $dao = CRM_Core_DAO::executeQuery(

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -133,6 +133,25 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the drop index if exists function for a non-existent index.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetRowCountForTable(): void {
+    // Hopefully running ANALYZE TABLE will consistently update the 'approximate' values
+    // so we can test them.
+    CRM_Core_DAO::singleValueQuery('ANALYZE TABLE civicrm_domain');
+    CRM_Core_DAO::singleValueQuery('ANALYZE TABLE civicrm_worldregion');
+    CRM_Core_DAO::singleValueQuery('ANALYZE TABLE civicrm_acl');
+    $this->assertEquals([
+      'civicrm_worldregion' => 6,
+      'civicrm_acl' => 0,
+      'civicrm_domain' => 2,
+    ], CRM_Core_BAO_SchemaHandler::getRowCountForTables(['civicrm_domain', 'civicrm_acl', 'random_name', 'civicrm_worldregion']));
+    $this->assertEquals(2, CRM_Core_BAO_SchemaHandler::getRowCountForTable('civicrm_domain'));
+  }
+
+  /**
    * @param string $tableName
    * @param string $columnName
    *

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -42,7 +42,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
   /**
    * Test the unsupervised dedupe rule against a group.
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function testUnsupervisedDupes(): void {
     // make dupe checks based on following contact sets:


### PR DESCRIPTION
Overview
----------------------------------------
Fix dedupe finder performance issue on looking up table size

Before
----------------------------------------
Our dedupe queries seem to be particularly slow, rule dependent, and I found that the the issue was slow `SELECT COUNT(*) FROM civicrm_address etc` queries. We recently fixed some of these in other place (SnapShot, an upgrade script). At the time I was under the impression the technique used here also had performance issues - ie 
```
      SELECT TABLE_ROWS as row_count, TABLE_NAME as table_name FROM information_schema.TABLES WHERE
      AND TABLE_SCHEMA = DATABASE();
```

However, I tested that query and it is not slow

``` 414 rows in set, 1 warning (0.103 sec)``` 

And is quicker for less tables.

I also traced back the origin of the code comment to that effect & nothing in there seems to back it up 

https://github.com/civicrm/civicrm-core/pull/8636
https://issues.civicrm.org/jira/browse/CRM-19027

After
----------------------------------------
Use of a faster function, which we can also use from those other places

Technical Details
----------------------------------------
This is very hard to access under r-run as it deals with the ordering of queries for a perceived performance improvement - however I could step through it with `CRM_Contact_Import_Parser_ContactTest.testIgnoreLocationTypeId` and per the screenshots you can see that it re-ordered the array to put the  `civicrm_address` query first based on the table size being smaller

**Original sort order**

See in the variable `$tableQueries` the query involving the contact table is first

![image](https://user-images.githubusercontent.com/336308/217658447-50ee05ae-f3e6-4989-93e4-42f1f0d70531.png)

**It decides the  the table lengths**

See in the `$cachedResults` there are more rows in the contact table

![image](https://user-images.githubusercontent.com/336308/217655887-27b758bf-7e67-4643-9805-728e62d92af9.png)

**And it re-orders based on that ** 

See in the variable `$tableQueries` the query involving the (shorter) address table is now first

![image](https://user-images.githubusercontent.com/336308/217662150-832a65a9-4e5d-47e4-9a78-15e40e06a6bb.png)

Comments
----------------------------------------
