### PR TITLE
dev/core#4130 add template support for imports

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -80,58 +80,11 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    * @return array
    *   reference to the array of default values
    */
-  public function setDefaultValues() {
-    $defaults = parent::setDefaultValues();
-    $defaults['contactType'] = 'Individual';
-    $defaults['disableUSPS'] = TRUE;
-
-    if ($this->get('loadedMapping')) {
-      $defaults['savedMapping'] = $this->get('loadedMapping');
-    }
-
-    return $defaults;
-  }
-
-  /**
-   * Call the DataSource's postProcess method.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function postProcess() {
-    $this->controller->resetPage('MapField');
-    $this->processDatasource();
-    // @todo - this params are being set here because they were / possibly still
-    // are in some places being accessed by forms later in the flow
-    // ie CRM_Contact_Import_Form_MapField, CRM_Contact_Import_Form_Preview
-    // which was the old way of saving values submitted on this form such that
-    // the other forms could access them. Now they should use
-    // `getSubmittedValue` or simply not get them if the only
-    // reason is to pass to the Parser which can itself
-    // call 'getSubmittedValue'
-    // Once the mentioned forms no longer call $this->get() all this 'setting'
-    // is obsolete.
-    $storeParams = [
-      'savedMapping' => $this->getSubmittedValue('savedMapping'),
-    ];
-
-    foreach ($storeParams as $storeName => $value) {
-      $this->set($storeName, $value);
-    }
-  }
-
-  /**
-   * General function for handling invalid configuration.
-   *
-   * I was going to statusBounce them all but when I tested I was 'bouncing' to weird places
-   * whereas throwing an exception gave no behaviour change. So, I decided to centralise
-   * and we can 'flip the switch' later.
-   *
-   * @param $message
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function invalidConfig($message) {
-    throw new CRM_Core_Exception($message);
+  public function setDefaultValues(): array {
+    return array_merge([
+      'contactType' => 'Individual',
+      'disableUSPS' => TRUE,
+    ], parent::setDefaultValues());
   }
 
   /**

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -24,6 +24,15 @@ use Civi\Api4\Tag;
 class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'contact_import';
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm(): void {

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -33,6 +33,13 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
     $this->setTitle($userJob['job_type:label']);
     $onDuplicate = $userJob['metadata']['submitted_values']['onDuplicate'];
     $this->assign('dupeError', FALSE);
+    $importBaseURL = $this->getUserJobInfo()['url'] ?? NULL;
+    $this->assign('templateURL', ($importBaseURL && $this->getTemplateID()) ? CRM_Utils_System::url($importBaseURL, ['template_id' => $this->getTemplateID(), 'reset' => 1]) : '');
+    // This can be overridden by Civi-Import so that the Download url
+    // links that go to SearchKit open in a new tab.
+    $this->assign('isOpenResultsInNewTab');
+    $this->assign('allRowsUrl');
+    $this->assign('importedRowsUrl');
 
     if ($onDuplicate === CRM_Import_Parser::DUPLICATE_UPDATE) {
       $this->assign('dupeActionString', ts('These records have been updated with the imported data.'));

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -95,17 +95,11 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
    * @throws \CRM_Core_Exception
    */
   public function setDefaultValues(): array {
-    parent::setDefaultValues();
-    $defaults['contactType'] = 'Individual';
-    // Perhaps never used, but permits url passing of the group.
-    $defaults['multipleCustomData'] = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-
-    $loadedMapping = $this->get('loadedMapping');
-    if ($loadedMapping) {
-      $defaults['savedMapping'] = $loadedMapping;
-    }
-
-    return $defaults;
+    return array_merge(parent::setDefaultValues(), [
+      'contactType' => 'Individual',
+      // Perhaps never used, but permits url passing of the group.
+      'multipleCustomData' => CRM_Utils_Request::retrieve('id', 'Positive', $this),
+    ]);
   }
 
   /**

--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -375,7 +375,7 @@ abstract class CRM_Import_DataSource {
    */
   protected function getTableName(): ?string {
     // The old name is still stored...
-    $tableName = $this->getDataSourceMetadata()['table_name'];
+    $tableName = $this->getDataSourceMetadata()['table_name'] ?? NULL;
     if (!$tableName) {
       return NULL;
     }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -15,6 +15,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Mapping;
 use Civi\Api4\UserJob;
 use League\Csv\Writer;
 
@@ -22,6 +23,12 @@ use League\Csv\Writer;
  * This class helps the forms within the import flow access submitted & parsed values.
  */
 class CRM_Import_Forms extends CRM_Core_Form {
+
+
+  /**
+   * @var int
+   */
+  protected $templateID;
 
   /**
    * User job id.
@@ -32,6 +39,46 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @var int
    */
   protected $userJobID;
+
+  /**
+   * Name of the import mapping (civicrm_mapping).
+   *
+   * @var string
+   */
+  protected $mappingName;
+
+  /**
+   * The id of the saved mapping being updated.
+   *
+   * Note this may not be the same as the saved mapping being used to
+   * load data. Use the `getSavedMappingID` function to access & any
+   * extra logic can be added in there.
+   *
+   * @var int
+   */
+  protected $savedMappingID;
+
+  /**
+   * @param int $savedMappingID
+   *
+   * @return CRM_Import_Forms
+   */
+  public function setSavedMappingID(int $savedMappingID): CRM_Import_Forms {
+    $this->savedMappingID = $savedMappingID;
+    return $this;
+  }
+
+  /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * This should be overridden.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    CRM_Core_Error::deprecatedWarning('this function should be overridden');
+    return '';
+  }
 
   /**
    * @return int|null
@@ -137,6 +184,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @param string $fieldName
    *
    * @return mixed|null
+   * @throws \CRM_Core_Exception
    */
   public function getSubmittedValue(string $fieldName) {
     if ($fieldName === 'dataSource') {
@@ -153,6 +201,57 @@ class CRM_Import_Forms extends CRM_Core_Form {
     }
     return parent::getSubmittedValue($fieldName);
 
+  }
+
+  /**
+   * Get the template ID from the url, if available.
+   *
+   * Otherwise there are other possibilities...
+   *  - it could already be saved to our UserJob.
+   *  - on the DataSource form we could determine if from the savedMapping field
+   *  (which will hold an ID that can be used to load it). We want to check this is
+   *  coming from the POST (ie fresh)
+   *  - on the MapField form it could be derived from the new mapping created from
+   *   saveMapping + saveMappingName.
+   *
+   * @return int|null
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  public function getTemplateID(): ?int {
+    if ($this->templateID === NULL) {
+      $this->templateID = CRM_Utils_Request::retrieve('template_id', 'Int', $this);
+      if ($this->templateID && $this->getTemplateJob()) {
+        return $this->templateID;
+      }
+      if ($this->getUserJobID()) {
+        $this->templateID = $this->getUserJob()['metadata']['template_id'] ?? NULL;
+      }
+      elseif (!empty($this->getSubmittedValue('savedMapping'))) {
+        if (!$this->getTemplateJob()) {
+          $this->createTemplateJob();
+        }
+      }
+    }
+    return $this->templateID ?? NULL;
+  }
+
+  /**
+   * @return string
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getMappingName(): string {
+    if ($this->mappingName === NULL) {
+      $savedMappingID = $this->getSavedMappingID();
+      if ($savedMappingID) {
+        $this->mappingName = Mapping::get(FALSE)
+          ->addWhere('id', '=', $savedMappingID)
+          ->execute()
+          ->first()['name'];
+      }
+    }
+    return $this->mappingName ?? '';
   }
 
   /**
@@ -263,10 +362,14 @@ class CRM_Import_Forms extends CRM_Core_Form {
     // We give the datasource a chance to clean up any tables it might have
     // created. If we are still using the same type of datasource (e.g still
     // an sql query
-    $oldDataSource = $this->getUserJobSubmittedValues()['dataSource'];
-    $oldDataSourceObject = new $oldDataSource($this->getUserJobID());
-    $newParams = $this->getSubmittedValue('dataSource') === $oldDataSource ? $this->getSubmittedValues() : [];
-    $oldDataSourceObject->purge($newParams);
+    $oldDataSource = $this->getUserJobSubmittedValues()['dataSource'] ?? NULL;
+    if ($oldDataSource) {
+      // Absence of an old data source likely means a template has been used (hence
+      // the user job exists) - but templates don't have data sources - so nothing to flush.
+      $oldDataSourceObject = new $oldDataSource($this->getUserJobID());
+      $newParams = $this->getSubmittedValue('dataSource') === $oldDataSource ? $this->getSubmittedValues() : [];
+      $oldDataSourceObject->purge($newParams);
+    }
     $this->updateUserJobMetadata('DataSource', []);
   }
 
@@ -332,6 +435,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * all forms.
    *
    * @return string[]
+   * @throws \CRM_Core_Exception
    */
   protected function getSubmittableFields(): array {
     $dataSourceFields = array_fill_keys($this->getDataSourceFields(), 'DataSource');
@@ -379,12 +483,30 @@ class CRM_Import_Forms extends CRM_Core_Form {
         'expires_date' => '+ 1 week',
         'metadata' => [
           'submitted_values' => $this->getSubmittedValues(),
+          'template_id' => $this->getTemplateID(),
+          'Template' => ['mapping_id' => $this->getSavedMappingID()],
         ],
       ])
       ->execute()
       ->first()['id'];
     $this->setUserJobID($id);
     return $id;
+  }
+
+  protected function createTemplateJob(): void {
+    if (!$this->getUserJobType()) {
+      // This could be hit in extensions while they transition.
+      CRM_Core_Error::deprecatedWarning('Classes should implement getUserJobType');
+      return;
+    }
+    $this->templateID = UserJob::create(FALSE)->setValues([
+      'is_template' => 1,
+      'created_id' => CRM_Core_Session::getLoggedInContactID(),
+      'job_type' => $this->getUserJobType(),
+      'status_id:name' => 'draft',
+      'name' => 'import_' . $this->getMappingName(),
+      'metadata' => ['submitted_values' => $this->getSubmittedValues()],
+    ])->execute()->first()['id'];
   }
 
   /**
@@ -399,11 +521,30 @@ class CRM_Import_Forms extends CRM_Core_Form {
       $this->getUserJob()['metadata'],
       [$key => $data]
     );
+    $this->getUserJob()['metadata'] = $metaData;
+    if ($this->isUpdateTemplateJob()) {
+      $this->updateTemplateUserJob($metaData);
+    }
+    // We likely don't need the empty check. A precaution against nulling it out by accident.
+    if (empty($metaData['template_id'])) {
+      $metaData['template_id'] = $this->templateID;
+    }
     UserJob::update(FALSE)
       ->addWhere('id', '=', $this->getUserJobID())
       ->setValues(['metadata' => $metaData])
       ->execute();
     $this->userJob['metadata'] = $metaData;
+  }
+
+  /**
+   * Is the user wanting to update the template / mapping.
+   *
+   * @return bool
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function isUpdateTemplateJob(): bool {
+    return $this->getSubmittedValue('updateMapping') || $this->getSubmittedValue('saveMapping');
   }
 
   /**
@@ -566,6 +707,18 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
+   * Get information about the user job parser.
+   *
+   * This is as per `CRM_Core_BAO_UserJob::getTypes()`
+   *
+   * @return array
+   */
+  protected function getUserJobInfo(): array {
+    $importInformation = $this->getParser()->getUserJobInfo();
+    return reset($importInformation);
+  }
+
+  /**
    * Get the fields available for import selection.
    *
    * @return array
@@ -631,6 +784,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * Get an instance of the parser class.
    *
    * @return \CRM_Contact_Import_Parser_Contact|\CRM_Contribute_Import_Parser_Contribution
+   * @throws \CRM_Core_Exception
    */
   protected function getParser() {
     foreach (CRM_Core_BAO_UserJob::getTypes() as $jobType) {
@@ -775,6 +929,58 @@ class CRM_Import_Forms extends CRM_Core_Form {
       'dedupeRules' => $parser->getAllDedupeRules(),
       'userJob' => $this->getUserJob(),
     ]);
+  }
+
+  /**
+   * Get the UserJob Template, if it exists.
+   *
+   * @return array|null
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getTemplateJob(): ?array {
+    $mappingName = $this->getMappingName();
+    if (!$mappingName) {
+      return NULL;
+    }
+    $templateJob = UserJob::get(FALSE)
+      ->addWhere('name', '=', 'import_' . $mappingName)
+      ->addWhere('is_template', '=', TRUE)
+      ->execute()->first();
+    $this->templateID = $templateJob['id'];
+    return $templateJob ?? NULL;
+  }
+
+  /**
+   * @param array $metaData
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected function updateTemplateUserJob(array $metaData): void {
+    if ($this->getTemplateID()) {
+      UserJob::update(FALSE)
+        ->addWhere('id', '=', $this->getTemplateID())
+        ->setValues(['metadata' => $metaData, 'is_template' => TRUE])
+        ->execute();
+    }
+    elseif ($this->getMappingName()) {
+      $this->createTemplateJob();
+    }
+  }
+
+  /**
+   * Get the saved mapping ID being updated.
+   *
+   * @return int|null
+   */
+  public function getSavedMappingID(): ?int {
+    if (!$this->savedMappingID) {
+      if (!empty($this->getUserJob()['metadata']['Template']['mapping_id'])) {
+        $this->savedMappingID = $this->getUserJob()['metadata']['Template']['mapping_id'];
+      }
+    }
+    return $this->savedMappingID;
   }
 
 }

