### PR TITLE
Deprecate CRM_Utils_Hook::$nullObject

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -40,6 +40,7 @@ abstract class CRM_Utils_Hook {
    * pattern as it can get contaminated & result in hard-to-diagnose bugs.
    *
    * @var null
+   * @deprecated
    */
   public static $_nullObject = NULL;
 
@@ -422,6 +423,7 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function links($op, $objectName, &$objectId, &$links, &$mask = NULL, &$values = []) {
+    $null = NULL;
     return self::singleton()->invoke(['op', 'objectName', 'objectId', 'links', 'mask', 'values'], $op, $objectName, $objectId, $links, $mask, $values, 'civicrm_links');
   }
 
@@ -437,8 +439,9 @@ abstract class CRM_Utils_Hook {
    * @see CRM_Core_Resources_CollectionInterface::filter()
    */
   public static function alterBundle($bundle) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['bundle'], $bundle, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_alterBundle');
+      ->invoke(['bundle'], $bundle, $null, $null, $null, $null, $null, 'civicrm_alterBundle');
   }
 
   /**
@@ -453,8 +456,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function preProcess($formName, &$form) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['formName', 'form'], $formName, $form, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_preProcess');
+      ->invoke(['formName', 'form'], $formName, $form, $null, $null, $null, $null, 'civicrm_preProcess');
   }
 
   /**
@@ -470,8 +474,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function buildForm($formName, &$form) {
+    $null = NULL;
     return self::singleton()->invoke(['formName', 'form'], $formName, $form,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_buildForm'
     );
   }
@@ -489,8 +494,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function postProcess($formName, &$form) {
+    $null = NULL;
     return self::singleton()->invoke(['formName', 'form'], $formName, $form,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_postProcess'
     );
   }
@@ -511,9 +517,10 @@ abstract class CRM_Utils_Hook {
    *                           an array of error messages which display a QF Error
    */
   public static function validateForm($formName, &$fields, &$files, &$form, &$errors) {
+    $null = NULL;
     return self::singleton()
       ->invoke(['formName', 'fields', 'files', 'form', 'errors'],
-        $formName, $fields, $files, $form, $errors, self::$_nullObject, 'civicrm_validateForm');
+        $formName, $fields, $files, $form, $errors, $null, 'civicrm_validateForm');
   }
 
   /**
@@ -532,8 +539,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function custom(string $op, int $groupID, int $entityID, &$params) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_custom');
+      ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, $null, $null, 'civicrm_custom');
   }
 
   /**
@@ -552,8 +560,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function customPre(string $op, int $groupID, int $entityID, array &$params) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, self::$_nullObject, self::$_nullObject, 'civicrm_customPre');
+      ->invoke(['op', 'groupID', 'entityID', 'params'], $op, $groupID, $entityID, $params, $null, $null, 'civicrm_customPre');
   }
 
   /**
@@ -575,8 +584,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function aclWhereClause($type, &$tables, &$whereTables, &$contactID, &$where) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['type', 'tables', 'whereTables', 'contactID', 'where'], $type, $tables, $whereTables, $contactID, $where, self::$_nullObject, 'civicrm_aclWhereClause');
+      ->invoke(['type', 'tables', 'whereTables', 'contactID', 'where'], $type, $tables, $whereTables, $contactID, $where, $null, 'civicrm_aclWhereClause');
   }
 
   /**
@@ -598,8 +608,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['type', 'contactID', 'tableName', 'allGroups', 'currentGroups'], $type, $contactID, $tableName, $allGroups, $currentGroups, self::$_nullObject, 'civicrm_aclGroup');
+      ->invoke(['type', 'contactID', 'tableName', 'allGroups', 'currentGroups'], $type, $contactID, $tableName, $allGroups, $currentGroups, $null, 'civicrm_aclGroup');
   }
 
   /**
@@ -609,8 +620,9 @@ abstract class CRM_Utils_Hook {
    */
   public static function selectWhereClause($entity, &$clauses) {
     $entityName = is_object($entity) ? _civicrm_api_get_entity_name_from_dao($entity) : $entity;
+    $null = NULL;
     return self::singleton()->invoke(['entity', 'clauses'], $entityName, $clauses,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_selectWhereClause'
     );
   }
@@ -625,8 +637,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function xmlMenu(&$files) {
+    $null = NULL;
     return self::singleton()->invoke(['files'], $files,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_xmlMenu'
     );
   }
@@ -640,8 +653,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function alterMenu(&$items) {
+    $null = NULL;
     return self::singleton()->invoke(['items'], $items,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_alterMenu'
     );
   }
@@ -677,8 +691,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function themes(&$themes) {
+    $null = NULL;
     return self::singleton()->invoke(['themes'], $themes,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_themes'
     );
   }
@@ -697,8 +712,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function activeTheme(&$theme, $context) {
+    $null = NULL;
     return self::singleton()->invoke(['theme', 'context'], $theme, $context,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_activeTheme'
     );
   }
