### PR TITLE
Fix cache clearing when import table is changed

### DIFF
--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -40,6 +40,9 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
       ->apply();
   }
 
+  /**
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
   public function tearDown():void {
     CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS abc');
     parent::tearDown();
@@ -52,7 +55,7 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
    */
   public function testApiActions():void {
     $this->createUserJobTable();
-    $userJobID = UserJob::create()->setValues([
+    $userJobParameters = [
       'metadata' => [
         'DataSource' => ['table_name' => 'abc', 'column_headers' => ['External Identifier', 'Amount Given', 'Date Received', 'Financial Type', 'In honor']],
         'submitted_values' => [
@@ -73,7 +76,8 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
       ],
       'status_id:name' => 'draft',
       'job_type' => 'contribution_import',
-    ])->execute()->first()['id'];
+    ];
+    $userJobID = UserJob::create()->setValues($userJobParameters)->execute()->first()['id'];
     $importFields = Import::getFields($userJobID)->execute();
     $this->assertEquals('abc', $importFields[0]['table_name']);
     $this->assertEquals('_id', $importFields[0]['column_name']);
@@ -135,13 +139,25 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
     $imported = Import::import($userJobID)->addWhere('_id', '=', $rowID)->setLimit(1)->execute()->first();
     $this->assertEquals('ERROR', $imported['_status']);
     $this->assertEquals('No matching Contact found', $imported['_status_message']);
+
+    // Update the table with a new table name & check the api still works.
+    // This relies on the change in table name being detected & caches being
+    // flushed.
+    CRM_Core_DAO::executeQuery('DROP TABLE abc');
+    $this->createUserJobTable('xyz');
+    $userJobParameters['metadata']['DataSource']['table_name'] = 'xyz';
+    UserJob::update(FALSE)->addWhere('id', '=', $userJobID)->setValues($userJobParameters)->execute();
+    // This is our new table, with nothing in it, but we if we api-call & don't get an exception so we are winning.
+    Import::get($userJobID)->setSelect(['external_identifier', 'amount_given', '_status'])->addWhere('_id', '=', $rowID)->execute()->first();
   }
 
   /**
    * Create a table for our Import api.
+   *
+   * @throws \Civi\Core\Exception\DBQueryException
    */
-  private function createUserJobTable(): void {
-    CRM_Core_DAO::executeQuery("CREATE TABLE IF NOT EXISTS `abc` (
+  private function createUserJobTable($tableName = 'abc'): void {
+    CRM_Core_DAO::executeQuery("CREATE TABLE IF NOT EXISTS `" . $tableName . "` (
       `external_identifier` text DEFAULT NULL,
       `amount_given` text DEFAULT NULL,
       `receive_date` text DEFAULT NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Fix cache clearing when import table is changed

Before
----------------------------------------
1) enable `Civi-Import`
2) Start an import - upload the csv then go back & re-do the csv upload
3) navigate to the import search - as long as caches have not otherwise been cleared the api call failure will be visible in the console

After
----------------------------------------
The cache is cleared whenever the table is changed, test coverage

Technical Details
----------------------------------------
We were clearing the cache on create & delete, but not when the table was updated - which meant we could hit errors when the cache was trying to access a now-deleted table

Comments
----------------------------------------

