### PR TITLE
Remove unused constants left over from import cleanup

### DIFF
--- a/CRM/Activity/Import/Form/DataSource.php
+++ b/CRM/Activity/Import/Form/DataSource.php
@@ -20,10 +20,6 @@
  */
 class CRM_Activity_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/import/activity';
-
-  const IMPORT_ENTITY = 'Activity';
-
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *

--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -20,10 +20,6 @@
  */
 class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/contribute/import';
-
-  const IMPORT_ENTITY = 'Contribution';
-
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -22,10 +22,6 @@ use Civi\Api4\CustomGroup;
  */
 class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/import/custom';
-
-  const IMPORT_ENTITY = 'Multi value custom data';
-
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -20,10 +20,6 @@
  */
 class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/event/import';
-
-  const IMPORT_ENTITY = 'Participant';
-
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -20,10 +20,6 @@
  */
 class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
 
-  const PATH = 'civicrm/member/import';
-
-  const IMPORT_ENTITY = 'Membership';
-
   /**
    * Get the name of the type to be stored in civicrm_user_job.type_id.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused constants left over from import cleanup

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/219531537-ead5b3b1-87bf-4500-80dc-8bf522404daf.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
The IMPORT_ENTITY became obsolete during https://github.com/civicrm/civicrm-core/pull/25173 - I didn't remove it then because it would have conflicted with removing PATH in https://github.com/civicrm/civicrm-core/pull/25171 - but having reviewed https://github.com/civicrm/civicrm-core/pull/25171 any update based on review will remove the focus on the class properties so we should procede with merging this

Comments
----------------------------------------
Note both @mattwire are I investigated the `PATH` constant 