### PR TITLE
dev/core#3514 Define hook to alter data once it has been mapped but before work is done on it.

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -205,6 +205,25 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
   }
 
   /**
+   * Validate the import values.
+   *
+   * This overrides the parent to call the hook - cos the other imports are not
+   * yet stable enough to add the hook to. If we add the hook to them now and then
+   * later switch them to APIv4 style keys we will have to worry about hook consumers.
+   *
+   * The values array represents a row in the datasource.
+   *
+   * @param array $values
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function validateValues(array $values): void {
+    $params = $this->getMappedRow($values);
+    CRM_Utils_Hook::importAlterMappedRow('validate', 'contribution_import', $params, $values, $this->getUserJobID());
+    $this->validateParams($params);
+  }
+
+  /**
    * Override parent to cope with params being separated by entity already.
    *
    * @todo - make this the parent method...
@@ -397,6 +416,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);
+      CRM_Utils_Hook::importAlterMappedRow('import', 'contribution_import', $params, $values, $this->getUserJobID());
+
       $contributionParams = $params['Contribution'];
       //CRM-10994
       if (isset($contributionParams['total_amount']) && $contributionParams['total_amount'] == 0) {

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1611,6 +1611,8 @@ abstract class CRM_Utils_Hook {
    * This hook is called after a row has been processed and the
    * record (and associated records imported
    *
+   * @deprecated
+   *
    * @param string $object
    *   Object being imported (for now Contact only, later Contribution, Activity,.
    *                               Participant and Member)
@@ -1633,6 +1635,31 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(['object', 'usage', 'objectRef', 'params'], $object, $usage, $objectRef, $params,
       $null, $null,
       'civicrm_import'
+    );
+  }
+
+  /**
+   * Alter import mappings.
+   *
+   * @param string $importType This corresponds to the value in `civicrm_user_job.job_type`.
+   * @param string $context import or validate.
+   *   In validate context only 'cheap' lookups should be done (e.g. using cached information).
+   *   Validate is intended to quickly process a whole file for errors. You should focus on
+   *   setting or unsetting key values to or from `'invalid_import_value'`.
+   *
+   *   During import mode heavier lookups can be done (e.g using custom logic to find the
+   *   relevant contact) as this is then passed to the api functions. If a row is invalid during
+   *   import mode you should throw an exception.
+   * @param array $mappedRow (reference) The rows that have been mapped to an array of params.
+   * @param array $rowValues The row from the data source (non-associative array)
+   * @param int $userJobID id from civicrm_user_job
+   *
+   * @return mixed
+   */
+  public static function importAlterMappedRow(string $importType, string $context, array &$mappedRow, array $rowValues, int $userJobID) {
+    $null = NULL;
+    return self::singleton()->invoke(['importType', 'context', 'mappedRow', 'rowValues', 'userJobID', 'fieldMappings'], $context, $importType, $mappedRow, $rowValues, $userJobID, $null,
+      'civicrm_importAlterMappedRow'
     );
   }
 

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -43,20 +43,20 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    * These extensions are inactive at the start. They may be activated during the test. They should be deactivated at the end.
    *
    * For the moment, the test is simply hard-coded to cleanup in a specific order. It's tempting to auto-detect and auto-uninstall these.
