### PR TITLE
Fix e-notice pattern around location not defined in formButtons.tpl

### DIFF
--- a/ext/civigrant/templates/CRM/Grant/Form/Task/Delete.tpl
+++ b/ext/civigrant/templates/CRM/Grant/Form/Task/Delete.tpl
@@ -14,5 +14,5 @@
           {ts}Are you sure you want to delete the selected Grants? This delete operation cannot be undone and will delete all transactions associated with these grants.{/ts}
           <p>{include file="CRM/Grant/Form/Task.tpl"}</p>
   </div>
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/MultipleValuesCriteria.tpl
@@ -86,7 +86,7 @@
                 </div>
             </div>
 
-        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
     </div><!-- /.crm-accordion-body -->
     </div><!-- /.crm-accordion-wrapper -->
 </div><!-- /.crm-form-block -->

--- a/templates/CRM/Admin/Form/ParticipantStatusType.tpl
+++ b/templates/CRM/Admin/Form/ParticipantStatusType.tpl
@@ -18,7 +18,7 @@
        {icon icon="fa-info-circle"}{/icon}
              {ts}WARNING: Deleting this Participant Status will remove all of its settings.{/ts} {ts}Do you want to continue?{/ts}
        </div>
-      <div>{include file="CRM/common/formButtons.tpl"}
+      <div>{include file="CRM/common/formButtons.tpl" location=''}
       </div>
     {else}
       <table class="form-layout-compressed">

--- a/templates/CRM/Admin/Form/Setting/Smtp.tpl
+++ b/templates/CRM/Admin/Form/Setting/Smtp.tpl
@@ -85,7 +85,7 @@
         </div>
         <div class="spacer"></div>
         <div class="crm-submit-buttons">
-            {include file="CRM/common/formButtons.tpl"}
+            {include file="CRM/common/formButtons.tpl" location=''}
         </div>
 
 {literal}

--- a/templates/CRM/Batch/Form/Search.tpl
+++ b/templates/CRM/Batch/Form/Search.tpl
@@ -17,7 +17,7 @@
         {ts}Complete OR partial batch name.{/ts}
         </span>
       </td>
-      <td>{include file="CRM/common/formButtons.tpl"}</td>
+      <td>{include file="CRM/common/formButtons.tpl" location=''}</td>
     </tr>
   </table>
 </div>

--- a/templates/CRM/Contact/Form/Inline/Address.tpl
+++ b/templates/CRM/Contact/Form/Inline/Address.tpl
@@ -13,7 +13,7 @@
     <tr>
       <td>
         <div class="crm-submit-buttons">
-          {include file="CRM/common/formButtons.tpl"}
+          {include file="CRM/common/formButtons.tpl" location=''}
           {if $addressId}
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             <a class="button delete-button" href="#" style="display:inline-block;float:none;"><div class="icon delete-icon"></div> {ts}Delete{/ts}</a>

--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -13,7 +13,7 @@
 
  <div class="crm-inline-edit-form">
     <div class="crm-inline-button">
-      {include file="CRM/common/formButtons.tpl"}
+      {include file="CRM/common/formButtons.tpl" location=''}
     </div>
     <div class="crm-clear">
       {foreach key=key item=item from=$commPreference}

