### PR TITLE
[PHP8.2] Remove unused variabls from `Member_Form_Task_PDFLetter::postProcessMembers`

### DIFF
--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -39,10 +39,9 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    *
-   * @return void
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $this->skipOnHold = $this->skipDeceased = FALSE;
     parent::preProcess();
     $this->setContactIDs();
     $this->preProcessPDF();
@@ -66,21 +65,17 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
    *
    *
    * @return void
+   * @throws \CRM_Core_Exception
    */
   public function postProcess() {
-    // TODO: rewrite using contribution token and one letter by contribution
     $this->setContactIDs();
-    $skipOnHold = $this->skipOnHold ?? FALSE;
-    $skipDeceased = $this->skipDeceased ?? TRUE;
-    $this->postProcessMembers($this->_memberIds, $skipOnHold, $skipDeceased, $this->_contactIds);
+    $this->postProcessMembers($this->_memberIds, $this->_contactIds);
   }
 
   /**
    * Process the form after the input has been submitted and validated.
    *
    * @param $membershipIDs
-   * @param $skipOnHold
-   * @param $skipDeceased
    * @param $contactIDs
    *
    * @throws \CRM_Core_Exception
@@ -88,10 +83,10 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
    * in fixing the existing pdfLetter classes to be suitably generic
    *
    */
-  public function postProcessMembers($membershipIDs, $skipOnHold, $skipDeceased, $contactIDs) {
+  public function postProcessMembers($membershipIDs, $contactIDs) {
     $form = $this;
     $formValues = $form->controller->exportValues($form->getName());
-    [$formValues, $html_message, $messageToken, $returnProperties] = $this->processMessageTemplate($formValues);
+    [$formValues, $html_message, $messageToken] = $this->processMessageTemplate($formValues);
 
     $html
       = $this->generateHTML(


### PR DESCRIPTION
Overview
----------------------------------------
[PHP8.2] Remove unused variabls from `Member_Form_Task_PDFLetter::postProcessMembers`

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/225450879-3ef78a7c-8b7b-4c06-bf78-da949d0df32b.png)


After
----------------------------------------
Removed variables & the reference to undeclared properties

Technical Details
----------------------------------------
The only other used reference to these undeclared properties is removed in https://github.com/civicrm/civicrm-core/pull/25829

![image](https://user-images.githubusercontent.com/336308/225451198-b9aa6c79-18ae-40a8-b449-a153910fcb09.png)



Comments
----------------------------------------
