### PR TITLE
dev/core#4146 Remove (old) Smarty-forward incompatible syntax from Address.tpl

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -31,7 +31,8 @@
               !empty($add.geo_code_2) AND
               is_numeric($add.geo_code_2)
           }
-          <br /><a href="{crmURL p='civicrm/contact/map' q="reset=1&cid=`$contactId`&lid=`$add.location_type_id`"}" title="{ts 1=`$add.location_type`}Map %1 Address{/ts}"><i class="crm-i fa-map-marker" aria-hidden="true"></i> {ts}Map{/ts}</a>
+          {assign var='mapLocationTypeID' value=$add.location_type_id}
+          <br /><a href="{crmURL p='civicrm/contact/map' q="reset=1&cid=$contactId&lid=$mapLocationTypeID"}" title="{ts 1=$add.location_type}Map %1 Address{/ts}"><i class="crm-i fa-map-marker" aria-hidden="true"></i> {ts}Map{/ts}</a>
           {/if}
         </div>
         <div class="crm-content">


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4146 Remove (old) Smarty-forward incompatible syntax from Address.tpl

Before
----------------------------------------
Use of ` in the template is not forward compatible - see https://lab.civicrm.org/dev/core/-/issues/4146

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/221316102-bc723475-cc0c-47ee-9ec5-0280ce4715a9.png)
The url on `map` still has location type id (`lid` - civicrm/contact/map?reset=1&cid=203&lid=1)

Technical Details
----------------------------------------
To r-run this I had to enable google geocoding with fake credentials AND add a fake geocode for the address

Comments
----------------------------------------
