### PR TITLE
Deprecate unused `CRM_Core_BAO_UFField::copy()` function

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -285,12 +285,15 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
    * Copy existing profile fields to
    * new profile from the already built profile
    *
+   * @deprecated
+   *
    * @param int $old_id
    *   From which we need to copy.
    * @param bool $new_id
    *   In which to copy.
    */
   public static function copy($old_id, $new_id) {
+    CRM_Core_Error::deprecatedFunctionWarning('');
     $ufField = new CRM_Core_DAO_UFField();
     $ufField->uf_group_id = $old_id;
     $ufField->find();


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate unused `CRM_Core_BAO_UFField::copy()` function

Before
----------------------------------------
I searched core code & universe for usages of this function and did not find them. The place where it logically WOULD have been called from does NOT call it -  ie when copying a profile the `copyGeneric` function is used to duplicate these fields
https://github.com/civicrm/civicrm-core/commit/3fec1adc393f63bb7acc9d51ec43716f4d987b9d#diff-a8aa0473142a72fc757b2dd20805fa12454951109989fab7cc06a4f0b112a9b1R2714

After
----------------------------------------
Future me will not have to do this research to discover it is unused

Technical Details
----------------------------------------
I was looking to see how consistent the signature for `copy` is - this function does not follow the more common pattern - see 

https://lab.civicrm.org/dev/core/-/issues/4130



Comments
----------------------------------------
