### PR TITLE
SchemaHandler - Add IF EXISTS to dropTable function

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -268,13 +268,13 @@ ALTER TABLE {$tableName}
   }
 
   /**
-   * Delete a CiviCRM-table.
+   * Drop a table if it exists.
    *
    * @param string $tableName
-   *   Name of the table to be created.
+   * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function dropTable($tableName) {
-    $sql = "DROP TABLE $tableName";
+  public static function dropTable(string $tableName): void {
+    $sql = "DROP TABLE IF EXISTS $tableName";
     CRM_Core_DAO::executeQuery($sql);
   }
 

--- a/api/v3/CustomGroup.php
+++ b/api/v3/CustomGroup.php
@@ -88,8 +88,9 @@ function _civicrm_api3_custom_group_create_spec(&$params) {
 function civicrm_api3_custom_group_delete($params) {
   $values = new CRM_Core_DAO_CustomGroup();
   $values->id = $params['id'];
-  $values->find(TRUE);
-
+  if (!$values->find(TRUE)) {
+    return civicrm_api3_create_error('Error while deleting custom group');
+  }
   $result = CRM_Core_BAO_CustomGroup::deleteGroup($values, TRUE);
   return $result ? civicrm_api3_create_success() : civicrm_api3_create_error('Error while deleting custom group');
 }


### PR DESCRIPTION
Overview
----------------------------------------
Prevents errors in the same way `dropColumn` does by checking that it exists before dropping.

Before
----------------------------------------
Error if table has already been dropped

After
----------------------------------------
No error

Comments
----------------
This is a tiny piece carved out from #25871 