### PR TITLE
[REF][PHP8.2] Only set properties which exist within ArrayFormatTrait->loadArray()

### DIFF
--- a/Civi/Schema/Traits/ArrayFormatTrait.php
+++ b/Civi/Schema/Traits/ArrayFormatTrait.php
@@ -66,7 +66,7 @@ trait ArrayFormatTrait {
       if (is_callable([$this, $setter])) {
         $this->{$setter}($value);
       }
-      else {
+      elseif (!$strict || property_exists($this, $field)) {
         $this->{$field} = $value;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Only set properties which exist within the `loadArray` method on `Civi\Schema\Traits\ArrayFormatTrait`.

Before
----------------------------------------
A large number of the remaining PHP 8.2 test failures (approx 10%) are resulting from `api\v4\Entity\ConformanceTest`:

<img width="1030" alt="Screenshot 2023-03-11 at 11 44 03" src="https://user-images.githubusercontent.com/1931323/224482362-84812e4d-ecf3-410e-bacb-058c142d64c2.png">

This is because in the test there is this code:
```
$class = empty($field['custom_field_id']) ? FieldSpec::class : CustomFieldSpec::class;
$spec = (new $class($field['name'], $field['entity']))->loadArray($field, TRUE);
```

`$field` always contains `custom_field_id`, but only `CustomFieldSpec` has getters and setters for `customFieldId`. Therefore, when `loadArray` is called on `FieldSpec`, `custom_field_id` is passed in as `null`, which `loadArray` tries to set as a dyamic property on the object. As dynamic properties are deprecated in PHP 8.2, this therefore throws a deprecation error.

After
----------------------------------------
`loadArray` only writes properties if they actually exist; in other words `property_exists($this, $field)`. 

Technical Details
----------------------------------------
`Civi\Schema\Traits\ArrayFormatTrait::loadArray` is also used in `Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait`, but without setting `$strict` to true. I think this `ReflectiveWorkflowTrait` is also likely to cause problems on PHP 8.2, although this is not causing test failures at the moment and I've not spent much time looking into how this `WorkflowMessage` functionality works.

For now, there is only a functionality change when `$strict` is `true`. I expect `Civi\WorkflowMessage\FieldSpec` may at some stage need to be marked with the `#[AllowDynamicProperties] attribute` to ensure PHP 8.2 compatiability there.