### PR TITLE
Use `DATABASE()` function rather than lossa code

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -547,23 +547,23 @@ MODIFY      {$columnName} varchar( $length )
 
   /**
    * Check if a foreign key Exists
+   *
    * @param string $table_name
    * @param string $constraint_name
+   *
    * @return bool TRUE if FK is found
    */
-  public static function checkFKExists($table_name, $constraint_name) {
-    $dao = new CRM_Core_DAO();
+  public static function checkFKExists(string $table_name, string $constraint_name): bool {
     $query = "
       SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
-      WHERE TABLE_SCHEMA = %1
-      AND TABLE_NAME = %2
-      AND CONSTRAINT_NAME = %3
+      WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = %1
+      AND CONSTRAINT_NAME = %2
       AND CONSTRAINT_TYPE = 'FOREIGN KEY'
     ";
     $params = [
-      1 => [$dao->_database, 'String'],
-      2 => [$table_name, 'String'],
-      3 => [$constraint_name, 'String'],
+      1 => [$table_name, 'String'],
+      2 => [$constraint_name, 'String'],
     ];
     $dao = CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, FALSE);
 


### PR DESCRIPTION
Overview
----------------------------------------
Use `DATABASE()` function rather than lossa code

Before
----------------------------------------
We use php to determine the db name

After
----------------------------------------
We use mysql `DATABASE()`

Technical Details
----------------------------------------
In working on https://github.com/civicrm/civicrm-core/pull/25527/files#diff-9589b113a3dd49088f06d683e7d4a399be6d143b24e052d3530f7946ad270d95R928 my IDE kindly pointed out that mysql offers a DATABASE() function to get the current schema. I found it in both mysql & mariaDB docs with no evidence of it being a new function - this is one of a bunch of places we can simplify the code by using it

https://mariadb.com/kb/en/database/

Comments
----------------------------------------

Places that could or do use it

![image](https://user-images.githubusercontent.com/336308/217438408-717b9024-15d4-451e-89d2-baeaf489369f.png)

