### PR TITLE
Return a more helpful server side validation message

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -56,7 +56,7 @@ class Submit extends AbstractProcessor {
     $errors = $event->getErrors();
     if ($errors) {
       \Civi::log('afform')->error('Afform Validation errors: ' . print_r($errors, TRUE));
-      throw new \CRM_Core_Exception(ts('Validation Error', ['plural' => '%1 Validation Errors', 'count' => count($errors)]), 0, ['validation' => $errors]);
+      throw new \CRM_Core_Exception(implode("\n", $errors));
     }
 
     // Save submission record

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -91,7 +91,7 @@ EOHTML;
       $this->fail();
     }
     catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('Validation Error', $e->getMessage());
+      $this->assertEquals('Illegal value for Existing Individual.', $e->getMessage());
     }
 
     // Submit with a valid ID, it should work
@@ -204,7 +204,7 @@ EOHTML;
       $this->fail();
     }
     catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('Validation Error', $e->getMessage());
+      $this->assertEquals('Illegal value for test_af_fields: contact_ref.', $e->getMessage());
     }
 
     // Submit with a valid ID, it should work
@@ -310,7 +310,7 @@ EOHTML;
       $this->fail();
     }
     catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('Validation Error', $e->getMessage());
+      $this->assertEquals('Illegal value for test_address_fields: contact_ref.', $e->getMessage());
     }
 
     // Submit with a valid ID, it should work

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -45,7 +45,7 @@ EOHTML;
     }
     catch (\CRM_Core_Exception $e) {
     }
-    $this->assertStringContainsString('Validation Error', $e->getMessage());
+    $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
 
     // Conditional field shown: this will fail validation
     $submission = [
@@ -59,7 +59,7 @@ EOHTML;
     }
     catch (\CRM_Core_Exception $e) {
     }
-    $this->assertStringContainsString('Validation Error', $e->getMessage());
+    $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
 
     // Conditional field hidden: this will pass validation
     $submission = [
@@ -119,7 +119,7 @@ EOHTML;
     }
     catch (\CRM_Core_Exception $e) {
     }
-    $this->assertStringContainsString('Validation Error', $e->getMessage());
+    $this->assertStringContainsString('Email is a required field.', $e->getMessage());
 
     // Conditional field hidden: this will pass validation
     $submission = [

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -513,9 +513,8 @@ EOHTML;
     }
     catch (\CRM_Core_Exception $e) {
       // Should fail required fields missing
-      $this->assertCount(2, $e->getErrorData()['validation']);
-      $this->assertEquals('First Name is a required field.', $e->getErrorData()['validation'][0]);
-      $this->assertEquals('Email is a required field.', $e->getErrorData()['validation'][1]);
+      $this->assertStringContainsString('First Name is a required field', $e->getMessage());
+      $this->assertStringContainsString('Email is a required field', $e->getMessage());
     }
 
   }
@@ -551,8 +550,7 @@ EOHTML;
     }
     catch (\CRM_Core_Exception $e) {
       // Should fail required fields missing
-      $this->assertCount(1, $e->getErrorData()['validation']);
-      $this->assertEquals('Last Name has a max length of 20.', $e->getErrorData()['validation'][0]);
+      $this->assertEquals('Last Name has a max length of 20.', $e->getMessage());
     }
   }
 
@@ -585,8 +583,7 @@ EOHTML;
     }
     catch (\CRM_Core_Exception $e) {
       // Should fail required fields missing
-      $this->assertCount(1, $e->getErrorData()['validation']);
-      $this->assertEquals('Email is a required field.', $e->getErrorData()['validation'][0]);
+      $this->assertEquals('Email is a required field.', $e->getMessage());
     }
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
Presently, a FormBuilder form that fails server-side validation doesn't give a helpful message to the user.  This makes it hard to fix their error.

Before
----------------------------------------
![Selection_1813](https://user-images.githubusercontent.com/1796012/225405861-7f65b7ba-ec37-41a6-b2d5-463ead8e554d.png)


After
----------------------------------------
![Selection_1814](https://user-images.githubusercontent.com/1796012/225405877-be22efc1-11c9-43a1-a313-8ad714bc541c.png)

Comments
----------------------------------------
See also #25533.
