### PR TITLE
BAO - Noisily deprecate and stop using deprecated functions

### DIFF
--- a/CRM/Price/BAO/PriceFieldValue.php
+++ b/CRM/Price/BAO/PriceFieldValue.php
@@ -223,6 +223,7 @@ class CRM_Price_BAO_PriceFieldValue extends CRM_Price_DAO_PriceFieldValue {
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -320,14 +320,12 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
         'label', 'id'
       );
 
-      if (CRM_Price_BAO_PriceFieldValue::del($this->_oid)) {
-        CRM_Core_Session::setStatus(ts('%1 option has been deleted.', [1 => $label]), ts('Record Deleted'), 'success');
-      }
+      CRM_Price_BAO_PriceFieldValue::deleteRecord(['id' => $this->_oid]);
+      CRM_Core_Session::setStatus(ts('%1 option has been deleted.', [1 => $label]), ts('Record Deleted'), 'success');
       return NULL;
     }
     else {
       $params = $this->controller->exportValues('Option');
-      $fieldLabel = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', $this->_fid, 'label');
 
       foreach ($this->_moneyFields as $field) {
         $params[$field] = CRM_Utils_Rule::cleanMoney(trim($params[$field]));


### PR DESCRIPTION
Overview
----------------------------------------
This noisily deprecates functions that have already been deprecated in the BAO, and ensures they are not called from any core code.

Before
----------------------------------------
A bunch of BAO functions superseded by `writeRecord` and `deleteRecord`, but only soft-deprecated and still called from some places.

After
----------------------------------------
Now they're deprecated-**er**!

Technical Details
-----------------------
The `@deprecated` flag means that neither APIv3 nor APIv4 will call these functions, which means they're already unused by the API, so this removes the rest of the references to them and adds noisy deprecation which gets us a step closer to completely removing them.
