### PR TITLE
Move getSubmittedValues to `CRM_Core_Form`

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -928,7 +928,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     // store the submitted values in an array
     if (!$params) {
-      $params = $this->controller->exportValues($this->_name);
+      $params = $this->getSubmittedValues();
+    }
+    else {
+      CRM_Core_Error::deprecatedWarning('passing params into postProcess is deprecated. Match parent function');
     }
 
     // Set activity type id.

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -206,6 +206,40 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * Get values submitted by the user.
+   *
+   * Compared with $this->controller->exportValues this has a couple of changes
+   * 1) any fields declared in $this->submittableMoneyFields will be de-formatted first.
+   * 2) it is possible to store access fields from related forms if they
+   * are declared in `getSubmittableFields()`. This is notably used in imports
+   * to combine fields from the various screens & save the resulting 'submitted_values'
+   * to the UserJob.
+   *
+   * @return array
+   */
+  public function getSubmittedValues(): array {
+    $values = [];
+    foreach (array_keys($this->getSubmittableFields()) as $key) {
+      $values[$key] = $this->getSubmittedValue($key);
+    }
+    return $values;
+  }
+
+  /**
+   * Get the fields that can be submitted in this form flow.
+   *
+   * To make fields in related forms (ie within the same wizard like
+   * Contribution_Main and Contribution_Confirm) accessible you can override
+   * this function as CRM_Import_Forms does.
+   *
+   * @return string[]
+   */
+  protected function getSubmittableFields(): array {
+    $fieldNames = array_keys($this->controller->exportValues($this->_name));
+    return array_fill_keys($fieldNames, $this->_name);
+  }
+
+  /**
    * Set context variable.
    */
   public function setContext() {

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -156,19 +156,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
-   * Get values submitted on any form in the multi-page import flow.
-   *
-   * @return array
-   */
-  public function getSubmittedValues(): array {
-    $values = [];
-    foreach (array_keys($this->getSubmittableFields()) as $key) {
-      $values[$key] = $this->getSubmittedValue($key);
-    }
-    return $values;
-  }
-
-  /**
    * Get the available datasource.
    *
    * Permission dependent, this will look like
@@ -206,7 +193,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * 2) User changes the source to SQL - the ajax updates the html but the
    * form was built with the expectation that the csv-specific fields would be
    * required.
-   * 3) When the user submits Quickform calls preProcess and buildForm and THEN
+   * 3) When the user submits QuickForm calls preProcess and buildForm and THEN
    * retrieves the submitted values based on what has been added in buildForm.
    * Only the submitted values for fields added in buildForm are available - but
    * these have to be added BEFORE the submitted values are determined. Hence
@@ -316,6 +303,8 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * This is called as a snippet in DataSourceConfig and
    * also from DataSource::buildForm to add the fields such
    * that quick form picks them up.
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function getDataSourceFields(): array {
     $className = $this->getDataSourceClassName();


### PR DESCRIPTION
Overview
----------------------------------------
Move getSubmittedValues to `CRM_Core_Form`

Before
----------------------------------------
In order to do this @highfalutin  would up repeating it & that kinda duplicates an approach we've already started on the path of
- see https://github.com/civicrm/civicrm-core/pull/25714/files#diff-51e41630c371334fd08c54c22906143630feb03645eee4708080fd3cd157a895R932

After
----------------------------------------
`$this->getSubmittedValues()` should work from any form to retrieve values that have been de-locale-formatted

It also supports some override behaviour that is helpful in wizards (ie where it already lived)


Technical Details
----------------------------------------
- this doesn't implement it - just sets is up for https://github.com/civicrm/civicrm-core/pull/25714/files#diff-51e41630c371334fd08c54c22906143630feb03645eee4708080fd3cd157a895R932 - which is the context I tested it in

Comments
----------------------------------------
