### PR TITLE
Fix more schema checks to use mysql DATABASE() function, deprecate php function

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1108,7 +1108,7 @@ class CRM_Core_DAO extends DB_DataObject {
     $dao = CRM_Core_DAO::executeQuery(
       "SELECT TABLE_NAME
        FROM information_schema.TABLES
-       WHERE TABLE_SCHEMA = '" . CRM_Core_DAO::getDatabaseName() . "'
+       WHERE TABLE_SCHEMA = DATABASE()
          AND TABLE_NAME LIKE 'civicrm_%'
          AND TABLE_NAME NOT LIKE '%_tmp%'
       ");
@@ -1130,7 +1130,7 @@ class CRM_Core_DAO extends DB_DataObject {
       "SELECT count(*)
        FROM information_schema.TABLES
        WHERE ENGINE = 'MyISAM'
-         AND TABLE_SCHEMA = '" . CRM_Core_DAO::getDatabaseName() . "'
+         AND TABLE_SCHEMA = DATABASE()
          AND TABLE_NAME LIKE 'civicrm_%'
          AND TABLE_NAME NOT LIKE 'civicrm_tmp_%'
       ");
@@ -1139,11 +1139,12 @@ class CRM_Core_DAO extends DB_DataObject {
   /**
    * Get the name of the CiviCRM database.
    *
+   * @deprecated use mysql DATABASE() within the query.
+   *
    * @return string
    */
-  public static function getDatabaseName() {
-    $daoObj = new CRM_Core_DAO();
-    return $daoObj->database();
+  public static function getDatabaseName(): string {
+    return (new CRM_Core_DAO())->database();
   }
 
   /**

--- a/CRM/Core/InnoDBIndexer.php
+++ b/CRM/Core/InnoDBIndexer.php
@@ -163,7 +163,7 @@ class CRM_Core_InnoDBIndexer {
     $dao = CRM_Core_DAO::executeQuery("
   SELECT index_name as index_name
   FROM information_Schema.STATISTICS
-  WHERE table_schema = '" . CRM_Core_DAO::getDatabaseName() . "'
+  WHERE table_schema = DATABASE()
     AND table_name = '$table'
     AND index_type = 'FULLTEXT'
   GROUP BY index_name

--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -207,12 +207,11 @@ class CRM_Upgrade_Snapshot {
     $query = '
       SELECT TABLE_NAME as tableName
       FROM   INFORMATION_SCHEMA.TABLES
-      WHERE  TABLE_SCHEMA = %1
-      AND TABLE_NAME LIKE %2
+      WHERE  TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME LIKE %1
     ';
     $tables = CRM_Core_DAO::executeQuery($query, [
-      1 => [$dao->database(), 'String'],
-      2 => ["snap_{$owner}_v%", 'String'],
+      1 => ["snap_{$owner}_v%", 'String'],
     ])->fetchMap('tableName', 'tableName');
 
     $oldTables = array_filter($tables, function($table) use ($owner, $cutoff) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix more schema checks to use mysql DATABASE() function, deprecate php function

Before
----------------------------------------
Use of php layer to get db name

After
----------------------------------------
Use of mysql `DATABASE()` function

Technical Details
----------------------------------------
This replaces enough of them that hopefully copy & paste will use it from now on - the php function most used is now deprecated

Comments
----------------------------------------
@seamuslee001 I think you merged the others of these