### PR TITLE
[REF] [php8.2] Remove unused parameters from `Contribute_PDFLetter::buildContributionArray`

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -39,7 +39,6 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
-    $this->skipOnHold = $this->skipDeceased = FALSE;
     $this->preProcessPDF();
     parent::preProcess();
     $this->assign('single', $this->isSingle());
@@ -168,7 +167,6 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $nowDate = date('YmdHis');
     $receipts = $thanks = $emailed = 0;
     $updateStatus = '';
-    $task = 'CRM_Contribution_Form_Task_PDFLetterCommon';
     $realSeparator = ', ';
     $tableSeparators = [
       'td' => '</td><td>',
@@ -188,9 +186,6 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
     $separator = '****~~~~';
     $groupBy = $this->getSubmittedValue('group_by');
 
-    // skip some contacts ?
-    $skipOnHold = $this->skipOnHold ?? FALSE;
-    $skipDeceased = $this->skipDeceased ?? TRUE;
     $contributionIDs = $this->getIDs();
     if ($this->isQueryIncludesSoftCredits()) {
       $contributionIDs = [];
@@ -200,7 +195,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
         $contributionIDs["{$result->contact_id}-{$result->contribution_id}"] = $result->contribution_id;
       }
     }
-    [$contributions, $contacts] = $this->buildContributionArray($groupBy, $contributionIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator, $this->isQueryIncludesSoftCredits());
+    [$contributions, $contacts] = $this->buildContributionArray($groupBy, $contributionIDs, $returnProperties, $messageToken, $separator, $this->isQueryIncludesSoftCredits());
     $html = [];
     $contactHtml = $emailedHtml = [];
     foreach ($contributions as $contributionId => $contribution) {
@@ -307,17 +302,14 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * @param string $groupBy
    * @param array $contributionIDs
    * @param array $returnProperties
-   * @param bool $skipOnHold
-   * @param bool $skipDeceased
    * @param array $messageToken
-   * @param string $task
    * @param string $separator
    * @param bool $isIncludeSoftCredits
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public function buildContributionArray($groupBy, $contributionIDs, $returnProperties, $skipOnHold, $skipDeceased, $messageToken, $task, $separator, $isIncludeSoftCredits) {
+  public function buildContributionArray($groupBy, $contributionIDs, $returnProperties, $messageToken, $separator, $isIncludeSoftCredits) {
     $contributions = $contacts = [];
     foreach ($contributionIDs as $item => $contributionId) {
       $contribution = CRM_Contribute_BAO_Contribution::getContributionTokenValues($contributionId, $messageToken)['values'][$contributionId];

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -159,7 +159,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
     ];
 
     $form = $this->getFormObject('CRM_Contribute_Form_Task_PDFLetter');
-    [$contributions, $contacts] = $form->buildContributionArray('contact_id', $contributionIDs, $returnProperties, TRUE, TRUE, $messageToken, 'test', '**', FALSE);
+    [$contributions, $contacts] = $form->buildContributionArray('contact_id', $contributionIDs, $returnProperties, $messageToken, '**', FALSE);
 
     $this->assertEquals('Anthony', $contacts[$this->_individualId]['first_name']);
     $this->assertEquals('Donation', $contributions[$result['id']]['financial_type']);


### PR DESCRIPTION
Overview
----------------------------------------
[REF] [php8.2] Remove unused parameters from Contribute_PDFLetter::buildContributionArray

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/225449391-c9ae59ab-03d0-46b2-8129-4a5704556866.png)

After
----------------------------------------
Both the unused variables & the php-unfriendly unused properties used to not store the information are removed

Technical Details
----------------------------------------
`skipDeceased` is actually not used anywhere else usefully - but left out of scope for this PR

![image](https://user-images.githubusercontent.com/336308/225449798-0a13fab4-4b56-46e9-a436-790d93bebaae.png)

Comments
----------------------------------------
