### PR TITLE
Make `activity_type_id` available to `links` hook, test

### DIFF
--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -303,6 +303,10 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
           'id' => $result->activity_id,
           'cid' => $contactId,
           'cxt' => $this->_context,
+          // Parameter for hook locked in by CRM_Activity_Selector_SearchTest
+          // Any additional parameters added should follow apiv4 style
+          // and be added to the test.
+          'activity_type_id' => $row['activity_type_id'],
         ],
         ts('more'),
         FALSE,

--- a/tests/phpunit/CRM/Activity/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Activity/Selector/SearchTest.php
@@ -78,9 +78,44 @@ class CRM_Activity_Selector_SearchTest extends CiviUnitTestCase {
    *
    * @return array
    */
-  protected function getSearchRows(array $queryParams, ?CRM_Utils_Sort $sort): array {
+  protected function getSearchRows(array $queryParams = [], ?CRM_Utils_Sort $sort = NULL): array {
     $searchSelector = new CRM_Activity_Selector_Search($queryParams, CRM_Core_Action::VIEW);
     return $searchSelector->getRows(4, 0, 50, $sort);
+  }
+
+  /**
+   * Test activity_type_id reaches the hook.
+   */
+  public function testActivityLinkHook(): void {
+    $this->activityCreate([]);
+    CRM_Utils_Hook::singleton()
+      ->setHook('civicrm_links', [__CLASS__, 'linkHook']);
+    $row = $this->getSearchRows()[0];
+    $this->assertEquals('<span></span>', $row['action'], 'Value should be unset by hook');
+  }
+
+  /**
+   * Implement link hook to check activity_type_id is set.
+   *
+   * @param string $op
+   *   The type of operation being performed.
+   * @param string $objectName
+   *   The name of the object.
+   * @param int $objectId
+   *   The unique identifier for the object.
+   * @param array $links
+   *   (optional) the links array (introduced in v3.2).
+   * @param int|null $mask
+   *   (optional) the bitmask to show/hide links.
+   * @param array $values
+   *   (optional) the values to fill the links.
+   *
+   * @noinspection PhpUnusedParameterInspection
+   */
+  public static function linkHook(string $op, string $objectName, int &$objectId, array &$links, int &$mask = NULL, array $values = []): void {
+    if ($values['activity_type_id']) {
+      $links = [];
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Make activity_type_id available to links hook, test

Before
----------------------------------------
The hook `links` has the opportunity to alter the search links for activities - but would have to do a db lookup to determine the `activity_type_id` - even though this is already known to the caller

After
----------------------------------------
`activity_type_id` added, tested

Technical Details
----------------------------------------
The use-case here is just to add anothe activity type as read-only. I would have liked to do it via the schema & make it configurable. However, the only 'free' field is the mysterious `grouping` and the hard-coded options are currently pretty complex ie

Participant activity types - view link is for the participant record
Contribution activity types - view link is for the contribution record
Payment & Refund activity types - view link is for the participant record, if there is one, otherwise activity record
Membership activity types - view link is for the membership record
Pledge Acknowledgement -, view only link - but with more fields (that are no more relevant) than Email 'civicrm/contact/view/activity'
Email, Bulk Email -, view only link - with limited fields `'civicrm/activity/view'`
Inbound email  - same as pledge, permissioned edit link
Case activities - default view link of overloaded edit form, no edit,delete
Default  - default view link of overloaded edit form


Comments
----------------------------------------