### PR TITLE
Add APIv4 MailingEventClickThrough

### DIFF
--- a/Civi/Api4/MailingEventClickThrough.php
+++ b/Civi/Api4/MailingEventClickThrough.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Tracked clicks on mailing links
+ *
+ * @see \Civi\Api4\Mailing
+ * @since 5.60
+ * @package Civi\Api4
+ */
+class MailingEventClickThrough extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnlyEntity;
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a missing API for tracking click-throughs in sent mailings.

It appears to be an oversight from #25059 which claimed to add it but didn't.