### PR TITLE
Don't overwrite (or duplicate) custom fields on Profile submission

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2290,7 +2290,7 @@ ORDER BY civicrm_email.is_primary DESC";
 
           // if auth source is not checksum / login && $value is blank, do not proceed - CRM-10128
           if (($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 &&
-            ($value == '' || !isset($value))
+            ($value == '' || !isset($value) || (is_array($value) && empty($value)))
           ) {
             continue;
           }


### PR DESCRIPTION
Overview
----------------------------------------
This PR re-addresses the issue raised on [PR #14390](https://github.com/civicrm/civicrm-core/pull/14390) and uses the simplified fix mentioned in @eileenmcnaughton's [comment](https://github.com/civicrm/civicrm-core/pull/14390#discussion_r289595347).

Before
----------------------------------------
The existing data is overwritten with NULL.

Replication Steps
----------------------------------------

  1. Create a custom field set for Contacts.
  1. Create a custom field value 
        * set *Data Type* to **Alphanumeric**
        * set *Field Type* to **Select**
        * make sure to check the "Multi-Select" box
  1. Add that custom field to a Profile.
       * on that Profile field, open up **Advanced Settings**
       * select **Update the matching contact** option for the question *What to do upon duplicate match*
  1.  Create a contact and fill in the new custom field.
  1.  Create a simple event registration page (no payment needed) with that new Profile, and whatever fields needed to match the Unsupervised Dedupe rule (i.e. Email). 
  1. As an anonymous user, submit the profile, but
     * a) leave the new custom field blank
     *  b) ensure that you match your new contact through the Unsupervised Dedupe rule.


After
----------------------------------------
This PR simplifies the evaluation of `$value` and prevents any overwriting or duplication of custom fields in the case that no values are passed in from a Profile submission.
