### PR TITLE
dev/core#4127 move mailing workflow check to userSystem

### DIFF
--- a/CRM/Mailing/Info.php
+++ b/CRM/Mailing/Info.php
@@ -159,21 +159,7 @@ class CRM_Mailing_Info extends CRM_Core_Component_Info {
    */
   public static function workflowEnabled() {
     $config = CRM_Core_Config::singleton();
-
-    // early exit, since not true for most
-    if (!$config->userSystem->is_drupal ||
-      !function_exists('module_exists')
-    ) {
-      return FALSE;
-    }
-
-    if (!module_exists('rules')) {
-      return FALSE;
-    }
-
-    $enableWorkflow = Civi::settings()->get('civimail_workflow');
-
-    return $enableWorkflow && $config->userSystem->is_drupal;
+    return $config->userSystem->mailingWorkflowIsEnabled();
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1152,4 +1152,13 @@ abstract class CRM_Utils_System_Base {
     return $_SERVER['REMOTE_ADDR'] ?? NULL;
   }
 
+  /**
+   * Check if mailing workflow is enabled
+   *
+   * @return bool
+   */
+  public function mailingWorkflowIsEnabled():bool {
+    return FALSE;
+  }
+
 }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -932,4 +932,17 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     return class_exists('Drupal') ? \Drupal::request()->getClientIp() : ($_SERVER['REMOTE_ADDR'] ?? NULL);
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function mailingWorkflowIsEnabled():bool {
+    if (!\Drupal::moduleHandler()->moduleExists('rules')) {
+      return FALSE;
+    }
+
+    $enableWorkflow = Civi::settings()->get('civimail_workflow');
+
+    return (bool) $enableWorkflow;
+  }
+
 }

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -763,4 +763,17 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     return $emailName;
   }
 
+  /**
+   * @inheritdoc
+   */
+  public function mailingWorkflowIsEnabled():bool {
+    if (!module_exists('rules')) {
+      return FALSE;
+    }
+
+    $enableWorkflow = Civi::settings()->get('civimail_workflow');
+
+    return (bool) $enableWorkflow;
+  }
+
 }


### PR DESCRIPTION
Refactors https://lab.civicrm.org/dev/core/-/issues/4127 (item 6).

Moves the check for the mailing workflow to the userSystem. It boils down to whether a Drupal/Backdrop Rules module is enabled and set to be used in civimail. Small change is to cast the return to a boolean since it's possible that the settings bag returns a NULL (not sure though).