### PR TITLE
Smarty - {htxt} blocks should not be evaluated unless needed

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -144,6 +144,7 @@ class CRM_Core_Smarty extends Smarty {
       $this->default_modifiers[] = 'escape:"htmlall"';
     }
     $this->load_filter('pre', 'resetExtScope');
+    $this->load_filter('pre', 'htxtFilter');
 
     $this->assign('crmPermissions', new CRM_Core_Smarty_Permissions());
 

--- a/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
+++ b/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * The content of an "{htxt}" block should not be evaluated unless
+ * the active request is relevant. Otherwise, it will try to
+ * evaluate unassigned variables.
+ *
+ * @param string $tpl_source
+ * @param $smarty
+ * @return string
+ */
+function smarty_prefilter_htxtFilter($tpl_source, &$smarty) {
+  if (strpos($tpl_source, '{htxt') === FALSE) {
+    return $tpl_source;
+  }
+
+  $htxts = 0;
+  $_htxts = 0;
+
+  $result = preg_replace_callback_array([
+    '/\{htxt id=([\'\"][^\'\"]+[\'\"])/' => function ($m) use (&$htxts) {
+      $htxts++;
+      return sprintf('{if $id == %s}%s', $m[1], $m[0]);
+    },
+    ';\{/htxt\};' => function($m) use (&$_htxts) {
+      $_htxts++;
+      return '{/htxt}{/if}';
+    },
+  ], $tpl_source);
+
+  if ($htxts !== $_htxts) {
+    throw new \RuntimeException(sprintf('Invalid {htxt} tag. Wrapped %d opening-tags and %d closing-tags.', $htxts, $_htxts));
+  }
+
+  return $result;
+}


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a common class of PHP warning about `*.hlp` files.

<img width="965" alt="Screen Shot 2023-02-23 at 2 01 56 PM" src="https://user-images.githubusercontent.com/1336047/221040913-b141f4f7-7adf-4a80-9de3-6ee5b1c0dee0.png">

Before
----------------------------------------

The `{htxt}` block appears to act _like_ a conditional expression. If you look at `function.htxt.php`, it checks the value of `$id` and conditionally enables or disables the content.

But it is not an effective conditional. The nested content is evaluated before it calls `smarty_block_htxt()`.

Consequently, if you try to show help for field `foo`, then it _actually_ evaluates the help message for _everything in the `.hlp` file_ (even if it's some quirky field that's not relevant and that requires extra data).

After
----------------------------------------

The `{htxt}` is literally like an `{if}`.

You don't get warnings about irrelevant data.