### PR TITLE
[REF][PHP8.2] Declare property on CRM_Core_ErrorTest

### DIFF
--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -17,6 +17,11 @@ use Civi\Core\Exception\DBQueryException;
  */
 class CRM_Core_ErrorTest extends CiviUnitTestCase {
 
+  /**
+   * @var string
+   */
+  private $oldConfigAndLogDir;
+
   public function setUp(): void {
     parent::setUp();
     $config = CRM_Core_Config::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
Declare property on CRM_Core_ErrorTest.

Before
----------------------------------------
`$oldConfigAndLogDir` was created as a dynamic property, dynamic properties are deprecated in PHP 8.2

After
----------------------------------------
Property declared, PHP 8.2 compatiable.