### PR TITLE
SearchKit - Handle comma-separated values passed from Afform url

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -806,7 +806,13 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     if (!$filters) {
       return;
     }
-
+    // Parse comma-separated values from filters passed through afform variables
+    // These values may have come from the url and should be transformed into arrays
+    foreach ($directiveFilters as $key) {
+      if (!empty($filters[$key]) && is_string($filters[$key]) && strpos($filters[$key], ',')) {
+        $filters[$key] = explode(',', $filters[$key]);
+      }
+    }
     // Add all filters to the WHERE or HAVING clause
     foreach ($filters as $key => $value) {
       $fieldNames = explode(',', $key);


### PR DESCRIPTION
Overview
----------------------------------------
Allows multiple filter values to be passed through the url to a SearchKit display

Before
----------------------------------------
A filter like `#/?case_type_id=2,3` will not work.

After
----------------------------------------
Now it does.