### PR TITLE
dev/core#4158 Fix for recurring double ups

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -544,7 +544,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
   public function doPaymentPayPalButton(&$params) {
     $args = [];
 
-    $result = $this->setStatusPaymentPending([]);
+    $result = [];
 
     $this->initialize($args, 'DoDirectPayment');
 
@@ -606,7 +606,6 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     }
 
     /* Success */
-    $result = $this->setStatusPaymentCompleted($result);
     $doQueryParams = [
       'gross_amount' => $apiResult['amt'] ?? NULL,
       'trxn_id' => $apiResult['transactionid'] ?? NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Reversion of change in error [here ](https://github.com/civicrm/civicrm-core/commit/8e819886095d90017b3af0a4adad66b7405fa73f#diff-4dbed7c747cbb3d586b3893862668d52fcb777d1ed663df9ebf4a2f512e42bd8R548)

The issue is `doPayment` correctly sets payment to pending when it is a recurring - but not if it is already set. The heavy handed update in #22683 sets it 'always' - which means the `doPayment` doesn't get a chance to do the right thing

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4158

After
----------------------------------------
Reported fixed by @Stoob 

Technical Details
----------------------------------------

Comments
----------------------------------------
