### PR TITLE
dev/core#3438 Drupal: Prevent cv fatal if logging before CMS bootstrap

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -542,6 +542,10 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    */
   public function logger($message, $priority = NULL) {
     if (CRM_Core_Config::singleton()->userFrameworkLogging) {
+      // dev/core#3438 Prevent cv fatal if logging before CMS bootstrap
+      if (!class_exists('Drupal') || !\Drupal::hasContainer()) {
+        return;
+      }
       \Drupal::logger('civicrm')->log($priority ?? \Drupal\Core\Logger\RfcLogLevel::DEBUG, '%message', ['%message' => $message]);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/3438

When using "Log to Drupal watchdog", using `cv` might fatal when logging.

To reproduce:

- enable "Administer > System Settings > Debugging and something something > Log to Drupal watchdog like it's 1999"
- on the CLI, run `cv api system.check`

Before
----------------------------------------

Fatal : "  \Drupal::$container is not initialized yet. \Drupal::setContainer() must be called with a real container. "

After
----------------------------------------

no fatal

Technical Details
----------------------------------------

Copied an ugly workaround used elsewhere for i18n, from back in the days of `rest.php` (when the CMS is manually bootstrapped).