### PR TITLE
Disambiguate `Address.state_province_id:abbr`

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1500,6 +1500,10 @@ WHERE  id = %1
     $from = 'FROM %3';
     $wheres = [];
     $order = 'ORDER BY %2';
+    if (in_array('id', $availableFields, TRUE)) {
+      // Example: 'ORDER BY abbreviation, id' because `abbreviation`s are not unique.
+      $order .= ', id';
+    }
 
     // Use machine name in certain contexts
     if ($context === 'validate' || $context === 'match') {


### PR DESCRIPTION
Overview
----------------------------------------

The test `ContactJoinTest::testCreateWithPrimaryAndBilling` is flaky. This stems from following:

```php
  'address_billing.state_province_id:abbr' => 'AK',
```

The symbol 'AK' can resolve to three places: Akwa Ibom (Nigeria), Atakora (Benin), and Alaska (USA). This is an ambiguous choice.  It should be resolved in a consistent way.

ping @colemanw 

Before
----------------------------------------

There are two layers of flakiness:

* __MySQL__: When it fetches `civicrm_state_province` records, it uses `ORDER BY abbreviation`. This is ambiguous.
* __PHP__: After receiving the list, it maps the results into various arrays and does some extra sorts. This provides a similar ordering. However,  depending on the PHP version, it may swap around equivalent abbreviations. (Thus, Akwa Ibom and Alaska can flip-flop their relative positions.)

The PHP flakiness is more apparent than the MySQL flakiness. You can easily switch PHP versions to observe the difference (which is why `testCreateWithPrimaryAndBilling` usually fails on `min` and usually passes on `max`). For MySQL, the problem depends more on internal/arbitrary details, and the test-assertions match the _usual_ behavior -- so failures there are less common.

After
----------------------------------------

Both layers should be consistent:

* __MySQL__: It fetches `civicrm_state_province` with `ORDER BY abbreviation, id`. This is unambiguous.
* __PHP__: PHP 7 now uses a different sort method - one which comes closer to the PHP 8 behavior.

