### PR TITLE
E-notice fix Ical display

### DIFF
--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -177,6 +177,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     }
 
     $this->assign('iCal', CRM_Event_BAO_Event::getICalLinks($this->_eventId));
+    $this->assign('isShowICalIconsInline', TRUE);
 
     $this->freeze();
 

--- a/CRM/Event/Page/DashBoard.php
+++ b/CRM/Event/Page/DashBoard.php
@@ -42,6 +42,7 @@ class CRM_Event_Page_DashBoard extends CRM_Core_Page {
     $this->assign('actionColumn', $actionColumn);
     $this->assign('eventSummary', $eventSummary);
     $this->assign('iCal', CRM_Event_BAO_Event::getICalLinks());
+    $this->assign('isShowICalIconsInline', FALSE);
   }
 
   /**

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -47,6 +47,7 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $this->assign('context', $context);
 
     $this->assign('iCal', CRM_Event_BAO_Event::getICalLinks($this->_id));
+    $this->assign('isShowICalIconsInline', TRUE);
 
     // Sometimes we want to suppress the Event Full msg
     $noFullMsg = CRM_Utils_Request::retrieve('noFullMsg', 'String', $this, FALSE, 'false');

--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -227,6 +227,7 @@ class CRM_Event_Page_ManageEvent extends CRM_Core_Page {
     // assign vars to templates
     $this->assign('action', $action);
     $this->assign('iCal', CRM_Event_BAO_Event::getICalLinks());
+    $this->assign('isShowICalIconsInline', FALSE);
     $id = CRM_Utils_Request::retrieve('id', 'Positive',
       $this, FALSE, 0, 'REQUEST'
     );

--- a/templates/CRM/Event/Page/iCalLinks.tpl
+++ b/templates/CRM/Event/Page/iCalLinks.tpl
@@ -9,7 +9,7 @@
 *}
 {* Display icons / links for ical download and feed for EventInfo.tpl, ThankYou.tpl, DashBoard.tpl, and ManageEvent.tpl *}
   {foreach from=$iCal item="iCalItem"}
-  <a href="{$iCalItem.url}" {if !empty($event)} class="crm-event-feed-link"{/if}>
+  <a href="{$iCalItem.url}" {if $isShowICalIconsInline} class="crm-event-feed-link"{/if}>
     <span class="fa-stack" aria-hidden="true"><i class="crm-i fa-calendar-o fa-stack-2x"></i><i style="top: 15%;" class="crm-i {$iCalItem.icon} fa-stack-1x"></i></span>
     <span class="label">{$iCalItem.text}</span>
   </a>


### PR DESCRIPTION
Overview
----------------------------------------
E-notice fix Ical display - shows with [smarty hardening enabled](https://docs.civicrm.org/dev/en/latest/security/outputs/)

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/219829364-6fb4de6d-4746-4eaa-99d2-d11d6dadf603.png)


After
----------------------------------------

![image](https://user-images.githubusercontent.com/336308/219829590-437750d9-4b2f-48db-86fb-0245fa50ac95.png)


Technical Details
----------------------------------------
@agh1 you consolidated this code here https://github.com/civicrm/civicrm-core/pull/17282/files#diff-a08f2607f559a427fd42efaff52632ccc3f70565cc367c4a67c7b992cc0ce10fR12 and used the sometimes-present `$event` variable as a standin for 'something'. To be notice free we really need to [use something that is always assigned](https://docs.civicrm.org/dev/en/latest/security/outputs/#gotcha-2-smarty-notices). It was fairly easy to make sure a variable was always assigned as there are 4 discrete places - slightly harder was knowing what to call it  - I came up with `isShowICalIconsInline` - do you think that is accurate?

Update I just realised it actually changes the 'linkiness' of the appearance too

![image](https://user-images.githubusercontent.com/336308/219829373-f2083236-922d-4733-8c0d-b02b7eb556c0.png)


Comments
----------------------------------------
