### PR TITLE
🦠 Code does not actually do what the code comments says: Include JS for auto renew membership if priceset is Quick Config

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -215,7 +215,7 @@
   {/strip}
 {/if}
 {* Include JS for auto renew membership if priceset is Quick Config*}
-{if $membershipBlock}
+{if $membershipBlock AND $is_quick_config}
 {literal}
   <script type="text/javascript">
     CRM.$(function($) {


### PR DESCRIPTION
Overview
----------------------------------------
Do what the code comments says: _Include JS for auto renew membership if priceset is Quick Config_

Before
----------------------------------------
JS for auto renew membership is output for **both** Quick Config priceset and non-Quick Config priceset.
Does not do what the code comments says: _Include JS for auto renew membership if priceset is Quick Config_

After
----------------------------------------
JS for auto renew membership is output for **only** Quick Config priceset.
Now does do what the code comments says: _Include JS for auto renew membership if priceset is Quick Config_

Technical Details
----------------------------------------

Comments
----------------------------------------
This came up as a support issue for Agileware because the auto renew checkbox was being unchecked when using Membership Priceset on a Membership Contribution page. Tracking down the bug, can see that the Javascript for both Priceset and QuickConfig priceset is being output on the page.

Agileware Ref: CIVICRM-2111