### PR TITLE
SearchKit - Add next_birthday calc field

### DIFF
--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -327,17 +327,21 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
   public function testAge(): void {
     $lastName = uniqid(__FUNCTION__);
     $sampleData = [
-      ['first_name' => 'abc', 'last_name' => $lastName, 'birth_date' => 'now - 1 year - 1 month'],
+      ['first_name' => 'abc', 'last_name' => $lastName, 'birth_date' => 'now - 2 year + 3 day'],
       ['first_name' => 'def', 'last_name' => $lastName, 'birth_date' => 'now - 21 year - 6 month'],
+      ['first_name' => 'ghi', 'last_name' => $lastName, 'birth_date' => 'now'],
     ];
     $this->saveTestRecords('Contact', ['records' => $sampleData]);
 
     $result = Contact::get(FALSE)
       ->addWhere('last_name', '=', $lastName)
-      ->addSelect('first_name', 'age_years')
+      ->addSelect('first_name', 'age_years', 'next_birthday')
       ->execute()->indexBy('first_name');
     $this->assertEquals(1, $result['abc']['age_years']);
+    $this->assertEquals(3, $result['abc']['next_birthday']);
     $this->assertEquals(21, $result['def']['age_years']);
+    $this->assertEquals(0, $result['ghi']['age_years']);
+    $this->assertEquals(0, $result['ghi']['next_birthday']);
 
     Contact::get(FALSE)
       ->addWhere('age_years', '=', 21)


### PR DESCRIPTION
Overview
----------------------------------------
Adds a calculated field to make it easy to perform "upcoming birthday" searches.

Before
----------------------------------------
Could not create "upcoming birthday" searches in SearchKit.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/2874912/223210021-65ec5742-1efe-449b-801a-086b1652f6a1.png)


Technical Details
----------------------------------------
This field returns an integer from 0 (birthday is today) to 364 (birthday was yesterday). Or maybe on leap years that would be 365.