### PR TITLE
Logging ReportDetail: update breadcrumb to use CiviCRM Home for disambiguation

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -80,7 +80,7 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
     CRM_Utils_System::resetBreadCrumb();
     $breadcrumb = [
       [
-        'title' => ts('Home'),
+        'title' => ts('Home', ['context' => 'menu']),
         'url' => CRM_Utils_System::url(),
       ],
       [


### PR DESCRIPTION
… with the "Home" Location Type translation.

Overview
----------------------------------------

This was changed a while back in CiviCRM, when using "Home" for navigation, we instead use "CiviCRM Home".

This makes it easier to disambiguate the translations for "Home" in other languages. For example, in French, "Home" translates to "Accueil" for navigation, and "Résidence" for the Location Type.
