### PR TITLE
[REF][PHP8.2] Remove unnecessary dynamic property

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -474,7 +474,6 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
    * @throws \Exception
    */
   public function testGetFieldsForImport() {
-    $this->entity = 'Contact';
     $this->createCustomGroupWithFieldsOfAllTypes();
     $customGroupID = $this->ids['CustomGroup']['Custom Group'];
     $expected = [

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -723,7 +723,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    */
   public function testExportCustomData(): void {
     $this->setUpContactExportData();
-    $this->entity = 'Contact';
     $this->createCustomGroupWithFieldsOfAllTypes();
     $longString = 'Blah';
     for ($i = 0; $i < 70; $i++) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unnecessary dynamic property `$entity`

Before
----------------------------------------
`$this->entity` is set as `'Contact'` which is then used in `createCustomGroup` which is called by `createCustomGroupWithFieldsOfAllTypes`. However, if `$this->entity` is not set then `'Contact'` is used as the default value, making the `$this->entity = 'Contact';` redundant.

The `$this->entity` calls were writing to dynamic properties, which are deprecated in PHP 8.2.

After
----------------------------------------
Cleaner code, and closer to PHP 8.2. support.