### PR TITLE
Filter expired searches from search kit results

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/IsCurrentFieldSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/IsCurrentFieldSpecProvider.php
@@ -51,7 +51,7 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
    * @return string
    */
   private function getRenderer(string $entity): string {
-    if (in_array($entity, ['UserJob', 'Search'])) {
+    if (in_array($entity, ['UserJob', 'SavedSearch'])) {
       return 'renderNonExpiredSql';
     }
     return 'renderIsCurrentSql';
@@ -69,7 +69,7 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
     }
     // TODO: If we wanted this to not be a hard-coded list, we could always return TRUE here
     // and then in the `modifySpec` function check for the 3 fields `is_active`, `start_date`, and `end_date`
-    return in_array($entity, ['Relationship', 'RelationshipCache', 'Event', 'Campaign', 'Search', 'UserJob'], TRUE);
+    return in_array($entity, ['Relationship', 'RelationshipCache', 'Event', 'Campaign', 'SavedSearch', 'UserJob'], TRUE);
   }
 
   /**

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -56,7 +56,7 @@
             ['Group AS group', 'LEFT', ['id', '=', 'group.saved_search_id']],
             ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],
           ],
-          where: [['api_entity', 'IS NOT NULL']],
+          where: [['api_entity', 'IS NOT NULL'], ['is_current', '=', true]],
           groupBy: ['id']
         }
       };

--- a/tests/phpunit/api/v4/Action/CurrentFilterTest.php
+++ b/tests/phpunit/api/v4/Action/CurrentFilterTest.php
@@ -22,6 +22,7 @@ namespace api\v4\Action;
 use Civi\Api4\Relationship;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Api4\SavedSearch;
 use Civi\Api4\UserJob;
 use Civi\Test\TransactionalInterface;
 
@@ -125,7 +126,37 @@ class CurrentFilterTest extends Api4TestBase implements TransactionalInterface {
 
     $this->assertTrue($getAll[$current['id']]['is_current']);
     $this->assertTrue($getAll[$indefinite['id']]['is_current']);
-    $this->assertFALSE($getAll[$expired['id']]['is_current']);
+    $this->assertFalse($getAll[$expired['id']]['is_current']);
+
+    $this->assertEquals([$current['id'], $indefinite['id']], array_keys($getCurrent));
+    $this->assertEquals([$expired['id']], array_keys($notCurrent));
+  }
+
+  /**
+   * Test saved search api checks expires_date.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCurrentSavedSearch(): void {
+    $current = SavedSearch::create()->setValues([
+      'expires_date' => '+ 1 week',
+      'name' => 'current',
+    ])->execute()->first();
+    $indefinite = SavedSearch::create()->setValues([
+      'name' => 'never expires',
+    ])->execute()->first();
+    $expired = SavedSearch::create()->setValues([
+      'expires_date' => '-1 week',
+      'name' => 'expired',
+    ])->execute()->first();
+
+    $getCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', TRUE)->execute()->indexBy('id');
+    $notCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', FALSE)->execute()->indexBy('id');
+    $getAll = (array) SavedSearch::get()->addSelect('is_current')->execute()->indexBy('id');
+
+    $this->assertTrue($getAll[$current['id']]['is_current']);
+    $this->assertTrue($getAll[$indefinite['id']]['is_current']);
+    $this->assertFalse($getAll[$expired['id']]['is_current']);
 
     $this->assertEquals([$current['id'], $indefinite['id']], array_keys($getCurrent));
     $this->assertEquals([$expired['id']], array_keys($notCurrent));


### PR DESCRIPTION
Overview
----------------------------------------
Filter expired searches from search kit results

Before
----------------------------------------
`expires_date` field ignored when deciding which searches to show in search kit screen


After
----------------------------------------
only `is_current` searches display

Technical Details
----------------------------------------
The `UserJob` searches have an expires date & respecting this helps reduce clutter & reduces risk of bad behaviour is the 
temp table is removed

Comments
----------------------------------------
