### PR TITLE
api4 explorer: make boolean params work in cv (short syntax)

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -798,6 +798,9 @@
                     code.short += ' +l ' + (params.limit || '0') + (params.offset ? ('@' + params.offset) : '');
                   }
                   break;
+                case (typeof param === 'boolean'):
+                  code.short += ' ' + key + '=' + (param ? 1 : 0);
+                  break;
                 default:
                   code.short += ' ' + key + '=' + (typeof param === 'string' ? cliFormat(param) : cliFormat(JSON.stringify(param)));
               }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4129

Before
----------------------------------------
In API v4 explorer, boolean params are rendered in CV (short) syntax as `true` or `false`. The generated code does not work in `cv`.

After
----------------------------------------
Params are rendered as `1` or `0`. Generated code works in `cv`.