### PR TITLE
[PHP8.2] declare deleteMessage on `entityFormTrait`

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -70,13 +70,6 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
   }
 
   /**
-   * Deletion message to be assigned to the form.
-   *
-   * @var string
-   */
-  protected $deleteMessage;
-
-  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -31,6 +31,13 @@ trait CRM_Core_Form_EntityFormTrait {
   protected $_entitySubTypeId = NULL;
 
   /**
+   * Deletion message to be assigned to the form.
+   *
+   * @var string
+   */
+  protected $deleteMessage;
+
+  /**
    * Get entity fields for the entity to be added to the form.
    *
    * @return array

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -33,6 +33,9 @@ trait CRM_Core_Form_EntityFormTrait {
   /**
    * Deletion message to be assigned to the form.
    *
+   * Depending on the screen, the deletionMessage may be plain-text (`{$deletionMessage|escape}`)
+   * or HTML (`{$deletionMessage|smarty:nodefaults}`). Be sure your controller+template agree.
+   *
    * @var string
    */
   protected $deleteMessage;

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -32,13 +32,6 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
   protected $entityFields = [];
 
   /**
-   * Deletion message to be assigned to the form.
-   *
-   * @var string
-   */
-  protected $deleteMessage;
-
-  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -122,13 +122,6 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
   }
 
   /**
-   * Deletion message to be assigned to the form.
-   *
-   * @var string
-   */
-  protected $deleteMessage;
-
-  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {

--- a/CRM/Price/Form/Set.php
+++ b/CRM/Price/Form/Set.php
@@ -77,13 +77,6 @@ class CRM_Price_Form_Set extends CRM_Core_Form {
   }
 
   /**
-   * Deletion message to be assigned to the form.
-   *
-   * @var string
-   */
-  protected $deleteMessage;
-
-  /**
    * Set the delete message.
    *
    * We do this from the constructor in order to do a translation.

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -41,13 +41,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
   protected $entityFields = [];
 
   /**
-   * Deletion message to be assigned to the form.
-   *
-   * @var string
-   */
-  protected $deleteMessage;
-
-  /**
    * @var bool
    */
   public $submitOnce = TRUE;

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -66,7 +66,7 @@
     {if $action eq 8}
     <div class="messages status no-popup">
       {icon icon="fa-info-circle"}{/icon}
-      {$deleteMessage}
+      {$deleteMessage|smarty:nodefaults}
     </div>
     {else}
       <table class="form-layout-compressed">


### PR DESCRIPTION
Overview
----------------------------------------
Php8.2 declare deleteMessage on `entityFormTrait`

Before
----------------------------------------
Property used in a `getter` but not declared. It is declared on some but not all of the classes that implement the trait

After
----------------------------------------
Declared on the trait, removed from implementing classes

Technical Details
----------------------------------------

Comments
----------------------------------------
