### PR TITLE
SearchKit - Add select options for MONTH date filter

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -28,7 +28,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       'basePath' => Civi::resources()->getUrl('civicrm'),
       'schema' => (array) \Civi\Api4\Entity::get()->setChain(['fields' => ['$name', 'getFields']])->execute(),
       'docs' => \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($apiDoc->getDocComment()),
-      'functions' => self::getSqlFunctions(),
+      'functions' => CoreUtil::getSqlFunctions(),
       'authxEnabled' => $extensions->isActiveModule('authx'),
       'restUrl' => rtrim(CRM_Utils_System::url('civicrm/ajax/api4/CRMAPI4ENTITY/CRMAPI4ACTION', NULL, TRUE, NULL, FALSE, TRUE), '/'),
     ];
@@ -44,31 +44,6 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       ->useApp(['defaultRoute' => '/explorer']);
 
     parent::run();
-  }
-
-  /**
-   * Gets info about all available sql functions
-   * @return array
-   */
-  public static function getSqlFunctions() {
-    $fns = [];
-    foreach (glob(Civi::paths()->getPath('[civicrm.root]/Civi/Api4/Query/SqlFunction*.php')) as $file) {
-      $matches = [];
-      if (preg_match('/(SqlFunction[A-Z_]+)\.php$/', $file, $matches)) {
-        $className = '\Civi\Api4\Query\\' . $matches[1];
-        if (is_subclass_of($className, '\Civi\Api4\Query\SqlFunction')) {
-          $fns[] = [
-            'name' => $className::getName(),
-            'title' => $className::getTitle(),
-            'description' => $className::getDescription(),
-            'params' => $className::getParams(),
-            'category' => $className::getCategory(),
-            'dataType' => $className::getDataType(),
-          ];
-        }
-      }
-    }
-    return $fns;
   }
 
 }

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -175,37 +175,7 @@ class BasicGetFieldsAction extends BasicGetAction {
         throw new \CRM_Core_Exception('Unsupported pseudoconstant type for field "' . $field['name'] . '"');
       }
     }
-    if (!$field['options'] || !is_array($field['options'])) {
-      return;
-    }
-
-    $formatted = [];
-    $first = reset($field['options']);
-    // Flat array requested
-    if ($this->loadOptions === TRUE) {
-      // Convert non-associative to flat array
-      if (is_array($first) && isset($first['id'])) {
-        foreach ($field['options'] as $option) {
-          $formatted[$option['id']] = $option['label'] ?? $option['name'] ?? $option['id'];
-        }
-        $field['options'] = $formatted;
-      }
-    }
-    // Non-associative array of multiple properties requested
-    else {
-      foreach ($field['options'] as $id => $option) {
-        // Transform a flat list
-        if (!is_array($option)) {
-          $option = [
-            'id' => $id,
-            'name' => $id,
-            'label' => $option,
-          ];
-        }
-        $formatted[] = array_intersect_key($option, array_flip($this->loadOptions));
-      }
-      $field['options'] = $formatted;
-    }
+    $field['options'] = CoreUtil::formatOptionList($field['options'], $this->loadOptions);
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -12,7 +12,14 @@
 namespace Civi\Api4\Query;
 
 /**
- * Base class for all Sql functions.
+ * Base class for all APIv4 Sql function definitions.
+ *
+ * SqlFunction classes don't actually process data, SQL itself does the real work.
+ * The role of each SqlFunction class is to:
+ *
+ * 1. Whitelist the SQL function for use by APIv4 (it doesn't allow any that don't have a SQLFunction class).
+ * 2. Document what the function does and what arguments it accepts.
+ * 3. Tell APIv4 how to treat the inputs and how to format the outputs.
  *
  * @package Civi\Api4\Query
  */
