### PR TITLE
[NFC/Unit Tests] Use phpunit polyfill for deprecated assertRegExp

### DIFF
--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -5,6 +5,8 @@ namespace Civi\Test;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
+// phpcs:ignore
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 /**
  * Class HttpTestTrait
@@ -156,7 +158,7 @@ trait HttpTestTrait {
     }
 
     $response = $this->resolveResponse($response);
-    $this->assertRegexp($regexp, (string) $response->getBody(),
+    $this->assertMatchesRegularExpression($regexp, (string) $response->getBody(),
       $message . 'Response body does not match pattern' . $this->formatFailure($response));
     return $this;
   }

--- a/ext/afform/mock/ang/mockPublicForm.test.php
+++ b/ext/afform/mock/ang/mockPublicForm.test.php
@@ -76,7 +76,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
       $this->fail('Plain text message did not have URL in expected place: ' . $text);
     }
     $url = $m[1];
-    $this->assertRegExp(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
+    $this->assertMatchesRegularExpression(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
 
     // Going to this page will cause us to authenticate as the target contact
     $http = $this->createGuzzle(['http_errors' => FALSE, 'cookies' => new \GuzzleHttp\Cookie\CookieJar()]);
@@ -102,7 +102,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
       $this->fail('HTML message did not have URL in expected place: ' . $html);
     }
     $url = html_entity_decode($m[1]);
-    $this->assertRegExp(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
+    $this->assertMatchesRegularExpression(';^https?:.*civicrm/mock-public-form.*;', $url, "URL should look plausible");
 
     // Going to this page will cause us to authenticate as the target contact
     $http = $this->createGuzzle(['cookies' => new \GuzzleHttp\Cookie\CookieJar()]);
@@ -126,7 +126,7 @@ class MockPublicFormTest extends \Civi\AfformMock\FormTestCase {
     $this->assertEquals(1, $doc->find('a')->count(), 'Document should have hyperlink');
     foreach ($doc->find('a') as $item) {
       /** @var \DOMElement $item */
-      $this->assertRegExp(';^https?:.*civicrm/mock-public-form.*;', $item->getAttribute('href'));
+      $this->assertMatchesRegularExpression(';^https?:.*civicrm/mock-public-form.*;', $item->getAttribute('href'));
       $this->assertEquals('My public form', $item->firstChild->data);
       $url = $item->getAttribute('href');
     }

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformContactUsageTest.php
@@ -90,7 +90,7 @@ EOHTML;
       ->execute()
       ->indexBy('name');
     $this->assertEquals('Logged In', $prefill['me']['values'][0]['fields']['first_name']);
