### PR TITLE
Upgrade test to use more recent methodology for testing forms

### DIFF
--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -95,6 +95,9 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
    * @param array|null $params
    */
   public function postProcess($params = NULL) {
+    if (!empty($params)) {
+      CRM_Core_Error::deprecatedWarning('params parameter is deprecated');
+    }
     $fv = $params ?: $this->controller->exportValues($this->_name);
     $locName = NULL;
 

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintMailingLabelTest.php
@@ -30,9 +30,9 @@ class CRM_Contact_Form_Task_PrintMailingLabelTest extends CiviUnitTestCase {
     Civi::settings()->set('searchPrimaryDetailsOnly', '0');
 
     $addresses = [];
-    // create non-primary and primary addresses of each contact
+    // Create non-primary and primary addresses of each contact.
     foreach ($contactIDs as $contactID) {
-      // create the non-primary address first
+      // Create the non-primary address first.
       foreach (['non-primary', 'primary'] as $flag) {
         // @TODO: bug - this doesn't affect as if its the first and only address created for a contact then it always consider it as primary
         $isPrimary = ($flag === 'primary');
@@ -59,15 +59,15 @@ class CRM_Contact_Form_Task_PrintMailingLabelTest extends CiviUnitTestCase {
       }
     }
 
-    $form = new CRM_Contact_Form_Task_Label();
-    $form->_contactIds = $contactIDs;
-    $params = [
+    /* @var CRM_Contact_Form_Task_Label $fom */
+    $form = $this->getFormObject('CRM_Contact_Form_Task_Label', [
       'label_name' => 3475,
       'location_type_id' => NULL,
       'do_not_mail' => 1,
-    ];
+    ]);
+    $form->_contactIds = $contactIDs;
     try {
-      $rows = $form->postProcess($params);
+      $rows = $form->postProcess();
       $this->fail('PrematureExitException expected');
     }
     catch (CRM_Core_Exception_PrematureExitException $e) {


### PR DESCRIPTION
The tested class had been hacked to accept parameters to postProcess, but we can now avoid that & it will likely be rejected in a later php version / muddy the waters

