### PR TITLE
Afform - set multi-select values from url

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -109,7 +109,7 @@
           }
           // Set default value from url with fieldName only
           else if (urlArgs && urlArgs[ctrl.fieldName]) {
-            $scope.dataProvider.getFieldData()[ctrl.fieldName] = urlArgs[ctrl.fieldName];
+            setValue(urlArgs[ctrl.fieldName]);
           }
           // Set default value based on field defn
           else if (ctrl.defn.afform_default) {
@@ -159,6 +159,11 @@
             '>=': ('' + value).split('-')[0],
             '<=': ('' + value).split('-')[1] || '',
           };
+        }
+        else if (!_.isArray(value) &&
+          ((['Select', 'EntityRef'].includes(ctrl.defn.input_type) && ctrl.defn.input_attrs.multiple) || ctrl.defn.input_type === 'CheckBox')
+        ) {
+          value =  value.split(',');
         }
         $scope.dataProvider.getFieldData()[ctrl.fieldName] = value;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Ensures that default values are set correctly for multi-valued fields
Modified version of #24787

Before
----------------------------------------
Passing default values for a multiselect/checkbox field through the url is not possible

After
----------------------------------------
Now it works