### PR TITLE
don't show USPS warning when USPS lookup disabled

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -30,19 +30,6 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   }
 
   /**
-   * Get any smarty elements that may not be present in the form.
-   *
-   * To make life simpler for smarty we ensure they are set to null
-   * rather than unset. This is done at the last minute when $this
-   * is converted to an array to be assigned to the form.
-   *
-   * @return array
-   */
-  public function getOptionalQuickFormElements(): array {
-    return ['disableUSPS'];
-  }
-
-  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
I spotted this in my last PR's screenshots.

Before
----------------------------------------
![Selection_1798](https://user-images.githubusercontent.com/1796012/223180673-60f7d039-f601-41b0-a111-d40d8e4573be.png)

After
----------------------------------------
![Selection_1800](https://user-images.githubusercontent.com/1796012/223180830-76654a97-2db5-4b19-9195-67a91c89a971.png)

Technical Details
----------------------------------------
This happened when removing e-notices from the Smarty. However, this array key will always exist because of [CRM_Contact_Import_Form_DataSource::getOptionalQuickFormElements](https://github.com/civicrm/civicrm-core/blob/da9cefc68baabd35731b668a517853bdfcfa8758/CRM/Contact/Import/Form/DataSource.php#L42).