### PR TITLE
WIP: initial support for locale-formatted number input in custom fields

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -928,7 +928,11 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // store the submitted values in an array
     if (!$params) {
-      $params = $this->controller->exportValues($this->_name);
+      $params = [];
+      $this->exportedValues = $this->controller->exportValues($this->_name);
+      foreach ($this->exportedValues as $fieldName => $value) {
+        $params[$fieldName] = $this->getSubmittedValue($fieldName);
+      }
     }
 
     // Set activity type id.

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -870,7 +870,12 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     }
 
     //get the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $params = [];
+    $this->exportedValues = $this->controller->exportValues($this->_name);
+    foreach ($this->exportedValues as $fieldName => $value) {
+      $params[$fieldName] = $this->getSubmittedValue($fieldName);
+    }
+
     if (!isset($params['preferred_communication_method'])) {
       // If this field is empty QF will trim it so we have to add it in.
       $params['preferred_communication_method'] = 'null';

--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -72,7 +72,11 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
   public function postProcess() {
     // Process / save custom data
     // Get the form values and groupTree
-    $params = $this->controller->exportValues($this->_name);
+    $params = [];
+    $this->exportedValues = $this->controller->exportValues($this->_name);
+    foreach ($this->exportedValues as $fieldName => $value) {
+      $params[$fieldName] = $this->getSubmittedValue($fieldName);
+    }
     CRM_Core_BAO_CustomValueTable::postProcess($params,
       'civicrm_contact',
       $this->_contactId,

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1103,11 +1103,11 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
       case 'Float':
         if ($field->is_search_range && $search) {
-          $qf->addRule($elementName . '_from', ts('%1 From must be a number (with or without decimal point).', [1 => $label]), 'numeric');
-          $qf->addRule($elementName . '_to', ts('%1 To must be a number (with or without decimal point).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName . '_from', ts('%1 From must be a number (with or without decimal separator).', [1 => $label]), 'localeNumeric');
+          $qf->addRule($elementName . '_to', ts('%1 To must be a number (with or without decimal separator).', [1 => $label]), 'localeNumeric');
         }
         elseif ($widget == 'Text') {
-          $qf->addRule($elementName, ts('%1 must be a number (with or without decimal point).', [1 => $label]), 'numeric');
+          $qf->addRule($elementName, ts('%1 must be a number (with or without decimal separator).', [1 => $label]), 'localeNumeric');
         }
         break;
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1432,7 +1432,12 @@ ORDER BY civicrm_custom_group.weight,
           }
           else {
             if ($field['data_type'] == "Float") {
-              $defaults[$elementName] = (float) $value;
+              if ($field['html_type'] == 'Text') {
+                $defaults[$elementName] = CRM_Utils_Number::formatLocaleNumeric($value);
+              }
+              else {
+                $defaults[$elementName] = (float) $value;
+              }
             }
             elseif ($field['data_type'] == 'Money' &&
               $field['html_type'] == 'Text'

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -394,6 +394,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       'autocomplete',
       'validContact',
       'email',
+      'localeNumeric',
     ];
 
     foreach ($rules as $rule) {
@@ -2887,6 +2888,15 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $value = $this->exportedValues[$fieldName] ?? NULL;
     if (in_array($fieldName, $this->submittableMoneyFields, TRUE)) {
       return CRM_Utils_Rule::cleanMoney($value);
+    }
+    else {
+      $fieldRules = $this->_rules[$fieldName] ?? [];
+      foreach ($fieldRules as $rule) {
+        if ('localeNumeric' === $rule['type']) {
+          $parsedNumber = \CRM_Utils_Number::parseLocaleNumeric($value);
+          return $parsedNumber;
+        }
+      }
     }
     return $value;
   }

--- a/CRM/Utils/Number.php
+++ b/CRM/Utils/Number.php
@@ -128,4 +128,24 @@ class CRM_Utils_Number {
     return $formatter->format($amount);
   }
 
+  /**
+   * Parse a string into a floating-point number according to the current or supplied locale.
+   *
+   * @param string $amount
+   * @param string $locale
+   *
+   * @return float|bool
+   */
+  public static function parseLocaleNumeric(string $amount, string $locale = NULL) {
+    if ($amount === "") {
+      CRM_Core_Error::deprecatedWarning('Passing an empty string for amount is deprecated.');
+      return NULL;
+    }
+
+    $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);
+    $formatter->setSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryDecimalPoint);
+    $formatter->setSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, CRM_Core_Config::singleton()->monetaryThousandSeparator);
+    return $formatter->parse($amount);
+  }
+
 }

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -487,7 +487,12 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function numeric($value) {
-    return is_numeric($value);
+    if (!is_numeric($value)) {
+      return FALSE;
+    }
+
+    // Don't allow all the variations that PHP does (e.g. scientific notation)
+    return (bool) preg_match('/(^-?\d\d*\.\d*$)|(^-?\d\d*$)|(^-?\.\d\d*$)/', $value);
   }
 
   /**

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -487,12 +487,16 @@ class CRM_Utils_Rule {
    * @return bool
    */
   public static function numeric($value) {
-    // lets use a php gatekeeper to ensure this is numeric
-    if (!is_numeric($value)) {
-      return FALSE;
-    }
+    return is_numeric($value);
+  }
 
-    return (bool) preg_match('/(^-?\d\d*\.\d*$)|(^-?\d\d*$)|(^-?\.\d\d*$)/', $value);
+  /**
+   * @param mixed $value
+   *
+   * @return bool
+   */
+  public static function localeNumeric($value) {
+    return CRM_Utils_Number::parseLocaleNumeric($value) !== FALSE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
For custom fields of type "Number" (float), interpret input according to locale settings. Bring input format into alignment with display format. Begins to fix https://lab.civicrm.org/dev/core/-/issues/4154

Before
----------------------------------------
Number-type custom fields on Contacts and Activities reject input in any format except whitespace-free digits with an optional minus sign and optional decimal point (period/full-stop).

After
----------------------------------------
Number-type custom fields on Contacts and Activities expect input in the format appropriate for the system locale (a site config setting). For example, in a Civi instance set to use the France locale, you would enter `98 765,42` and this would be interpreted correctly as ninety-eight thousand, seven hundred sixty-five, and forty-two one hundredths.

The input format now matches the display format for these fields.

Technical Details
----------------------------------------
Custom field form input is handled in several ways throughout the codebase. My first commit contains some redundancies. It would be nice to refactor, but I'll wait for others to weigh in about the general approach here.

Comments
----------------------------------------
To do an `r-run`, just set the site locale to something that uses a non-period decimal point, create a custom field of type Number on either Contacts or Activities, and try filling the field out using different number formats.

This PR only fixes a couple forms. There are several others that should receive the same treatment if this approach is approved.