-    $this->assertRegExp('/^User/', $prefill['me']['values'][0]['fields']['last_name']);
+    $this->assertMatchesRegularExpression('/^User/', $prefill['me']['values'][0]['fields']['last_name']);
 
     $submission = [
       ['fields' => ['first_name' => 'Firsty', 'last_name' => 'Lasty']],

--- a/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/AfformRoutingTest.php
@@ -81,8 +81,8 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
   private function assertNotAuthorized(Psr\Http\Message\ResponseInterface $result, $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(403, $result->getStatusCode());
-    $this->assertRegExp(';You are not authorized to access;', $contents);
-    $this->assertNotRegExp(';' . preg_quote("<$directive>", ';') . ';', $contents);
+    $this->assertMatchesRegularExpression(';You are not authorized to access;', $contents);
+    $this->assertDoesNotMatchRegularExpression(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 
   /**
@@ -93,8 +93,8 @@ class api_v4_AfformRoutingTest extends \PHPUnit\Framework\TestCase implements \C
   private function assertOpensPage(Psr\Http\Message\ResponseInterface $result, $directive) {
     $contents = $result->getBody()->getContents();
     $this->assertEquals(200, $result->getStatusCode());
-    $this->assertNotRegExp(';You are not authorized to access;', $contents);
-    $this->assertRegExp(';' . preg_quote("<$directive>", ';') . ';', $contents);
+    $this->assertDoesNotMatchRegularExpression(';You are not authorized to access;', $contents);
+    $this->assertMatchesRegularExpression(';' . preg_quote("<$directive>", ';') . ';', $contents);
   }
 
 }

--- a/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AllFlowsTest.php
@@ -557,7 +557,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
       $loginArgs = ['principal' => [$principalField => $principalValue]];
       $report = $withCv(sprintf('try { return authx_login(%s); } catch (Exception $e) { return [get_class($e), $e->getMessage()]; }', var_export($loginArgs, 1)));
       $this->assertTrue(isset($report[0], $report[1]), "authx_login() should fail with invalid credentials ($principalField=>$principalValue). Received array: " . json_encode($report));
-      $this->assertRegExp($expectExceptionMessage, $report[1], "Invalid principal ($principalField=>$principalValue) should generate exception.");
+      $this->assertMatchesRegularExpression($expectExceptionMessage, $report[1], "Invalid principal ($principalField=>$principalValue) should generate exception.");
       $this->assertEquals($expectExceptionClass, $report[0], "Invalid principal ($principalField=>$principalValue) should generate exception.");
     }
   }
@@ -585,7 +585,7 @@ class AllFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
       $this->fail('Untrusted sessions should require authentication credentials');
     }
     catch (JsonRpcMethodException $e) {
-      $this->assertRegExp(';not trusted;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';not trusted;', $e->getMessage());
     }
 
     $login = $rpc->call('login', ['cred' => $this->credJwt($this->getDemoCID())]);

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -91,7 +91,7 @@ class ValidatorTest extends \CiviUnitTestCase {
       array_keys($expectedErrors)
     );
     foreach ($expectedErrors as $key => $pat) {
-      $this->assertRegExp($pat, $actualErrors[$key], "Error for \"$key\" should match pattern");
+      $this->assertMatchesRegularExpression($pat, $actualErrors[$key], "Error for \"$key\" should match pattern");
     }
   }
 

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -48,11 +48,11 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
       $this->assertEquals('/one/auth', $url['path']);
       \parse_str($url['query'], $actualQuery);
       $this->assertEquals('code', $actualQuery['response_type']);
-      $this->assertRegExp(';^[cs]_[a-zA-Z0-9]+$;', $actualQuery['state']);
+      $this->assertMatchesRegularExpression(';^[cs]_[a-zA-Z0-9]+$;', $actualQuery['state']);
       $this->assertEquals('scope-1-foo,scope-1-bar', $actualQuery['scope']);
       // ? // $this->assertEquals('auto', $actualQuery['approval_prompt']);
       $this->assertEquals('example-id', $actualQuery['client_id']);
-      $this->assertRegExp(';civicrm/oauth-client/return;', $actualQuery['redirect_uri']);
+      $this->assertMatchesRegularExpression(';civicrm/oauth-client/return;', $actualQuery['redirect_uri']);
     }
   }
 

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
@@ -79,7 +79,7 @@ class api_v4_OAuthClientTest extends \PHPUnit\Framework\TestCase implements Head
       $this->fail("Expected exception: invalid provider");
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp(';Invalid provider;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Invalid provider;', $e->getMessage());
     }
   }
 
@@ -105,7 +105,7 @@ class api_v4_OAuthClientTest extends \PHPUnit\Framework\TestCase implements Head
       $this->fail("Expected exception: invalid provider");
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp(';Invalid provider;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Invalid provider;', $e->getMessage());
     }
 
     Civi\Api4\OAuthClient::update()

--- a/mixin/menu-xml@1/example/tests/mixin/MenuXmlTest.php
+++ b/mixin/menu-xml@1/example/tests/mixin/MenuXmlTest.php
@@ -2,6 +2,9 @@
 
 namespace Civi\Shimmy\Mixins;
 
+// phpcs:ignore
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+
 /**
  * Assert that the `xml/Menu/*.xml` mixin is working properly.
  *
@@ -31,7 +34,7 @@ class MenuXmlTest extends \PHPUnit\Framework\Assert {
     $this->url = cv('url civicrm/shimmy/foobar');
     $this->assertTrue(is_string($this->url));
     $response = file_get_contents($this->url);
-    $this->assertRegExp(';hello world;', $response);
+    $this->assertMatchesRegularExpression(';hello world;', $response);
   }
 
   public function testDisabled($cv): void {
@@ -40,8 +43,8 @@ class MenuXmlTest extends \PHPUnit\Framework\Assert {
 
     $this->assertNotEmpty($this->url);
     $response = file_get_contents($this->url, FALSE, stream_context_create(['http' => ['ignore_errors' => TRUE]]));
-    $this->assertNotRegExp(';hello world;', $response);
-    $this->assertNotRegExp(';HTTP.*200.*;', $http_response_header[0]);
+    $this->assertDoesNotMatchRegularExpression(';hello world;', $response);
+    $this->assertDoesNotMatchRegularExpression(';HTTP.*200.*;', $http_response_header[0]);
   }
 
   public function testUninstalled($cv): void {

--- a/tests/events/civi_region_render.evch.php
+++ b/tests/events/civi_region_render.evch.php
@@ -24,7 +24,7 @@ return new class() extends \Civi\Test\EventCheck implements \Civi\Test\HookInter
     $this->assertTrue($e->region instanceof \CRM_Core_Region);
     /** @var \CRM_Core_Region $region */
     $region = $e->region;
-    $this->assertRegexp($this->validRegion, $region->_name);
+    $this->assertMatchesRegularExpression($this->validRegion, $region->_name);
     foreach ($region->getAll() as $snippet) {
       $this->assertContains($snippet['type'], $this->validSnippetTypes);
     }

--- a/tests/events/hook_civicrm_alterMailParams.evch.php
+++ b/tests/events/hook_civicrm_alterMailParams.evch.php
@@ -2,6 +2,8 @@
 
 use Civi\Test\EventCheck;
 use Civi\Test\HookInterface;
+// phpcs:ignore
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 return new class() extends EventCheck implements HookInterface {
 
@@ -107,7 +109,7 @@ return new class() extends EventCheck implements HookInterface {
     $msg = 'Non-conforming hook_civicrm_alterMailParams(..., $context)';
     $dump = print_r($params, 1);
 
-    $this->assertRegExp('/^(messageTemplate|civimail|singleEmail|flexmailer)$/',
+    $this->assertMatchesRegularExpression('/^(messageTemplate|civimail|singleEmail|flexmailer)$/',
       $context, "$msg: Unrecognized context ($context)\n$dump");
 
     $contexts = [$context];
@@ -131,7 +133,7 @@ return new class() extends EventCheck implements HookInterface {
         $this->assertType($paramSpecs[$key]['type'], $value, "$msg: Bad data-type found in param ($key)\n$dump");
       }
       if (isset($paramSpecs[$key]['regex']) && $value !== NULL) {
-        $this->assertRegExp($paramSpecs[$key]['regex'], $value, "Parameter [$key => $value] should match regex ({$paramSpecs[$key]['regex']})");
+        $this->assertMatchesRegularExpression($paramSpecs[$key]['regex'], $value, "Parameter [$key => $value] should match regex ({$paramSpecs[$key]['regex']})");
       }
     }
 

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1448,8 +1448,8 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $contactId = $this->individualCreate();
 
     $origTimestamps = CRM_Contact_BAO_Contact::getTimestamps($contactId);
-    $this->assertRegexp('/^\d\d\d\d-\d\d-\d\d /', $origTimestamps['created_date']);
-    $this->assertRegexp('/^\d\d\d\d-\d\d-\d\d /', $origTimestamps['modified_date']);
+    $this->assertMatchesRegularExpression('/^\d\d\d\d-\d\d-\d\d /', $origTimestamps['created_date']);
+    $this->assertMatchesRegularExpression('/^\d\d\d\d-\d\d-\d\d /', $origTimestamps['modified_date']);
     $this->assertTrue($origTimestamps['created_date'] <= $origTimestamps['modified_date']);
 
     $prevTimestamps = $origTimestamps;
@@ -1459,8 +1459,8 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
 
       $callback($contactId);
       $newTimestamps = CRM_Contact_BAO_Contact::getTimestamps($contactId);
-      $this->assertRegexp('/^\d\d\d\d-\d\d-\d\d /', $newTimestamps['created_date'], "Malformed created_date (after $callbackName)");
-      $this->assertRegexp('/^\d\d\d\d-\d\d-\d\d /', $newTimestamps['modified_date'], "Malformed modified_date (after $callbackName)");
+      $this->assertMatchesRegularExpression('/^\d\d\d\d-\d\d-\d\d /', $newTimestamps['created_date'], "Malformed created_date (after $callbackName)");
+      $this->assertMatchesRegularExpression('/^\d\d\d\d-\d\d-\d\d /', $newTimestamps['modified_date'], "Malformed modified_date (after $callbackName)");
       $this->assertEquals($origTimestamps['created_date'], $newTimestamps['created_date'], "Changed created_date (after $callbackName)");
       $this->assertTrue($prevTimestamps['modified_date'] < $newTimestamps['modified_date'], "Misordered modified_date (after $callbackName)");
 

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -127,7 +127,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     // check that contribution page ID isn't changed
     $this->assertEquals($contributionPageID1, $contribution['contribution_page_id']);
     // check that paid later information is present in contribution's source
-    $this->assertRegExp("/Paid later via page ID: $contributionPageID2/", $contribution['contribution_source']);
+    $this->assertMatchesRegularExpression("/Paid later via page ID: $contributionPageID2/", $contribution['contribution_source']);
     // check that contribution status is changed to 'Completed' from 'Pending'
     $this->assertEquals('Completed', $contribution['contribution_status']);
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionViewTest.php
@@ -71,7 +71,7 @@ class CRM_Contribute_Form_ContributionViewTest extends CiviUnitTestCase {
     unset($_GET['id'], $_REQUEST['id']);
     unset($_GET['cid'], $_REQUEST['cid']);
 
-    $this->assertRegExp('/Contribution Total:\s+\$10\.00/', $contents);
+    $this->assertMatchesRegularExpression('/Contribution Total:\s+\$10\.00/', $contents);
     $this->assertStringContainsString('Mr. Anthony Anderson II', $contents);
   }
 

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1084,7 +1084,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       }
 
       foreach ($patterns as $field => $pattern) {
-        $this->assertRegExp($pattern, $messageArray[$field],
+        $this->assertMatchesRegularExpression($pattern, $messageArray[$field],
           "Check that '$field'' matches regex. " . print_r(['expected' => $patterns, 'actual' => $messageArray], 1));
       }
     }

--- a/tests/phpunit/CRM/Core/ComposerConfigTest.php
+++ b/tests/phpunit/CRM/Core/ComposerConfigTest.php
@@ -34,7 +34,7 @@ class CRM_Core_ComposerConfigTest extends \PHPUnit\Framework\TestCase {
 
     foreach ($lock['packages'] as $package) {
       if (isset($hardLocks[$package['name']])) {
-        $this->assertRegExp($hardLocks[$package['name']], $package['version'],
+        $this->assertMatchesRegularExpression($hardLocks[$package['name']], $package['version'],
           "Check hardlock for " . $package['name']);
         unset($hardLocks[$package['name']]);
       }

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -34,7 +34,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
   public function testFormatBacktrace_debug() {
     $bt = debug_backtrace();
     $msg = CRM_Core_Error::formatBacktrace($bt);
-    $this->assertRegexp('/CRM_Core_ErrorTest->testFormatBacktrace_debug/', $msg);
+    $this->assertMatchesRegularExpression('/CRM_Core_ErrorTest->testFormatBacktrace_debug/', $msg);
   }
 
   /**
@@ -43,7 +43,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
   public function testFormatBacktrace_exception() {
     $e = new Exception('foo');
     $msg = CRM_Core_Error::formatBacktrace($e->getTrace());
-    $this->assertRegexp('/CRM_Core_ErrorTest->testFormatBacktrace_exception/', $msg);
+    $this->assertMatchesRegularExpression('/CRM_Core_ErrorTest->testFormatBacktrace_exception/', $msg);
   }
 
   public function testExceptionLogging() {
@@ -85,7 +85,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     $logFiles = glob($config->configAndLogDir . '/CiviCRM*.log');
     $this->assertEquals(1, count($logFiles), 'Expect to find 1 file matching: ' . $config->configAndLogDir . '/CiviCRM*log*/');
     foreach ($logFiles as $logFile) {
-      $this->assertRegexp($pattern, file_get_contents($logFile));
+      $this->assertMatchesRegularExpression($pattern, file_get_contents($logFile));
     }
   }
 

--- a/tests/phpunit/CRM/Core/InvokeTest.php
+++ b/tests/phpunit/CRM/Core/InvokeTest.php
@@ -62,7 +62,7 @@ class CRM_Core_InvokeTest extends CiviUnitTestCase {
     $contents = ob_get_clean();
 
     unset($_GET['reset']);
-    $this->assertRegExp('/form.+id="Builder" class="CRM_Contact_Form_Search_Builder/', $contents);
+    $this->assertMatchesRegularExpression('/form.+id="Builder" class="CRM_Contact_Form_Search_Builder/', $contents);
   }
 
   public function testContactSummary(): void {

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -204,7 +204,7 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
       $this->fail('Expected disable to fail due to dependency');
     }
     catch (CRM_Extension_Exception $e) {
-      $this->assertRegExp('/test.foo.downstream/', $e->getMessage());
+      $this->assertMatchesRegularExpression('/test.foo.downstream/', $e->getMessage());
     }
 
     // Status unchanged

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -59,7 +59,7 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     Civi::settings()->set('logging', TRUE);
     $log_table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE log_civicrm_acl');
     while ($log_table->fetch()) {
-      $this->assertRegexp('/ENGINE=InnoDB/', $log_table->Create_Table);
+      $this->assertMatchesRegularExpression('/ENGINE=InnoDB/', $log_table->Create_Table);
     }
   }
 
@@ -71,7 +71,7 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     Civi::settings()->set('logging', TRUE);
     $log_table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE log_civicrm_acl');
     while ($log_table->fetch()) {
-      $this->assertRegexp('/ENGINE=MyISAM/', $log_table->Create_Table);
+      $this->assertMatchesRegularExpression('/ENGINE=MyISAM/', $log_table->Create_Table);
     }
   }
 
@@ -110,19 +110,19 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     CRM_Core_DAO::executeQuery('ALTER TABLE log_civicrm_acl ENGINE ARCHIVE');
     $log_table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE log_civicrm_acl');
     while ($log_table->fetch()) {
-      $this->assertRegexp('/ENGINE=ARCHIVE/', $log_table->Create_Table);
+      $this->assertMatchesRegularExpression('/ENGINE=ARCHIVE/', $log_table->Create_Table);
     }
     // engine should not change by default
     $schema->updateLogTableSchema(['updateChangedEngineConfig' => FALSE, 'forceEngineMigration' => FALSE]);
     $log_table = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE log_civicrm_acl");
     while ($log_table->fetch()) {
-      $this->assertRegExp('/ENGINE=ARCHIVE/', $log_table->Create_Table);
+      $this->assertMatchesRegularExpression('/ENGINE=ARCHIVE/', $log_table->Create_Table);
     }
     // update with forceEngineMigration should convert to InnoDB
     $schema->updateLogTableSchema(['updateChangedEngineConfig' => FALSE, 'forceEngineMigration' => TRUE]);
     $log_table = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE log_civicrm_acl");
     while ($log_table->fetch()) {
-      $this->assertRegExp('/ENGINE=InnoDB/', $log_table->Create_Table);
+      $this->assertMatchesRegularExpression('/ENGINE=InnoDB/', $log_table->Create_Table);
     }
   }
 
@@ -423,8 +423,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE civicrm_test_table");
     $dao->fetch();
     // using regex since not sure it's always int(10), so accept int(10), int(11), integer, etc...
-    $this->assertRegExp('/`id` int(.*) unsigned NOT NULL AUTO_INCREMENT/', $dao->Create_Table);
-    $this->assertRegExp('/`activity_id` int(.*) unsigned NOT NULL/', $dao->Create_Table);
+    $this->assertMatchesRegularExpression('/`id` int(.*) unsigned NOT NULL AUTO_INCREMENT/', $dao->Create_Table);
+    $this->assertMatchesRegularExpression('/`activity_id` int(.*) unsigned NOT NULL/', $dao->Create_Table);
     $this->assertStringContainsString('`texty` varchar(255)', $dao->Create_Table);
     $this->assertStringContainsString('ENGINE=InnoDB', $dao->Create_Table);
     $this->assertStringContainsString('FOREIGN KEY (`activity_id`) REFERENCES `civicrm_activity` (`id`) ON DELETE CASCADE', $dao->Create_Table);
@@ -434,8 +434,8 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     $dao->fetch();
     $this->assertStringNotContainsString('AUTO_INCREMENT', $dao->Create_Table);
     // This seems debatable whether `id` should lose its NOT NULL status
-    $this->assertRegExp('/`id` int(.*) unsigned DEFAULT NULL/', $dao->Create_Table);
-    $this->assertRegExp('/`activity_id` int(.*) unsigned DEFAULT NULL/', $dao->Create_Table);
+    $this->assertMatchesRegularExpression('/`id` int(.*) unsigned DEFAULT NULL/', $dao->Create_Table);
+    $this->assertMatchesRegularExpression('/`activity_id` int(.*) unsigned DEFAULT NULL/', $dao->Create_Table);
     $this->assertStringContainsString('`texty` varchar(255)', $dao->Create_Table);
     $this->assertStringContainsString('ENGINE=InnoDB', $dao->Create_Table);
     $this->assertStringNotContainsString('FOREIGN KEY', $dao->Create_Table);

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -83,10 +83,10 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertEquals("Mr. Foo{$offset} Anderson II", $message->to[0]->name);
       $this->assertEquals("mail{$offset}@nul.example.com", $message->to[0]->email);
 
-      $this->assertRegExp('#^text/plain; charset=utf-8#', $message->headers['Content-Type']);
-      $this->assertRegExp(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['Return-Path']);
-      $this->assertRegExp(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['X-CiviMail-Bounce'][0]);
-      $this->assertRegExp(';^\<mailto:u\.[\d\.a-f]+@chaos.org\>$;', $message->headers['List-Unsubscribe'][0]);
+      $this->assertMatchesRegularExpression('#^text/plain; charset=utf-8#', $message->headers['Content-Type']);
+      $this->assertMatchesRegularExpression(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['Return-Path']);
+      $this->assertMatchesRegularExpression(';^b\.[\d\.a-f]+@chaos.org$;', $message->headers['X-CiviMail-Bounce'][0]);
+      $this->assertMatchesRegularExpression(';^\<mailto:u\.[\d\.a-f]+@chaos.org\>$;', $message->headers['List-Unsubscribe'][0]);
       $this->assertEquals('bulk', $message->headers['Precedence'][0]);
     }
   }
@@ -108,7 +108,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       $this->assertTrue($message->body instanceof ezcMailText);
 
       $this->assertEquals('plain', $message->body->subType);
-      $this->assertRegExp(
+      $this->assertMatchesRegularExpression(
         ";" .
         // Default header
         "Sample Header for TEXT formatted content.\n" .
@@ -141,7 +141,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       [$textPart, $htmlPart] = $message->body->getParts();
 
       $this->assertEquals('html', $htmlPart->subType);
-      $this->assertRegExp(
+      $this->assertMatchesRegularExpression(
         ";" .
         // Default header
         "Sample Header for HTML formatted content.\n" .
@@ -157,7 +157,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       );
 
       $this->assertEquals('plain', $textPart->subType);
-      $this->assertRegExp(
+      $this->assertMatchesRegularExpression(
         ";" .
         // Default header
         "Sample Header for TEXT formatted content.\n" .
@@ -198,7 +198,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       [$textPart, $htmlPart] = $message->body->getParts();
 
       $this->assertEquals('html', $htmlPart->subType);
-      $this->assertRegExp(
+      $this->assertMatchesRegularExpression(
         ";" .
         // body_html
         "<p>You can go to <a href=['\"].*(extern/url.php|civicrm/mailing/url)(\?|&amp\\;)u=\d+&amp\\;qid=\d+['\"] rel='nofollow'>Google</a>" .
@@ -213,7 +213,7 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       );
 
       $this->assertEquals('plain', $textPart->subType);
-      $this->assertRegExp(
+      $this->assertMatchesRegularExpression(
         ";" .
         //  body_html, filtered
         "You can go to Google \\[1\\] or opt out \\[2\\]\\.\n" .
@@ -343,13 +343,13 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
       if ($htmlUrlRegex) {
         $caseName = print_r(['inputHtml' => $inputHtml, 'params' => $params, 'htmlUrlRegex' => $htmlUrlRegex, 'htmlPart' => $htmlPart->text], 1);
         $this->assertEquals('html', $htmlPart->subType, "Should have HTML part in case: $caseName");
-        $this->assertRegExp($htmlUrlRegex, $htmlPart->text, "Should have correct HTML in case: $caseName");
+        $this->assertMatchesRegularExpression($htmlUrlRegex, $htmlPart->text, "Should have correct HTML in case: $caseName");
       }
 
       if ($textUrlRegex) {
         $caseName = print_r(['inputHtml' => $inputHtml, 'params' => $params, 'textUrlRegex' => $textUrlRegex, 'textPart' => $textPart->text], 1);
         $this->assertEquals('plain', $textPart->subType, "Should have text part in case: $caseName");
-        $this->assertRegExp($textUrlRegex, $textPart->text, "Should have correct text in case: $caseName");
+        $this->assertMatchesRegularExpression($textUrlRegex, $textPart->text, "Should have correct text in case: $caseName");
       }
     }
   }

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -92,8 +92,8 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_BaseMailingSystemTest {
 
     $result = $this->callAPISuccess('mailing', 'create', $params);
     $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
-    $this->assertRegexp('!>Forward this email written in ckeditor</a>!', $previewResult['values']['body_html']);
-    $this->assertRegexp('!<a href="([^"]+)civicrm/mailing/forward&amp;amp;reset=1&amp;jid=&amp;qid=&amp;h=\w*">!', $previewResult['values']['body_html']);
+    $this->assertMatchesRegularExpression('!>Forward this email written in ckeditor</a>!', $previewResult['values']['body_html']);
+    $this->assertMatchesRegularExpression('!<a href="([^"]+)civicrm/mailing/forward&amp;amp;reset=1&amp;jid=&amp;qid=&amp;h=\w*">!', $previewResult['values']['body_html']);
     $this->assertStringNotContainsString("http://http://", $previewResult['values']['body_html']);
   }
 

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -59,7 +59,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $p->evaluate();
     $count = 0;
     foreach ($p->getRows() as $row) {
-      $this->assertRegExp($expectRegex, $row->render('example'));
+      $this->assertMatchesRegularExpression($expectRegex, $row->render('example'));
       $count++;
     }
     $this->assertEquals(1, $count);
@@ -96,7 +96,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $p->evaluate();
     $count = 0;
     foreach ($p->getRows() as $row) {
-      $this->assertRegExp($expectRegex, $row->render('example'));
+      $this->assertMatchesRegularExpression($expectRegex, $row->render('example'));
       $count++;
     }
     $this->assertEquals(1, $count);
@@ -138,14 +138,14 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     //      $this->fail('TokenProcessor::evaluate() should have thrown an exception');
     //    }
     //    catch (CRM_Core_Exception $e) {
-    //      $this->assertRegExp(';Cannot use action tokens unless context defines mailingJobId and mailingActionTarget;', $e->getMessage());
+    //      $this->assertMatchesRegularExpression(';Cannot use action tokens unless context defines mailingJobId and mailingActionTarget;', $e->getMessage());
     //    }
 
     $p->evaluate();
 
     // FIXME: For compatibility with
     $actual = $p->getRow(0)->render('example');
-    $this->assertRegExp($expectRegex, $actual);
+    $this->assertMatchesRegularExpression($expectRegex, $actual);
   }
 
 }

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -87,7 +87,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
       $this->fail('Should fail without error policy');
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp('/Invalid error mode/', $e->getMessage());
+      $this->assertMatchesRegularExpression('/Invalid error mode/', $e->getMessage());
     }
 
     $q2 = Civi::queue('test/complete/2', [
@@ -386,7 +386,7 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
       $this->fail('Queue lookup should fail. There is neither pre-existing registration nor new details.');
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp(';Missing field "type";', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Missing field "type";', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/CRM/Upgrade/SnapshotTest.php
+++ b/tests/phpunit/CRM/Upgrade/SnapshotTest.php
@@ -25,14 +25,14 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
       $this->fail('Accepted invalid name');
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp('/Malformed snapshot name/', $e->getMessage());
+      $this->assertMatchesRegularExpression('/Malformed snapshot name/', $e->getMessage());
     }
     try {
       CRM_Upgrade_Snapshot::createTableName('civicrm', '5.45', 'loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmod');
       $this->fail('Accepted excessive name');
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp('/Snapshot name is too long/', $e->getMessage());
+      $this->assertMatchesRegularExpression('/Snapshot name is too long/', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/CRM/Utils/CacheTest.php
+++ b/tests/phpunit/CRM/Utils/CacheTest.php
@@ -10,7 +10,7 @@ class CRM_Utils_CacheTest extends CiviUnitTestCase {
     $values = [];
     for ($i = 0; $i < 5; $i++) {
       $nack = CRM_Utils_Cache::nack();
-      $this->assertRegExp('/^NACK:[a-z0-9]+$/', $nack);
+      $this->assertMatchesRegularExpression('/^NACK:[a-z0-9]+$/', $nack);
       $values[] = $nack;
     }
     sort($values);

--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -47,13 +47,13 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
   public function testFetchHttp() {
     $result = $this->client->fetch(self::VALID_HTTP_URL, $this->tmpFile);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $result);
-    $this->assertRegExp(self::VALID_HTTP_REGEX, file_get_contents($this->tmpFile));
+    $this->assertMatchesRegularExpression(self::VALID_HTTP_REGEX, file_get_contents($this->tmpFile));
   }
 
   public function testFetchHttps_valid() {
     $result = $this->client->fetch(self::VALID_HTTPS_URL, $this->tmpFile);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $result);
-    $this->assertRegExp(self::VALID_HTTPS_REGEX, file_get_contents($this->tmpFile));
+    $this->assertMatchesRegularExpression(self::VALID_HTTPS_REGEX, file_get_contents($this->tmpFile));
   }
 
   public function testFetchHttps_invalid_verify() {
@@ -71,7 +71,7 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
 
     $result = $this->client->fetch(self::SELF_SIGNED_HTTPS_URL, $this->tmpFile);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $result);
-    $this->assertRegExp(self::SELF_SIGNED_HTTPS_REGEX, file_get_contents($this->tmpFile));
+    $this->assertMatchesRegularExpression(self::SELF_SIGNED_HTTPS_REGEX, file_get_contents($this->tmpFile));
   }
 
   public function testFetchHttp_badOutFile() {
@@ -82,13 +82,13 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
   public function testGetHttp() {
     [$status, $data] = $this->client->get(self::VALID_HTTP_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $status);
-    $this->assertRegExp(self::VALID_HTTP_REGEX, $data);
+    $this->assertMatchesRegularExpression(self::VALID_HTTP_REGEX, $data);
   }
 
   public function testGetHttps_valid() {
     [$status, $data] = $this->client->get(self::VALID_HTTPS_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $status);
-    $this->assertRegExp(self::VALID_HTTPS_REGEX, $data);
+    $this->assertMatchesRegularExpression(self::VALID_HTTPS_REGEX, $data);
   }
 
   public function testGetHttps_invalid_verify() {
@@ -106,7 +106,7 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
 
     [$status, $data] = $this->client->get(self::SELF_SIGNED_HTTPS_URL);
     $this->assertEquals(CRM_Utils_HttpClient::STATUS_OK, $status);
-    $this->assertRegExp(self::SELF_SIGNED_HTTPS_REGEX, $data);
+    $this->assertMatchesRegularExpression(self::SELF_SIGNED_HTTPS_REGEX, $data);
   }
 
 }

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -154,7 +154,7 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
       $this->fail('In output mode, we should reject requests to interpolate inputs.');
     }
     catch (Exception $e) {
-      $this->assertRegExp("/Cannot mix interpolation modes/", $e->getMessage());
+      $this->assertMatchesRegularExpression("/Cannot mix interpolation modes/", $e->getMessage());
     }
 
     $outputModeFragment = CRM_Utils_SQL_Select::fragment()
@@ -166,7 +166,7 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
       $this->fail('In output-mode, we should reject requests to merge from input-mode.');
     }
     catch (Exception $e) {
-      $this->assertRegExp("/Cannot merge queries that use different interpolation modes/", $e->getMessage());
+      $this->assertMatchesRegularExpression("/Cannot merge queries that use different interpolation modes/", $e->getMessage());
     }
   }
 
@@ -253,7 +253,7 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
       $this->fail('Unknown variables should throw errors in strict mode.');
     }
     catch (Exception $e) {
-      $this->assertRegExp('/Cannot build query. Variable "@johnMcClane" is unknown./', $e->getMessage());
+      $this->assertMatchesRegularExpression('/Cannot build query. Variable "@johnMcClane" is unknown./', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -33,7 +33,7 @@ class CRM_Utils_SQLTest extends CiviUnitTestCase {
       ]);
     }
     catch (CRM_Core_Exception $e) {
-      $this->assertRegExp(';Cannot build query. Variable "!the_table" is unknown.;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Cannot build query. Variable "!the_table" is unknown.;', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -118,11 +118,11 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     for ($i = 0; $i < 4; $i++) {
       $actual = CRM_Utils_String::createRandom(4, 'abc');
       $this->assertEquals(4, strlen($actual));
-      $this->assertRegExp('/^[abc]+$/', $actual);
+      $this->assertMatchesRegularExpression('/^[abc]+$/', $actual);
 
       $actual = CRM_Utils_String::createRandom(6, '12345678');
       $this->assertEquals(6, strlen($actual));
-      $this->assertRegExp('/^[12345678]+$/', $actual);
+      $this->assertMatchesRegularExpression('/^[12345678]+$/', $actual);
     }
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -785,7 +785,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       $this->fail('Expected unquoted parameter to fail');
     }
     catch (\CRM_Core_Exception $e) {
-      $this->assertRegExp(';Malformed token param;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Malformed token param;', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/DynamicFKAuthorizationTest.php
@@ -209,7 +209,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
       '$params' => $params,
       '$result' => $result,
     ], TRUE));
-    $this->assertRegExp($expectedError, $result['error_message']);
+    $this->assertMatchesRegularExpression($expectedError, $result['error_message']);
   }
 
   /**
@@ -229,7 +229,7 @@ class DynamicFKAuthorizationTest extends \CiviUnitTestCase {
     // run with permission check
     $result = $this->kernel->runSafe('FakeFile', 'create', $params);
     $this->assertTrue((bool) $result['is_error'], 'Undelegated entity with check_permissions = 1 should fail');
-    $this->assertRegExp('/Unrecognized target entity table \(civicrm_membership\)/', $result['error_message']);
+    $this->assertMatchesRegularExpression('/Unrecognized target entity table \(civicrm_membership\)/', $result['error_message']);
     // repeat without permission check
     $params['check_permissions'] = 0;
     $result = $this->kernel->runSafe('FakeFile', 'create', $params);

--- a/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/WhitelistSubscriberTest.php
@@ -388,7 +388,7 @@ class WhitelistSubscriberTest extends \CiviUnitTestCase {
     }
     else {
       $this->assertAPIFailure($result);
-      $this->assertRegExp('/The request does not match any active API authorizations./', $result['error_message']);
+      $this->assertMatchesRegularExpression('/The request does not match any active API authorizations./', $result['error_message']);
     }
   }
 

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -313,7 +313,7 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
         $this->assertEquals($expectMessage['to'], $actualMessage['to'], $errorText);
       }
       if (isset($expectMessage['subject'])) {
-        $this->assertRegExp($expectMessage['subject'], $actualMessage['subject'], $errorText);
+        $this->assertMatchesRegularExpression($expectMessage['subject'], $actualMessage['subject'], $errorText);
       }
     }
   }

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -99,7 +99,7 @@ class ManagerTest extends \CiviUnitTestCase {
    */
   public function testGetPartials() {
     $partials = $this->angular->getPartials('crmMailing');
-    $this->assertRegExp('/ng-form="crmMailingSubform">/', $partials['~/crmMailing/EditMailingCtrl/2step.html']);
+    $this->assertMatchesRegularExpression('/ng-form="crmMailingSubform">/', $partials['~/crmMailing/EditMailingCtrl/2step.html']);
     // If crmMailing changes, feel free to use a different example.
   }
 
@@ -110,7 +110,7 @@ class ManagerTest extends \CiviUnitTestCase {
     \CRM_Utils_Hook::singleton()->setHook('civicrm_alterAngular', [$this, 'hook_civicrm_alterAngular']);
 
     $partials = $this->angular->getPartials('crmMailing');
-    $this->assertRegExp('/ng-form="crmMailingSubform" cat-stevens="ts\\(\'wild world\'\\)">/', $partials['~/crmMailing/EditMailingCtrl/2step.html']);
+    $this->assertMatchesRegularExpression('/ng-form="crmMailingSubform" cat-stevens="ts\\(\'wild world\'\\)">/', $partials['~/crmMailing/EditMailingCtrl/2step.html']);
     // If crmMailing changes, feel free to use a different example.
   }
 
@@ -118,11 +118,11 @@ class ManagerTest extends \CiviUnitTestCase {
     \CRM_Utils_Hook::singleton()->setHook('civicrm_angularModules', [$this, 'hook_civicrm_angularModules_fooBar']);
 
     $paths = $this->angular->getResources(['fooBar'], 'js', 'path');
-    $this->assertRegExp('/visual-bundle.[a-z0-9]+.js/', $paths[0]);
-    $this->assertRegExp('/crossfilter/', file_get_contents($paths[0]));
+    $this->assertMatchesRegularExpression('/visual-bundle.[a-z0-9]+.js/', $paths[0]);
+    $this->assertMatchesRegularExpression('/crossfilter/', file_get_contents($paths[0]));
 
-    $this->assertRegExp('/Common.js/', $paths[1]);
-    $this->assertRegExp('/console/', file_get_contents($paths[1]));
+    $this->assertMatchesRegularExpression('/Common.js/', $paths[1]);
+    $this->assertMatchesRegularExpression('/console/', file_get_contents($paths[1]));
   }
 
   /**

--- a/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
+++ b/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
@@ -47,7 +47,7 @@ class CiviEventDispatcherTest extends \CiviUnitTestCase {
       $this->fail('Expected exception');
     }
     catch (\Exception $e) {
-      $this->assertRegExp(';The dispatch policy prohibits event;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';The dispatch policy prohibits event;', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
@@ -48,7 +48,7 @@ class CryptoJwtTest extends \CiviUnitTestCase {
       $this->fail('Expected decode to fail with exception');
     }
     catch (CryptoException $e) {
-      $this->assertRegExp(';Expired token;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Expired token;', $e->getMessage());
     }
   }
 
@@ -89,7 +89,7 @@ class CryptoJwtTest extends \CiviUnitTestCase {
         $this->fail('Expected decode to fail with exception');
       }
       catch (CryptoException $e) {
-        $this->assertRegExp(';Signature verification failed;', $e->getMessage());
+        $this->assertMatchesRegularExpression(';Signature verification failed;', $e->getMessage());
       }
     }
   }

--- a/tests/phpunit/Civi/Crypto/CryptoRegistryTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoRegistryTest.php
@@ -102,7 +102,7 @@ class CryptoRegistryTest extends \CiviUnitTestCase {
       $this->fail("Expected crypto exception");
     }
     catch (CryptoException $e) {
-      $this->assertRegExp(';Malformed key ID;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Malformed key ID;', $e->getMessage());
     }
   }
 

--- a/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
@@ -44,7 +44,7 @@ class CryptoTokenTest extends \CiviUnitTestCase {
       $this->fail("Expected CryptoException");
     }
     catch (CryptoException $e) {
-      $this->assertRegExp(';Cannot decrypt token. Invalid format.;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Cannot decrypt token. Invalid format.;', $e->getMessage());
     }
 
     $goodExample = $cryptoToken->encrypt('mess with me', 'UNIT-TEST');
@@ -57,7 +57,7 @@ class CryptoTokenTest extends \CiviUnitTestCase {
       $this->fail("Expected CryptoException");
     }
     catch (CryptoException $e) {
-      $this->assertRegExp(';Cannot decrypt token. Invalid format.;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';Cannot decrypt token. Invalid format.;', $e->getMessage());
     }
   }
 
@@ -84,7 +84,7 @@ class CryptoTokenTest extends \CiviUnitTestCase {
    */
   public function testRoundtrip($inputText, $inputKeyIdOrTag, $expectTokenRegex, $expectTokenLen, $expectPlain) {
     $token = \Civi::service('crypto.token')->encrypt($inputText, $inputKeyIdOrTag);
-    $this->assertRegExp($expectTokenRegex, $token);
+    $this->assertMatchesRegularExpression($expectTokenRegex, $token);
     $this->assertEquals($expectTokenLen, strlen($token));
     $this->assertEquals($expectPlain, \Civi::service('crypto.token')->isPlainText($token));
 
@@ -99,7 +99,7 @@ class CryptoTokenTest extends \CiviUnitTestCase {
     $cryptoToken = \Civi::service('crypto.token');
 
     $first = $cryptoToken->encrypt("hello world", 'UNIT-TEST');
-    $this->assertRegExp(';k=asdf-key-1;', $first);
+    $this->assertMatchesRegularExpression(';k=asdf-key-1;', $first);
     $this->assertEquals('hello world', $cryptoToken->decrypt($first));
 
     // If the keys haven't changed yet, then rekey() is a null-op.
@@ -113,8 +113,8 @@ class CryptoTokenTest extends \CiviUnitTestCase {
       'id' => 'new-key',
     ]);
     $third = $cryptoToken->rekey($first, 'UNIT-TEST');
-    $this->assertNotRegExp(';k=asdf-key-1;', $third);
-    $this->assertRegExp(';k=new-key;', $third);
+    $this->assertDoesNotMatchRegularExpression(';k=asdf-key-1;', $third);
+    $this->assertMatchesRegularExpression(';k=new-key;', $third);
     $this->assertEquals('hello world', $cryptoToken->decrypt($third));
   }
 
@@ -141,7 +141,7 @@ class CryptoTokenTest extends \CiviUnitTestCase {
       'id' => 'interim-key',
     ]);
     $third = $cryptoToken->rekey($first, 'APPLE');
