### PR TITLE
Stop passing invariable variables to private function

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1687,7 +1687,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *   Of the contact whose contact type is needed.
    * @param int $entityID
    * @param array $subTypes
-   *   Only return specified subtype or return specified subtype + unrestricted fields.
    * @param bool|int $checkPermission
    *   Either a CRM_Core_Permission constant or FALSE to disable checks
    *
@@ -1695,7 +1694,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *   Custom field 'tree'.
    *
    *   The returned array is keyed by group id and has the custom group table fields
-   *   and a subkey 'fields' holding the specific custom fields.
+   *   and a sub-key 'fields' holding the specific custom fields.
    *   If entityId is passed in the fields keys have a subkey 'customValue' which holds custom data
    *   if set for the given entity. This is structured as an array of values with each one having the keys 'id', 'data'
    *
@@ -1707,9 +1706,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   private static function getTree(
     $entityType,
-    $entityID = NULL,
-    $subTypes = [],
-    $checkPermission = CRM_Core_Permission::EDIT
+    $entityID,
+    $subTypes,
+    $checkPermission
   ) {
     $toReturn = NULL;
     $groupID = -1;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1607,12 +1607,12 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     }
 
     // handle custom fields
-    $mainTree = self::getTree($main['contact_type'], NULL, $mainId, -1,
-      CRM_Utils_Array::value('contact_sub_type', $main), NULL, TRUE, NULL, TRUE,
+    $mainTree = self::getTree($main['contact_type'], $mainId,
+      CRM_Utils_Array::value('contact_sub_type', $main),
       $checkPermissions ? CRM_Core_Permission::EDIT : FALSE
     );
-    $otherTree = self::getTree($main['contact_type'], NULL, $otherId, -1,
-      CRM_Utils_Array::value('contact_sub_type', $other), NULL, TRUE, NULL, TRUE,
+    $otherTree = self::getTree($main['contact_type'], $otherId,
+      CRM_Utils_Array::value('contact_sub_type', $other),
       $checkPermissions ? CRM_Core_Permission::EDIT : FALSE
     );
 
@@ -1685,18 +1685,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    *
    * @param string $entityType
    *   Of the contact whose contact type is needed.
-   * @param array $toReturn
-   *   What data should be returned. ['custom_group' => ['id', 'name', etc.], 'custom_field' => ['id', 'label', etc.]]
    * @param int $entityID
-   * @param int $groupID
    * @param array $subTypes
-   * @param string $subName
-   * @param bool $fromCache
-   * @param bool $onlySubType
    *   Only return specified subtype or return specified subtype + unrestricted fields.
-   * @param bool $returnAll
-   *   Do not restrict by subtype at all. (The parameter feels a bit cludgey but is only used from the
-   *   api - through which it is properly tested - so can be refactored with some comfort.)
    * @param bool|int $checkPermission
    *   Either a CRM_Core_Permission constant or FALSE to disable checks
    *
@@ -1716,16 +1707,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   private static function getTree(
     $entityType,
-    $toReturn = [],
     $entityID = NULL,
-    $groupID = NULL,
     $subTypes = [],
-    $subName = NULL,
-    $fromCache = TRUE,
-    $onlySubType = NULL,
-    $returnAll = FALSE,
+
     $checkPermission = CRM_Core_Permission::EDIT
   ) {
+    $toReturn = NULL;
+    $groupID = -1;
+    $fromCache = TRUE;
+    $subName = NULL;
+    $onlySubType = NULL;
+    $returnAll = TRUE;
     if ($checkPermission === TRUE) {
       CRM_Core_Error::deprecatedWarning('Unexpected TRUE passed to CustomGroup::getTree $checkPermission param.');
       $checkPermission = CRM_Core_Permission::EDIT;

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1608,11 +1608,11 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
     // handle custom fields
     $mainTree = self::getTree($main['contact_type'], $mainId,
-      CRM_Utils_Array::value('contact_sub_type', $main),
+      $main['contact_sub_type'] ?? NULL,
       $checkPermissions ? CRM_Core_Permission::EDIT : FALSE
     );
     $otherTree = self::getTree($main['contact_type'], $otherId,
-      CRM_Utils_Array::value('contact_sub_type', $other),
+      $other['contact_sub_type'] ?? NULL,
       $checkPermissions ? CRM_Core_Permission::EDIT : FALSE
     );
 
@@ -1709,7 +1709,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $entityType,
     $entityID = NULL,
     $subTypes = [],
-
     $checkPermission = CRM_Core_Permission::EDIT
   ) {
     $toReturn = NULL;
@@ -1718,10 +1717,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $subName = NULL;
     $onlySubType = NULL;
     $returnAll = TRUE;
-    if ($checkPermission === TRUE) {
-      CRM_Core_Error::deprecatedWarning('Unexpected TRUE passed to CustomGroup::getTree $checkPermission param.');
-      $checkPermission = CRM_Core_Permission::EDIT;
-    }
     if ($entityID) {
       $entityID = CRM_Utils_Type::escape($entityID, 'Integer');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing invariable variables to private function

Before
----------------------------------------
This previously shared function is called from 2 places. In both cases there are a number of hard-coded variables that are the same

![image](https://user-images.githubusercontent.com/336308/221675366-6cb3c9f2-4dfe-4e87-9262-9bab943aafb5.png)


After
----------------------------------------
Hard-coding moved to within function (most of them could be fully removed but I've excluded that change to keep the PR readable & focus on the inputs of the function). Handling for invalid permissions value removed as it is now always valid

![image](https://user-images.githubusercontent.com/336308/221678407-f1254374-e7d1-47d9-b826-13b390a7dfab.png)


Technical Details
----------------------------------------

Comments
----------------------------------------