### PR TITLE
[REF][PHP8.2] Use variable instead of dynmaic property (CRM_Group_Page_AjaxTest)

### DIFF
--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -723,10 +723,10 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
       ) VALUES (55, 'civicrm_group', $groupId, 1);
     ");
     // Put the user into this group
-    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    $loggedInUser = CRM_Core_Session::singleton()->get('userID');
     $this->callAPISuccess('group_contact', 'create', [
       'group_id' => $groupId,
-      'contact_id' => $this->_loggedInUser,
+      'contact_id' => $loggedInUser,
     ]);
     // Add the ACL
     CRM_Core_DAO::executeQuery("


### PR DESCRIPTION
Overview
----------------------------------------
Use variable instead of dynmaic property (CRM_Group_Page_AjaxTest)

Before
----------------------------------------
`_loggedInUser` is a dynamic property. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
There appears to be no reason this just can't be a standard variable. 