-    $this->assertRegExp(';k=interim-key;', $third);
+    $this->assertMatchesRegularExpression(';k=interim-key;', $third);
     $this->assertEquals('hello world', $cryptoToken->decrypt($third));
 
     // But if we add another key with earlier priority,

--- a/tests/phpunit/Civi/Payment/PropertyBagTest.php
+++ b/tests/phpunit/Civi/Payment/PropertyBagTest.php
@@ -467,7 +467,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
       $propertyBag->setBillingCountry($bad);
       $this->assertCount(1, $propertyBag->logs);
       $latestLog = end($propertyBag->logs);
-      $this->assertRegExp("/setBillingCountry input warnings.*Expected string.*munged to: \"\"/s", $latestLog);
+      $this->assertMatchesRegularExpression("/setBillingCountry input warnings.*Expected string.*munged to: \"\"/s", $latestLog);
       $this->assertEquals('', $propertyBag->getBillingCountry());
     }
 
@@ -477,7 +477,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $propertyBag->setBillingCountry('');
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
-    $this->assertRegExp('/setBillingCountry input warnings.+\nNot ISO 3166-1.+\n.*munged to: ""/', $latestLog);
+    $this->assertMatchesRegularExpression('/setBillingCountry input warnings.+\nNot ISO 3166-1.+\n.*munged to: ""/', $latestLog);
     $this->assertEquals('', $propertyBag->getBillingCountry());
 
     // Invalid country name
