### PR TITLE
dev/core#4000 Fix (old) regression - ensure only template contribution updates update recur

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -17,6 +17,7 @@ use Civi\Api4\ContributionRecur;
 use Civi\Api4\LineItem;
 use Civi\Api4\ContributionSoft;
 use Civi\Api4\PaymentProcessor;
+use Civi\Core\Event\PostEvent;
 
 /**
  *
@@ -604,9 +605,12 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
   /**
    * Event fired after modifying a contribution.
+   *
    * @param \Civi\Core\Event\PostEvent $event
+   *
+   * @throws \CRM_Core_Exception
    */
-  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+  public static function self_hook_civicrm_post(PostEvent $event): void {
     if ($event->action === 'edit') {
       CRM_Contribute_BAO_ContributionRecur::updateOnTemplateUpdated($event->object);
     }

--- a/CRM/Upgrade/Incremental/php/FiveSixtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyOne.php
@@ -21,6 +21,23 @@
  */
 class CRM_Upgrade_Incremental_php_FiveSixtyOne extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
+    if ($rev === '5.61.alpha1' && CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_contribution_recur LIMIT 1')) {
+      $documentationUrl = 'https://docs.civicrm.org/dev/en/latest/financial/recurring-contributions/';
+      $documentationAnchor = 'target="_blank" href="' . htmlentities($documentationUrl) . '"';
+      $extensionUrl = 'https://docs.civicrm.org/dev/en/latest/financial/recurring-contributions/';
+      $extensionAnchor = 'target="_blank" href="' . htmlentities($extensionUrl) . '"';
+
+      $preUpgradeMessage .= '<p>' .
+        ts('This release contains a change to the behaviour of recurring contributions under some edge-case circumstances.')
+        . ' ' . ts('Since 5.49 the amount and currency on the recurring contribution record changed when the amount of any contribution against it was changed, indicating a change in future intent.')
+        . ' ' . ts('It is generally not possible to edit the amount for contributions linked to recurring contributions so for most sites this would never occur anyway.')
+        . ' ' . ts('If you still want this behaviour you should install the <a %1>Recur future amounts extension</a>', [1 => $extensionAnchor])
+        . ' ' . ts('Please <a %1>read about recurring contribution templates</a> for more information', [1 => $documentationAnchor])
+        . '</p>';
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -117,23 +117,40 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test we don't change unintended fields on API edit
+   * Test we don't change unintended fields on the recurring contribution.
+   *
+   * This tests two scenarios
+   *  - editing a contribution_recur and changing unrelated fields should leave the
+   *    currency unchanged
+   *  - Adding (or editing) contributions on the recurring should only alter
+   *    it if the contribution is a template contribution.
    *
    * @throws \CRM_Core_Exception
    */
   public function testUpdateRecur(): void {
     $createParams = $this->_params;
     $createParams['currency'] = 'XAU';
-    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $createParams);
-    $editParams = [
-      'id' => $contributionRecur['id'],
+    $contributionRecurID = $this->callAPISuccess('ContributionRecur', 'create', $createParams)['id'];
+    $contributionID = Contribution::create()->setValues([
+      'contribution_recur_id' => $contributionRecurID,
+      'total_amount' => 5,
+      'currency' => 'USD',
+      'contact_id' => $this->_params['contact_id'],
+      'financial_type_id:name' => 'Donation',
+    ])->execute()->first()['id'];
+    $this->assertContributionRecurValues($contributionRecurID, 3, 'XAU', 'a non template contribution should not change the recurring amount details');
+
+    Contribution::update()->setValues(['receive_date' => 'yesterday'])->addWhere('id', '=', $contributionID)->execute();
+    $this->assertContributionRecurValues($contributionRecurID, 3, 'XAU', 'a non template contribution should not change the recurring amount details');
+
+    $contributionRecurID = $this->callAPISuccess('ContributionRecur', 'create', [
+      'id' => $contributionRecurID,
       'end_date' => '+ 4 weeks',
-    ];
-    $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', $editParams);
-    $dao = new CRM_Contribute_BAO_ContributionRecur();
-    $dao->id = $contributionRecur['id'];
-    $dao->find(TRUE);
-    $this->assertEquals('XAU', $dao->currency, 'Edit clobbered recur currency');
+    ])['id'];
+    $this->assertContributionRecurValues($contributionRecurID, 3, 'XAU', 'an unrelated contribution recur update should not change the amount details');
+
+    Contribution::update()->setValues(['is_template' => TRUE])->addWhere('id', '=', $contributionID)->execute();
+    $this->assertContributionRecurValues($contributionRecurID, 5, 'USD', 'a change to a template contribution should change the recurring amount details');
   }
 
   /**
@@ -737,6 +754,25 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
     $recurring3 = $this->callAPISuccess('ContributionRecur', 'create', $createParams);
     $recurring3Get = $this->callAPISuccess('ContributionRecur', 'getsingle', ['id' => $recurring3['id']]);
     $this->assertEquals('0', $recurring3Get['is_email_receipt']);
+  }
+
+  /**
+   * Assert the contribution recur values match.
+   *
+   * @param int $contributionRecurID
+   * @param int $amount
+   * @param string $currency
+   * @param string $message
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function assertContributionRecurValues(int $contributionRecurID, int $amount, string $currency, string $message = ''): void {
+    $contributionRecur = ContributionRecur::get()->setSelect([
+      'amount',
+      'currency',
+    ])->addWhere('id', '=', $contributionRecurID)->execute()->first();
+    $this->assertEquals($currency, $contributionRecur['currency'], $message);
+    $this->assertEquals($amount, $contributionRecur['amount'], $message);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This revives https://github.com/civicrm/civicrm-core/pull/25023 which stalled

To address the stalling of the last PR I have 
- Fixed test issues that were unrelated but made that un-mergeable (already merged, not in this PR)
- Documented how recurrings, template contributions  & `repeattransation` work - https://docs.civicrm.org/dev/en/latest/financial/recurring-contributions/
- Created an extension for those who want the behaviour being removed https://docs.civicrm.org/dev/en/latest/financial/recurring-contributions
- Added an upgrade message pointing to the above
![image](https://user-images.githubusercontent.com/336308/224239323-54b1d7ad-cad6-44ba-b988-e2d34327cb27.png)


The issue is that in 5.49 / https://github.com/civicrm/civicrm-core/pull/21473 a change was added to update `ContributionRecur` records to match the amount and currency of any contributions attached to them if those contribution amounts or currencies were edited. This is expected behaviour for `TemplateContributions` as any change to a template contribution represents a change in expected future behaviour (and possibilty should be extended to `create` for template contributions).

However, for other contributions we do not know if this is a one-off change or a change in expectations. If the former the change should be ring-fenced to the Contribution in question. In the latter the `ContributionRecur` should be updated. The `post` hook is not in position to know which of these is the case so the responsibility of determining whether to change the `ContributionRecur` should be on the code that edits the contribution.

Users are not able to edit contributions linked to `RecurringContributions` under normal core usage and core recurring `PaymentProcessors` do their own updating - so this scenario never happens without custom code in play. So the issue is we have a behaviour where a change initiated by custom code triggers another change that often does not make sense, and which the custom code could make for itself.

@mattwire suggested that rather than limit the code to only make a change if the `TemplateContribution` changes we also include `pseudo-TemplateContributions` - ie the latest contribution if no `TemplateContribution` exists. However, this is not always correct as payment processors and sites support a range of behaviours such as ad hoc payments of variable amounts against a `RecurringContribution`.

In order to preserve the core-for-a-bit behaviour for those who do want it I have put up an extension that people can install if they do https://docs.civicrm.org/dev/en/latest/financial/recurring-contributions (I was unable to explain when someone would want it but there was resisitance to just removing the behaviour when I last worked on this.)

I have documented how recurrings and template contributions work here 

https://docs.civicrm.org/dev/en/latest/financial/recurring-contributions/





Before
----------------------------------------
This is pretty hard to replicate in standard core because with no extensions installed users cannot edit contributions attached to payment processors. It is more likely in code - e.g if a payment processor created a one-off pending contribution against the record & then becomes aware the amount actually processed differs for some reason. It is an edge case but what we know about payment processors is that they are full of edge cases & hence we should not assume that if the code for some reason adds & then edits a contribution linked to a recurring contribution what it REALLY means is that the recurring record should change.

So to replicate on master, create a recurring payment & then add a contribution to it & update it using the UI

```
CRM.api4('Contribution', 'create', {
  values: {"financial_type_id":1, "contribution_recur_id":1, "total_amount":90, "contact_id":203},
  chain: {"name_me_0":["Contribution", "update", {"values":{"total_amount":777, "id":"$id"}}]}
})
```

After
----------------------------------------
In the above scenario there would be no change UNLESS we are dealing with a `TemplateContribution`

Technical Details
----------------------------------------


Comments
----------------------------------------