### PR TITLE
Afform: Add required flag to select2

### DIFF
--- a/ext/afform/core/ang/af/fields/Select.html
+++ b/ext/afform/core/ang/af/fields/Select.html
@@ -1,6 +1,6 @@
 <div class="{{:: $ctrl.defn.search_range ? 'form-inline' : 'form-group' }}">
-  <input class="form-control" id="{{:: fieldId }}" ng-if="!$ctrl.defn.input_attrs.multiple" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
-  <input class="form-control" id="{{:: fieldId }}" ng-if="$ctrl.defn.input_attrs.multiple" ng-list crm-ui-select="{data: select2Options, multiple: true, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
-  <input class="form-control" ng-if=":: $ctrl.defn.search_range && !$ctrl.defn.is_date" id="{{:: fieldId }}2" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder2 || $ctrl.defn.input_attrs.placeholder}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" >
+  <input class="form-control" ng-required="$ctrl.defn.required" id="{{:: fieldId }}" ng-if="!$ctrl.defn.input_attrs.multiple" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
+  <input class="form-control" ng-required="$ctrl.defn.required" id="{{:: fieldId }}" ng-if="$ctrl.defn.input_attrs.multiple" ng-list crm-ui-select="{data: select2Options, multiple: true, placeholder: $ctrl.defn.input_attrs.placeholder}" ng-model="getSetSelect" ng-model-options="{getterSetter: true}" >
+  <input class="form-control" ng-required="$ctrl.defn.required" ng-if=":: $ctrl.defn.search_range && !$ctrl.defn.is_date" id="{{:: fieldId }}2" crm-ui-select="{data: select2Options, placeholder: $ctrl.defn.input_attrs.placeholder2 || $ctrl.defn.input_attrs.placeholder}" ng-model="dataProvider.getFieldData()[$ctrl.fieldName]['<=']" >
   <div ng-if="$ctrl.defn.search_range && $ctrl.defn.is_date && getSetSelect() === '{}'" class="form-group" ng-include="'~/af/fields/Date.html'"></div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Seems like https://github.com/civicrm/civicrm-core/pull/23604 did not implement support for Select2 making it pretty confusing when some fields get validated and some don't - even though the UI shows the little required *.

Before
----------------------------------------
Select2 not validated.

After
----------------------------------------
Select2 has required flag and should be validated.

Technical Details
----------------------------------------


Comments
----------------------------------------
This needs further testing but the current situation is pretty horrible from a user/UI perspective! It looks like it should work but doesn't - and worse it silently fails when it hits server-side validation.
