### PR TITLE
AutoClean - Optionally allow explicit cleanup

### DIFF
--- a/CRM/Utils/AutoClean.php
+++ b/CRM/Utils/AutoClean.php
@@ -27,6 +27,13 @@ class CRM_Utils_AutoClean {
   protected $args;
 
   /**
+   * Have we run this cleanup method yet?
+   *
+   * @var bool
+   */
+  protected $isDone = FALSE;
+
+  /**
    * Call a cleanup function when the current context shuts down.
    *
    * ```
@@ -144,6 +151,21 @@ class CRM_Utils_AutoClean {
   }
 
   public function __destruct() {
+    $this->cleanup();
+  }
+
+  /**
+   * Explicitly apply the cleanup.
+   *
+   * Use this if you want to do the cleanup work immediately.
+   *
+   * @return void
+   */
+  public function cleanup(): void {
+    if ($this->isDone) {
+      return;
+    }
+    $this->isDone = TRUE;
     \Civi\Core\Resolver::singleton()->call($this->callback, $this->args);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

The `AutoClean` helper provides a way to insert cleanup logic into existing code. But it produces quirky artifacts in some IDEs/linters. This PR allows some slightly different code-patterns that will give the same functionality - and look more pleasing to the IDE/linter.

Before
----------------------------------------

```php
function doStuff() {
  $l10n = CRM_Utils_AutoClean::swapLocale('EX_ex');
  moreStuff();
  additionalStuff();
  someExtraBits();
}
```

The locale will be restored when the function closes.

After
----------------------------------------

The above works the same. And it's still guaranteed to cleanup at the end. But you have the option to do some extra hints, e.g.

* Advise the IDE/linter that `$l10n` really does matter -- and advise the reader that the *ordinary* process is to cleanup at the end. (This example is functionally equivalent as before; it just communicates norms.)

    ```php
    function doStuff() {
      $l10n = CRM_Utils_AutoClean::swapLocale('EX_ex');
      moreStuff();
      additionalStuff();
      someExtraBits();
      $l10n->cleanup();
    }
    ```

* Actually do the cleanup earlier.

    ```php
    function doStuff() {
      $l10n = CRM_Utils_AutoClean::swapLocale('EX_ex');
      moreStuff();
      if ($nevermind) {
        $l10n->cleanup();
        additionalStuff();
      }
      else {
        someExtraBits();
      }
    }
    ```

