### PR TITLE
Show friendlier labels when Civi-Import enabled

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -449,7 +449,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
         continue;
       }
       $childField = [
-        'text' => $field['title'],
+        'text' => $field['html']['label'] ?? $field['title'],
         'id' => $fieldName,
         'has_location' => !empty($field['hasLocationType']),
         'default_value' => $field['default_value'] ?? '',


### PR DESCRIPTION
Overview
----------------------------------------
Show friendlier labels when Civi-Import enabled

Before
----------------------------------------
When Civi-Import is enabled the Contribution MapField screen shows (eg) 'Financial Type ID`

![image](https://user-images.githubusercontent.com/336308/226804183-acf28820-eb75-4fc6-a3e3-275e5ae397b1.png)


After
----------------------------------------
When Civi-Import is enabled the Contribution MapField screen shows (eg) 'Financial Type`

![image](https://user-images.githubusercontent.com/336308/226804106-6f78df23-f021-441b-abb7-f2e14b814899.png)

Technical Details
----------------------------------------
This is consistent with how the fields are otherwise presented & less confusing for users

Comments
----------------------------------------
