### PR TITLE
Disambiguate `Address.state_province_id:abbr` (PHP asort)

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -580,6 +580,10 @@ class CRM_Utils_Array {
       $collator = new Collator($lcMessages . '.utf8');
       $collator->asort($array);
     }
+    elseif (version_compare(PHP_VERSION, '8', '<') && class_exists('Collator')) {
+      $collator = new Collator('en_US.utf8');
+      $collator->asort($array);
+    }
     else {
       // This calls PHP's built-in asort().
       asort($array);

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -117,7 +117,35 @@ class ContactJoinTest extends Api4TestBase {
       ->execute();
     $this->assertCount(1, $addr);
     $this->assertEquals('Hello', $contact['address_billing.city']);
+    $this->assertEquals(1001, $contact['address_billing.state_province_id']);
     $this->assertEquals(1228, $contact['address_billing.country_id']);
+    $emails = Email::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(2, $emails);
+    $this->assertEquals('a@test.com', $contact['email_primary.email']);
+    $this->assertEquals('b@test.com', $contact['email_billing.email']);
+  }
+
+  /**
+   * This is the same as testCreateWithPrimaryAndBilling, but the ambiguous
+   * state "AK" is resolved within a different country "NG".
+   */
+  public function testCreateWithPrimaryAndBilling_Nigeria() {
+    $contact = $this->createTestRecord('Contact', [
+      'email_primary.email' => 'a@test.com',
+      'email_billing.email' => 'b@test.com',
+      'address_billing.city' => 'Hello',
+      'address_billing.state_province_id:abbr' => 'AK',
+      'address_billing.country_id:abbr' => 'NG',
+    ]);
+    $addr = Address::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->execute();
+    $this->assertCount(1, $addr);
+    $this->assertEquals('Hello', $contact['address_billing.city']);
+    $this->assertEquals(3885, $contact['address_billing.state_province_id']);
+    $this->assertEquals(1157, $contact['address_billing.country_id']);
     $emails = Email::get(FALSE)
       ->addWhere('contact_id', '=', $contact['id'])
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------

The test `ContactJoinTest::testCreateWithPrimaryAndBilling` is flaky. This stems from following:

```php
  'address_billing.state_province_id:abbr' => 'AK',
```

The symbol 'AK' can resolve to three places: Akwa Ibom (Nigeria), Atakora (Benin), and Alaska (USA). This is an ambiguous choice.  It should be resolved in a consistent way.

(This is extracted from the bigger PR #25550. This one only addresses the PHP ambiguity. cc @colemanw)

Before
----------------------------------------

After loading the list of abbreviations from MySQL, it maps the results into various arrays and does some extra sorts (via `\CRM_Utils_Array::asort()` => `\asort()`). However,  as described in https://www.php.net/asort, the behavior is version-dependent:

>  If two members compare as equal, they retain their original order. Prior to PHP 8.0.0, their relative order in the sorted array was undefined.

In PHP 7, it can+does shift the relative positions of `1001=>AK` (*Alaska*), `1894=>AK` (*Atakora*), and  `3885=>AK` (*Akwa Ibom*).

After
----------------------------------------

PHP 7 now uses a different sort method - one which comes closer to the PHP 8 behavior.

The effect is to preserve the relative order determined by MySQL.

Comments
----------------------------------------

The `Collator` class is provided by extension `intl`. As per `CRM/Utils/Check/Component/Env.php` (`checkPHPIntlExists`), the extension is already recommended.