### PR TITLE
(dev/core#4124) Past campaigns are not to be assigned via batch updat…

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2174,7 +2174,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       if (CRM_Campaign_BAO_Campaign::isComponentEnabled()) {
         $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(CRM_Utils_Array::value($contactId,
           $form->_componentCampaigns
-        ));
+        ), NULL, TRUE, FALSE);
         $form->add('select', $name, $title,
           $campaigns, $required,
           [


### PR DESCRIPTION
…e/update contributions

Overview
----------------------------------------
- Create a campaign with end date in past

![campaign](https://user-images.githubusercontent.com/3455173/221763860-88531ac1-5d56-494e-8268-1a399b290f5c.png)


- Create a profile configured for contribution fields (including the campaign field)
- Find Contributions, and select a few and use the created profile to update the campaign

- The campaign is NOT available in the drop down

![batch_update](https://user-images.githubusercontent.com/3455173/221763925-100f8e15-1c14-471d-897a-a020abfaabf9.png)


- On new/edit contributions, you are able to choose the past campaigns as well (which is the correct behavior).
![new_contribution](https://user-images.githubusercontent.com/3455173/221764046-187267a7-831d-4c9e-9650-11ca9d39e85f.png)


Before
----------------------------------------
No past campaigns available for batch update.

After
----------------------------------------
Past campaigns are available for batch update.
