### PR TITLE
Deprecate pledge_payment::del

### DIFF
--- a/CRM/Pledge/BAO/PledgePayment.php
+++ b/CRM/Pledge/BAO/PledgePayment.php
@@ -201,6 +201,7 @@ WHERE     pledge_id = %1
    * @return bool
    */
   public static function del($id) {
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
     return (bool) self::deleteRecord(['id' => $id]);
   }
 
@@ -228,7 +229,7 @@ WHERE     pledge_id = %1
         if ($payment->contribution_id) {
           CRM_Contribute_BAO_Contribution::deleteContribution($payment->contribution_id);
         }
-        self::del($payment->id);
+        self::deleteRecord(['id' => $payment->id]);
       }
     }
 

--- a/api/v3/PledgePayment.php
+++ b/api/v3/PledgePayment.php
@@ -71,22 +71,19 @@ function _civicrm_api3_pledge_payment_create_spec(&$params) {
 }
 
 /**
- * Delete a pledge Payment - Note this deletes the contribution not just the link.
+ * Delete a pledge Payment - Note this deletes the contribution not just the
+ * link.
  *
  * @param array $params
  *   Input parameters.
  *
  * @return array
  *   API result
+ * @throws \CRM_Core_Exception
+ * @noinspection PhpUnused
  */
-function civicrm_api3_pledge_payment_delete($params) {
-
-  if (CRM_Pledge_BAO_PledgePayment::del($params['id'])) {
-    return civicrm_api3_create_success(['id' => $params['id']], $params, 'PledgePayment', 'delete');
-  }
-  else {
-    return civicrm_api3_create_error('Could not delete payment');
-  }
+function civicrm_api3_pledge_payment_delete(array $params): array {
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**


### PR DESCRIPTION
Partial of https://github.com/civicrm/civicrm-core/pull/25677 - but I changed the exception handling @colemanw I don't think we need to catch the exception - I think the api should handle it & it is a legacy pattern