### PR TITLE
Afform: Fix broken syntax for saving reciprocal relationships

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -361,9 +361,11 @@ class Submit extends AbstractProcessor {
           ];
           // Reciprocal relationship types need an extra check
           if ($isReciprocal) {
-            $where[] = ['OR',
-              ['AND', ['contact_id_a', '=', $contact_id_a], ['contact_id_b', '=', $contact_id_b]],
-              ['AND', ['contact_id_a', '=', $contact_id_b], ['contact_id_b', '=', $contact_id_a]],
+            $where[] = [
+              'OR', [
+                ['AND', [['contact_id_a', '=', $contact_id_a], ['contact_id_b', '=', $contact_id_b]]],
+                ['AND', [['contact_id_a', '=', $contact_id_b], ['contact_id_b', '=', $contact_id_a]]],
+              ],
             ];
           }
           else {


### PR DESCRIPTION
Overview
----------------------------------------
The syntax for saving reciprocal relationships is wrong and API4 fails (with 500 internal server error) on form submission if you have a relationship of that type on the form.

Before
----------------------------------------
Form submission fails with 500 internal server error if you have reciprocal relationship on the form.

After
----------------------------------------
Form submission succeeds - relationship is saved!

Technical Details
----------------------------------------
After inserting a bunch of debug statements I narrowed down the issue to the `processRelationships()` function and then the API4 syntax. Comparing with API4 explorer shows the code was wrong and did not have enough [[[[]]]]

Comments
----------------------------------------
@colemanw 