### PR TITLE
Afform: If multiple checkbox is set to required make it required

### DIFF
--- a/ext/afform/core/ang/af/fields/CheckBox.html
+++ b/ext/afform/core/ang/af/fields/CheckBox.html
@@ -1,6 +1,6 @@
 <ul class="crm-checkbox-list" id="{{ fieldId }}" ng-if="$ctrl.defn.options">
   <li ng-repeat="opt in $ctrl.defn.options track by opt.id" >
-    <input type="checkbox" checklist-model="dataProvider.getFieldData()[$ctrl.fieldName]" id="{{ fieldId + opt.id }}" checklist-value="opt.id" />
+    <input type="checkbox" ng-required="$ctrl.defn.required" checklist-model="dataProvider.getFieldData()[$ctrl.fieldName]" id="{{ fieldId + opt.id }}" checklist-value="opt.id" />
     <label for="{{ fieldId + opt.id }}">{{:: opt.label }}</label>
   </li>
 </ul>


### PR DESCRIPTION
Overview
----------------------------------------
Currently you can set a checkboxes field to required but it won't do anything.

Before
----------------------------------------
Set a (multiple) checkboxes field to required. It is not validated before form submission.

After
----------------------------------------
Set a (multiple) checkboxes field to required. It is validated before form submission.

Technical Details
----------------------------------------


Comments
----------------------------------------
It would be nice to have options like "one of the checkboxes must be selected" but that's out of scope. It's a bit odd saying all are required or none are required but that's what the user interface lets you do currently. And it looks like "single" checkbox custom fields are added as if they are multiple checkbox fields so this PR makes the situation better because the "required" flag actually makes it get validated client-side.
