### PR TITLE
dev/core#4153 Extend the fields available for PrimaryContact on search

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -208,7 +208,7 @@ class Admin {
         }
         // Useful address fields (see ContactSchemaMapSubscriber)
         if ($entity['name'] === 'Contact') {
-          $addressFields = ['city', 'state_province_id', 'country_id'];
+          $addressFields = ['city', 'state_province_id', 'country_id', 'street_address', 'postal_code', 'supplemental_address_1'];
           foreach ($addressFields as $fieldName) {
             foreach (['primary', 'billing'] as $type) {
               $newField = \CRM_Utils_Array::findAll($schema['Address']['fields'], ['name' => $fieldName])[0];


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4153 Extend the fields available for PrimaryContact on search

Before
----------------------------------------
Limited fields available

![image](https://user-images.githubusercontent.com/336308/222619988-63ea7f10-b832-4133-90e5-b35d28582ad7.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/222620116-d7eac39c-da92-4a40-858f-51c4169e11de.png)

Technical Details
----------------------------------------
This adds street address, supplemental address 1 & postal code.

Supplemental address 2 & 3 and postal code suffix are also strong contenders & I probably lean towards adding them in as well

Comments
----------------------------------------
