### PR TITLE
[REF][PHP8.2] Tidy up properties on api_v3_GroupContactTest

### DIFF
--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -17,18 +17,30 @@ use Civi\Api4\SubscriptionHistory;
  */
 class api_v3_GroupContactTest extends CiviUnitTestCase {
 
-  protected $_contactId;
-  protected $_contactId1;
+  /**
+   * @var int
+   */
+  protected $contactID;
 
   /**
    * @var int
    */
-  protected $_groupId1;
+  protected $contactID1;
+
+  /**
+   * @var array
+   */
+  protected $groups;
 
   /**
    * @var int
    */
-  protected $_groupId2;
+  protected $groupID1;
+
+  /**
+   * @var int
+   */
+  protected $groupID2;
 
   /**
    * Set up for group contact tests.
@@ -37,16 +49,16 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
    */
   public function setUp(): void {
     parent::setUp();
-    $this->_contactId = $this->individualCreate();
+    $this->contactID = $this->individualCreate();
 
-    $this->_groupId1 = $this->groupCreate();
+    $this->groupID1 = $this->groupCreate();
 
     $this->callAPISuccess('group_contact', 'create', [
-      'contact_id' => $this->_contactId,
-      'group_id' => $this->_groupId1,
+      'contact_id' => $this->contactID,
+      'group_id' => $this->groupID1,
     ]);
 
-    $this->_groupId2 = $this->groupCreate([
+    $this->groupID2 = $this->groupCreate([
       'name' => 'Test Group 2',
       'domain_id' => 1,
       'title' => 'New Test Group2 Created',
@@ -55,13 +67,13 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
     ]);
 
-    $this->_group = [
-      $this->_groupId1 => [
+    $this->groups = [
+      $this->groupID1 => [
         'title' => 'New Test Group Created',
         'visibility' => 'Public Pages',
         'in_method' => 'API',
       ],
-      $this->_groupId2 => [
+      $this->groupID2 => [
         'title' => 'New Test Group2 Created',
         'visibility' => 'User and User Admin Only',
         'in_method' => 'API',
@@ -82,13 +94,13 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
    */
   public function testGet() {
     $params = [
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->contactID,
     ];
     $result = $this->callAPIAndDocument('group_contact', 'get', $params, __FUNCTION__, __FILE__);
     foreach ($result['values'] as $v) {
-      $this->assertEquals($v['title'], $this->_group[$v['group_id']]['title']);
-      $this->assertEquals($v['visibility'], $this->_group[$v['group_id']]['visibility']);
-      $this->assertEquals($v['in_method'], $this->_group[$v['group_id']]['in_method']);
+      $this->assertEquals($v['title'], $this->groups[$v['group_id']]['title']);
+      $this->assertEquals($v['visibility'], $this->groups[$v['group_id']]['visibility']);
+      $this->assertEquals($v['in_method'], $this->groups[$v['group_id']]['in_method']);
     }
   }
 
@@ -96,15 +108,15 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
     $description = "Get all from group and display contacts.";
     $subfile = "GetWithGroupID";
     $params = [
-      'group_id' => $this->_groupId1,
+      'group_id' => $this->groupID1,
       'api.group.get' => 1,
       'sequential' => 1,
     ];
     $result = $this->callAPIAndDocument('group_contact', 'get', $params, __FUNCTION__, __FILE__, $description, $subfile);
     foreach ($result['values'][0]['api.group.get']['values'] as $values) {
       $key = $values['id'];
-      $this->assertEquals($values['title'], $this->_group[$key]['title']);
-      $this->assertEquals($values['visibility'], $this->_group[$key]['visibility']);
+      $this->assertEquals($values['title'], $this->groups[$key]['title']);
+      $this->assertEquals($values['visibility'], $this->groups[$key]['visibility']);
     }
   }
 
@@ -112,7 +124,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
    * Test group contact create.
    */
   public function testCreate(): void {
-    $this->_contactId1 = $this->individualCreate([
+    $this->contactID1 = $this->individualCreate([
       'first_name' => 'Amiteshwar',
       'middle_name' => 'L.',
       'last_name' => 'Prasad',
@@ -122,9 +134,9 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
     ]);
     $params = [
-      'contact_id' => $this->_contactId,
-      'contact_id.2' => $this->_contactId1,
-      'group_id' => $this->_groupId1,
+      'contact_id' => $this->contactID,
+      'contact_id.2' => $this->contactID1,
+      'group_id' => $this->groupID1,
     ];
 
     $result = $this->callAPIAndDocument('GroupContact', 'create', $params, __FUNCTION__, __FILE__);
@@ -138,8 +150,8 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
    */
   public function testDelete(): void {
     $params = [
-      'contact_id' => $this->_contactId,
-      'group_id' => $this->_groupId1,
+      'contact_id' => $this->contactID,
+      'group_id' => $this->groupID1,
     ];
 
     $result = $this->callAPIAndDocument('group_contact', 'delete', $params, __FUNCTION__, __FILE__);
@@ -148,7 +160,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
   }
 
   public function testDeletePermanent() {
-    $result = $this->callAPISuccess('group_contact', 'get', ['contact_id' => $this->_contactId]);
+    $result = $this->callAPISuccess('group_contact', 'get', ['contact_id' => $this->contactID]);
     $params = [
       'id' => $result['id'],
       'skip_undelete' => TRUE,
@@ -165,8 +177,8 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
    */
   public function testDeleteWithId() {
     $groupContactParams = [
-      'contact_id' => $this->_contactId,
-      'group_id' => $this->_groupId1,
+      'contact_id' => $this->contactID,
+      'group_id' => $this->groupID1,
     ];
     $groupContact = $this->callAPISuccess('group_contact', 'get', $groupContactParams);
     $params = [
@@ -184,8 +196,8 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
    */
   public function testDeleteAndReAddWithId() {
     $groupContactParams = [
-      'contact_id' => $this->_contactId,
-      'group_id' => $this->_groupId1,
+      'contact_id' => $this->contactID,
+      'group_id' => $this->groupID1,
     ];
     $groupContact = $this->callAPISuccess('group_contact', 'get', $groupContactParams);
     $params = [
@@ -221,7 +233,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
     ]);
     $groupContactCreateParams = [
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->contactID,
       'group_id' => $groupId3,
       'status' => 'Pending',
     ];
@@ -231,7 +243,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       ->addSelect('*')
       ->addWhere('group_id', '=', $groupId3)
       ->addWhere('status', '=', 'Pending')
-      ->addWhere('contact_id', '=', $this->_contactId)
+      ->addWhere('contact_id', '=', $this->contactID)
       ->execute();
     $this->assertCount(1, $history);
     if ($version === 3) {
@@ -258,7 +270,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'visibility' => 'User and User Admin Only',
     ]);
     $groupContactCreateParams = [
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->contactID,
       'group_id' => $groupId3,
       'status' => 'Pending',
     ];
@@ -282,7 +294,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'title' => 'Child group',
       'description' => 'Child group',
       'is_active' => 1,
-      'parents' => $this->_groupId1,
+      'parents' => $this->groupID1,
       'visibility' => 'User and User Admin Only',
     ]);
 
@@ -290,15 +302,15 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'name' => 'Individuals',
       'title' => 'Individuals',
       'is_active' => 1,
-      'parents' => $this->_groupId1,
+      'parents' => $this->groupID1,
       'formValues' => ['contact_type' => 'Goat'],
     ];
     $smartGroup2 = CRM_Contact_BAO_Group::createSmartGroup($params);
 
-    $this->callAPISuccess('GroupContact', 'create', ['contact_id' => $this->_contactId, 'status' => 'Added', 'group_id' => $this->_groupId2]);
-    $this->callAPISuccess('GroupContact', 'create', ['contact_id' => $this->_contactId, 'status' => 'Added', 'group_id' => $smartGroup2->id]);
-    $this->callAPISuccess('GroupContact', 'create', ['contact_id' => $this->_contactId, 'status' => 'Added', 'group_id' => $childGroupID]);
-    $groups = $this->callAPISuccess('GroupContact', 'get', ['contact_id' => $this->_contactId]);
+    $this->callAPISuccess('GroupContact', 'create', ['contact_id' => $this->contactID, 'status' => 'Added', 'group_id' => $this->groupID2]);
+    $this->callAPISuccess('GroupContact', 'create', ['contact_id' => $this->contactID, 'status' => 'Added', 'group_id' => $smartGroup2->id]);
+    $this->callAPISuccess('GroupContact', 'create', ['contact_id' => $this->contactID, 'status' => 'Added', 'group_id' => $childGroupID]);
+    $groups = $this->callAPISuccess('GroupContact', 'get', ['contact_id' => $this->contactID]);
 
     // Although the contact is actually hard-added to 4 groups the smart groups are conventionally not returned by the api or displayed
     // on the main part of the groups tab on the contact (which calls the same function. So, 3 groups is an OK number to return.


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up properties on api_v3_GroupContactTest, with the primary purpose of removing dynamic properties.

Before
----------------------------------------
`_group` was a dynamic property, deprecated in PHP 8.2.

After
----------------------------------------
No longer any dyamic properties in use.

Properties have been renamed for better readability, and consistency with the rest of the CiviCRM codebase.