### PR TITLE
UpdateConfigBackend: use api4 to flush the cache

### DIFF
--- a/CRM/Admin/Form/Setting/UpdateConfigBackend.php
+++ b/CRM/Admin/Form/Setting/UpdateConfigBackend.php
@@ -45,25 +45,11 @@ class CRM_Admin_Form_Setting_UpdateConfigBackend extends CRM_Admin_Form_Setting 
 
   public function postProcess() {
     if (isset($_REQUEST['_qf_UpdateConfigBackend_next_cleanup'])) {
-      $config = CRM_Core_Config::singleton();
-
-      // cleanup templates_c directory
-      $config->cleanup(1, FALSE);
-
-      // clear all caches
-      CRM_Core_Config::clearDBCache();
-      Civi::cache('session')->clear();
-      CRM_Utils_System::flushCache();
-
-      parent::rebuildMenu();
-
-      CRM_Core_BAO_WordReplacement::rebuild();
-
+      \Civi\Api4\System::flush(FALSE)->execute();
       CRM_Core_Session::setStatus(ts('Cache has been cleared and menu has been rebuilt successfully.'), ts("Success"), "success");
     }
     elseif (isset($_REQUEST['_qf_UpdateConfigBackend_next_resetpaths'])) {
       $msg = CRM_Core_BAO_ConfigSetting::doSiteMove();
-
       CRM_Core_Session::setStatus($msg, ts("Success"), "success");
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM has a few places where it flushes the cache, and sometimes they work in slightly different ways.

This removes one of those  slightly different ways.

Before
----------------------------------------

Flushing the cache would not refresh the list of installed reports provided by an extension.

(It's a custom extension where new `mgd` files are being added by devs)

Running `system.flush` via the API worked fine, but not when using this form/button.

After
----------------------------------------

Flushing the cache works as expected.