### PR TITLE
[REF][PHP8.2] Declare property on CRM_Event_Import_Parser_ParticipantTest

### DIFF
--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -18,6 +18,11 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   protected $entity = 'Participant';
 
   /**
+   * @var int
+   */
+  protected $userJobID;
+
+  /**
    * Tears down the fixture, for example, closes a network connection.
    * This method is called after a test is executed.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Declare property on `CRM_Event_Import_Parser_ParticipantTest`

Before
----------------------------------------
`CRM_Event_Import_Parser_ParticipantTest` used `$userJobID` as a dynamic property. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
This test class is now PHP 8.2 compatiable. 