### PR TITLE
dev/core#4079 Add Pledge Tokens

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -17,13 +17,6 @@ use Civi\Token\TokenRow;
  * Class CRM_Event_Tokens
  *
  * Generate "event.*" tokens.
- *
- * This TokenSubscriber was produced by refactoring the code from the
- * scheduled-reminder system with the goal of making that system
- * more flexible. The current implementation is still coupled to
- * scheduled-reminders. It would be good to figure out a more generic
- * implementation which is not tied to scheduled reminders, although
- * that is outside the current scope.
  */
 class CRM_Event_Tokens extends CRM_Core_EntityTokens {
 

--- a/CRM/Pledge/Tokens.php
+++ b/CRM/Pledge/Tokens.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Pledge_Tokens
+ *
+ * Generate "pledge.*" tokens.
+ *
+ * @noinspection PhpUnused
+ */
+class CRM_Pledge_Tokens extends CRM_Core_EntityTokens {
+
+  /**
+   * Get the entity name for api v4 calls.
+   *
+   * @return string
+   */
+  protected function getApiEntityName(): string {
+    return 'Pledge';
+  }
+
+  /**
+   * Get entity fields that should be exposed as tokens.
+   *
+   * These are the fields that seem most likely to be useful as tokens.
+   *
+   * @todo - add more pseudo-fields like 'paid_amount', 'balance_amount'
+   * to v4 api - see the ContributionGetSpecProvider for how.
+   *
+   * @return string[]
+   *
+   */
+  protected function getExposedFields(): array {
+    return [
+      'amount',
+      'currency',
+      'frequency_unit',
+      'frequency_interval',
+      'frequency_day',
+      'installments',
+      'start_date',
+      'create_date',
+      'cancel_date',
+      'end_date',
+    ];
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -345,9 +345,9 @@ class Container {
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
-    foreach (['Activity', 'Contact', 'Contribute', 'Event', 'Mailing', 'Member', 'Case'] as $comp) {
-      $container->setDefinition('crm_' . strtolower($comp) . '_tokens', new Definition(
-        "CRM_{$comp}_Tokens",
+    foreach (['Activity', 'Contact', 'Contribute', 'Event', 'Mailing', 'Member', 'Case', 'Pledge'] as $component) {
+      $container->setDefinition('crm_' . strtolower($component) . '_tokens', new Definition(
+        "CRM_{$component}_Tokens",
         []
       ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
     }

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -528,6 +528,37 @@ contribution_recur.payment_instrument_id:name :Check
 
   }
 
+  public function testPledgeTokens(): void {
+    $pledgeID = $this->pledgeCreate(['contact_id' => $this->individualCreate(), 'create_date' => '2022-04-07', 'start_date' => '2022-04-07']);
+    $tokenProcessor = $this->getTokenProcessor(['schema' => ['pledgeId']]);
+    $list = $tokenProcessor->listTokens();
+    $this->assertEquals(array_merge($this->getPledgeTokens(), $this->getDomainTokens()), $list);
+    $tokenString = implode(', ', array_keys($this->getPledgeTokens()));
+    $tokenProcessor->addMessage('text', $tokenString, 'text/plain');
+    $tokenProcessor->addRow(['pledgeId' => $pledgeID]);
+    $tokenProcessor->evaluate();
+    $this->assertEquals($this->getExpectedPledgeTokenOutput(), $tokenProcessor->getRow(0)->render('text'));
+  }
+
+  public function getExpectedPledgeTokenOutput(): string {
+    return '$100.00, US Dollar, year, 5, 15, 5, April 7th, 2022, April 7th, 2022, , ';
+  }
+
+  public function getPledgeTokens(): array {
+    return [
+      '{pledge.amount}' => 'Total Pledged',
+      '{pledge.currency:label}' => 'Pledge Currency',
+      '{pledge.frequency_unit:label}' => 'Pledge Frequency Unit',
+      '{pledge.frequency_interval}' => 'Pledge Frequency Interval',
+      '{pledge.frequency_day}' => 'Pledge day',
+      '{pledge.installments}' => 'Pledge Number of Installments',
+      '{pledge.start_date}' => 'Pledge Start Date',
+      '{pledge.create_date}' => 'Pledge Made',
+      '{pledge.cancel_date}' => 'Pledge Cancelled Date',
+      '{pledge.end_date}' => 'Pledge End Date',
+    ];
+  }
+
   /**
    * Get the advertised tokens the legacy function doesn't know about.
    *


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4079 Add Pledge Tokens

Before
----------------------------------------
Not possible to use Pledge Tokens

After
----------------------------------------
Pledge tokens can now be used 
- see https://docs.civicrm.org/dev/en/latest/framework/token/#compose-batch for how to use tokens
- 
Technical Details
----------------------------------------

Comments
----------------------------------------
@seamuslee001 @yashodha - this is just the basic implementation - I expect that in the future things like `{pledge.paid_amount}` will be added - which is a case of doing something similar to https://github.com/civicrm/civicrm-core/blob/45ebb03fe1b2b71366aeb4641a625d44610c5764/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php#L31 & adding them to the exposed tokens list