### PR TITLE
Fix profile search listings columns are sometimes blank.

### DIFF
--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -488,7 +488,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
     }
     $links = self::links($this->_map, $this->_editLink, $this->_linkToUF, $this->_profileIds);
 
-    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+    $locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id', ['labelColumn' => 'name']);
 
     $names = [];
     static $skipFields = ['group', 'tag'];


### PR DESCRIPTION
The bug is that the query results have the column names formatted like [location_type_machine_name]-[field_name], like "Work-email", while the code that handles rendering the row is looking for [location_type_display_name]-[field_name], like "Office_1-email". I've adjusted the code that handles rendering the row to instead use the machine name rather than the display name for the location type.

This only becomes an issue if the location type display name has been changed from the default so it no longer matches the internal machine name.