### PR TITLE
[REF][PHP8.2] Declare property in CRM_Utils_FakeObject

### DIFF
--- a/CRM/Utils/FakeObject.php
+++ b/CRM/Utils/FakeObject.php
@@ -29,7 +29,12 @@
 class CRM_Utils_FakeObject {
 
   /**
-   * @param $array
+   * @var array
+   */
+  protected $array;
+
+  /**
+   * @param array $array
    */
   public function __construct($array) {
     $this->array = $array;


### PR DESCRIPTION
Overview
----------------------------------------
Declare `$array` property on class `CRM_Utils_FakeObject`.

Before
----------------------------------------
`CRM_Utils_FakeObject` used a dynamic property `$array`; dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
Property declared.

Comments
----------------------------------------
This `CRM_Utils_FakeObject` is only used in core in `CRM_Core_Config_MailerTest`, and therefore this change should allow `CRM_Core_Config_MailerTest` to pass on PHP 8.2. 

I doubt `CRM_Utils_FakeObject` is widely used in the Civi ecosystem, so making `$array` protected hopefully won't cause any problems (although I've not actually done a universe check)
