### PR TITLE
dev/core#4145 Prevent fatal on event sched reminders when CiviEvent enabled

### DIFF
--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -37,6 +37,9 @@ class CRM_Event_ActionMapping extends \Civi\ActionSchedule\Mapping {
    * @param \Civi\ActionSchedule\Event\MappingRegisterEvent $registrations
    */
   public static function onRegisterActionMappings(\Civi\ActionSchedule\Event\MappingRegisterEvent $registrations) {
+    if (!CRM_Core_Component::isEnabled('CiviEvent')) {
+      return;
+    }
     $registrations->register(CRM_Event_ActionMapping::create([
       'id' => CRM_Event_ActionMapping::EVENT_TYPE_MAPPING_ID,
       'entity' => 'civicrm_participant',

--- a/Civi/ActionSchedule/Mapping.php
+++ b/Civi/ActionSchedule/Mapping.php
@@ -275,15 +275,17 @@ abstract class Mapping implements MappingInterface {
       asort($valueLabelMap['activity_type']);
 
       $valueLabelMap['activity_status'] = \CRM_Core_PseudoConstant::activityStatus();
-      $valueLabelMap['event_type'] = \CRM_Event_PseudoConstant::eventType();
-      $valueLabelMap['civicrm_event'] = \CRM_Event_PseudoConstant::event(NULL, FALSE, "( is_template IS NULL OR is_template != 1 )");
-      $valueLabelMap['civicrm_participant_status_type'] = \CRM_Event_PseudoConstant::participantStatus(NULL, NULL, 'label');
-      $valueLabelMap['event_template'] = \Civi\Api4\Event::get(FALSE)
-        ->addWhere('is_template', '=', TRUE)
-        ->addWhere('is_active', '=', TRUE)
-        ->execute()
-        ->indexBy('id')
-        ->column('template_title');
+      if (\CRM_Core_Component::isEnabled('CiviEvent')) {
+        $valueLabelMap['event_type'] = \CRM_Event_PseudoConstant::eventType();
+        $valueLabelMap['civicrm_event'] = \CRM_Event_PseudoConstant::event(NULL, FALSE, "( is_template IS NULL OR is_template != 1 )");
+        $valueLabelMap['civicrm_participant_status_type'] = \CRM_Event_PseudoConstant::participantStatus(NULL, NULL, 'label');
+        $valueLabelMap['event_template'] = \Civi\Api4\Event::get(FALSE)
+          ->addWhere('is_template', '=', TRUE)
+          ->addWhere('is_active', '=', TRUE)
+          ->execute()
+          ->indexBy('id')
+          ->column('template_title');
+      }
       $valueLabelMap['auto_renew_options'] = \CRM_Core_OptionGroup::values('auto_renew_options');
       $valueLabelMap['contact_date_reminder_options'] = \CRM_Core_OptionGroup::values('contact_date_reminder_options');
       $valueLabelMap['civicrm_membership_type'] = \CRM_Member_PseudoConstant::membershipType();


### PR DESCRIPTION

Overview
----------------------------------------
[dev/core#4145 Prevent fatal on event sched reminders when CiviEvent enabled
](https://lab.civicrm.org/dev/core/-/issues/4145)

Before
----------------------------------------
Fatal error on create sched reminder with CiviEvent disabled

civicrm/admin/scheduleReminders?action=add&reset=1

After
----------------------------------------
No fatal

Technical Details
----------------------------------------
I think the changes to `IsCurrentSubscriber` made this bubble up - as a quick fix this works but additional considerations include doing the same for `CiviMember` & conditionally adding the `listener` (probably OK as an AND but might be grumpy when toggling)

Comments
----------------------------------------
