### PR TITLE
Fix handling of invalid sql query during import

### DIFF
--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -81,7 +81,12 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
   public function initialize(): void {
     $table = CRM_Utils_SQL_TempTable::build()->setDurable();
     $tableName = $table->getName();
-    $table->createWithQuery($this->getSubmittedValue('sqlQuery'));
+    try {
+      $table->createWithQuery($this->getSubmittedValue('sqlQuery'));
+    }
+    catch (PEAR_Exception $e) {
+      throw new CRM_Core_Exception($e->getMessage(), 0, ['exception' => $e]);
+    }
 
     // Get the names of the fields to be imported.
     $columnsResult = CRM_Core_DAO::executeQuery(

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -177,7 +177,12 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       $this->flushDataSource();
       $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     }
-    $this->instantiateDataSource();
+    try {
+      $this->instantiateDataSource();
+    }
+    catch (CRM_Core_Exception $e) {
+      CRM_Core_Error::statusBounce($e->getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix handling of invalid sql query during import

To replicate this be sure to log in as admin rather than demo

Attempt an import with an invalid sql query

![image](https://user-images.githubusercontent.com/336308/219524443-32e1969e-9539-44c3-b797-90c152ffd10d.png)


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/219524357-8b6209ce-011d-45a3-94be-46c51a85b723.png)


After
----------------------------------------
Page reloads as 

![image](https://user-images.githubusercontent.com/336308/219520845-13e82153-703f-45fc-9f65-e179ab4d339d.png)


Technical Details
----------------------------------------
UPDATE - the exception stuff is being moved to a separate PR

The main thing going on in this PR is trying to think about what is going on with Exceptions. My general thoughts on Exceptions is that any anticipated Exception that arises from within CiviCRM that is handled in a different subsystem than it was generated in should be a version of `CRM_Core_Exception`. This would mean that all CiviCRM code or DB errors arising from CiviCRM sql calls would be caught by catching `CRM_Core_Exception`. From there we can have more nuanced exceptions.

This is not currently the case. Any code that runs `CRM_Core_DAO::executeQuery()` indirectly or directly may have to deal with an uncaught `PEAR_Exception`. 

This PR doesn't change that but starts to propose what an alternative that implements some / most of what `PEAR_Exception` provides - ie

- a way to get the mysql error code `getErrorCode`
- a way to get the PEAR error code `getPEARErrorCode`
- a way to get a message suitable for display to users `getUserMessage` 
- a way to get the erroneous sql
- a way to get the debug info

One thing it doesn't do is handle protecting the usefulness of the backtrace - I figured I'd worry about that if it became the blocker

A couple more things I realised in the process
- the API Kernel has helpers to get info out of the error object - I copied these in since getting db error out of exceptions is kinda tricky
- `CRM_Core_Exception` extends `PEAR_Exception` - I'm not a fan.

Comments
----------------------------------------
This is an alternative to https://github.com/civicrm/civicrm-core/pull/25171 - although I suspect it will stall so I'm going to put up the context part as a more limited patch to get that merged
