### PR TITLE
Import link - fix search Import SearchDisplays to link to the created contact

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -146,7 +146,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
    * @return array
    */
   public static function getTypes(): array {
-    $types = Civi::cache()->get('UserJobTypes');
+    $types = Civi::cache('metadata')->get('UserJobTypes');
     if ($types === NULL) {
       $types = [];
       $classes = ClassScanner::get(['interface' => UserJobInterface::class]);
@@ -158,7 +158,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
         }
         $types = array_merge($types, $declaredTypes);
       }
-      Civi::cache()->set('UserJobTypes', $types);
+      Civi::cache('metadata')->set('UserJobTypes', $types);
     }
     // Rekey to numeric to prevent https://lab.civicrm.org/dev/core/-/issues/3719
     return array_values($types);

--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -19,6 +19,7 @@ use Civi\Api4\UserJob;
 use Civi\BAO\Import;
 use Civi\Core\Service\AutoService;
 use CRM_Core_BAO_UserJob;
+use CRM_Civiimport_ExtensionUtil as E;
 
 /**
  * @service
@@ -43,7 +44,7 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
     // CheckPermissions does not reach us here - so we will have to rely on earlier permission filters.
     $userJobID = substr($spec->getEntity(), (strpos($spec->getEntity(), '_') + 1));
     $userJob = UserJob::get(FALSE)->addWhere('id', '=', $userJobID)->addSelect('metadata', 'job_type', 'created_id')->execute()->first();
-
+    $entity = CRM_Core_BAO_UserJob::getType($userJob['job_type'])['entity'];
     foreach ($columns as $column) {
       $isInternalField = strpos($column['name'], '_') === 0;
       $exists = $isInternalField && $spec->getFieldByName($column['name']);
@@ -54,6 +55,7 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
       $field->setTitle(ts('Import field') . ':' . $column['label']);
       $field->setLabel($column['label']);
       $field->setType('Field');
+      $field->setDataType($column['data_type']);
       $field->setReadonly($isInternalField);
       $field->setDescription(ts('Data being imported into the field.'));
       $field->setColumnName($column['name']);
@@ -63,6 +65,7 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
           if ($userJob['job_type'] === $jobType['id'] && $jobType['entity']) {
             $field->setFkEntity($jobType['entity']);
             $field->setInputType('EntityRef');
+            $field->setInputAttrs(['label' => $entity]);
           }
         }
       }

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -137,7 +137,7 @@ class Import extends CRM_Core_DAO {
   public function table(): array {
     $table = [];
     foreach (self::getFieldsForTable($this->tableName()) as $value) {
-      $table[$value['name']] = $value['type'] ?? CRM_Utils_Type::T_STRING;
+      $table[$value['name']] = ($value['data_type'] === 'Integer') ? CRM_Utils_Type::T_INT : CRM_Utils_Type::T_STRING;
       if (!empty($value['required'])) {
         $table[$value['name']] += self::DB_DAO_NOTNULL;
       }
@@ -196,14 +196,21 @@ class Import extends CRM_Core_DAO {
    * @throws \CRM_Core_Exception
    */
   public static function getFieldsForTable(string $tableName): array {
+    $cacheKey = 'civiimport_table_fields' . $tableName;
+    if (\Civi::cache('metadata')->has($cacheKey)) {
+      return \Civi::cache('metadata')->get($cacheKey);
+    }
     if (!CRM_Utils_Rule::alphanumeric($tableName)) {
       // This is purely precautionary so does not need to be a translated string.
       throw new CRM_Core_Exception('Invalid import table');
     }
     $columns = [];
-    $headers = UserJob::get(FALSE)
+    $userJob = UserJob::get(FALSE)
       ->addWhere('metadata', 'LIKE', '%' . $tableName . '%')
-      ->addSelect('metadata')->execute()->first()['metadata']['DataSource']['column_headers'] ?? [];
+      ->addSelect('metadata', 'job_type')->execute()->first();
+    $headers = $userJob['metadata']['DataSource']['column_headers'] ?? [];
+    $entity = \CRM_Core_BAO_UserJob::getType($userJob['job_type'])['entity'];
+
     try {
       $result = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM $tableName");
     }
@@ -213,14 +220,22 @@ class Import extends CRM_Core_DAO {
       }
       throw $e;
     }
