### PR TITLE
[PHP8.2] (Ref) Remove unused dynamic property in report form class

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -5651,16 +5651,6 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       $spec = array_merge($spec, $individualFields);
     }
 
-    if (!empty($options['custom_fields'])) {
-      $this->_customGroupExtended[$options['prefix'] . 'civicrm_contact'] = [
-        'extends' => $options['custom_fields'],
-        'title' => $options['prefix_label'],
-        'filters' => $options['filters'],
-        'prefix' => $options['prefix'],
-        'prefix_label' => $options['prefix_label'],
-      ];
-    }
-
     return $this->buildColumns($spec, $options['prefix'] . 'civicrm_contact', 'CRM_Contact_DAO_Contact', $tableAlias, $this->getDefaultsFromOptions($options), $options);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused dynamic property in report form class

Before
----------------------------------------
`_customGroupExtended` is written to, but never read in CiviCRM core.

After
----------------------------------------
Reference to `_customGroupExtended` removed.

Comments
----------------------------------------
`_customGroupExtended` is used by https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport. It looks like it was mistakenly copy-pasted into core at some point. 

@eileenmcnaughton This is the one I checked with you.