### PR TITLE
(REF) Remove test reference to property which no longer exists

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -1794,7 +1794,6 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->userJobID = $this->getUserJobID(['mapper' => $mapper, 'onDuplicate' => $onDuplicateAction, 'dedupe_rule_id' => $ruleGroupId]);
     $parser = new CRM_Contact_Import_Parser_Contact();
     $parser->setUserJobID($this->userJobID);
-    $parser->_dedupeRuleGroupID = $ruleGroupId;
     $parser->init();
 
     $parser->import($values);


### PR DESCRIPTION
Overview
----------------------------------------
Remove test reference to property which no longer exists.

Before
----------------------------------------
The test code referenced `$parser->_dedupeRuleGroupID = $ruleGroupId;`, despite their being no other references to `_dedupeRuleGroupID` in the codebase; therefore this property is not doing anything.

Furthermore, this means `_dedupeRuleGroupID` was a dynamic property, deprecated in PHP 8.2.

After
----------------------------------------
Pointless line of code removed.

Technical Details
----------------------------------------
The commit https://github.com/civicrm/civicrm-core/commit/3592a5e4098c9d14b2577a0f6eee5c6c7d471501` removed the `_dedupeRuleGroupID`  property from the `CRM_Contact_Import_Parser_Contact` class in June last year. Prior to that, setting the `_dedupeRuleGroupID` property in the test would have made sense.