### PR TITLE
Stricter typing in Apiv4

### DIFF
--- a/Civi/Api4/Service/Spec/RequestSpec.php
+++ b/Civi/Api4/Service/Spec/RequestSpec.php
@@ -53,7 +53,7 @@ class RequestSpec implements \Iterator {
    * @param string $action
    * @param array $values
    */
-  public function __construct($entity, $action, $values = []) {
+  public function __construct(string $entity, string $action, array $values = []) {
     $this->entity = $entity;
     $this->action = $action;
     $this->entityTableName = CoreUtil::getTableName($entity);

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -32,7 +32,6 @@ class SpecGatherer extends AutoService {
   /**
    * Returns a RequestSpec with all the fields available. Uses spec providers
    * to add or modify field specifications.
-   * @see \Civi\Api4\Service\Spec\Provider\CustomFieldCreationSpecProvider
    *
    * @param string $entity
    * @param string $action
@@ -40,8 +39,11 @@ class SpecGatherer extends AutoService {
    * @param array $values
    *
    * @return \Civi\Api4\Service\Spec\RequestSpec
+   * @throws \CRM_Core_Exception
+   * @see \Civi\Api4\Service\Spec\Provider\CustomFieldCreationSpecProvider
+   *
    */
-  public function getSpec($entity, $action, $includeCustom, $values = []) {
+  public function getSpec(string $entity, string $action, bool $includeCustom, array $values = []): RequestSpec {
     $specification = new RequestSpec($entity, $action, $values);
 
     // Real entities

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -74,7 +74,7 @@ class CoreUtil {
    *
    * @return string
    */
-  public static function getTableName($entityName) {
+  public static function getTableName(string $entityName) {
     return self::getInfoItem($entityName, 'table_name');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Stricter typing in Apiv4

Before
----------------------------------------
A someone common error is for `entity` to be null - which is picked up by strict typing - but not until futher down the chain

After
----------------------------------------
Pick up invalid data earlier through strict typing

Technical Details
----------------------------------------
@colemanw

Comments
----------------------------------------
