### PR TITLE
dev/core#4119 Only generate error on blank confirm_title if confirmat…

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -444,7 +444,8 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       if (($values['registration_link_text'] ?? '') === '') {
         $errorMsg['registration_link_text'] = ts('Please enter Registration Link Text');
       }
-      if (($values['confirm_title'] ?? '') === '') {
+      // Check if the confirm text is set if we have enabled the confirmation page or page is monetary which forces the confirm page.
+      if (($values['confirm_title'] ?? '') === '' && (!empty($values['is_confirm_enabled']) || CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_id, 'is_monetary'))) {
         $errorMsg['confirm_title'] = ts('Please enter a Title for the registration Confirmation Page');
       }
       if (($values['thankyou_title'] ?? '') === '') {


### PR DESCRIPTION
…ion page is enabled or the event is monetary

Overview
----------------------------------------
When executing the form rule the confirm title is checked to make sure it is not empty even if is_confirm_enabled is false

Before
----------------------------------------
False error message displays

After
----------------------------------------
Proper checking for confirm title is done

Technical Details
----------------------------------------
Is confirm enabled checkbox only shows if the event is not monetary https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/ManageEvent/Registration.php#L383 so that is why we need to check both is_monetary and if is_confirm_enabled is set

ping @totten @eileenmcnaughton 