### PR TITLE
CiviTestListener - Headless tests should initialize timezone

### DIFF
--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -121,6 +121,7 @@ else {
       \CRM_Core_Session::singleton()->set('userID', NULL);
       // ugh, performance
       $config = \CRM_Core_Config::singleton(TRUE, TRUE);
+      $config->userSystem->setMySQLTimeZone();
 
       if (property_exists($config->userPermissionClass, 'permissions')) {
         $config->userPermissionClass->permissions = NULL;

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -114,6 +114,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     \CRM_Core_Session::singleton()->set('userID', NULL);
     // ugh, performance
     $config = \CRM_Core_Config::singleton(TRUE, TRUE);
+    $config->userSystem->setMySQLTimeZone();
 
     if (property_exists($config->userPermissionClass, 'permissions')) {
       $config->userPermissionClass->permissions = NULL;

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -111,6 +111,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     \CRM_Core_Session::singleton()->set('userID', NULL);
     // ugh, performance
     $config = \CRM_Core_Config::singleton(TRUE, TRUE);
+    $config->userSystem->setMySQLTimeZone();
 
     if (property_exists($config->userPermissionClass, 'permissions')) {
       $config->userPermissionClass->permissions = NULL;


### PR DESCRIPTION
Before
------

* `CiviUnitTestCase` calls `setMySQLTimeZone()`
* Headless tests (which are initialized via `CiviTestListener`) do not call `setMySQLTimeZone()`
* If you have a test like 5.57's flavor of `QueueTest`, then the tests pass or fail depending on happenstance of server timezone configuration.

After
-----

* `CiviUnitTestCase` and `CiviTestListener` both call `setMySQLTimeZone()`
* If you have a test like 5.57's flavor of `QueueTest`, then the tests pass more consistently.

Comments
--------

Since this patch specifically targets the test-suite, the main thing to look out for is the overall results of the test matrix.

This branch should work cleanly as PR for `5.59` (rc) or `master`.  I'd rather like to use this in `5.57-esr` (so that tests run more cleanly). So maybe `5.59` is the better target (but it doesn't strictly have to be).

