### PR TITLE
[REF][PHP8.2] Refactor api_v3_PriceFieldValueTest with primary aim of improving PHP 8.2 compatiability

### DIFF
--- a/tests/phpunit/api/v3/PriceFieldValueTest.php
+++ b/tests/phpunit/api/v3/PriceFieldValueTest.php
@@ -15,15 +15,38 @@
  */
 class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
   protected $_apiversion = 3;
-  protected $_params;
-  protected $id = 0;
-  protected $priceSetID = 0;
-  protected $_entity = 'price_field_value';
+
+  const ENTITY = 'price_field_value';
+
+  /**
+   * @var array
+   */
+  protected $params;
 
   /**
    * @var int
    */
-  protected $priceFieldID;
+  protected $membershipTypeID;
+
+  /**
+   * @var int
+   */
+  protected $priceSetID1;
+
+  /**
+   * @var int
+   */
+  protected $priceFieldID1;
+
+  /**
+   * @var int
+   */
+  protected $priceSetID2;
+
+  /**
+   * @var int
+   */
+  protected $priceFieldID2;
 
   /**
    * Setup function.
@@ -43,11 +66,11 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'is_reserved' => 1,
     ];
 
-    $price_set = $this->callAPISuccess('price_set', 'create', $priceSetParams);
-    $this->priceSetID = $price_set['id'];
+    $priceSet = $this->callAPISuccess('price_set', 'create', $priceSetParams);
+    $this->priceSetID1 = $priceSet['id'];
 
     $priceFieldParams = [
-      'price_set_id' => $this->priceSetID,
+      'price_set_id' => $this->priceSetID1,
       'name' => 'grassvariety',
       'label' => 'Grass Variety',
       'html_type' => 'Text',
@@ -55,9 +78,9 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
     $priceField = $this->callAPISuccess('price_field', 'create', $priceFieldParams);
-    $this->priceFieldID = $priceField['id'];
-    $this->_params = [
-      'price_field_id' => $this->priceFieldID,
+    $this->priceFieldID1 = $priceField['id'];
+    $this->params = [
+      'price_field_id' => $this->priceFieldID1,
       'name' => 'rye grass',
       'label' => 'juicy and healthy',
       'amount' => 1,
@@ -65,8 +88,9 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
     ];
 
     $membershipOrgId = $this->organizationCreate(NULL);
-    $this->_membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $membershipOrgId]);
-    $priceSetParams1 = [
+    $this->membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $membershipOrgId]);
+
+    $priceSetParams2 = [
       'name' => 'priceset',
       'title' => 'Priceset with Multiple Terms',
       'is_active' => 1,
@@ -75,18 +99,18 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'is_quick_config' => 1,
       'is_reserved' => 1,
     ];
-    $price_set1 = $this->callAPISuccess('price_set', 'create', $priceSetParams1);
-    $this->priceSetID1 = $price_set1['id'];
-    $priceFieldParams1 = [
-      'price_set_id' => $this->priceSetID1,
+    $priceSet2 = $this->callAPISuccess('price_set', 'create', $priceSetParams2);
+    $this->priceSetID2 = $priceSet2['id'];
+    $priceFieldParams2 = [
+      'price_set_id' => $this->priceSetID2,
       'name' => 'memtype',
       'label' => 'memtype',
       'html_type' => 'Radio',
       'is_enter_qty' => 1,
       'is_active' => 1,
     ];
-    $priceField1 = $this->callAPISuccess('price_field', 'create', $priceFieldParams1);
-    $this->priceFieldID1 = $priceField1['id'];
+    $priceField2 = $this->callAPISuccess('price_field', 'create', $priceFieldParams2);
+    $this->priceFieldID2 = $priceField2['id'];
   }
 
   /**
@@ -100,62 +124,61 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'civicrm_contribution',
     ];
     $this->quickCleanup($tablesToTruncate);
-    $this->membershipTypeDelete(['id' => $this->_membershipTypeID]);
+    $this->membershipTypeDelete(['id' => $this->membershipTypeID]);
     $this->callAPISuccess('PriceField', 'delete', [
       'id' => $this->priceFieldID1,
     ]);
-    $this->callAPISuccess('PriceSet', 'delete', [
+    $delete = $this->callAPISuccess('PriceSet', 'delete', [
       'id' => $this->priceSetID1,
     ]);
     $this->callAPISuccess('PriceField', 'delete', [
-      'id' => $this->priceFieldID,
+      'id' => $this->priceFieldID2,
     ]);
-    $delete = $this->callAPISuccess('PriceSet', 'delete', [
-      'id' => $this->priceSetID,
+    $this->callAPISuccess('PriceSet', 'delete', [
+      'id' => $this->priceSetID2,
     ]);
 
     $this->assertAPISuccess($delete);
   }
 
   public function testCreatePriceFieldValue() {
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument(self::ENTITY, 'create', $this->params, __FUNCTION__, __FILE__);
     $this->assertAPISuccess($result);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
-    $this->getAndCheck($this->_params, $result['id'], $this->_entity);
+    $this->getAndCheck($this->params, $result['id'], self::ENTITY);
   }
 
   public function testGetBasicPriceFieldValue() {
-    $createResult = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $this->id = $createResult['id'];
+    $createResult = $this->callAPISuccess(self::ENTITY, 'create', $this->params);
     $this->assertAPISuccess($createResult);
     $getParams = [
       'name' => 'contribution_amount',
     ];
-    $getResult = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $getResult = $this->callAPIAndDocument(self::ENTITY, 'get', $getParams, __FUNCTION__, __FILE__);
     $this->assertEquals(1, $getResult['count']);
     $this->callAPISuccess('price_field_value', 'delete', ['id' => $createResult['id']]);
   }
 
   public function testDeletePriceFieldValue() {
-    $startCount = $this->callAPISuccess($this->_entity, 'getcount', []);
-    $createResult = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $startCount = $this->callAPISuccess(self::ENTITY, 'getcount', []);
+    $createResult = $this->callAPISuccess(self::ENTITY, 'create', $this->params);
     $deleteParams = ['id' => $createResult['id']];
-    $deleteResult = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $deleteResult = $this->callAPIAndDocument(self::ENTITY, 'delete', $deleteParams, __FUNCTION__, __FILE__);
 
-    $endCount = $this->callAPISuccess($this->_entity, 'getcount', []);
+    $endCount = $this->callAPISuccess(self::ENTITY, 'getcount', []);
     $this->assertEquals($startCount, $endCount);
   }
 
   public function testGetFieldsPriceFieldValue() {
-    $result = $this->callAPISuccess($this->_entity, 'getfields', ['action' => 'create']);
+    $result = $this->callAPISuccess(self::ENTITY, 'getfields', ['action' => 'create']);
     $this->assertEquals(1, $result['values']['max_value']['type']);
   }
 
   public function testCreatePriceFieldValuewithMultipleTerms() {
     $params = [
-      'price_field_id' => $this->priceFieldID1,
-      'membership_type_id' => $this->_membershipTypeID,
+      'price_field_id' => $this->priceFieldID2,
+      'membership_type_id' => $this->membershipTypeID,
       'name' => 'memType1',
       'label' => 'memType1',
       'amount' => 90,
@@ -163,16 +186,16 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'is_active' => 1,
       'financial_type_id' => 2,
     ];
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPIAndDocument(self::ENTITY, 'create', $params, __FUNCTION__, __FILE__);
     $this->assertEquals($result['values'][$result['id']]['membership_num_terms'], 2);
     $this->assertEquals(1, $result['count']);
-    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
+    $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result['id']]);
   }
 
   public function testGetPriceFieldValuewithMultipleTerms() {
-    $params1 = [
-      'price_field_id' => $this->priceFieldID1,
-      'membership_type_id' => $this->_membershipTypeID,
+    $params2 = [
+      'price_field_id' => $this->priceFieldID2,
+      'membership_type_id' => $this->membershipTypeID,
       'name' => 'memType1',
       'label' => 'memType1',
       'amount' => 90,
@@ -181,8 +204,8 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'financial_type_id' => 2,
     ];
     $params2 = [
-      'price_field_id' => $this->priceFieldID1,
-      'membership_type_id' => $this->_membershipTypeID,
+      'price_field_id' => $this->priceFieldID2,
+      'membership_type_id' => $this->membershipTypeID,
       'name' => 'memType2',
       'label' => 'memType2',
       'amount' => 120,
@@ -190,12 +213,12 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'is_active' => 1,
       'financial_type_id' => 2,
     ];
-    $result1 = $this->callAPISuccess($this->_entity, 'create', $params1);
-    $result2 = $this->callAPISuccess($this->_entity, 'create', $params2);
-    $result = $this->callAPISuccess($this->_entity, 'get', ['price_field_id' => $this->priceFieldID1]);
+    $result1 = $this->callAPISuccess(self::ENTITY, 'create', $params2);
+    $result2 = $this->callAPISuccess(self::ENTITY, 'create', $params2);
+    $result = $this->callAPISuccess(self::ENTITY, 'get', ['price_field_id' => $this->priceFieldID2]);
     $this->assertEquals(2, $result['count']);
-    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result1['id']]);
-    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result2['id']]);
+    $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result1['id']]);
+    $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result2['id']]);
   }
 
   public function testCreatePriceFieldValueWithDisabledFinancialType() {
@@ -205,27 +228,27 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
     ];
     $financialType = $this->callAPISuccess('financial_type', 'create', $financialTypeParams);
     $params = [
-      'price_field_id' => $this->priceFieldID,
+      'price_field_id' => $this->priceFieldID1,
       'name' => 'DonType1',
       'label' => 'DonType1',
       'amount' => 90,
       'is_active' => 1,
       'financial_type_id' => $financialType['id'],
     ];
-    $this->callAPIFailure($this->_entity, 'create', $params);
+    $this->callAPIFailure(self::ENTITY, 'create', $params);
   }
 
   /**
    * This is the same as testCreatePriceFieldValue but where is_default = 1.
    */
   public function testCreatePriceFieldValueAsDefault() {
-    $params = $this->_params;
+    $params = $this->params;
     $params['is_default'] = 1;
-    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+    $result = $this->callAPISuccess(self::ENTITY, 'create', $params);
     $this->assertAPISuccess($result);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
-    $this->getAndCheck($params, $result['id'], $this->_entity);
+    $this->getAndCheck($params, $result['id'], self::ENTITY);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Refactor api_v3_PriceFieldValueTest with primary aim of improving PHP 8.2 compatiability

Before
----------------------------------------
1. Some properties were declared dynamically. Dynamic properties are deprecated in PHP 8.2. 
2. Some properties were declared but not used. (e.g. `id`).
3. `_entity` was declared as a property, but as it's value never changes a `const` is more appropriate.
4. The clas had the properties `priceSetID` and `priceSetID1`. To make things clearer these have been changed to `priceSetID1` and `priceSetID2`, so that both values are numbered, starting from 1.

After
----------------------------------------
The class has been refactored to resolve the above issues with the prior version.