### PR TITLE
dev/core#4126 - Fix force-url parameters on case dashboard

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -765,7 +765,7 @@ HERESQL;
     $caseTypes = array_flip($caseTypes);
 
     // get statuses as headers for the table
-    $url = CRM_Utils_System::url('civicrm/case/search', "reset=1&force=1&all=1&status=");
+    $url = CRM_Utils_System::url('civicrm/case/search', "reset=1&force=1&all=1&case_status_id=");
     foreach ($caseStatuses as $key => $name) {
       $caseSummary['headers'][$key]['status'] = $name;
       $caseSummary['headers'][$key]['url'] = $url . $key;
@@ -831,7 +831,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
         $rows[$res->case_type][$res->case_status] = [
           'count' => 1,
           'url' => CRM_Utils_System::url('civicrm/case/search',
-            "reset=1&force=1&status={$res->status_id}&type={$res->case_type_id}&case_owner={$case_owner}"
+            "reset=1&force=1&case_status_id={$res->status_id}&case_type_id={$res->case_type_id}&case_owner={$case_owner}"
           ),
         ];
       }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4126

Before
----------------------------------------
1. Go to case dashboard, or case dashboard dashlet.
2. In the summary grid, click on one of the numbers or the status headers.
3. It will go to the Find Cases page and the search results will be correct, but if you expand the search criteria section you'll see the type and status fields are not filled in.
4. Thus, when you choose an action from the Actions menu it will act on ALL the cases not the expected results.

After
----------------------------------------
Fields are filled in.

Technical Details
----------------------------------------
I'm not sure when this broke. About 2 years ago there was a flurry of changes to force-urls, but I don't know if it's related.

Comments
----------------------------------------