### PR TITLE
Filter 'My imports' to only show non-expired

### DIFF
--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -37,6 +37,11 @@ return [
               '=',
               FALSE,
             ],
+            [
+              'is_current',
+              '=',
+              TRUE,
+            ],
           ],
           'groupBy' => [],
           'join' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Filter 'My imports' to only show non-expired


Before
----------------------------------------
the packaged search 'My Imports' (In Civi-Import) includes expired searches (which have broken links as a result)

![image](https://user-images.githubusercontent.com/336308/222329081-47f21d82-1e6e-40bf-8889-4b8060712c15.png)

After
----------------------------------------
is_current filter applied (same as with similar searches

Technical Details
----------------------------------------

Comments
----------------------------------------
