### PR TITLE
Fix custom field bug on UFMatch sync

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -179,16 +179,16 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
 
       $dao = NULL;
       if (!empty($_POST) && !$isLogin) {
-        $params = $_POST;
-        $params['email'] = $uniqId;
+        $dedupeParameters = $_POST;
+        $dedupeParameters['email'] = $uniqId;
         // dev/core#1858 Ensure that if we have a contactID parameter which is set in the Create user Record contact task form
-        // That this contacID value is passed through as the contact_id to the get duplicate contacts function. This is necessary because for Drupal 8 this function gets invoked
+        // That this contactID value is passed through as the contact_id to the get duplicate contacts function. This is necessary because for Drupal 8 this function gets invoked
         // Before the civicrm_uf_match record is added where as in D7 it isn't called until the user tries to actually login.
-        if (!empty($params['contactID'])) {
-          $params['contact_id'] = $params['contactID'];
+        if (!empty($dedupeParameters['contactID'])) {
+          $dedupeParameters['contact_id'] = $dedupeParameters['contactID'];
         }
 
-        $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($params, 'Individual', 'Unsupervised', [], FALSE);
+        $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($dedupeParameters, 'Individual', 'Unsupervised', [], FALSE);
 
         if (!empty($ids) && Civi::settings()->get('uniq_email_per_site')) {
           // restrict dupeIds to ones that belong to current domain/site.
@@ -235,6 +235,7 @@ AND    domain_id = %2
       }
 
       if (!$found) {
+        $contactParameters = [];
         // Not sure why we're testing for this. Is there ever a case
         // in which $user is not an object?
         if (is_object($user)) {
@@ -247,36 +248,39 @@ AND    domain_id = %2
           else {
             $primary_email = $user->email;
           }
-          $params['email'] = $primary_email;
+          $contactParameters['email'] = $primary_email;
+        }
+        else {
+          CRM_Core_Error::deprecatedWarning('please log how you hit this...');
         }
 
         if ($ctype === 'Organization') {
-          $params['organization_name'] = $uniqId;
+          $contactParameters['organization_name'] = $uniqId;
         }
         elseif ($ctype === 'Household') {
-          $params['household_name'] = $uniqId;
+          $contactParameters['household_name'] = $uniqId;
         }
 
-        $params['contact_type'] = $ctype ?? 'Individual';
+        $contactParameters['contact_type'] = $ctype ?? 'Individual';
 
         // extract first / middle / last name
         // for joomla
         if ($uf === 'Joomla' && $user->name) {
-          CRM_Utils_String::extractName($user->name, $params);
+          CRM_Utils_String::extractName($user->name, $dedupeParameters);
         }
 
         if ($uf === 'WordPress') {
           if ($user->first_name) {
-            $params['first_name'] = $user->first_name;
+            $contactParameters['first_name'] = $user->first_name;
           }
 
           if ($user->last_name) {
-            $params['last_name'] = $user->last_name;
+            $contactParameters['last_name'] = $user->last_name;
           }
         }
 
-        $contactId = civicrm_api3('Contact', 'create', $params)['id'];
-        $ufmatch->contact_id = $contactId;
+        $contactID = civicrm_api3('Contact', 'create', $contactParameters)['id'];
+        $ufmatch->contact_id = $contactID;
         $ufmatch->uf_name = $uniqId;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is an alternate fix to https://github.com/civicrm/civicrm-core/pull/25495

Before
----------------------------------------
If custom field data is in the profile an error can occur on contact create

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
The thinking here is that we have 2 use cases provided by `$params`

1) `$dedupeParameters` - use the `POST` parameters to see if the contact matches an existing contact
2) `$contactParamsters` - parameters used to create a contact if it does not already exist - only a limited set appears to be needed here as the rest of the save process seems to save the other variables as per this backtrace which happens afterwards

![image](https://user-images.githubusercontent.com/336308/218007616-0ede567e-3fc8-4b7b-9e6f-43f8cda72a65.png)


A better fix I think would be for the various UF classes to pass in the contact parameters rather than extract them in the function as this process starts with the CMS & the CMS should sort the parameters out before calling the Civi function

Comments
----------------------------------------

In my test I created a contact like this

![image](https://user-images.githubusercontent.com/336308/218007860-95d80578-9391-44dc-a8f2-29b051d7df51.png)

and all these fields are saved

![image](https://user-images.githubusercontent.com/336308/218007937-7f2dd953-5fb5-43e8-b5c2-85d8a8fa9064.png)

