### PR TITLE
(NFC) Version Check Test - Fix multi-user and concurrent execution

### DIFF
--- a/tests/phpunit/CRM/Utils/versionCheckTest.php
+++ b/tests/phpunit/CRM/Utils/versionCheckTest.php
@@ -8,9 +8,16 @@ use Civi\Test\Invasive;
  */
 class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
 
+  /**
+   * @var string
+   */
+  protected $tempDir;
+
   public function setUp(): void {
     $this->useTransaction();
     parent::setUp();
+    $this->tempDir = sys_get_temp_dir() . '/VersionCheck-' . rand() . rand();
+    mkdir($this->tempDir);
   }
 
   /**
@@ -98,11 +105,14 @@ class CRM_Utils_versionCheckTest extends CiviUnitTestCase {
     if (file_exists($vc->cacheFile)) {
       unlink($vc->cacheFile);
     }
+    if (file_exists($this->tempDir)) {
+      CRM_Utils_File::cleanDir($this->tempDir, TRUE, FALSE);
+    }
   }
 
   public function testCronFallback() {
     // Fake "remote" source data
-    $tmpSrc = '/tmp/versionCheckTestFile.json';
+    $tmpSrc = $this->tempDir . '/versionCheckTestFile.json';
     file_put_contents($tmpSrc, json_encode($this->sampleVersionInfo));
 
     $vc = new CRM_Utils_VersionCheck();


### PR DESCRIPTION
Overview
-------------
This is a small change to the way the tests run. It doesn't change the meaning of the test.

Before
------

* Writes example file to `/tmp/versionCheckTestFile.json`.
* File left behind at end of test.
* If two users runs the same test at different times, they could interfere with each other.
* If one user with two concurrent processes run the same test, they could interfere with each other.

After
-----

* Writes example file to `/tmp/VersionCheck-NNNNNNN/versionCheckTestFile.json`
* Temp folder cleaned up at end
* If two users or two processes run the test, they're fine. They use separate folders.

