### PR TITLE
Add test that shows api not doing validation right

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -33,6 +33,16 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
     parent::tearDown();
   }
 
+  public function testAPiv4Validates() {
+    $this->expectExceptionMessage("fail");
+    Contribution::create()->setValues([
+      'total_amount' => 5,
+      'contact_id' => $this->individualCreate(),
+      'financial_type_id' => 1,
+      'contribution_status_id' => 'I made up some rubbish'
+    ])->execute();
+
+  }
   /**
    * Test create method (create and update modes).
    */


### PR DESCRIPTION
Overview
----------------------------------------
Add test that shows api not doing validation right

Before
----------------------------------------
@colemanw I switched some code from apiv3 to apiv4 & found that it started saving records with invalid `contribution_status_id` - it should be on the api layer to validate that it is an integer at this point....

(Note the exception isn't thrown at all - if it were it would still fail as it isn't the right error message - but I'm not expecting this test to go in as is)