### PR TITLE
dev/core#4123 Support contribution recur tokens when accessing from a…

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -10,6 +10,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\ContributionRecur;
+
 /**
  * Class CRM_Contribute_Tokens
  *
@@ -44,6 +46,28 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
    */
   public function getCurrencyFieldName() {
     return ['currency'];
+  }
+
+  /**
+   * Get Related Entity tokens.
+   *
+   * @return array[]
+   */
+  protected function getRelatedTokens(): array {
+    $tokens = [];
+    $hiddenTokens = ['modified_date', 'create_date', 'trxn_id', 'invoice_id', 'is_test', 'payment_token_id', 'payment_processor_id', 'payment_instrument_id', 'cycle_day', 'installments', 'processor_id', 'next_sched_contribution_date', 'failure_count', 'failure_retry_date', 'auto_renew', 'is_email_receipt', 'contribution_status_id'];
+    $contributionRecurFields = ContributionRecur::getFields(FALSE)->setLoadOptions(TRUE)->execute();
+    foreach ($contributionRecurFields as $contributionRecurField) {
+      $tokens['contribution_recur_id.' . $contributionRecurField['name']] = [
+        'title' => $contributionRecurField['title'],
+        'name' => 'contribution_recur_id.' . $contributionRecurField['name'],
+        'type' => 'mapped',
+        'options' => $contributionRecurField['options'] ?? NULL,
+        'data_type' => $contributionRecurField['data_type'],
+        'audience' => in_array($contributionRecurField['name'], $hiddenTokens) ? 'hidden' : 'user',
+      ];
+    }
+    return $tokens;
   }
 
 }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -78,6 +78,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     $cacheKey = $this->getCacheKey();
     if (!Civi::cache('metadata')->has($cacheKey)) {
       $tokensMetadata = $this->getBespokeTokens();
+      $tokensMetadata = array_merge($tokensMetadata, $this->getRelatedTokens());
       foreach ($this->getFieldMetadata() as $field) {
         $this->addFieldToTokenMetadata($tokensMetadata, $field, $this->getExposedFields());
       }
@@ -272,6 +273,13 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * Get any tokens with custom calculation.
    */
   protected function getBespokeTokens(): array {
+    return [];
+  }
+
+  /**
+   * Get related entity tokens.
+   */
+  protected function getRelatedTokens(): array {
     return [];
   }
 

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -10,6 +10,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\ContributionRecur;
+
 /**
  * Class CRM_Member_Tokens
  *
@@ -120,6 +122,26 @@ class CRM_Member_Tokens extends CRM_Core_EntityTokens {
         'audience' => 'user',
       ],
     ];
+  }
+
+  /**
+   * Get related tokens related to membership e.g. recurring contribution tokens
+   */
+  protected function getRelatedTokens(): array {
+    $tokens = [];
+    $hiddenTokens = ['modified_date', 'create_date', 'trxn_id', 'invoice_id', 'is_test', 'payment_token_id', 'payment_processor_id', 'payment_instrument_id', 'cycle_day', 'installments', 'processor_id', 'next_sched_contribution_date', 'failure_count', 'failure_retry_date', 'auto_renew', 'is_email_receipt', 'contribution_status_id'];
+    $contributionRecurFields = ContributionRecur::getFields(FALSE)->setLoadOptions(TRUE)->execute();
+    foreach ($contributionRecurFields as $contributionRecurField) {
+      $tokens['contribution_recur_id.' . $contributionRecurField['name']] = [
+        'title' => $contributionRecurField['title'],
+        'name' => 'contribution_recur_id.' . $contributionRecurField['name'],
+        'type' => 'mapped',
+        'options' => $contributionRecurField['options'] ?? NULL,
+        'data_type' => $contributionRecurField['data_type'],
+        'audience' => in_array($contributionRecurField['name'], $hiddenTokens) ? 'hidden' : 'user',
+      ];
+    }
+    return $tokens;
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -426,6 +426,18 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends \Civi\ActionSchedule\Abstr
         'paid_amount' => 'Amount Paid',
         'balance_amount' => 'Balance',
         'tax_exclusive_amount' => 'Tax Exclusive Amount',
+        'contribution_recur_id.id' => 'Recurring Contribution ID',
+        'contribution_recur_id.contact_id' => 'Contact ID',
+        'contribution_recur_id.amount' => 'Amount',
+        'contribution_recur_id.currency' => 'Currency',
+        'contribution_recur_id.frequency_unit' => 'Frequency Unit',
+        'contribution_recur_id.frequency_interval' => 'Interval (number of units)',
+        'contribution_recur_id.start_date' => 'Start Date',
+        'contribution_recur_id.cancel_date' => 'Cancel Date',
+        'contribution_recur_id.cancel_reason' => 'Cancellation Reason',
+        'contribution_recur_id.end_date' => 'Recurring Contribution End Date',
+        'contribution_recur_id.financial_type_id' => 'Financial Type ID',
+        'contribution_recur_id.campaign_id' => 'Campaign ID',
       ], $comparison);
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -520,7 +520,7 @@ contribution_recur.payment_instrument_id:name :Check
     $tokens = $tokenProcessor->listTokens();
     // Add in custom tokens as token processor supports these.
     $expectedTokens = array_merge($expectedTokens, $this->getTokensAdvertisedByTokenProcessorButNotLegacy());
