### PR TITLE
Log server-side validation errors so it is easier to troubleshoot/debug afform issues

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -68,6 +68,7 @@ class Submit extends AbstractProcessor {
     \Civi::dispatcher()->dispatch('civi.afform.validate', $event);
     $errors = $event->getErrors();
     if ($errors) {
+      \Civi::log('afform')->error('Afform Validation errors: ' . print_r($errors, TRUE));
       throw new \CRM_Core_Exception(ts('Validation Error', ['plural' => '%1 Validation Errors', 'count' => count($errors)]), 0, ['validation' => $errors]);
     }
 
@@ -210,7 +211,7 @@ class Submit extends AbstractProcessor {
 
     $isRequired = $attributes['defn']['required'] ?? $fullDefn['required'] ?? FALSE;
     if ($isRequired) {
-      $label = $attributes['defn']['label'] ?? $fullDefn['label'];
+      $label = $attributes['defn']['label'] ?? $fullDefn['label'] ?? $fieldName;
       return E::ts('%1 is a required field.', [1 => $label]);
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Validation error not always returned to the form making it difficult to debug. Log it so we can easily debug.

Before
----------------------------------------
Validation error details not returned to form.

After
----------------------------------------
Validation error detail logged.

Technical Details
----------------------------------------


Comments
----------------------------------------

