### PR TITLE
Remove dependence on cache/integration-tests

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -65,6 +65,7 @@ class CRM_Core_ClassLoader {
       'CiviTestSuite',
       'CiviUnitTestCase',
       'CiviEndToEndTestCase',
+      'CiviSimpleCacheTest',
       'Contact',
       'ContributionPage',
       'Custom',

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,6 @@
     "ext-fileinfo": "*"
   },
   "require-dev": {
-    "cache/integration-tests": "~0.17.0",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffb03895d9af38da0efae629556c6cf5",
+    "content-hash": "b23e2fe75cf3ec9fb2e7752846954735",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5569,131 +5569,6 @@
     ],
     "packages-dev": [
         {
-            "name": "cache/integration-tests",
-            "version": "0.17.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/integration-tests.git",
-                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
-                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
-                "shasum": ""
-            },
-            "require": {
-                "cache/tag-interop": "^1.0",
-                "php": ">=5.5.9",
-                "psr/cache": "~1.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "cache/cache": "^1.0",
-                "illuminate/cache": "^5.4|^5.5|^5.6",
-                "mockery/mockery": "^1.0",
-                "symfony/cache": "^3.4.31|^4.3.4|^5.0",
-                "symfony/phpunit-bridge": "^5.1",
-                "tedivm/stash": "^0.14"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cache\\IntegrationTests\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Scherer",
-                    "email": "aequasi@gmail.com",
-                    "homepage": "https://github.com/aequasi"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
-                }
-            ],
-            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
-            "homepage": "https://github.com/php-cache/integration-tests",
-            "keywords": [
-                "cache",
-                "psr16",
-                "psr6",
-                "test"
-            ],
-            "support": {
-                "issues": "https://github.com/php-cache/integration-tests/issues",
-                "source": "https://github.com/php-cache/integration-tests/tree/0.17.0"
-            },
-            "time": "2020-11-03T12:52:23+00:00"
-        },
-        {
-            "name": "cache/tag-interop",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/tag-interop.git",
-                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
-                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "psr/cache": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Cache\\TagInterop\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com",
-                    "homepage": "https://github.com/nicolas-grekas"
-                }
-            ],
-            "description": "Framework interoperable interfaces for tags",
-            "homepage": "http://www.php-cache.com/en/latest/",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr6",
-                "tag"
-            ],
-            "support": {
-                "issues": "https://github.com/php-cache/tag-interop/issues",
-                "source": "https://github.com/php-cache/tag-interop/tree/master"
-            },
-            "time": "2017-03-13T09:14:27+00:00"
-        },
-        {
             "name": "doctrine/instantiator",
             "version": "1.5.0",
             "source": {
@@ -6408,55 +6283,6 @@
                 }
             ],
             "time": "2023-02-04T13:37:15+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
