### PR TITLE
Fix typing, comments in new StandardFilters class

### DIFF
--- a/Civi/Token/StandardFilters.php
+++ b/Civi/Token/StandardFilters.php
@@ -3,7 +3,7 @@
 namespace Civi\Token;
 
 /**
- * This class is a collection of CiviMail filter functions. For example, consider this message:
+ * This class is a collection of token filter functions. For example, consider this message:
  *
  * "Hello {contact.first_name|upper}!"
  *
@@ -21,9 +21,13 @@ class StandardFilters {
    *   The list of filter criteria, as requested in this template.
    * @param string $format
    *   The format of the active template ('text/plain' or 'text/html').
-   * @return mixed
+   *
+   * @return string
+   *
+   * @throws \CRM_Core_Exception
+   * @noinspection PhpUnusedParameterInspection
    */
-  public static function upper($value, array $filter, string $format) {
+  public static function upper($value, array $filter, string $format): string {
     switch ($format) {
       case 'text/plain':
         return mb_strtoupper($value);
@@ -36,7 +40,19 @@ class StandardFilters {
     }
   }
 
-  public static function lower($value, array $filter, string $format) {
+  /**
+   * Convert to lowercase.
+   *
+   * @param string $value
+   * @param array $filter
+   * @param string $format
+   *
+   * @return string
+   *
+   * @throws \CRM_Core_Exception
+   * @noinspection PhpUnusedParameterInspection
+   */
+  public static function lower($value, array $filter, string $format): string {
     switch ($format) {
       case 'text/plain':
         return mb_strtolower($value);
@@ -49,7 +65,17 @@ class StandardFilters {
     }
   }
 
-  public static function boolean($value, array $filter, string $format) {
+  /**
+   * Convert to boolean.
+   *
+   * @param string $value
+   * @param array $filter
+   * @param string $format
+   *
+   * @return int
+   * @noinspection PhpUnusedParameterInspection
+   */
+  public static function boolean($value, array $filter, string $format): int {
     return (int) ((bool) $value);
   }
 
@@ -68,13 +94,21 @@ class StandardFilters {
     return static::default($value, $filter, $format);
   }
 
+  /**
+   * Return value, falling back to default.
+   *
+   * @param $value
+   * @param array $filter
+   * @param string $format
+   *
+   * @return mixed
+   * @noinspection PhpUnusedParameterInspection
+   */
   public static function default($value, array $filter, string $format) {
     if (!$value) {
       return $filter[1];
     }
-    else {
-      return $value;
-    }
+    return $value;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix typing, comments in new StandardFilters class

Before
----------------------------------------
After merging https://github.com/civicrm/civicrm-core/pull/25727/files#diff-fa6af4a0aa5d42524fadaa8f5e4b1176da2475ce01f03e9e3a2ffe78d8a64a5cR6 for @totten  I spotted a problem with code comments & also a lack of types / return hints 

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/222815968-efa01a54-3596-4908-8655-7bcde01d2a80.png)


Technical Details
----------------------------------------
 I held off marking them as inspections to ignore cos I don't think we should. I type hints might not bubble up nicely though - so they probably should throw exceptions if not string

Comments
----------------------------------------