@@ -745,8 +761,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function managed(&$entities, ?array $modules = NULL) {
+    $null = NULL;
     self::singleton()->invoke(['entities', 'modules'], $entities, $modules,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_managed'
     );
     if ($modules) {
@@ -769,8 +786,9 @@ abstract class CRM_Utils_Hook {
    *   the html snippet to include in the dashboard
    */
   public static function dashboard($contactID, &$contentPlacement = self::DASHBOARD_BELOW) {
+    $null = NULL;
     $retval = self::singleton()->invoke(['contactID', 'contentPlacement'], $contactID, $contentPlacement,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_dashboard'
     );
 
@@ -795,8 +813,9 @@ abstract class CRM_Utils_Hook {
    * @return array
    */
   public static function recent(&$recentArray) {
+    $null = NULL;
     return self::singleton()->invoke(['recentArray'], $recentArray,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_recent'
     );
   }
@@ -816,8 +835,9 @@ abstract class CRM_Utils_Hook {
    *   Return is not really intended to be used.
    */
   public static function referenceCounts($dao, &$refCounts) {
+    $null = NULL;
     return self::singleton()->invoke(['dao', 'refCounts'], $dao, $refCounts,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_referenceCounts'
     );
   }
@@ -835,8 +855,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function buildAmount($pageType, &$form, &$amount) {
-    return self::singleton()->invoke(['pageType', 'form', 'amount'], $pageType, $form, $amount, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_buildAmount');
+    $null = NULL;
+    return self::singleton()->invoke(['pageType', 'form', 'amount'], $pageType, $form, $amount, $null,
+      $null, $null, 'civicrm_buildAmount');
   }
 
   /**
@@ -849,8 +870,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function buildStateProvinceForCountry($countryID, &$states) {
+    $null = NULL;
     return self::singleton()->invoke(['countryID', 'states'], $countryID, $states,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_buildStateProvinceForCountry'
     );
   }
@@ -869,8 +891,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function tabset($tabsetName, &$tabs, $context) {
+    $null = NULL;
     return self::singleton()->invoke(['tabsetName', 'tabs', 'context'], $tabsetName, $tabs,
-      $context, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tabset'
+      $context, $null, $null, $null, 'civicrm_tabset'
     );
   }
 
@@ -883,8 +906,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function tokens(&$tokens) {
+    $null = NULL;
     return self::singleton()->invoke(['tokens'], $tokens,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_tokens'
+      $null, $null, $null, $null, $null, 'civicrm_tokens'
     );
   }
 
@@ -897,8 +921,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterAdminPanel(&$panels) {
+    $null = NULL;
     return self::singleton()->invoke(['panels'], $panels,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_alterAdminPanel'
     );
   }
@@ -927,8 +952,9 @@ abstract class CRM_Utils_Hook {
     $tokens = [],
     $className = NULL
   ) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['details', 'contactIDs', 'jobID', 'tokens', 'className'], $details, $contactIDs, $jobID, $tokens, $className, self::$_nullObject, 'civicrm_tokenValues');
+      ->invoke(['details', 'contactIDs', 'jobID', 'tokens', 'className'], $details, $contactIDs, $jobID, $tokens, $className, $null, 'civicrm_tokenValues');
   }
 
   /**
@@ -941,8 +967,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function pageRun(&$page) {
+    $null = NULL;
     return self::singleton()->invoke(['page'], $page,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_pageRun'
     );
   }
@@ -959,8 +986,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function copy($objectName, &$object) {
+    $null = NULL;
     return self::singleton()->invoke(['objectName', 'object'], $objectName, $object,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_copy'
     );
   }
@@ -984,8 +1012,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function unsubscribeGroups($op, $mailingId, $contactId, &$groups, &$baseGroups) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['op', 'mailingId', 'contactId', 'groups', 'baseGroups'], $op, $mailingId, $contactId, $groups, $baseGroups, self::$_nullObject, 'civicrm_unsubscribeGroups');
+      ->invoke(['op', 'mailingId', 'contactId', 'groups', 'baseGroups'], $op, $mailingId, $contactId, $groups, $baseGroups, $null, 'civicrm_unsubscribeGroups');
   }
 
   /**
@@ -1010,8 +1039,9 @@ abstract class CRM_Utils_Hook {
    */
   public static function customFieldOptions($customFieldID, &$options, $detailedFormat = FALSE, $selectAttributes = []) {
     // Weird: $selectAttributes is inputted but not outputted.
+    $null = NULL;
     return self::singleton()->invoke(['customFieldID', 'options', 'detailedFormat'], $customFieldID, $options, $detailedFormat,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_customFieldOptions'
     );
   }
@@ -1027,8 +1057,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function fieldOptions($entity, $field, &$options, $params) {
+    $null = NULL;
     return self::singleton()->invoke(['entity', 'field', 'options', 'params'], $entity, $field, $options, $params,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_fieldOptions'
     );
   }
@@ -1053,8 +1084,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function searchTasks($objectType, &$tasks) {
+    $null = NULL;
     return self::singleton()->invoke(['objectType', 'tasks'], $objectType, $tasks,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_searchTasks'
     );
   }
@@ -1066,8 +1098,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function eventDiscount(&$form, &$params) {
+    $null = NULL;
     return self::singleton()->invoke(['form', 'params'], $form, $params,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_eventDiscount'
     );
   }
@@ -1084,8 +1117,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function mailSetupActions(&$setupActions) {
-    return self::singleton()->invoke(['setupActions'], $setupActions, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['setupActions'], $setupActions, $null, $null,
+      $null, $null, $null,
       'civicrm_mailSetupActions'
     );
   }
@@ -1103,8 +1137,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function mailingGroups(&$form, &$groups, &$mailings) {
+    $null = NULL;
     return self::singleton()->invoke(['form', 'groups', 'mailings'], $form, $groups, $mailings,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_mailingGroups'
     );
   }
@@ -1120,8 +1155,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function mailingTemplateTypes(&$types) {
-    return self::singleton()->invoke(['types'], $types, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['types'], $types, $null, $null,
+      $null, $null, $null,
       'civicrm_mailingTemplateTypes'
     );
   }
@@ -1141,8 +1177,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function membershipTypeValues(&$form, &$membershipTypes) {
+    $null = NULL;
     return self::singleton()->invoke(['form', 'membershipTypes'], $form, $membershipTypes,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_membershipTypeValues'
     );
   }
@@ -1161,8 +1198,9 @@ abstract class CRM_Utils_Hook {
    *   The html snippet to include in the contact summary
    */
   public static function summary($contactID, &$content, &$contentPlacement = self::SUMMARY_BELOW) {
+    $null = NULL;
     return self::singleton()->invoke(['contactID', 'content', 'contentPlacement'], $contactID, $content, $contentPlacement,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_summary'
     );
   }
@@ -1192,8 +1230,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function contactListQuery(&$query, $queryText, $context, $id) {
+    $null = NULL;
     return self::singleton()->invoke(['query', 'queryText', 'context', 'id'], $query, $queryText, $context, $id,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_contactListQuery'
     );
   }
@@ -1225,8 +1264,9 @@ abstract class CRM_Utils_Hook {
     &$rawParams,
     &$cookedParams
   ) {
+    $null = NULL;
     return self::singleton()->invoke(['paymentObj', 'rawParams', 'cookedParams'], $paymentObj, $rawParams, $cookedParams,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_alterPaymentProcessorParams'
     );
   }
@@ -1243,8 +1283,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailParams(&$params, $context = NULL) {
+    $null = NULL;
     return self::singleton()->invoke(['params', 'context'], $params, $context,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_alterMailParams'
     );
   }
@@ -1270,8 +1311,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailStore(&$params) {
+    $null = NULL;
     return self::singleton()->invoke(['params'], $params, $context,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_alterMailStore'
     );
   }
@@ -1295,8 +1337,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterCalculatedMembershipStatus(&$membershipStatus, $arguments, $membership) {
+    $null = NULL;
     return self::singleton()->invoke(['membershipStatus', 'arguments', 'membership'], $membershipStatus, $arguments,
-      $membership, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $membership, $null, $null, $null,
       'civicrm_alterCalculatedMembershipStatus'
     );
   }
@@ -1310,8 +1353,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailContent(&$content) {
+    $null = NULL;
     return self::singleton()->invoke(['content'], $content,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_alterMailContent'
     );
   }
@@ -1327,8 +1371,9 @@ abstract class CRM_Utils_Hook {
    *   and the value is an array with keys 'label' and 'value' specifying label/value pairs
    */
   public static function caseSummary($caseID) {
+    $null = NULL;
     return self::singleton()->invoke(['caseID'], $caseID,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_caseSummary'
     );
   }
@@ -1341,8 +1386,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function caseTypes(&$caseTypes) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['caseTypes'], $caseTypes, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseTypes');
+      ->invoke(['caseTypes'], $caseTypes, $null, $null, $null, $null, $null, 'civicrm_caseTypes');
   }
 
   /**
@@ -1363,8 +1409,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function caseEmailSubjectPatterns(&$subjectPatterns) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['caseEmailSubjectPatterns'], $subjectPatterns, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_caseEmailSubjectPatterns');
+      ->invoke(['caseEmailSubjectPatterns'], $subjectPatterns, $null, $null, $null, $null, $null, 'civicrm_caseEmailSubjectPatterns');
   }
 
   /**
@@ -1377,8 +1424,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function config(&$config) {
+    $null = NULL;
     return self::singleton()->invoke(['config'], $config,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_config'
     );
   }
@@ -1396,8 +1444,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function optionValues(&$options, $groupName) {
+    $null = NULL;
     return self::singleton()->invoke(['options', 'groupName'], $options, $groupName,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_optionValues'
     );
   }
@@ -1411,8 +1460,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function navigationMenu(&$params) {
+    $null = NULL;
     return self::singleton()->invoke(['params'], $params,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_navigationMenu'
     );
   }
@@ -1434,7 +1484,8 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function merge($type, &$data, $mainId = NULL, $otherId = NULL, $tables = NULL) {
-    return self::singleton()->invoke(['type', 'data', 'mainId', 'otherId', 'tables'], $type, $data, $mainId, $otherId, $tables, self::$_nullObject, 'civicrm_merge');
+    $null = NULL;
+    return self::singleton()->invoke(['type', 'data', 'mainId', 'otherId', 'tables'], $type, $data, $mainId, $otherId, $tables, $null, 'civicrm_merge');
   }
 
   /**
@@ -1452,7 +1503,8 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterLocationMergeData(&$blocksDAO, $mainId, $otherId, $migrationInfo) {
-    return self::singleton()->invoke(['blocksDAO', 'mainId', 'otherId', 'migrationInfo'], $blocksDAO, $mainId, $otherId, $migrationInfo, self::$_nullObject, self::$_nullObject, 'civicrm_alterLocationMergeData');
+    $null = NULL;
+    return self::singleton()->invoke(['blocksDAO', 'mainId', 'otherId', 'migrationInfo'], $blocksDAO, $mainId, $otherId, $migrationInfo, $null, $null, 'civicrm_alterLocationMergeData');
   }
 
   /**
@@ -1464,8 +1516,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function notePrivacy(&$noteValues) {
+    $null = NULL;
     return self::singleton()->invoke(['noteValues'], $noteValues,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_notePrivacy'
     );
   }
@@ -1509,8 +1562,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function dupeQuery($obj, $type, &$query) {
+    $null = NULL;
     return self::singleton()->invoke(['obj', 'type', 'query'], $obj, $type, $query,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_dupeQuery'
     );
   }
@@ -1534,8 +1588,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function findDuplicates($dedupeParams, &$dedupeResults, $contextParams) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['dedupeParams', 'dedupeResults', 'contextParams'], $dedupeParams, $dedupeResults, $contextParams, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_findDuplicates');
+      ->invoke(['dedupeParams', 'dedupeResults', 'contextParams'], $dedupeParams, $dedupeResults, $contextParams, $null, $null, $null, 'civicrm_findDuplicates');
   }
 
   /**
@@ -1553,8 +1608,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function emailProcessor($type, &$params, $mail, &$result, $action = NULL) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['type', 'params', 'mail', 'result', 'action'], $type, $params, $mail, $result, $action, self::$_nullObject, 'civicrm_emailProcessor');
+      ->invoke(['type', 'params', 'mail', 'result', 'action'], $type, $params, $mail, $result, $action, $null, 'civicrm_emailProcessor');
   }
 
   /**
@@ -1579,8 +1635,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function import($object, $usage, &$objectRef, &$params) {
+    $null = NULL;
     return self::singleton()->invoke(['object', 'usage', 'objectRef', 'params'], $object, $usage, $objectRef, $params,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_import'
     );
   }
@@ -1599,8 +1656,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterAPIPermissions($entity, $action, &$params, &$permissions) {
+    $null = NULL;
     return self::singleton()->invoke(['entity', 'action', 'params', 'permissions'], $entity, $action, $params, $permissions,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_alterAPIPermissions'
     );
   }
@@ -1612,8 +1670,9 @@ abstract class CRM_Utils_Hook {
    */
   public static function postSave(&$dao) {
     $hookName = 'civicrm_postSave_' . $dao->getTableName();
+    $null = NULL;
     return self::singleton()->invoke(['dao'], $dao,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       $hookName
     );
   }
@@ -1629,8 +1688,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function summaryActions(&$actions, $contactID = NULL) {
+    $null = NULL;
     return self::singleton()->invoke(['actions', 'contactID'], $actions, $contactID,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_summaryActions'
     );
   }
@@ -1657,8 +1717,9 @@ abstract class CRM_Utils_Hook {
    *   modify the header and values object to pass the data you need
    */
   public static function searchColumns($objectName, &$headers, &$rows, &$selector) {
+    $null = NULL;
     return self::singleton()->invoke(['objectName', 'headers', 'rows', 'selector'], $objectName, $headers, $rows, $selector,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_searchColumns'
     );
   }
@@ -1674,8 +1735,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function buildUFGroupsForModule($moduleName, &$ufGroups) {
+    $null = NULL;
     return self::singleton()->invoke(['moduleName', 'ufGroups'], $moduleName, $ufGroups,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_buildUFGroupsForModule'
     );
   }
@@ -1690,8 +1752,8 @@ abstract class CRM_Utils_Hook {
    *   List of classes which may be of interest to the class-scanner.
    */
   public static function scanClasses(array &$classes) {
-    self::singleton()->invoke(['classes'], $classes, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    self::singleton()->invoke(['classes'], $classes, $null,
+      $null, $null, $null, $null,
       'civicrm_scanClasses'
     );
   }
@@ -1715,8 +1777,9 @@ abstract class CRM_Utils_Hook {
    * @return null
    */
   public static function emailProcessorContact($email, $contactID, &$result) {
+    $null = NULL;
     return self::singleton()->invoke(['email', 'contactID', 'result'], $email, $contactID, $result,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_emailProcessorContact'
     );
   }
@@ -1755,9 +1818,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailingLabelParams(&$args) {
+    $null = NULL;
     return self::singleton()->invoke(['args'], $args,
-      self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_alterMailingLabelParams'
     );
   }
@@ -1777,8 +1840,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterContent(&$content, $context, $tplName, &$object) {
+    $null = NULL;
     return self::singleton()->invoke(['content', 'context', 'tplName', 'object'], $content, $context, $tplName, $object,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_alterContent'
     );
   }
@@ -1799,8 +1863,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterTemplateFile($formName, &$form, $context, &$tplName) {
+    $null = NULL;
     return self::singleton()->invoke(['formName', 'form', 'context', 'tplName'], $formName, $form, $context, $tplName,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null,
       'civicrm_alterTemplateFile'
     );
   }
@@ -1818,9 +1883,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function crypto($crypto) {
-    return self::singleton()->invoke(['crypto'], $crypto, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['crypto'], $crypto, $null,
+      $null, $null, $null, $null,
       'civicrm_crypto'
     );
   }
@@ -1844,9 +1909,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function triggerInfo(&$info, $tableName = NULL) {
+    $null = NULL;
     return self::singleton()->invoke(['info', 'tableName'], $info, $tableName,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_triggerInfo'
     );
   }
@@ -1862,9 +1927,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function translateFields(&$fields) {
-    return self::singleton()->invoke(['fields'], $fields, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['fields'], $fields, $null,
+      $null, $null, $null, $null,
       'civicrm_translateFields'
     );
   }
@@ -1877,9 +1942,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterLogTables(&$logTableSpec) {
+    $null = NULL;
     return self::singleton()->invoke(['logTableSpec'], $logTableSpec, $_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_alterLogTables'
     );
   }
@@ -1965,9 +2030,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function alterRedirect(&$url, &$context) {
+    $null = NULL;
     return self::singleton()->invoke(['url', 'context'], $url,
-      $context, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $context, $null, $null, $null, $null,
       'civicrm_alterRedirect'
     );
   }
@@ -1980,9 +2045,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterReportVar($varType, &$var, &$object) {
+    $null = NULL;
     return self::singleton()->invoke(['varType', 'var', 'object'], $varType, $var, $object,
-      self::$_nullObject,
-      self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_alterReportVar'
     );
   }
@@ -2001,9 +2066,9 @@ abstract class CRM_Utils_Hook {
    *   FALSE, if $op is 'check' and upgrades are not pending.
    */
   public static function upgrade($op, CRM_Queue_Queue $queue = NULL) {
+    $null = NULL;
     return self::singleton()->invoke(['op', 'queue'], $op, $queue,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_upgrade'
     );
   }
@@ -2019,9 +2084,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function postEmailSend(&$params) {
+    $null = NULL;
     return self::singleton()->invoke(['params'], $params,
-      self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_postEmailSend'
     );
   }
@@ -2035,9 +2100,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function postMailing($mailingId) {
+    $null = NULL;
     return self::singleton()->invoke(['mailingId'], $mailingId,
-      self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_postMailing'
     );
   }
@@ -2051,9 +2116,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterSettingsFolders(&$settingsFolders) {
+    $null = NULL;
     return self::singleton()->invoke(['settingsFolders'], $settingsFolders,
-      self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_alterSettingsFolders'
     );
   }
@@ -2070,9 +2135,10 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterSettingsMetaData(&$settingsMetaData, $domainID, $profile) {
+    $null = NULL;
     return self::singleton()->invoke(['settingsMetaData', 'domainID', 'profile'], $settingsMetaData,
       $domainID, $profile,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_alterSettingsMetaData'
     );
   }
@@ -2088,9 +2154,11 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function apiWrappers(&$wrappers, $apiRequest) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['wrappers', 'apiRequest'], $wrappers, $apiRequest, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-        self::$_nullObject, 'civicrm_apiWrappers'
+      ->invoke(['wrappers', 'apiRequest'], $wrappers, $apiRequest,
+        $null, $null, $null, $null,
+        'civicrm_apiWrappers'
       );
   }
 
@@ -2103,8 +2171,9 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored.
    */
   public static function cron($jobManager) {
+    $null = NULL;
     return self::singleton()->invoke(['jobManager'],
-      $jobManager, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $jobManager, $null, $null, $null, $null, $null,
       'civicrm_cron'
     );
   }
@@ -2120,8 +2189,9 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function permission(&$newPermissions) {
-    return self::singleton()->invoke(['permissions'], $newPermissions, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['permissions'], $newPermissions, $null,
+      $null, $null, $null, $null,
       'civicrm_permission'
     );
   }
@@ -2145,8 +2215,9 @@ abstract class CRM_Utils_Hook {
    * @see Civi\Api4\Permission::get()
    */
   public static function permissionList(&$permissions) {
+    $null = NULL;
     return self::singleton()->invoke(['permissions'], $permissions,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_permissionList'
     );
   }
@@ -2166,8 +2237,9 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function permission_check($permission, &$granted, $contactId) {
+    $null = NULL;
     return self::singleton()->invoke(['permission', 'granted', 'contactId'], $permission, $granted, $contactId,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_permission_check'
     );
   }
@@ -2207,8 +2279,9 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function cryptoRotateKey($tag, $log) {
-    return self::singleton()->invoke(['tag', 'log'], $tag, $log, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['tag', 'log'], $tag, $log, $null,
+      $null, $null, $null,
       'civicrm_cryptoRotateKey'
     );
   }
@@ -2219,7 +2292,8 @@ abstract class CRM_Utils_Hook {
    *   Reserved for future use.
    */
   public static function unhandledException($exception, $request = NULL) {
-    $event = new \Civi\Core\Event\UnhandledExceptionEvent($exception, self::$_nullObject);
+    $null = NULL;
+    $event = new \Civi\Core\Event\UnhandledExceptionEvent($exception, $null);
     \Civi::dispatcher()->dispatch('hook_civicrm_unhandled_exception', $event);
   }
 
@@ -2241,8 +2315,9 @@ abstract class CRM_Utils_Hook {
    *   The return value is ignored
    */
   public static function entityTypes(&$entityTypes) {
-    return self::singleton()->invoke(['entityTypes'], $entityTypes, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_entityTypes'
+    $null = NULL;
+    return self::singleton()->invoke(['entityTypes'], $entityTypes, $null, $null,
+      $null, $null, $null, 'civicrm_entityTypes'
     );
   }
 
@@ -2265,8 +2340,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function buildProfile($profileName) {
-    return self::singleton()->invoke(['profileName'], $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_buildProfile');
+    $null = NULL;
+    return self::singleton()->invoke(['profileName'], $profileName, $null, $null, $null,
+      $null, $null, 'civicrm_buildProfile');
   }
 
   /**
@@ -2276,8 +2352,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function validateProfile($profileName) {
-    return self::singleton()->invoke(['profileName'], $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_validateProfile');
+    $null = NULL;
+    return self::singleton()->invoke(['profileName'], $profileName, $null, $null, $null,
+      $null, $null, 'civicrm_validateProfile');
   }
 
   /**
@@ -2287,8 +2364,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function processProfile($profileName) {
-    return self::singleton()->invoke(['profileName'], $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_processProfile');
+    $null = NULL;
+    return self::singleton()->invoke(['profileName'], $profileName, $null, $null, $null,
+      $null, $null, 'civicrm_processProfile');
   }
 
   /**
@@ -2298,8 +2376,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function viewProfile($profileName) {
-    return self::singleton()->invoke(['profileName'], $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_viewProfile');
+    $null = NULL;
+    return self::singleton()->invoke(['profileName'], $profileName, $null, $null, $null,
+      $null, $null, 'civicrm_viewProfile');
   }
 
   /**
@@ -2309,8 +2388,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function searchProfile($profileName) {
-    return self::singleton()->invoke(['profileName'], $profileName, self::$_nullObject, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_searchProfile');
+    $null = NULL;
+    return self::singleton()->invoke(['profileName'], $profileName, $null, $null, $null,
+      $null, $null, 'civicrm_searchProfile');
   }
 
   /**
@@ -2329,8 +2409,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function alterBadge($labelName, &$label, &$format, &$participant) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['labelName', 'label', 'format', 'participant'], $labelName, $label, $format, $participant, self::$_nullObject, self::$_nullObject, 'civicrm_alterBadge');
+      ->invoke(['labelName', 'label', 'format', 'participant'], $labelName, $label, $format, $participant, $null, $null, 'civicrm_alterBadge');
   }
 
   /**
@@ -2346,8 +2427,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterBarcode(&$data, $type = 'barcode', $context = 'name_badge') {
-    return self::singleton()->invoke(['data', 'type', 'context'], $data, $type, $context, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, 'civicrm_alterBarcode');
+    $null = NULL;
+    return self::singleton()->invoke(['data', 'type', 'context'], $data, $type, $context, $null,
+      $null, $null, 'civicrm_alterBarcode');
   }
 
   /**
@@ -2364,8 +2446,9 @@ abstract class CRM_Utils_Hook {
    * @see Mail::factory
    */
   public static function alterMailer(&$mailer, $driver, $params) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['mailer', 'driver', 'params'], $mailer, $driver, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_alterMailer');
+      ->invoke(['mailer', 'driver', 'params'], $mailer, $driver, $params, $null, $null, $null, 'civicrm_alterMailer');
   }
 
   /**
@@ -2378,8 +2461,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function queryObjects(&$queryObjects, $type = 'Contact') {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['queryObjects', 'type'], $queryObjects, $type, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_queryObjects');
+      ->invoke(['queryObjects', 'type'], $queryObjects, $type, $null, $null, $null, $null, 'civicrm_queryObjects');
   }
 
   /**
@@ -2393,8 +2477,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function dashboard_defaults($availableDashlets, &$defaultDashlets) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['availableDashlets', 'defaultDashlets'], $availableDashlets, $defaultDashlets, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_dashboard_defaults');
+      ->invoke(['availableDashlets', 'defaultDashlets'], $availableDashlets, $defaultDashlets, $null, $null, $null, $null, 'civicrm_dashboard_defaults');
   }
 
   /**
@@ -2409,8 +2494,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function pre_case_merge($mainContactId, $mainCaseId = NULL, $otherContactId = NULL, $otherCaseId = NULL, $changeClient = FALSE) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['mainContactId', 'mainCaseId', 'otherContactId', 'otherCaseId', 'changeClient'], $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, self::$_nullObject, 'civicrm_pre_case_merge');
+      ->invoke(['mainContactId', 'mainCaseId', 'otherContactId', 'otherCaseId', 'changeClient'], $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, $null, 'civicrm_pre_case_merge');
   }
 
   /**
@@ -2425,8 +2511,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function post_case_merge($mainContactId, $mainCaseId = NULL, $otherContactId = NULL, $otherCaseId = NULL, $changeClient = FALSE) {
+    $null = NULL;
     return self::singleton()
-      ->invoke(['mainContactId', 'mainCaseId', 'otherContactId', 'otherCaseId', 'changeClient'], $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, self::$_nullObject, 'civicrm_post_case_merge');
+      ->invoke(['mainContactId', 'mainCaseId', 'otherContactId', 'otherCaseId', 'changeClient'], $mainContactId, $mainCaseId, $otherContactId, $otherCaseId, $changeClient, $null, 'civicrm_post_case_merge');
   }
 
   /**
@@ -2443,9 +2530,10 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterDisplayName(&$displayName, $contactId, $dao) {
+    $null = NULL;
     return self::singleton()->invoke(['displayName', 'contactId', 'dao'],
-      $displayName, $contactId, $dao, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_contact_get_displayname'
+      $displayName, $contactId, $dao, $null, $null,
+      $null, 'civicrm_contact_get_displayname'
     );
   }
 
@@ -2502,8 +2590,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function angularModules(&$angularModules) {
+    $null = NULL;
     return self::singleton()->invoke(['angularModules'], $angularModules,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_angularModules'
     );
   }
@@ -2543,8 +2632,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function getAssetUrl(&$asset, &$params) {
+    $null = NULL;
     return self::singleton()->invoke(['asset', 'params'],
-      $asset, $params, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $asset, $params, $null, $null, $null, $null,
       'civicrm_getAssetUrl'
     );
   }
@@ -2567,8 +2657,9 @@ abstract class CRM_Utils_Hook {
    *   the return value is ignored
    */
   public static function buildAsset($asset, $params, &$mimeType, &$content) {
+    $null = NULL;
     return self::singleton()->invoke(['asset', 'params', 'mimeType', 'content'],
-      $asset, $params, $mimeType, $content, self::$_nullObject, self::$_nullObject,
+      $asset, $params, $mimeType, $content, $null, $null,
       'civicrm_buildAsset'
     );
   }
@@ -2609,7 +2700,8 @@ abstract class CRM_Utils_Hook {
    * @see http://symfony.com/doc/current/components/dependency_injection/index.html
    */
   public static function container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
-    self::singleton()->invoke(['container'], $container, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_container');
+    $null = NULL;
+    self::singleton()->invoke(['container'], $container, $null, $null, $null, $null, $null, 'civicrm_container');
   }
 
   /**
@@ -2617,8 +2709,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function fileSearches(&$fileSearches) {
+    $null = NULL;
     return self::singleton()->invoke(['fileSearches'], $fileSearches,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null, $null,
       'civicrm_fileSearches'
     );
   }
@@ -2635,9 +2728,10 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function check(&$messages, $statusNames = [], $includeDisabled = FALSE) {
+    $null = NULL;
     return self::singleton()->invoke(['messages', 'statusNames', 'includeDisabled'],
       $messages, $statusNames, $includeDisabled,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_check'
     );
   }
@@ -2650,8 +2744,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function batchQuery(&$query) {
-    return self::singleton()->invoke(['query'], $query, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['query'], $query, $null,
+      $null, $null, $null, $null,
       'civicrm_batchQuery'
     );
   }
@@ -2668,8 +2763,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterDeferredRevenueItems(&$deferredRevenues, $contributionDetails, $update, $context) {
+    $null = NULL;
     return self::singleton()->invoke(['deferredRevenues', 'contributionDetails', 'update', 'context'], $deferredRevenues, $contributionDetails, $update, $context,
-      self::$_nullObject, self::$_nullObject, 'civicrm_alterDeferredRevenueItems'
+      $null, $null, 'civicrm_alterDeferredRevenueItems'
     );
   }
 
@@ -2682,8 +2778,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function batchItems(&$results, &$items) {
+    $null = NULL;
     return self::singleton()->invoke(['results', 'items'], $results, $items,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_batchItems'
     );
   }
@@ -2697,8 +2794,9 @@ abstract class CRM_Utils_Hook {
    * @param string $region
    */
   public static function coreResourceList(&$list, $region) {
+    $null = NULL;
     self::singleton()->invoke(['list', 'region'], $list, $region,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_coreResourceList'
     );
   }
@@ -2712,8 +2810,9 @@ abstract class CRM_Utils_Hook {
    * @param array $links
    */
   public static function entityRefFilters(&$filters, &$links = NULL) {
-    self::singleton()->invoke(['filters', 'links'], $filters, $links, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    self::singleton()->invoke(['filters', 'links'], $filters, $links, $null,
+      $null, $null, $null,
       'civicrm_entityRefFilters'
     );
   }
@@ -2726,8 +2825,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function idsException(&$skip) {
-    return self::singleton()->invoke(['skip'], $skip, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+    $null = NULL;
+    return self::singleton()->invoke(['skip'], $skip, $null,
+      $null, $null, $null, $null,
       'civicrm_idsException'
     );
   }
@@ -2742,8 +2842,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function geocoderFormat($geoProvider, &$values, $xml) {
+    $null = NULL;
     return self::singleton()->invoke(['geoProvider', 'values', 'xml'], $geoProvider, $values, $xml,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_geocoderFormat'
     );
   }
@@ -2756,7 +2857,8 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function inboundSMS(&$message) {
-    return self::singleton()->invoke(['message'], $message, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_inboundSMS');
+    $null = NULL;
+    return self::singleton()->invoke(['message'], $message, $null, $null, $null, $null, $null, 'civicrm_inboundSMS');
   }
 
   /**
@@ -2767,8 +2869,9 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterEntityRefParams(&$params, $formName) {
+    $null = NULL;
     return self::singleton()->invoke(['params', 'formName'], $params, $formName,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_alterEntityRefParams'
     );
   }
@@ -2795,8 +2898,9 @@ abstract class CRM_Utils_Hook {
     if (empty($runner) || !preg_match(';^[A-Za-z0-9_]+$;', $runner)) {
       throw new \CRM_Core_Exception("Cannot autorun queue: " . $queue->getName());
     }
+    $null = NULL;
     return self::singleton()->invoke(['queue', 'items', 'outcomes'], $queue, $items,
-      $outcomes, $exception, self::$_nullObject, self::$_nullObject,
+      $outcomes, $exception, $null, $null,
       'civicrm_queueRun_' . $runner
     );
   }
@@ -2810,8 +2914,9 @@ abstract class CRM_Utils_Hook {
    *   Ex: 'completed', 'active', 'aborted'
    */
   public static function queueStatus(CRM_Queue_Queue $queue, string $status): void {
+    $null = NULL;
     self::singleton()->invoke(['queue', 'status'], $queue, $status,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_queueStatus'
     );
   }
@@ -2838,8 +2943,9 @@ abstract class CRM_Utils_Hook {
    *   If the task failed, this is the cause of the failure.
    */
   public static function queueTaskError(CRM_Queue_Queue $queue, $item, &$outcome, ?Throwable $exception) {
+    $null = NULL;
     return self::singleton()->invoke(['job', 'params'], $queue, $item,
-      $outcome, $exception, self::$_nullObject, self::$_nullObject,
+      $outcome, $exception, $null, $null,
       'civicrm_queueTaskError'
     );
   }
@@ -2853,8 +2959,9 @@ abstract class CRM_Utils_Hook {
    *   The arguments to be given to the job
    */
   public static function preJob($job, $params) {
+    $null = NULL;
     return self::singleton()->invoke(['job', 'params'], $job, $params,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null, $null,
       'civicrm_preJob'
     );
   }
@@ -2870,8 +2977,9 @@ abstract class CRM_Utils_Hook {
    *   The result of the API call, or the thrown exception if any
    */
   public static function postJob($job, $params, $result) {
+    $null = NULL;
     return self::singleton()->invoke(['job', 'params', 'result'], $job, $params, $result,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_postJob'
     );
   }
@@ -2890,9 +2998,10 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterMailingRecipients(&$mailingObject, &$criteria, $context) {
+    $null = NULL;
     return self::singleton()->invoke(['mailingObject', 'params', 'context'],
       $mailingObject, $criteria, $context,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $null, $null, $null,
       'civicrm_alterMailingRecipients'
     );
   }
@@ -2903,9 +3012,10 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function postIPNProcess(&$IPNData) {
+    $null = NULL;
     return self::singleton()->invoke(['IPNData'],
-      $IPNData, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $IPNData, $null, $null,
+      $null, $null, $null,
       'civicrm_postIPNProcess'
     );
   }
@@ -2917,9 +3027,10 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterUFFields(&$fields) {
+    $null = NULL;
     return self::singleton()->invoke(['fields'],
-      $fields, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, self::$_nullObject, self::$_nullObject,
+      $fields, $null, $null,
+      $null, $null, $null,
       'civicrm_alterUFFields'
     );
   }
@@ -2935,10 +3046,11 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterCustomFieldDisplayValue(&$displayValue, $value, $entityId, $fieldInfo) {
+    $null = NULL;
     return self::singleton()->invoke(
       ['displayValue', 'value', 'entityId', 'fieldInfo'],
-      $displayValue, $value, $entityId, $fieldInfo, self::$_nullObject,
-      self::$_nullObject, 'civicrm_alterCustomFieldDisplayValue'
+      $displayValue, $value, $entityId, $fieldInfo, $null,
+      $null, 'civicrm_alterCustomFieldDisplayValue'
     );
   }
 
@@ -2968,10 +3080,12 @@ abstract class CRM_Utils_Hook {
    * @return mixed
    */
   public static function alterApiRoutePermissions(&$permissions, $entity, $action) {
+    $null = NULL;
     return self::singleton()->invoke(
       ['permissions', 'entity', 'action'],
-      $permissions, $entity, $action, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_alterApiRoutePermissions'
+      $permissions, $entity, $action,
+      $null, $null, $null,
+      'civicrm_alterApiRoutePermissions'
     );
   }
 
@@ -2987,10 +3101,12 @@ abstract class CRM_Utils_Hook {
    *   Leave this at FALSE to allow the core code to perform validation. Set to TRUE to invalidate
    */
   public static function invalidateChecksum($contactID, $checksum, &$invalid) {
+    $null = NULL;
     return self::singleton()->invoke(
       ['contactID', 'checksum', 'invalid'],
-      $contactID, $checksum, $invalid, self::$_nullObject, self::$_nullObject,
-      self::$_nullObject, 'civicrm_invalidateChecksum'
+      $contactID, $checksum, $invalid,
+      $null, $null, $null,
+      'civicrm_invalidateChecksum'
     );
   }
 

--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -296,30 +296,31 @@ class CiviEventDispatcher implements CiviEventDispatcherInterface {
     $hooks = \CRM_Utils_Hook::singleton();
     $params = $event->getHookValues();
     $count = count($params);
+    $null = NULL;
 
     switch ($count) {
       case 0:
-        $fResult = $hooks->invokeViaUF($count, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        $fResult = $hooks->invokeViaUF($count, $null, $null, $null, $null, $null, $null, $hookName);
         break;
 
       case 1:
-        $fResult = $hooks->invokeViaUF($count, $params[0], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        $fResult = $hooks->invokeViaUF($count, $params[0], $null, $null, $null, $null, $null, $hookName);
         break;
 
       case 2:
-        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $null, $null, $null, $null, $hookName);
         break;
 
       case 3:
-        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $null, $null, $null, $hookName);
         break;
 
       case 4:
-        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], \CRM_Utils_Hook::$_nullObject, \CRM_Utils_Hook::$_nullObject, $hookName);
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], $null, $null, $hookName);
         break;
 
       case 5:
-        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], $params[4], \CRM_Utils_Hook::$_nullObject, $hookName);
+        $fResult = $hooks->invokeViaUF($count, $params[0], $params[1], $params[2], $params[3], $params[4], $null, $hookName);
         break;
 
       case 6:


### PR DESCRIPTION
Overview
----------------------------------------
Deprecates a not-very-nice variable.

Before
----------------------------------------
Variable heavily used, but contains a warning not to use it.

After
----------------------------------------
Variable deprecated and used a great deal less.
