### PR TITLE
[NFC] Remove some no-longer-used properties on Contribution import parser

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -69,54 +69,10 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   protected $_separator;
 
   /**
-   * Running total number of valid soft credit rows
-   * @var int
-   */
-  protected $_validSoftCreditRowCount;
-
-  /**
-   * Running total number of invalid soft credit rows
-   * @var int
-   */
-  protected $_invalidSoftCreditRowCount;
-
-  /**
-   * Running total number of valid pledge payment rows
-   * @var int
-   */
-  protected $_validPledgePaymentRowCount;
-
-  /**
-   * Running total number of invalid pledge payment rows
-   * @var int
-   */
-  protected $_invalidPledgePaymentRowCount;
-
-  /**
    * Array of pledge payment error lines, bounded by MAX_ERROR
    * @var array
    */
   protected $_pledgePaymentErrors;
-
-  /**
-   * Array of pledge payment error lines, bounded by MAX_ERROR
-   * @var array
-   */
-  protected $_softCreditErrors;
-
-  /**
-   * Filename of pledge payment error data
-   *
-   * @var string
-   */
-  protected $_pledgePaymentErrorsFileName;
-
-  /**
-   * Filename of soft credit error data
-   *
-   * @var string
-   */
-  protected $_softCreditErrorsFileName;
 
   /**
    * Get the field mappings for the import.
@@ -559,15 +515,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       return TRUE;
     }
     return FALSE;
-  }
-
-  /**
-   * Get the array of successfully imported contribution id's
-   *
-   * @return array
-   */
-  public function &getImportedContributions() {
-    return $this->_newContributions;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[NFC] Remove some no-longer-used properties on Contribution import parser

Before
----------------------------------------
These are all relics of when we used to track the processing in memory rather than the import table

![image](https://user-images.githubusercontent.com/336308/226147361-e3260c08-49db-4f8e-a904-fc116af1c832.png)

![image](https://user-images.githubusercontent.com/336308/226147393-b9e61d8b-5b01-4dac-ab5a-32faa5a86bdf.png)

![image](https://user-images.githubusercontent.com/336308/226147517-020dc272-159a-4f5f-8be1-179d2aaaa654.png)

![image](https://user-images.githubusercontent.com/336308/226147522-e594901f-0a47-463f-9cbb-aacd55254644.png)

Also this function which the IDE doesn't highlight due to the dreaded '&'

![image](https://user-images.githubusercontent.com/336308/226147599-dcbfe7ec-e8e8-412b-9065-21d80b942148.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
