### PR TITLE
Remove deprecated function calls to Event::del, Membership functions del, OptionValue

### DIFF
--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -120,7 +120,7 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
     CRM_Utils_System::flushCache();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Core_BAO_OptionGroup::del($this->_id);
+      CRM_Core_BAO_OptionGroup::deleteRecord(['id' => $this->_id]);
       CRM_Core_Session::setStatus(ts('Selected option group has been deleted.'), ts('Record Deleted'), 'success');
     }
     else {

--- a/CRM/Admin/Form/Options.php
+++ b/CRM/Admin/Form/Options.php
@@ -459,7 +459,7 @@ class CRM_Admin_Form_Options extends CRM_Admin_Form {
       $fieldValues = ['option_group_id' => $this->_gid];
       CRM_Utils_Weight::delWeight('CRM_Core_DAO_OptionValue', $this->_id, $fieldValues);
 
-      if (CRM_Core_BAO_OptionValue::del($this->_id)) {
+      if (CRM_Core_BAO_OptionValue::deleteRecord(['id' => $this->_id])) {
         if ($this->_gName == 'phone_type') {
           CRM_Core_BAO_Phone::setOptionToNull(CRM_Utils_Array::value('value', $this->_defaultValues));
         }

--- a/CRM/Campaign/Form/Survey/Main.php
+++ b/CRM/Campaign/Form/Survey/Main.php
@@ -187,7 +187,7 @@ class CRM_Campaign_Form_Survey_Main extends CRM_Campaign_Form_Survey {
       );
       // delete option group if no any survey is using it.
       if (!$countSurvey) {
-        CRM_Core_BAO_OptionGroup::del($this->_values['result_id']);
+        CRM_Core_BAO_OptionGroup::deleteRecord(['id' => $this->_values['result_id']]);
       }
     }
 

--- a/CRM/Campaign/Form/SurveyType.php
+++ b/CRM/Campaign/Form/SurveyType.php
@@ -122,7 +122,7 @@ class CRM_Campaign_Form_SurveyType extends CRM_Admin_Form {
       $fieldValues = ['option_group_id' => $this->_gid];
       $wt = CRM_Utils_Weight::delWeight('CRM_Core_DAO_OptionValue', $this->_id, $fieldValues);
 
-      if (CRM_Core_BAO_OptionValue::del($this->_id)) {
+      if (CRM_Core_BAO_OptionValue::deleteRecord(['id' => $this->_id])) {
         CRM_Core_Session::setStatus(ts('Selected Survey type has been deleted.'), ts('Record Deleted'), 'success');
       }
     }

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2485,7 +2485,7 @@ WHERE  option_group_id = {$optionGroupId}";
 
     if ($count < 2) {
       //delete the option group
-      CRM_Core_BAO_OptionGroup::del($optionGroupId);
+      CRM_Core_BAO_OptionGroup::deleteRecord(['id' => $optionGroupId]);
     }
   }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -172,6 +172,7 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event implements \Civi\Core\Hook
    * @deprecated
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) static::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Event/Form/ManageEvent/Delete.php
+++ b/CRM/Event/Form/ManageEvent/Delete.php
@@ -81,7 +81,7 @@ class CRM_Event_Form_ManageEvent_Delete extends CRM_Event_Form_ManageEvent {
       ), ts('Deletion Error'), 'error');
       return;
     }
