### PR TITLE
Fixes common PHP8 warnings in templates

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -9,7 +9,7 @@
 *}
 {crmRegion name="price-set-1"}
 <div id="priceset" class="crm-section price_set-section">
-    {if $priceSet.help_pre}
+    {if isset($priceSet.help_pre) && $priceSet.help_pre}
         <div class="messages help">{$priceSet.help_pre}</div>
     {/if}
 
@@ -28,7 +28,7 @@
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
         {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
-            {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
+            {if isset($priceSet.help_pre) && $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
             <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_"|cat:$field_id}
@@ -52,7 +52,7 @@
                     {/if}
                   {/if}
                 {/foreach}
-                {if $element.help_post}
+                {if isset($element.help_post) && $element.help_post}
                   <div class="description">{$element.help_post}</div>
                 {/if}
               </div>
@@ -91,7 +91,7 @@
                       {/if}
                     {/if}
                   {/if}
-                  {if $element.help_post}<br /><span class="description">{$element.help_post}</span>{/if}
+                  {if isset($element.help_post) && $element.help_post}<br /><span class="description">{$element.help_post}</span>{/if}
                 </div>
 
             {/if}
@@ -115,7 +115,7 @@
         {/if}
     {/foreach}
 
-    {if $priceSet.help_post}
+    {if isset($element.help_post) && $priceSet.help_post}
       <div class="messages help">{$priceSet.help_post}</div>
     {/if}
 

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -4,7 +4,7 @@
   {/if}
 
   {assign var=profileFieldName value=$field.name}
-  {if $prefix}
+  {if isset($prefix) && $prefix}
     {assign var="formElement" value=$form.$prefix.$profileFieldName}
     {assign var="rowIdentifier" value=$form.$prefix.$profileFieldName.id}
   {else}
@@ -47,7 +47,7 @@
         <div class="content description">{$field.help_pre}</div>
       </div>
     {/if}
-    {if $field.options_per_line != 0}
+    {if isset($field.options_per_line) && $field.options_per_line != 0}
       <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
         <div class="label option-label">{$formElement.label}</div>
         <div class="content 3">
@@ -93,7 +93,7 @@
             {include file="CRM/Profile/Form/GreetingType.tpl"}
           {elseif ($profileFieldName eq 'group' && $form.group) || ($profileFieldName eq 'tag' && $form.tag)}
             {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$profileFieldName title=null context="profile"}
-          {elseif $field.is_datetime_field && $action & 4}
+          {elseif isset($field.is_datetime_field) && $field.is_datetime_field && $action & 4}
             <span class="crm-frozen-field">
               {$formElement.value|crmDate:$field.smarty_view_format}
               <input type="hidden"
@@ -117,7 +117,7 @@
               &nbsp;{$form.$phone_ext_field.html}
             {/if}
           {else}
-            {if $prefix}
+            {if isset($prefix) && $prefix}
               {if $profileFieldName eq 'organization_name' && !empty($form.onbehalfof_id)}
                 {$form.onbehalfof_id.html}
               {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Patch to handle common PHP8 warnings - undefined array key

Before
----------------------------------------
`{if $prefix}`

After
----------------------------------------
`{if isset($prefix) && $prefix}`

