### PR TITLE
Fix really annoying notice on mispelt variable name `$isCheked`

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -111,8 +111,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   public function buildQuickForm(): void {
     $this->addSavedMappingFields();
 
-    $this->addFormRule(['CRM_Contact_Import_Form_MapField', 'formRule']);
-
     //-------- end of saved mapping stuff ---------
 
     $defaults = [];
@@ -304,24 +302,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   }
 
   /**
-   * Global validation rules for the form.
-   *
-   * @param array $fields
-   *   Posted values of the form.
-   *
-   * @return bool
-   *   list of errors to be posted back to the form
-   */
-  public static function formRule(array $fields): bool {
-    if (!empty($fields['saveMapping'])) {
-      // todo - this is nonsensical - sane js is better. PR to fix got stale but
-      // is here https://github.com/civicrm/civicrm-core/pull/23950
-      CRM_Core_Smarty::singleton()->assign('isCheked', TRUE);
-    }
-    return TRUE;
-  }
-
-  /**
    * Process the mapped fields and map it into the uploaded file.
    *
    * @throws \CRM_Core_Exception
@@ -381,7 +361,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     //Updating Mapping Records
     if (!empty($params['updateMapping'])) {
       foreach (array_keys($this->getColumnHeaders()) as $i) {
-        $this->saveMappingField($params['mappingId'], $i, TRUE);
+        $this->saveMappingField($this->getSavedMappingID(), $i, TRUE);
       }
     }
 
@@ -394,6 +374,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       ];
 
       $saveMapping = civicrm_api3('Mapping', 'create', $mappingParams);
+      $this->updateUserJobMetadata('MapField', ['mapping_id' => $saveMapping['id']]);
 
       foreach (array_keys($this->getColumnHeaders()) as $i) {
         $this->saveMappingField($saveMapping['id'], $i);

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -41,18 +41,6 @@
    </script>
  {/literal}
 
-<script type="text/javascript" >
-{literal}
-if ( document.getElementsByName("saveMapping")[0].checked ) {
-    document.getElementsByName("updateMapping")[0].checked = true;
-    document.getElementsByName("saveMapping")[0].checked = false;
-}
-{/literal}
-{if $isCheked}
-    document.getElementsByName("saveMapping")[0].checked = true;
-{/if}
-</script>
-
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
  {$initHideBoxes|smarty:nodefaults}
 

--- a/templates/CRM/Import/Form/MapTableCommon.tpl
+++ b/templates/CRM/Import/Form/MapTableCommon.tpl
@@ -68,17 +68,24 @@
             } else {
               cj('#saveDetails').hide();
             }
-
-            function showSaveDetails(chkbox) {
-              if (chkbox.checked) {
-                document.getElementById("saveDetails").style.display = "block";
-                document.getElementById("saveMappingName").disabled = false;
-                document.getElementById("saveMappingDesc").disabled = false;
+            cj('#updateMapping').change(function() {
+              cj('#saveMapping').prop("checked", !this.checked).change();
+            });
+            cj('#saveMapping').change(function() {
+              if (this.checked) {
+                cj('#saveDetails').show();
+                cj('#updateMapping').prop('checked', false);
+                cj('#saveMappingName').removeAttr('disabled')
+                cj('#saveMappingDesc').removeAttr('disabled')
               } else {
-                document.getElementById("saveDetails").style.display = "none";
-                document.getElementById("saveMappingName").disabled = true;
-                document.getElementById("saveMappingDesc").disabled = true;
+                cj('#saveDetails').hide();
+                cj('#saveMappingName').attr('disabled','disabled');
+                cj('#saveMappingDesc').attr('disabled','disabled');
               }
+            });
+            // Load in update mode if we have already saved the name - ie gone forwards & back.
+            if (cj('#saveMappingName').val()) {
+              cj('#updateMapping').prop("checked", true).change();
             }
             cj('select[id^="mapper"][id$="[0]"]').addClass('huge');
             {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Fix really annoying notice on mispelt variable name `$isCheked`

This has had patches put up before but they have always gone stale but it is soooo annoying when they can't even spell the really-bad variable name

The goal of the code in question is this.

1) Do an import using an exisitng mapping
![image](https://user-images.githubusercontent.com/336308/223613043-ea210f9a-f917-4814-8f1d-9a6631c8d738.png)

2) Choose to save with a new mapping name
![image](https://user-images.githubusercontent.com/336308/223613140-4968d3df-83b3-4765-ac8c-807f8488af31.png)


3) go back
![image](https://user-images.githubusercontent.com/336308/223613182-6519b563-fab0-451d-9b54-ae807ad86df6.png)

4) see the new mapping showing up to be updated

![image](https://user-images.githubusercontent.com/336308/223613223-eaa322bc-b127-430c-a92b-e67936dc8fbc.png)



Before
----------------------------------------
The mapping form loads with an e-notice - 

![image](https://user-images.githubusercontent.com/336308/223612197-d18a8f80-9171-448d-9d2b-5fef2ec0b694.png)



After
----------------------------------------
The e-notice is gone 

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
