### PR TITLE
EntityRef - Format custom field display value on QuickForms

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1251,7 +1251,19 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
             $display = implode(', ', $displayNames);
           }
         }
-        elseif ($field['data_type'] == 'ContactReference') {
+        elseif ($field['data_type'] == 'EntityReference' && $value) {
+          try {
+            $result = civicrm_api4($field['fk_entity'], 'autocomplete', [
+              'checkPermissions' => FALSE,
+              'ids' => [$value],
+            ]);
+            $display = $result->single()['label'];
+          }
+          catch (CRM_Core_Exception $e) {
+            $display = '';
+          }
+        }
+        elseif (in_array($field['data_type'], ['ContactReference', 'EntityReference'])) {
           $display = $value;
         }
         elseif (is_array($value)) {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #25471 - fixes display of field value on quickforms.

Before
----------------------------------------
1. Add a new entityReference custom field for contacts (referencing any activity e.g. Activity)
2. Edit a contact and add a value for that field
3. Note the value does not show up on the contact summary screen.

https://user-images.githubusercontent.com/2874912/220211690-f725b1f1-ec99-4c78-920a-5d918f20e7cb.mp4

After
----------------------------------------
Fixed