### PR TITLE
Deprecations for Mailing::delete functions

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2405,6 +2405,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
    * @deprecated
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     static::deleteRecord(['id' => $id]);
   }
 
@@ -2436,7 +2437,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
 
     CRM_Core_Error::deprecatedWarning('This function is deprecated, use CRM_Mailing_BAO_MailingJob::del instead');
 
-    CRM_Mailing_BAO_MailingJob::del($id);
+    CRM_Mailing_BAO_MailingJob::deleteRecord(['id' => $id]);
   }
 
   /**

--- a/CRM/Mailing/BAO/MailingAB.php
+++ b/CRM/Mailing/BAO/MailingAB.php
@@ -52,6 +52,7 @@ class CRM_Mailing_BAO_MailingAB extends CRM_Mailing_DAO_MailingAB implements \Ci
    * @deprecated
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     static::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -1102,6 +1102,7 @@ AND    record_type_id = $targetRecordID
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Mailing/Form/Approve.php
+++ b/CRM/Mailing/Form/Approve.php
@@ -155,7 +155,7 @@ class CRM_Mailing_Form_Approve extends CRM_Core_Form {
       $job = new CRM_Mailing_BAO_MailingJob();
       $job->mailing_id = $params['id'];
       while ($job->fetch()) {
-        CRM_Mailing_BAO_MailingJob::del($job->id);
+        CRM_Mailing_BAO_MailingJob::deleteRecord(['id' => $job->id]);
       }
     }
     else {

--- a/CRM/Mailing/Form/Browse.php
+++ b/CRM/Mailing/Form/Browse.php
@@ -61,7 +61,7 @@ class CRM_Mailing_Form_Browse extends CRM_Core_Form {
 
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Mailing_BAO_Mailing::del($this->_mailingId);
+      CRM_Mailing_BAO_Mailing::deleteRecord(['id' => $this->_mailingId]);
       CRM_Core_Session::setStatus(ts('Selected mailing has been deleted.'), ts('Deleted'), 'success');
     }
     elseif ($this->_action & CRM_Core_Action::DISABLE) {

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -199,7 +199,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
           CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
         }
 
-        CRM_Mailing_BAO_Mailing::del($this->_mailingId);
+        CRM_Mailing_BAO_Mailing::deleteRecord(['id' => $this->_mailingId]);
         CRM_Core_Session::setStatus(ts('Selected mailing has been deleted.'), ts('Deleted'), 'success');
         CRM_Utils_System::redirect($context);
       }


### PR DESCRIPTION
Another partial on https://github.com/civicrm/civicrm-core/pull/25677 - I didn't r-run but I checked the `del` functions in the ones now bypassed to be sure there was no change