### PR TITLE
Smarty - Defer initialization

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -69,14 +69,14 @@ class CRM_Core_Smarty extends Smarty {
   private function initialize() {
     $config = CRM_Core_Config::singleton();
 
+    $this->template_dir = $config->templateDir;
     if (isset($config->customTemplateDir) && $config->customTemplateDir) {
-      $this->template_dir = array_merge([$config->customTemplateDir],
-        $config->templateDir
-      );
+      $this->addTemplateDir($config->customTemplateDir);
     }
-    else {
-      $this->template_dir = $config->templateDir;
+    foreach (\Civi::$statics['CRM_Core_Smarty']['PATHS'] ?? [] as $dir) {
+      $this->addTemplateDir($dir);
     }
+
     $this->compile_dir = CRM_Utils_File::addTrailingSlash(CRM_Utils_File::addTrailingSlash($config->templateCompileDir) . $this->getLocale());
     CRM_Utils_File::createDir($this->compile_dir);
     CRM_Utils_File::restrictAccess($this->compile_dir);
@@ -158,10 +158,12 @@ class CRM_Core_Smarty extends Smarty {
    * Method providing static instance of SmartTemplate, as
    * in Singleton pattern.
    *
+   * @param bool $autoCreate
+   *   If TRUE, and if the Smarty service does not exist already, then create it.
    * @return \CRM_Core_Smarty
    */
-  public static function &singleton() {
-    if (!isset(self::$_singleton)) {
+  public static function &singleton(bool $autoCreate = TRUE) {
+    if (!isset(self::$_singleton) && $autoCreate) {
       self::$_singleton = new CRM_Core_Smarty();
       self::$_singleton->initialize();
 

--- a/mixin/smarty-v2@1/mixin.php
+++ b/mixin/smarty-v2@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty-v2
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.1.0
  * @since 5.59
  *
  * @param CRM_Extension_MixInfo $mixInfo
@@ -19,13 +19,12 @@ return function ($mixInfo, $bootCache) {
   }
 
   $register = function() use ($dir) {
-    // This implementation is useful for older versions of CiviCRM. It can be replaced/updated going forward (v1.1+).
-    $smarty = CRM_Core_Smarty::singleton();
-    if (!is_array($smarty->template_dir)) {
-      $this->template_dir = [$smarty->template_dir];
-    }
-    if (!in_array($dir, $smarty->template_dir)) {
-      array_unshift($smarty->template_dir, $dir);
+    \Civi::$statics['CRM_Core_Smarty']['PATHS'][] = $dir;;
+    if (class_exists('CRM_Core_Smarty', FALSE)) {
+      $smarty = CRM_Core_Smarty::singleton(FALSE);
+      if ($smarty !== NULL) {
+        $smarty->addTemplateDir($dir);
+      }
     }
   };
 

--- a/tools/mixin/bin/mixer
+++ b/tools/mixin/bin/mixer
@@ -273,7 +273,7 @@ function main($args) {
     }
   }
 
-  if (function_exists($task)) {
+  if ($task && function_exists($task)) {
     call_user_func($task, $newOptions, ...$newArgs);
   }
   else {


### PR DESCRIPTION
Overview
----------------------------------------

TBD related to #25362

Before
----------------------------------------

Suppose an extension registers for `<mixin>smarty-v2@1</mixin>`. In the usual page-load, it registers a `hook_config` listener that accesses `CRM_Core_Config::singleton()` (*and therefore initializes Smarty during the middle of `hook_config`*).

After
----------------------------------------

Suppose an extension registers for `<mixin>smarty-v2@1</mixin>`. In the usual page-load, it registers a `hook_config` listener to enqueue a new dir -- but it does instantiate `CRM_Core_Config`.

Technical Details
----------------------------------------

To see this in action, it's a little tricky - because many extensions do the same thing. You need all the extensions to play ball. So, here's how I checked it:

1. Trim the list of active extensions:

    ```
    [bknix-max:~/bknix/build/dmaster/web/sites/all/modules/civicrm/ext] cv ext:list -Li
    +----------+------------------------+------------+-------------+-----------+-------------+
    | location | key                    | name       | version     | status    | downloadUrl |
    +----------+------------------------+------------+-------------+-----------+-------------+
    | local    | authx                  | authx      | 5.60.alpha1 | installed |             |
    | local    | greenwich              | greenwich  | 5.60.alpha1 | installed |             |
    | local    | org.civicrm.flexmailer | flexmailer | 5.60.alpha1 | installed |             |
    | local    | org.civicrm.search_kit | search_kit | 5.60.alpha1 | installed |             |
    +----------+------------------------+------------+-------------+-----------+-------------+
    ```

2. [Locally upgrade the remaining extensions](https://github.com/civicrm/civicrm-core/commit/9898db925e19ca9ee80efdebfed2689c00333d20)

3. Set a break-point in `CRM_Core_Smarty::initialize()` and view a web-page. Note the callstack -- we are _not_ in the middle of hook-config. We've actually started running the page.

    <img width="905" alt="Screen Shot 2023-02-10 at 6 41 39 PM" src="https://user-images.githubusercontent.com/1336047/218235308-119cff6d-c282-4500-a290-a9ad1134c9d2.png">


