### PR TITLE
Remove code deprecated in 2018

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -61,21 +61,11 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
    *
    * @param array $params
    *   Reference array contains the values submitted by the form.
-   * @param array $ids
-   *   Array contains the id (deprecated).
    *
    * @return \CRM_Member_DAO_MembershipType
    * @throws \CRM_Core_Exception
    */
-  public static function add(&$params, $ids = []) {
-    // DEPRECATED Check if membershipType ID was passed in via $ids
-    if (empty($params['id'])) {
-      if (isset($ids['membershipType'])) {
-        Civi::log()->warning('Deprecated: Passing membershipType by $ids array in CRM_Member_BAO_MembershipType::add');
-      }
-      $params['id'] = $ids['membershipType'] ?? NULL;
-    }
-
+  public static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'MembershipType', CRM_Utils_Array::value('id', $params), $params);
 

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -67,34 +67,32 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
    */
   public static function add(&$params) {
     $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'MembershipType', CRM_Utils_Array::value('id', $params), $params);
+    $membershipTypeID = $params['id'] ?? NULL;
+    CRM_Utils_Hook::pre($hook, 'MembershipType', $membershipTypeID, $params);
 
-    $membershipTypeId = $params['id'] ?? NULL;
-
-    if (!$membershipTypeId && !isset($params['domain_id'])) {
+    if (!$membershipTypeID && !isset($params['domain_id'])) {
       $params['domain_id'] = CRM_Core_Config::domainID();
     }
 
     // $previousID is the old organization id for membership type i.e 'member_of_contact_id'. This is used when an organization is changed.
     $previousID = NULL;
-    if ($membershipTypeId) {
-      $previousID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $membershipTypeId, 'member_of_contact_id');
+    if ($membershipTypeID) {
+      $previousID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $membershipTypeID, 'member_of_contact_id');
     }
 
-    // action is taken depending upon the mode
     $membershipType = new CRM_Member_DAO_MembershipType();
     $membershipType->copyValues($params);
     $membershipType->save();
 
-    if ($membershipTypeId) {
+    if ($membershipTypeID) {
       // on update we may need to retrieve some details for the price field function - otherwise we get e-notices on attempts to retrieve
       // name etc - the presence of previous id tells us this is an update
       $params = array_merge(civicrm_api3('membership_type', 'getsingle', ['id' => $membershipType->id]), $params);
     }
     self::createMembershipPriceField($params, $previousID, $membershipType->id);
     // update all price field value for quick config when membership type is set CRM-11718
-    if ($membershipTypeId) {
-      self::updateAllPriceFieldValue($membershipTypeId, $params);
+    if ($membershipTypeID) {
+      self::updateAllPriceFieldValue($membershipTypeID, $params);
     }
 
     CRM_Utils_Hook::post($hook, 'MembershipType', $membershipType->id, $membershipType);


### PR DESCRIPTION
Overview
----------------------------------------
Remove code deprecated by @mattwire  in 2018

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/221712077-7ecceff1-7301-4a35-9e85-646e3697e412.png)

After
----------------------------------------
poof - also cleaned up use of `CRM_Utils_Array::value`

Technical Details
----------------------------------------

Comments
----------------------------------------
