### PR TITLE
Fix for issue when optional contact_id is blank importing contributions

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -232,7 +232,19 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         $params[$entity][$this->getFieldMetadata($mappedField['name'])['name']] = $this->getTransformedFieldValue($mappedField['name'], $fieldValue);
       }
     }
-    return $params;
+    return $this->removeEmptyValues($params);
+  }
+
+  protected function removeEmptyValues($array) {
+    foreach ($array as $key => $value) {
+      if (is_array($value)) {
+        $array[$key] = $this->removeEmptyValues($value);
+      }
+      elseif ($value === '') {
+        unset($array[$key]);
+      }
+    }
+    return $array;
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -597,6 +597,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => ''],
       ['name' => 'trxn_id'],
       ['name' => 'contribution_campaign_id'],
+      ['name' => 'contribution_contact_id'],
     ];
     // First we try to create without total_amount mapped.
     // It will fail in create mode as total_amount is required for create.
@@ -616,7 +617,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->importCSV('contributions.csv', $fieldMappings, ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 
     $row = $this->getDataSource()->getRows()[0];
-    $this->assertEquals('IMPORTED', $row[10]);
+    $this->assertEquals('IMPORTED', $row[11]);
     $contribution = Contribution::get()->addSelect('source', 'id')->execute()->first();
     $this->assertEmpty($contribution['source']);
 
@@ -635,7 +636,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->importCSV('contributions.csv', $fieldMappings, ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
 
     $row = $this->getDataSource()->getRows()[0];
-    $this->assertEquals('IMPORTED', $row[10]);
+    $this->assertEquals('IMPORTED', $row[11]);
     $contribution = Contribution::get()->addSelect('source', 'id')->execute()->first();
     $this->assertEquals('Call him back', $contribution['source']);
   }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
@@ -1,2 +1,2 @@
-External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to,Source,Note,Transaction ID,Campaign ID
-bob,65,2008-09-20,Donation,mum@example.com,Word of mouth,Call him back,999,1
+External Identifier,Total Amount,Receive Date,Financial Type,Soft Credit to,Source,Note,Transaction ID,Campaign ID,Blank column
+bob,65,2008-09-20,Donation,mum@example.com,Word of mouth,Call him back,999,1,


### PR DESCRIPTION
Overview
----------------------------------------
Fix for issue when optional contact_id is blank importing contributions

Before
----------------------------------------
Contribution import falls over if `contact_id` is present as an optional field (ie some contacts have it & not others) due to an empty string rather than NULL be passed into a function with a type hint

After
----------------------------------------
Fixed... with test

Technical Details
----------------------------------------
@mlutfy this is the same as the soft credit contact one - probably a bit less common to hit it.

Comments
----------------------------------------
