### PR TITLE
(dev/core#4176) Allow to search on participant id

### DIFF
--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -639,6 +639,7 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
 
     $form->addRule('participant_fee_amount_low', ts('Please enter a valid money value.'), 'money');
     $form->addRule('participant_fee_amount_high', ts('Please enter a valid money value.'), 'money');
+    $form->add('number', 'participant_id', ts('Participant ID'), ['class' => 'four', 'min' => 1]);
 
     self::addCustomFormFields($form, ['Participant', 'Event']);
 

--- a/templates/CRM/Event/Form/Search/Common.tpl
+++ b/templates/CRM/Event/Form/Search/Common.tpl
@@ -50,6 +50,9 @@
     {$form.participant_fee_amount_high.label} &nbsp; {$form.participant_fee_amount_high.html}
   </td>
 </tr>
+<tr>
+  <td colspan="2"><label>{$form.participant_id.label}</label> {$form.participant_id.html}</td>
+</tr>
 
 {* campaign in contribution search *}
 {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"


### PR DESCRIPTION
Overview
----------------------------------------

Allow to search on participant id.
The participant search doesn't have an option to quickly search on ID, this should fix that.
This is already available for contribution and membership search.

Before
----------------------------------------
Can't search on participant id on _Find Participants_
![id_b4](https://user-images.githubusercontent.com/3455173/224688285-6330ecc8-b474-4543-88e4-25a015f787b3.png)


After
----------------------------------------
Voila!
![pid_after](https://user-images.githubusercontent.com/3455173/224688092-8c1f9ed0-bdae-4816-9243-8de054a42abe.png)
