### PR TITLE
[REF] Replace use of legacy `$dao->query()` with `CRM_Core_DAO::executeQuery()`

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -52,7 +52,7 @@ class CRM_Dedupe_Finder {
     while ($dao->fetch()) {
       $dupes[] = [$dao->id1, $dao->id2, $dao->weight];
     }
-    CRM_Core_DAO::executeQuery(($rgBao->tableDropQuery()));
+    CRM_Core_DAO::executeQuery($rgBao->tableDropQuery());
 
     return $dupes;
   }
@@ -122,15 +122,15 @@ class CRM_Dedupe_Finder {
     }
     $rgBao->params = $params;
     $rgBao->fillTable();
-    $dao = new CRM_Core_DAO();
-    $dao->query($rgBao->thresholdQuery($checkPermission));
+
+    $dao = CRM_Core_DAO::executeQuery($rgBao->thresholdQuery($checkPermission));
     $dupes = [];
     while ($dao->fetch()) {
       if (isset($dao->id) && $dao->id) {
         $dupes[] = $dao->id;
       }
     }
-    $dao->query($rgBao->tableDropQuery());
+    CRM_Core_DAO::executeQuery($rgBao->tableDropQuery());
     return array_diff($dupes, $except);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Replace use of legacy  `$dao->query()` with `CRM_Core_DAO::executeQuery()`

Before
----------------------------------------
 `$dao->query()`

After
----------------------------------------
`CRM_Core_DAO::executeQuery()`

Technical Details
----------------------------------------
This is mostly a standardisation up but in the past we have fixed memory leaks with this change as `executeQuery` handles releasing memory better.

I have no idea if there are any memory issues here - my reasoning is just to make the same best-practice change here we have made elsewhere

There is a theoretical list that `tableName` might be stored in a translated fashion but the core supported fields do not support that & I also did a universe search. There are non candidate tables that seem likely. Our documentation does not explain how to use the hook to add a field

@seamuslee001 I think you merged previous ones of these

Comments
----------------------------------------
