### PR TITLE
Log Smarty debug to it's own channel

### DIFF
--- a/CRM/Core/Smarty.php
+++ b/CRM/Core/Smarty.php
@@ -485,7 +485,7 @@ class CRM_Core_Smarty extends Smarty {
 
     $value = smarty_modifier_escape($string, $esc_type, $char_set);
     if ($value !== $string) {
-      Civi::log()->debug('smarty escaping original {original}, escaped {escaped} type {type} charset {charset}', [
+      Civi::log('smarty')->debug('smarty escaping original {original}, escaped {escaped} type {type} charset {charset}', [
         'original' => $string,
         'escaped' => $value,
         'type' => $esc_type,


### PR DESCRIPTION


Overview
----------------------------------------
I just wrote the docs on the right way to log using this example https://docs.civicrm.org/dev/en/latest/framework/logging/

- so we should make it the same. I tested locally & this results in the smarty debugging going to a separate file (good).

I personally think we should send all the IPN files off to their own channel but am loath to be pro-active on changing that

Before
----------------------------------------
Output from smarty secure mode goes into the same log file as all the rest

After
----------------------------------------
Output from smarty secure mode goes into it's own file

Technical Details
----------------------------------------

Comments
----------------------------------------
