### PR TITLE
Fix Contact Import tests custom date testing, remove duplicate handling

### DIFF
--- a/CRM/Contact/Import/Form/DataSource.php
+++ b/CRM/Contact/Import/Form/DataSource.php
@@ -111,15 +111,12 @@ class CRM_Contact_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     // Once the mentioned forms no longer call $this->get() all this 'setting'
     // is obsolete.
     $storeParams = [
-      'dateFormats' => $this->getSubmittedValue('dateFormats'),
       'savedMapping' => $this->getSubmittedValue('savedMapping'),
     ];
 
     foreach ($storeParams as $storeName => $value) {
       $this->set($storeName, $value);
     }
-    CRM_Core_Session::singleton()->set('dateTypes', $storeParams['dateFormats']);
-
   }
 
   /**

--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -301,20 +301,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
     $addressCustomFields = CRM_Core_BAO_CustomField::getFields('Address');
     $customFields = $customFields + $addressCustomFields;
 
-    //format date first
-    $session = CRM_Core_Session::singleton();
-    $dateType = $session->get("dateTypes");
     foreach ($params as $key => $val) {
       $customFieldID = CRM_Core_BAO_CustomField::getKeyID($key);
       if ($customFieldID &&
         !array_key_exists($customFieldID, $addressCustomFields)
       ) {
-        //we should not update Date to null, CRM-4062
-        if ($val && ($customFields[$customFieldID]['data_type'] == 'Date')) {
-          //CRM-21267
-          $this->formatCustomDate($params, $formatted, $dateType, $key);
-        }
-        elseif ($customFields[$customFieldID]['data_type'] == 'Boolean') {
+        if ($customFields[$customFieldID]['data_type'] == 'Boolean') {
           if (empty($val) && !is_numeric($val) && $this->isFillDuplicates()) {
             //retain earlier value when Import mode is `Fill`
             unset($params[$key]);

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2140,26 +2140,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * Convert any given date string to default date array.
-   *
-   * @param array $params
-   *   Has given date-format.
-   * @param array $formatted
-   *   Store formatted date in this array.
-   * @param int $dateType
-   *   Type of date.
-   * @param string $dateParam
-   *   Index of params.
-   *
-   * @deprecated
-   */
-  public static function formatCustomDate(&$params, &$formatted, $dateType, $dateParam) {
-    //fix for CRM-2687
-    CRM_Utils_Date::convertToDefaultDate($params, $dateType, $dateParam);
-    $formatted[$dateParam] = CRM_Utils_Date::processDate($params[$dateParam]);
-  }
-
-  /**
    * Get the value to use for option comparison purposes.
    *
    * We do a case-insensitive comparison, also swapping ’ for '

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -150,9 +150,6 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     $this->contactID2 = $this->individualCreate($contact2Params);
     $this->contactID3 = $this->individualCreate(['first_name' => 'bobby', 'email' => 'c@d.com']);
     $this->contactID4 = $this->individualCreate(['first_name' => 'bobbynita', 'email' => 'c@de.com']);
-
-    $session = CRM_Core_Session::singleton();
-    $session->set('dateTypes', 1);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------


Fix Contact Import tests custom date testing, remove duplicate handling

All the code in the formatCommonData function is legacy contact import handling for stuff that is already handled in the generic metadata based code.  We have been slowly removing it to fix bugs (ie someone finds a bug, we look in that function & find that it is messing with something that would work fine it we remove the code, so we do)

This fixes the test so it is actually testing it for contact and address custom date fields & removes the handling (which actually works with or without it here)


Before
----------------------------------------
Test doesn't work. Code that does nothing hanging around like a bad code smell

After
----------------------------------------
better...

Technical Details
----------------------------------------

Comments
----------------------------------------