-    $this->assertEquals(array_merge($expectedTokens, $this->getDomainTokens()), $tokens);
+    $this->assertEquals(array_merge($expectedTokens, $this->getDomainTokens(), $this->getRecurEntityTokens('membership')), $tokens);
     $tokenProcessor->addMessage('html', $tokenString, 'text/plain');
     $tokenProcessor->addRow(['membershipId' => $this->getMembershipID()]);
     $tokenProcessor->evaluate();
@@ -954,6 +954,27 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{event.registration_url}' => 'Event Registration URL',
       '{event.pay_later_receipt}' => 'Pay Later Receipt Text',
       '{event.' . $this->getCustomFieldName('text') . '}' => 'Enter text here :: Group with field text',
+    ];
+  }
+
+  /**
+   * @param string $entity
+   *
+   * @return string[]
+   */
+  protected function getRecurEntityTokens($entity): array {
+    return [
+      '{' . $entity . '.contribution_recur_id.id}' => 'Recurring Contribution ID',
+      '{' . $entity . '.contribution_recur_id.contact_id}' => 'Contact ID',
+      '{' . $entity . '.contribution_recur_id.amount}' => 'Amount',
+      '{' . $entity . '.contribution_recur_id.currency}' => 'Currency',
+      '{' . $entity . '.contribution_recur_id.frequency_unit}' => 'Frequency Unit',
+      '{' . $entity . '.contribution_recur_id.frequency_interval}' => 'Interval (number of units)',
+      '{' . $entity . '.contribution_recur_id.start_date}' => 'Start Date',
+      '{' . $entity . '.contribution_recur_id.cancel_date}' => 'Cancel Date',
+      '{' . $entity . '.contribution_recur_id.cancel_reason}' => 'Cancellation Reason',
+      '{' . $entity . '.contribution_recur_id.end_date}' => 'Recurring Contribution End Date',
+      '{' . $entity . '.contribution_recur_id.financial_type_id}' => 'Financial Type ID',
     ];
   }
 


### PR DESCRIPTION
… contribution or membership

Overview
----------------------------------------
This is an alterative to https://github.com/civicrm/civicrm-core/pull/22450 and picks up Eileen's comment on that PR to add support for using `{contribution.contribution_recur_id.x}` or `{membership.contribution_recur_id.x}` tokens

Before
----------------------------------------
Cannot access Contribution Recur Related fields from contribution or membership records in token process

After
----------------------------------------
Can do so

ping @eileenmcnaughton @mattwire @JoeMurray 