### PR TITLE
Afform - Fix editing search filters nested within multiple containers

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -78,9 +78,10 @@
         }
       };
 
-      this.getSearchDisplay = function(node) {
-        var searchKey = $scope.getSearchKey(node);
-        if (searchKey) {
+      // Finds a SearchDisplay within this container or within the fieldset containing this container
+      this.getSearchDisplay = function() {
+        var searchKey = ctrl.getDataEntity();
+        if (searchKey && !ctrl.entityName) {
           return afGui.getSearchDisplay.apply(null, searchKey.split('.'));
         }
       };
@@ -416,8 +417,7 @@
           var joinType = ctrl.entityName.split('-join-');
           entityType = joinType[1] || (ctrl.editor && ctrl.editor.getEntity(joinType[0]).type);
         } else {
-          var searchKey = ctrl.getDataEntity(),
-            searchDisplay = afGui.getSearchDisplay.apply(null, searchKey.split('.')),
+          var searchDisplay = ctrl.getSearchDisplay(),
             fieldName = fieldKey.substr(fieldKey.indexOf('.') + 1),
             prefix = _.includes(fieldKey, '.') ? fieldKey.split('.')[0] : null;
           if (prefix) {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -89,8 +89,8 @@
       this.getDefn = function() {
         var defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name);
         // Calc fields are specific to a search display, not part of the schema
-        if (!defn && ctrl.container.getSearchDisplay(ctrl.container.node)) {
-          var searchDisplay = ctrl.container.getSearchDisplay(ctrl.container.node);
+        if (!defn && ctrl.container.getSearchDisplay()) {
+          var searchDisplay = ctrl.container.getSearchDisplay();
           defn = _.findWhere(searchDisplay.calc_fields, {name: ctrl.node.name});
         }
         defn = defn || {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the Afform GUI where placing a search filter for a calculated field within a nested container would break the editor.

Before
----------------------------------------
1. Create a searchdisplay with at least one calculated field (using field transformations).
2. Try dragging that filter into a form using some nested containers.
3. Editor goes boink.

After
----------------------------------------
Fixed.