### PR TITLE
Fix test method eventCreatePaid for php 8.2

### DIFF
--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -105,8 +105,9 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       $sum += $financialItem['amount'];
     }
     $this->assertEquals(55, $sum);
-
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $participant['id'], 'participant', $contribution['id'], $this->eventFeeBlock, $lineItem);
+    $priceSetID = $this->ids['PriceSet']['event'];
+    $eventFeeBlock = CRM_Price_BAO_PriceSet::getSetDetail($priceSetID)[$priceSetID]['fields'];
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $participant['id'], 'participant', $contribution['id'], $eventFeeBlock, $lineItem);
     // Check that no payment records have been created.
     // In https://lab.civicrm.org/dev/financial/issues/94 we had an issue where payments were created when none happend.
     $payments = $this->callAPISuccess('Payment', 'get', [])['values'];

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1089,9 +1089,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->ids['Event'][$key] = (int) $event['id'];
     $this->ids['PriceSet'][$key] = $this->eventPriceSetCreate(55, 0, 'Radio', $options);
     CRM_Price_BAO_PriceSet::addTo('civicrm_event', $event['id'], $this->ids['PriceSet'][$key]);
-    $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($this->ids['PriceSet'][$key], TRUE, FALSE);
-    $priceSet = $priceSet[$this->ids['PriceSet'][$key]] ?? NULL;
-    $this->eventFeeBlock = $priceSet['fields'] ?? NULL;
     return $event;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix test method eventCreatePaid for php 8.2

There was another fix in here but it led to a tricky e-notice