### PR TITLE
Deprecated code removal

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -553,23 +553,6 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
   }
 
   /**
-   * Get the empty spaces for event those we can allocate
-   * to pending participant to become confirm.
-   *
-   * @deprecated
-   *
-   * @param int $eventId
-   *   Event id.
-   *
-   * @return int
-   *   $spaces  Number of Empty Seats/null.
-   */
-  public static function pendingToConfirmSpaces($eventId) {
-    CRM_Core_Error::deprecatedFunctionWarning('CRM_Event_BAO_Participant::eventFull');
-    return CRM_Event_BAO_Participant::eventFull($eventId, TRUE, FALSE, TRUE, FALSE, TRUE);
-  }
-
-  /**
    * Combine all the importable fields from the lower levels object.
    *
    * @param string $contactType

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -979,9 +979,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     if (!empty($params['contact_id'])) {
       $this->_contactID = $this->_contactId = $params['contact_id'];
     }
-    if (!$this->_priceSetId && $this->_isPaidEvent) {
-      CRM_Core_Error::deprecatedFunctionWarning('this should never be true, handling to be removed');
-    }
     if ($this->_priceSetId && $isQuickConfig = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config')) {
       $this->_quickConfig = $isQuickConfig;
     }
@@ -1797,10 +1794,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       //re-enter the values for UPDATE mode
       $params['fee_level'] = $params['amount_level'] = $this->getParticipantValue('fee_level');
       $params['fee_amount'] = $this->getParticipantValue('fee_amount');
-      if (isset($params['priceSetId'])) {
-        CRM_Core_Error::deprecatedFunctionWarning('It seems this line is never hit & can go.');
-        $lineItem[0] = CRM_Price_BAO_LineItem::getLineItems($this->_id);
-      }
+
       //also add additional participant's fee level/priceset
       if (CRM_Event_BAO_Participant::isPrimaryParticipant($this->_id)) {
         $additionalIds = CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_id);

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -110,66 +110,6 @@ class CRM_Utils_PDF_Utils {
   }
 
   /**
-   * Convert html to tcpdf.
-   *
-   * @deprecated
-   * @param $paper_size
-   * @param $orientation
-   * @param $margins
-   * @param $html
-   * @param $output
-   * @param $fileName
-   * @param $stationery_path
-   */
-  public static function _html2pdf_tcpdf($paper_size, $orientation, $margins, $html, $output, $fileName, $stationery_path) {
-    CRM_Core_Error::deprecatedFunctionWarning('CRM_Utils_PDF::_html2pdf_dompdf');
-    return self::_html2pdf_dompdf($paper_size, $orientation, $margins, $html, $output, $fileName);
-    // Documentation on the TCPDF library can be found at: http://www.tcpdf.org
-    // This function also uses the FPDI library documented at: http://www.setasign.com/products/fpdi/about/
-    // Syntax borrowed from https://github.com/jake-mw/CDNTaxReceipts/blob/master/cdntaxreceipts.functions.inc
-    require_once 'tcpdf/tcpdf.php';
-    // This library is only in the 'packages' area as of version 4.5
-    require_once 'FPDI/fpdi.php';
-
-    $paper_size_arr = [$paper_size[2], $paper_size[3]];
-
-    $pdf = new TCPDF($orientation, 'pt', $paper_size_arr);
-    $pdf->Open();
-
-    if (is_readable($stationery_path)) {
-      $pdf->SetStationery($stationery_path);
-    }
-
-    $pdf->SetAuthor('');
-    $pdf->SetKeywords('CiviCRM.org');
-    $pdf->setPageUnit($margins[0]);
-    $pdf->SetMargins($margins[4], $margins[1], $margins[2], TRUE);
-
-    $pdf->setJPEGQuality('100');
-    $pdf->SetAutoPageBreak(TRUE, $margins[3]);
-
-    $pdf->AddPage();
-
-    $ln = TRUE;
-    $fill = FALSE;
-    $reset_parm = FALSE;
-    $cell = FALSE;
-    $align = '';
-
-    // output the HTML content
-    $pdf->writeHTML($html, $ln, $fill, $reset_parm, $cell, $align);
-
-    // reset pointer to the last page
-    $pdf->lastPage();
-
-    // close and output the PDF
-    $pdf->Close();
-    $pdf_file = 'CiviLetter' . '.pdf';
-    $pdf->Output($pdf_file, 'D');
-    CRM_Utils_System::civiExit();
-  }
-
-  /**
    * @param $paper_size
    * @param $orientation
    * @param $html

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1102,7 +1102,7 @@ class CRM_Utils_System {
    * Encode url.
    *
    * @param string $url
-   *
+   * @deprecated
    * @return null|string
    */
   public static function urlEncode($url) {
@@ -1596,7 +1596,7 @@ class CRM_Utils_System {
    * Given a URL, return a relative URL if possible.
    *
    * @param string $url
-   *
+   * @deprecated
    * @return string
    */
   public static function relativeURL($url) {


### PR DESCRIPTION
Overview
----------------------------------------
Removes code that's been noisily deprecated > 3 years; ensures more recently noisy deprecations have an accompanying `@deprecated` annotation.
