### PR TITLE
Reduce processing load in test `assertAPIFailure`

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -74,16 +74,20 @@ trait Api3TestTrait {
    *   Api result.
    * @param string $prefix
    *   Extra test to add to message.
-   * @param null $expectedError
+   * @param string|null $expectedError
    */
-  public function assertAPIFailure($apiResult, $prefix = '', $expectedError = NULL) {
+  public function assertAPIFailure(array $apiResult, string $prefix = '', ?string $expectedError = NULL): void {
     if (!empty($prefix)) {
       $prefix .= ': ';
     }
     if ($expectedError && !empty($apiResult['is_error'])) {
       $this->assertStringContainsString($expectedError, $apiResult['error_message'], 'api error message not as expected' . $prefix);
     }
-    $this->assertEquals(1, $apiResult['is_error'], "api call should have failed but it succeeded " . $prefix . (print_r($apiResult, TRUE)));
+    if (!$apiResult['is_error']) {
+      // This section only called when it is going to fail - that means we don't have to parse the print_r in the message
+      // if it is not going to be used anyway. It's really helpful for debugging when needed, but potentially expensive otherwise.
+      $this->fail('api call should have failed but it succeeded ' . $prefix . (print_r($apiResult, TRUE)));
+    }
     $this->assertNotEmpty($apiResult['error_message']);
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Reduce processing load in test `assertAPIFailure`

Before
----------------------------------------
`apiResult` is parsed through `print_r` regardless of whether we want the output

After
----------------------------------------
`apiResult` only parsed through `print_r` it the outut will be used

Technical Details
----------------------------------------
In trying to figure out why adding 'too much' (an exception) to the return caused a memory out I realised that the print_r here is realised regardless of whether it is needed. This fixes to only resolve if it is going to be displayed. Arguably this would have been a case where an inline function would have made sense - but at the cost of readability - ie it's more helpful
to add code comments to explain the if than to make the codd hard to follow. The only downside is the hypothetical
possibility of is_error being something other than 1,'1',TRUE - I think if we thought that was a remote possibilty we would add a unit test to add it - not cover it in an assertion

Comments
----------------------------------------
