### PR TITLE
Remove deprecation from a hook that's actually uniquely useful

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -232,9 +232,6 @@ class CRM_Dedupe_Merger {
     }
 
     CRM_Utils_Hook::merge('cidRefs', $contactReferences);
-    if ($contactReferences !== $coreReferences) {
-      CRM_Core_Error::deprecatedWarning("Deprecated hook ::merge in context of 'cidRefs. Use entityTypes instead.");
-    }
     \Civi::$statics[__CLASS__]['contact_references'] = $contactReferences;
     return \Civi::$statics[__CLASS__]['contact_references'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
`hook_civicrm_merge` has a sub-hook `cidRefs`, [documented here](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_merge/). This subhook has been deprecated since 2018 (@eileenmcnaughton) -- see the [code change](https://github.com/civicrm/civicrm-core/commit/e3e87c738e8276dbfd4d3a0f9d74302896074558#diff-fe60c89ebe94bbd40114d135459371cc53708db1f2952ade6c0ce9b3468c4dabL231-R222) and the [documentation change](https://lab.civicrm.org/documentation/docs/dev/-/commit/91aed74641dfbd26bb4082056e50dbc4da31fa63).

I'm glad the sub-hook was never removed after it was deprecated, because it actually offers something that [`hook_civicrm_entityTypes`](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes/) (the suggested replacement) does not: an opportunity to prevent an entity from being merged along with its associated Contact.

`cidRefs` is invoked _only_ in the context of a merge, and there are some times when that's very helpful. I have a Flag entity that's joined to the Contact entity. In most contexts, I want the Flag's FK to `civicrm_contact` to behave as usual: the join should be accessible through API4 so that you can get the Contact for a Flag and the Flags for a Contact; a Flag should be cascade-deleted when its Contact is deleted. But, in my use case, Flags _should not be reassigned_ when a Contact is merged into another Contact. The `cidRefs` sub-hook lets me do this by simply writing
````php
function flagger_civicrm_merge($type, &$data, $idBeingKept = NULL, $idBeingDeleted = NULL, $tables = NULL) {
    if ('cidRefs' === $type) {
        unset($data['civicrm_flag']);
    }
}
````

`entityTypes` is a more blunt instrument. I can't accomplish what I want to do with `entityTypes` or with any hook besides `cidRefs`, to my knowledge.

Before
----------------------------------------
If you use the `cidRefs` phase of `hook_civicrm_merge`, you get a deprecation notice in your logs.

After
----------------------------------------
Nice control over the contact merge process, in peace and quiet.