### PR TITLE
Add noisy deprecation to deprecated function, after universe search

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -723,6 +723,7 @@ class CRM_Utils_Token {
    * @deprecated
    */
   public static function parseThroughSmarty($tokenHtml, $entity, $entityType = 'contact') {
+    CRM_Core_Error::deprecatedFunctionWarning('no replacement');
     if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
       $smarty = CRM_Core_Smarty::singleton();
       // also add the tokens to the template


### PR DESCRIPTION
Overview
----------------------------------------
Add noisy deprecation to deprecated function, after universe search

Before
----------------------------------------
Function is long deprecated - unused but I had to do a universe search to determine that 

After
----------------------------------------
I could possibly just remove it but functions usually get a chunk of time in noisy-deprecation purgaroty first

Technical Details
----------------------------------------

Comments
----------------------------------------