--- a/templates/CRM/Contact/Form/Inline/ContactInfo.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactInfo.tpl
@@ -10,7 +10,7 @@
 {$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
   </div>
 
   <div class="crm-clear">

--- a/templates/CRM/Contact/Form/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactName.tpl
@@ -11,7 +11,7 @@
 {$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
   </div>
   {crmRegion name="contact-form-inline-contactname"}
     {if $contactType eq 'Individual'}

--- a/templates/CRM/Contact/Form/Inline/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Inline/CustomData.tpl
@@ -11,7 +11,7 @@
 {$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
   </div>
   {include file="CRM/Custom/Form/CustomData.tpl" skipTitle=true}
 </div> <!-- end of main -->

--- a/templates/CRM/Contact/Form/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Inline/Demographics.tpl
@@ -10,7 +10,7 @@
 {$form.oplock_ts.html}
 <div class="crm-inline-edit-form">
   <div class="crm-inline-button">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
   </div>
 
   <div class="crm-clear">

--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -13,7 +13,7 @@
   <tr>
     <td colspan="5">
       <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl"}
+        {include file="CRM/common/formButtons.tpl" location=''}
       </div>
     </td>
   </tr>

--- a/templates/CRM/Contact/Form/Inline/IM.tpl
+++ b/templates/CRM/Contact/Form/Inline/IM.tpl
@@ -13,7 +13,7 @@
     <tr>
       <td colspan="5">
         <div class="crm-submit-buttons">
-          {include file="CRM/common/formButtons.tpl"}
+          {include file="CRM/common/formButtons.tpl" location=''}
         </div>
       </td>
     </tr>

--- a/templates/CRM/Contact/Form/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Inline/OpenID.tpl
@@ -13,7 +13,7 @@
   <tr>
     <td colspan="4">
       <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl"}
+        {include file="CRM/common/formButtons.tpl" location=''}
       </div>
     </td>
   </tr>

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -13,7 +13,7 @@
     <tr>
       <td colspan="5">
         <div class="crm-submit-buttons">
-          {include file="CRM/common/formButtons.tpl"}
+          {include file="CRM/common/formButtons.tpl" location=''}
         </div>
       </td>
     </tr>

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -13,7 +13,7 @@
     <tr>
       <td colspan="5">
         <div class="crm-submit-buttons">
-          {include file="CRM/common/formButtons.tpl"}
+          {include file="CRM/common/formButtons.tpl" location=''}
         </div>
       </td>
     </tr>

--- a/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
@@ -84,7 +84,7 @@
                     <div class="description">
 
                     </div>
-               <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+               <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
             </div>
 
 

--- a/templates/CRM/Contact/Form/Task/Delete.tpl
+++ b/templates/CRM/Contact/Form/Task/Delete.tpl
@@ -22,5 +22,5 @@
 
 
     <h3>{include file="CRM/Contact/Form/Task.tpl"}</h3>
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/templates/CRM/Contact/Form/Task/PickProfile.tpl
+++ b/templates/CRM/Contact/Form/Task/PickProfile.tpl
@@ -21,6 +21,6 @@
         </td>
     </tr>
 </table>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>
 

--- a/templates/CRM/Contact/Form/Task/Unhold.tpl
+++ b/templates/CRM/Contact/Form/Task/Unhold.tpl
@@ -14,5 +14,5 @@
           <p>{ts}Are you sure you want to unhold email of selected contact(s)?.{/ts} {ts}This action cannot be undone.{/ts}</p>
       <p>{include file="CRM/Contact/Form/Task.tpl"}</p>
     </div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/templates/CRM/Contact/Page/View/Delete.tpl
+++ b/templates/CRM/Contact/Page/View/Delete.tpl
@@ -14,4 +14,4 @@
         <p>{ts}This action cannot be undone.{/ts}</p>
 </div>
 <p>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>

--- a/templates/CRM/Contact/Page/View/Note.tpl
+++ b/templates/CRM/Contact/Page/View/Note.tpl
@@ -83,7 +83,7 @@
 {/if}
 {if ($action eq 8)}
 <div class=status>{ts 1=$notes.$id.note}Are you sure you want to delete the note '%1'?{/ts}</div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 
 {/if}
 

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -11,7 +11,7 @@
   {include file="CRM/Contribute/Form/PaymentInfoBlock.tpl"}
   {if !$suppressPaymentFormButtons}
     <div class="crm-submit-buttons">
-       {include file="CRM/common/formButtons.tpl"}
+       {include file="CRM/common/formButtons.tpl" location=''}
     </div>
   {/if}
 {else}
@@ -39,7 +39,7 @@
     {/if}
   {/if}
   <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
   </div>
   <table class="form-layout-compressed">
     <tr>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -56,7 +56,7 @@
       </div>
     {/if}
       <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl"}
+        {include file="CRM/common/formButtons.tpl" location=''}
       </div>
       {if !empty($isOnline)}{assign var=valueStyle value=" class='view-value'"}{else}{assign var=valueStyle value=""}{/if}
       <table class="form-layout-compressed">

--- a/templates/CRM/Contribute/Form/ContributionPage/AddProduct.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/AddProduct.tpl
@@ -52,7 +52,7 @@
   </div>
 {else}
   <div class="crm-done-button">
-      {include file="CRM/common/formButtons.tpl"}
+      {include file="CRM/common/formButtons.tpl" location=''}
   </div>
 {/if} {* $action ne view *}
 </div>

--- a/templates/CRM/Contribute/Form/ContributionPage/Delete.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Delete.tpl
@@ -17,5 +17,5 @@
         {/if}
       </div>
 <div class="form-item">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
 </div>

--- a/templates/CRM/Contribute/Form/SearchContribution.tpl
+++ b/templates/CRM/Contribute/Form/SearchContribution.tpl
@@ -34,5 +34,5 @@
     campaignTrClass='' campaignTdClass=''}
 
  </table>
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+ <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
+++ b/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
@@ -55,7 +55,7 @@
 </div>
 
 <div id="crm-submit-buttons" class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
 </div>
 </div>
 

--- a/templates/CRM/Event/Form/Search.tpl
+++ b/templates/CRM/Event/Form/Search.tpl
@@ -24,7 +24,7 @@
         {include file="CRM/Event/Form/Search/Common.tpl"}
 
         <tr>
-           <td colspan="2">{include file="CRM/common/formButtons.tpl"}</td>
+           <td colspan="2">{include file="CRM/common/formButtons.tpl" location=''}</td>
         </tr>
         </table>
     {/strip}

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -47,7 +47,7 @@
     {* campaign in event search *}
     {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
     campaignTrClass='crm-event-searchevent-form-block-campaign_id' campaignTdClass=''}
-    <td class="right">{include file="CRM/common/formButtons.tpl"}</td>
+    <td class="right">{include file="CRM/common/formButtons.tpl" location=''}</td>
   </table>
     </div>
   </div>

--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -93,7 +93,7 @@
            </tr>
          </table>
 <div class="crm-submit-buttons">
-{if $fields}{$form._qf_Batch_refresh.html}{/if}{include file="CRM/common/formButtons.tpl"}
+{if $fields}{$form._qf_Batch_refresh.html}{/if}{include file="CRM/common/formButtons.tpl" location=''}
 </div>
 </div>
 

--- a/templates/CRM/Event/Form/Task/Print.tpl
+++ b/templates/CRM/Event/Form/Task/Print.tpl
@@ -54,7 +54,7 @@
 </table>
 
 <div class="form-item">
-     <span class="element-right">{include file="CRM/common/formButtons.tpl"}</span>
+     <span class="element-right">{include file="CRM/common/formButtons.tpl" location=''}</span>
 </div>
 
 {else}

--- a/templates/CRM/Event/Form/Task/Result.tpl
+++ b/templates/CRM/Event/Form/Task/Result.tpl
@@ -9,6 +9,6 @@
 *}
 <div class='spacer'></div>
 <div class="crm-submit-buttons">
-     {include file="CRM/common/formButtons.tpl"}
+     {include file="CRM/common/formButtons.tpl" location=''}
 </div>
 

--- a/templates/CRM/Mailing/Form/Approve.tpl
+++ b/templates/CRM/Mailing/Form/Approve.tpl
@@ -22,7 +22,7 @@
     </tr>
   </tbody>
 </table>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 
 <div class="crm-accordion-wrapper crm-plain_text_email-accordion collapsed">
     <div class="crm-accordion-header">

--- a/templates/CRM/Mailing/Form/Component.tpl
+++ b/templates/CRM/Mailing/Form/Component.tpl
@@ -20,5 +20,5 @@
     <tr class="crm-mailing-component-form-block-is_active"><td class="label">{$form.is_active.label}</td><td>{$form.is_active.html}</td>
   </table>
 </fieldset>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/templates/CRM/Member/Form/Search.tpl
+++ b/templates/CRM/Member/Form/Search.tpl
@@ -19,7 +19,7 @@
           {include file="CRM/Member/Form/Search/Common.tpl"}
 
           <tr>
-              <td colspan="2">{include file="CRM/common/formButtons.tpl"}</td>
+              <td colspan="2">{include file="CRM/common/formButtons.tpl" location=''}</td>
           </tr>
       </table>
   {/strip}

--- a/templates/CRM/Member/Form/Task/Result.tpl
+++ b/templates/CRM/Member/Form/Task/Result.tpl
@@ -10,7 +10,7 @@
 <div class='spacer'></div>
 <div class="form-item">
     <p>
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
     </p>
 </div>
 

--- a/templates/CRM/Price/Form/DeleteSet.tpl
+++ b/templates/CRM/Price/Form/DeleteSet.tpl
@@ -11,9 +11,9 @@
     <div class="messages status no-popup">
      <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
           {ts 1=$title}WARNING: Deleting this price set will result in the loss of all '%1' data.{/ts} {ts}This action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
-       
+
     </div>
 
 <div class="form-item">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
 </div>

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -114,7 +114,7 @@
 
 
   <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl"}
+    {include file="CRM/common/formButtons.tpl" location=''}
   </div>
 
 </div>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -50,7 +50,7 @@
     {if $action eq 2 and $multiRecordFieldListing}
       <h1>{ts}Edit Details{/ts}</h1>
       <div class="crm-submit-buttons" style='float:right'>
-      {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
+      {include file="CRM/common/formButtons.tpl" location=''}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
       </div>
     {/if}
 
@@ -201,7 +201,7 @@
         </div>
       {/if}
       <div class="crm-submit-buttons" style='{$floatStyle}'>
-        {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
+        {include file="CRM/common/formButtons.tpl" location=''}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
         {if $includeCancelButton}
           <a class="button cancel" href="{$cancelURL}">
             <span>

--- a/templates/CRM/Profile/Form/Search.tpl
+++ b/templates/CRM/Profile/Form/Search.tpl
@@ -75,7 +75,7 @@
       <tr><td colspan="2">{include file="CRM/Contact/Form/Task/ProximityCommon.tpl"}</td></tr>
     {/if}
 
-    <tr><td></td><td>{include file="CRM/common/formButtons.tpl"}</td></tr>
+    <tr><td></td><td>{include file="CRM/common/formButtons.tpl" location=''}</td></tr>
   </table>
 
   {if $groupId}

--- a/templates/CRM/SMS/Form/Group.tpl
+++ b/templates/CRM/SMS/Form/Group.tpl
@@ -49,7 +49,7 @@
  </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->
 
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>
 
 </div>

--- a/templates/CRM/SMS/Form/Schedule.tpl
+++ b/templates/CRM/SMS/Form/Schedule.tpl
@@ -24,7 +24,7 @@
   </div>
   <div class="description">{ts}Set a date and time when you want CiviSMS to start sending this Mass SMS.{/ts}</div>
 </div>
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 
 {if $preview}
 <div class="crm-accordion-wrapper crm-plain_text_sms-accordion collapsed">

--- a/templates/CRM/SMS/Form/Upload.tpl
+++ b/templates/CRM/SMS/Form/Upload.tpl
@@ -40,7 +40,7 @@
     </table>
   </fieldset>
 
-  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div><!-- / .crm-form-block -->
 
 {* -- Javascript for showing/hiding the upload/compose options -- *}

--- a/templates/CRM/UF/Form/Preview.tpl
+++ b/templates/CRM/UF/Form/Preview.tpl
@@ -40,6 +40,6 @@
 {/if} {* fields array is not empty *}
 
   <div class="crm-submit-buttons">
-  {include file="CRM/common/formButtons.tpl"}
+  {include file="CRM/common/formButtons.tpl" location=''}
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

Fix e-notice pattern around location not defined in formButtons.tpl

This applies when secure smarty is enabled as there is a partially effective `empty` that was added in the past (& removed here)

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/221295211-c949e0e9-9d82-495c-83c0-a0e7c2b820ad.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/221295357-266dd17f-847b-4479-87db-c75f9b25145b.png)


Technical Details
----------------------------------------
location is passed in when loading the template - the notice occurs when it isn't

![image](https://user-images.githubusercontent.com/336308/221295150-515e5a62-8b57-4889-8f9b-962783fd8a77.png)

Comments
----------------------------------------
Note I used a find & replace to do this & eyeballed during `git add -p`

@seamuslee001 this re-does the e-notice fix you originally did
