### PR TITLE
Fix e-notice & php8.2 issue on user dashboard

### DIFF
--- a/CRM/Contact/Page/View/UserDashBoard.php
+++ b/CRM/Contact/Page/View/UserDashBoard.php
@@ -50,17 +50,12 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
     $userID = CRM_Core_Session::getLoggedInContactID();
 
     $userChecksum = $this->getUserChecksum();
-    $validUser = FALSE;
-    if ($userChecksum) {
-      $this->assign('userChecksum', $userChecksum);
-      $validUser = CRM_Contact_BAO_Contact_Utils::validChecksum($this->_contactId, $userChecksum);
-      $this->_isChecksumUser = $validUser;
-    }
+    $this->assign('userChecksum', $userChecksum);
 
     if (!$this->_contactId) {
       $this->_contactId = $userID;
     }
-    elseif ($this->_contactId != $userID && !$validUser) {
+    elseif ($this->_contactId != $userID && !$userChecksum) {
       if (!CRM_Contact_BAO_Contact_Permission::allow($this->_contactId, CRM_Core_Permission::VIEW)) {
         CRM_Core_Error::statusBounce(ts('You do not have permission to access this contact.'));
       }
@@ -92,6 +87,8 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
 
   /**
    * Build user dashboard.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildUserDashBoard() {
     //build component selectors
@@ -154,7 +151,7 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
       $this->assign('pcpInfo', $pcpInfo);
     }
 
-    if (!empty($dashboardOptions['Assigned Activities']) && empty($this->_isChecksumUser)) {
+    if (!empty($dashboardOptions['Assigned Activities']) && !$this->getUserChecksum()) {
       // Assigned Activities section
       $dashboardElements[] = [
         'class' => 'crm-dashboard-assignedActivities',
@@ -246,11 +243,12 @@ class CRM_Contact_Page_View_UserDashBoard extends CRM_Core_Page {
   /**
    * Get the user checksum from the url to use in links.
    *
-   * @return string
+   * @return string|false
+   * @throws \CRM_Core_Exception
    */
   protected function getUserChecksum() {
     $userChecksum = CRM_Utils_Request::retrieve('cs', 'String', $this);
-    if (empty($userID) && $this->_contactId) {
+    if ($this->_contactId && CRM_Contact_BAO_Contact_Utils::validChecksum($this->_contactId, $userChecksum)) {
       return $userChecksum;
     }
     return FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Fix e-notice & php8.2 issue on user dashboard

This addresses the first notice on the image below - but on looking I realised that there was also use of an undefined property. I removed it in favour of a function to be called.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/217964056-f350787e-8517-46a8-b3dd-2eb0d2e9e7cd.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/217964283-4a0960a9-38ab-4884-a3e1-5ce127dcbf55.png)

Technical Details
----------------------------------------
  I also moved the validation into the `getCheckSum` function - the checksum is only returned if `_contactId` is set (I considered renaming the property to `contactID` but sometimes on `CRM_Core_Form` the 2 variables are used differently....) so it makes sense to validate before returning rather than remember in the calling code. The Contribution dash also calls this code but the extra check seems fine or even good

Comments
----------------------------------------

