### PR TITLE
Fix master-only regression - upgrade script is in wrong version

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFiftyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveFiftyNine.php
@@ -39,7 +39,6 @@ class CRM_Upgrade_Incremental_php_FiveFiftyNine extends CRM_Upgrade_Incremental_
   public function upgrade_5_59_alpha1(string $rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Drop column civicrm_custom_field.mask', 'dropColumn', 'civicrm_custom_field', 'mask');
-    $this->addTask('Add column civicrm_custom_field.fk_entity', 'addColumn', 'civicrm_custom_field', 'fk_entity', "varchar(255) DEFAULT NULL COMMENT 'Name of entity being referenced.'");
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveSixty.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixty.php
@@ -30,6 +30,8 @@ class CRM_Upgrade_Incremental_php_FiveSixty extends CRM_Upgrade_Incremental_Base
   public function upgrade_5_60_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Add scheduled_reminder_smarty setting', 'addScheduledReminderSmartySetting');
+    $this->addTask('Add column civicrm_custom_field.fk_entity', 'addColumn', 'civicrm_custom_field', 'fk_entity', "varchar(255) DEFAULT NULL COMMENT 'Name of entity being referenced.'");
+
   }
 
   public function setPostUpgradeMessage(&$postUpgradeMessage, $rev): void {


### PR DESCRIPTION
I merged https://github.com/civicrm/civicrm-core/pull/25471 yesterday, well after 5.60 branch forked, into master. However, it includes upgrade script targetting 5.59 - which means that for anyone already on 5.59 it doesn't run. This moves it to the correct branch (5.60 aka master)
