### PR TITLE
Load submitted `fieldSeparator` on back on `Import Datasource` screen

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -23,7 +23,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    *
    * @var string[]
    */
-  protected $submittableFields = ['skipColumnHeader', 'uploadField'];
+  protected $submittableFields = ['skipColumnHeader', 'uploadField', 'fieldSeparator'];
 
   /**
    * Provides information about the data source.


### PR DESCRIPTION
Overview
----------------------------------------
Load submitted fieldSeparator on back on Import Datasource screen

Before
----------------------------------------
If you go to import contacts & on the second (`MapField`) screen use the back button the `fieldSeparator` checkbox does not hold the submitted value

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/223602283-76562b59-508a-43cc-b51d-6abcabdde650.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
@MegaphoneJon - this relates to your battles...
