### PR TITLE
[REF] Fix issue where the strict typing was causing false notices to …

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -445,7 +445,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     if (!$contribution->find(TRUE)) {
       throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: "]);
     }
-    if ($contribution->contact_id !== $this->getContactID()) {
+    if ((int) $contribution->contact_id !== $this->getContactID()) {
       CRM_Core_Error::debug_log_message("Contact ID in IPN not found but contact_id found in contribution.");
     }
     return $contribution;


### PR DESCRIPTION
…appear in Config And Log

Overview
----------------------------------------
A client of mine was having the message about the contact in the ipn not found error appearing a lot in their logs. I discovered this was because the DAO returns a string not an Int and the strict typing comparision fails here. PayPalProIPN has been fixed this way https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Payment/PayPalProIPN.php#L583 but I don't think we need that here 

Before
----------------------------------------
Strict typing causes false notices to show in log

After
----------------------------------------
Less notices in log

ping @eileenmcnaughton 