### PR TITLE
Add new `\Civi\Exception\DBQueryException` & throw that rather than a `PEAR_Exception`

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1644,6 +1644,8 @@ LIKE %1
    *   object that holds the results of the query
    *   NB - if this is defined as just returning a DAO phpstorm keeps pointing
    *   out all the properties that are not part of the DAO
+   *
+   * @throws \Civi\Core\Exception\DBQueryException
    */
   public static function &executeQuery(
     $query,

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -17,6 +17,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Core\Exception\DBQueryException;
+
 require_once 'PEAR/ErrorStack.php';
 require_once 'PEAR/Exception.php';
 require_once 'CRM/Core/Exception.php';
@@ -946,7 +948,10 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   public static function exceptionHandler($pearError) {
     CRM_Core_Error::debug_var('Fatal Error Details', self::getErrorDetails($pearError), TRUE, TRUE, '', PEAR_LOG_ERR);
     CRM_Core_Error::backtrace('backTrace', TRUE);
-    throw new PEAR_Exception($pearError->getMessage(), $pearError);
+    if ($pearError instanceof DB_Error) {
+      throw new DBQueryException($pearError->getMessage(), $pearError->getCode(), ['exception' => $pearError]);
+    }
+    throw new CRM_Core_Exception($pearError->getMessage(), $pearError->getCode(), ['exception' => $pearError]);
   }
 
   /**

--- a/CRM/Core/Exception.php
+++ b/CRM/Core/Exception.php
@@ -39,8 +39,13 @@ class CRM_Core_Exception extends PEAR_Exception {
    *   A previous exception which caused this new exception.
    */
   public function __construct($message, $error_code = 0, $errorData = [], $previous = NULL) {
-    // Using int for error code "old way") ?
-    if (is_numeric($error_code)) {
+
+    if (($errorData['exception'] ?? NULL) instanceof DB_Error) {
+      // Pass the exception to the PEAR_Exception parent as the code for it to handle.
+      $code = $errorData['exception'];
+    }
+    elseif (is_numeric($error_code)) {
+      // Using int for error code "old way") ?
       $code = $error_code;
     }
     else {
@@ -97,6 +102,15 @@ class CRM_Core_Exception extends PEAR_Exception {
    */
   public function getExtraParams() {
     return $this->errorData;
+  }
+
+  /**
+   * Get a message suitable to be presented to the user.
+   *
+   * @return string
+   */
+  public function getUserMessage(): string {
+    return $this->getMessage();
   }
 
   /**

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -81,12 +81,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
   public function initialize(): void {
     $table = CRM_Utils_SQL_TempTable::build()->setDurable();
     $tableName = $table->getName();
-    try {
-      $table->createWithQuery($this->getSubmittedValue('sqlQuery'));
-    }
-    catch (PEAR_Exception $e) {
-      throw new CRM_Core_Exception($e->getMessage(), 0, ['exception' => $e]);
-    }
+    $table->createWithQuery($this->getSubmittedValue('sqlQuery'));
 
     // Get the names of the fields to be imported.
     $columnsResult = CRM_Core_DAO::executeQuery(

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -181,7 +181,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       $this->instantiateDataSource();
     }
     catch (CRM_Core_Exception $e) {
-      CRM_Core_Error::statusBounce($e->getMessage());
+      CRM_Core_Error::statusBounce($e->getUserMessage());
     }
   }
 

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -336,6 +336,13 @@ class Kernel {
    */
   public function formatApiException($e, $apiRequest) {
     $data = $e->getExtraParams();
+    $errorCode = $e->getCode();
+    if (($data['exception'] ?? NULL) instanceof \DB_Error) {
+      $errorCode = $e->getDBErrorMessage();
+      $data['sql'] = $e->getSQL();
+      $data['debug_info'] = $e->getUserInfo();
+    }
+    unset($data['exception']);
     $data['entity'] = $apiRequest['entity'] ?? NULL;
     $data['action'] = $apiRequest['action'] ?? NULL;
 
@@ -346,7 +353,7 @@ class Kernel {
       $data['trace'] = $e->getTraceAsString();
     }
 
-    return $this->createError($e->getMessage(), $data, $apiRequest, $e->getCode());
+    return $this->createError($e->getMessage(), $data, $apiRequest, $errorCode);
   }
 
   /**

--- a/Civi/Core/Exception/DBQueryException.php
+++ b/Civi/Core/Exception/DBQueryException.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core\Exception;
+
+/**
+ * Error when the syntax of a DB query is incorrect.
+ *
+ * @param string $message
+ *   The human friendly error message.
+ * @param string $error_code
+ *   A computer friendly error code. By convention, no space (but underscore allowed).
+ *   ex: mandatory_missing, duplicate, invalid_format
+ * @param array $data
+ *   - exception The original PEAR Exception
+ */
+class DBQueryException extends \CRM_Core_Exception {
+
+  /**
+   * Get a message suitable to be presented to the user.
+   *
+   * @return string
+   */
+  public function getUserMessage(): string {
+    return ts('Invalid Query') . ' ' . $this->getDBErrorMessage() . $this->getErrorCodeSpecificMessage();
+  }
+
+  /**
+   * Is the error message safe to show to users.
+   *
+   * Probably most of them are but error 1146 leaks the database name - eg.
+   * 'table dmaster.civicrm_contact does not exist'.
+   *
+   * However, for missing fields and syntax errors the error message gives
+   * useful clues we should pass on. We can add to this / tweak over time - if
+   * we care to.
+   *
+   * @return bool
+   */
+  private function isErrorMessageUserSafe(): bool {
+    $errors = [
+      // No such field, does not leak any table information.
+      1054 => TRUE,
+      // Invalid schema - helpful hint as to where the error is, no leakage.
+      1064 => TRUE,
+      // No such table - leaks db name.
+      1146 => FALSE,
+    ];
+    return $errors[$this->getSQLErrorCode()] ?? FALSE;
+  }
+
+  /**
+   * @return int
+   */
+  protected function getPEARErrorCode(): int {
+    return $this->getDBError()->getCode();
+  }
+
+  /**
+   * @return \DB_Error
+   */
+  protected function getDBError(): \DB_Error {
+    return $this->getErrorData()['exception'];
+  }
+
+  /**
+   * Get the mysql error code.
+   *
+   * @see https://mariadb.com/kb/en/mariadb-error-codes/
+   *
+   * @return int
+   */
+  public function getSQLErrorCode(): int {
+    $dbErrorMessage = $this->getUserInfo();
+    $matches = [];
+    preg_match('/\[nativecode=(\d*) /', $dbErrorMessage, $matches);
+    return (int) $matches[1];
+  }
+
+  /**
+   * Get the PEAR data intended to be use useful to the user.
+   *
+   * @return string
+   */
+  public function getUserInfo(): string {
+    return $this->getCause()->getUserInfo();
+  }
+
+  /**
+   * Get the attempted sql.
+   *
+   * @return string
+   */
+  public function getSQL(): string {
+    $dbErrorMessage = $this->getUserInfo();
+    $matches = [];
+    preg_match('/(.*) \[nativecode=/', $dbErrorMessage, $matches);
+    return $matches[1];
+  }
+
+  /**
+   * Get the attempted sql.
+   *
+   * @return string
+   */
+  public function getDebugInfo(): string {
+    return $this->getDBError()->getUserInfo();
+  }
+
+  /**
+   * Get additional user-safe error message information.
+   *
+   * @return string
+   */
+  private function getErrorCodeSpecificMessage(): string {
+    $matches = [];
+    preg_match('/\[nativecode=\d* \*\* (.*)]/', $this->getUserInfo(), $matches);
+    if ($this->isErrorMessageUserSafe()) {
+      return ' ' . $matches[1];
+    }
+    // We could return additional info e.g when we log deadlocks we log
+    // 'Database deadlock encountered' (1213) or 'Database lock encountered' (1205).
+    return '';
+  }
+
+  /**
+   * Get the DB error code converted to a test code.
+   *
+   * @return string
+   */
+  public function getDBErrorMessage(): string {
+    return \DB::errorMessage($this->getPEARErrorCode());
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add new `\Civi\Core\Exception\DBQueryException` & throw that rather than a `PEAR_Exception`

Before
----------------------------------------
When a DB error occurs an instance of `PEAR_Exception` is thrown. `CRM_Core_Exception` extends `PEAR_Exception` and is the target of most `try-catch` blocks but does NOT catch the `PEAR_Exception`

After
----------------------------------------
`\Civi\Core\Exception\DBQueryException` is thrown for DB exceptions, otherwise `CRM_Core_Exceptions` are thrown

Technical Details
----------------------------------------

Comments
----------------------------------------
