### PR TITLE
APIv4 - Limited support for casting

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -227,7 +227,7 @@ abstract class AbstractAction implements \ArrayAccess {
           return $this->$param;
 
         case 'set':
-          $this->$param = $arguments[0];
+          $this->$param = ReflectionUtils::castTypeSoftly($arguments[0], $this->getParamInfo()[$param] ?? []);
           return $this;
       }
     }

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -217,19 +217,26 @@ class ReflectionUtils {
   }
 
   /**
-   * Cast the $value to the preferred $type.
+   * Cast the $value to the preferred $type (if we're fairly confident).
    *
    * This is like PHP's `settype()` but totally not. It only casts in narrow circumstances.
-   * This reflects an opinion that some casts are better than others.
+   * This reflects an opinion that some castings are better than others.
    *
-   *    - Good:   1         =>   TRUE
-   *    - Bad:    'hello'   =>   TRUE
+   * These will be converted:
+   *
+   *    cast('123', 'int') => 123
+   *    cast('123.4', 'float') => 123.4
+   *    cast('0', 'bool') => FALSE
+   *    cast(1, 'bool') => TRUE
+   *
+   * However, a string like 'hello' will never cast to bool, int, or float -- because that's
+   * a senseless request. We'll leave that to someone else to figure.
    *
    * @param mixed $value
    * @param array $paramInfo
    * @return mixed
    *   If the $value is agreeable to casting according to a type-rule from $paramInfo, then
-   *   we return the converted value. Otherwise, leave return the original value.
+   *   we return the converted value. Otherwise, return the original value.
    */
   public static function castTypeSoftly($value, array $paramInfo) {
     if (count($paramInfo['type'] ?? []) !== 1) {
@@ -243,6 +250,19 @@ class ReflectionUtils {
           return (bool) $value;
         }
         break;
+
+      case 'int':
+        if (is_numeric($value)) {
+          return (int) $value;
+        }
+        break;
+
+      case 'float':
+        if (is_numeric($value)) {
+          return (float) $value;
+        }
+        break;
+
     }
 
     return $value;

--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -216,4 +216,36 @@ class ReflectionUtils {
     }
   }
 
+  /**
+   * Cast the $value to the preferred $type.
+   *
+   * This is like PHP's `settype()` but totally not. It only casts in narrow circumstances.
+   * This reflects an opinion that some casts are better than others.
+   *
+   *    - Good:   1         =>   TRUE
+   *    - Bad:    'hello'   =>   TRUE
+   *
+   * @param mixed $value
+   * @param array $paramInfo
+   * @return mixed
+   *   If the $value is agreeable to casting according to a type-rule from $paramInfo, then
+   *   we return the converted value. Otherwise, leave return the original value.
+   */
+  public static function castTypeSoftly($value, array $paramInfo) {
+    if (count($paramInfo['type'] ?? []) !== 1) {
+      // I don't know when or why fields can have multiple types. We're just gone leave-be.
+      return $value;
+    }
+
+    switch ($paramInfo['type'][0]) {
+      case 'bool':
+        if (in_array($value, [0, 1, '0', '1'], TRUE)) {
+          return (bool) $value;
+        }
+        break;
+    }
+
+    return $value;
+  }
+
 }

--- a/tests/phpunit/Civi/API/RequestTest.php
+++ b/tests/phpunit/Civi/API/RequestTest.php
@@ -68,4 +68,34 @@ class RequestTest extends \CiviUnitTestCase {
     Request::create($inEntity, $inAction, ['version' => $inVersion], NULL);
   }
 
