### PR TITLE
[REF][PHP8.2] Refactor getParticipantOrderParams to never write a dynamic property

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Search/Custom/PriceSetTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Search/Custom/PriceSetTest.php
@@ -57,13 +57,14 @@
 class CRM_Contact_Form_Search_Custom_PriceSetTest extends CiviUnitTestCase {
 
   public function testRunSearch() {
-    $order = $this->callAPISuccess('Order', 'create', $this->getParticipantOrderParams());
+    $event = $this->eventCreate();
+    $order = $this->callAPISuccess('Order', 'create', $this->getParticipantOrderParams($event['id']));
     $this->callAPISuccess('Payment', 'create', [
       'order_id' => $order['id'],
       'total_amount' => 50,
     ]);
     $this->validateAllPayments();
-    $formValues = ['event_id' => $this->_eventId];
+    $formValues = ['event_id' => $event['id']];
     $form = new CRM_Contact_Form_Search_Custom_PriceSet($formValues);
     $sql = $form->all();
     // Assert that we have created a standard temp table

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3432,19 +3432,24 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   /**
    * Get parameters to set up a multi-line participant order.
    *
+   * @param null|int $eventId
+   *   Optional event ID. A new event will be created if no event ID is given.
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function getParticipantOrderParams(): array {
-    $event = $this->eventCreate();
-    $this->_eventId = $event['id'];
+  protected function getParticipantOrderParams($eventId = NULL): array {
+    if (!$eventId) {
+      $event = $this->eventCreate();
+      $eventId = $event['id'];
+    }
+
     $eventParams = [
-      'id' => $this->_eventId,
+      'id' => $eventId,
       'financial_type_id' => 4,
       'is_monetary' => 1,
     ];
     $this->callAPISuccess('event', 'create', $eventParams);
-    $priceFields = $this->createPriceSet('event', $this->_eventId);
+    $priceFields = $this->createPriceSet('event', $eventId);
     $orderParams = [
       'total_amount' => 300,
       'currency' => 'USD',
@@ -3469,7 +3474,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
         ],
         'params' => [
           'financial_type_id' => 4,
-          'event_id' => $this->_eventId,
+          'event_id' => $eventId,
           'role_id' => 1,
           'status_id' => 14,
           'fee_currency' => 'USD',


### PR DESCRIPTION
Overview
----------------------------------------
Refactor `getParticipantOrderParams` to never write a dynamic property.

Before
----------------------------------------
Various tests use `getParticipantOrderParams` which is a method on the parent `CiviUnitTestCase` class and which set the property `_eventId`. However, not all test classes which use `getParticipantOrderParams` declare and use `_eventId`.

After
----------------------------------------
`getParticipantOrderParams` no longer sets `_eventId`. For the one case where the property was acually needed, the event ID can not be passed into the method, allowing the event creation to be pulled up into the calling function. 

Technical Details
----------------------------------------
I did think about changing `getParticipantOrderParams` to only write the property if `property_exists($this, '_eventId')`, but it seemed cleaner to just avoid using properties at all. The new function argument has a default value, so there should be no chance of accedential breakage as a result of this change.