### PR TITLE
dev/core#4156 Fix failure to update organization_name on employees during merge

### DIFF
--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\Contact;
+
 /**
  * Class CRM_Dedupe_DedupeMergerTest
  *
@@ -812,7 +814,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
     // update the text custom field for duplicate contact 1 with value 'def'
     $this->callAPISuccess('Contact', 'create', [
       'id' => $duplicateContactID1,
-      "{$customFieldName}" => 'def',
+      $customFieldName => 'def',
     ]);
     $this->assertCustomFieldValue($duplicateContactID1, 'def', $customFieldName);
 
@@ -1453,7 +1455,28 @@ WHERE
     CRM_Core_DAO_AllCoreTables::flush();
     $contact1 = $this->individualCreate();
     $contact2 = $this->individualCreate(['api.Im.create' => ['name' => 'chat_handle']]);
-    $this->callAPISuccess('Contact', 'merge', ['to_keep_id' => $contact1, 'to_remove_id' => $contact2]);
+    $this->callAPISuccess('Contact', 'merge', [
+      'to_keep_id' => $contact1,
+      'to_remove_id' => $contact2,
+    ]);
+  }
+
+  /**
+   * Test that organization name is updated for employees of merged organizations..
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMergeWithEmployer(): void {
+    $organizationToRemoveID = $this->organizationCreate(['organization_name' => 'remove']);
+    $organizationToKeepID = $this->organizationCreate(['organization_name' => 'keep']);
+    $individualID = $this->createContactWithEmployerRelationship([
+      'contact_id_b' => $organizationToRemoveID,
+    ]);
+    $employerName = Contact::get()->addSelect('organization_name')->addWhere('id', '=', $individualID)->execute()->first()['organization_name'];
+    $this->assertEquals('remove', $employerName);
+    $this->callAPISuccess('Contact', 'merge', ['to_keep_id' => $organizationToKeepID, 'to_remove_id' => $organizationToRemoveID, 'mode' => 'aggressive']);
+    $employerName = Contact::get()->addSelect('organization_name')->addWhere('id', '=', $individualID)->execute()->first()['organization_name'];
+    $this->assertEquals('keep', $employerName);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4156 Fix failure to update organization_name on employees during merge

Before
----------------------------------------
1) set an employer's relationship to an organization
2) merge that organization into another organization (you can generally do an organization search that is narrow enough to find your organization & merge it into any other one)
3) check your individual - their relationship will be updated & employer_id but not organization_name - so it shows incorrectly on the contact summary

After
----------------------------------------
organization name updated

Technical Details
----------------------------------------
Passing in `organization_name` triggers the code to update the employee record. This is kinda black-magicky but the test protects it 

Comments
----------------------------------------
There is some suggestion this regressed at some point but I couldn't see anything in the code to point me to it -I think 5.60 with no backport makes sense