### PR TITLE
dev/core#3937 Remove legacy code causing custom boolean import bug

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -311,9 +311,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
             //retain earlier value when Import mode is `Fill`
             unset($params[$key]);
           }
-          else {
-            $params[$key] = CRM_Utils_String::strtoboolstr($val);
-          }
         }
       }
     }
@@ -1028,24 +1025,6 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
 
       _civicrm_api3_store_values($fields[$values['contact_type']], $values, $params);
       return TRUE;
-    }
-
-    // Check for custom field values
-    $customFields = CRM_Core_BAO_CustomField::getFields(CRM_Utils_Array::value('contact_type', $values),
-      FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE
-    );
-
-    foreach ($values as $key => $value) {
-      if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        // check if it's a valid custom field id
-
-        if (!array_key_exists($customFieldID, $customFields)) {
-          return civicrm_api3_create_error('Invalid custom field ID');
-        }
-        else {
-          $params[$key] = $value;
-        }
-      }
     }
     return TRUE;
   }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1603,7 +1603,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     if ($fieldMetadata['type'] === CRM_Utils_Type::T_BOOLEAN) {
       $value = CRM_Utils_String::strtoboolstr($importedValue);
       if ($value !== FALSE) {
-        return (bool) $value;
+        return (int) $value;
       }
       return 'invalid_import_value';
     }

--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_boolean.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_boolean.csv
@@ -1,0 +1,11 @@
+first_name,Last Name,Street Address,Do Not Email,Contact Custom Field, Address Custom Field
+Joe,1,Main Street,0,0,0
+Joe,2,Main Street,FALSE,FALSE,FALSE
+Joe,3,Main Street,false,false,false
+Joe,4,Main st,no,no,no
+Joe,5,Main Street,NO,NO,NO
+Betty,1,Main Street,1,1,1
+Betty,2,Main Street,TRUE,TRUE,TRUE
+Betty,3,Main Street,true,true,true
+Betty,4,Main Street,yes,yes,yes
+Betty,5,Main Street,YES,YES,YES

--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -94,7 +94,7 @@ trait CRMTraits_Custom_CustomDataTrait {
    *
    */
   public function createCustomGroupWithFieldOfType(array $groupParams = [], string $customFieldType = 'text', ?string $identifier = NULL, array $fieldParams = []): void {
-    $supported = ['text', 'select', 'date', 'checkbox', 'int', 'contact_reference', 'radio', 'multi_country'];
+    $supported = ['text', 'select', 'date', 'checkbox', 'int', 'contact_reference', 'radio', 'multi_country', 'boolean'];
     if (!in_array($customFieldType, $supported, TRUE)) {
       $this->fail('we have not yet extracted other custom field types from createCustomFieldsOfAllTypes, Use consistent syntax when you do');
     }
@@ -136,6 +136,9 @@ trait CRMTraits_Custom_CustomDataTrait {
         $reference = $this->createMultiCountryCustomField($fieldParams)['id'];
         return;
 
+      case 'boolean':
+        $reference = $this->createBooleanCustomField($fieldParams)['id'];
+        return;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[dev/core#3937 Remove legacy code causing custom boolean import bug](https://lab.civicrm.org/dev/core/-/issues/3937)

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/3937 - the legacy code handling appears to be clobbering the correct handling from the shared code

After
----------------------------------------
Removed, tests added

Technical Details
----------------------------------------

Comments
----------------------------------------
@elisseck are you able to check this out - it also includes a test + tidy up on dates