### PR TITLE
Remove empty on location - it should always be set now

### DIFF
--- a/templates/CRM/common/formButtons.tpl
+++ b/templates/CRM/common/formButtons.tpl
@@ -30,7 +30,7 @@
 
 {foreach from=$form.buttons item=button key=key name=btns}
   {if $key|substring:0:4 EQ '_qf_'}
-    {if !empty($location)}
+    {if $location}
       {$form.buttons.$key.html|crmReplace:id:"$key-$location"}
     {else}
       {$form.buttons.$key.html}


### PR DESCRIPTION
See https://github.com/civicrm/civicrm-core/pull/25668

Per comment by @demeritcowboy - this is not longer needed & having them there would hide any new fails to add