### PR TITLE
[REF][PHP8.2] Fix use of self in callables deprecation

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -457,7 +457,7 @@ class CRM_Core_BAO_Block {
    * @param array $locations
    */
   public static function sortPrimaryFirst(&$locations) {
-    uasort($locations, 'self::primaryComparison');
+    uasort($locations, [__CLASS__, 'primaryComparison']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix `Use of "self" in callables is deprecated` issue.

Before
----------------------------------------
On PHP 8.2 many tests are failing due to the error `Use of "self" in callables is deprecated`. For example:

```
CRM_Core_BAO_AddressTest::testGetValues
Use of "self" in callables is deprecated

/home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Core/BAO/Block.php:460
/home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/CRM/Core/BAO/Address.php:1339
/home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/tests/phpunit/CRM/Core/BAO/AddressTest.php:386
/home/jenkins/bknix-edge/build/build-1/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:236
/home/jenkins/bknix-edge/extern/phpunit8/phpunit8.phar:1721
```

More detail on the deprecation can be found at https://php.watch/versions/8.2/partially-supported-callable-deprecation.

After
----------------------------------------
Use of a PHP 8.2 valid syntax.

Comments
----------------------------------------
To be honest I suspect the `sortPrimaryFirst` functionality isn't really providing any value, can could maybe be removed. But I'll leave that tidy up for another day.
