### PR TITLE
[REF] Simplify import preProcess

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -73,7 +73,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function preProcess(): void {
-    $this->_mapperFields = $this->getAvailableFields();
+    parent::preProcess();
     //format custom field names, CRM-2676
     $contactType = $this->getContactType();
 
@@ -100,7 +100,6 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     $formattedFieldNames = $this->formatCustomFieldName($this->_mapperFields);
 
     $this->_formattedFieldNames[$contactType] = $this->_mapperFields = array_merge($this->_mapperFields, $formattedFieldNames);
-    $this->assignMapFieldVariables();
   }
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -57,9 +57,15 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
 
   /**
    * Shared preProcess code.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $this->assignMapFieldVariables();
+    $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
+    $this->assign('columnNames', $this->getColumnHeaders());
+    $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');
+    $this->assign('highlightedFields', $this->getHighlightedFields());
+    $this->assign('dataValues', array_values($this->getDataRows([], 2)));
     $this->_mapperFields = $this->getAvailableFields();
     asort($this->_mapperFields);
     parent::preProcess();

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -680,19 +680,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
-   * Assign variables required for the MapField form.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function assignMapFieldVariables(): void {
-    $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
-    $this->assign('columnNames', $this->getColumnHeaders());
-    $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');
-    $this->assign('highlightedFields', $this->getHighlightedFields());
-    $this->assign('dataValues', array_values($this->getDataRows([], 2)));
-  }
-
-  /**
    * Get the fields to be highlighted in the UI.
    *
    * The highlighted fields are those used to match


### PR DESCRIPTION
Overview
----------------------------------------
[REF] Simplify import preProcess

Before
----------------------------------------
Per [https://github.com/civicrm/civicrm-core/pull/25866 the ](https://github.com/civicrm/civicrm-core/pull/25866#issuecomment-1475279270) - it's a bit of a hunt to find what `preProcess` is doing. It's because the `Contact_MapField` was calling the same function - but we are now at the point where the `Contact_MapField` can just call the `parent::Preprocess` 

After
----------------------------------------
Function folded back into `preProcess` now it is only called from one place

Technical Details
----------------------------------------

Comments
----------------------------------------
