### PR TITLE
Add links to search kits to import preview screen, when Civ-Import is enabled

### DIFF
--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -72,6 +72,10 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     $this->assign('mapper', $this->getMappedFieldLabels());
     $this->assign('dataValues', $this->getDataRows([], 2));
     $this->assign('columnNames', $this->getColumnHeaders());
+    // This can be overridden by Civi-Import so that the Download url
+    // links that go to SearchKit open in a new tab.
+    $this->assign('isOpenResultsInNewTab');
+    $this->assign('allRowsURL');
     //get the mapping name displayed if the mappingId is set
     $mappingId = $this->get('loadMappingId');
     if ($mappingId) {

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -238,7 +238,12 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
     }
   }
 
-  if ($formName === 'CRM_Contact_Import_Form_Summary') {
+  //@todo - do for all Preview forms - just need to fix each Preview.tpl to
+  // not open in new tab as they are not yet consolidated into one file.
+  // (Or consolidate them now).
+  if ($formName === 'CRM_Contact_Import_Form_Summary' || $formName === 'CRM_Contribute_Import_Form_Preview') {
+    $form->assign('isOpenResultsInNewTab', TRUE);
     $form->assign('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR', FALSE));
+    $form->assign('allRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID(), FALSE));
   }
 }

--- a/templates/CRM/Contribute/Import/Form/Preview.tpl
+++ b/templates/CRM/Contribute/Import/Form/Preview.tpl
@@ -20,7 +20,7 @@
 
     {if $invalidRowCount}
         <p class="error">
-        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped.  You can download a file with just these problem records: <a href='%2'>Download Errors</a>.  If you wish, you can then correct them in the original import file, cancel this import, and begin again at step 1.{/ts}
+        {ts 1=$invalidRowCount 2=$downloadErrorRecordsUrl}CiviCRM has detected invalid data or formatting errors in %1 records. If you continue, these records will be skipped.  You can review these problem records: <a href='%2' {if $isOpenResultsInNewTab} target="_blank" rel="noopener noreferrer"{/if}>See Errors</a>.  If you wish, you can then correct them in the original import file, cancel this import, and begin again at step 1.{/ts}
         </p>
     {/if}
 
@@ -32,7 +32,9 @@
  <table id="preview-counts" class="report">
     <tr><td class="label crm-grid-cell">{ts}Total Rows{/ts}</td>
         <td class="data">{$totalRowCount}</td>
-        <td class="explanation">{ts}Total rows (contribution records) in uploaded file.{/ts}</td>
+        <td class="explanation">{ts}Total rows (contribution records) in uploaded file.{/ts}
+          {if $allRowsUrl} <a href="{$allRowsUrl}" target="_blank" rel="noopener noreferrer">{ts}See rows{/ts}</a>{/if}
+        </td>
     </tr>
 
     {if $invalidRowCount}
@@ -40,7 +42,7 @@
         <td class="data">{$invalidRowCount}</td>
         <td class="explanation">{ts}Rows with invalid data in one or more fields. These rows will be skipped (not imported).{/ts}
             {if $invalidRowCount}
-                <p><a href="{$downloadErrorRecordsUrl}">{ts}Download Errors{/ts}</a></p>
+                <p><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}" {if $isOpenResultsInNewTab} target="_blank" rel="noopener noreferrer"{/if}>{ts}See Errors{/ts}</a></p>
             {/if}
         </td>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Add links to search kits to import preview screen, when Civ-Import is enabled

Before
----------------------------------------
It's kinda hard to figure out what went wrong cos the whole Download spreadsheet process is a bit of a pain

![image](https://user-images.githubusercontent.com/336308/225176877-69406986-c20e-4777-9c51-38566553328c.png)


After
----------------------------------------
the errors links are 'See Errors' not Download Errors  & ff Civi-Import is enabled &  go to the relevant Import Search. In addition there is a link to see the unfiltered list ('See Rows'). We used `See Errors` earlier on the Summary screen

![image](https://user-images.githubusercontent.com/336308/225175909-a653d633-8a14-42b2-a776-a41c57d63b8a.png)

Technical Details
----------------------------------------
I mostly did this cos when doing development it removes a pain point - hence I have also just done for Contribute import at the moment  - unfortunately the `Preview.tpl` files need a sync pass & probably can be squashed into a shared file, at which point the links apply to all Preview screens

One challenge is these links should open in a new tab whereas the standard one shouldn't - this addresses that using another variable

Comments
----------------------------------------