-            },
-            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -7550,5 +7376,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/tests/phpunit/CiviTest/CiviSimpleCacheTest.php
+++ b/tests/phpunit/CiviTest/CiviSimpleCacheTest.php
@@ -1,0 +1,744 @@
+<?php
+
+/**
+ * This file has been pulled out of cache/integration-tests
+ * ********************************************************
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+abstract class CiviSimpleCacheTest extends TestCase {
+  /**
+   * @var array
+   * with functionName => reason.
+   */
+  protected $skippedTests = [];
+
+  /**
+   * @var CiviSimpleCacheTest
+   */
+  protected $cache;
+
+  /**
+   * @return CiviSimpleCacheTest that is used in the tests
+   */
+  abstract public function createSimpleCache();
+
+  /**
+   * Advance time perceived by the cache for the purposes of testing TTL.
+   *
+   * The default implementation sleeps for the specified duration,
+   * but subclasses are encouraged to override this,
+   * adjusting a mocked time possibly set up in {@link createSimpleCache()},
+   * to speed up the tests.
+   *
+   * @param int $seconds
+   */
+  public function advanceTime($seconds) {
+    sleep($seconds);
+  }
+
+  /**
+   * @before
+   */
+  public function setupService() {
+    $this->cache = $this->createSimpleCache();
+  }
+
+  /**
+   * @after
+   */
+  public function tearDownService() {
+    if ($this->cache !== NULL) {
+      $this->cache->clear();
+    }
+  }
+
+  /**
+   * Data provider for invalid cache keys.
+   *
+   * @return array
+   */
+  public static function invalidKeys() {
+    return array_merge(
+      self::invalidArrayKeys(),
+      [
+        [2],
+      ]
+    );
+  }
+
+  /**
+   * Data provider for invalid array keys.
+   *
+   * @return array
+   */
+  public static function invalidArrayKeys() {
+    return [
+      [''],
+      [TRUE],
+      [FALSE],
+      [NULL],
+      [2.5],
+      ['{str'],
+      ['rand{'],
+      ['rand{str'],
+      ['rand}str'],
+      ['rand(str'],
+      ['rand)str'],
+      ['rand/str'],
+      ['rand\\str'],
+      ['rand@str'],
+      ['rand:str'],
+      [new \stdClass()],
+      [['array']],
+    ];
+  }
+
+  /**
+   * @return array
+   */
+  public static function invalidTtl() {
+    return [
+      [''],
+      [TRUE],
+      [FALSE],
+      ['abc'],
+      [2.5],
+      // can be casted to a int
+      [' 1'],
+      // can be casted to a int
+      ['12foo'],
+      // can be interpreted as hex
+      ['025'],
+      [new \stdClass()],
+      [['array']],
+    ];
+  }
+
+  /**
+   * Data provider for valid keys.
+   *
+   * @return array
+   */
+  public static function validKeys() {
+    return [
+      ['AbC19_.'],
+      ['1234567890123456789012345678901234567890123456789012345678901234'],
+    ];
+  }
+
+  /**
+   * Data provider for valid data to store.
+   *
+   * @return array
+   */
+  public static function validData() {
+    return [
+      ['AbC19_.'],
+      [4711],
+      [47.11],
+      [TRUE],
+      [NULL],
+      [['key' => 'value']],
+      [new \stdClass()],
+    ];
+  }
+
+  public function testSet() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $result = $this->cache->set('key', 'value');
+    $this->assertTrue($result, 'set() must return true if success');
+    $this->assertEquals('value', $this->cache->get('key'));
+  }
+
+  /**
+   * @medium
+   */
+  public function testSetTtl() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $result = $this->cache->set('key1', 'value', 2);
+    $this->assertTrue($result, 'set() must return true if success');
+    $this->assertEquals('value', $this->cache->get('key1'));
+
+    $this->cache->set('key2', 'value', new \DateInterval('PT2S'));
+    $this->assertEquals('value', $this->cache->get('key2'));
+
+    $this->advanceTime(3);
+
+    $this->assertNull($this->cache->get('key1'), 'Value must expire after ttl.');
+    $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
+  }
+
+  public function testSetExpiredTtl() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set('key0', 'value');
+    $this->cache->set('key0', 'value', 0);
+    $this->assertNull($this->cache->get('key0'));
+    $this->assertFalse($this->cache->has('key0'));
+
+    $this->cache->set('key1', 'value', -1);
+    $this->assertNull($this->cache->get('key1'));
+    $this->assertFalse($this->cache->has('key1'));
+  }
+
+  public function testGet() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->assertNull($this->cache->get('key'));
+    $this->assertEquals('foo', $this->cache->get('key', 'foo'));
+
+    $this->cache->set('key', 'value');
+    $this->assertEquals('value', $this->cache->get('key', 'foo'));
+  }
+
+  public function testDelete() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->assertTrue($this->cache->delete('key'), 'Deleting a value that does not exist should return true');
+    $this->cache->set('key', 'value');
+    $this->assertTrue($this->cache->delete('key'), 'Delete must return true on success');
+    $this->assertNull($this->cache->get('key'), 'Values must be deleted on delete()');
+  }
+
+  public function testClear() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->assertTrue($this->cache->clear(), 'Clearing an empty cache should return true');
+    $this->cache->set('key', 'value');
+    $this->assertTrue($this->cache->clear(), 'Delete must return true on success');
+    $this->assertNull($this->cache->get('key'), 'Values must be deleted on clear()');
+  }
+
+  public function testSetMultiple() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $result = $this->cache->setMultiple(['key0' => 'value0', 'key1' => 'value1']);
+    $this->assertTrue($result, 'setMultiple() must return true if success');
+    $this->assertEquals('value0', $this->cache->get('key0'));
+    $this->assertEquals('value1', $this->cache->get('key1'));
+  }
+
+  public function testSetMultipleWithIntegerArrayKey() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $result = $this->cache->setMultiple(['0' => 'value0']);
+    $this->assertTrue($result, 'setMultiple() must return true if success');
+    $this->assertEquals('value0', $this->cache->get('0'));
+  }
+
+  /**
+   * @medium
+   */
+  public function testSetMultipleTtl() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->setMultiple(['key2' => 'value2', 'key3' => 'value3'], 2);
+    $this->assertEquals('value2', $this->cache->get('key2'));
+    $this->assertEquals('value3', $this->cache->get('key3'));
+
+    $this->cache->setMultiple(['key4' => 'value4'], new \DateInterval('PT2S'));
+    $this->assertEquals('value4', $this->cache->get('key4'));
+
+    $this->advanceTime(3);
+    $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
+    $this->assertNull($this->cache->get('key3'), 'Value must expire after ttl.');
+    $this->assertNull($this->cache->get('key4'), 'Value must expire after ttl.');
+  }
+
+  public function testSetMultipleExpiredTtl() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->setMultiple(['key0' => 'value0', 'key1' => 'value1'], 0);
+    $this->assertNull($this->cache->get('key0'));
+    $this->assertNull($this->cache->get('key1'));
+  }
+
+  public function testSetMultipleWithGenerator() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $gen = function () {
+      yield 'key0' => 'value0';
+      yield 'key1' => 'value1';
+    };
+
+    $this->cache->setMultiple($gen());
+    $this->assertEquals('value0', $this->cache->get('key0'));
+    $this->assertEquals('value1', $this->cache->get('key1'));
+  }
+
+  public function testGetMultiple() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $result = $this->cache->getMultiple(['key0', 'key1']);
+    $keys   = [];
+    foreach ($result as $i => $r) {
+      $keys[] = $i;
+      $this->assertNull($r);
+    }
+    sort($keys);
+    $this->assertSame(['key0', 'key1'], $keys);
+
+    $this->cache->set('key3', 'value');
+    $result = $this->cache->getMultiple(['key2', 'key3', 'key4'], 'foo');
+    $keys   = [];
+    foreach ($result as $key => $r) {
+      $keys[] = $key;
+      if ($key === 'key3') {
+        $this->assertEquals('value', $r);
+      }
+      else {
+        $this->assertEquals('foo', $r);
+      }
+    }
+    sort($keys);
+    $this->assertSame(['key2', 'key3', 'key4'], $keys);
+  }
+
+  public function testGetMultipleWithGenerator() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $gen = function () {
+      yield 1 => 'key0';
+      yield 1 => 'key1';
+    };
+
+    $this->cache->set('key0', 'value0');
+    $result = $this->cache->getMultiple($gen());
+    $keys   = [];
+    foreach ($result as $key => $r) {
+      $keys[] = $key;
+      if ($key === 'key0') {
+        $this->assertEquals('value0', $r);
+      }
+      elseif ($key === 'key1') {
+        $this->assertNull($r);
+      }
+      else {
+        $this->assertFalse(TRUE, 'This should not happend');
+      }
+    }
+    sort($keys);
+    $this->assertSame(['key0', 'key1'], $keys);
+    $this->assertEquals('value0', $this->cache->get('key0'));
+    $this->assertNull($this->cache->get('key1'));
+  }
+
+  public function testDeleteMultiple() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->assertTrue($this->cache->deleteMultiple([]), 'Deleting a empty array should return true');
+    $this->assertTrue($this->cache->deleteMultiple(['key']), 'Deleting a value that does not exist should return true');
+
+    $this->cache->set('key0', 'value0');
+    $this->cache->set('key1', 'value1');
+    $this->assertTrue($this->cache->deleteMultiple(['key0', 'key1']), 'Delete must return true on success');
+    $this->assertNull($this->cache->get('key0'), 'Values must be deleted on deleteMultiple()');
+    $this->assertNull($this->cache->get('key1'), 'Values must be deleted on deleteMultiple()');
+  }
+
+  public function testDeleteMultipleGenerator() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $gen = function () {
+      yield 1 => 'key0';
+      yield 1 => 'key1';
+    };
+    $this->cache->set('key0', 'value0');
+    $this->assertTrue($this->cache->deleteMultiple($gen()), 'Deleting a generator should return true');
+
+    $this->assertNull($this->cache->get('key0'), 'Values must be deleted on deleteMultiple()');
+    $this->assertNull($this->cache->get('key1'), 'Values must be deleted on deleteMultiple()');
+  }
+
+  public function testHas() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->assertFalse($this->cache->has('key0'));
+    $this->cache->set('key0', 'value0');
+    $this->assertTrue($this->cache->has('key0'));
+  }
+
+  public function testBasicUsageWithLongKey() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $key = str_repeat('a', 300);
+
+    $this->assertFalse($this->cache->has($key));
+    $this->assertTrue($this->cache->set($key, 'value'));
+
+    $this->assertTrue($this->cache->has($key));
+    $this->assertSame('value', $this->cache->get($key));
+
+    $this->assertTrue($this->cache->delete($key));
+
+    $this->assertFalse($this->cache->has($key));
+  }
+
+  /**
+   * @dataProvider invalidKeys
+   */
+  public function testGetInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->get($key);
+  }
+
+  /**
+   * @dataProvider invalidKeys
+   */
+  public function testGetMultipleInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $result = $this->cache->getMultiple(['key1', $key, 'key2']);
+  }
+
+  public function testGetMultipleNoIterable() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $result = $this->cache->getMultiple('key');
+  }
+
+  /**
+   * @dataProvider invalidKeys
+   */
+  public function testSetInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->set($key, 'foobar');
+  }
+
+  /**
+   * @dataProvider invalidArrayKeys
+   */
+  public function testSetMultipleInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $values = function () use ($key) {
+      yield 'key1' => 'foo';
+      yield $key => 'bar';
+      yield 'key2' => 'baz';
+    };
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->setMultiple($values());
+  }
+
+  public function testSetMultipleNoIterable() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->setMultiple('key');
+  }
+
+  /**
+   * @dataProvider invalidKeys
+   */
+  public function testHasInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->has($key);
+  }
+
+  /**
+   * @dataProvider invalidKeys
+   */
+  public function testDeleteInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->delete($key);
+  }
+
+  /**
+   * @dataProvider invalidKeys
+   */
+  public function testDeleteMultipleInvalidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->deleteMultiple(['key1', $key, 'key2']);
+  }
+
+  public function testDeleteMultipleNoIterable() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->deleteMultiple('key');
+  }
+
+  /**
+   * @dataProvider invalidTtl
+   */
+  public function testSetInvalidTtl($ttl) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->set('key', 'value', $ttl);
+  }
+
+  /**
+   * @dataProvider invalidTtl
+   */
+  public function testSetMultipleInvalidTtl($ttl) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->expectException('Psr\SimpleCache\InvalidArgumentException');
+    $this->cache->setMultiple(['key' => 'value'], $ttl);
+  }
+
+  public function testNullOverwrite() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set('key', 5);
+    $this->cache->set('key', NULL);
+
+    $this->assertNull($this->cache->get('key'), 'Setting null to a key must overwrite previous value');
+  }
+
+  public function testDataTypeString() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set('key', '5');
+    $result = $this->cache->get('key');
+    $this->assertTrue('5' === $result, 'Wrong data type. If we store a string we must get an string back.');
+    $this->assertTrue(is_string($result), 'Wrong data type. If we store a string we must get an string back.');
+  }
+
+  public function testDataTypeInteger() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set('key', 5);
+    $result = $this->cache->get('key');
+    $this->assertTrue(5 === $result, 'Wrong data type. If we store an int we must get an int back.');
+    $this->assertTrue(is_int($result), 'Wrong data type. If we store an int we must get an int back.');
+  }
+
+  public function testDataTypeFloat() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $float = 1.23456789;
+    $this->cache->set('key', $float);
+    $result = $this->cache->get('key');
+    $this->assertTrue(is_float($result), 'Wrong data type. If we store float we must get an float back.');
+    $this->assertEquals($float, $result);
+  }
+
+  public function testDataTypeBoolean() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set('key', FALSE);
+    $result = $this->cache->get('key');
+    $this->assertTrue(is_bool($result), 'Wrong data type. If we store boolean we must get an boolean back.');
+    $this->assertFalse($result);
+    $this->assertTrue($this->cache->has('key'), 'has() should return true when true are stored. ');
+  }
+
+  public function testDataTypeArray() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $array = ['a' => 'foo', 2 => 'bar'];
+    $this->cache->set('key', $array);
+    $result = $this->cache->get('key');
+    $this->assertTrue(is_array($result), 'Wrong data type. If we store array we must get an array back.');
+    $this->assertEquals($array, $result);
+  }
+
+  public function testDataTypeObject() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $object    = new \stdClass();
+    $object->a = 'foo';
+    $this->cache->set('key', $object);
+    $result = $this->cache->get('key');
+    $this->assertTrue(is_object($result), 'Wrong data type. If we store object we must get an object back.');
+    $this->assertEquals($object, $result);
+  }
+
+  public function testBinaryData() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $data = '';
+    for ($i = 0; $i < 256; $i++) {
+      $data .= chr($i);
+    }
+
+    $array = ['a' => 'foo', 2 => 'bar'];
+    $this->cache->set('key', $data);
+    $result = $this->cache->get('key');
+    $this->assertTrue($data === $result, 'Binary data must survive a round trip.');
+  }
+
+  /**
+   * @dataProvider validKeys
+   */
+  public function testSetValidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set($key, 'foobar');
+    $this->assertEquals('foobar', $this->cache->get($key));
+  }
+
+  /**
+   * @dataProvider validKeys
+   */
+  public function testSetMultipleValidKeys($key) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->setMultiple([$key => 'foobar']);
+    $result = $this->cache->getMultiple([$key]);
+    $keys   = [];
+    foreach ($result as $i => $r) {
+      $keys[] = $i;
+      $this->assertEquals($key, $i);
+      $this->assertEquals('foobar', $r);
+    }
+    $this->assertSame([$key], $keys);
+  }
+
+  /**
+   * @dataProvider validData
+   */
+  public function testSetValidData($data) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->set('key', $data);
+    $this->assertEquals($data, $this->cache->get('key'));
+  }
+
+  /**
+   * @dataProvider validData
+   */
+  public function testSetMultipleValidData($data) {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $this->cache->setMultiple(['key' => $data]);
+    $result = $this->cache->getMultiple(['key']);
+    $keys   = [];
+    foreach ($result as $i => $r) {
+      $keys[] = $i;
+      $this->assertEquals($data, $r);
+    }
+    $this->assertSame(['key'], $keys);
+  }
+
+  public function testObjectAsDefaultValue() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $obj      = new \stdClass();
+    $obj->foo = 'value';
+    $this->assertEquals($obj, $this->cache->get('key', $obj));
+  }
+
+  public function testObjectDoesNotChangeInCache() {
+    if (isset($this->skippedTests[__FUNCTION__])) {
+      $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+    }
+
+    $obj      = new \stdClass();
+    $obj->foo = 'value';
+    $this->cache->set('key', $obj);
+    $obj->foo = 'changed';
+
+    $cacheObject = $this->cache->get('key');
+    $this->assertEquals('value', $cacheObject->foo, 'Object in cache should not have their values changed.');
+  }
+
+}

--- a/tests/phpunit/E2E/Cache/CacheTestCase.php
+++ b/tests/phpunit/E2E/Cache/CacheTestCase.php
@@ -14,7 +14,7 @@
  *
  * @group e2e
  */
-abstract class E2E_Cache_CacheTestCase extends \Cache\IntegrationTests\SimpleCacheTest implements \Civi\Test\EndToEndInterface {
+abstract class E2E_Cache_CacheTestCase extends CiviSimpleCacheTest implements \Civi\Test\EndToEndInterface {
 
   const MAX_KEY = 255;
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove dependence on abandoned package cache/integration-tests which is only used in unit tests.

Before
----------------------------------------
The problem is the cache tests fail in the drupal 8 runs.

After
----------------------------------------
* Runs should be fixed.
* Less unused/abandoned stuff.

Technical Details
----------------------------------------


Comments
----------------------------------------
@totten @seamuslee001 This is what I was a-thinkin'.
