### PR TITLE
Deprecate relationship::del

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -161,7 +161,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
    */
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
-      CRM_Contact_BAO_RelationshipType::del($this->_id);
+      CRM_Contact_BAO_RelationshipType::deleteRecord(['id' => $this->_id]);
       CRM_Core_Session::setStatus(ts('Selected Relationship type has been deleted.'), ts('Record Deleted'), 'success');
     }
     else {

--- a/CRM/Contact/BAO/RelationshipType.php
+++ b/CRM/Contact/BAO/RelationshipType.php
@@ -98,12 +98,8 @@ class CRM_Contact_BAO_RelationshipType extends CRM_Contact_DAO_RelationshipType 
    * @return mixed
    */
   public static function del($relationshipTypeId) {
-    // make sure relationshipTypeId is an integer
-    // @todo review this as most delete functions rely on the api & form layer for this
-    // or do a find first & throw error if no find
-    if (!CRM_Utils_Rule::positiveInteger($relationshipTypeId)) {
-      throw new CRM_Core_Exception(ts('Invalid relationship type'));
-    }
+    CRM_Core_Error::deprecatedFunctionWarning('deleteRecord');
+
     return static::deleteRecord(['id' => $relationshipTypeId]);
   }
 

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -508,7 +508,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
    *   Relationship ID
    */
   private function deleteAction($id) {
-    CRM_Contact_BAO_Relationship::del($id);
+    CRM_Contact_BAO_Relationship::deleteRecord(['id' => $id]);
     CRM_Core_Session::setStatus(ts('Selected relationship has been deleted successfully.'), ts('Record Deleted'), 'success');
 
     // reload all blocks to reflect this change on the user interface.

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -181,7 +181,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
       }
 
       // delete relationship
-      CRM_Contact_BAO_Relationship::del($this->getEntityId());
+      CRM_Contact_BAO_Relationship::deleteRecord(['id' => $this->getEntityId()]);
       CRM_Core_Session::setStatus(ts('Selected relationship has been deleted successfully.'), ts('Record Deleted'), 'success');
 
       CRM_Utils_System::redirect($url);
@@ -240,7 +240,7 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
    */
   public function delete() {
     // calls a function to delete relationship
-    CRM_Contact_BAO_Relationship::del($this->getEntityId());
+    CRM_Contact_BAO_Relationship::deleteRecord(['id' => $this->getEntityId()]);
     CRM_Core_Session::setStatus(ts('Selected relationship has been deleted successfully.'), ts('Record Deleted'), 'success');
   }
 

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -56,22 +56,11 @@ function _civicrm_api3_relationship_create_spec(&$params) {
  *
  * @return array
  *   API Result Array
+ *
+ * @throws \CRM_Core_Exception
  */
-function civicrm_api3_relationship_delete($params) {
-
-  if (!CRM_Utils_Rule::integer($params['id'])) {
-    return civicrm_api3_create_error('Invalid value for relationship ID');
-  }
-
-  $relationBAO = new CRM_Contact_BAO_Relationship();
-  $relationBAO->id = $params['id'];
-  if (!$relationBAO->find(TRUE)) {
-    return civicrm_api3_create_error('Relationship id is not valid');
-  }
-  else {
-    $relationBAO->del($params['id']);
-    return civicrm_api3_create_success('Deleted relationship successfully');
-  }
+function civicrm_api3_relationship_delete(array $params): array {
+  return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }
 
 /**


### PR DESCRIPTION
Partial of https://github.com/civicrm/civicrm-core/pull/25677 but @colemanw I ripped the  rubbish out relationship_delete api  - there didn't seem to be any reason not to just call the `basic_delete` - the rest looked like cruft...