### PR TITLE
field separator is a required field

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -56,7 +56,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
     $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
     $form->assign('uploadSize', $uploadSize);
     $form->add('File', 'uploadFile', ts('Import Data File'), NULL, TRUE);
-    $form->addElement('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2]);
+    $form->add('text', 'fieldSeparator', ts('Import Field Separator'), ['size' => 2], TRUE);
     $form->setMaxFileSize($uploadFileSize);
     $form->addRule('uploadFile', ts('File size should be less than %1 MBytes (%2 bytes)', [
       1 => $uploadSize,


### PR DESCRIPTION
Overview
----------------------------------------
Field Separator is required.  Leaving it out gives you an error 

Before
----------------------------------------
Fatal error:
```
ValueError: fgetcsv(): Argument #3 ($separator) must be a single character in fgetcsv() (line 126 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Import/DataSource/CSV.php).
```

After
----------------------------------------
Gentle chiding:
```
 Please correct the following errors in the form fields below:
    Import Field Separator is a required field.
```

Comments
----------------------------------------
This is the PR that I was trying to do when I made my last 2 PRs.
