### PR TITLE
Angular Coder: Fix unescaping of quotes breaking attributes 

### DIFF
--- a/Civi/Angular/Coder.php
+++ b/Civi/Angular/Coder.php
@@ -61,8 +61,16 @@ class Coder {
     return $html;
   }
 
+  /**
+   * Angular is not as strict about special characters inside html attributes as the xhtml spec.
+   *
+   * This unescapes everything that angular expects to be unescaped.
+   *
+   * @param $matches
+   * @return string
+   */
   protected function cleanupAttribute($matches) {
-    list ($full, $attr, $lquote, $value, $rquote) = $matches;
+    [$full, $attr, $lquote, $value, $rquote] = $matches;
 
     switch ($attr) {
       case 'href':
@@ -72,7 +80,9 @@ class Coder {
         break;
 
       default:
-        $value = html_entity_decode($value);
+        $value = html_entity_decode($value, ENT_NOQUOTES);
+        $oppositeQuote = $lquote === '"' ? "'" : '"';
+        $value = str_replace(htmlspecialchars($oppositeQuote, ENT_QUOTES), $oppositeQuote, $value);
         break;
     }
 

--- a/tests/phpunit/Civi/Angular/PartialSyntaxTest.php
+++ b/tests/phpunit/Civi/Angular/PartialSyntaxTest.php
@@ -68,6 +68,10 @@ class PartialSyntaxTest extends \CiviUnitTestCase {
       '<div ng-if="a && b"></div>',
       '<div ng-if="a && b"></div>',
     ];
+    $cases[7] = [
+      '<div double="{a: \'abc\', &quot;b.c&quot;: \'b&c\'}" single=\'{"foo": &quot;bar&quot;}\'></div>',
+      '<div double="{a: \'abc\', &quot;b.c&quot;: \'b&c\'}" single=\'{"foo": "bar"}\'></div>',
+    ];
 
     return $cases;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug described in https://github.com/civicrm/civicrm-core/pull/25471#issuecomment-1423233785

Before
-----------------------
Quotes are incorrectly unescaped in html attributes, breaking afforms with e.g. custom fields set for an entity's "Values".

After
-------------------------------------
Fixed.

Technical Details
----------------------------------------
When adding a custom field to the "Values" section of an entity (e.g. the pre-determined values on the left side) it will put quotes around the key because it contains a dot. This is fine, valid html. BUT when it passes through Angular Coder, the encoding gets undone which is usually fine but was breaking quoted attributes when those attributes contained a quote character.
