### PR TITLE
[REF] Minor code simplification - extract `getHighlightedFields` in Contribution import `MapField`

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -21,41 +21,6 @@
 class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
-   * Set variables up before form is built.
-   */
-  public function preProcess() {
-    parent::preProcess();
-
-    $highlightedFields = ['financial_type_id', 'total_amount'];
-    //CRM-2219 removing other required fields since for updation only
-    //invoice id or trxn id or contribution id is required.
-    if ($this->isUpdateExisting()) {
-      //modify field title only for update mode. CRM-3245
-      foreach ([
-        'contribution_id',
-        'invoice_id',
-        'trxn_id',
-      ] as $key) {
-        $highlightedFields[] = $key;
-      }
-    }
-    elseif ($this->isSkipExisting()) {
-      $highlightedFieldsArray = [
-        'contribution_contact_id',
-        'email',
-        'first_name',
-        'last_name',
-        'external_identifier',
-      ];
-      foreach ($highlightedFieldsArray as $name) {
-        $highlightedFields[] = $name;
-      }
-    }
-
-    $this->assign('highlightedFields', $highlightedFields);
-  }
-
-  /**
    * Should contact fields be filtered which determining fields to show.
    *
    * This applies to Contribution import as we put all contact fields in the metadata
@@ -265,6 +230,34 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       return $rule['rule_message'];
     }
     return NULL;
+  }
+
+  /**
+   * @return string[]
+   */
+  protected function getHighlightedFields(): array {
+    $highlightedFields = ['financial_type_id', 'total_amount'];
+    //CRM-2219 removing other required fields since for updating only
+    //invoice id or trxn id or contribution id is required.
+    if ($this->isUpdateExisting()) {
+      //modify field title only for update mode. CRM-3245
+      foreach (['contribution_id', 'invoice_id', 'trxn_id'] as $key) {
+        $highlightedFields[] = $key;
+      }
+    }
+    elseif ($this->isSkipExisting()) {
+      $highlightedFieldsArray = [
+        'contribution_contact_id',
+        'email',
+        'first_name',
+        'last_name',
+        'external_identifier',
+      ];
+      foreach ($highlightedFieldsArray as $name) {
+        $highlightedFields[] = $name;
+      }
+    }
+    return $highlightedFields;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Minor code simplification - extract `getHighlightedFields` in Contribution import `MapField`

Before
----------------------------------------
The `MapField` `preProcess` does 2 things
1) calls the parent
2) assigns 'highlightedFields'

The parent calls `assignMapFieldVariables`
![image](https://user-images.githubusercontent.com/336308/226144876-b3f60ecf-7eca-4181-adee-5b54d7819b58.png)

which assigns `highlightedFields` based on the output of `getHighlightedFields`

![image](https://user-images.githubusercontent.com/336308/226144903-97ac8e40-4ad4-4abc-8398-ea89d94f5fe9.png)

As there is currently no function for this on `Contribution_Import_Form_MapField` the parent `getHighlightedFields` is called. It returns an empty array - which is overwritten in  `Contribution_Import_Form_MapField::preProcess`

After
----------------------------------------
We extract the code to `getHighlightedFields` so the parent can assign it. No more need for the `preProcess` override - but the fields are still highlighted 

![image](https://user-images.githubusercontent.com/336308/226144983-c69e9046-d66c-41b7-baf2-5cb7f6b0a2fe.png)


Technical Details
----------------------------------------
Minor cleanup

Comments
----------------------------------------