@@ -486,7 +486,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $propertyBag->setBillingCountry('UnitedKing');
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
-    $this->assertRegExp('/setBillingCountry input warnings.+\nNot ISO 3166-1.+\nGiven input did not match a country name\.\n.*munged to: ""/', $latestLog);
+    $this->assertMatchesRegularExpression('/setBillingCountry input warnings.+\nNot ISO 3166-1.+\nGiven input did not match a country name\.\n.*munged to: ""/', $latestLog);
     $this->assertEquals('', $propertyBag->getBillingCountry());
 
     // Valid country name
@@ -495,7 +495,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $propertyBag->setBillingCountry('United Kingdom');
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
-    $this->assertRegExp('/setBillingCountry input warnings.+\nNot ISO 3166-1.+\nGiven input matched a country name.*?\n.*munged to: "GB"/', $latestLog);
+    $this->assertMatchesRegularExpression('/setBillingCountry input warnings.+\nNot ISO 3166-1.+\nGiven input matched a country name.*?\n.*munged to: "GB"/', $latestLog);
     $this->assertEquals('GB', $propertyBag->getBillingCountry());
 
     // Invalid country ID
@@ -504,7 +504,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $propertyBag->setBillingCountry(-1);
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
-    $this->assertRegExp('/setBillingCountry input warnings.+\nExpected string\nGiven input looked like it could be a country ID but did not.*?\n.*munged to: ""/', $latestLog);
+    $this->assertMatchesRegularExpression('/setBillingCountry input warnings.+\nExpected string\nGiven input looked like it could be a country ID but did not.*?\n.*munged to: ""/', $latestLog);
     $this->assertEquals('', $propertyBag->getBillingCountry());
 
     // Valid country ID
