### PR TITLE
[REF][PHP8.2] Remove property which is no longer used

### DIFF
--- a/CRM/Campaign/Form/Search.php
+++ b/CRM/Campaign/Form/Search.php
@@ -58,7 +58,6 @@ class CRM_Campaign_Form_Search extends CRM_Core_Form_Search {
     $this->_defaults = [];
 
     //set the button name.
-    $this->_printButtonName = $this->getButtonName('next', 'print');
     $this->_actionButtonName = $this->getButtonName('next', 'action');
 
     $this->loadStandardSearchOptionsFromUrl();


### PR DESCRIPTION
Overview
----------------------------------------
Remove property which is no longer used.

Before
----------------------------------------
`_printButtonName` has only one match accross the whole codebase:

<img width="502" alt="Screenshot 2023-03-21 at 18 18 22" src="https://user-images.githubusercontent.com/1931323/226705573-98a469dc-1fa8-4ca8-b18f-97469bb741f4.png">


After
----------------------------------------
The (dynamic, deprecated) property is gone.

Technical Details
----------------------------------------
This improves PHP 8.2 support by knocking off another dynamic propery.

Comments
----------------------------------------
Looks like the code which used this property was removed in 2016: https://github.com/civicrm/civicrm-core/commit/3b6d61f2ee4b5d66c791afa46ef168e445d5d1a0
