### PR TITLE
dev/core#4152 Fix custom data code to not cast to a float

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1431,11 +1431,17 @@ ORDER BY civicrm_custom_group.weight,
             }
           }
           else {
-            if ($field['data_type'] == "Float") {
-              $defaults[$elementName] = (float) $value;
+            if ($field['data_type'] === 'Float') {
+              if ($field['html_type'] === 'Text') {
+                $defaults[$elementName] = CRM_Utils_Number::formatLocaleNumeric($value);
+              }
+              else {
+                // This casting came in from svn & may not be right.
+                $defaults[$elementName] = (float) $value;
+              }
             }
-            elseif ($field['data_type'] == 'Money' &&
-              $field['html_type'] == 'Text'
+            elseif ($field['data_type'] === 'Money' &&
+              $field['html_type'] === 'Text'
             ) {
               $defaults[$elementName] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($value);
             }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4152 Fix custom data code to not cast to a float

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4152

After
----------------------------------------
The value is not set back

Technical Details
----------------------------------------
@highfalutin this is your fix for the narrow part of the bug in https://lab.civicrm.org/dev/core/-/issues/4152 - If you are still happy with it / can't see any mistakes in the break-out  - I will merge this & get this part / that issue closed

Comments
----------------------------------------