### PR TITLE
fix permission on Api4 Contact.GetDuplicates

### DIFF
--- a/Civi/Api4/Action/Contact/GetDuplicates.php
+++ b/Civi/Api4/Action/Contact/GetDuplicates.php
@@ -147,6 +147,7 @@ class GetDuplicates extends \Civi\Api4\Generic\DAOCreateAction {
         'action' => 'create',
         'loadOptions' => $action->getLoadOptions(),
         'where' => [['name', 'NOT IN', $ignore], ['type', 'IN', ['Field', 'Custom']]],
+        'checkPermissions' => FALSE,
       ]);
       if ($entity !== 'Contact') {
         $prefix = strtolower($entity) . '_primary.';


### PR DESCRIPTION
Overview
----------------------------------------
Submitting a FormBuilder submission form with duplicate checking enabled fails for anonymous users.

Before
----------------------------------------
"Saving" just shows continuously at the top of the screen.

After
----------------------------------------
Submission succeeds.