### PR TITLE
(REF) Remove unused onPopupClose variables

### DIFF
--- a/CRM/Profile/Form/Edit.php
+++ b/CRM/Profile/Form/Edit.php
@@ -39,9 +39,6 @@ class CRM_Profile_Form_Edit extends CRM_Profile_Form {
   public function preProcess() {
     $this->_mode = CRM_Profile_Form::MODE_CREATE;
 
-    $this->_onPopupClose = CRM_Utils_Request::retrieve('onPopupClose', 'String', $this);
-    $this->assign('onPopupClose', $this->_onPopupClose);
-
     //set the context for the profile
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 

--- a/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
+++ b/templates/CRM/Profile/Page/MultipleRecordFieldsListing.tpl
@@ -104,7 +104,7 @@
         <br/><a accesskey="N" title="{ts 1=$customGroupTitle}Add %1 Record{/ts}" href="{crmURL p='civicrm/contact/view/cd/edit' q="reset=1&type=$ctype&groupID=$customGroupId&entityID=$contactId&cgcount=$newCgCount&multiRecordDisplay=single&mode=add"}"
          class="button action-item"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts 1=$customGroupTitle}Add %1 Record{/ts}</span></a>
       {else}
-        <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="reset=1&id=`$contactId`&multiRecord=add&gid=`$gid`&context=multiProfileDialog&onPopupClose=`$onPopupClose`"}"
+        <a accesskey="N" href="{crmURL p='civicrm/profile/edit' q="reset=1&id=`$contactId`&multiRecord=add&gid=`$gid`&context=multiProfileDialog"}"
          class="button action-item"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}Add New Record{/ts}</span></a>
       {/if}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused onPopupClose variables.

Before
----------------------------------------
Looking back through the Git history it appears that `onPopupClose` logic was mostly removed in https://github.com/civicrm/civicrm-core/commit/7ab9bfe887ee64514fcb27bd8b7fc413ebd38fab, a commit from 9 years ago.

This pull request removes the last references to `onPopupClose` which on their own have no purpose.

`$this->_onPopupClose` is set as a dynamic property, so this tidy up improves PHP 8.2 compatiability.

After
----------------------------------------
References to `onPopupClose` removed from CiviCRM code.

Comments
----------------------------------------
It is possible that a third party library is still setting or using `onPopupClose`, but I consider it unlikely. I have not gone as checking _universe_.