### PR TITLE
Php8.x compatibility - do not try to count NULL

### DIFF
--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -15,7 +15,7 @@
   <div>{$form.hidden}</div>
 {/if}
 
-{if ($snippet !== 'json') and !$suppressForm and count($form.errors) gt 0}
+{if ($snippet !== 'json') and !$suppressForm and $form.errors !== NULL && count($form.errors) gt 0}
    <div class="messages crm-error">
        <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>
      {ts}Please correct the following errors in the form fields below:{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
From https://github.com/civicrm/civicrm-core/pull/25606 this count is causing a hard error when applied to NULL on some php versions. Since we never see it as a notice it must be assigned as NULL rather than not assigned