### PR TITLE
Afform - Fix validateBySavedSearch

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -112,7 +112,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
 
     $api4 = $this->_formDataModel->getSecureApi4($entity['name']);
     $idField = CoreUtil::getIdFieldName($entity['type']);
-    if ($ids && !empty($entity['fields'][$idField]['saved_search'])) {
+    if ($ids && !empty($entity['fields'][$idField]['defn']['saved_search'])) {
       $ids = $this->validateBySavedSearch($entity, $ids);
     }
     if (!$ids) {
@@ -144,6 +144,14 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     }
   }
 
+  /**
+   * Validate that given id(s) are actually returned by the Autocomplete API
+   *
+   * @param $entity
+   * @param array $ids
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
   private function validateBySavedSearch($entity, array $ids) {
     $idField = CoreUtil::getIdFieldName($entity['type']);
     $fetched = civicrm_api4($entity['type'], 'autocomplete', [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the autocomplete-based validation of Afform entities

Before
----------------------------------------
Autocomplete validation skipped

After
----------------------------------------
Works

This is taken from @mattwire's #25464