### PR TITLE
Import data source Re-use already uploaded data, optionally on use of 'back' button

### DIFF
--- a/CRM/Import/DataSource/CSV.php
+++ b/CRM/Import/DataSource/CSV.php
@@ -23,7 +23,7 @@ class CRM_Import_DataSource_CSV extends CRM_Import_DataSource {
    *
    * @var string[]
    */
-  protected $submittableFields = ['skipColumnHeader', 'uploadField', 'fieldSeparator'];
+  protected $submittableFields = ['skipColumnHeader', 'uploadFile', 'fieldSeparator'];
 
   /**
    * Provides information about the data source.

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -113,17 +113,12 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @var string[]
    */
   protected $submittableFields = [
-    // Skip column header is actually a field that would be added from the
-    // datasource - but currently only in contact, it is always there for
-    // other imports, ditto uploadFile.
-    'skipColumnHeader' => 'DataSource',
-    'fieldSeparator' => 'DataSource',
-    'uploadFile' => 'DataSource',
     'contactType' => 'DataSource',
     'contactSubType' => 'DataSource',
     'dateFormats' => 'DataSource',
     'savedMapping' => 'DataSource',
     'dataSource' => 'DataSource',
+    'use_existing_upload' => 'DataSource',
     'dedupe_rule_id' => 'DataSource',
     'onDuplicate' => 'DataSource',
     'disableUSPS' => 'DataSource',
@@ -285,6 +280,19 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $oldDataSourceObject = new $oldDataSource($this->getUserJobID());
     $newParams = $this->getSubmittedValue('dataSource') === $oldDataSource ? $this->getSubmittedValues() : [];
     $oldDataSourceObject->purge($newParams);
+    $this->updateUserJobMetadata('DataSource', []);
+  }
+
+  /**
+   * Is the data already uploaded.
+   *
+   * This would be true on the DataSource screen when using the back button
+   * and ideally we can re-use that data rather than make them upload anew.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function isImportDataUploaded(): bool {
+    return $this->getUserJobID() && !empty($this->getUserJob()['metadata']['DataSource']['table_name']);
   }
 
   /**

--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -126,9 +126,9 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
       if (!is_array($metadata)) {
         return NULL;
       }
-      return $metadata['DataSource']['table_name'] ?: NULL;
+      return $metadata['DataSource']['table_name'] ?? NULL;
     }
-    return $event->params['metadata']['DataSource']['table_name'] ?: NULL;
+    return $event->params['metadata']['DataSource']['table_name'] ?? NULL;
   }
 
   /**

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -27,6 +27,16 @@
   <div id="choose-data-source" class="form-item">
     <h3>{ts}Choose Data Source{/ts}</h3>
     <table class="form-layout">
+      {if array_key_exists('use_existing_upload', $form)}
+        <tr class="crm-import-datasource-form-block-use_existing_upload">
+          <td class="label">{$form.use_existing_upload.label}</td>
+          <td>{$form.use_existing_upload.html}</td>
+          {* If the there is already an uploaded file then check the box when the form loads. This will
+          cause it be checked regardless of whether they checked it last time (we assume they want
+          to re-use) and also triggers the hide script for the dataSource field *}
+          {literal}<script type="text/javascript">CRM.$('#use_existing_upload').prop('checked',true).change();</script>{/literal}
+        </tr>
+      {/if}
       <tr class="crm-import-datasource-form-block-dataSource">
         <td class="label">{$form.dataSource.label}</td>
         <td>{$form.dataSource.html} {help id='data-source-selection'}</td>
@@ -191,5 +201,11 @@
     }
   </script>
 {/literal}
+  {if array_key_exists('use_existing_upload', $form)}
+    {* If the there is already an uploaded file then check the box when the form loads. This will
+    cause it be checked regardless of whether they checked it last time (we assume they want
+    to re-use) and also triggers the hide script for the dataSource field *}
+    {literal}<script type="text/javascript">CRM.$('#use_existing_upload').prop('checked',true).change();</script>{/literal}
+  {/if}
 </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Import data source Re-use already uploaded data, optionally on 'back'

Without this patch a user who uses the 'back' button must re-upload the csv / sql they just uploaded....


Before
----------------------------------------
Every time you go BACK to the `DataSource` screen you must re-upload the csv

After
----------------------------------------
Optionally use the data already uploaded

![image](https://user-images.githubusercontent.com/336308/224475943-fdf40f5e-79f9-4bec-ace8-2432e43be5db.png)

Technical Details
----------------------------------------
This is the sequence I used in testing

1) upload csv & progress to MapField
2) go back, uncheck the box & upload a different csv
3) go back, leave the box checked & proceed without uploading one
4) go back, uncheck the box & upload a different csv
5) go back, use sql query SELECT first_name FROM civicrm_contact
6) go back, use a different sql query SELECT last_name FROM civicrm_contact
7) go back, leave the box checked & proceed with query 2
8) go back, uncheck the box & upload a different csv

The only issue I hit was (with the final code) is that the csv defaults don't load when switching from `sql` datasource to `csv` - I don't think this is a new or issue or one users would hit much - but merging https://github.com/civicrm/civicrm-core/pull/25738 will render it more harmless. (That one would ideally be merged via the rc but is otherwise merge-ready)


Comments
----------------------------------------
