### PR TITLE
Regression: Fix DB syntax error on Parse address scheduled  job

### DIFF
--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -134,7 +134,10 @@ class CRM_Utils_Address_BatchUpdate {
       $clause[] = '( a.country_id is not null )';
     }
 
-    $whereClause = implode(' AND ', $clause);
+    $whereClause = '';
+    if (!empty($clause)) {
+      $whereClause = 'WHERE ' . implode(' AND ', $clause);
+    }
 
     $query = "
       SELECT c.id,
@@ -152,7 +155,7 @@ class CRM_Utils_Address_BatchUpdate {
         ON a.country_id = o.id
       LEFT JOIN civicrm_state_province s
         ON a.state_province_id = s.id
-      WHERE {$whereClause}
+      {$whereClause}
       ORDER BY a.id
     ";
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix DB syntax error on `Geocode and Parse Addresses` scheduled job when geocoding is set to 0

Before
----------------------------------------
The `Geocode and Parse Addresses` scheduled job fails with a DB:Syntax error

![image](https://user-images.githubusercontent.com/5929648/219844618-caa1ade0-52b6-49dc-87f3-1e360628edeb.png)

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Related PR: https://github.com/civicrm/civicrm-core/pull/23351
