### PR TITLE
[NFC] Add metadata about import jobs to `MapField` form

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -21,6 +21,15 @@
 class CRM_Activity_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'activity_import';
+  }
+
+  /**
    * @var bool
    */
   public $submitOnce = TRUE;

--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -40,6 +40,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         'name' => 'activity_import',
         'label' => ts('Activity Import'),
         'entity' => 'Activity',
+        'url' => 'civicrm/import/activity',
       ],
     ];
   }

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -25,6 +25,15 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   use CRM_Contact_Import_MetadataTrait;
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'contact_import';
+  }
+
+  /**
    * An array of all contact fields with
    * formatted custom field names.
    *

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -91,6 +91,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
         'name' => 'contact_import',
         'label' => ts('Contact Import'),
         'entity' => 'Contact',
+        'url' => 'civicrm/import/contact',
       ],
     ];
   }

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -21,6 +21,15 @@
 class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'contribution_import';
+  }
+
+  /**
    * Should contact fields be filtered which determining fields to show.
    *
    * This applies to Contribution import as we put all contact fields in the metadata

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -52,6 +52,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         'name' => 'contribution_import',
         'label' => ts('Contribution Import'),
         'entity' => 'Contribution',
+        'url' => 'civicrm/import/contribution',
       ],
     ];
   }

--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -144,6 +144,7 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements \Civi\Core\Ho
    *   -label
    *   -class
    *   -entity
+   *   -url
    *
    * @return array
    */

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -6,6 +6,15 @@
 class CRM_Custom_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'custom_field_import';
+  }
+
+  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -26,6 +26,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
         'name' => 'custom_field_import',
         'label' => ts('Multiple Value Custom Field Import'),
         'entity' => 'Contact',
+        'url' => 'civicrm/import/custom',
       ],
     ];
   }

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -21,6 +21,15 @@
 class CRM_Event_Import_Form_MapField extends CRM_Import_Form_MapField {
 
   /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'participant_import';
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @return void

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -77,6 +77,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         'name' => 'participant_import',
         'label' => ts('Participant Import'),
         'entity' => 'Participant',
+        'url' => 'civicrm/import/participant',
       ],
     ];
   }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -65,6 +65,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         'name' => 'membership_import',
         'label' => ts('Membership Import'),
         'entity' => 'Membership',
+        'url' => 'civicrm/import/membership',
+
       ],
     ];
   }

--- a/Civi/UserJob/UserJobInterface.php
+++ b/Civi/UserJob/UserJobInterface.php
@@ -18,6 +18,8 @@ interface UserJobInterface {
    *  - name
    *  - id (generally the same as name)
    *  - label
+   *  - entity
+   *  - url
    *
    *  e.g. ['activity_import' => ['id' => 'activity_import', 'label' => ts('Activity Import'), 'name' => 'activity_import']]
    *


### PR DESCRIPTION
This extra metadata has been part of a whole lot of PRs & somehow always winds up in conflict or otherwise so I'm adding it by itself, wihout any usage of it.

Note that
- this brings MapField into line with DataSource
- there is nothing calling these functions as of this PR - it's just an attempt to get the extra metadata added to the forms/ parsers without conflict
