### PR TITLE
[REF][PHP8.2] Refactor use of pageParams properties

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -29,7 +29,6 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
   protected $_entity = 'Contribution';
   protected $_params;
   protected $_ids = [];
-  protected $_pageParams = [];
   protected $_userId;
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -829,7 +829,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *   Array of contribution page
    */
   public function contributionPageCreate($params = []) {
-    $this->_pageParams = array_merge([
+    $pageParams = array_merge([
       'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
       'currency' => 'USD',
@@ -839,7 +839,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'min_amount' => 10,
       'max_amount' => 1000,
     ], $params);
-    return $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
+    return $this->callAPISuccess('contribution_page', 'create', $pageParams);
   }
 
   /**

--- a/tests/phpunit/E2E/Extern/WidgetTest.php
+++ b/tests/phpunit/E2E/Extern/WidgetTest.php
@@ -100,7 +100,7 @@ class E2E_Extern_WidgetTest extends CiviEndToEndTestCase {
    *   Array of contribution page
    */
   public function contributionPageCreate($params = []) {
-    $this->_pageParams = array_merge([
+    $pageParams = array_merge([
       'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
       'currency' => 'USD',
@@ -111,7 +111,7 @@ class E2E_Extern_WidgetTest extends CiviEndToEndTestCase {
       'max_amount' => 1000,
       'goal_amount' => '10000',
     ], $params);
-    return $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
+    return $this->callAPISuccess('contribution_page', 'create', $pageParams);
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -38,7 +38,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   protected $entity = 'Contribution';
   protected $_params;
   protected $_ids = [];
-  protected $_pageParams = [];
+  protected $pageParams = [];
 
   /**
    * Payment processor ID (dummy processor).
@@ -97,7 +97,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'billing_mode' => 1,
     ];
     $this->paymentProcessorID = $this->processorCreate();
-    $this->_pageParams = [
+    $this->pageParams = [
       'title' => 'Test Contribution Page',
       'financial_type_id' => 1,
       'currency' => 'USD',
@@ -1072,7 +1072,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function testContributionCreateExample() {
     //make sure at least on page exists since there is a truncate in tear down
-    $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
+    $this->callAPISuccess('contribution_page', 'create', $this->pageParams);
     require_once 'api/v3/examples/Contribution/Create.ex.php';
     $result = contribution_create_example();
     $id = $result['id'];
@@ -1136,7 +1136,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function testCreateContributionOnline(): void {
     CRM_Financial_BAO_PaymentProcessor::create($this->_processorParams);
-    $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
+    $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->pageParams);
     $this->assertAPISuccess($contributionPage);
     $params = [
       'contact_id' => $this->individualID,
@@ -1201,8 +1201,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreateContributionPayLaterOnline(): void {
-    $this->_pageParams['is_pay_later'] = 1;
-    $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
+    $this->pageParams['is_pay_later'] = 1;
+    $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->pageParams);
     $this->assertAPISuccess($contributionPage);
     $params = [
       'contact_id' => $this->individualID,
@@ -1235,7 +1235,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    */
   public function testCreateContributionPendingOnline() {
     CRM_Financial_BAO_PaymentProcessor::create($this->_processorParams);
-    $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->_pageParams);
+    $contributionPage = $this->callAPISuccess('contribution_page', 'create', $this->pageParams);
     $this->assertAPISuccess($contributionPage);
     $params = [
       'contact_id' => $this->individualID,

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -27,7 +27,6 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
   public $debug = 0;
   protected $_params;
   protected $_ids = [];
-  protected $_pageParams = [];
 
   /**
    * Parameters to create payment processor.
@@ -72,17 +71,6 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
       'url_site' => 'http://dummy.com',
       'url_recur' => 'http://dummy.com',
       'billing_mode' => 1,
-    ];
-    $this->_pageParams = [
-      'title' => 'Test Contribution Page',
-      'financial_type_id' => 1,
-      'currency' => 'USD',
-      'financial_account_id' => 1,
-      'payment_processor' => $this->processorCreate(),
-      'is_active' => 1,
-      'is_allow_other_amount' => 1,
-      'min_amount' => 10,
-      'max_amount' => 1000,
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Refactor use of pageParams properties.

Before
----------------------------------------
`CiviUnitTestCase::contributionPageCreate` set a property `_pageParams` dynamically without needing to. Other classes using `contributionPageCreate` also in many cases set `_pageParams` which in most cases was not neccesary or used. 

After
----------------------------------------
Tidies up references to `_pageParams` so that properties and variables with this name are only set when actually necessary.

This improves PHP 8.2 support by reducing the number of uses of deprecated dynamic properties.