### PR TITLE
Remove un-used, un-displayed button

### DIFF
--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -39,12 +39,6 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_SKIP => ts('Insert new contributions'),
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing contributions'),
     ]);
-
-    $this->addElement('xbutton', 'loadMapping', ts('Load Mapping'), [
-      'type' => 'submit',
-      'onclick' => 'checkSelect()',
-    ]);
-
     $this->addContactTypeSelector();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove un-used, un-displayed button `'loadMapping'` - the js it has onClick (`checkSelect()`) is not in our code base 

Before
----------------------------------------
This button is being added, but not displayed, for the `Contribution_DataSource` form.

All the tpl & processing here is shared with the other classes who don't have the button - so this is just some left over cruft

![image](https://user-images.githubusercontent.com/336308/225511338-65c7a52a-fe3b-4676-b0a6-14740a81bafa.png)

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
