### PR TITLE
APIv4 - Deprecate unnecessary constants

### DIFF
--- a/Civi/Api4/Event/Events.php
+++ b/Civi/Api4/Event/Events.php
@@ -12,15 +12,20 @@
 
 namespace Civi\Api4\Event;
 
+/**
+ * @deprecated
+ */
 class Events {
 
   /**
-   * Build the database schema, allow adding of custom joins and tables.
+   * @deprecated
+   * Just use the string instead of the constant when listening for this event
    */
   const SCHEMA_MAP_BUILD = 'api.schema_map.build';
 
   /**
-   * Add back POST_SELECT_QUERY const due to Joomla upgrade failure
+   * @deprecated
+   * Unused - there is no longer an event with this name
    * https://lab.civicrm.org/dev/joomla/-/issues/28#note_39487
    */
   const POST_SELECT_QUERY = 'api.select_query.post';

--- a/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ActivitySchemaMapSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Civi\Api4\Event\Subscriber;
 
-use Civi\Api4\Event\Events;
 use Civi\Api4\Event\SchemaMapBuildEvent;
 use Civi\Api4\Service\Schema\Joinable\ExtraJoinable;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
@@ -18,7 +17,7 @@ class ActivitySchemaMapSubscriber extends \Civi\Core\Service\AutoService impleme
    */
   public static function getSubscribedEvents() {
     return [
-      Events::SCHEMA_MAP_BUILD => 'onSchemaBuild',
+      'api.schema_map.build' => 'onSchemaBuild',
     ];
   }
 

--- a/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Civi\Api4\Event\Subscriber;
 
-use Civi\Api4\Event\Events;
 use Civi\Api4\Event\SchemaMapBuildEvent;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -17,7 +16,7 @@ class ContactSchemaMapSubscriber extends \Civi\Core\Service\AutoService implemen
    */
   public static function getSubscribedEvents() {
     return [
-      Events::SCHEMA_MAP_BUILD => 'onSchemaBuild',
+      'api.schema_map.build' => 'onSchemaBuild',
     ];
   }
 

--- a/Civi/Api4/Event/Subscriber/MessageTemplateSchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/MessageTemplateSchemaMapSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Civi\Api4\Event\Subscriber;
 
-use Civi\Api4\Event\Events;
 use Civi\Api4\Event\SchemaMapBuildEvent;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -17,7 +16,7 @@ class MessageTemplateSchemaMapSubscriber extends \Civi\Core\Service\AutoService 
    */
   public static function getSubscribedEvents() {
     return [
-      Events::SCHEMA_MAP_BUILD => 'onSchemaBuild',
+      'api.schema_map.build' => 'onSchemaBuild',
     ];
   }
 

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -13,7 +13,6 @@
 namespace Civi\Api4\Service\Schema;
 
 use Civi\Api4\Entity;
-use Civi\Api4\Event\Events;
 use Civi\Api4\Event\SchemaMapBuildEvent;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
@@ -52,7 +51,7 @@ class SchemaMapBuilder extends AutoService {
     $this->loadTables($map);
 
     $event = new SchemaMapBuildEvent($map);
-    $this->dispatcher->dispatch(Events::SCHEMA_MAP_BUILD, $event);
+    $this->dispatcher->dispatch('api.schema_map.build', $event);
 
     return $map;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Continues the pattern of using strings for event names rather than constants.
