### PR TITLE
[REF][PHP8.2] Fix use of self in callables deprecation

### DIFF
--- a/CRM/Dedupe/BAO/DedupeRuleGroup.php
+++ b/CRM/Dedupe/BAO/DedupeRuleGroup.php
@@ -342,7 +342,7 @@ class CRM_Dedupe_BAO_DedupeRuleGroup extends CRM_Dedupe_DAO_DedupeRuleGroup {
    * @param array $tableQueries
    */
   public static function orderByTableCount(array &$tableQueries): void {
-    uksort($tableQueries, 'self::isTableBigger');
+    uksort($tableQueries, [__CLASS__, 'isTableBigger']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix `Use of "self" in callables is deprecated` issue.

Before
----------------------------------------
Fixes use of a syntax deprecated in PHP 8.2.

More detail on the deprecation can be found at https://php.watch/versions/8.2/partially-supported-callable-deprecation.

After
----------------------------------------
Use of a PHP 8.2 valid syntax.

Comments
----------------------------------------
This fixes a very recent change made here https://github.com/civicrm/civicrm-core/commit/bafcc2468c2f7dc899937c64ee56c7f5301a519b. Ping @eileenmcnaughton, you are likely not aware that you used a syntax that is now deprecated in the latest version of PHP.

This is the same fix as was previously merged for another class here: https://github.com/civicrm/civicrm-core/pull/25625