### PR TITLE
Smarty notice fix on Merge

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1576,6 +1576,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
       $relTables[$name]['main_url'] = str_replace('$cid', $mainId, $relTables[$name]['url']);
       $relTables[$name]['other_url'] = str_replace('$cid', $otherId, $relTables[$name]['url']);
+      $relTables[$name]['has_operation'] = 0;
+
       if ($name === 'rel_table_users') {
         // @todo - this user url stuff is only needed for the form layer - move to CRM_Contact_Form_Merge
         $relTables[$name]['main_url'] = str_replace('%ufid', CRM_Core_BAO_UFMatch::getUFId($mainId), $relTables[$name]['url']);
@@ -1599,6 +1601,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           $attributes,
         ];
         $migrationInfo["operation"]["move_{$name}"]['add'] = 1;
+        $relTables[$name]['has_operation'] = 1;
       }
     }
     foreach ($relTables as $name => $null) {

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -114,7 +114,7 @@
           </td>
 
           <td style='white-space: nowrap'>
-             {if $form.$field}=={$form.$field.html|crmAddClass:"select-row"}==&gt;{/if}
+             {if array_key_exists($field, $form) && $form.$field}=={$form.$field.html|crmAddClass:"select-row"}==&gt;{/if}
           </td>
 
           {* For location blocks *}
@@ -219,7 +219,7 @@
       </tr>
       {else}
       <tr class="{cycle values="even-row,odd-row"}">
-        <td><strong>{ts}Move related...{/ts}</strong></td><td><a href="{$params.other_url}">{$params.title}</a></td><td style='white-space: nowrap'>=={$form.$paramName.html|crmAddClass:"select-row"}==&gt;</td><td><a href="{$params.main_url}">{$params.title}</a>{if $form.operation.$paramName.add.html}&nbsp;{$form.operation.$paramName.add.html}{/if}</td>
+        <td><strong>{ts}Move related...{/ts}</strong></td><td><a href="{$params.other_url}">{$params.title}</a></td><td style='white-space: nowrap'>=={$form.$paramName.html|crmAddClass:"select-row"}==&gt;</td><td><a href="{$params.main_url}">{$params.title}</a>{if $params.has_operation}&nbsp;{$form.operation.$paramName.add.html}{/if}</td>
          <td>({ts}migrate{/ts})</td>
       </tr>
       {/if}


### PR DESCRIPTION
Fixes Smarty "Undefined array key" warnings on contact merge screen on PHP 8.

Follows suggestions at https://docs.civicrm.org/dev/en/latest/security/outputs/#gotcha-2-smarty-notices