### PR TITLE
civiimport - PEAR Exception handling - Mitigation of scenario where an import table has been deleted and the metadata is out of date

### DIFF
--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -32,8 +32,14 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
    */
   public function modifySpec(RequestSpec $spec): void {
     $tableName = $spec->getEntityTableName();
-    $columns = Import::getFieldsForTable($tableName);
-    $action = $spec->getAction();
+    try {
+      $columns = Import::getFieldsForTable($tableName);
+    }
+    catch (\CRM_Core_Exception $e) {
+      // The api metadata may retain the expectation that this entity exists after the
+      // table is deleted - & hence we get an error.
+      return;
+    }
     // CheckPermissions does not reach us here - so we will have to rely on earlier permission filters.
     $userJobID = substr($spec->getEntity(), (strpos($spec->getEntity(), '_') + 1));
     $userJob = UserJob::get(FALSE)->addWhere('id', '=', $userJobID)->addSelect('metadata', 'job_type', 'created_id')->execute()->first();

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -203,7 +203,12 @@ class Import extends CRM_Core_DAO {
     $headers = UserJob::get(FALSE)
       ->addWhere('metadata', 'LIKE', '%' . $tableName . '%')
       ->addSelect('metadata')->execute()->first()['metadata']['DataSource']['column_headers'] ?? [];
-    $result = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM $tableName");
+    try {
+      $result = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM $tableName");
+    }
+    catch (\PEAR_Exception $e) {
+      throw new CRM_Core_Exception('Import table no longer exists');
+    }
     $userFieldIndex = 0;
     while ($result->fetch()) {
       $columns[$result->Field] = ['name' => $result->Field, 'table_name' => $tableName];


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a situation where a fatal error on the main SearchKit screen which arises if the temp table for an import is deleted but the metadata cache for `\Civi::cache('metadata')->get('api4.entities.info', []);` still retains it.

~~This is most easily replicated by doing an import, deleting the temp table in the DB and then going to the search kit screen~~

Steps to reproduce:

* Enable `civiimport`
* Start an import. Upload a CSV. Press "Back" to submit a new upload.
* In another tab, open `/civicrm/admin/search#/list?tab=packaged`.

Before
----------------------------------------
With Civi Import enabled....

![image](https://user-images.githubusercontent.com/336308/220211567-eca8e2f8-ceeb-49bf-a0ef-28e351738434.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/220211613-a8b6d308-ad23-4731-b924-09a1c3c7a9d4.png)

Technical Details
----------------------------------------
Although a `try-catch- was added to `SearchKit` it is by-passed by the `PEAR_Exception`. I could catch the `PEAR_Exception` in SearchKit but SearchKit 'shouldn't have to' so handling in the ImportProvider / converting the exceptions.

https://github.com/civicrm/civicrm-core/blob/4d8aca08c94b64c3fc482bcdcd3c797d0d19a5fe/ext/search_kit/Civi/Search/Admin.php#L147-L157

Thoughts about exceptions in https://github.com/civicrm/civicrm-core/pull/25600

Comments
----------------------------------------
I've figured out the scenario where this was happening & will separately address - but I think we should handle this regardless as I think there will always be some chance of it arising

Not strictly a regression but the handling that did not have enough cover to catch the `PEAR_Exception` is in 5.59