### PR TITLE
Fix fatal error on upgrade success screen

### DIFF
--- a/templates/CRM/common/success.tpl
+++ b/templates/CRM/common/success.tpl
@@ -48,10 +48,6 @@
         </p>
       </div>
       <p><span class="crm-status-icon success"> </span>{$message}</p>
-      {if array_key_exists($afterUpgradeMessage, $form) && $afterUpgradeMessage}
-        <h3>{ts}Important Notes{/ts}</h3>
-        <p>{$afterUpgradeMessage|smarty:nodefaults}</p>
-      {/if}
       <p><a href="{crmURL p='civicrm/dashboard' q='reset=1'}" title="{ts}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
     </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/25544

Before
----------------------------------------
Fatal error since there is no $form variable.

After
----------------------------------------

Technical Details
----------------------------------------
There is no such variable as afterUpgradeMessage either - it's old code. You can see this if you grep for it it doesn't show up anywhere but here, and note that it used to exist [in svn](https://github.com/civicrm/civicrm-svn/blob/46df80d543362780c1661eb51aa32503e5ec53e5/CRM/Upgrade/Incremental/php/FourOne.php#L77).

Comments
----------------------------------------

