### PR TITLE
[REF][PHP8.2] Refactor api_v3_ParticipantPaymentTest

### DIFF
--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -18,13 +18,45 @@
  */
 class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
 
-  protected $_apiversion = 3;
-  protected $_contactID;
-  protected $_createdParticipants;
-  protected $_participantID;
-  protected $_eventID;
-  protected $_participantPaymentID;
-  protected $_financialTypeId;
+  /**
+   * @var int
+   */
+  protected $contactID;
+
+  /**
+   * @var int
+   */
+  protected $contactID2;
+
+  /**
+   * @var int
+   */
+  protected $contactID3;
+
+  /**
+   * @var int
+   */
+  protected $participantID;
+
+  /**
+   * @var int
+   */
+  protected $participantID2;
+
+  /**
+   * @var int
+   */
+  protected $participantID3;
+
+  /**
+   * @var int
+   */
+  protected $participantID4;
+
+  /**
+   * @var int
+   */
+  protected $eventID;
 
   /**
    * Set up for tests.
@@ -33,30 +65,28 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     parent::setUp();
     $this->useTransaction(TRUE);
     $event = $this->eventCreate();
-    $this->_eventID = $event['id'];
-    $this->_contactID = $this->individualCreate();
-    $this->_createdParticipants = [];
-    $this->_individualId = $this->individualCreate();
-    $this->_financialTypeId = 1;
+    $this->eventID = $event['id'];
+    $this->contactID = $this->individualCreate();
+    $this->individualCreate();
 
-    $this->_participantID = $this->participantCreate([
-      'contactID' => $this->_contactID,
-      'eventID' => $this->_eventID,
+    $this->participantID = $this->participantCreate([
+      'contactID' => $this->contactID,
+      'eventID' => $this->eventID,
     ]);
-    $this->_contactID2 = $this->individualCreate();
-    $this->_participantID2 = $this->participantCreate([
-      'contactID' => $this->_contactID2,
-      'eventID' => $this->_eventID,
+    $contactID2 = $this->individualCreate();
+    $this->participantID2 = $this->participantCreate([
+      'contactID' => $contactID2,
+      'eventID' => $this->eventID,
     ]);
-    $this->_participantID3 = $this->participantCreate([
-      'contactID' => $this->_contactID2,
-      'eventID' => $this->_eventID,
+    $this->participantID3 = $this->participantCreate([
+      'contactID' => $contactID2,
+      'eventID' => $this->eventID,
     ]);
 
-    $this->_contactID3 = $this->individualCreate();
-    $this->_participantID4 = $this->participantCreate([
-      'contactID' => $this->_contactID3,
-      'eventID' => $this->_eventID,
+    $this->contactID3 = $this->individualCreate();
+    $this->participantID4 = $this->participantCreate([
+      'contactID' => $this->contactID3,
+      'eventID' => $this->eventID,
     ]);
   }
 
@@ -65,15 +95,15 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
    */
   public function testPaymentCreate(): void {
     //Create Contribution & get contribution ID
-    $contributionID = $this->contributionCreate(['contact_id' => $this->_contactID]);
+    $contributionID = $this->contributionCreate(['contact_id' => $this->contactID]);
 
     //Create Participant Payment record With Values
     $params = [
-      'participant_id' => $this->_participantID,
+      'participant_id' => $this->participantID,
       'contribution_id' => $contributionID,
     ];
 
-    $this->callAPIAndDocument('participant_payment', 'create', $params, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('participantPayment', 'create', $params, __FUNCTION__, __FILE__);
   }
 
   /**
@@ -82,17 +112,17 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
    */
   public function testPaymentInfoForEvent(): void {
     //Create Contribution & get contribution ID
-    $contributionID = $this->contributionCreate(['contact_id' => $this->_contactID]);
+    $contributionID = $this->contributionCreate(['contact_id' => $this->contactID]);
 
     //Create Participant Payment record With Values
     $params = [
-      'participant_id' => $this->_participantID4,
+      'participant_id' => $this->participantID4,
       'contribution_id' => $contributionID,
     ];
-    $this->callAPISuccess('participant_payment', 'create', $params);
+    $this->callAPISuccess('participantPayment', 'create', $params);
 
     //Check if participant payment is correctly retrieved.
-    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->_participantID4, 'event');
+    $paymentInfo = CRM_Contribute_BAO_Contribution::getPaymentInfo($this->participantID4, 'event');
     $this->assertEquals('Completed', $paymentInfo['contribution_status']);
     $this->assertEquals('100.00', $paymentInfo['total']);
   }