@@ -513,7 +513,7 @@ class PropertyBagTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $propertyBag->setBillingCountry(1154); /* should be New Zealand */
     $this->assertCount(1, $propertyBag->logs);
     $latestLog = end($propertyBag->logs);
-    $this->assertRegExp('/setBillingCountry input warnings.+\nExpected string\nGiven input matched a country ID.*?\n.*munged to: "NZ"/', $latestLog);
+    $this->assertMatchesRegularExpression('/setBillingCountry input warnings.+\nExpected string\nGiven input matched a country ID.*?\n.*munged to: "NZ"/', $latestLog);
     $this->assertEquals('NZ', $propertyBag->getBillingCountry());
   }
 

--- a/tests/phpunit/Civi/Pipe/JsonRpcSessionTest.php
+++ b/tests/phpunit/Civi/Pipe/JsonRpcSessionTest.php
@@ -123,7 +123,7 @@ class JsonRpcSessionTest extends \CiviUnitTestCase {
     $decode = json_decode($responses[1], TRUE);
     $this->assertEquals('2.0', $decode['jsonrpc']);
     $this->assertEquals('bad1', $decode['id']);
-    $this->assertRegexp(';API.*System.*zznnzznnzz.*not exist;', $decode['error']['message']);
+    $this->assertMatchesRegularExpression(';API.*System.*zznnzznnzz.*not exist;', $decode['error']['message']);
 
     $decode = json_decode($responses[2], TRUE);
     $this->assertEquals('2.0', $decode['jsonrpc']);
@@ -134,7 +134,7 @@ class JsonRpcSessionTest extends \CiviUnitTestCase {
     $this->assertEquals('2.0', $decode['jsonrpc']);
     $this->assertEquals('bad2', $decode['id']);
     $this->assertEquals(1, $decode['result']['is_error']);
-    $this->assertRegexp(';API.*System.*zznnzznnzz.*not exist;', $decode['result']['error_message']);
+    $this->assertMatchesRegularExpression(';API.*System.*zznnzznnzz.*not exist;', $decode['result']['error_message']);
   }
 
   public function testApi4() {
@@ -168,7 +168,7 @@ class JsonRpcSessionTest extends \CiviUnitTestCase {
     };
     $apiFail = function($line, $caseId) {
       $decode = json_decode($line, TRUE);
-      $this->assertRegExp(';Authorization failed;', $decode['error']['message'], "($caseId) Should have authorization error. Got: $line");
+      $this->assertMatchesRegularExpression(';Authorization failed;', $decode['error']['message'], "($caseId) Should have authorization error. Got: $line");
     };
 
     $cases = []; /* [ ActivePerms?, Trusted?, CheckPerms?, ExpectResult */
@@ -193,7 +193,7 @@ class JsonRpcSessionTest extends \CiviUnitTestCase {
       [$inActivePerms, $inTrusted, $inApiCall, $expect] = $case;
       $this->setPermissions($inActivePerms);
       $responses = $this->runLines([$useException, $inApiCall], $inTrusted);
-      $this->assertRegExp($inTrusted === 'u' ? ';"untrusted";' : ';"trusted";', $responses[0], "($caseId) Header should indicate trust level");
+      $this->assertMatchesRegularExpression($inTrusted === 'u' ? ';"untrusted";' : ';"trusted";', $responses[0], "($caseId) Header should indicate trust level");
       $expect($responses[2], $caseId);
     }
   }
@@ -212,7 +212,7 @@ class JsonRpcSessionTest extends \CiviUnitTestCase {
     $decode = json_decode($responses[1], TRUE);
     $this->assertEquals('2.0', $decode['jsonrpc']);
     $this->assertEquals('bad1', $decode['id']);
-    $this->assertRegexp(';Api.*System.*zznnzznnzz.*not exist;', $decode['error']['message']);
+    $this->assertMatchesRegularExpression(';Api.*System.*zznnzznnzz.*not exist;', $decode['error']['message']);
 
     $decode = json_decode($responses[2], TRUE);
     $this->assertEquals('2.0', $decode['jsonrpc']);
@@ -223,7 +223,7 @@ class JsonRpcSessionTest extends \CiviUnitTestCase {
     $this->assertEquals('2.0', $decode['jsonrpc']);
     $this->assertEquals('bad2', $decode['id']);
     $this->assertEquals(1, $decode['result']['is_error']);
-    $this->assertRegexp(';Api.*System.*zznnzznnzz.*not exist;', $decode['result']['error_message']);
+    $this->assertMatchesRegularExpression(';Api.*System.*zznnzznnzz.*not exist;', $decode['result']['error_message']);
   }
 
   /**

--- a/tests/phpunit/Civi/Schema/MagicGetterSetterTest.php
+++ b/tests/phpunit/Civi/Schema/MagicGetterSetterTest.php
@@ -102,7 +102,7 @@ class MagicGetterSetterTest extends \CiviUnitTestCase {
       }
       catch (\CRM_Core_Exception $e) {
         $message = $e->getMessage();
-        $this->assertRegExp('/Unknown method.*::' . $nonMethod . '()/', $message);
+        $this->assertMatchesRegularExpression('/Unknown method.*::' . $nonMethod . '()/', $message);
       }
     }
   }

--- a/tests/phpunit/Civi/Test/ExampleHookTest.php
+++ b/tests/phpunit/Civi/Test/ExampleHookTest.php
@@ -90,7 +90,7 @@ class ExampleHookTest extends TestCase implements HeadlessInterface, HookInterfa
     $p = new Main();
     $p->run();
     $content = ob_get_clean();
-    $this->assertRegExp('; hook_civicrm_alterContent on_hook_civicrm_alterContent;', $content);
+    $this->assertMatchesRegularExpression('; hook_civicrm_alterContent on_hook_civicrm_alterContent;', $content);
   }
 
   /**

--- a/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
+++ b/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
@@ -75,7 +75,7 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
     $p->run();
     $content = ob_get_contents();
     ob_end_clean();
-    $this->assertRegExp(';myAlterContentObject myAlterContentParams;', $content);
+    $this->assertMatchesRegularExpression(';myAlterContentObject myAlterContentParams;', $content);
   }
 
   public function testGetFields() {

--- a/tests/phpunit/CiviTest/CiviEndToEndTestCase.php
+++ b/tests/phpunit/CiviTest/CiviEndToEndTestCase.php
@@ -9,6 +9,10 @@
  * Note: If you need to work as a different user, try using `cv()` or
  * a web-service.
  */
+
+// phpcs:ignore
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+
 class CiviEndToEndTestCase extends PHPUnit\Framework\TestCase implements \Civi\Test\EndToEndInterface {
 
   public static function setUpBeforeClass(): void {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -43,6 +43,8 @@ use Civi\Payment\System;
 use Civi\Api4\OptionValue;
 use Civi\Test\Api3DocTrait;
 use League\Csv\Reader;
+// phpcs:ignore
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 /**
  *  Include class definitions

--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -133,7 +133,7 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     \Civi::service('asset_builder')->setCacheEnabled(TRUE);
     $url = \Civi::service('asset_builder')->getUrl($asset, $params);
     $this->assertEquals(1, $this->fired['hook_civicrm_buildAsset']);
-    $this->assertRegExp(';^https?:.*dyn/square.[0-9a-f]+.(txt|js)$;', $url);
+    $this->assertMatchesRegularExpression(';^https?:.*dyn/square.[0-9a-f]+.(txt|js)$;', $url);
     $this->assertEquals($expectedContent, file_get_contents($url));
     // Note: This actually relies on httpd to determine MIME type.
     // That could be ambiguous for javascript.
@@ -157,7 +157,7 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     $url = \Civi::service('asset_builder')->getUrl($asset, $params);
     $this->assertEquals(0, $this->fired['hook_civicrm_buildAsset']);
     // Ex: Traditional URLs on D7 have "/". Traditional URLs on WP have "%2F".
-    $this->assertRegExp(';^https?:.*civicrm(/|%2F)asset(/|%2F)builder.*square.(txt|js);', $url);
+    $this->assertMatchesRegularExpression(';^https?:.*civicrm(/|%2F)asset(/|%2F)builder.*square.(txt|js);', $url);
 
     // Simulate a request. Our fake hook won't fire in a real request.
     parse_str(parse_url($url, PHP_URL_QUERY), $get);

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -64,7 +64,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
 
     foreach (array_merge($urlOnly, $pathAndUrl) as $var) {
       $url = \Civi::paths()->getVariable($var, 'url');
-      $this->assertRegExp(';^https?:;', $url, "The URL for $var should resolve a URL.");
+      $this->assertMatchesRegularExpression(';^https?:;', $url, "The URL for $var should resolve a URL.");
     }
   }
 
@@ -73,9 +73,9 @@ class PathUrlTest extends \CiviEndToEndTestCase {
    * @param string $url
    */
   private function assertUrlContentRegex($expectContentRegex, $url) {
-    $this->assertRegexp(';^https?:;', $url, "The URL ($url) should be absolute.");
+    $this->assertMatchesRegularExpression(';^https?:;', $url, "The URL ($url) should be absolute.");
     $content = file_get_contents($url);
-    $this->assertRegexp($expectContentRegex, $content);
+    $this->assertMatchesRegularExpression($expectContentRegex, $content);
   }
 
   /**
@@ -85,7 +85,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
   private function assertFileContentRegex($expectContentRegex, $file) {
     $this->assertFileExists($file);
     $content = file_get_contents($file);
-    $this->assertRegexp($expectContentRegex, $content);
+    $this->assertMatchesRegularExpression($expectContentRegex, $content);
   }
 
   /**

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -320,7 +320,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
     $this->assertEquals($entity_table, $createResult['values'][$fileId]['entity_table']);
     $this->assertEquals($entity->id, $createResult['values'][$fileId]['entity_id']);
     $this->assertEquals('My test description', $createResult['values'][$fileId]['description']);
-    $this->assertRegExp('/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $createResult['values'][$fileId]['upload_date']);
+    $this->assertMatchesRegularExpression('/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $createResult['values'][$fileId]['upload_date']);
     $this->assertTrue(!isset($createResult['values'][$fileId]['content']));
     $this->assertTrue(!empty($createResult['values'][$fileId]['url']));
     $this->assertAttachmentExistence(TRUE, $createResult);
@@ -376,7 +376,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
       'entity_table' => $entity_table,
       'entity_id' => $entity->id,
     ]);
-    $this->assertRegExp($expectedError, $createResult['error_message']);
+    $this->assertMatchesRegularExpression($expectedError, $createResult['error_message']);
   }
 
   /**
@@ -401,7 +401,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
     $updateResult = $this->callAPIFailure('Attachment', 'create', $updateParams + [
       'id' => $fileId,
     ]);
-    $this->assertRegExp($expectedError, $updateResult['error_message']);
+    $this->assertMatchesRegularExpression($expectedError, $updateResult['error_message']);
   }
 
   /**
@@ -557,7 +557,7 @@ class api_v3_AttachmentTest extends CiviUnitTestCase {
     }
 
     $getResult = $this->callAPIFailure('Attachment', 'get', $getParams);
-    $this->assertRegExp($expectedError, $getResult['error_message']);
+    $this->assertMatchesRegularExpression($expectedError, $getResult['error_message']);
   }
 
   /**

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -906,8 +906,8 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $case_1 = $this->callAPISuccess('Case', 'getsingle', [
       'id' => $case_created['id'],
     ]);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_1['created_date']);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_1['modified_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_1['created_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_1['modified_date']);
     $this->assertApproxEquals(strtotime($case_1['created_date']), strtotime($case_1['modified_date']), 2);
 
     $activity_1 = $this->callAPISuccess('activity', 'getsingle', [
@@ -916,8 +916,8 @@ class api_v3_CaseTest extends CiviCaseTestCase {
         'limit' => 1,
       ],
     ]);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_1['created_date']);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_1['modified_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_1['created_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_1['modified_date']);
     $this->assertApproxEquals(strtotime($activity_1['created_date']), strtotime($activity_1['modified_date']), 2);
 
     usleep(1.5 * 1000000);
@@ -929,8 +929,8 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $activity_2 = $this->callAPISuccess('activity', 'getsingle', [
       'id' => $activity_1['id'],
     ]);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_2['created_date']);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_2['modified_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_2['created_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_2['modified_date']);
     $this->assertNotEquals($activity_2['created_date'], $activity_2['modified_date']);
 
     $this->assertEquals($activity_1['created_date'], $activity_2['created_date']);
@@ -941,8 +941,8 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $case_2 = $this->callAPISuccess('Case', 'getsingle', [
       'id' => $case_created['id'],
     ]);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_2['created_date']);
-    $this->assertRegExp(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_2['modified_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_2['created_date']);
+    $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_2['modified_date']);
     $this->assertEquals($case_1['created_date'], $case_2['created_date']);
     $this->assertNotEquals($case_2['created_date'], $case_2['modified_date']);
   }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -622,7 +622,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'id' => $contactId,
       'api_key' => 'defg4321',
     ]);
-    $this->assertRegExp(';Permission denied to modify api key;', $result['error_message']);
+    $this->assertMatchesRegularExpression(';Permission denied to modify api key;', $result['error_message']);
 
     // Return everything -- because permissions are not being checked
     $config->userPermissionClass->permissions = [];
@@ -2656,7 +2656,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $result = $this->callAPIFailure('Contact', 'get', [
       'id' => '@user:exampleUser',
     ]);
-    $this->assertRegExp('/cannot be resolved to a contact ID/', $result['error_message']);
+    $this->assertMatchesRegularExpression('/cannot be resolved to a contact ID/', $result['error_message']);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -176,7 +176,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals(95.00, $contribution['net_amount']);
     $this->assertEquals(23456, $contribution['trxn_id']);
     $this->assertEquals(78910, $contribution['invoice_id']);
-    $this->assertRegExp('/INV_\d+/', $contribution['invoice_number']);
+    $this->assertMatchesRegularExpression('/INV_\d+/', $contribution['invoice_number']);
     $this->assertEquals('SSF', $contribution['contribution_source']);
     $this->assertEquals('Completed', $contribution['contribution_status']);
     // Create a second contribution - we are testing that 'id' gets the right contribution id (not the contact id).

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -301,8 +301,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $this->assertEquals("Hello $displayName", $previewResult['values']['subject']);
     $this->assertStringContainsString("This is $displayName", $previewResult['values']['body_text']);
     $this->assertStringContainsString("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
-    $this->assertRegexp('!>Forward this email</a>!', $previewResult['values']['body_html']);
-    $this->assertRegexp('!<a href="([^"]+)civicrm/mailing/forward&amp;amp;reset=1&amp;jid=&amp;qid=&amp;h=\w*">!', $previewResult['values']['body_html']);
+    $this->assertMatchesRegularExpression('!>Forward this email</a>!', $previewResult['values']['body_html']);
+    $this->assertMatchesRegularExpression('!<a href="([^"]+)civicrm/mailing/forward&amp;amp;reset=1&amp;jid=&amp;qid=&amp;h=\w*">!', $previewResult['values']['body_html']);
     $this->assertStringNotContainsString("http://http://", $previewResult['values']['body_html']);
   }
 
@@ -677,7 +677,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $submitParams['id'] = $id;
     if ($expectedFailure) {
       $submitResult = $this->callAPIFailure('mailing', 'submit', $submitParams);
-      $this->assertRegExp($expectedFailure, $submitResult['error_message']);
+      $this->assertMatchesRegularExpression($expectedFailure, $submitResult['error_message']);
     }
     else {
       $submitResult = $this->callAPIAndDocument('Mailing', 'submit', $submitParams, __FUNCTION__, __FILE__);
@@ -1076,7 +1076,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
       $this->callAPISuccess('mailing', 'create', $this->_params + ['id' => $mail['id'], 'modified_date' => '2 seconds ago']);
     }
     catch (Exception $e) {
-      $this->assertRegExp("/Failure in api call for mailing create:  Mailing has not been saved, Content maybe out of date, please refresh the page and try again/", $e->getMessage());
+      $this->assertMatchesRegularExpression("/Failure in api call for mailing create:  Mailing has not been saved, Content maybe out of date, please refresh the page and try again/", $e->getMessage());
     }
   }
 

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -803,7 +803,7 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
     $result = civicrm_api($Entity, 'Get', ['version' => 3]);
     $this->assertEquals(1, $result['is_error']);
     // $this->assertStringContainsString("API ($Entity, Get) does not exist", $result['error_message']);
-    $this->assertRegExp('/API (.*) does not exist/', $result['error_message']);
+    $this->assertMatchesRegularExpression('/API (.*) does not exist/', $result['error_message']);
   }
 
   /**

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -79,7 +79,7 @@ class api_v3_SystemTest extends CiviUnitTestCase {
 
   public function testSystemGet() {
     $result = $this->callAPISuccess('system', 'get', []);
-    $this->assertRegExp('/^[0-9]+\.[0-9]+\.[0-9a-z\-]+$/', $result['values'][0]['version']);
+    $this->assertMatchesRegularExpression('/^[0-9]+\.[0-9]+\.[0-9a-z\-]+$/', $result['values'][0]['version']);
     $this->assertEquals('UnitTests', $result['values'][0]['uf']);
   }
 

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -98,7 +98,7 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     catch (\CRM_Core_Exception $e) {
       $msg = $e->getMessage();
     }
-    $this->assertRegExp(';Expected to find one Contact record;', $msg);
+    $this->assertMatchesRegularExpression(';Expected to find one Contact record;', $msg);
     $limit1 = Contact::get(FALSE)->addWhere('last_name', '=', $last_name)->setLimit(1)->execute();
     $this->assertCount(1, (array) $limit1);
     $this->assertCount(1, $limit1);

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -25,6 +25,8 @@ use Civi\Test\Api4TestTrait;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use PHPUnit\Framework\TestCase;
+// phpcs:ignore
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 /**
  * @group headless

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -174,7 +174,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
     $this->assertNotEmpty($info['description']);
     $this->assertIsArray($info['primary_key']);
     $this->assertNotEmpty($info['primary_key']);
-    $this->assertRegExp(';^\d\.\d+$;', $info['since']);
+    $this->assertMatchesRegularExpression(';^\d\.\d+$;', $info['since']);
     $this->assertContains($info['searchable'], ['primary', 'secondary', 'bridge', 'none']);
     // Bridge must be between exactly 2 entities
     if (in_array('EntityBridge', $info['type'], TRUE)) {

--- a/tests/phpunit/api/v4/Entity/TranslationTest.php
+++ b/tests/phpunit/api/v4/Entity/TranslationTest.php
@@ -191,7 +191,7 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface, Ho
       $this->fail('Create should have failed');
     }
     catch (\CRM_Core_Exception $e) {
-      $this->assertRegExp($errorRegex, $e->getMessage());
+      $this->assertMatchesRegularExpression($errorRegex, $e->getMessage());
     }
   }
 
@@ -221,7 +221,7 @@ class TranslationTest extends Api4TestBase implements TransactionalInterface, Ho
         $this->fail('Update should fail');
       }
       catch (\CRM_Core_Exception $e) {
-        $this->assertRegExp($errorRegex, $e->getMessage());
+        $this->assertMatchesRegularExpression($errorRegex, $e->getMessage());
       }
     }
   }

--- a/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
+++ b/tests/phpunit/api/v4/Entity/ValidateValuesTest.php
@@ -162,9 +162,9 @@ class ValidateValuesTest extends Api4TestBase implements TransactionalInterface 
     }
     catch (\CRM_Core_Exception $e) {
       $this->assertEquals(1, $hookCount);
-      $this->assertRegExp(';not sufficiently namey;', $e->getMessage());
-      $this->assertRegExp(';tongue twister;', $e->getMessage());
-      $this->assertRegExp(';disagree with the spelling;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';not sufficiently namey;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';tongue twister;', $e->getMessage());
+      $this->assertMatchesRegularExpression(';disagree with the spelling;', $e->getMessage());
     }
   }
 
@@ -185,8 +185,8 @@ class ValidateValuesTest extends Api4TestBase implements TransactionalInterface 
   }
 
   protected function assertWellFormedEvent(ValidateValuesEvent $e) {
-    $this->assertRegExp('/Contact/', $e->getEntityName());
-    $this->assertRegExp('/create|save|update/', $e->getActionName());
+    $this->assertMatchesRegularExpression('/Contact/', $e->getEntityName());
+    $this->assertMatchesRegularExpression('/create|save|update/', $e->getActionName());
     $this->assertTrue(count($e->records) > 0);
     foreach ($e->records as $record) {
       $this->assertWellFormedFields($record);
@@ -207,7 +207,7 @@ class ValidateValuesTest extends Api4TestBase implements TransactionalInterface 
 
   protected function assertWellFormedFields($record) {
     foreach ($record as $field => $value) {
-      $this->assertRegExp('/^[a-zA-Z0-9_]+$/', $field);
+      $this->assertMatchesRegularExpression('/^[a-zA-Z0-9_]+$/', $field);
     }
   }
 

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -52,7 +52,7 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
       ->execute()
       ->single();
     $result = $ex['render'][0];
-    $this->assertRegExp('/Case ID : 1234/', $result['text']);
+    $this->assertMatchesRegularExpression('/Case ID : 1234/', $result['text']);
   }
 
   public function testRenderCustomTemplate() {
@@ -69,7 +69,7 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
       ])
       ->execute()
       ->single();
-    $this->assertRegExp('/The role is myrole./', $result['text']);
+    $this->assertMatchesRegularExpression('/The role is myrole./', $result['text']);
   }
 
   public function testRenderExamplesBaseline() {
@@ -131,7 +131,7 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
     foreach ($example['asserts']['default'] as $num => $assert) {
       $msg = sprintf('Check assertion(%s) on example (%s)', $num, $example['name']);
       if (isset($assert['regex'])) {
-        $this->assertRegExp($assert['regex'], $result[$assert['for']], $msg);
+        $this->assertMatchesRegularExpression($assert['regex'], $result[$assert['for']], $msg);
       }
       else {
         $this->fail('Unrecognized assertion: ' . json_encode($assert));


### PR DESCRIPTION
Overview
----------------------------------------
assertRegExp is deprecated in phpunit 9, but the replacement isn't available yet in phpunit 8. The polyfill fills the gap.

Before
----------------------------------------
Can't replace deprecated functions yet.

After
----------------------------------------
Can replace deprecated functions.

Technical Details
----------------------------------------
The meat of it is the `use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;` in CiviUnitTestCase. The rest is just find/replace.

I expect this will cause (more) tests to fail in the drupal 8 matrix. The way the build works there it doesn't pull in the dev dependencies. I won't rant about composer here just will say that civi is a subproject in that matrix not the root, so dev dependencies need to be pulled in by the build script.

Comments
----------------------------------------
The original diff I was using for drupal 10 tests also had a fix in CRM_Utils_System::fixUrl for null input, but I've left that out since it doesn't really belong here, and I can't remember offhand what triggered it. I think I was going to go back and try to find out what was passing in null for the url. I don't think it will come up in the run here.