### PR TITLE
[PHP8.2] [Test] Remove use of (often undeclared) property `_invoiceID` in tests & one instance of `paymentProcessorID2`

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -17,7 +17,6 @@ use Civi\Api4\ContributionRecur;
  */
 class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   protected $_contributionID;
-  protected $_invoiceID = 'c2r9c15f7be20b4f3fef1f77e4c37424';
   protected $_financialTypeID = 1;
   protected $_contactID;
   protected $_contributionRecurID;
@@ -76,7 +75,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->_paymentProcessorID,
       'contact_id' => $this->_contactID,
       'trxn_id' => NULL,
-      'invoice_id' => $this->_invoiceID,
+      'invoice_id' => 'xyz',
       'contribution_status_id' => $pendingStatusID,
       'is_email_receipt' => TRUE,
     ];
@@ -119,7 +118,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testIPNPaymentRecurSuccess(): void {
-    $this->setupRecurringPaymentProcessorTransaction([], ['total_amount' => '15.00']);
+    $this->setupRecurringPaymentProcessorTransaction([], ['total_amount' => '15.00', 'contribution_page_id' => $this->_contributionPageID]);
     $mut = new CiviMailUtils($this, TRUE);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
     $paypalIPN->main();
@@ -204,11 +203,11 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   /**
    * Get IPN style details for an incoming recurring transaction.
    */
-  public function getPaypalRecurTransaction() {
+  public function getPaypalRecurTransaction(): array {
     return [
       'contactID' => $this->_contactID,
       'contributionID' => $this->_contributionID,
-      'invoice' => $this->_invoiceID,
+      'invoice' => 'xyz',
       'contributionRecurID' => $this->_contributionRecurID,
       'mc_gross' => '15.00',
       'module' => 'contribute',
@@ -216,7 +215,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'payment_status' => 'Completed',
       'receiver_email' => 'sunil._1183377782_biz_api1.webaccess.co.in',
       'txn_type' => 'subscr_payment',
-      'last_name' => 'Roberty',
+      'last_name' => 'Roberts',
       'payment_fee' => '0.63',
       'first_name' => 'Robert',
       'txn_id' => '8XA571746W2698126',
@@ -231,7 +230,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     return [
       'contactID' => $this->_contactID,
       'contributionID' => $this->_contributionID,
-      'invoice' => $this->_invoiceID,
+      'invoice' => 'xyz',
       'mc_gross' => '100.00',
       'mc_fee' => '5.00',
       'settle_amount' => '95.00',
@@ -272,7 +271,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->_paymentProcessorID,
       'contact_id' => $this->_contactID,
       'trxn_id' => NULL,
-      'invoice_id' => $this->_invoiceID,
+      'invoice_id' => 'xyz',
       'contribution_status_id' => $pendingStatusID,
       'is_email_receipt' => TRUE,
     ];
@@ -307,7 +306,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'payment_processor_id' => $this->_paymentProcessorID,
       'contact_id' => $this->_contactID,
       'trxn_id' => NULL,
-      'invoice_id' => $this->_invoiceID,
+      'invoice_id' => 'xyz',
       'contribution_status_id' => $pendingStatusID,
       'is_email_receipt' => TRUE,
     ];

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -200,10 +200,10 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
    * @return array
    *   array representing a Paypal IPN POST
    */
-  public function getPaypalExpressTransactionIPN() {
+  public function getPaypalExpressTransactionIPN(): array {
     return [
       'mc_gross' => '200.00',
-      'invoice' => $this->_invoiceID,
+      'invoice' => 'xyz',
       'protection_eligibility' => 'Eligible',
       'address_status' => 'confirmer',
       'payer_id' => 'ZYXHBZSULPQE3',
@@ -267,7 +267,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'payment_status' => 'Completed',
       'product_name' => '5 Per 1 month',
       'charset' => 'windows-1252',
-      'rp_invoice_id' => 'i=' . $this->_invoiceID . '&m=&c=&r=&b=&p=' . $this->_contributionPageID,
+      'rp_invoice_id' => 'i=xyz&m=&c=&r=&b=&p=' . $this->_contributionPageID,
       'recurring_payment_id' => 'I-3EEUC094KYQW',
       'address_zip' => '90210',
       'first_name' => 'Alanna',
@@ -308,7 +308,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
   /**
    * Get IPN style details for an incoming recurring transaction.
    */
-  public function getPaypalProRecurTransaction() {
+  public function getPaypalProRecurTransaction(): array {
     return [
       'amount' => '15.00',
       'initial_payment_amount' => '0.00',
@@ -337,7 +337,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'amount_per_cycle' => '15.00',
       'mc_gross' => '15.00',
       'payment_date' => '03:59:05 Jul 14, 2013 PDT',
-      'rp_invoice_id' => 'i=' . $this->_invoiceID . '&m=contribute&c=' . $this->_contactID . '&r=' . $this->_contributionRecurID . '&b=' . $this->_contributionID . '&p=null',
+      'rp_invoice_id' => 'i=xyz&m=contribute&c=' . $this->_contactID . '&r=' . $this->_contributionRecurID . '&b=' . $this->_contributionID . '&p=null',
       'payment_status' => 'Completed',
       'business' => 'nowhere@civicrm.org',
       'last_name' => 'Roberty',
@@ -367,7 +367,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
   /**
    * Test IPN response update for a paypal express profile creation confirmation.
    */
-  public function testIPNPaymentExpressRecurSuccess() {
+  public function testIPNPaymentExpressRecurSuccess(): void {
     $this->setupRecurringPaymentProcessorTransaction(['processor_id' => '']);
     $paypalIPN = new CRM_Core_Payment_PayPalProIPN($this->getPaypalExpressRecurSubscriptionConfirmation());
     $paypalIPN->main();
@@ -388,7 +388,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'next_payment_date' => '03:00:00 May 09, 2018 PDT',
       'residence_country' => 'GB',
       'initial_payment_amount' => '0.00',
-      'rp_invoice_id' => 'i=' . $this->_invoiceID
+      'rp_invoice_id' => 'i=xyz'
       . '&m=&c=' . $this->_contributionID
       . '&r=' . $this->_contributionRecurID
       . '&b=' . $this->_contactID

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -425,7 +425,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->contactMembershipCreate(['contact_id' => $this->contactIDs[0]]);
 
     $this->_contactID = $this->contactIDs[0];
-    $this->_invoiceID = 1234;
     $this->_contributionPageID = NULL;
     $this->_paymentProcessorID = $this->paymentProcessorCreate();
     $this->setupMembershipRecurringPaymentProcessorTransaction();

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -23,7 +23,6 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
    */
   public function testSelectorGetRows(): void {
     $this->_contactID = $this->individualCreate();
-    $this->_invoiceID = 1234;
     $this->_contributionPageID = NULL;
     $this->_paymentProcessorID = $this->paymentProcessorCreate();
     $this->setupMembershipRecurringPaymentProcessorTransaction();

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -36,7 +36,7 @@ trait CRMTraits_Financial_OrderTrait {
       'installments' => 5,
       'frequency_unit' => 'Month',
       'frequency_interval' => 1,
-      'invoice_id' => $this->_invoiceID,
+      'invoice_id' => 'xyz',
       'contribution_status_id' => 2,
       'payment_processor_id' => $this->_paymentProcessorID,
       // processor provided ID - use contact ID as proxy.

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1849,7 +1849,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   /**
    * Recreate default membership types.
    *
-   * @throws \CRM_Core_Exception
+   * @noinspection PhpUnhandledExceptionInspection
    */
   public function restoreMembershipTypes(): void {
     MembershipType::delete(FALSE)->addWhere('id', '>', 0)->execute();
@@ -2330,7 +2330,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->ids['campaign'][0] = $this->callAPISuccess('Campaign', 'create', ['title' => 'get the money'])['id'];
     $contributionParams = array_merge([
       'total_amount' => '200',
-      'invoice_id' => $this->_invoiceID,
+      'invoice_id' => 'xyz',
       'financial_type_id' => 'Donation',
       'contact_id' => $this->_contactID,
       'contribution_page_id' => $this->_contributionPageID,
@@ -2348,8 +2348,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'installments' => 5,
       'frequency_unit' => 'Month',
       'frequency_interval' => 1,
-      'invoice_id' => $this->_invoiceID,
       'contribution_status_id' => 2,
+      'invoice_id' => $contributionParams['invoice_id'],
       'payment_processor_id' => $this->_paymentProcessorID,
       // processor provided ID - use contact ID as proxy.
       'processor_id' => $this->_contactID,
@@ -2364,10 +2364,12 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * We don't have a good way to set up a recurring contribution with a membership so let's just do one then alter it
    *
    * @param array $params Optionally modify params for membership/recur (duration_unit/frequency_unit)
+   * @param array $contributionParams Parameters to pass to contribution create.
    *
-   * @throws \CRM_Core_Exception
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
    */
-  public function setupMembershipRecurringPaymentProcessorTransaction($params = []): void {
+  public function setupMembershipRecurringPaymentProcessorTransaction(array $params = [], array $contributionParams = []): void {
     $membershipParams = $recurParams = [];
     if (!empty($params['duration_unit'])) {
       $membershipParams['duration_unit'] = $params['duration_unit'];
@@ -2389,7 +2391,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       ]);
     }
 
-    $this->setupRecurringPaymentProcessorTransaction($recurParams, [
+    $this->setupRecurringPaymentProcessorTransaction($recurParams, array_merge($contributionParams, [
       'line_items' => [
         [
           'line_item' => [
@@ -2409,7 +2411,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
           ],
         ],
       ],
-    ]);
+    ]));
     $this->ids['membership'] = LineItem::get()
       ->addWhere('contribution_id', '=', $this->ids['Contribution'][0])
       ->addWhere('entity_table', '=', 'civicrm_membership')


### PR DESCRIPTION
Overview
----------------------------------------
Remove use of (often undeclared) property `_invoiceID` in tests & one instance of `paymentProcessorID2`

Before
----------------------------------------
Invoice ID is being set for e-notice purposes within test setup functions but is not really relevant to the tests

After
----------------------------------------
Removed to the extent possible

Technical Details
----------------------------------------

Comments
----------------------------------------
