### PR TITLE
[REF][PHP8.2] Don't use a property where a variable will do (CRM_Contact_Page_View_Summary)

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -208,12 +208,12 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     $defaults['privacy_values'] = CRM_Core_SelectValues::privacy();
 
     //Show blocks only if they are visible in edit form
-    $this->_editOptions = CRM_Core_BAO_Setting::valueOptions(
+    $editOptions = CRM_Core_BAO_Setting::valueOptions(
       CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
       'contact_edit_options'
     );
 
-    foreach ($this->_editOptions as $blockName => $value) {
+    foreach ($editOptions as $blockName => $value) {
       $varName = '_show' . $blockName;
       $this->$varName = $value;
       $this->assign(substr($varName, 1), $this->$varName);


### PR DESCRIPTION
Overview
----------------------------------------
Improves PHP 8.2 compatiability in class `CRM_Contact_Page_View_Summary`.

Before
----------------------------------------
`CRM_Contact_Page_View_Summary` writes and reads a dynamic property `_editOptions` within a single method. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
A variable is used instead for better PHP 8.2 support.

Comments
----------------------------------------
There is scope for this to cause a breaking change for any extensions trying to read `_editOptions` but I consider the risk to be very limited:

 1. The leading underscore implicitely implies the property is private,
 2. If an extension does need this information they can just read it themselves out of the `contact_edit_options` setting.
