### PR TITLE
Do not use reference for Object parameter, death to `_NULLObject`

### DIFF
--- a/CRM/Contact/Page/Inline/Email.php
+++ b/CRM/Contact/Page/Inline/Email.php
@@ -27,7 +27,7 @@ class CRM_Contact_Page_Inline_Email extends CRM_Core_Page {
    */
   public function run() {
     // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', NULL, TRUE);
 
     $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'display_name']);
 

--- a/CRM/Core/BAO/Log.php
+++ b/CRM/Core/BAO/Log.php
@@ -89,9 +89,9 @@ class CRM_Core_BAO_Log extends CRM_Core_DAO_Log {
     }
 
     if (!$userID) {
-      $api_key = CRM_Utils_Request::retrieve('api_key', 'String', $store, FALSE, NULL, 'REQUEST');
+      $api_key = CRM_Utils_Request::retrieve('api_key', 'String');
 
-      if ($api_key && strtolower($api_key) != 'null') {
+      if ($api_key && strtolower($api_key) !== 'null') {
         $userID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $api_key, 'id', 'api_key');
       }
     }

--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -69,7 +69,7 @@ class CRM_Utils_Request {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function retrieve($name, $type, &$store = NULL, $abort = FALSE, $default = NULL, $method = 'REQUEST') {
+  public static function retrieve($name, $type, $store = NULL, $abort = FALSE, $default = NULL, $method = 'REQUEST') {
 
     $value = NULL;
     switch ($method) {


### PR DESCRIPTION
Overview
----------------------------------------
Do not use reference for Object parameter, death to `_NULLObject`

Before
----------------------------------------
We don't need to pass by ref as the only case for that is an object

![image](https://user-images.githubusercontent.com/336308/217722650-c0fdbf24-1a1d-4aae-8719-b80064971802.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
