### PR TITLE
dev/core#4190 Fix issue where defaultValues needs to be an array not …

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -200,7 +200,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
    */
   public function setDefaultValues() {
     if ($this->_action & CRM_Core_Action::DELETE || $this->_action & CRM_Core_Action::RENEW) {
-      return TRUE;
+      return [];
     }
     $className = "CRM_Case_Form_Activity_{$this->_activityTypeFile}";
     $defaults = $className::setDefaultValues($this);


### PR DESCRIPTION
…boolean

Overview
----------------------------------------
This fixes https://lab.civicrm.org/dev/core/-/issues/4190 by returning an array instead of boolean

Before
----------------------------------------
Case Delete fails on PHP8

After
----------------------------------------
Case Delete doesn't fail on PHP8

ping @eileenmcnaughton 