### PR TITLE
Populate custom fields URL params when the custom group extends only …

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -342,8 +342,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
    * @param bool $onlySubType
    *   Only return specified subtype or return specified subtype + unrestricted fields.
    * @param bool $returnAll
-   *   Do not restrict by subtype at all. (The parameter feels a bit cludgey but is only used from the
-   *   api - through which it is properly tested - so can be refactored with some comfort.)
+   *   Do not restrict by subtype at all.
    * @param bool|int $checkPermission
    *   Either a CRM_Core_Permission constant or FALSE to disable checks
    * @param string|int $singleRecord
@@ -1599,7 +1598,7 @@ ORDER BY civicrm_custom_group.weight,
       return [];
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree($type);
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($type, [], NULL, NULL, [], NULL, TRUE, NULL, TRUE);
     $customValue = [];
     $htmlType = [
       'CheckBox',


### PR DESCRIPTION
…particular types of event/contribution/etc.

Overview
----------------------------------------
You can pass default values for custom fields on event reg/contribution pages/etc.  However, if your custom field only extends certain contribution/event types, it won't be populated.

To replicate, create a new custom field group that extends only contributions of type "Donation" and add it to a profile on a contribution page.  Try to populate it from the URL, e.g. https://mysite.org/civicrm/contribute/transact?reset=1&id=4&custom_62=Friend

Before
----------------------------------------
Value doesn't populate (but does if the custom group extends all contributions and not just some types).

After
----------------------------------------
Value is populated.

Technical Details
----------------------------------------
We just need to be passing the `returnAll` parameter to `CRM_Core_BAO_CustomGroup::getTree`.

Comments
----------------------------------------
There's a second bug here - out of scope for me at present - because `CRM_Contribute_Form_Contribution_Main` has a line like this:     $getDefaults = CRM_Core_BAO_CustomGroup::extractGetParams($this, "'Contact', 'Individual', 'Contribution'");`  While passing three entities at once technically works, `getTree()` is clearly not designed to support multiple entities like this, and we can't pick up custom fields that belong only to contact subtypes this way.