### PR TITLE
Api4 - Prevent developer error mixing up `addValue` with `addWhere`

### DIFF
--- a/Civi/Api4/Action/Setting/Set.php
+++ b/Civi/Api4/Action/Setting/Set.php
@@ -22,6 +22,8 @@ use Civi\Api4\Generic\Result;
  */
 class Set extends AbstractSettingAction {
 
+  use \Civi\Api4\Generic\Traits\GetSetValueTrait;
+
   /**
    * Setting names/values to set.
    *
@@ -49,17 +51,6 @@ class Set extends AbstractSettingAction {
         'domain_id' => $domain,
       ];
     }
-  }
-
-  /**
-   * Add an item to the values array
-   * @param string $settingName
-   * @param mixed $value
-   * @return $this
-   */
-  public function addValue($settingName, $value) {
-    $this->values[$settingName] = $value;
-    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/AbstractCreateAction.php
+++ b/Civi/Api4/Generic/AbstractCreateAction.php
@@ -26,31 +26,14 @@ use Civi\Api4\Utils\CoreUtil;
  */
 abstract class AbstractCreateAction extends AbstractAction {
 
+  use Traits\GetSetValueTrait;
+
   /**
    * Field values to set for the new $ENTITY.
    *
    * @var array
    */
   protected $values = [];
-
-  /**
-   * @param string $fieldName
-   * @return mixed|null
-   */
-  public function getValue(string $fieldName) {
-    return $this->values[$fieldName] ?? NULL;
-  }
-
-  /**
-   * Add a field value.
-   * @param string $fieldName
-   * @param mixed $value
-   * @return $this
-   */
-  public function addValue(string $fieldName, $value) {
-    $this->values[$fieldName] = $value;
-    return $this;
-  }
 
   /**
    * @throws \CRM_Core_Exception

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -28,6 +28,8 @@ use Civi\Api4\Utils\CoreUtil;
  */
 abstract class AbstractUpdateAction extends AbstractBatchAction {
 
+  use Traits\GetSetValueTrait;
+
   /**
    * Field values to update.
    *
@@ -105,27 +107,6 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
 
     $this->validateValues();
     $result->exchangeArray($this->updateRecords($items));
-  }
-
-  /**
-   * @param string $fieldName
-   *
-   * @return mixed|null
-   */
-  public function getValue(string $fieldName) {
-    return $this->values[$fieldName] ?? NULL;
-  }
-
-  /**
-   * Add an item to the values array.
-   *
-   * @param string $fieldName
-   * @param mixed $value
-   * @return $this
-   */
-  public function addValue(string $fieldName, $value) {
-    $this->values[$fieldName] = $value;
-    return $this;
   }
 
   /**

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -32,6 +32,8 @@ use Civi\Api4\Utils\CoreUtil;
  */
 class BasicGetFieldsAction extends BasicGetAction {
 
+  use Traits\GetSetValueTrait;
+
   /**
    * Fetch option lists for fields?
    *
@@ -204,17 +206,6 @@ class BasicGetFieldsAction extends BasicGetAction {
       'replace' => 'create',
     ];
     return $sub[$this->action] ?? $this->action;
-  }
-
-  /**
-   * Add an item to the values array
-   * @param string $fieldName
-   * @param mixed $value
-   * @return $this
-   */
-  public function addValue(string $fieldName, $value) {
-    $this->values[$fieldName] = $value;
-    return $this;
   }
 
   /**

--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -24,6 +24,8 @@ use Civi\Api4\Utils\CoreUtil;
  */
 class CheckAccessAction extends AbstractAction {
 
+  use Traits\GetSetValueTrait;
+
   /**
    * @var string
    * @required
@@ -57,17 +59,6 @@ class CheckAccessAction extends AbstractAction {
    */
   public function isAuthorized(): bool {
     return TRUE;
-  }
-
-  /**
-   * Add an item to the values array
-   * @param string $fieldName
-   * @param mixed $value
-   * @return $this
-   */
-  public function addValue(string $fieldName, $value) {
-    $this->values[$fieldName] = $value;
-    return $this;
   }
 
 }

--- a/Civi/Api4/Generic/Traits/GetSetValueTrait.php
+++ b/Civi/Api4/Generic/Traits/GetSetValueTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic\Traits;
+
+/**
+ * Trait for actions with a `$values` array
+ */
+trait GetSetValueTrait {
+
+  /**
+   * Add an item to the values array.
+   *
+   * @param string $fieldName
+   * @param mixed $value
+   * @return $this
+   */
+  public function addValue(string $fieldName, $value) {
+    // Prevent accidentally using this function like `addWhere` which takes 3 args.
+    if ($value === '=' && func_num_args() > 2) {
+      throw new \CRM_Core_Exception('APIv4 function `addValue` incorrectly called with 3 arguments.');
+    }
+    $this->values[$fieldName] = $value;
+    return $this;
+  }
+
+  /**
+   * Overwrite all values
+   *
+   * @param array $values
+   * @return $this
+   */
+  public function setValues(array $values) {
+    $this->values = $values;
+    return $this;
+  }
+
+  /**
+   * Retrieve a single value
+   *
+   * @param string $fieldName
+   * @return mixed|null
+   */
+  public function getValue(string $fieldName) {
+    return $this->values[$fieldName] ?? NULL;
+  }
+
+  /**
+   * @return array
+   */
+  public function getValues() {
+    return $this->values;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds a sanity check in the api to prevent the common mistake of accidentally using `addValue` as if it takes 3 arguments like `addWhere`.

Technical Details
----------------------------------------
This is an easy mistake to make because the function is similar to `addWhere`:

**Wrong:**
```
Address::create()
  ->addValue('city', '=', 'Paris')
```

**Right:**
```
Address::create()
  ->addValue('city', 'Paris')
```

Now the API will throw an exception telling you what you did wrong.

Comments
----------------
Instead of pasting this check in 5 places I used a trait.