### PR TITLE
Skip adding script when it won't have anything to run on

### DIFF
--- a/templates/CRM/common/Tagset.tpl
+++ b/templates/CRM/common/Tagset.tpl
@@ -45,7 +45,7 @@
   </td>
 {/if}
 
-{if empty($skipEntityAction) and empty($form.frozen)}
+{if !empty($tagsetInfo) and empty($skipEntityAction) and empty($form.frozen)}
   <script type="text/javascript">
     {* Add/remove entity tags via ajax api *}
     {literal}


### PR DESCRIPTION
Overview
----------------------------------------
In the Tagset template, only load a script for form controls if those controls exist.

Before
----------------------------------------
Script was always added to the page.

After
----------------------------------------
Script is only inserted when necessary.

Comments
----------------------------------------
I'd also like to get rid of the whole empty table that's created when there's no tagset data:
* `templates/CRM/Case/Form/Activity.tpl:244`
* `templates/CRM/Case/Form/Case.tpl:108`

Probably using this model? `templates/CRM/Activity/Form/Activity.tpl:168`

But that can be a separate PR