### PR TITLE
dev/core#4184 Permit access to template user jobs (imports)

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -97,7 +97,9 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
   public function addSelectWhereClause(): array {
     $clauses = [];
     if (!\CRM_Core_Permission::check('administer queues')) {
-      $clauses['created_id'] = '= ' . (int) CRM_Core_Session::getLoggedInContactID();
+      // @todo - the is_template should really be prefixed. We need to add support
+      // for that in the compiler & then this would be `{table}.is_template`
+      $clauses['created_id'] = '= ' . (int) CRM_Core_Session::getLoggedInContactID() . ' OR is_template = 1';
     }
     CRM_Utils_Hook::selectWhereClause($this, $clauses);
     return $clauses;


### PR DESCRIPTION
Overview
----------------------------------------
Permit access to template user jobs (imports)

Before
----------------------------------------
Users cannot access an import template created by a different user

After
----------------------------------------
New query is

```
SELECT COUNT(*) AS `c`
FROM civicrm_user_job a
WHERE ((`a`.`created_id` IS NULL OR (`a`.`created_id` = 204 OR is_template = 1))) AND (`a`.`id` = "1")
```

Technical Details
----------------------------------------
Per discussion with @colemanw ideally a {table} in there would stand in for the `a.` - but in the short term this is unlikely to be joined in a way that causes problems...

Comments
----------------------------------------

