### PR TITLE
Remove forward incompatible syntax from template 

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -26,7 +26,7 @@
           {assign var="index" value="1"}
           {foreach name=outer key=key item=item from=$formElement}
           {if $index < 10}
-          {assign var="index" value=`$index+1`}
+          {assign var="index" value=$index+1}
           {else}
           <td class="labels font-light">{$formElement.$key.html}</td>
           {if $count == $element.options_per_line}
@@ -34,7 +34,7 @@
         <tr>
           {assign var="count" value="1"}
           {else}
-          {assign var="count" value=`$count+1`}
+          {assign var="count" value=$count+1}
           {/if}
           {/if}
           {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
smarty 3 balks at the ` at url civicrm/contact/add?reset=1&action=update&cid=203

Before
----------------------------------------
Smarty3 won't parse this

![image](https://user-images.githubusercontent.com/336308/221102827-a1ee1fb1-965b-40b6-9f95-45705a72842e.png)


After
----------------------------------------
It still works :-)

Note that I set options per line to 2 on the top field (Most important issue) which is where this kicks in

![image](https://user-images.githubusercontent.com/336308/221104335-67bf7e52-93a6-42b0-9b72-082e4bcf9081.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
