### PR TITLE
CiviUnitTestCase - During teardown, ensure that we cleanup locks

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -453,6 +453,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       $this->quickCleanup($tablesToTruncate);
       $this->createDomainContacts();
     }
+    $releasedLocks = CRM_Core_DAO::singleValueQuery('SELECT RELEASE_ALL_LOCKS()');
+    $this->assertEquals(0, $releasedLocks, "The test should not leave any dangling locks. Found $releasedLocks");
 
     $this->cleanTempDirs();
     $this->unsetExtensionSystem();


### PR DESCRIPTION
Overview
----------------------------------------

Off-shoot from test-interaction observed in https://github.com/civicrm/civicrm-core/pull/25673

Before
----------------------------------------

If a test acquires a lock and fails to release, then... we just continue holding the lock... indefinitely.

After
----------------------------------------

* Locks are released at end
* If there are any unreleased locks, the leaky test fails.

Comments
----------------------------------------

I have no idea what to expect in terms of results. Failures, perhaps?