### PR TITLE
Fix empty values of Note on Import contribution

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -810,6 +810,9 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    * @throws \CRM_Core_Exception
    */
   protected function processNote(int $contributionID, int $contactID, array $noteParams): void {
+    if (!$noteParams['note']) {
+      return;
+    }
     $noteParams = array_merge([
       'entity_table' => 'civicrm_contribution',
       'entity_id' => $contributionID,


### PR DESCRIPTION
Overview
----------------------------------------
Related to [https://lab.civicrm.org/dev/core/-/issues/4105](https://lab.civicrm.org/dev/core/-/issues/4105)

If in import contributions I map the field 'Note' and if there are rows with an empty value, I get this error:

**`"Mandatory values missing from Api4 Note::save: note"`**

Before
----------------------------------------
For rows with emtpy notes I have this error: 

**`"Mandatory values missing from Api4 Note::save: note"`**


After
----------------------------------------
Now Notes can be emtpy.
