### PR TITLE
Smarty notice fix on bank_account_number

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -287,7 +287,7 @@
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
     </div>
 
-    {if $is_monetary and $form.bank_account_number}
+    {if $is_monetary && array_key_exists('bank_account_number', $form)}
       <div id="payment_notice">
         <fieldset class="crm-public-form-item crm-group payment_notice-group">
           <legend>{ts}Agreement{/ts}</legend>


### PR DESCRIPTION
Overview
----------------------------------------
Smarty notice fix on bank_account_number

Before
----------------------------------------
Notice

After
----------------------------------------
poof

Technical Details
----------------------------------------
`bank_account_number` is a possibly present field - I think for fields `array_key_exists` is the best method

Comments
----------------------------------------
page still loads afterwards :-)