### PR TITLE
APIv4 - Don't link to non-existent API entities

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -14,7 +14,6 @@ namespace Civi\Api4\Service\Spec;
 
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\FormattingUtil;
-use CRM_Core_DAO_AllCoreTables as AllCoreTables;
 
 class SpecFormatter {
 
@@ -97,7 +96,7 @@ class SpecFormatter {
     $fkAPIName = $data['FKApiName'] ?? NULL;
     $fkClassName = $data['FKClassName'] ?? NULL;
     if ($fkAPIName || $fkClassName) {
-      $field->setFkEntity($fkAPIName ?: AllCoreTables::getBriefName($fkClassName));
+      $field->setFkEntity($fkAPIName ?: CoreUtil::getApiNameFromBAO($fkClassName));
     }
 
     return $field;

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -35,6 +35,19 @@ class CoreUtil {
   }
 
   /**
+   * Returns API entity name given an BAO/DAO class name
+   *
+   * Returns null if the API has not been implemented
+   *
+   * @param $baoClassName
+   * @return string|null
+   */
+  public static function getApiNameFromBAO($baoClassName) {
+    $briefName = AllCoreTables::getBriefName($baoClassName);
+    return $briefName && self::getApiClass($briefName) ? $briefName : NULL;
+  }
+
+  /**
    * @param $entityName
    * @return string|\Civi\Api4\Generic\AbstractEntity
    */


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug described in https://lab.civicrm.org/dev/core/-/issues/4163

Before
----------------------------------------
FormBuilder tries and fails to autocomplete ParticipantStatusID

After
----------------------------------------
Since that entity hasn't (yet) been implemented in APIv4, it falls back to using the option list.

Technical Details
----------------------------------------
Since APIv4 getFields is specific to, well, APIv4, it probably shouldn't link to entities that don't exist in APIv4.