### PR TITLE
Fix for 5.59 upgrade on multilingual

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -527,6 +527,10 @@ class CRM_Upgrade_Incremental_Base {
     if ($schema->isEnabled()) {
       $schema->fixSchemaDifferencesFor($table);
     }
+    $locales = CRM_Core_I18n::getMultilingual();
+    if ($locales) {
+      CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, NULL, TRUE);
+    }
     return TRUE;
   }
 
@@ -612,6 +616,9 @@ class CRM_Upgrade_Incremental_Base {
     $schema = new CRM_Logging_Schema();
     if ($schema->isEnabled()) {
       $schema->fixSchemaDifferencesFor($table);
+    }
+    if ($locales) {
+      CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales, NULL, TRUE);
     }
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4155

Before
----------------------------------------
Can't access CiviCRM after upgrading to 5.59.0.

After
----------------------------------------
Can access site after upgrading to 5.59.1.

Technical Details
----------------------------------------
The fix in `CRM_Upgrade_Incremental_Base` is what should have been there to begin with, and will prevent this in the future.  I've tested that successfully.  The fix in `CRM_Upgrade_Incremental_php_FiveFiftyNine` is untested because I'm not 100% sure this is all that's needed, but I'm sure whomever reviews this will point out my errors :). Mainly I just want a fix available ASAP.