### PR TITLE
Mailing Summary Report: support pseudofields

### DIFF
--- a/CRM/Report/Form/Mailing/Summary.php
+++ b/CRM/Report/Form/Mailing/Summary.php
@@ -334,9 +334,11 @@ class CRM_Report_Form_Mailing_Summary extends CRM_Report_Form {
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
+          if (!empty($field['pseudofield'])) {
+            continue;
+          }
           if (!empty($field['required']) || !empty($this->_params['fields'][$fieldName])) {
-
-            # for statistics
+            // For statistics
             if (!empty($field['statistics'])) {
               switch ($field['statistics']['calc']) {
                 case 'PERCENTAGE':


### PR DESCRIPTION
Overview
----------------------------------------

Report columns maybe be "pseudofields", i.e. fields that are ignored in the automatic SQL generation (ex: to run a separate SQL query during the `alterDisplay`).

Before
----------------------------------------

Mailing Summary Report crashes if a pseudo field is added by an extension.

After
----------------------------------------

Does not crash.

Comments
----------------------------------------

If you're wondering why:

I have an old extension that calculates "[mailing engagement](https://civicrm.org/extensions/mailing-engagement)", and more specifically, how many donations came in after a specific mailing (by assuming that any mailing recipient who donated 5 days following the mailing, probably did because of the mailing).

So I know reports are what they are, but this patch would allow me to pretty easily add those metrics to the Mailing Summary report (and doing by adding to the `rows`, because otherwise the SQL query would be too heavy/complex).

https://lab.civicrm.org/extensions/mailingengagement/-/blob/master/CRM/Mailingengagement/Report/MailingSummary.php