### PR TITLE
Remove legacy handling of locks for discontinued mysql/mariaDB versions

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2962,9 +2962,6 @@ ORDER BY civicrm_custom_group.weight,
    */
   protected static function getLocksOnContacts($contacts):array {
     $locks = [];
-    if (!CRM_Utils_SQL::supportsMultipleLocks()) {
-      return $locks;
-    }
     foreach ($contacts as $contactID) {
       $lock = Civi::lockManager()->acquire("data.core.contact.{$contactID}");
       if ($lock->isAcquired()) {

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -136,30 +136,6 @@ class CRM_Utils_SQL {
   }
 
   /**
-   * Does the DB version support mutliple locks per
-   *
-   * https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
-   *
-   * This is a conservative measure to introduce the change which we expect to deprecate later.
-   *
-   * @todo we only check mariadb & mysql right now but maybe can add percona.
-   */
-  public static function supportsMultipleLocks() {
-    static $isSupportLocks = NULL;
-    if (!isset($isSupportLocks)) {
-      $version = self::getDatabaseVersion();
-      if (stripos($version, 'mariadb') !== FALSE) {
-        $isSupportLocks = version_compare($version, '10.0.2', '>=');
-      }
-      else {
-        $isSupportLocks = version_compare($version, '5.7.5', '>=');
-      }
-    }
-
-    return $isSupportLocks;
-  }
-
-  /**
    * Get the version string for the database.
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
Remove legacy handling of locks for discontinued mysql/mariaDB versions

Before
----------------------------------------
unreachable handling for locks in legacy mysql/maria db versions

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
