### PR TITLE
dev/financial#214 - Use correct id when creating record payment link for change selections on event

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3607,7 +3607,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $info['transaction'] = self::getContributionTransactionInformation($contributionId, $contribution['financial_type_id']);
     }
 
-    $info['payment_links'] = self::getContributionPaymentLinks($id, $info['contribution_status']);
+    $info['payment_links'] = self::getContributionPaymentLinks($contributionId, $info['contribution_status']);
     return $info;
   }
 

--- a/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Event/BAO/AdditionalPaymentTest.php
@@ -199,6 +199,10 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testAddPartialPayment() {
+    // First add an unrelated contribution since otherwise the contribution and
+    // participant ids are all 1 so they might match by accident.
+    $this->contributionCreate(['contact_id' => $this->individualCreate([], 0, TRUE)]);
+
     $feeAmt = 100;
     $amtPaid = (float) 60;
     $balance = (float) 40;
@@ -212,6 +216,13 @@ class CRM_Event_BAO_AdditionalPaymentTest extends CiviUnitTestCase {
 
     $this->assertEquals('Partially paid', $result['contribution']['contribution_status']);
     $this->assertEquals('Partially paid', $result['participant']['participant_status']);
+
+    // Check the record payment link has the right id and that it doesn't
+    // match by accident.
+    $this->assertNotEquals($result['contribution']['id'], $result['participant']['id']);
+    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($result['participant']['id'], 'event');
+    $this->assertEquals('Record Payment', $paymentInfo['payment_links'][0]['title']);
+    $this->assertEquals($result['contribution']['id'], $paymentInfo['payment_links'][0]['qs']['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/214

Before
----------------------------------------
1. Register an event participant for a paid event.
2. In the record payment section of the registration, change the amount to less than the total so it's just a partial payment.
3. Save.
4. View/edit the participant record. Note the id in the url.
5. Click Change Selections.
6. Click View Payments.
7. Click Record Payment. Note the id in the url. It's the participant id not the contribution id. If a contribution with that id doesn't exist then at this point it crashes.
8. If it does exist, note now at this point the balance owed displayed may be incorrect because it's from an unrelated contribution.
9. Fill it out and save.
10. Note it takes you to a different contact and has applied the payment to the unrelated contribution.

This is only from the Change Selections section. The other Record Payment link found at the bottom of the participant record when you expand the triangle is correct.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
There's some code above the affected line that calculates the contributionId if the id is not a contribution id, but then it uses the original id anyway when making the links.

Comments
----------------------------------------
Has test.