@@ -197,6 +204,19 @@ abstract class SqlFunction extends SqlExpression {
    */
   public static function getCategory(): string {
     return static::$category;
+  }
+
+  /**
+   * For functions which output a finite set of values,
+   * this allows the API to treat it as pseudoconstant options.
+   *
+   * e.g. MONTH() only returns integers 1-12, which can be formatted like
+   * [1 => January, 2 => February, etc.]
+   *
+   * @return array|null
+   */
+  public static function getOptions(): ?array {
+    return NULL;
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionEXTRACT.php
+++ b/Civi/Api4/Query/SqlFunctionEXTRACT.php
@@ -60,7 +60,7 @@ class SqlFunctionEXTRACT extends SqlFunction {
    * @return string
    */
   public static function getDescription(): string {
-    return ts('The numeric month (1-12) of a date.');
+    return ts('Extract part(s) of a date (e.g. the day, year, etc.)');
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionMONTH.php
+++ b/Civi/Api4/Query/SqlFunctionMONTH.php
@@ -43,4 +43,24 @@ class SqlFunctionMONTH extends SqlFunction {
     return ts('The numeric month (1-12) of a date.');
   }
 
+  /**
+   * @return array
+   */
+  public static function getOptions(): ?array {
+    return [
+      1 => ts('January'),
+      2 => ts('February'),
+      3 => ts('March'),
+      4 => ts('April'),
+      5 => ts('May'),
+      6 => ts('June'),
+      7 => ts('July'),
+      8 => ts('August'),
+      9 => ts('September'),
+      10 => ts('October'),
+      11 => ts('November'),
+      12 => ts('December'),
+    ];
+  }
+
 }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -458,7 +458,7 @@ class Admin {
    * @return array
    */
   private static function getSqlFunctions():array {
-    $functions = \CRM_Api4_Page_Api4Explorer::getSqlFunctions();
+    $functions = CoreUtil::getSqlFunctions();
     // Add faux function "e" for SqlEquations
     $functions[] = [
       'name' => 'e',
@@ -466,6 +466,7 @@ class Admin {
       'description' => ts('Add, subtract, multiply, divide'),
       'category' => SqlFunction::CATEGORY_MATH,
       'data_type' => 'Number',
+      'options' => FALSE,
       'params' => [
         [
           'label' => ts('Value'),

--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -70,12 +70,18 @@ class Meta {
           $dataType = $field['data_type'] ?? 'String';
           $inputType = $field['input_type'] ?? $dataTypeToInputType[$dataType] ?? 'Text';
         }
+        $options = FALSE;
+        if ($expr->getType() === 'SqlFunction' && $expr::getOptions()) {
+          $inputType = 'Select';
+          $options = CoreUtil::formatOptionList($expr::getOptions(), ['id', 'label']);
+        }
 
         $calcFields[] = [
           'name' => $expr->getAlias(),
           'label' => $label,
           'input_type' => $inputType,
           'data_type' => $dataType,
+          'options' => $options,
         ];
       }
     }

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -23,6 +23,7 @@ use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
+use Civi\Api4\Utils\CoreUtil;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -31,12 +32,15 @@ use Civi\Test\TransactionalInterface;
 class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
 
   public function testGetFunctions() {
-    $functions = array_column(\CRM_Api4_Page_Api4Explorer::getSqlFunctions(), NULL, 'name');
+    $functions = array_column(CoreUtil::getSqlFunctions(), NULL, 'name');
     $this->assertArrayHasKey('SUM', $functions);
     $this->assertArrayNotHasKey('', $functions);
     $this->assertArrayNotHasKey('SqlFunction', $functions);
     $this->assertEquals(1, $functions['MAX']['params'][0]['min_expr']);
     $this->assertEquals(1, $functions['MAX']['params'][0]['max_expr']);
+    $this->assertFalse($functions['YEAR']['options']);
+    $this->assertEquals(1, $functions['MONTH']['options'][0]['id']);
+    $this->assertEquals(12, $functions['MONTH']['options'][11]['id']);
   }
 
   public function testGroupAggregates() {


### PR DESCRIPTION
Overview
----------------------------------------
Makes the "Month Only" field transformation in SearchKit into a dropdown select.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/223204816-76d39205-79ca-4861-879b-6bd8c8e276df.png)


![image](https://user-images.githubusercontent.com/2874912/223203174-6838d306-a9d0-4890-91da-25157c3b3b58.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/223202684-5f4e82b7-eb8a-4e11-a8a5-76c672c2a0be.png)

![image](https://user-images.githubusercontent.com/2874912/223202953-ae44fd28-5b7a-4a2c-81d5-511f7de35c1f.png)


Technical Details
----------------------------------------
Includes a couple function extractions to move shared code to the central `CoreUtil` class.