### PR TITLE
WorkflowMessage - Enable strict parsing of annotations

### DIFF
--- a/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
+++ b/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
@@ -63,7 +63,7 @@ trait ReflectiveWorkflowTrait {
         /** @var \ReflectionProperty $property */
         $parsed = ReflectionUtils::getCodeDocs($property, 'Property');
         $field = new \Civi\WorkflowMessage\FieldSpec();
-        $field->setName($property->getName())->loadArray($parsed);
+        $field->setName($property->getName())->loadArray($parsed, TRUE);
         $cache[$field->getName()] = $field;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------

Not sure it's a good or bad idea. Spot-checked some local tests, and they seemed OK. Let's see what Jenkins thinks.

