### PR TITLE
don't create tagset markup if there's no tagset

### DIFF
--- a/templates/CRM/Case/Form/Activity.tpl
+++ b/templates/CRM/Case/Form/Activity.tpl
@@ -241,7 +241,9 @@
       </td>
     </tr>
     {/if}
+{if $isTagset}
   <tr class="crm-case-activity-form-block-tag_set"><td colspan="2">{include file="CRM/common/Tagset.tpl" tagsetType='activity'}</td></tr>
+{/if}
   </table>
 
   {/if}

--- a/templates/CRM/Case/Form/Case.tpl
+++ b/templates/CRM/Case/Form/Case.tpl
@@ -105,9 +105,11 @@
     </td>
 </tr>
 
+{if $isTagset}
 <tr class="crm-case-form-block-tag_set">
     {include file="CRM/common/Tagset.tpl" tagsetType='case' tableLayout=true}
 </tr>
+{/if}
 
 </table>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Remove an html artifact that creates awkward whitespace on some themes.

Before
----------------------------------------
On themes that assign a `height` to `td` elements, like Drupal 8/9/10's core Claro theme, an annoying extra empty space appears at the bottom of the Activity edit form and Case edit form.

<img width="411" alt="before" src="https://user-images.githubusercontent.com/385812/226490691-935fa0e6-4794-4eb4-b59e-462330367c8c.png">

After
----------------------------------------
More tidy.

<img width="411" alt="after" src="https://user-images.githubusercontent.com/385812/226490750-99d2aad3-d59c-4cae-b187-9e0eae4dc9ba.png">

Technical Details
----------------------------------------
Just does the same thing as what [CRM/Activity/Form/Activity.tpl](https://github.com/civicrm/civicrm-core/blob/f03972e2efe0c6a08842c4d3005fd2147ad32d78/templates/CRM/Activity/Form/Activity.tpl#L168) has been doing for a couple years.

Comments
----------------------------------------
Tested with and without case and activity tagsets. Works fine either way.
