### PR TITLE
PHP8 - Update symfony/var-dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "symfony/event-dispatcher": "~4.4 || ~6.0",
     "symfony/filesystem": "~4.4 || ~6.0",
     "symfony/process": "~4.4 || ~6.0",
-    "symfony/var-dumper": "~3.0 || ~4.4 || ~5.1 || ~6.0",
+    "symfony/var-dumper": "~4.4 || ~5.1 || ~6.0",
     "symfony/service-contracts": "~2.2 || ~3.1",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
     "symfony/finder": "~4.4 || ~6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18f17bf90f8002419597da6e8c7db3b1",
+    "content-hash": "7c6659d5a4e0f2fb75f5ca1e5965b5f6",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -4909,34 +4909,42 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.47",
+            "version": "v4.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0719f6cf4633a38b2c1585140998579ce23b4b7d"
+                "reference": "1069c7a3fca74578022fab6f81643248d02f8e63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0719f6cf4633a38b2c1585140998579ce23b4b7d",
-                "reference": "0719f6cf4633a38b2c1585140998579ce23b4b7d",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/1069c7a3fca74578022fab6f81643248d02f8e63",
+                "reference": "1069c7a3fca74578022fab6f81643248d02f8e63",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.5",
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/console": "<3.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^1.43|^2.13|^3.0.4"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
                 "ext-intl": "To show region name in time zone dump",
-                "ext-symfony_debug": ""
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
             "type": "library",
             "autoload": {
                 "files": [
@@ -4963,14 +4971,14 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
             "homepage": "https://symfony.com",
             "keywords": [
                 "debug",
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v3.4.47"
+                "source": "https://github.com/symfony/var-dumper/tree/v4.4.47"
             },
             "funding": [
                 {
@@ -4986,7 +4994,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2022-10-03T15:15:11+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -5584,5 +5592,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
Civi locks var-dumper at v3, which is pretty old.

Before
----------------------------------------
1. Log in as a user with permission to see debug output.
1. Turn on Display Backtrace at Administer - System Settings - Debugging.
1. Click around until you generate a CRM_Core_Exception. If you don't like clicking, you can use `cv` as below.
   `cv ev '$x = array(1,2); echo CRM_Core_Error::debug_var("x", $x, false);'`
1. `Deprecated: Return type of Symfony\Component\VarDumper\Cloner\Data::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...\civicrm\vendor\symfony\var-dumper\Cloner\Data.php on line 141`
1. If you don't see the error, sometimes they seem to get swallowed somewhere. You can use this variation:
   `cv ev '$x = array(1,2); set_error_handler(function($a, $b) { fprintf(STDERR, $b); }); echo CRM_Core_Error::debug_var("x", $x, false);'`

Drupal 9 sites have been running for a long time now with v5 so you won't see this on drupal 9.

After
----------------------------------------


Technical Details
----------------------------------------
I picked v4 just out of caution. Note php 7.1+ is still supported by it, and this doesn't change any other packages.

Comments
----------------------------------------
