### PR TITLE
distmaker - Fix export of WordPress patches

### DIFF
--- a/distmaker/dists/patchset.sh
+++ b/distmaker/dists/patchset.sh
@@ -30,7 +30,11 @@ dm_export_patches "$SRC/drupal-8"   "$TRG/civicrm-drupal-8"   $REFTAG..$DM_REF_D
 dm_export_patches "$SRC/backdrop"   "$TRG/civicrm-backdrop"   1.x-$REFTAG..$DM_REF_BACKDROP
 dm_export_patches "$SRC/packages"   "$TRG/civicrm-packages"   $REFTAG..$DM_REF_PACKAGES
 dm_export_patches "$SRC/joomla"     "$TRG/civicrm-joomla"     $REFTAG..$DM_REF_JOOMLA
-dm_export_patches "$SRC/wordpress"  "$TRG/civicrm-wordpress"  $REFTAG..$DM_REF_WORDPRESS
+if [ -d "$SRC/WordPress" ]; then
+  dm_export_patches "$SRC/WordPress"  "$TRG/civicrm-wordpress"  $REFTAG..$DM_REF_WORDPRESS
+else
+  dm_export_patches "$SRC/wordpress"  "$TRG/civicrm-wordpress"  $REFTAG..$DM_REF_WORDPRESS
+fi
 
 
 # gen tarball


### PR DESCRIPTION
Overview
----------------------------------------

When generating releases for ESR, there's an extra file called `*-patchset.tar.gz` that includes patch files for each repo.

There is a bug when generating `*-patchset.tar.gz` on the standard build system (`cividist`) in which it skips the WordPress patches.

cc @kcristiano @seamuslee001 

Before
----------------------------------------

`cividist` creates `$SRC/WordPress`, but the patch-export looks for `$SRC/wordpress`.

After
----------------------------------------

Patch-export works with either (and prefers the canonical `$SRC/WordPress`).

Comments
----------------------------------------

This is particularly tricky to test. I can say that I ran it locally (with the patch applied to my copy of `5.57-security`), and it worked fine.

For normal public releases, this file isn't needed or generated. (It's easy to get the git repos.) So it's really only important to get it into `5.57-security` and future `X.Y-security` branches (i.e. `5.63-security`).