### PR TITLE
[REF][PHP8.2] Remove use of dynamic properties in CRM_Contact_Form_Task_EmailTest

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/EmailTest.php
@@ -18,16 +18,23 @@ use Civi\Api4\Activity;
 class CRM_Contact_Form_Task_EmailTest extends CiviUnitTestCase {
 
   /**
+   * Option value for 'From Email Address' option,
+   * created as part of test setup.
+   *
+   * @var array
+   */
+  private $optionValue;
+
+  /**
    * Set up for tests.
    *
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->_contactIds = [
-      $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']),
-      $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']),
-    ];
-    $this->_optionValue = $this->callAPISuccess('optionValue', 'create', [
+    $this->individualCreate(['first_name' => 'Antonia', 'last_name' => 'D`souza']);
+    $this->individualCreate(['first_name' => 'Anthony', 'last_name' => 'Collins']);
+
+    $this->optionValue = $this->callAPISuccess('optionValue', 'create', [
       'label' => '"Seamus Lee" <seamus@example.com>',
       'option_group_id' => 'from_email_address',
     ]);
@@ -50,10 +57,10 @@ class CRM_Contact_Form_Task_EmailTest extends CiviUnitTestCase {
     $emails = CRM_Core_BAO_Email::domainEmails();
     $this->assertNotEmpty($emails);
     $optionValue = $this->callAPISuccess('OptionValue', 'Get', [
-      'id' => $this->_optionValue['id'],
+      'id' => $this->optionValue['id'],
     ]);
     $this->assertArrayHasKey('"Seamus Lee" <seamus@example.com>', $emails);
-    $this->assertEquals('"Seamus Lee" <seamus@example.com>', $optionValue['values'][$this->_optionValue['id']]['label']);
+    $this->assertEquals('"Seamus Lee" <seamus@example.com>', $optionValue['values'][$this->optionValue['id']]['label']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove use of dynamic properties in CRM_Contact_Form_Task_EmailTest

Before
----------------------------------------
Use of dynamic properties, which are deperecated in PHP 8.2.

After
----------------------------------------
Properties are declared and/or removed; no longer used dynamically.

Comments
----------------------------------------
I think there may still be an issue where the test assigns to `$form->_fromEmails`, but I think that's best looked at seperately as it's not a property on the test class itself.
