### PR TITLE
dev/core#4144 Fix smarty notice on isDuplicate

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -62,11 +62,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
   public $_grid;
 
   /**
-   * Name of button for saving matching contacts.
-   * @var string
-   */
-  protected $_duplicateButtonName;
-  /**
    * The title of the category we are editing.
    *
    * @var string
@@ -206,7 +201,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $form->_id = $ids[0];
       }
       else {
-        if ($form->_context == 'dialog') {
+        if ($form->isEntityReferenceContactCreateMode()) {
           $contactLinks = CRM_Contact_BAO_Contact_Utils::formatContactIDSToLinks($ids, TRUE, TRUE);
 
           $duplicateContactsLinks = '<div class="matching-contacts-found">';
@@ -249,9 +244,10 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
           $errors['_qf_default'] = $duplicateContactsLinks;
 
-          // let smarty know that there are duplicates
-          $template = CRM_Core_Smarty::singleton();
-          $template->assign('isDuplicate', 1);
+          // The button 'Save Matching Contact' is added in buildForm
+          // but we only decide here whether ot not to show it - ie
+          // if validation failed due to there being duplicates.
+          CRM_Core_Smarty::singleton()->assign('isDuplicate', 1);
         }
         else {
           $errors['_qf_default'] = ts('A record already exists with the same information.');
@@ -259,6 +255,18 @@ class CRM_Profile_Form extends CRM_Core_Form {
       }
     }
     return $errors;
+  }
+
+  /**
+   * Is this being called from an entity reference field.
+   *
+   * E.g clicking on 'New Organization' from the employer field
+   * would create a link with the context = 'dialog' in the url.
+   *
+   * @return bool
+   */
+  public function isEntityReferenceContactCreateMode(): bool {
+    return $this->_context === 'dialog';
   }
 
   /**
@@ -329,7 +337,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
         CRM_Core_Error::statusBounce(ts('Proper action not specified for this custom value record profile'));
       }
     }
-    $this->_duplicateButtonName = $this->getButtonName('upload', 'duplicate');
 
     $gids = explode(',', (CRM_Utils_Request::retrieve('gid', 'String', CRM_Core_DAO::$_nullObject, FALSE, 0) ?? ''));
 
@@ -897,10 +904,13 @@ class CRM_Profile_Form extends CRM_Core_Form {
       $this->freeze();
     }
 
-    if ($this->_context == 'dialog') {
+    if ($this->isEntityReferenceContactCreateMode()) {
+      // Assign FALSE, here - this is overwritten during form validation
+      // if duplicates are found during submit.
+      CRM_Core_Smarty::singleton()->assign('isDuplicate', FALSE);
       $this->addElement(
         'xbutton',
-        $this->_duplicateButtonName,
+        $this->getButtonName('upload', 'duplicate'),
         ts('Save Matching Contact'),
         [
           'type' => 'submit',

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -247,7 +247,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
           // The button 'Save Matching Contact' is added in buildForm
           // but we only decide here whether ot not to show it - ie
           // if validation failed due to there being duplicates.
-          CRM_Core_Smarty::singleton()->assign('isDuplicate', 1);
+          CRM_Core_Smarty::singleton()->assign('showSaveDuplicateButton', 1);
         }
         else {
           $errors['_qf_default'] = ts('A record already exists with the same information.');
@@ -904,10 +904,11 @@ class CRM_Profile_Form extends CRM_Core_Form {
       $this->freeze();
     }
 
+    // Assign FALSE, here - this is overwritten during form validation
+    // if duplicates are found during submit.
+    CRM_Core_Smarty::singleton()->assign('showSaveDuplicateButton', FALSE);
+
     if ($this->isEntityReferenceContactCreateMode()) {
-      // Assign FALSE, here - this is overwritten during form validation
-      // if duplicates are found during submit.
-      CRM_Core_Smarty::singleton()->assign('isDuplicate', FALSE);
       $this->addElement(
         'xbutton',
         $this->getButtonName('upload', 'duplicate'),

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -35,7 +35,7 @@
   <div id="crm-container" class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
   {/if}
 
-  {if array_key_exists('_qf_Edit_upload_duplicate', $form) && $isDuplicate}
+  {if $showSaveDuplicateButton}
     <div class="crm-submit-buttons">
       {$form._qf_Edit_upload_duplicate.html}
     </div>
@@ -50,7 +50,7 @@
     {if $action eq 2 and $multiRecordFieldListing}
       <h1>{ts}Edit Details{/ts}</h1>
       <div class="crm-submit-buttons" style='float:right'>
-      {include file="CRM/common/formButtons.tpl" location=''}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
+      {include file="CRM/common/formButtons.tpl" location=''}{if $showSaveDuplicateButton}{$form._qf_Edit_upload_duplicate.html}{/if}
       </div>
     {/if}
 
@@ -94,7 +94,7 @@
             <div class="content description">{$field.help_pre}</div>
           </div>
         {/if}
-        {if $field.options_per_line}
+        {if array_key_exists('options_per_line', $field) && $field.options_per_line}
           <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
             <div class="label">{$form.$n.label}</div>
             <div class="content edit-value">
@@ -201,7 +201,7 @@
         </div>
       {/if}
       <div class="crm-submit-buttons" style='{$floatStyle}'>
-        {include file="CRM/common/formButtons.tpl" location=''}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
+        {include file="CRM/common/formButtons.tpl" location=''}{if $showSaveDuplicateButton}{$form._qf_Edit_upload_duplicate.html}{/if}
         {if $includeCancelButton}
           <a class="button cancel" href="{$cancelURL}">
             <span>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -35,7 +35,7 @@
   <div id="crm-container" class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
   {/if}
 
-  {if $isDuplicate and ( ($action eq 1 and $mode eq 4 ) or ($action eq 2) or ($action eq 8192) ) }
+  {if array_key_exists('_qf_Edit_upload_duplicate', $form) && $isDuplicate}
     <div class="crm-submit-buttons">
       {$form._qf_Edit_upload_duplicate.html}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4144 Fix smarty notice on isDuplicate

Before
----------------------------------------
![image](https://lab.civicrm.org/dev/core/uploads/ba2d754f522299cfb57ab10184e701ae/image.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/221058937-92288448-570f-4097-8878-0ecc1c526efb.png)


Technical Details
----------------------------------------
It was really hard to figure out the point of this variable / how it was reached. Most of the change is code commentary to try to make that clearer

The way `isDuplicate` comes into play is that duplicate checking is done if (& only if) the profile is used in the context of creating a new (e.g) individual from an entity reference field

Comments
----------------------------------------
