### PR TITLE
add locale param to smarty crmMoney()

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.crmMoney.php
+++ b/CRM/Core/Smarty/plugins/modifier.crmMoney.php
@@ -22,13 +22,15 @@
  *   The monetary amount up for display.
  * @param string|null $currency
  *   The (optional) currency.
+ * @param string|null $locale
+ *   The (optional) locale.
  *
  * @return string
  *   formatted monetary amount
  */
-function smarty_modifier_crmMoney($amount, ?string $currency = NULL): string {
+function smarty_modifier_crmMoney($amount, ?string $currency = NULL, ?string $locale = NULL): string {
   try {
-    return Civi::format()->money($amount, $currency);
+    return Civi::format()->money($amount, $currency, $locale);
   }
   catch (CRM_Core_Exception $e) {
     // @todo escalate this to a deprecation notice. It turns out to be depressingly


### PR DESCRIPTION
Overview
----------------------------------------
Add new (optional) `locale` parameter to smarty function `crmMoney()`

Before
----------------------------------------
locale cannot be defined when using smarty function `{$total|crmMoney:USD}`

After
----------------------------------------
locale can be defined when using smarty function `{$total|crmMoney:USD:es_ES}`

Technical Details
----------------------------------------
Adapt smarty function `crmMoney()` to use all available parameters of `Civi::format()->money()`: 
```php
public function money($amount, ?string $currency = NULL, ?string $locale = NULL): string {}
```

