### PR TITLE
(REF) PHPUnit - Allow env-var to specify version

### DIFF
--- a/tools/mixin/bin/mixer
+++ b/tools/mixin/bin/mixer
@@ -196,7 +196,8 @@ function deep_copy(array $srcDirs, string $targetDir): void {
 
 function phpunit(array $args = []) {
   $argString = implode(' ' , array_map('escapeshellarg', $args));
-  passthru_ok('phpunit8 ' . $argString);
+  $phpunit = getenv('PHPUNIT') ?: 'phpunit8';
+  passthru_ok($phpunit . ' ' . $argString);
 }
 
 function passthru_ok($cmd) {

--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -15,46 +15,34 @@ $argFilters = [];
 if (PHP_SAPI !== 'cli') {
   die("phpunit can only be run from command line.");
 }
-if (version_compare(PHP_VERSION, '7.2', '>=')) {
-  $phpunit = findCommand('phpunit8');
-  $argFilters[] = function ($argv) {
-    $pos = array_search('--tap', $argv);
-    if ($pos !== FALSE) {
-      array_splice($argv, $pos, 1, ['--printer', '\Civi\Test\TAP']);
-    }
-    return $argv;
-  };
+
+$phpunitCmd = pickPhpunitCommand();
+$phpunitPath = findCommand($phpunitCmd);
+switch ($phpunitCmd) {
+  case 'phpunit9':
+    $argFilters[] = function ($argv) {
+      // WISHLIST: Update TAP adapter for phpunit9. It's easier to search logs for problems.
+      return preg_replace('/--tap/', '--debug', $argv);
+    };
+    break;
+
+  case 'phpunit8':
+  case 'phpunit7':
+  case 'phpunit6':
+    $argFilters[] = function ($argv) {
+      $pos = array_search('--tap', $argv);
+      if ($pos !== FALSE) {
+        array_splice($argv, $pos, 1, ['--printer', '\Civi\Test\TAP']);
+      }
+      return $argv;
+    };
+    break;
 }
-elseif (version_compare(PHP_VERSION, '7.1', '>=')) {
-  $phpunit = findCommand('phpunit7');
-  $argFilters[] = function ($argv) {
-    $pos = array_search('--tap', $argv);
-    if ($pos !== FALSE) {
-      array_splice($argv, $pos, 1, ['--printer', '\Civi\Test\TAP']);
-    }
-    return $argv;
-  };
+
+if (!$phpunitPath) {
+  $phpunitPath = findCommand('phpunit');
 }
-elseif (version_compare(PHP_VERSION, '7.0', '>=')) {
-  $phpunit = findCommand('phpunit6');
-  $argFilters[] = function ($argv) {
-    $pos = array_search('--tap', $argv);
-    if ($pos !== FALSE) {
-      array_splice($argv, $pos, 1, ['--printer', '\Civi\Test\TAP']);
-    }
-    return $argv;
-  };
-}
-elseif (version_compare(PHP_VERSION, '5.6', '>=')) {
-  $phpunit = findCommand('phpunit5');
-}
-else {
-  $phpunit = findCommand('phpunit4');
-}
-if (!$phpunit) {
-  $phpunit = findCommand('phpunit');
-}
-if (!$phpunit) {
+if (!$phpunitPath) {
   echo "Plesae ensure that:\n";
   echo " * PHPUnit is installed.\n";
   echo " * The extensions for dbunit and selenium are installed.\n" ;
@@ -101,10 +89,31 @@ $cmd =
   findPhp() // In case this system has multiple copies of PHP, use the active/preferred one.
   // . ' -ddisplay_errors=1'
   . ' '
-  . escapeshellarg($phpunit)
+  . escapeshellarg($phpunitPath)
   . ' '
   . implode(' ', array_map('escapeshellarg', $argv));
 passthru($cmd);
+
+function pickPhpunitCommand() {
+  if (getenv('PHPUNIT')) {
+    return getenv('PHPUNIT');
+  }
+  elseif (version_compare(PHP_VERSION, '7.2', '>=')) {
+    return 'phpunit8';
+  }
+  elseif (version_compare(PHP_VERSION, '7.1', '>=')) {
+    return 'phpunit7';
+  }
+  elseif (version_compare(PHP_VERSION, '7.0', '>=')) {
+    return 'phpunit6';
+  }
+  elseif (version_compare(PHP_VERSION, '5.6', '>=')) {
+    return 'phpunit5';
+  }
+  else {
+    return 'phpunit';
+  }
+}
 
 function findPhp() {
   // The autodetect behavior here is a potential point of contention. These two cases are hard to reconcile:


### PR DESCRIPTION
Overview
----------------------------------------

This is a small update to the "tools/" to make it easier to pre-run tests on newer versions of phpunit.

Before
----------------------------------------

* Autodetect PHPUnit version based on PHP version. (De facto choice: `phpunit8`)
 
After
----------------------------------------

* Optionally, set env-var `PHPUNIT` to the name/path of the PHPUnit command.
* Autodetect PHPUnit version based on PHP version. (De facto choice: `phpunit8`)
