### PR TITLE
Pull over a few more deprecations + blockDelete deprecation

### DIFF
--- a/CRM/Badge/BAO/Layout.php
+++ b/CRM/Badge/BAO/Layout.php
@@ -92,6 +92,7 @@ class CRM_Badge_BAO_Layout extends CRM_Core_DAO_PrintLabel {
    * @deprecated
    */
   public static function del($printLabelId) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     self::deleteRecord(['id' => $printLabelId]);
   }
 

--- a/CRM/Badge/Form/Layout.php
+++ b/CRM/Badge/Form/Layout.php
@@ -164,7 +164,7 @@ class CRM_Badge_Form_Layout extends CRM_Admin_Form {
    */
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Badge_BAO_Layout::del($this->_id);
+      CRM_Badge_BAO_Layout::deleteRecord(['id' => $this->_id]);
       CRM_Core_Session::setStatus(ts('Selected badge layout has been deleted.'), ts('Record Deleted'), 'success');
       return;
     }

--- a/CRM/Batch/BAO/EntityBatch.php
+++ b/CRM/Batch/BAO/EntityBatch.php
@@ -63,6 +63,7 @@ class CRM_Batch_BAO_EntityBatch extends CRM_Batch_DAO_EntityBatch {
    * @return CRM_Batch_DAO_EntityBatch
    */
   public static function del($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     if (!is_array($params)) {
       $params = ['id' => $params];
     }

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -439,6 +439,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
    * @return CRM_Case_DAO_CaseType
    */
   public static function del($caseTypeId) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return static::deleteRecord(['id' => $caseTypeId]);
   }
 

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -33,6 +33,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
    * @deprecated
    */
   public static function add(array $params): CRM_Contact_DAO_GroupContact {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 
@@ -503,7 +504,7 @@ SELECT    *
     // As of Aug 2020 it's not called from anywhere so we can remove the below code after some time
 
     CRM_Core_Error::deprecatedFunctionWarning('Use the GroupContact API');
-    return self::add($params);
+    return self::writeRecord($params);
   }
 
   /**


### PR DESCRIPTION
@colemanw I meant to deprecate `blockDelete` in https://github.com/civicrm/civicrm-core/pull/25693 - I put it in here (+ a couple more from your big list)