@@ -104,30 +134,30 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
 
     // create contribution w/o fee
     $contributionID = $this->contributionCreate([
-      'contact_id' => $this->_contactID,
-      'financial_type_id' => $this->_financialTypeId,
+      'contact_id' => $this->contactID,
+      'financial_type_id' => 1,
       'payment_instrument_id' => 4,
       'fee_amount' => 0,
       'net_amount' => 100,
     ]);
 
-    $this->_participantPaymentID = $this->participantPaymentCreate($this->_participantID, $contributionID);
+    $participantPaymentID = $this->participantPaymentCreate($this->participantID, $contributionID);
     $params = [
-      'id' => $this->_participantPaymentID,
-      'participant_id' => $this->_participantID,
+      'id' => $participantPaymentID,
+      'participant_id' => $this->participantID,
       'contribution_id' => $contributionID,
     ];
 
     // Update Payment
-    $participantPayment = $this->callAPISuccess('participant_payment', 'create', $params);
-    $this->assertEquals($participantPayment['id'], $this->_participantPaymentID);
+    $participantPayment = $this->callAPISuccess('participantPayment', 'create', $params);
+    $this->assertEquals($participantPayment['id'], $participantPaymentID);
     $this->assertTrue(array_key_exists('id', $participantPayment));
     // check Financial records
     $this->_checkFinancialRecords($params, 'offline');
     $params = [
-      'id' => $this->_participantPaymentID,
+      'id' => $participantPaymentID,
     ];
-    $deletePayment = $this->callAPISuccess('participant_payment', 'delete', $params);
+    $deletePayment = $this->callAPISuccess('participantPayment', 'delete', $params);
   }
 
   /**
@@ -138,30 +168,30 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     $pageParams['processor_id'] = $this->processorCreate();
     $contributionPage = $this->contributionPageCreate($pageParams);
     $contributionParams = [
-      'contact_id' => $this->_contactID,
+      'contact_id' => $this->contactID,
       'contribution_page_id' => $contributionPage['id'],
       'payment_processor' => $pageParams['processor_id'],
       'financial_type_id' => 1,
     ];
     $contributionID = $this->contributionCreate($contributionParams);
 
-    $this->_participantPaymentID = $this->participantPaymentCreate($this->_participantID, $contributionID);
+    $participantPaymentID = $this->participantPaymentCreate($this->participantID, $contributionID);
     $params = [
-      'id' => $this->_participantPaymentID,
-      'participant_id' => $this->_participantID,
+      'id' => $participantPaymentID,
+      'participant_id' => $this->participantID,
       'contribution_id' => $contributionID,
     ];
 
     // Update Payment
-    $participantPayment = $this->callAPISuccess('participant_payment', 'create', $params);
-    $this->assertEquals($participantPayment['id'], $this->_participantPaymentID);
+    $participantPayment = $this->callAPISuccess('participantPayment', 'create', $params);
+    $this->assertEquals($participantPayment['id'], $participantPaymentID);
     $this->assertTrue(array_key_exists('id', $participantPayment));
     // check Financial records
     $this->_checkFinancialRecords($params, 'online');
     $params = [
-      'id' => $this->_participantPaymentID,
+      'id' => $participantPaymentID,
     ];
-    $this->callAPISuccess('participant_payment', 'delete', $params);
+    $this->callAPISuccess('participantPayment', 'delete', $params);
   }
 
   /**
@@ -172,7 +202,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     $pageParams['is_pay_later'] = 1;
     $contributionPage = $this->contributionPageCreate($pageParams);
     $contributionParams = [
-      'contact_id' => $this->_contactID,
+      'contact_id' => $this->contactID,
       'contribution_page_id' => $contributionPage['id'],
       'contribution_status_id' => 2,
       'is_pay_later' => 1,
@@ -180,23 +210,23 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     ];
     $contributionID = $this->contributionCreate($contributionParams);
 
-    $this->_participantPaymentID = $this->participantPaymentCreate($this->_participantID, $contributionID);
+    $participantPaymentID = $this->participantPaymentCreate($this->participantID, $contributionID);
     $params = [
-      'id' => $this->_participantPaymentID,
-      'participant_id' => $this->_participantID,
+      'id' => $participantPaymentID,
+      'participant_id' => $this->participantID,
       'contribution_id' => $contributionID,
     ];
 
     // Update Payment
-    $participantPayment = $this->callAPISuccess('participant_payment', 'create', $params);
+    $participantPayment = $this->callAPISuccess('participantPayment', 'create', $params);
     // check Financial Records
     $this->_checkFinancialRecords($params, 'payLater');
-    $this->assertEquals($participantPayment['id'], $this->_participantPaymentID);
+    $this->assertEquals($participantPayment['id'], $participantPaymentID);
     $this->assertTrue(array_key_exists('id', $participantPayment));
     $params = [
-      'id' => $this->_participantPaymentID,
+      'id' => $participantPaymentID,
     ];
-    $this->callAPISuccess('participant_payment', 'delete', $params);
+    $this->callAPISuccess('participantPayment', 'delete', $params);
   }
 
   /**
@@ -206,7 +236,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     $params = [
       'id' => 0,
     ];
-    $deletePayment = $this->callAPIFailure('participant_payment', 'delete', $params);
+    $deletePayment = $this->callAPIFailure('participantPayment', 'delete', $params);
     $this->assertEquals($deletePayment['error_message'], 'Error while deleting participantPayment');
   }
 
@@ -215,32 +245,32 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
    */
   public function testPaymentDelete() {
     $contributionID = $this->contributionCreate([
-      'contact_id' => $this->_contactID,
+      'contact_id' => $this->contactID,
     ]);
 
-    $this->_participantPaymentID = $this->participantPaymentCreate($this->_participantID, $contributionID);
+    $participantPaymentID = $this->participantPaymentCreate($this->participantID, $contributionID);
 
     $params = [
-      'id' => $this->_participantPaymentID,
+      'id' => $participantPaymentID,
     ];
-    $this->callAPIAndDocument('participant_payment', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPIAndDocument('participantPayment', 'delete', $params, __FUNCTION__, __FILE__);
   }
 
   /**
    * Test civicrm_participantPayment_get - success expected.
    */
   public function testGet() {
-    $contributionID = $this->contributionCreate(['contact_id' => $this->_contactID3]);
-    $this->participantPaymentCreate($this->_participantID4, $contributionID);
+    $contributionID = $this->contributionCreate(['contact_id' => $this->contactID3]);
+    $this->participantPaymentCreate($this->participantID4, $contributionID);
 
     //Create Participant Payment record With Values
     $params = [
-      'participant_id' => $this->_participantID4,
+      'participant_id' => $this->participantID4,
       'contribution_id' => $contributionID,
     ];
 
-    $result = $this->callAPIAndDocument('participant_payment', 'get', $params, __FUNCTION__, __FILE__);
-    $this->assertEquals($result['values'][$result['id']]['participant_id'], $this->_participantID4, 'Check Participant Id');
+    $result = $this->callAPIAndDocument('participantPayment', 'get', $params, __FUNCTION__, __FILE__);
+    $this->assertEquals($result['values'][$result['id']]['participant_id'], $this->participantID4, 'Check Participant Id');
     $this->assertEquals($result['values'][$result['id']]['contribution_id'], $contributionID, 'Check Contribution Id');
   }
 
@@ -290,7 +320,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
       'entity_table' => 'civicrm_financial_item',
     ];
     $entityTrxn = current($this->retrieveEntityFinancialTrxn($entityParams));
