### PR TITLE
Smarty - Fix warnings about 'mb_truncate' modifier

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.mb_truncate.php
+++ b/CRM/Core/Smarty/plugins/modifier.mb_truncate.php
@@ -58,7 +58,7 @@ function smarty_modifier_mb_truncate($string, $length = 80, $etc = '...',
 
   }
 
-  if ($strlen($string ?: '') > $length) {
+  if ($string !== NULL && $strlen($string) > $length) {
     $length -= $strlen($etc);
     if (!$break_words) {
       $string = preg_replace('/\s+?(\S+)?$/', '', $substr($string, 0, $length + 1));

--- a/CRM/Core/Smarty/plugins/modifier.mb_truncate.php
+++ b/CRM/Core/Smarty/plugins/modifier.mb_truncate.php
@@ -58,7 +58,7 @@ function smarty_modifier_mb_truncate($string, $length = 80, $etc = '...',
 
   }
 
-  if ($strlen($string) > $length) {
+  if ($strlen($string ?: '') > $length) {
     $length -= $strlen($etc);
     if (!$break_words) {
       $string = preg_replace('/\s+?(\S+)?$/', '', $substr($string, 0, $length + 1));


### PR DESCRIPTION
Steps to reproduce
------------------

* Use PHP 8.1 and D7 with a default logging policy (eg "All Messages" or "Errors and Warnings")
* Use "Search > Find Contacts"
* On the listing page, observe a bunch of warnings

Before
------

~25 warnings, including ~10 related to modifier.mb_truncate.php

After
-----

~15 warnings, none involving `mb_truncate`

Comment
----------

Branch is based on a revision that should be equally amenable to 5.59 or master.