### PR TITLE
PayPal Pro IPN - Fix incorrect option_group update

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -291,7 +291,7 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
 
           // In future moving to create pending & then complete, but this OK for now.
           // Also consider accepting 'Failed' like other processors.
-          $input['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Completed');
+          $input['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
           $input['invoice_id'] = md5(uniqid(rand(), TRUE));
           $input['original_contribution_id'] = $this->getContributionID();
           $input['contribution_recur_id'] = $this->getContributionRecurID();

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -90,7 +90,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'fee_amount' => 5.00,
       'net_amount' => 95.00,
       'source' => 'SSF',
-      'contribution_status_id' => 1,
+      'contribution_status_id' => 'Completed',
     ];
     $this->_processorParams = [
       'domain_id' => 1,

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -57,6 +57,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * Cleanup after test.
    */
   public function tearDown(): void {
+    $this->resetHooks();
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_website', 'civicrm_phone', 'civicrm_job', 'civicrm_action_log', 'civicrm_action_schedule', 'civicrm_group', 'civicrm_group_contact'], TRUE);
     $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_website', 'civicrm_phone'], TRUE);
@@ -124,6 +125,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * e.g {if {contact.first_name|boolean}
    *
    * @dataProvider dataProviderNamesAndGreetings
+   * @throws \CRM_Core_Exception
    */
   public function testUpdateGreetingBooleanToken($params, $expectedEmailGreeting): void {
     $this->setEmailGreetingTemplateToConditional();
@@ -287,7 +289,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       'return' => 'id',
       'name_a_b' => 'Employee of',
     ]);
-    $result = $this->callAPISuccess('relationship', 'create', [
+    $result = $this->callAPISuccess('Relationship', 'create', [
       'relationship_type_id' => $relationshipTypeID,
       'contact_id_a' => $individualID,
       'contact_id_b' => $orgID,
@@ -451,8 +453,6 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * Check that the merge carries across various related entities.
    *
    * Note the group combinations & expected results:
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testBatchMergeWithAssets(): void {
     $contactID = $this->individualCreate();


### PR DESCRIPTION
Overview
----------------------------------------

This is primarily a theoretical bug which occurs if the value of the Completed status has been changed for the contribution or contribution_recur option group.

It was picked up in  https://lab.civicrm.org/dev/core/-/issues/4158  but does not appear to be the fix for that issue

Before
----------------------------------------
In a test I was able to verify existing test/s fail if the value for Completed in the contribution status option group is not the same as the contribution recur option group. 

After
----------------------------------------
Correct option group referenced, test checks

Technical Details
----------------------------------------
I think an rc merge without a stable back port is OK (although a backport is OK too)

Comments
----------------------------------------
Incorrect change was https://github.com/civicrm/civicrm-core/commit/ba2fb5afa3aa403467ae4934731684cc51bc830d#diff-fca5e61bfa602d8d253d868b26ca6e7469f343fa3623d937d70480f650cdd3f0R296