-    $fitemParams = [
+    $financialItemParams = [
       'id' => $entityTrxn['entity_id'],
     ];
     if ($context === 'offline' || $context === 'online') {
@@ -307,15 +337,15 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
         'financial_account_id' => 1,
       ];
     }
-    $this->assertDBCompareValues('CRM_Financial_DAO_FinancialItem', $fitemParams, $compareParams);
+    $this->assertDBCompareValues('CRM_Financial_DAO_FinancialItem', $financialItemParams, $compareParams);
   }
 
   /**
    * test getParticipantIds() function
    */
   public function testGetParticipantIds() {
-    $contributionID = $this->contributionCreate(['contact_id' => $this->_contactID]);
-    $expectedParticipants = [$this->_participantID, $this->_participantID2];
+    $contributionID = $this->contributionCreate(['contact_id' => $this->contactID]);
+    $expectedParticipants = [$this->participantID, $this->participantID2];
 
     //Create Participant Payment record With Values
     foreach ($expectedParticipants as $pid) {
@@ -323,7 +353,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
         'participant_id' => $pid,
         'contribution_id' => $contributionID,
       ];
-      $this->callAPISuccess('participant_payment', 'create', $params);
+      $this->callAPISuccess('participantPayment', 'create', $params);
     }
     //Check if all participants are listed.
     $participants = CRM_Event_BAO_Participant::getParticipantIds($contributionID);


### PR DESCRIPTION
Overview
----------------------------------------
Refactor `api_v3_ParticipantPaymentTest`

Before
----------------------------------------
Use of dynamic properties meant this classes tests failed on PHP 8.2.

After
----------------------------------------
No more dyanmic properties, properties are all declared.

Other general tidy-ups, including:

 - Renaming properties with better consistency with current best practices
 - Using camel case where appropriate for better consistency with the prefered coding style.