+  public function getCastingExamples(): array {
+    $exs = [];
+    // We run the same tests on `$checkPermissions` (which has real PHP setter method)
+    // and `$useTrash` (which has a generic magic method) to show that casting is similar.
+    $exs[] = ['Contact.delete checkPermissions', 0, FALSE];
+    $exs[] = ['Contact.delete checkPermissions', '0', FALSE];
+    $exs[] = ['Contact.delete checkPermissions', 1, TRUE];
+    $exs[] = ['Contact.delete checkPermissions', '1', TRUE];
+    $exs[] = ['Contact.delete useTrash', 0, FALSE];
+    $exs[] = ['Contact.delete useTrash', '0', FALSE];
+    $exs[] = ['Contact.delete useTrash', 1, TRUE];
+    $exs[] = ['Contact.delete useTrash', '1', TRUE];
+    return $exs;
+  }
+
+  /**
+   * @param $entityActionField
+   * @param $inputValue
+   * @param $expectValue
+   * @dataProvider getCastingExamples
+   */
+  public function testCasting(string $entityActionField, $inputValue, $expectValue): void {
+    [$entity, $action, $field] = preg_split('/[ \.]/', $entityActionField);
+    $request = Request::create($entity, $action, ['version' => 4, $field => $inputValue]);
+    $getter = 'get' . ucfirst($field);
+    $actualValue = call_user_func([$request, $getter]);
+    $this->assertEquals(gettype($actualValue), gettype($expectValue));
+    $this->assertTrue($actualValue === $expectValue);
+  }
+
 }

--- a/tests/phpunit/Civi/API/RequestTest.php
+++ b/tests/phpunit/Civi/API/RequestTest.php
@@ -68,34 +68,4 @@ class RequestTest extends \CiviUnitTestCase {
     Request::create($inEntity, $inAction, ['version' => $inVersion], NULL);
   }
 
-  public function getCastingExamples(): array {
-    $exs = [];
-    // We run the same tests on `$checkPermissions` (which has real PHP setter method)
-    // and `$useTrash` (which has a generic magic method) to show that casting is similar.
-    $exs[] = ['Contact.delete checkPermissions', 0, FALSE];
-    $exs[] = ['Contact.delete checkPermissions', '0', FALSE];
-    $exs[] = ['Contact.delete checkPermissions', 1, TRUE];
-    $exs[] = ['Contact.delete checkPermissions', '1', TRUE];
-    $exs[] = ['Contact.delete useTrash', 0, FALSE];
-    $exs[] = ['Contact.delete useTrash', '0', FALSE];
-    $exs[] = ['Contact.delete useTrash', 1, TRUE];
-    $exs[] = ['Contact.delete useTrash', '1', TRUE];
-    return $exs;
-  }
-
-  /**
-   * @param $entityActionField
-   * @param $inputValue
-   * @param $expectValue
-   * @dataProvider getCastingExamples
-   */
-  public function testCasting(string $entityActionField, $inputValue, $expectValue): void {
-    [$entity, $action, $field] = preg_split('/[ \.]/', $entityActionField);
-    $request = Request::create($entity, $action, ['version' => 4, $field => $inputValue]);
-    $getter = 'get' . ucfirst($field);
-    $actualValue = call_user_func([$request, $getter]);
-    $this->assertEquals(gettype($actualValue), gettype($expectValue));
-    $this->assertTrue($actualValue === $expectValue);
-  }
-
 }

--- a/tests/phpunit/api/v4/Action/AbstractActionTest.php
+++ b/tests/phpunit/api/v4/Action/AbstractActionTest.php
@@ -41,10 +41,46 @@ class AbstractActionTest extends Api4TestBase {
       protected $magicBool;
 
       /**
+       * @var float
+       */
+      protected $simpleFloat;
+
+      /**
+       * @var float
+       */
+      protected $magicFloat;
+
+      /**
+       * @var int
+       */
+      protected $simpleInt;
+
+      /**
+       * @var int
+       */
+      protected $magicInt;
+
+      /**
        * @param bool $simpleBool
        */
       public function setSimpleBool(bool $simpleBool) {
         $this->simpleBool = $simpleBool;
+        return $this;
+      }
+
+      /**
+       * @param float $simpleFloat
+       */
+      public function setSimpleFloat(float $simpleFloat) {
+        $this->simpleFloat = $simpleFloat;
+        return $this;
+      }
+
+      /**
+       * @param int $simpleInt
+       */
+      public function setSimpleInt(int $simpleInt) {
+        $this->simpleInt = $simpleInt;
         return $this;
       }
 
@@ -69,6 +105,36 @@ class AbstractActionTest extends Api4TestBase {
         [1, TRUE],
         ['1', TRUE],
       ],
+    ];
+
+    $exs['float'] = [
+      ['simpleFloat', 'magicFloat'],
+      [
+        // Each item is an example: [$inputValue, $expectValue]
+        [0, 0.0],
+        ['0', 0.0],
+        [100, 100.0],
+        ['200', 200.0],
+        [300.5, 300.5],
+        ['400.6', 400.6],
+      ],
+    ];
+
+    $exs['int'] = [
+      ['simpleInt', 'magicInt'],
+      [
+        // Each item is an example: [$inputValue, $expectValue]
+        [0, 0],
+        ['0', 0],
+        [100, 100],
+        ['200', 200],
+      ],
+    ];
+
+    // Magic fields are nullable. Not saying that's good or bad. It just is.
+    $exs['null'] = [
+      ['magicBool', 'magicFloat', 'magicInt'],
+      [[NULL, NULL]],
     ];
 
     return $exs;

