### PR TITLE
Contribution pages crash for logged-in users when CiviMember is disabled

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2366,6 +2366,9 @@ WHERE {$whereClause}";
    * @return array
    */
   public static function getAllContactMembership($contactID, $isTest = FALSE, $onlyLifeTime = FALSE) : array {
+    if (!\CRM_Core_Component::isEnabled('CiviMember')) {
+      return [];
+    }
     $contactMembershipType = [];
     if (!$contactID) {
       return $contactMembershipType;


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a regression in https://github.com/civicrm/civicrm-core/pull/25456.
Civi calculates lifetime memberships differently in different parts of the codebase.  In #25456 I replaced one that used the BAO with a call to a standardized function that uses API4. 

This means a logged-in user visiting a contribution page will always invoke a call to the Membership API, but of course, API4 throws an error if you try to access a disabled entity.

Before
----------------------------------------
When visiting a contribution page while logged in with CiviMember disabled, you get this error:
```
Civi\API\Exception\NotImplementedException: Membership API is not available because CiviMember component is disabled in /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Generic/AbstractAction.php on line 454
```

After
----------------------------------------
We return early from looking up contact memberships if CiviMember is disabled.