### PR TITLE
Allow to disable an invalid relationship (eg. contact subtype was changed so no longer valid)

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -49,14 +49,16 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship implemen
   public static function create(&$params) {
 
     $extendedParams = self::loadExistingRelationshipDetails($params);
-    // When id is specified we always wan't to update, so we don't need to
-    // check for duplicate relations.
+    // When id is specified we always want to update, so we don't need to check for duplicate relations.
     if (!isset($params['id']) && self::checkDuplicateRelationship($extendedParams, (int) $extendedParams['contact_id_a'], (int) $extendedParams['contact_id_b'], CRM_Utils_Array::value('id', $extendedParams, 0))) {
       throw new CRM_Core_Exception('Duplicate Relationship');
     }
     $params = $extendedParams;
-    if (!CRM_Contact_BAO_Relationship::checkRelationshipType($params['contact_id_a'], $params['contact_id_b'],
-      $params['relationship_type_id'])) {
+    // Check if this is a "simple" disable relationship. If it is don't check the relationshipType
+    if (!empty($params['id']) && array_key_exists('is_active', $params) && empty($params['is_active'])) {
+      $disableRelationship = TRUE;
+    }
+    if (empty($disableRelationship) && !CRM_Contact_BAO_Relationship::checkRelationshipType($params['contact_id_a'], $params['contact_id_b'], $params['relationship_type_id'])) {
       throw new CRM_Core_Exception('Invalid Relationship');
     }
     $relationship = self::add($params);

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1398,10 +1398,9 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
    * @throws \CRM_Core_Exception
    */
   public static function relatedMemberships($contactId, $params, $ids, $action = CRM_Core_Action::ADD, $active = TRUE) {
-    // Check the end date and set the status of the relationship
-    // accordingly.
+    // Check the end date and set the status of the relationship accordingly.
     $status = self::CURRENT;
-    $targetContact = $targetContact = CRM_Utils_Array::value('contact_check', $params, []);
+    $targetContact = $params['contact_check'] ?? [];
     $today = date('Ymd');
 
     // If a relationship hasn't yet started, just return for now
@@ -1451,8 +1450,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
     // Build the 'values' array for
     // 1. ContactA
     // 2. ContactB
-    // This will allow us to check if either of the contacts in
-    // relationship have active memberships.
+    // This will allow us to check if either of the contacts in relationship have active memberships.
 
     $values = [];
 
@@ -1511,8 +1509,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
           ($status & self::PAST) &&
           ($membershipValues['owner_membership_id'])
         ) {
-          // If relationship is PAST and action is UPDATE
-          // then delete the RELATED membership
+          // If relationship is PAST and action is UPDATE then delete the RELATED membership
           CRM_Member_BAO_Membership::deleteRelatedMemberships($membershipValues['owner_membership_id'],
             $membershipValues['contact_id']
           );
@@ -1538,9 +1535,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         }
         $relTypeDir = $details['relationshipTypeId'] . $details['relationshipTypeDirection'];
         if (in_array($relTypeDir, $relTypeDirs)) {
-          // Check if relationship being created/updated is
-          // similar to that of membership type's
-          // relationship.
+          // Check if relationship being created/updated is similar to that of membership type's relationship.
 
           $membershipValues['owner_membership_id'] = $membershipId;
           unset($membershipValues['id']);
@@ -1563,11 +1558,10 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
                 continue;
               }
 
-              //delete the membership record for related
-              //contact before creating new membership record.
+              // delete the membership record for related contact before creating new membership record.
               CRM_Member_BAO_Membership::deleteRelatedMemberships($membershipId, $relatedContactId);
             }
-            //skip status calculation for pay later memberships.
+            // skip status calculation for pay later memberships.
             if ('Pending' === CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membershipValues['status_id'])) {
               $membershipValues['skipStatusCal'] = TRUE;
             }


### PR DESCRIPTION
Overview
----------------------------------------
If you use (and change) contact sub-types it is easy to end up with invalid relationships that you can't do anything with.
It should be possible to disable these relationships without having to modify them (eg. a contact who had "Staff" subtype is changed to "Ex-Staff" subtype).
The relationship is now invalid according to CiviCRM but it is still correct from a historical data perspective. This also affects the "update expired relationships" scheduled job which can get stuck if it finds and invalid relationship.

Before
----------------------------------------
Invalid relationships can't be disabled..

After
----------------------------------------
Invalid relationships can be disabled.

Technical Details
----------------------------------------
Explained above. It would be nice to have a separate API call for disable so we don't have to have so much logic in ::create. But that would require changes to various parts of the API/UI etc. so out of scope for now.

Comments
----------------------------------------