-    CRM_Event_BAO_Event::del($this->_id);
+    CRM_Event_BAO_Event::deleteRecord(['id' => $this->_id]);
     if ($this->_isTemplate) {
       CRM_Core_Session::setStatus(ts("'%1' has been deleted.", [1 => $this->_title]), ts('Template Deleted'), 'success');
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/eventTemplate', 'reset=1'));

--- a/CRM/Member/BAO/MembershipBlock.php
+++ b/CRM/Member/BAO/MembershipBlock.php
@@ -24,6 +24,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
    * @return CRM_Member_DAO_MembershipBlock
    */
   public static function create($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 
@@ -35,6 +36,7 @@ class CRM_Member_BAO_MembershipBlock extends CRM_Member_DAO_MembershipBlock {
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -81,6 +81,7 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Member/BAO/MembershipStatus.php
+++ b/CRM/Member/BAO/MembershipStatus.php
@@ -151,6 +151,7 @@ class CRM_Member_BAO_MembershipStatus extends CRM_Member_DAO_MembershipStatus im
    * @throws CRM_Core_Exception
    */
   public static function del($membershipStatusId) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     static::deleteRecord(['id' => $membershipStatusId]);
   }
 

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -123,6 +123,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
    * @return bool
    */
   public static function del($membershipTypeId) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     try {
       static::deleteRecord(['id' => $membershipTypeId]);
       return TRUE;

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -151,7 +151,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       //CRM-15573
       if (!empty($params['id'])) {
         $params['membership_types'] = serialize($membershipRequired);
-        CRM_Member_BAO_MembershipBlock::create($params);
+        CRM_Member_BAO_MembershipBlock::writeRecord($params);
       }
       $this->add('hidden', "mem_price_field_id", '', ['id' => "mem_price_field_id"]);
       $this->assign('is_recur', $isRecur);

--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -150,7 +150,7 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       try {
-        CRM_Member_BAO_MembershipStatus::del($this->_id);
+        CRM_Member_BAO_MembershipStatus::deleteRecord(['id' => $this->_id]);
       }
       catch (CRM_Core_Exception $e) {
         CRM_Core_Error::statusBounce($e->getMessage(), NULL, ts('Delete Failed'));

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -383,7 +383,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       try {
-        CRM_Member_BAO_MembershipType::del($this->_id);
+        CRM_Member_BAO_MembershipType::deleteRecord(['id' => $this->_id]);
       }
       catch (CRM_Core_Exception $e) {
         CRM_Core_Error::statusBounce($e->getMessage(), NULL, ts('Membership Type Not Deleted'));

--- a/api/v3/Event.php
+++ b/api/v3/Event.php
@@ -165,9 +165,12 @@ function _civicrm_api3_event_get_legacy_support_42(&$event, $event_id) {
  * @param array $params
  *
  * @return array
+ * @throws \CRM_Core_Exception
+ * @noinspection PhpUnused
  */
-function civicrm_api3_event_delete($params) {
-  return CRM_Event_BAO_Event::del($params['id']) ? civicrm_api3_create_success() : civicrm_api3_create_error(ts('Error while deleting event'));
+function civicrm_api3_event_delete(array $params): array {
+  CRM_Event_BAO_Event::deleteRecord($params);
+  return civicrm_api3_create_success();
 }
 
 /**

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -105,16 +105,13 @@ function civicrm_api3_membership_status_update($params) {
  * This API is used for deleting a membership status
  *
  * @param array $params
+ *
  * @return array
  * @throws CRM_Core_Exception
- * @throws CRM_Core_Exception
+ * @noinspection PhpUnused
  */
-function civicrm_api3_membership_status_delete($params) {
-
-  $memberStatusDelete = CRM_Member_BAO_MembershipStatus::del($params['id'], TRUE);
-  if ($memberStatusDelete) {
-    throw new CRM_Core_Exception($memberStatusDelete['error_message']);
-  }
+function civicrm_api3_membership_status_delete(array $params): array {
+  CRM_Member_BAO_MembershipStatus::deleteRecord($params);
   return civicrm_api3_create_success();
 }
 

--- a/api/v3/OptionValue.php
+++ b/api/v3/OptionValue.php
@@ -91,7 +91,7 @@ function _civicrm_api3_option_value_create_spec(&$params) {
 function civicrm_api3_option_value_delete($params) {
   // We will get the option group id before deleting so we can flush pseudoconstants.
   $optionGroupID = civicrm_api('option_value', 'getvalue', ['version' => 3, 'id' => $params['id'], 'return' => 'option_group_id']);
-  $result = CRM_Core_BAO_OptionValue::del($params['id']);
+  $result = CRM_Core_BAO_OptionValue::deleteRecord($params);
   if ($result) {
     civicrm_api('option_value', 'getfields', ['version' => 3, 'cache_clear' => 1, 'option_group_id' => $optionGroupID]);
     return civicrm_api3_create_success();


### PR DESCRIPTION
Per https://github.com/civicrm/civicrm-core/pull/25677

@colemanw I changed the event api ones here - rather than catching the exception I let it bubble up - that is more correct apiv3 behaviour 