### PR TITLE
[REF] Improve function signature for `retrieve()` in `PaypalProIPN` , add test for when trxn_id is present

### DIFF
--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -197,22 +197,20 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
    *   Data type.
    *   - String
    *   - Integer
-   * @param string $location
-   *   Deprecated.
    * @param bool $abort
    *   Abort if empty.
    *
    * @throws CRM_Core_Exception
    * @return mixed
    */
-  public function retrieve($name, $type, $location = 'POST', $abort = TRUE) {
+  public function retrieve($name, $type, $abort = TRUE) {
     $value = CRM_Utils_Type::validate(
       CRM_Utils_Array::value($name, $this->_inputParameters),
       $type,
       FALSE
     );
     if ($abort && $value === NULL) {
-      throw new CRM_Core_Exception("Could not find an entry for $name in $location");
+      throw new CRM_Core_Exception("Could not find an entry for $name");
     }
     return $value;
   }
@@ -465,15 +463,15 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
   public function getInput(&$input) {
     $billingID = CRM_Core_BAO_LocationType::getBilling();
 
-    $input['txnType'] = self::retrieve('txn_type', 'String', 'POST', FALSE);
-    $input['paymentStatus'] = self::retrieve('payment_status', 'String', 'POST', FALSE);
+    $input['txnType'] = $this->retrieve('txn_type', 'String', FALSE);
+    $input['paymentStatus'] = $this->retrieve('payment_status', 'String', FALSE);
 
-    $input['amount'] = self::retrieve('mc_gross', 'Money', 'POST', FALSE);
-    $input['reasonCode'] = self::retrieve('ReasonCode', 'String', 'POST', FALSE);
+    $input['amount'] = $this->retrieve('mc_gross', 'Money', FALSE);
+    $input['reasonCode'] = $this->retrieve('ReasonCode', 'String', FALSE);
 
     $lookup = [
-      "first_name" => 'first_name',
-      "last_name" => 'last_name',
+      'first_name' => 'first_name',
+      'last_name' => 'last_name',
       "street_address-{$billingID}" => 'address_street',
       "city-{$billingID}" => 'address_city',
       "state-{$billingID}" => 'address_state',
@@ -481,15 +479,15 @@ class CRM_Core_Payment_PayPalProIPN extends CRM_Core_Payment_BaseIPN {
       "country-{$billingID}" => 'address_country_code',
     ];
     foreach ($lookup as $name => $paypalName) {
-      $value = self::retrieve($paypalName, 'String', 'POST', FALSE);
+      $value = $this->retrieve($paypalName, 'String', FALSE);
       $input[$name] = $value ? $value : NULL;
     }
 
-    $input['is_test'] = self::retrieve('test_ipn', 'Integer', 'POST', FALSE);
-    $input['fee_amount'] = self::retrieve('mc_fee', 'Money', 'POST', FALSE);
-    $input['net_amount'] = self::retrieve('settle_amount', 'Money', 'POST', FALSE);
-    $input['trxn_id'] = self::retrieve('txn_id', 'String', 'POST', FALSE);
-    $input['payment_date'] = $input['receive_date'] = self::retrieve('payment_date', 'String', 'POST', FALSE);
+    $input['is_test'] = $this->retrieve('test_ipn', 'Integer', FALSE);
+    $input['fee_amount'] = $this->retrieve('mc_fee', 'Money', FALSE);
+    $input['net_amount'] = $this->retrieve('settle_amount', 'Money', FALSE);
+    $input['trxn_id'] = $this->retrieve('txn_id', 'String', FALSE);
+    $input['payment_date'] = $input['receive_date'] = $this->retrieve('payment_date', 'String', FALSE);
     $input['total_amount'] = $input['amount'];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix `retrieve()` in `PaypalProIPN` , add test for when trxn_id is present

Before
----------------------------------------
`retrieve` signature has deprecated `location` parameter which only exists to log misinformation
![image](https://user-images.githubusercontent.com/336308/223347224-c6a0a690-30a9-41d3-bad4-e59451950cfc.png)

Also the function is called statically
 
After
----------------------------------------
old (already deprecated) `location` removed from the `retrieve` function signature, calls made non-static. Test added that shows the reported problem not occurring - when trxn_id can be retrieved

Technical Details
----------------------------------------
In trying to understand https://lab.civicrm.org/dev/core/-/issues/4158 I wrote a unit test that replicates the problem NOT occurring & I was able to confirm the vital thing that prevents it is retrieving `trxn_id` in [this line](https://github.com/civicrm/civicrm-core/blob/a64f2b3564bce2a8660396c97062472ed4fbf4f2/CRM/Core/Payment/PayPalProIPN.php#L491)
However, that line was deepl confusing as it implied the value came from `$_POST` which is not necessarily true & not helpful in the course of the code. 

`inputParameters` is set [here](https://github.com/civicrm/civicrm-core/blob/9ffd78de31ed823edc6687054e1c7512234f32f7/CRM/Core/Payment/PayPalImpl.php#L796) or possibly [here](https://github.com/civicrm/civicrm-core/blob/f452d72c08c27b1881af42f12c669185c43c3e30/extern/ipn.php#L56) if sites configured the old url & it somehow still works

Comments
----------------------------------------