### PR TITLE
[REF][PHP8.2] Refactor api_v3_ImTest with primary aim of improving PHP 8.2 compatiability

### DIFF
--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -17,18 +17,21 @@
  * @group headless
  */
 class api_v3_ImTest extends CiviUnitTestCase {
-  protected $_params;
-  protected $id;
-  protected $_entity;
+
+  const ENTITY = 'im';
+
+  /**
+   * @var array
+   */
+  protected $params;
 
   public function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);
 
-    $this->_entity = 'im';
-    $this->_contactID = $this->organizationCreate();
-    $this->_params = [
-      'contact_id' => $this->_contactID,
+    $contactID = $this->organizationCreate();
+    $this->params = [
+      'contact_id' => $contactID,
       'name' => 'My Yahoo IM Handle',
       'location_type_id' => 1,
       'provider_id' => 1,
@@ -44,9 +47,9 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testCreateIm($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument(self::ENTITY, 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
-    $this->getAndCheck($this->_params, $result['id'], $this->_entity);
+    $this->getAndCheck($this->params, $result['id'], self::ENTITY);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
 
@@ -59,11 +62,11 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testCreateImDefaultLocation($version) {
     $this->_apiversion = $version;
-    $params = $this->_params;
+    $params = $this->params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument(self::ENTITY, 'create', $params, __FUNCTION__, __FILE__);
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
-    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+    $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result['id']]);
   }
 
   /**
@@ -73,11 +76,11 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testGetIm($version) {
     $this->_apiversion = $version;
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->_params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess(self::ENTITY, 'create', $this->params);
+    $result = $this->callAPIAndDocument(self::ENTITY, 'get', $this->params, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
-    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+    $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result['id']]);
   }
 
   /**
@@ -87,10 +90,10 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testDeleteIm($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess(self::ENTITY, 'create', $this->params);
     $deleteParams = ['id' => $result['id']];
-    $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
-    $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
+    $this->callAPIAndDocument(self::ENTITY, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $checkDeleted = $this->callAPISuccess(self::ENTITY, 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }
 
@@ -98,10 +101,10 @@ class api_v3_ImTest extends CiviUnitTestCase {
    * Skip api4 test - delete behaves differently
    */
   public function testDeleteImInvalid() {
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $this->callAPISuccess(self::ENTITY, 'create', $this->params);
     $deleteParams = ['id' => 600];
-    $this->callAPIFailure($this->_entity, 'delete', $deleteParams);
-    $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
+    $this->callAPIFailure(self::ENTITY, 'delete', $deleteParams);
+    $checkDeleted = $this->callAPISuccess(self::ENTITY, 'get', []);
     $this->assertEquals(1, $checkDeleted['count']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Refactor api_v3_ImTest with primary aim of improving PHP 8.2 compatiability.

Before
----------------------------------------

1. `_contactID` was set as a dynamic property, despite not being used outside of the scope where it was set. Dynamic properties are deprecated in PHP 8.2.
2. The property `id` was declared, but not used.
3. Some of the properties did not use the current prefered naming conventions.

After
----------------------------------------

Properties tidied up. The class is now PHP 8.2 compatiable.