### PR TITLE
Add 'SavePoint' to import to statusBounce back to

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2616,6 +2616,17 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * Push the current url to the userContext.
+   *
+   * This is like a save point :-). The next status bounce will
+   * return the browser to this url unless another is added.
+   */
+  protected function pushUrlToUserContext(): void {
+    CRM_Core_Session::singleton()
+      ->pushUserContext(CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1'));
+  }
+
+  /**
    * Set options and attributes for chain select fields based on the controlling field's value
    */
   private function preProcessChainSelectFields() {

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -25,6 +25,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
    * Set variables up before form is built.
    */
   public function preProcess(): void {
+    $this->pushUrlToUserContext();
     // check for post max size
     CRM_Utils_Number::formatUnitSize(ini_get('post_max_size'), TRUE);
     $this->assign('importEntity', $this->getTranslatedEntity());


### PR DESCRIPTION
Overview
----------------------------------------
Add 'SavePoint' to import to statusBounce back to

Before
----------------------------------------
If you `statusBounce` during imports you could wind up anyway & lost all your game progress

After
----------------------------------------
New savePoint at the start of the import - you only go back that far

Technical Details
----------------------------------------
This is a partial from https://github.com/civicrm/civicrm-core/pull/25171 / 
https://github.com/civicrm/civicrm-core/pull/25600 - it took me a while to figure out how to do this without all the extra code in the original PR so I decided to put it in it's own function.... 

Comments
----------------------------------------
@mattwire if we merge this then only the exception part remains from your PR