### PR TITLE
Fix mixin to use `addTemplateDir`

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -315,7 +315,9 @@ class CRM_Core_Smarty extends Smarty {
       return parent::addTemplateDir($template_dir, $key, $isConfig);
     }
     if (is_array($this->template_dir)) {
-      array_unshift($this->template_dir, $template_dir);
+      if (!in_array($template_dir, $this->template_dir)) {
+        array_unshift($this->template_dir, $template_dir);
+      }
     }
     else {
       $this->template_dir = [$template_dir, $this->template_dir];

--- a/mixin/smarty-v2@1/mixin.php
+++ b/mixin/smarty-v2@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register "templates/" folder.
  *
  * @mixinName smarty-v2
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.0.1
  * @since 5.59
  *
  * @param CRM_Extension_MixInfo $mixInfo
@@ -19,14 +19,9 @@ return function ($mixInfo, $bootCache) {
   }
 
   $register = function() use ($dir) {
-    // This implementation is useful for older versions of CiviCRM. It can be replaced/updated going forward (v1.1+).
-    $smarty = CRM_Core_Smarty::singleton();
-    if (!is_array($smarty->template_dir)) {
-      $this->template_dir = [$smarty->template_dir];
-    }
-    if (!in_array($dir, $smarty->template_dir)) {
-      array_unshift($smarty->template_dir, $dir);
-    }
+    // This implementation has a theoretical edge-case bug on older versions of CiviCRM where a template could
+    // be registered more than once.
+    CRM_Core_Smarty::singleton()->addTemplateDir($dir);
   };
 
   // Let's figure out what environment we're in -- so that we know the best way to call $register().


### PR DESCRIPTION
Overview
----------------------------------------
Fix mixin to use `addTemplate`

Before
----------------------------------------
We recently fixed Civix to use `addTemplate` rather than add to the templates array. Then we added a mixin that reverted this change. I think @totten might have done this deliberately because of the possibiliy (at least theoretical) of double adding paths and the possibility (at least theoretical) of this having some negative impact on performance. 

However, this left us having undone the improvement

After
----------------------------------------
The improvement is back in on the core version of the mixin and the paths are 'deduped' to remove the possibility

Technical Details
----------------------------------------

Comments
----------------------------------------
