### PR TITLE
Extract `isMembershipPriceSet` (`useForMember`)

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -339,8 +339,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_bltID = $this->get('bltID');
     $this->_paymentProcessor = $this->get('paymentProcessor');
 
-    $this->order = new CRM_Financial_BAO_Order();
-    $this->order->setPriceSetID($this->getPriceSetID());
+    // In tests price set id is not always set - it is unclear if this is just
+    // poor test set up or it is possible in 'the real world'
+    if ($this->getPriceSetID()) {
+      $this->order = new CRM_Financial_BAO_Order();
+      $this->order->setPriceSetID($this->getPriceSetID());
+    }
     $this->_priceSet = $this->get('priceSet');
 
     if (!$this->_values) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -60,6 +60,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public $_paymentObject = NULL;
 
   /**
+   * Order object, used to calculate amounts, line items etc.
+   *
+   * @var \CRM_Financial_BAO_Order
+   */
+  protected $order;
+
+  /**
    * The membership block for this page
    *
    * @var array
@@ -332,9 +339,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_bltID = $this->get('bltID');
     $this->_paymentProcessor = $this->get('paymentProcessor');
 
-    // This get will ensure it is set for later. Once we are sure all places
-    // access via the get & not directly, it can go.
-    $this->getPriceSetID();
+    $this->order = new CRM_Financial_BAO_Order();
+    $this->order->setPriceSetID($this->getPriceSetID());
     $this->_priceSet = $this->get('priceSet');
 
     if (!$this->_values) {
@@ -1278,6 +1284,26 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       }
     }
     return $this->_membershipBlock;
+  }
+
+  /**
+   * Is a (non-quick-config) membership price set in use.
+   *
+   * @return bool
+   */
+  protected function isMembershipPriceSet(): bool {
+    if ($this->_useForMember === NULL) {
+      if (CRM_Core_Component::isEnabled('CiviMember') &&
+        (!$this->isQuickConfig() || !empty($this->_ccid)) &&
+        CRM_Core_Component::getComponentID('CiviMember') === (int) $this->order->getPriceSetMetadata()['extends']) {
+        $this->_useForMember = 1;
+      }
+      else {
+        $this->_useForMember = 0;
+      }
+      $this->set('useForMember', $this->_useForMember);
+    }
+    return (bool) $this->_useForMember;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -1367,12 +1367,9 @@ Paid By: Check',
 
   /**
    * Check payment processor is correctly assigned for a contribution page.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \CRM_Contribute_Exception_InactiveContributionPageException
    */
   public function testContributionBasePreProcess(): void {
-    //Create contribution page with only pay later enabled.
+    // Create contribution page with only pay later enabled.
     $params = [
       'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
@@ -1387,14 +1384,11 @@ Paid By: Check',
       'receipt_from_name' => 'Ego Freud',
     ];
 
-    $page1 = $this->callAPISuccess('ContributionPage', 'create', $params);
-
-    //Execute CRM_Contribute_Form_ContributionBase preProcess
-    //and check the assignment of payment processors
-    $form = new CRM_Contribute_Form_ContributionBase();
-    $form->controller = new CRM_Core_Controller();
-    $form->set('id', $page1['id']);
-    $_REQUEST['id'] = $page1['id'];
+    // Execute CRM_Contribute_Form_ContributionBase preProcess (via child class).
+    // Check the assignment of payment processors.
+    /* @var \CRM_Contribute_Form_Contribution_Main $form */
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution_Main', ['payment_processor_id' => 0]);
+    $_REQUEST['id'] = $this->callAPISuccess('ContributionPage', 'create', $params)['id'];
 
     $form->preProcess();
     $this->assertEquals('pay_later', $form->_paymentProcessor['name']);
@@ -1403,12 +1397,12 @@ Paid By: Check',
     $params['is_pay_later'] = 0;
     $page2 = $this->callAPISuccess('ContributionPage', 'create', $params);
 
-    //Assert an exception is thrown on loading the contribution page.
-    $form = new CRM_Contribute_Form_ContributionBase();
-    $form->controller = new CRM_Core_Controller();
-    $_REQUEST['id'] = $page2['id'];
-    $form->set('id', $page2['id']);
-    $form->preProcess();
+    // @todo - these lines were supposed to assert an exception is thrown on loading the contribution page.
+    // However the test has been quietly passing with that not happening.
+    /* @var \CRM_Contribute_Form_Contribution_Main $form */
+    // $form = $this->getFormObject('CRM_Contribute_Form_Contribution_Main', ['payment_processor_id' => 0]);
+    // $_REQUEST['id'] = $page2['id'];
+    // $form->preProcess();
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3162,6 +3162,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
         }
         break;
 
+      case 'CRM_Contribute_Form_Contribution_Main':
+        $form->controller = new CRM_Contribute_Controller_Contribution();
+        break;
+
       case 'CRM_Contribute_Form_Contribution_Confirm':
         $form->controller = new CRM_Contribute_Controller_Contribution();
         $form->controller->setStateMachine(new CRM_Contribute_StateMachine_Contribution($form->controller));


### PR DESCRIPTION
Overview
----------------------------------------
Extract isMembershipPriceSet (useForMember) 

Before
----------------------------------------
I've spent hours trying to figure out what `useForMember` means & how it is set & used

After
----------------------------------------
Hopefully the meaning & how it is derieved is clear-ish. As for used - still figuring that out - see technical details....

Technical Details
----------------------------------------
@demeritcowboy I'm hoping you can help me here. I *think* I got the `if` for `ccid` right but it broke my brain a bit

In the online receipt we see

```     {if $membership_assign && !$useForMember}```

After working through this I think that effectively means ```     {if $membership_assign && !$isQuickConfig}``` and if true then present basic membership data & no line items

```      {if !$useForMember and isset($membership_amount) and !empty($is_quick_config)}```

- I think `$useFormMember` is redundant here & just checking `quickConfig` is enough

Ditto in this line

```    {elseif empty($useForMember) && !empty($lineItem) and $priceSetID and empty($is_quick_config)}```

and 

```       {if $useForMember && $lineItem and empty($is_quick_config)}
```

My eventual theory is that `useForMember` wasn't robust enough and `is_quick_config` was added, without removing `useForMember`.

If you agree then I will remove all the usages of `useForMember` in the `online_membership_receipt` template

I'm trying to get rid of the `issets` around `membership_amount` and `amount_level` - but kept getting confused on what `useForMember` means

Comments
----------------------------------------
