### PR TITLE
APIv4 - Support `match` in replaceAction

### DIFF
--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -119,40 +119,6 @@ abstract class AbstractSaveAction extends AbstractAction {
   }
 
   /**
-   * Find existing record based on $this->match param
-   *
-   * @param $record
-   */
-  protected function matchExisting(&$record) {
-    $primaryKey = CoreUtil::getIdFieldName($this->getEntityName());
-    if (empty($record[$primaryKey]) && !empty($this->match)) {
-      $where = [];
-      foreach ($record as $key => $val) {
-        if (in_array($key, $this->match, TRUE)) {
-          if ($val === '' || is_null($val)) {
-            // If we want to match empty string we have to match on NULL/''
-            $where[] = [$key, 'IS EMPTY'];
-          }
-          else {
-            $where[] = [$key, '=', $val];
-          }
-        }
-      }
-      if (count($where) === count($this->match)) {
-        $existing = civicrm_api4($this->getEntityName(), 'get', [
-          'select' => [$primaryKey],
-          'where' => $where,
-          'checkPermissions' => $this->checkPermissions,
-          'limit' => 2,
-        ]);
-        if ($existing->count() === 1) {
-          $record[$primaryKey] = $existing->first()[$primaryKey];
-        }
-      }
-    }
-  }
-
-  /**
    * @return string
    * @deprecated
    */

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -30,6 +30,7 @@ namespace Civi\Api4\Generic;
  * @method bool getReload()
  */
 class BasicReplaceAction extends AbstractBatchAction {
+  use Traits\MatchParamTrait;
 
   /**
    * Array of $ENTITY records.
@@ -86,6 +87,13 @@ class BasicReplaceAction extends AbstractBatchAction {
       }
     }
 
+    // Merge in defaults and perform non-id matching if match field(s) are specified
+    foreach ($this->records as &$record) {
+      $record += $this->defaults;
+      $this->formatWriteValues($record);
+      $this->matchExisting($record);
+    }
+
     $idField = $this->getSelect()[0];
     $toDelete = array_diff_key(array_column($items, NULL, $idField), array_flip(array_filter(\CRM_Utils_Array::collect($idField, $this->records))));
 
@@ -93,8 +101,7 @@ class BasicReplaceAction extends AbstractBatchAction {
     $saveAction
       ->setCheckPermissions($this->getCheckPermissions())
       ->setReload($this->reload)
-      ->setRecords($this->records)
-      ->setDefaults($this->defaults);
+      ->setRecords($this->records);
     $result->exchangeArray((array) $saveAction->execute());
 
     if ($toDelete) {

--- a/Civi/Api4/Generic/Traits/MatchParamTrait.php
+++ b/Civi/Api4/Generic/Traits/MatchParamTrait.php
@@ -12,6 +12,8 @@
 
 namespace Civi\Api4\Generic\Traits;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * @method $this setMatch(array $match) Specify fields to match for update.
  * @method bool getMatch()
@@ -31,6 +33,40 @@ trait MatchParamTrait {
    * @optionsCallback getMatchFields
    */
   protected $match = [];
+
+  /**
+   * Find existing record based on $this->match param
+   *
+   * @param $record
+   */
+  protected function matchExisting(&$record) {
+    $primaryKey = CoreUtil::getIdFieldName($this->getEntityName());
+    if (empty($record[$primaryKey]) && !empty($this->match)) {
+      $where = [];
+      foreach ($record as $key => $val) {
+        if (in_array($key, $this->match, TRUE)) {
+          if ($val === '' || is_null($val)) {
+            // If we want to match empty string we have to match on NULL/''
+            $where[] = [$key, 'IS EMPTY'];
+          }
+          else {
+            $where[] = [$key, '=', $val];
+          }
+        }
+      }
+      if (count($where) === count($this->match)) {
+        $existing = civicrm_api4($this->getEntityName(), 'get', [
+          'select' => [$primaryKey],
+          'where' => $where,
+          'checkPermissions' => $this->checkPermissions,
+          'limit' => 2,
+        ]);
+        if ($existing->count() === 1) {
+          $record[$primaryKey] = $existing->first()[$primaryKey];
+        }
+      }
+    }
+  }
 
   /**
    * Options callback for $this->match

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -114,6 +114,7 @@
         if (params.tag_id && params.tag_id.length) {
           chain.tag_id = ['EntityTag', 'replace', {
             where: [['entity_id', '=', '$id'], ['entity_table', '=', 'civicrm_saved_search']],
+            match: ['entity_id', 'entity_table', 'tag_id'],
             records: _.transform(params.tag_id, function(records, id) {records.push({tag_id: id});})
           }];
         } else if (params.id) {

--- a/tests/phpunit/api/v4/Action/ReplaceTest.php
+++ b/tests/phpunit/api/v4/Action/ReplaceTest.php
@@ -26,6 +26,7 @@ use Civi\Api4\Email;
 use api\v4\Traits\TableDropperTrait;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Api4\EntityTag;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -182,6 +183,48 @@ class ReplaceTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('new two', $newRecords->last()['Custom2']);
     $this->assertEquals('changed one', $newRecords[$cid1Records[0]['id']]['Custom1']);
     $this->assertEquals('changed two', $newRecords[$cid1Records[0]['id']]['Custom2']);
+  }
+
+  public function testReplaceEntityTag(): void {
+    $t1 = uniqid();
+    $t2 = uniqid();
+    $t3 = uniqid();
+    $this->saveTestRecords('Tag', [
+      'records' => [['name' => $t1], ['name' => $t2], ['name' => $t3]],
+      'defaults' => ['used_for' => ['civicrm_contact']],
+    ]);
+
+    $cid = $this->createTestRecord('Contact')['id'];
+
+    EntityTag::replace(FALSE)
+      ->addWhere('entity_id', '=', $cid)
+      ->setRecords([['tag_id:name' => $t1], ['tag_id:name' => $t2]])
+      ->addDefault('entity_table', 'civicrm_contact')
+      ->setMatch(['entity_table', 'entity_id', 'tag_id'])
+      ->execute();
+
+    $result = EntityTag::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_contact')
+      ->addWhere('entity_id', '=', $cid)
+      ->addSelect('tag_id:name')
+      ->execute()->column('tag_id:name');
+
+    $this->assertEquals([$t1, $t2], $result);
+
+    EntityTag::replace(FALSE)
+      ->addWhere('entity_id', '=', $cid)
+      ->setRecords([['tag_id:name' => $t1], ['tag_id:name' => $t3]])
+      ->addDefault('entity_table', 'civicrm_contact')
+      ->setMatch(['entity_table', 'entity_id', 'tag_id'])
+      ->execute();
+
+    $result = EntityTag::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_contact')
+      ->addWhere('entity_id', '=', $cid)
+      ->addSelect('tag_id:name')
+      ->execute()->column('tag_id:name');
+
+    $this->assertEquals([$t1, $t3], $result);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This allows the replaceAction to support non-id matching, the same way as the saveAction does.
Fixes [dev/core#4168](https://lab.civicrm.org/dev/core/-/issues/4168)

Before
----------------------------------------
Can't update tags from SearchKit edit screen (master-only regression)

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
The regression was caused by [updating the EntityTag api](https://github.com/civicrm/civicrm-core/pull/25674/commits/4df6b683d20f0d0584fd6b93c532f69fc21bc5a4) in v4 to use the standard `writeRecord` which loses its special handling (which was basically an implicit `match`). This fixes it by making it possible to explicitly match.