### PR TITLE
Php8.2 fixes in unit tests

### DIFF
--- a/tests/phpunit/CRM/Pledge/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Pledge/Form/SearchTest.php
@@ -8,8 +8,7 @@ class CRM_Pledge_Form_SearchTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
-    $this->individualID = $this->individualCreate();
-    $this->pledgeCreate(['contact_id' => $this->individualID]);
+    $this->pledgeCreate(['contact_id' => $this->individualCreate()]);
   }
 
   public function tearDown(): void {
@@ -25,7 +24,7 @@ class CRM_Pledge_Form_SearchTest extends CiviUnitTestCase {
   /**
    *  Test submitted the search form.
    */
-  public function testSearch() {
+  public function testSearch(): void {
     $form = new CRM_Pledge_Form_Search();
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $form->controller = new CRM_Pledge_Controller_Search();


### PR DESCRIPTION
Overview
----------------------------------------
Php8.2 fixes in unit tests

Before
----------------------------------------
Undefined property
```
 $this->individualID = $this->individualCreate();
```


After
----------------------------------------
Removed

Technical Details
----------------------------------------
@braders inspired me to clean up a couple more

Comments
----------------------------------------