--- a/CRM/Report/Form/Contact/Summary.php
+++ b/CRM/Report/Form/Contact/Summary.php
@@ -16,7 +16,7 @@
  */
 class CRM_Report_Form_Contact_Summary extends CRM_Report_Form {
 
-  public $_summary = NULL;
+  public $_summary;
 
   protected $_emailField = FALSE;
 

--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -122,7 +122,7 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
    */
   private function getImportTableFromEvent(GenericHookEvent $event): ?string {
     if (isset($event->object)) {
-      $metadata = json_decode($event->object->metadata, TRUE);
+      $metadata = json_decode((string) $event->object->metadata, TRUE);
       if (!is_array($metadata)) {
         return NULL;
       }

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -208,7 +208,7 @@ function civiimport_civicrm_searchKitTasks(array &$tasks, bool $checkPermissions
  * Load the angular app for our form.
  *
  * @param string $formName
- * @param \CRM_Core_Form|CRM_Contribute_Import_Form_MapField $form
+ * @param CRM_Contribute_Import_Form_MapField $form
  *
  * @throws \CRM_Core_Exception
  */
@@ -217,7 +217,7 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
     // Add import-ui app
     Civi::service('angularjs.loader')->addModules('crmCiviimport');
     $form->assignCiviimportVariables();
-    $savedMappingID = (int) $form->getSubmittedValue('savedMapping');
+    $savedMappingID = (int) $form->getSavedMappingID();
     $savedMapping = [];
     if ($savedMappingID) {
       $savedMapping = Mapping::get()->addWhere('id', '=', $savedMappingID)->addSelect('id', 'name', 'description')->execute()->first();
@@ -245,5 +245,6 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
     $form->assign('isOpenResultsInNewTab', TRUE);
     $form->assign('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR', FALSE));
     $form->assign('allRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID(), FALSE));
+    $form->assign('importedRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=IMPORTED', FALSE));
   }
 }

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -22,6 +22,10 @@
        <strong>{ts}Import has completed successfully.{/ts}</strong>
      {/if}
    </p>
+   {if $templateURL}
+     <p>
+       {ts 1=$templateURL|smarty:nodefaults}You can re-use this import configuration <a href="%1">here</a>{/ts}</p>
+   {/if}
 
    {if $unMatchCount}
         <p class="error">
@@ -61,7 +65,7 @@
   {* Summary of Import Results (record counts) *}
   <table id="summary-counts" class="report">
     <tr><td class="label crm-grid-cell">{ts}Total Rows{/ts}</td>
-      <td class="data">{$totalRowCount}</td>
+      <td class="data">{if $allRowsUrl} <a href="{$allRowsUrl}" target="_blank" rel="noopener noreferrer">{$totalRowCount}</a>{else}{$totalRowCount}{/if}</td>
       <td class="explanation">{ts}Total number of rows in the imported data.{/ts}</td>
     </tr>
     {if $unprocessedRowCount}
@@ -100,7 +104,7 @@
 
     <tr>
       <td class="label crm-grid-cell">{ts}Total Rows Imported{/ts}</td>
-      <td class="data">{$importedRowCount}</td>
+      <td class="data">{if $importedRowsUrl} <a href="{$importedRowsUrl}" target="_blank" rel="noopener noreferrer">{$importedRowCount}</a>{else}{$importedRowCount}{/if}</td>
       <td class="explanation">{ts}Total number of primary records created or modified during the import.{/ts}</td>
     </tr>
     {foreach from=$trackingSummary item="summaryRow"}

--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -116,7 +116,7 @@
          <tr class="crm-import-uploadfile-form-block-savedMapping">
            <td class="label"><label for="savedMapping">{$form.savedMapping.label}</label></td>
            <td>{$form.savedMapping.html}<br />
-             <span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>
+             {if !$form.savedMapping.frozen}<span class="description">{ts}If you want to use a previously saved import field mapping - select it here.{/ts}</span>{/if}
            </td>
          </tr>
        {/if}

--- a/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/MapFieldTest.php
@@ -40,7 +40,7 @@ class CRM_Contact_Import_Form_MapFieldTest extends CiviUnitTestCase {
    * Delete any saved mapping config.
    */
   public function tearDown(): void {
-    $this->quickCleanup(['civicrm_mapping', 'civicrm_mapping_field'], TRUE);
+    $this->quickCleanup(['civicrm_mapping', 'civicrm_mapping_field', 'civicrm_user_job', 'civicrm_queue'], TRUE);
     parent::tearDown();
   }
 

--- a/tests/phpunit/CRM/Import/DataSource/FormsTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/FormsTest.php
@@ -1,0 +1,181 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Mapping;
+use Civi\Api4\UserJob;
+
+/**
+ *  Test various forms extending CRM_Import_Forms.
+ *
+ * @package CiviCRM
+ * @group import
+ */
+class CRM_Import_FormsTest extends CiviUnitTestCase {
+
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_user_job', 'civicrm_mapping', 'civicrm_mapping_field', 'civicrm_queue']);
+    parent::tearDown();
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testLoadDataSourceSavedTemplate(): void {
+    // First do a basic submission, creating a Mapping and UserJob template in the process.
+    [$templateJob, $mapping] = $this->runImportSavingImportTemplate();
+
+    // Now try this template in in the url to load the defaults for DataSource.
+    $_REQUEST['template_id'] = $templateJob['id'];
+    $form = $this->getFormObject('CRM_Contribute_Import_Form_DataSource');
+    $this->formController = $form->controller;
+    $form->buildForm();
+    $defaults = $this->getFormDefaults($form);
+    // These next 2 fields should be loaded as defaults from the UserJob template.
+    $this->assertEquals('Organization', $defaults['contactType']);
+    $this->assertEquals([$mapping['id']], $defaults['savedMapping']);
+  }
+
+  /**
+   * Test that when we Process the MapField form without updating the saved template it is still retained.
+   *
+   * This is important because if we use the BACK button we still want 'Update Mapping'
+   * to show.
+   */
+  public function testSaveRetainingMappingID(): void {
+    // First do a basic submission, creating a Mapping and UserJob template in the process.
+    [, $mapping] = $this->runImportSavingImportTemplate();
+    $this->formController = NULL;
+
+    $dataSourceForm = $this->processForm('CRM_Contribute_Import_Form_DataSource', [
+      'contactType' => 'Organization',
+      'savedMapping' => 1,
+    ]);
+    $userJobID = $dataSourceForm->getUserJobID();
+    $this->processForm('CRM_Contribute_Import_Form_MapField', [
+      'savedMapping' => $mapping['id'],
+      'contactType' => 'Organization',
+      'mapper' => [['id'], ['source']],
+    ]);
+
+    // Now we want to submit this form without updating the mapping used & make sure the mapping_id
+    // is still saved in the metadata.
+    /* @var CRM_Contribute_Import_Form_MapField $mapFieldForm */
+    $mapFieldValues = [
+      'dataSource' => 'CRM_Import_DataSource_SQL',
+      'sqlQuery' => 'SELECT id, source FROM civicrm_contact',
+      'mapper' => [['id'], ['financial_type_id']],
+    ];
+    $mapFieldForm = $this->getFormObject('CRM_Contribute_Import_Form_MapField', $mapFieldValues);
+    $mapFieldForm->buildForm();
+
+    $userJob = UserJob::get()->addWhere('id', '=', $userJobID)->execute()->first();
+    $this->assertEquals($mapping['id'], $userJob['metadata']['Template']['mapping_id']);
+  }
+
+  /**
+   * Get the values specified as defaults for the form.
+   *
+   * I originally wanted to make this a public function on `CRM_Core_Form`
+   * but I think it might need to mature first.
+   */
+  public function getFormDefaults($form): array {
+    $defaults = [];
+    if (!empty($form->_elementIndex)) {
+      foreach ($form->_elementIndex as $elementName => $elementIndex) {
+        $element = $form->_elements[$elementIndex];
+        $defaults[$elementName] = $element->getValue();
+      }
+    }
+    return $defaults;
+  }
+
+  /**
+   * @param string $class
+   * @param array $formValues
+   *
+   * @return \CRM_Core_Form
+   */
+  protected function processForm(string $class, array $formValues = []): CRM_Core_Form {
+    $form = $this->getImportForm($class, $formValues);
+    $form->buildForm();
+    $form->mainProcess();
+    return $form;
+  }
+
+  /**
+   * Get some default values to use when we don't care.
+   *
+   * @return array
+   */
+  protected function getDefaultValues(): array {
+    return [
+      'contactType' => 'Individual',
+      'contactSubType' => '',
+      'dataSource' => 'CRM_Import_DataSource_SQL',
+      'sqlQuery' => 'SELECT id, source FROM civicrm_contact',
+      'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
+      'mapper' => [['id'], ['source']],
+    ];
+  }
+
+  /**
+   * @param array $submittedValues
+   */
+  protected function processContributionForms(array $submittedValues): void {
+    try {
+      $this->processForm('CRM_Contribute_Import_Form_DataSource', $submittedValues);
+      $this->processForm('CRM_Contribute_Import_Form_MapField', $submittedValues);
+      $this->processForm('CRM_Contribute_Import_Form_Preview', $submittedValues);
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      // We expect this to happen as it re-directs to the queue runner.
+    }
+  }
+
+  /**
+   * @param string $class
+   * @param array $formValues
+   *
+   * @return \CRM_Core_Form
+   */
+  protected function getImportForm(string $class, array $formValues = []): CRM_Core_Form {
+    $formValues = array_merge($this->getDefaultValues(), $formValues);
+    return $this->getFormObject($class, $formValues);
+  }
+
+  /**
+   * @return array
+   */
+  protected function runImportSavingImportTemplate(): array {
+    $this->processContributionForms([
+      'saveMapping' => 1,
+      'saveMappingName' => 'mapping',
+      'contactType' => 'Organization',
+    ]);
+
+    // Check that a template job and a mapping have been created.
+    $templateJob = UserJob::get()
+      ->addWhere('is_template', '=', 1)
+      ->execute()
+      ->first();;
+    $this->assertNotEmpty($templateJob);
+    $this->assertArrayNotHasKey('table_name', $templateJob['metadata']['DataSource']);
+    $mapping = Mapping::get()
+      ->addWhere('name', '=', substr($templateJob['name'], 7))
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($mapping);
+    // Reset the formController so this doesn't leak into further tests.
+    $this->formController = NULL;
+    return [$templateJob, $mapping];
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -471,9 +471,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->unsetExtensionSystem();
     $this->assertEquals([], CRM_Core_DAO::$_nullArray);
     $this->assertEquals(NULL, CRM_Core_DAO::$_nullObject);
-    // Ensure the destruct runs by unsetting it. Also, unsetting
-    // classes frees memory as they are not otherwise unset until the
-    // very end.
+    // Setting large properties to NULL here ensures memory is released as each
+    // test class is held in memory until the very end.
+    $this->formController = NULL;
+    // Ensure the destruct runs by unsetting the Mutt.
     unset($this->mut);
     parent::tearDown();
   }
@@ -3183,8 +3184,15 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       case 'CRM_Contribute_Import_Form_DataSource':
       case 'CRM_Contribute_Import_Form_MapField':
       case 'CRM_Contribute_Import_Form_Preview':
-        $form->controller = new CRM_Contribute_Import_Controller();
-        $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
+        if ($this->formController) {
+          // Add to the existing form controller.
+          $form->controller = $this->formController;
+        }
+        else {
+          $form->controller = new CRM_Contribute_Import_Controller();
+          $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
+          $this->formController = $form->controller;
+        }
         // The submitted values should be set on one or the other of the forms in the flow.
         // For test simplicity we set on all rather than figuring out which ones go where....
         $_SESSION['_' . $form->controller->_name . '_container']['values']['DataSource'] = $formValues;


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4130 add template support for imports

This creates UserJob Templates in tandem wtih the use of saved civicrm_mapping records for imports.

This provides a nice-to-have functionality for non-Civi-Import imports - ie the import can store details from the initial `DataSource` screen - anyone who always has to remember to save dates will appreciate that. In addition for Civi-import imports it can store more nuanced defaults for Civi-Import (which works on the Contribution Import)

The templates are loaded when

1) the url holds a valid `template_id` - eg. civicrm/contribute/import?reset=1&template_id=2. A link to that url appears on the Summary screen - 
![image](https://user-images.githubusercontent.com/336308/225214698-a6c6cb0d-5e8a-4f93-b569-4fab8b02f0e2.png)

or

2) a Saved Mapping is selected on the DataSource screen. In this case the defaults for the DataSource screen are not re-loaded but the defaults for MapField is. In practice this is invisible when civi-import is not enabled


**E.g - DataSource with contact type default loaded**


![image](https://user-images.githubusercontent.com/336308/225213584-a41f69f2-3074-4ad7-8828-6dadd658e3a0.png)


**E.g - The sort of field you can set defaults for with Civi-import enabled**
![image](https://user-images.githubusercontent.com/336308/225171283-e6615f8c-3405-4f91-8f19-a4ceea6de274.png)

https://lab.civicrm.org/dev/core/-/issues/4130

Before
----------------------------------------
`MappingFields` are too blunt to save the options available in Contribution Import with CiviImport enabled or the general options on the `DataSource` screen. 

The goal is to work towards replacing the old `civicrm_mapping`  - which is also inadequate for some soft credit details -  with UserJob template records.


After
----------------------------------------
Records in `civicrm_user_job` with `is_template` = ` used to provide templates for full import configurration.

Both the `UserJob` Template and the SavedMapping are managed in tandem with a soft link based on name - ie
if civicrm_mapping.name = 'saved_map' then civicrm_user_job.name = 'import_saved_map' for the relevant template.

If the UserJob does not exist it will be created when the DataSource form is submitted with `savedMapping` not empty or when the MapField form is submitted with `saveMapping` not empty. Since there are not yet any template UserJobs in the database the reverse will not occur. We could instead create on upgrade. At this stage I decided it would be easier to create as needed in the first iteration.

When the Mapping is updated on the MapField form (either by `SaveMapping` or `UpdateMapping` being selected the UserJob template will also be updated.

On the Summary screen a link to use the template is included.


Technical Details
----------------------------------------
*Flow - do an import, saving a saved mapping. *
- This will import an associated UserJob Template when the Mapping is saved - ie
![image](https://user-images.githubusercontent.com/336308/225171391-4fc39196-aee8-44ca-92c9-6608b06520a2.png)
- a link to it will be present on the Summary screen allowing 
**Flow 2 Use the template from the url**

Add template_id =x to the url & process the import....

**Flow 3 Update a template loaded by url**

Make a change to an import loaded from the url - note even if the change is on the DataSource page it will only be updated if the Update or Save option is chosen on the MapField page

 **Flow 3 Update a template loaded by SavedMapping field on the DataSource page**

In this case no change will be visible with Civi-Import disabled




Comments
----------------------------------------
