### PR TITLE
update entity mapping logic for profile fields to include contact subtypes

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -629,8 +629,19 @@ function _civicrm_api3_order_by_weight($a, $b) {
  */
 function _civicrm_api3_map_profile_fields_to_entity(&$field) {
   $entity = $field['field_type'];
-  $contactTypes = civicrm_api3('contact', 'getoptions', ['field' => 'contact_type']);
-  if (in_array($entity, $contactTypes['values'])) {
+  // let's get the contact types and subtypes so that we can change the entity
+  // of such fields to 'contact'
+  $result = civicrm_api3('ContactType', 'get', [
+    'return' => ["name"],
+    'options' => ['limit' => 0],
+  ]);
+
+  $contactTypes = [];
+  foreach ($result['values'] as $type) {
+    $contactTypes[$type['id']] = $type['name'];
+  }
+
+  if (in_array($entity, $contactTypes)) {
     $entity = 'contact';
   }
   $entity = _civicrm_api_get_entity_name_from_camel($entity);


### PR DESCRIPTION
Overview
----------------------------------------
Currently fields belonging to contact subtypes are not mapped to correct entity hence it results in a fatal error using profile submit API.

Steps to replicate
----------------------------------------
- Use Contact Summary Layout extension and add a section using profile with fields that belong to contact sub type.
- Inline edit fails

Proposed solution
----------------------------------------
- We already update fields that belong to contact types to `contact`. In this PR I have extended the logic to also include contact subtypes.
 

