### PR TITLE
🩹 dev/core#4149 Change CKEditor 4 default to not encode HTML entities by default which breaks Smarty syntax and prevents use of crmDate function

### DIFF
--- a/ext/ckeditor4/CRM/Ckeditor4/Form/CKEditorConfig.php
+++ b/ext/ckeditor4/CRM/Ckeditor4/Form/CKEditorConfig.php
@@ -309,7 +309,7 @@ class CRM_Ckeditor4_Form_CKEditorConfig extends CRM_Core_Form {
    */
   public static function setConfigDefault() {
     if (!self::getConfigFile()) {
-      $config = self::fileHeader() . "CKEDITOR.editorConfig = function( config ) {\n\tconfig.allowedContent = true;\n};\n";
+      $config = self::fileHeader() . "CKEDITOR.editorConfig = function( config ) {\n\tconfig.allowedContent = true;\n\tconfig.entities = false;\n};\n";
       // Make sure directories exist
       if (!is_dir(Civi::paths()->getPath('[civicrm.files]/persist'))) {
         mkdir(Civi::paths()->getPath('[civicrm.files]/persist'));


### PR DESCRIPTION
Change CKEditor 4 default to not encode HTML entities by default which breaks Smarty syntax and prevents use of crmDate function. Looks like this has been a reported problem since 2015, https://civicrm.stackexchange.com/questions/7212/escaping-quotes-in-ckeditor-breaks-smarty-syntax/7213#7213

Overview
----------------------------------------

User editable Message Templates, the Contact Action: Send an Email and the Contact Action: Print Merge/Document cannot use any Smarty Tokens with the crmDate function because CKEditor 4 unnecessarily HTML encodes single quotes (') and double quotes (").

So if you use a Smarty Token like:

```{contribution.receive_date|crmDate:"%E%f %B %Y"}```

```{contribution.receive_date|crmDate:'%E%f %B %Y'}```

When CKEditor 4 parses the HTML it converts this into:

```{contribution.receive_date|crmDate:&quot;%E%f %B %Y&quot;}```

```{contribution.receive_date|crmDate:&#39;%E%f %B %Y&#39;}```

Effectively rendering the crmDate function unusable in these situations.

https://civicrm.stackexchange.com/questions/7212/escaping-quotes-in-ckeditor-breaks-smarty-syntax/7213#7213
https://lab.civicrm.org/dev/core/-/issues/4149

Before
----------------------------------------

As per the description above.

After
----------------------------------------

These Smarty tokens are rendered correctly.

```{contribution.receive_date|crmDate:"%E%f %B %Y"}```

```{contribution.receive_date|crmDate:'%E%f %B %Y'}```

Technical Details
----------------------------------------


Comments
----------------------------------------

Also noting that the CKEditor configuration file is written to a "persistent" location: [civicrm.files]/persist/crm-ckeditor.js  and really should be stored in a "dynamic" location: [civicrm.files]/persist/contribute/dyn/crm-ckeditor.js


Agileware Ref: CIVICRM-2103