### PR TITLE
CiviTestListener - Headless tests should have initialized timezone

### DIFF
--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -121,6 +121,7 @@ else {
       \CRM_Core_Session::singleton()->set('userID', NULL);
       // ugh, performance
       $config = \CRM_Core_Config::singleton(TRUE, TRUE);
+      $config->userSystem->setMySQLTimeZone();
 
       if (property_exists($config->userPermissionClass, 'permissions')) {
         $config->userPermissionClass->permissions = NULL;

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -114,6 +114,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     \CRM_Core_Session::singleton()->set('userID', NULL);
     // ugh, performance
     $config = \CRM_Core_Config::singleton(TRUE, TRUE);
+    $config->userSystem->setMySQLTimeZone();
 
     if (property_exists($config->userPermissionClass, 'permissions')) {
       $config->userPermissionClass->permissions = NULL;

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -111,6 +111,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
     \CRM_Core_Session::singleton()->set('userID', NULL);
     // ugh, performance
     $config = \CRM_Core_Config::singleton(TRUE, TRUE);
+    $config->userSystem->setMySQLTimeZone();
 
     if (property_exists($config->userPermissionClass, 'permissions')) {
       $config->userPermissionClass->permissions = NULL;


### PR DESCRIPTION
Backport #25534 from 5.59-rc to 5.58-stable.