### PR TITLE
Php8.2 stop accessing undefined form Property isQuickConfig in `PriceField:addQuickFormElement`

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -268,6 +268,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     }
 
     $is_pay_later = 0;
+    $isQuickConfig = CRM_Price_BAO_PriceSet::isQuickConfig($field->price_set_id);
     if (isset($qf->_mode) && empty($qf->_mode)) {
       $is_pay_later = 1;
     }
@@ -324,13 +325,13 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         ]);
 
         $extra = [];
-        if (!empty($qf->_membershipBlock) && !empty($qf->_quickConfig) && $field->name == 'other_amount' && empty($qf->_contributionAmount)) {
+        if (!empty($qf->_membershipBlock) && $isQuickConfig && $field->name == 'other_amount' && empty($qf->_contributionAmount)) {
           $useRequired = 0;
         }
         elseif (!empty($fieldOptions[$optionKey]['label'])) {
           //check for label.
           $label = $fieldOptions[$optionKey]['label'];
-          if (!empty($qf->_quickConfig) && !empty($qf->_contributionAmount) && strtolower($fieldOptions[$optionKey]['name']) == 'other_amount') {
+          if ($isQuickConfig && !empty($qf->_contributionAmount) && strtolower($fieldOptions[$optionKey]['name']) == 'other_amount') {
             $label .= '  ' . $currencySymbol;
             $qf->assign('priceset', $elementName);
             $extra = [
@@ -361,7 +362,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         }
 
         //CRM-10117
-        if (!empty($qf->_quickConfig)) {
+        if ($isQuickConfig) {
           $message = ts('Please enter a valid amount.');
           $type = 'money';
         }
@@ -376,7 +377,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
       case 'Radio':
         $choice = [];
 
-        if (!empty($qf->_quickConfig) && !empty($qf->_contributionAmount)) {
+        if ($isQuickConfig && !empty($qf->_contributionAmount)) {
           $qf->assign('contriPriceset', $elementName);
         }
 
@@ -418,7 +419,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             'data-price-field-values' => json_encode($customOption),
             'visibility' => $visibility_id,
           ];
-          if (!empty($qf->_quickConfig) && $field->name == 'contribution_amount') {
+          if ($isQuickConfig && $field->name == 'contribution_amount') {
             $extra += ['onclick' => 'clearAmountOther();'];
           }
           if ($field->name == 'membership_amount') {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -510,6 +510,20 @@ WHERE  id = %1";
   }
 
   /**
+   * Is the price set 'quick config'.
+   *
+   * Quick config price sets have a simplified configuration on
+   * contribution and event pages.
+   *
+   * @param int $priceSetID
+   *
+   * @return bool
+   */
+  public static function isQuickConfig(int $priceSetID): bool {
+    return (bool) self::getCachedPriceSetDetail($priceSetID)['is_quick_config'];
+  }
+
+  /**
    * Get the Price Field ID.
    *
    * We call this function when more than one being present would represent an error
@@ -1320,8 +1334,7 @@ WHERE       ps.id = %1
   public static function copyPriceSet($baoName, $id, $newId) {
     $priceSetId = CRM_Price_BAO_PriceSet::getFor($baoName, $id);
     if ($priceSetId) {
-      $isQuickConfig = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config');
-      if ($isQuickConfig) {
+      if (self::isQuickConfig($priceSetId)) {
         $copyPriceSet = CRM_Price_BAO_PriceSet::copy($priceSetId);
         CRM_Price_BAO_PriceSet::addTo($baoName, $newId, $copyPriceSet->id);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Php8.2 stop accessing undefined form Property isQuickConfig in `PriceField:addQuickFormElement`

Before
----------------------------------------
Value passed around on an undefined property in a form

After
----------------------------------------
We can still load it in a cached way with less complexity...

Technical Details
----------------------------------------

Comments
----------------------------------------
@seamuslee001 there are also 'hits' on this 'property' in the Contribution Page form class - I thought this would be a fairly readable chunk & it has test cover but I can add those ones in ( I did them locally)