### PR TITLE
Event registration activity target

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1629,6 +1629,7 @@ WHERE      activity.id IN ($activityIds)";
     //CRM-4027
     if ($targetContactID) {
       $activityParams['target_contact_id'][] = $targetContactID;
+      $activityParams['target_contact_id'] = array_unique($activityParams['target_contact_id'], SORT_NUMERIC);
     }
     // @todo - use api - remove lots of wrangling above. Remove deprecated fatal & let form layer
     // deal with any exceptions.

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -181,7 +181,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
     ) {
       // Default status if not specified
       $participant->status_id = $participant->status_id ?: self::fields()['participant_status_id']['default'];
-      CRM_Activity_BAO_Activity::addActivity($participant, 'Event Registration');
+      CRM_Activity_BAO_Activity::addActivity($participant, 'Event Registration', $participant->contact_id);
     }
 
     //CRM-5403

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -279,6 +279,9 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->assertDBCompareValue('CRM_Activity_DAO_Activity', $this->_contactId, 'source_record_id',
       'source_contact_id', $participant->id, 'Check DB for activity added for the participant'
     );
+    //Checking for participant contact_id added to activity target.
+    $params_activity = ['contact_id' => $this->_contactId, 'record_type_id' => 3];
+    $this->assertDBCompareValues('CRM_Activity_DAO_ActivityContact', $params_activity, $params_activity);
 
     $params = array_merge($params, [
       'id' => $participant->id,
@@ -303,6 +306,9 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $this->assertDBCompareValue('CRM_Activity_DAO_Activity', $this->_contactId, 'source_record_id',
       'source_contact_id', $participant->id, 'Check DB for activity added for the participant'
     );
+    //Checking for participant contact_id added to activity target.
+    $params_activity = ['contact_id' => $this->_contactId, 'record_type_id' => 3];
+    $this->assertDBCompareValues('CRM_Activity_DAO_ActivityContact', $params_activity, $params_activity);
 
     //Checking for Note added in the table for relative participant.
     $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4142

Before
----------------------------------------
Event Registration activity target is empty when registering through online form.

After
----------------------------------------
Event Registration activity target is the contact who registered (same as source).

Comments
----------------------------------------
Removing duplicate `target_contact_id` in `CRM_Activity_BAO_Activity::addActivity()` might be unneeded as according to my tests it works with duplicate ids also, it just seemed the right thing to do... :smile: 
