### PR TITLE
Add `crmUrl function` to smarty in the standard way

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -131,7 +131,6 @@ class CRM_Core_Smarty extends Smarty {
       $this->assign('langSwitch', CRM_Core_I18n::uiLanguages());
     }
 
-    $this->register_function('crmURL', ['CRM_Utils_System', 'crmURL']);
     if (CRM_Utils_Constant::value('CIVICRM_SMARTY_DEFAULT_ESCAPE')) {
       // When default escape is enabled if the core escape is called before
       // any custom escaping is done the modifier_escape function is not

--- a/CRM/Core/Smarty/plugins/function.crmURL.php
+++ b/CRM/Core/Smarty/plugins/function.crmURL.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC
+ *
+ */
+
+/**
+ * Generate a url
+ *
+ * @param array $params
+ *   The values to construct the url.
+ *   - p  string $path
+ *   The path being linked to, such as "civicrm/add".
+ *   - q array|string $query
+ *   A query string to append to the link, or an array of key-value pairs.
+ *   -a bool $absolute
+ *   Whether to force the output to be an absolute link (beginning with a
+ *   URI-scheme such as 'http:'). Useful for links that will be displayed
+ *   outside the site, such as in an RSS feed.
+ *   -f  string $fragment
+ *   A fragment identifier (named anchor) to append to the link.
+ *   -h  bool $htmlize
+ *   Whether to encode special html characters such as &.
+ *   -fe bool $frontend
+ *   This link should be to the CMS front end (applies to WP & Joomla).
+ *   -fb bool $forceBackend
+ *   This link should be to the CMS back end (applies to WP & Joomla).
+ *
+ * @return string
+ */
+function smarty_function_crmURL($params) {
+  return CRM_Utils_System::crmURL($params);
+}


### PR DESCRIPTION
Even with Smarty2 this method of registering functions was being phased out for putting the file in the folder

