### PR TITLE
dev/core#4080 Fix wrong pdf format selection for invoice, when configured

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -233,10 +233,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     $refundedStatusId = CRM_Utils_Array::key('Refunded', $contributionStatusID);
     $cancelledStatusId = CRM_Utils_Array::key('Cancelled', $contributionStatusID);
     $pendingStatusId = CRM_Utils_Array::key('Pending', $contributionStatusID);
-    $pdfFormat = CRM_Core_BAO_PdfFormat::getByName('default_invoice_pdf_format');
-
+    $pdfFormat = CRM_Core_BAO_MessageTemplate::getPDFFormatForTemplate('contribution_invoice_receipt');
     foreach ($elementDetails as $contributionID => $detail) {
-      $input = $ids = [];
+      $input = [];
       if (in_array($detail['contact'], $excludedContactIDs)) {
         continue;
       }

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -203,7 +203,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
    */
   public static function getMessageTemplates($all = TRUE, $isSMS = FALSE) {
 
-    $messageTemplates = \Civi\Api4\MessageTemplate::get()
+    $messageTemplates = MessageTemplate::get()
       ->addSelect('id', 'msg_title')
       ->addWhere('is_active', '=', TRUE)
       ->addWhere('is_sms', '=', $isSMS);
@@ -216,6 +216,24 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
 
     asort($msgTpls);
     return $msgTpls;
+  }
+
+  /**
+   * Get the appropriate pdf format for the given template.
+   *
+   * @param string $workflow
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function getPDFFormatForTemplate(string $workflow): array {
+    $pdfFormatID = MessageTemplate::get(FALSE)
+      ->addWhere('workflow_name', '=', $workflow)
+      ->addSelect('pdf_format_id')
+      ->execute()->first()['pdf_format_id'] ?? 0;
+    // Get by ID will fall back to retrieving the default values if
+    // it does not find the appropriate ones - hence passing in 0 works.
+    return CRM_Core_BAO_PdfFormat::getById($pdfFormatID);
   }
 
   /**

--- a/CRM/Core/BAO/PdfFormat.php
+++ b/CRM/Core/BAO/PdfFormat.php
@@ -230,6 +230,7 @@ class CRM_Core_BAO_PdfFormat extends CRM_Core_DAO_OptionValue {
    *   (reference) associative array of name/value pairs
    */
   public static function &getByName($name) {
+    CRM_Core_Error::deprecatedFunctionWarning('none');
     return self::getPdfFormat('name', $name);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fix wrong pdf format selection for invoice, when configured

To replicate this I

1) created a new pdf format at civicrm/admin/pdfFormats?reset=1 with a top margin of about 6 metres
2) edited the invoice MessageTemplate to use this pdf format 3) enabled invoicing
4) generated a pdf from the user dashboard
5) lots of white space is the correct version
6) reset the invoice MessageTemplate not to have a selected pdf 7) it should look sane again



Before
----------------------------------------
Per the instructions - without this patch the insane version of the template is never used

After
----------------------------------------
The configured template is preferred

Technical Details
----------------------------------------

Comments
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4080