### PR TITLE
Fix typo that causes e-notice in just-merged commit

### DIFF
--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -75,7 +75,7 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     // This can be overridden by Civi-Import so that the Download url
     // links that go to SearchKit open in a new tab.
     $this->assign('isOpenResultsInNewTab');
-    $this->assign('allRowsURL');
+    $this->assign('allRowsUrl');
     //get the mapping name displayed if the mappingId is set
     $mappingId = $this->get('loadMappingId');
     if ($mappingId) {


### PR DESCRIPTION
I'm gonna self-merge this cos it fixes a notice I only just added - I mixed the capitalization of `URL` & `Url` 