### PR TITLE
dev/core#4127 use userSystem method to check for Views

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -401,7 +401,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
     // prompt Drupal Views users to update $db_prefix in settings.php, if necessary
     global $db_prefix;
     $config = CRM_Core_Config::singleton();
-    if (is_array($db_prefix) && $config->userSystem->is_drupal && module_exists('views')) {
+    if (is_array($db_prefix) && $config->userSystem->viewsExists()) {
       // get table_name for each custom group
       $tables = [];
       $sql = "SELECT table_name FROM civicrm_custom_group WHERE is_active = 1";


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/4127 (first item)

**For testing:** when creating a Group, if any tables are not in the civi tables array in Drupal's settings file, then it will list the tables to add.

(This is fine for Drupal 7 and Backdrop, but this is not needed for Drupal 8+ so there should be a future issue to fix that.)