### PR TITLE
CiviUnitTestCase (etal) - Resolve spooky interaction

### DIFF
--- a/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
@@ -12,8 +12,8 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/BAO/RelationshipCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/RelationshipCacheTest.php
@@ -18,8 +18,8 @@
 class CRM_Contact_BAO_RelationshipCacheTest extends CiviUnitTestCase {
 
   protected function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Contact/Page/AjaxTest.php
@@ -15,8 +15,8 @@ class CRM_Contact_Page_AjaxTest extends CiviUnitTestCase {
   protected $originalRequest = [];
 
   public function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->originalRequest = $_REQUEST;
   }
 

--- a/tests/phpunit/CRM/Core/ManagedEntitiesTest.php
+++ b/tests/phpunit/CRM/Core/ManagedEntitiesTest.php
@@ -23,8 +23,8 @@ class CRM_Core_ManagedEntitiesTest extends CiviUnitTestCase {
   protected $fixtures;
 
   public function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->modules = [
       'one' => new CRM_Core_Module('com.example.one', TRUE),
       'two' => new CRM_Core_Module('com.example.two', TRUE),

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -21,8 +21,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   protected $fromEmailAddressOptions = [];
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -12,8 +12,8 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   use CRMTraits_Profile_ProfileTrait;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -19,8 +19,8 @@ use Civi\Api4\FinancialType;
 class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->organizationCreate();
   }
 

--- a/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/BaseMailingSystemTest.php
@@ -36,8 +36,8 @@ abstract class CRM_Mailing_BaseMailingSystemTest extends CiviUnitTestCase {
   private $_mut;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
 
     $this->_groupID = $this->groupCreate();

--- a/tests/phpunit/CRM/Mailing/MailStoreTest.php
+++ b/tests/phpunit/CRM/Mailing/MailStoreTest.php
@@ -8,8 +8,8 @@ class CRM_Mailing_MailStoreTest extends \CiviUnitTestCase {
   protected $workDir;
 
   public function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->workDir = tempnam(sys_get_temp_dir(), 'mailstoretest');
     @unlink($this->workDir);
   }

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -6,8 +6,8 @@
 class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     $this->callAPISuccess('mail_settings', 'get',
       ['api.mail_settings.create' => ['domain' => 'chaos.org']]);
   }

--- a/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
@@ -12,8 +12,8 @@ class CRM_Utils_API_MatchOptionTest extends CiviUnitTestCase {
   public $noise;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     $this->assertDBQuery(0, "SELECT count(*) FROM civicrm_contact WHERE first_name='Jeffrey' and last_name='Lebowski'");
 
     // Create noise to ensure we don't accidentally/coincidentally match the first record

--- a/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/ReloadOptionTest.php
@@ -12,8 +12,8 @@
 class CRM_Utils_API_ReloadOptionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     CRM_Utils_Hook_UnitTests::singleton()->setHook('civicrm_post', [$this, 'onPost']);
   }
 

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -10,8 +10,8 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testAsColumns() {

--- a/tests/phpunit/CRM/Utils/AutoCleanTest.php
+++ b/tests/phpunit/CRM/Utils/AutoCleanTest.php
@@ -9,8 +9,8 @@ class CRM_Utils_AutoCleanTest extends CiviUnitTestCase {
   public $foo;
 
   protected function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testAutoclean() {

--- a/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/EnvTest.php
@@ -9,8 +9,8 @@
 class CRM_Utils_Check_Component_EnvTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/OptionGroupsTest.php
@@ -9,8 +9,8 @@
 class CRM_Utils_Check_Component_OptionGroupsTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testCheckOptionGroupValues() {

--- a/tests/phpunit/CRM/Utils/ColorTest.php
+++ b/tests/phpunit/CRM/Utils/ColorTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_ColorTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -30,8 +30,8 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/GlobalStackTest.php
+++ b/tests/phpunit/CRM/Utils/GlobalStackTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_GlobalStackTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/HTMLTest.php
+++ b/tests/phpunit/CRM/Utils/HTMLTest.php
@@ -16,8 +16,8 @@
 class CRM_Utils_HTMLTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/HookTest.php
+++ b/tests/phpunit/CRM/Utils/HookTest.php
@@ -27,8 +27,8 @@ class CRM_Utils_HookTest extends CiviUnitTestCase {
   public $hook;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     $this->fakeModules = [
       'hooktesta',
       'hooktestb',

--- a/tests/phpunit/CRM/Utils/HtmlToTextTest.php
+++ b/tests/phpunit/CRM/Utils/HtmlToTextTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_HtmlToTextTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/HttpClientTest.php
+++ b/tests/phpunit/CRM/Utils/HttpClientTest.php
@@ -25,8 +25,8 @@ class CRM_Utils_HttpClientTest extends CiviUnitTestCase {
   protected $client;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
 
     $this->tmpFile = $this->createTempDir() . '/example.txt';
 

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -16,8 +16,8 @@
 class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -19,8 +19,8 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/LazyArrayTest.php
+++ b/tests/phpunit/CRM/Utils/LazyArrayTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_LazyArrayTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testAssoc() {

--- a/tests/phpunit/CRM/Utils/Mail/FilteredPearMailerTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/FilteredPearMailerTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_Mail_FilteredPearMailerTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testFilter() {

--- a/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/IncomingTest.php
@@ -32,8 +32,8 @@ class CRM_Utils_Mail_IncomingTest extends CiviUnitTestCase {
   protected $name;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
 
     $rand = rand(0, 1000);
     $this->email = "test{$rand}@example.com";

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_MailTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/MoneyTest.php
+++ b/tests/phpunit/CRM/Utils/MoneyTest.php
@@ -8,8 +8,8 @@
 class CRM_Utils_MoneyTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/NumberTest.php
+++ b/tests/phpunit/CRM/Utils/NumberTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_NumberTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/PDF/UtilsTest.php
+++ b/tests/phpunit/CRM/Utils/PDF/UtilsTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_PDF_UtilsTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -10,8 +10,8 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_SQL_DeleteTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testGetDefault() {

--- a/tests/phpunit/CRM/Utils/SQL/InsertTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/InsertTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_SQL_InsertTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testRow_twice() {

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testGetDefault() {

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_SQLTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testInterpolate() {

--- a/tests/phpunit/CRM/Utils/SignerTest.php
+++ b/tests/phpunit/CRM/Utils/SignerTest.php
@@ -16,8 +16,8 @@
 class CRM_Utils_SignerTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testSignValidate() {

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -10,8 +10,8 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testBase64Url(): void {

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -8,8 +8,8 @@
 class CRM_Utils_SystemTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testUrlQueryString() {

--- a/tests/phpunit/CRM/Utils/TimeTest.php
+++ b/tests/phpunit/CRM/Utils/TimeTest.php
@@ -7,8 +7,8 @@
 class CRM_Utils_TimeTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/TokenTest.php
+++ b/tests/phpunit/CRM/Utils/TokenTest.php
@@ -9,8 +9,8 @@ use Civi\Token\TokenProcessor;
 class CRM_Utils_TokenTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/XMLTest.php
+++ b/tests/phpunit/CRM/Utils/XMLTest.php
@@ -10,8 +10,8 @@ class CRM_Utils_XMLTest extends CiviUnitTestCase {
    * Set up for tests.
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function testFilterMarkupTest(): void {

--- a/tests/phpunit/CRM/Utils/ZipTest.php
+++ b/tests/phpunit/CRM/Utils/ZipTest.php
@@ -22,8 +22,8 @@ class CRM_Utils_ZipTest extends CiviUnitTestCase {
   private $file = FALSE;
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     $this->file = FALSE;
   }
 

--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -9,8 +9,8 @@ use Civi\Test\Invasive;
 class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/Civi/Angular/ManagerTest.php
+++ b/tests/phpunit/Civi/Angular/ManagerTest.php
@@ -30,8 +30,8 @@ class ManagerTest extends \CiviUnitTestCase {
    * @inheritDoc
    */
   protected function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->createLoggedInUser();
     $this->res = \CRM_Core_Resources::singleton();
     $this->angular = new Manager($this->res);

--- a/tests/phpunit/Civi/Angular/PartialSyntaxTest.php
+++ b/tests/phpunit/Civi/Angular/PartialSyntaxTest.php
@@ -30,8 +30,8 @@ class PartialSyntaxTest extends \CiviUnitTestCase {
    * @inheritDoc
    */
   protected function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->createLoggedInUser();
     $this->res = \CRM_Core_Resources::singleton();
     $this->angular = new Manager($this->res);

--- a/tests/phpunit/Civi/Core/ThemesTest.php
+++ b/tests/phpunit/Civi/Core/ThemesTest.php
@@ -10,8 +10,8 @@ namespace Civi\Core;
 class ThemesTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function getThemeExamples() {

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -20,8 +20,8 @@ class TokenProcessorTest extends \CiviUnitTestCase {
   protected $counts;
 
   protected function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $this->dispatcher = new CiviEventDispatcher();
     $this->dispatcher->addListener('civi.token.list', [$this, 'onListTokens']);
     $this->dispatcher->addListener('civi.token.eval', [$this, 'onEvalTokens']);

--- a/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
@@ -21,8 +21,8 @@ use Civi\Test\Invasive;
 class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/Civi/WorkflowMessage/FieldSpecTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/FieldSpecTest.php
@@ -17,8 +17,8 @@ namespace Civi\WorkflowMessage;
 class FieldSpecTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   public function getScopeExamples() {

--- a/tests/phpunit/Civi/WorkflowMessage/Traits/AddressingTraitTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/Traits/AddressingTraitTest.php
@@ -16,8 +16,8 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
 class AddressingTraitTest extends \CiviUnitTestCase {
 
   protected function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -269,6 +269,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    *  Common setup functions for all unit tests.
    */
   protected function setUp(): void {
+    if ($this->tx !== NULL) {
+      throw new \RuntimeException("CiviUnitTestCase requires that parent::setUp() run before useTransaction()");
+    }
+
     CRM_Core_I18n::clearLocale();
     parent::setUp();
     CRM_Core_Session::singleton()->set('userID');

--- a/tests/phpunit/api/v3/EntityTagACLTest.php
+++ b/tests/phpunit/api/v3/EntityTagACLTest.php
@@ -46,8 +46,8 @@ class api_v3_EntityTagACLTest extends CiviUnitTestCase {
    * Set up permissions for test.
    */
   public function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
     $individualID = $this->individualCreate();
     $daoObj = new CRM_Core_DAO();
     $this->callAPISuccess('Attachment', 'create', [

--- a/tests/phpunit/api/v3/ExceptionTest.php
+++ b/tests/phpunit/api/v3/ExceptionTest.php
@@ -23,8 +23,8 @@ class api_v3_ExceptionTest extends CiviUnitTestCase {
    * This method is called before a test is executed.
    */
   protected function setUp(): void {
-    $this->useTransaction(TRUE);
     parent::setUp();
+    $this->useTransaction(TRUE);
   }
 
   /**

--- a/tests/phpunit/api/v3/PaymentTokenTest.php
+++ b/tests/phpunit/api/v3/PaymentTokenTest.php
@@ -23,8 +23,8 @@ class api_v3_PaymentTokenTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function setUp(): void {
-    $this->useTransaction();
     parent::setUp();
+    $this->useTransaction();
     $contactID = $this->individualCreate();
     $this->params = [
       'token' => "fancy-token-xxxx",

--- a/tests/phpunit/api/v3/SurveyTest.php
+++ b/tests/phpunit/api/v3/SurveyTest.php
@@ -33,6 +33,7 @@ class api_v3_SurveyTest extends CiviUnitTestCase {
   protected $entity = 'survey';
 
   public function setUp(): void {
+    parent::setUp();
     $phoneBankActivityTypeID = $this->callAPISuccessGetValue('Option_value', [
       'label' => 'PhoneBank',
       'return' => 'value',
@@ -45,7 +46,6 @@ class api_v3_SurveyTest extends CiviUnitTestCase {
       'max_number_of_contacts' => 12,
       'instructions' => "Call people, ask for money",
     ];
-    parent::setUp();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

In #25673, there was a [spooky interaction between tests](https://github.com/civicrm/civicrm-core/pull/25673#issuecomment-1473092399) -- which originated in a subtle detail of the `setUp()` process.

That PR includes the minimal change. This PR aims to be more proactive -- normalizing the `setUp()` and (hopefully) preventing similar spookiness in the future.

Before
----------------------------------------

Four tests in `api_v3_*` use this uncommon formulation:

```php
   protected function setUp(): void {
     $this->useTransaction(TRUE);
     parent::setUp();
   }
```

After
----------------------------------------

The tests now match their 54 siblings in `api_v3_*` which use:

```php
   protected function setUp(): void {
     parent::setUp();
     $this->useTransaction(TRUE);
   }
```

Anything with a flipped sequence will raise an error.

Comments
----------------------------------------

I only looked at `tests/phpunit/api/v3`. The testbot should now complain about similar issues in other suites.