### PR TITLE
(dev/core#4137) Tokens - Filters should be HTML-sensitive

### DIFF
--- a/Civi/Token/StandardFilters.php
+++ b/Civi/Token/StandardFilters.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Civi\Token;
+
+/**
+ * This class is a collection of CiviMail filter functions. For example, consider this message:
+ *
+ * "Hello {contact.first_name|upper}!"
+ *
+ * The "upper" filter corresponds to method `upper()`.
+ *
+ * All public methods should have the same signature (mixed $value, array $filter, string $format).
+ */
+class StandardFilters {
+
+  /**
+   * Convert to uppercase.
+   *
+   * @param mixed $value
+   * @param array $filter
+   *   The list of filter criteria, as requested in this template.
+   * @param string $format
+   *   The format of the active template ('text/plain' or 'text/html').
+   * @return mixed
+   */
+  public static function upper($value, array $filter, string $format) {
+    return mb_strtoupper($value);
+  }
+
+  public static function lower($value, array $filter, string $format) {
+    return mb_strtolower($value);
+  }
+
+  public static function boolean($value, array $filter, string $format) {
+    return (int) ((bool) $value);
+  }
+
+  public static function crmDate($value, array $filter, string $format) {
+    if ($value instanceof \DateTime) {
+      // @todo cludgey.
+      require_once 'CRM/Core/Smarty/plugins/modifier.crmDate.php';
+      return \smarty_modifier_crmDate($value->format('Y-m-d H:i:s'), $filter[1] ?? NULL);
+    }
+    if ($value === '') {
+      return $value;
+    }
+
+    // I don't think this makes sense, but it matches the pre-refactor
+    // behavior (where the old `switch()` block would fall-through to `case "default"`.
+    return static::default($value, $filter, $format);
+  }
+
+  public static function default($value, array $filter, string $format) {
+    if (!$value) {
+      return $filter[1];
+    }
+    else {
+      return $value;
+    }
+  }
+
+}

--- a/Civi/Token/StandardFilters.php
+++ b/Civi/Token/StandardFilters.php
@@ -24,11 +24,29 @@ class StandardFilters {
    * @return mixed
    */
   public static function upper($value, array $filter, string $format) {
-    return mb_strtoupper($value);
+    switch ($format) {
+      case 'text/plain':
+        return mb_strtoupper($value);
+
+      case 'text/html':
+        return \CRM_Utils_XML::filterMarkupText((string) $value, 'mb_strtoupper');
+
+      default:
+        throw new \CRM_Core_Exception(sprintf('Filter %s does not support format %s', __FUNCTION__, $format));
+    }
   }
 
   public static function lower($value, array $filter, string $format) {
-    return mb_strtolower($value);
+    switch ($format) {
+      case 'text/plain':
+        return mb_strtolower($value);
+
+      case 'text/html':
+        return \CRM_Utils_XML::filterMarkupText((string) $value, 'mb_strtolower');
+
+      default:
+        throw new \CRM_Core_Exception(sprintf('Filter %s does not support format %s', __FUNCTION__, $format));
+    }
   }
 
   public static function boolean($value, array $filter, string $format) {

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -377,10 +377,10 @@ class TokenProcessor {
     $useSmarty = !empty($row->context['smarty']);
 
     $tokens = $this->rowValues[$row->tokenRow][$message['format']];
-    $getToken = function(?string $fullToken, ?string $entity, ?string $field, ?array $modifier) use ($tokens, $useSmarty, $row) {
+    $getToken = function(?string $fullToken, ?string $entity, ?string $field, ?array $modifier) use ($tokens, $useSmarty, $row, $message) {
       if (isset($tokens[$entity][$field])) {
         $v = $tokens[$entity][$field];
-        $v = $this->filterTokenValue($v, $modifier, $row);
+        $v = $this->filterTokenValue($v, $modifier, $row, $message['format']);
         if ($useSmarty) {
           $v = \CRM_Utils_Token::tokenEscapeSmarty($v);
         }
@@ -456,10 +456,12 @@ class TokenProcessor {
    * @param array|null $filter
    * @param TokenRow $row
    *   The current target/row.
+   * @param string $messageFormat
+   *   Ex: 'text/plain' or 'text/html'
    * @return string
    * @throws \CRM_Core_Exception
    */
-  private function filterTokenValue($value, ?array $filter, TokenRow $row) {
+  private function filterTokenValue($value, ?array $filter, TokenRow $row, string $messageFormat) {
     // KISS demonstration. This should change... e.g. provide a filter-registry or reuse Smarty's registry...
 
     if ($value instanceof \DateTime && $filter === NULL) {
@@ -470,6 +472,7 @@ class TokenProcessor {
       }
     }
 
+    // TODO: Move this to StandardFilters
     if ($value instanceof Money) {
       switch ($filter[0] ?? NULL) {
         case NULL:
@@ -484,40 +487,14 @@ class TokenProcessor {
       }
     }
 
-    switch ($filter[0] ?? NULL) {
-      case NULL:
-        return $value;
-
-      case 'upper':
-        return mb_strtoupper($value);
-
-      case 'lower':
-        return mb_strtolower($value);
-
-      case 'boolean':
-        // Cast to 0 or 1 for use in text.
-        return (int) ((bool) $value);
-
-      case 'crmDate':
-        if ($value instanceof \DateTime) {
-          // @todo cludgey.
-          require_once 'CRM/Core/Smarty/plugins/modifier.crmDate.php';
-          return \smarty_modifier_crmDate($value->format('Y-m-d H:i:s'), $filter[1] ?? NULL);
-        }
-        if ($value === '') {
-          return $value;
-        }
-
-      case 'default':
-        if (!$value) {
-          return $filter[1];
-        }
-        else {
-          return $value;
-        }
-
-      default:
-        throw new \CRM_Core_Exception('Invalid token filter: ' . json_encode($filter, JSON_UNESCAPED_SLASHES));
+    if (!isset($filter[0])) {
+      return $value;
+    }
+    elseif (is_callable([StandardFilters::class, $filter[0]])) {
+      return call_user_func([StandardFilters::class, $filter[0]], $value, $filter, $messageFormat);
+    }
+    else {
+      throw new \CRM_Core_Exception('Invalid token filter: ' . json_encode($filter, JSON_UNESCAPED_SLASHES));
     }
   }
 

--- a/tests/phpunit/CRM/Utils/XMLTest.php
+++ b/tests/phpunit/CRM/Utils/XMLTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class CRM_Utils_XMLTest
+ * @group headless
+ */
+class CRM_Utils_XMLTest extends CiviUnitTestCase {
+
+  /**
+   * Set up for tests.
+   */
+  public function setUp(): void {
+    $this->useTransaction();
+    parent::setUp();
+  }
+
+  public function testFilterMarkupTest(): void {
+    $examples = [
+      ['<b>', 'mb_strtoupper', '<b>'],
+      ['<b>Ok</b>', 'mb_strtoupper', '<b>OK</b>'],
+      ['<b>Ok</b>', 'mb_strtolower', '<b>ok</b>'],
+      ['<b>This &amp; That</b>', 'mb_strtoupper', '<b>THIS &amp; THAT</b>'],
+      ['<b>This &amp; That</b>', 'mb_strtolower', '<b>this &amp; that</b>'],
+      ['One<b>Two</b>Three', 'mb_strtoupper', 'ONE<b>TWO</b>THREE'],
+      ['One<b>Two</b>Three', 'mb_strtolower', 'one<b>two</b>three'],
+      ['<a href="https://example.com/FooBar">The Foo Bar</a>', 'mb_strtoupper', '<a href="https://example.com/FooBar">THE FOO BAR</a>'],
+      ['<a href="https://example.com/FooBar">The Foo Bar</a>', 'mb_strtolower', '<a href="https://example.com/FooBar">the foo bar</a>'],
+      ['<a onclick="window.location=\'https://google.COM\'" target=\'_blank\'>The Foo Bar</a>', 'mb_strtoupper', '<a onclick="window.location=\'https://google.COM\'" target=\'_blank\'>THE FOO BAR</a>'],
+    ];
+    foreach ($examples as $example) {
+      [$input, $filter, $expect] = $example;
+      $actual = CRM_Utils_XML::filterMarkupText($input, $filter);
+      $this->assertEquals($expect, $actual, sprintf('Filter "%s" via "%s"', $input, $filter));
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4137 presents two issues. This addresses the second issue, wherein the filters `{foo.bar|upper}` and `{foo.bar|lower}` may produce distorted output when handling HTML  data.

Before
----------------------------------------

`{foo.bar|upper}` is strictly treated as plain-text.

If the value of `foo.bar` is markup , then tags and entities will be capitalized incorrectly.

```php
"this &amp; that"` => "THIS &AMP; THAT"`
```

After
----------------------------------------

`{foo.bar|upper}` is  evaluated in a template-sensitive way (as plain text or HTML).

If the value of `foo.bar` is markup, then the textual data will be filtered -- but the tags and entities will be preserve their original values.

```php
"this &amp; that"` => "THIS &amp; THAT"`
```

