### PR TITLE
[REF][PHP8.2] Declare property in CRM_Contact_Form_DedupeFind

### DIFF
--- a/CRM/Contact/Form/DedupeFind.php
+++ b/CRM/Contact/Form/DedupeFind.php
@@ -21,10 +21,16 @@
 class CRM_Contact_Form_DedupeFind extends CRM_Admin_Form {
 
   /**
-   *  Indicate if this form should warn users of unsaved changes
+   * Indicate if this form should warn users of unsaved changes
    * @var bool
    */
   protected $unsavedChangesWarn = FALSE;
+
+  /**
+   * Dedupe rule group ID
+   * @var int
+   */
+  protected $rgid;
 
   /**
    * Pre processing.


### PR DESCRIPTION
Overview
----------------------------------------
Declare property in CRM_Contact_Form_DedupeFind.

Before
----------------------------------------
`$rgid` declared as a dynamic property. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
Property declared.

Technical Details
----------------------------------------
Technically speaking this is a breaking change as we've now made `rgid` protected, and an extension could be reading it via a hook like https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess/. That said, in this case I think the chance of an extension being impacted is very small. It's also easy for an impacted extension to just read the value directly from `CRM_Utils_Request::retrieve('rgid', 'Positive', $this, FALSE, 0);` if needed.