### PR TITLE
Revert "CiviUnitTestCase - During cleanup, ensure that we have a clean slate (wrt locking)"

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -453,8 +453,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       $this->quickCleanup($tablesToTruncate);
       $this->createDomainContacts();
     }
-    $releasedLocks = CRM_Core_DAO::singleValueQuery('SELECT RELEASE_ALL_LOCKS()');
-    $this->assertEquals(0, $releasedLocks, "The test should not leave any dangling locks. Found $releasedLocks");
 
     $this->cleanTempDirs();
     $this->unsetExtensionSystem();


### PR DESCRIPTION
This reverts commit bf4ebf9d00201a835b9c921620184f7aa499e2d1.

@totten this function does not exist on my local dev environment (10.4.20-MariaDB-1:10.4.20+maria~focal) .

 It was a nice-to-have but we should quick-revert IMHO & then reconsider 

![image](https://user-images.githubusercontent.com/336308/226210994-c35b9db2-4321-4523-965d-ea1d06b93b2f.png)