+
     $userFieldIndex = 0;
     while ($result->fetch()) {
       $columns[$result->Field] = ['name' => $result->Field, 'table_name' => $tableName];
-      if (substr($result->Field, 1) !== '_') {
-        $columns[$result->Field]['label'] = $headers[$userFieldIndex] ?? $result->Field;
+      if (strpos($result->Field, '_') !== 0) {
+        $columns[$result->Field]['label'] = ts('Import field') . ':' . ($headers[$userFieldIndex] ?? $result->Field);
+        $columns[$result->Field]['data_type'] = 'String';
         $userFieldIndex++;
       }
+      else {
+        $columns[$result->Field]['label'] = ($result->Field === '_entity_id') ? E::ts('Row Imported to %1 ID', [1 => $entity]) : $result->Field;
+        $columns[$result->Field]['fk_entity'] = ($result->Field === '_entity_id') ? $entity : NULL;
+        $columns[$result->Field]['data_type'] = strpos($result->Type, 'int') === 0 ? 'Integer' : 'String';
+      }
     }
+    \Civi::cache('metadata')->set($cacheKey, $columns);
     return $columns;
   }
 

--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -7,11 +7,17 @@ $managedEntities = [];
 $importEntities = Import::getImportTables();
 foreach ($importEntities as $importEntity) {
   try {
-    $fields = array_merge(['_id' => TRUE, '_status' => TRUE, '_status_message' => TRUE], Import::getFieldsForUserJobID($importEntity['user_job_id'], FALSE));
+    $fields = array_merge(['_id' => TRUE, '_status' => TRUE, '_status_message' => TRUE, '_entity_id' => TRUE], Import::getFieldsForUserJobID($importEntity['user_job_id'], FALSE));
   }
   catch (CRM_Core_Exception $e) {
     continue;
   }
+  $fields['_entity_id']['link'] = [
+    'entity' => $fields['_entity_id']['fk_entity'],
+    'action' => 'view',
+    'target' => '_blank',
+    'join' => '_entity_id',
+  ];
   $createdBy = empty($importEntity['created_by']) ? '' : ' (' . E::ts('Created by %1', [$importEntity['created_by'], 'String']) . ')';
   $managedEntities[] = [
     'name' => 'SavedSearch_Import' . $importEntity['user_job_id'],
@@ -78,6 +84,7 @@ foreach ($importEntities as $importEntity) {
       'label' => $field['title'] ?? $field['label'],
       'sortable' => TRUE,
       'editable' => strpos($field['name'], '_') !== 0,
+      'link' => $field['link'] ?? NULL,
     ];
   }
   $managedEntities[] = [

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -239,6 +239,6 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
   }
 
   if ($formName === 'CRM_Contact_Import_Form_Summary') {
-    $form->assign('downloadErrorRecordsUrl', '/civicrm/search#/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR');
+    $form->assign('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR', FALSE));
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
This affects the view created when an import is done. To replicate

1) Enable Civi-Import (note name change in https://github.com/civicrm/civicrm-core/pull/25474) not yet merged
2) Import something :-) There are some files in the test folders - eg https://github.com/civicrm/civicrm-core/blob/19f33b0958e24b4ba68bc07d653a11aa6ca59bb4/tests/phpunit/CRM/Contact/Import/Form/data/individual_genders.csv 
3) After importing a search is created - you can find it under packages searches, from the summary screen or from Reports->my imports (although I think the path to get to it could be made easier with better use of links)
4) make sure you have an unfiltered view!
5) there should be a column showing the id you imported to with a link to that entity 
6) the link part isn't working yet....



Before
----------------------------------------
Note the field `_entity_id` near the right 

![image](https://user-images.githubusercontent.com/336308/222652334-76b50f8a-217e-45d2-bfec-4072ba4c628c.png)

After
----------------------------------------
The label indicates the entity & it is moved to the left...

![image](https://user-images.githubusercontent.com/336308/222652677-0c5fb208-3d7a-4716-9740-7b78f1267403.png)

Technical Details
----------------------------------------
The outstanding problem is the field is configured as a link

![image](https://user-images.githubusercontent.com/336308/222652906-59e8ab01-a859-411a-b4ec-7de992db4b9d.png)

But doesn't actually render as one

![image](https://user-images.githubusercontent.com/336308/222653178-90d4d31e-1d97-47ba-bcfa-10dd13c5c209.png)

Comments
----------------------------------------
