### PR TITLE
CiviContribute - Fix warning about 'suppressedEmails' when generating PDF

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -244,14 +244,13 @@ AND    {$this->_componentClause}";
     $pdfElements = [];
     $pdfElements['details'] = self::getDetails(implode(',', $contribIds));
     $excludeContactIds = [];
+    $suppressedEmails = 0;
     if (!$isCreatePDF) {
       $contactDetails = civicrm_api3('Contact', 'get', [
         'return' => ['email', 'do_not_email', 'is_deceased', 'on_hold'],
         'id' => ['IN' => $contactIds],
         'options' => ['limit' => 0],
       ])['values'];
-      $pdfElements['suppressedEmails'] = 0;
-      $suppressedEmails = 0;
       foreach ($contactDetails as $id => $values) {
         if (empty($values['email']) ||
           (empty($params['override_privacy']) && !empty($values['do_not_email']))
@@ -259,11 +258,11 @@ AND    {$this->_componentClause}";
           || !empty($values['on_hold'])
         ) {
           $suppressedEmails++;
-          $pdfElements['suppressedEmails'] = $suppressedEmails;
           $excludeContactIds[] = $values['contact_id'];
         }
       }
     }
+    $pdfElements['suppressedEmails'] = $suppressedEmails;
     $pdfElements['excludeContactIds'] = $excludeContactIds;
 
     return $pdfElements;


### PR DESCRIPTION
Overview
----------------------------------------

Use-case:

* Open and execute "Find Contributions"
* Next to a contribution, choose "more > Send receipt"
* Make a PDF
    ![Screenshot from 2023-02-14 19-11-09](https://user-images.githubusercontent.com/1336047/218918208-30a98cf8-ff0a-4005-837f-73f025695c8d.png)
* Open another tab and view any other page.
* There is warning: `Undefined index: suppressedEmails in CRM_Contribute_Form_Task_PDF->postProcess()`

    ![Screenshot from 2023-02-14 19-11-20](https://user-images.githubusercontent.com/1336047/218918206-bbc695c6-cfb9-49b1-9006-864457041cc0.png)



Before
----------------------------------------

* `$pdfElements['suppressedEmails']` is not always returned
* `$pdfElements['excludeContactIds']` is alsways returned

After
----------------------------------------

* Both are always returned, even if empty