-   * However, the shape of their dependencies makes it tricky to auto-uninstall (e.g. some exts have managed-entities that rely on other
-   * exts -- you need to fully disable+uninstall the downstream managed-entity-ext before disabling or uninstalling the upstream
+   * However, the shape of their dependencies makes it tricky to auto-uninstall (e.g. some extensions have managed-entities that rely on other
+   * extensions -- you need to fully disable+uninstall the downstream managed-entity-ext before disabling or uninstalling the upstream
    * entity-provider-ext).
    *
-   * You may need to edit `$toggleExts` whenever the dependency-graph changes.
+   * You may need to edit `$toggleExtensions` whenever the dependency-graph changes.
    *
    * @var string[]
    */
-  protected $toggleExts = ['civiimport', 'org.civicrm.afform', 'authx'];
+  protected $toggleExtensions = ['civiimport', 'org.civicrm.afform', 'authx'];
 
   protected function setUp(): void {
     parent::setUp();
     $originalExtensions = array_column(CRM_Extension_System::singleton()->getMapper()->getActiveModuleFiles(), 'fullName');
-    $this->assertEquals([], array_intersect($originalExtensions, $this->toggleExts), 'These extensions may be enabled and disabled during the test. The start-state and end-state should be the same. It appears that we have an unexpected start-state. Perhaps another test left us with a weird start-state?');
+    $this->assertEquals([], array_intersect($originalExtensions, $this->toggleExtensions), 'These extensions may be enabled and disabled during the test. The start-state and end-state should be the same. It appears that we have an unexpected start-state. Perhaps another test left us with a weird start-state?');
     $this->enableBackgroundQueueOriginalValue = Civi::settings()->get('enableBackgroundQueue');
   }
 
@@ -72,7 +72,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     DedupeRule::delete()
       ->addWhere('rule_table', '!=', 'civicrm_email')
       ->addWhere('dedupe_rule_group_id.name', '=', 'IndividualUnsupervised')->execute();
-    foreach ($this->toggleExts as $ext) {
+    foreach ($this->toggleExtensions as $ext) {
       CRM_Extension_System::singleton()->getManager()->disable([$ext]);
       CRM_Extension_System::singleton()->getManager()->uninstall([$ext]);
     }
@@ -423,8 +423,8 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'id' => $unsupervisedRuleGroup['id'],
       'used' => 'Unsupervised',
     ]);
-    Civi\Api4\DedupeRule::delete()->addWhere('dedupe_rule_group_id', '=', $ruleGroup['id'])->execute();
-    Civi\Api4\DedupeRuleGroup::delete()->addWhere('id', '=', $ruleGroup['id'])->execute();
+    DedupeRule::delete()->addWhere('dedupe_rule_group_id', '=', $ruleGroup['id'])->execute();
+    DedupeRuleGroup::delete()->addWhere('id', '=', $ruleGroup['id'])->execute();
   }
 
   /**
@@ -634,7 +634,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => ''],
       ['name' => ''],
       ['name' => ''],
-      ['name' => 'source'],
+      ['name' => 'contribution_source'],
       ['name' => 'trxn_id'],
       ['name' => 'campaign_id'],
     ];
@@ -874,7 +874,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'receive_date'],
       ['name' => 'financial_type_id'],
       ['name' => 'email_primary.email'],
-      ['name' => 'source'],
+      ['name' => 'contribution_source'],
       ['name' => 'note'],
       ['name' => 'trxn_id'],
     ], $submittedValues);
@@ -914,7 +914,10 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test the Import api works from the extension when the extension is enabled after the import.
+   * Test the Import api works from the extension when the extension is enabled
+   * after the import.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testEnableExtension(): void {
     $this->importContributionsDotCSV();

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -370,8 +370,6 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test importing to a custom field.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testImportCustomData(): void {
     $donaldDuckID = $this->individualCreate(['first_name' => 'Donald', 'last_name' => 'Duck']);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#3514 Define hook to alter data once it has been mapped but before work is done on it.

Before
----------------------------------------

After
----------------------------------------
Hook parameters look like

![image](https://user-images.githubusercontent.com/336308/226318043-756a14b7-eba3-4d84-ad10-821e7d9330f4.png)

Technical Details
----------------------------------------
- validation is done on the results of `getMappedRow` - so this is a chance to alter before vaildation fails
- I kinda want to get the custom fields switched to api v4 style before putting this in...
- the existing `import` hook is pretty flawed - it doesn't get called at a sensible point in the code
- one of my concerns is to only pass out data that has become pretty fixed - hence wanting to switch to apiv4
- this is currently only on contribution as it doesnt' share the parent function & I want to go through entity-by-entity carefully for fixed-ness
- 

Comments
----------------------------------------

