### PR TITLE
Stop using deprecated methods, `ufField::del`

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -189,7 +189,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
     CRM_Utils_System::flushCache();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Core_BAO_Job::del($this->_id);
+      CRM_Core_BAO_Job::deleteRecord(['id' => $this->_id]);
       CRM_Core_Session::setStatus("", ts('Scheduled Job Deleted.'), "success");
       return;
     }

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -166,6 +166,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * @return CRM_Core_DAO_Domain
    */
   public static function create($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 

--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -126,6 +126,7 @@ ORDER BY
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -164,6 +164,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 
@@ -319,7 +320,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
     $ufField->find();
     while ($ufField->fetch()) {
       //enable/ disable profile
-      CRM_Core_BAO_UFField::del($ufField->id);
+      CRM_Core_BAO_UFField::deleteRecord(['id' => $ufField->id]);
     }
   }
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1404,6 +1404,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
    * @deprecated
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) static::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/Core/BAO/WordReplacement.php
+++ b/CRM/Core/BAO/WordReplacement.php
@@ -65,6 +65,7 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implemen
    * @return array
    */
   public static function create($params) {
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     if (array_key_exists("domain_id", $params) === FALSE) {
       $params["domain_id"] = CRM_Core_Config::domainID();
     }
@@ -85,6 +86,7 @@ class CRM_Core_BAO_WordReplacement extends CRM_Core_DAO_WordReplacement implemen
    * @return CRM_Core_DAO_WordReplacement
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return static::deleteRecord(['id' => $id]);
   }
 

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -482,7 +482,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     if ($this->_action & CRM_Core_Action::DELETE) {
       $fieldValues = ['uf_group_id' => $this->_gid];
       CRM_Utils_Weight::delWeight('CRM_Core_DAO_UFField', $this->_id, $fieldValues);
-      $deleted = CRM_Core_BAO_UFField::del($this->_id);
+      $deleted = CRM_Core_BAO_UFField::deleteRecord(['id' => $this->_id]);
 
       //update group_type every time. CRM-3608
       if ($this->_gid && $deleted) {

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -350,7 +350,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       $title = CRM_Core_BAO_UFGroup::getTitle($this->_id);
-      CRM_Core_BAO_UFGroup::del($this->_id);
+      CRM_Core_BAO_UFGroup::deleteRecord(['id' => $this->_id]);
       CRM_Core_Session::setStatus(ts("Your CiviCRM Profile '%1' has been deleted.", [1 => $title]), ts('Profile Deleted'), 'success');
     }
     elseif ($this->_action & CRM_Core_Action::DISABLE) {

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -77,7 +77,7 @@ function civicrm_api3_uf_field_delete($params) {
     throw new CRM_Core_Exception('Invalid value for field_id.');
   }
 
-  $result = CRM_Core_BAO_UFField::del($fieldId);
+  $result = CRM_Core_BAO_UFField::deleteRecord(['id' => $fieldId]);
 
   $fieldsType = CRM_Core_BAO_UFGroup::calculateGroupType($ufGroupId, TRUE);
   CRM_Core_BAO_UFGroup::updateGroupTypes($ufGroupId, $fieldsType);


### PR DESCRIPTION
From https://github.com/civicrm/civicrm-core/pull/25677