### PR TITLE
Avoid type error in CRM_Core_Form on php 8

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -198,7 +198,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form {
   /**
    * Set default values for the form.
    */
-  public function setDefaultValues() {
+  public function setDefaultValues(): array {
     if ($this->_action & CRM_Core_Action::DELETE || $this->_action & CRM_Core_Action::RENEW) {
       return [];
     }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -694,7 +694,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     $this->buildQuickForm();
 
     $defaults = $this->setDefaultValues();
-    unset($defaults['qfKey']);
+    if (isset($defaults['qfKey'])) {
+      unset($defaults['qfKey']);
+    }
 
     if (!empty($defaults)) {
       $this->setDefaults($defaults);


### PR DESCRIPTION
More insurance against implementations of `setDefaultValues()` returning non-array values, like the one reported in [dev/core#4190](https://lab.civicrm.org/dev/core/-/issues/4190) and fixed (for that one instance) by #25849.