### PR TITLE
Fix recently added import url

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -52,7 +52,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         'name' => 'contribution_import',
         'label' => ts('Contribution Import'),
         'entity' => 'Contribution',
-        'url' => 'civicrm/import/contribution',
+        'url' => 'civicrm/contribute/import',
       ],
     ];
   }


### PR DESCRIPTION
my head hurts - every other import url follows the other format - ie civicrm/import/contribution & is
defined in Import.xml

Consistency wishmistancy
