### PR TITLE
Ensure delays from transactions don't cause cache race condition

### DIFF
--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -212,7 +212,14 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
 
       $query = "SELECT RELEASE_LOCK( %1 )";
       $params = [1 => [$this->_id, 'String']];
-      return CRM_Core_DAO::singleValueQuery($query, $params);
+      if (CRM_Core_Transaction::isActive()) {
+        CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_COMMIT, function () {
+          return CRM_Core_DAO::singleValueQuery($query, $params);
+        });
+      }
+      else {
+        return CRM_Core_DAO::singleValueQuery($query, $params);
+      }
     }
   }
 

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -216,6 +216,9 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
         CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_COMMIT, function ($query, $params) {
           return CRM_Core_DAO::singleValueQuery($query, $params);
         }, [$query, $params]);
+        CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_ROLLBACK, function ($query, $params) {
+          return CRM_Core_DAO::singleValueQuery($query, $params);
+        }, [$query, $params]);
       }
       else {
         return CRM_Core_DAO::singleValueQuery($query, $params);

--- a/CRM/Core/Lock.php
+++ b/CRM/Core/Lock.php
@@ -213,9 +213,9 @@ class CRM_Core_Lock implements \Civi\Core\Lock\LockInterface {
       $query = "SELECT RELEASE_LOCK( %1 )";
       $params = [1 => [$this->_id, 'String']];
       if (CRM_Core_Transaction::isActive()) {
-        CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_COMMIT, function () {
+        CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_COMMIT, function ($query, $params) {
           return CRM_Core_DAO::singleValueQuery($query, $params);
-        });
+        }, [$query, $params]);
       }
       else {
         return CRM_Core_DAO::singleValueQuery($query, $params);


### PR DESCRIPTION


Overview
----------------------------------------

CRM_Core_Lock should ensure that two processes cannot get the same lock.

However, if each process is writing to the database via a SQL Transaction (which delays the insert), then two processes could get two consecutive locks before either one's transaction completes. That's because we are releasing the lock before the transactions complete.

This PR resolves that problem by checking for an active transaction and if found, delaying the release of a lock until after the currently active transaction is complete.

More discussion is here:

https://lab.civicrm.org/dev/core/-/issues/3988



Before
----------------------------------------
Two processes that set the exact same cache item from within a transaction might both successfully get a lock while each transaction is in process.  When each transaction is complete, the first cache set will succeed but the second one will fail.

After
----------------------------------------
If two processes try to set the exact same cache item during a transaction, the second one will encounter the lock until the first one's transaction has been completed.

Technical Details
----------------------------------------

There is some debate in [the issue 3988](https://lab.civicrm.org/dev/core/-/issues/3988) about whether the cause for the error being encountered is two different processes writing the same cache item OR one process writing the same cache item recursively.

This PR is based on the idea that two separate processes are writing the same cache item. A fix for the recursive problem is [here](https://github.com/civicrm/civicrm-core/pull/22013).

Comments
----------------------------------------
I haven't tested this code in production.
