### PR TITLE
Deprecate unused, exception class with non-standard name-spacing

### DIFF
--- a/Civi/Token/TokenException.php
+++ b/Civi/Token/TokenException.php
@@ -1,6 +1,11 @@
 <?php
 namespace Civi\Token;
 
+/**
+ * @deprecated
+ *
+ * Unused - non-compliant namespace -see https://github.com/civicrm/civicrm-core/pull/25634
+ */
 class TokenException extends \CRM_Core_Exception {
 
 }


### PR DESCRIPTION
@totten per https://github.com/civicrm/civicrm-core/pull/25634#issuecomment-1437807798 - this exception class is unused & does not follow what appears to be our exception namespace convention

The other 3 ARE in use

```
CRM/Utils/Cache/CacheException.php
CRM/Utils/Cache/InvalidArgumentException.php
Civi/Pipe/JsonRpcMethodException.php
```