### PR TITLE
Remove meaningless property over-rides

### DIFF
--- a/CRM/Contact/Form/DedupeFind.php
+++ b/CRM/Contact/Form/DedupeFind.php
@@ -21,12 +21,6 @@
 class CRM_Contact_Form_DedupeFind extends CRM_Admin_Form {
 
   /**
-   * Indicate if this form should warn users of unsaved changes
-   * @var bool
-   */
-  protected $unsavedChangesWarn = FALSE;
-
-  /**
    * Dedupe rule group ID
    * @var int
    */

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -253,7 +253,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
   }
 
   public function buildQuickForm() {
-    $this->unsavedChangesWarn = FALSE;
     $this->setTitle(ts('Merge %1 contacts', [1 => $this->_contactType]));
     $buttons = [];
 


### PR DESCRIPTION
unsavedChangesWarn is set on CRM_Core_Form (to NULL) - the only meaningful override is setting it to TRUE. Remove some FALSE-setters

![image](https://user-images.githubusercontent.com/336308/226762113-8a48537d-9734-4277-a3c1-b138e70b5c16.png)