--- a/tests/phpunit/api/v4/Action/AbstractActionTest.php
+++ b/tests/phpunit/api/v4/Action/AbstractActionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ * @group headless
+ */
+class AbstractActionTest extends Api4TestBase {
+
+  protected function createExample(): AbstractAction {
+    return new class('Example', 'gogo') extends AbstractAction {
+
+      /**
+       * @var bool
+       */
+      protected $simpleBool;
+
+      /**
+       * @var bool
+       */
+      protected $magicBool;
+
+      /**
+       * @param bool $simpleBool
+       */
+      public function setSimpleBool(bool $simpleBool) {
+        $this->simpleBool = $simpleBool;
+        return $this;
+      }
+
+      /**
+       * @param \Civi\Api4\Generic\Result $result
+       */
+      public function _run(Result $result) {
+      }
+
+    };
+  }
+
+  public function getCastingExamples(): array {
+    $exs = [];
+
+    $exs['bool'] = [
+      ['simpleBool', 'magicBool'],
+      [
+        // Each item is an example: [$inputValue, $expectValue]
+        [0, FALSE],
+        ['0', FALSE],
+        [1, TRUE],
+        ['1', TRUE],
+      ],
+    ];
+
+    return $exs;
+  }
+
+  /**
+   * When you set a property on an APIv4 action, it should apply some type-casting rules -- even
+   * if the property has magic methods.
+   *
+   * @param string[] $fields
+   *   Name of a PHP properties to test. (See `createExample()` object.)
+   * @param array $conversions
+   *   List of inputs and their expected outputs.
+   *   Ex: [[1, TRUE], ['1', TRUE]]
+   * @dataProvider getCastingExamples
+   * @see \Civi\Api4\Utils\ReflectionUtils::castTypeSoftly()
+   */
+  public function testCasting(array $fields, array $conversions): void {
+    $this->assertTrue(!empty($fields) && !empty($conversions));
+    foreach ($fields as $field) {
+      foreach ($conversions as $conversion) {
+        [$inputValue, $expectValue] = $conversion;
+        $desc = sprintf("For field %s, casting should convert %s to %s", $field, json_encode($inputValue), json_encode($expectValue));
+        $setter = 'set' . ucfirst($field);
+        $getter = 'get' . ucfirst($field);
+
+        $request = $this->createExample();
+        call_user_func([$request, $setter], $inputValue);
+        $actualValue = call_user_func([$request, $getter]);
+        $this->assertEquals(gettype($actualValue), gettype($expectValue), "$desc");
+        $this->assertTrue($actualValue === $expectValue, $desc);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
-------------

Update the handling of top-level request options (`AbstractAction::$foo`) so that the magic setter behaves more like a simple setter.

ping @highfalutin cc @colemanw 

Before
------

* `setCheckPermissions(0)` casts the `0` to `false`.
    * This is because it's a concrete setter with explict typing, so PHP rules kick-in.
    * Subsequently, APIv4 validation of `$this->checkPermissions` passes.
* `setUseTrash(0)` does not.
    * This is because it's a magic setter with no typing, so PHP rules don't kick in.
    * Subsequently, APIv4 validation of `$this->useTrash` fails.

After
-----

* Both `setCheckPermissions(0)` and `setUseTrash(0)` cast the `0` to `false`.
* `setUseTrash(0)` does not support all the same conversion rules as PHP. It just supports the 0/1 rule.

Technical Details
-----------------

I initially drafted in a way where `setUseTrash()` performed exactly the same casting as `setCheckPermissions()`, but there was a countervailing test to assert that `setDebug('debug')` is invalid, and that seemed fair.
