### PR TITLE
[PHP8.2] Remove unused setting on undeclared properties

### DIFF
--- a/CRM/Case/Form/Task/PDF.php
+++ b/CRM/Case/Form/Task/PDF.php
@@ -38,7 +38,6 @@ class CRM_Case_Form_Task_PDF extends CRM_Case_Form_Task {
    */
   public function preProcess() {
     $this->preProcessPDF();
-    $this->skipOnHold = $this->skipDeceased = FALSE;
     parent::preProcess();
     $this->setContactIDs();
   }

--- a/CRM/Contact/Form/Task/PDF.php
+++ b/CRM/Contact/Form/Task/PDF.php
@@ -39,8 +39,6 @@ class CRM_Contact_Form_Task_PDF extends CRM_Contact_Form_Task {
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
-
-    $this->skipOnHold = $this->skipDeceased = FALSE;
     $this->preProcessPDF();
 
     // store case id if present


### PR DESCRIPTION
Overview
----------------------------------------
[PHP8.2] Remove unused setting on undeclared properties

Before
----------------------------------------
Properties declared over the objections of PHP8.2 but never used

After
----------------------------------------
poof

Technical Details
----------------------------------------
With this & https://github.com/civicrm/civicrm-core/pull/25829 & https://github.com/civicrm/civicrm-core/pull/25830 merged there are no further usages of these - see screenshots on those PRs

Comments
----------------------------------------