### PR TITLE
dev/core#4132 Fix import for multi-custom boxes

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -420,12 +420,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
               if ((strtolower($v2['label']) == strtolower(trim($v1))) ||
                 (strtolower($v2['value']) == strtolower(trim($v1)))
               ) {
-                if ($htmlType == 'CheckBox') {
-                  $params[$key][$v2['value']] = $formatted[$key][$v2['value']] = 1;
-                }
-                else {
-                  $params[$key][] = $formatted[$key][] = $v2['value'];
-                }
+                $params[$key][] = $formatted[$key][] = $v2['value'];
               }
             }
           }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2548,16 +2548,20 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
   /**
    * @param array|null $row
+   *
+   * @return bool
    */
-  public function validateRow(?array $row): void {
+  public function validateRow(?array $row): bool {
     try {
       $rowNumber = $row['_id'];
       $values = array_values($row);
       $this->validateValues($values);
       $this->setImportStatus($rowNumber, 'VALID', '');
+      return TRUE;
     }
     catch (CRM_Core_Exception $e) {
       $this->setImportStatus($rowNumber, 'ERROR', $e->getMessage());
+      return FALSE;
     }
   }
 

--- a/ext/civiimport/Civi/Api4/Import/Import.php
+++ b/ext/civiimport/Civi/Api4/Import/Import.php
@@ -25,10 +25,12 @@ class Import extends DAOGetAction {
   public function _run(Result $result): void {
     $userJobID = (int) str_replace('Import_', '', $this->_entityName);
     $where = $this->where;
-    $this->addWhere('_status', 'IN', ['new', 'valid']);
     $this->getImportRows($result);
     $parser = $this->getParser($userJobID);
     foreach ($result as $row) {
+      if (!in_array($row['_status'], ['new', 'valid'], TRUE) && !$parser->validateRow($row)) {
+        continue;
+      }
       $parser->import(array_values($row));
     }
     $parser->doPostImportActions();

--- a/ext/civiimport/Civi/Api4/Import/ImportProcessTrait.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportProcessTrait.php
@@ -66,6 +66,7 @@ trait ImportProcessTrait {
       ->indexBy('name'));
     $importFields[] = '_id';
     $importFields[] = '_entity_id';
+    $importFields[] = '_status';
     $this->setSelect($importFields);
     parent::_run($result);
     foreach ($result as &$row) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4132 Fix import for multi-custom boxes

This is a combination of https://github.com/civicrm/civicrm-core/pull/24902 and a fix to the `Import_x.import` action for easier testing and to stop brain damage

#24902 is not against the rc & should be, as a regression. I did a new PR rather than asking @jmcclelland to rebase his

Before
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4132

- enable Civi Import - note the first part of this is agnostic to the extension but there is a fix to the extension in the PR too
- create a new custom contact field of type checkbox 
    ![image](https://user-images.githubusercontent.com/336308/220491984-5ad83300-ee6d-4a84-abd4-b0c437aaa09d.png)
    ![image](https://user-images.githubusercontent.com/336308/220492080-842d22cb-7c45-4076-8389-73bde7e5c4f5.png)

- do a contact import with a csv that looks like this (be sure to choose update on the first screen)
ID,Field
5,"a,b"
6,a
- map it like this
    ![image](https://user-images.githubusercontent.com/336308/220492564-2426e783-083d-404e-9fd0-946c61054c80.png)



- run the import
- click through to the error screen, 
    ![image](https://user-images.githubusercontent.com/336308/220492414-1d19df71-c2e6-4b6b-bf74-ea02b9853168.png)

- select the failed row & try the import again
    ![image](https://user-images.githubusercontent.com/336308/220492685-87b519cb-8834-4ca0-ae63-c12973a3d521.png)


Import of the row with one value fails, still fails on re-import


After
----------------------------------------
Rather than re-replicate the whole process just keep the error screen loaded. You can then pull the patch down and re-do the import action 

It  will re-import the row & it will go through! The right values should appear on contact 5 & contact 6

Technical Details
----------------------------------------
There are 2 parts here
1) the patch from @jmcclelland - that works because it removes some code that became redundant during the big cleanup but I didn't remove as I was perhaps a bit scared it might be there for some reason. Since it actively breaks stuff it should go
2) a fix to the import action. This isn't a regression - just a new-ish feature that is really confusing because it offers the user the chance to re-import a row & then actually skips trying if the row failed validation. Since the feature is in the extension & there are other import fixes already in 5.59 & it helps with this bug I figured it was OK to include

Comments
----------------------------------------
