### PR TITLE
SearchKit - Clarify how to view SQL output

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/debug.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/debug.html
@@ -9,9 +9,8 @@
       <strong>API:</strong>
     </div>
     <pre>{{ $ctrl.debug.apiParams }}</pre>
-    <div ng-if="$ctrl.debug.sql">
-      <strong>SQL:</strong>
-    </div>
+    <strong>SQL:</strong>
+    <pre ng-if="!$ctrl.debug.sql">{{:: ts('Run search to view SQL') }}</pre>
     <pre ng-repeat="query in $ctrl.debug.sql">{{ query }}</pre>
   </div>
 </fieldset>


### PR DESCRIPTION
Overview
----------------------------------------
Clarification in the SearchKit UI about how to view SQL output.

Before
----------------------------------------
Under "Query Info," the section for SQL doesn't appear if you haven't run the search, possibly causing a misconception that viewing SQL isn't possible.

After
----------------------------------------
Section for SQL is always there, with an explanation if the search hasn't been run:

![image](https://user-images.githubusercontent.com/2874912/221456759-e619a74a-606b-4b6c-8780-80d2fb1eb7b2.png)

