### PR TITLE
dev/core#4166 Fix Contribute Import Parser fatal when soft-credit is empty

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -434,7 +434,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       $softCreditParams = [];
       foreach ($params['SoftCreditContact'] ?? [] as $index => $softCreditContact) {
         $softCreditParams[$index]['soft_credit_type_id'] = $softCreditContact['soft_credit_type_id'];
-        $softCreditParams[$index]['contact_id'] = $this->getContactID($softCreditContact['Contact'], $softCreditContact['Contact']['id'] ?? NULL, 'SoftCreditContact', $this->getDedupeRulesForEntity('SoftCreditContact'));
+        $softCreditParams[$index]['contact_id'] = $this->getContactID($softCreditContact['Contact'], !empty($softCreditContact['Contact']['id']) ? $softCreditContact['Contact']['id'] : NULL, 'SoftCreditContact', $this->getDedupeRulesForEntity('SoftCreditContact'));
         if (empty($softCreditParams[$index]['contact_id']) && in_array($this->getActionForEntity('SoftCreditContact'), ['update', 'select'])) {
           throw new CRM_Core_Exception(ts('Soft Credit Contact not found'));
         }


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4166

To reproduce:

- use this CSV file: [test-soft-credit.csv](https://lab.civicrm.org/dev/core/uploads/742ab3a01099b5de3ef33325e3686b54/test-soft-credit.csv)
- on dmaster, Contributions > Import
- upload the CSV file, leave the rest as-it
- in field mappings, make sure to select the Soft-Credit ID:

![image](https://user-images.githubusercontent.com/254741/224865384-1d799cf8-3551-439d-8766-9f5b409d73aa.png)

Then run the import, it will be stuck like this:

![image](https://user-images.githubusercontent.com/254741/224865405-2a7e2498-86d2-4322-b607-aaf2edc35892.png)

Fatal error:

```
Argument 2 passed to CRM_Import_Parser::getContactID() must be of the type int or null, string given, called in                                                 
CRM/Contribute/Import/Parser/Contribution.php on line 443 in CRM_Import_Parser->getContactID()
(line 2321 of CRM/Import/Parser.php).            
```

Before
----------------------------------------

Stuck/fatal import

After
----------------------------------------

Not stuck.

Comments
----------------------------------------

I can write a unit test separately if anyone has pointers.