### PR TITLE
EntityRef custom fields don't get returned, can't be joined in API4

### DIFF
--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -106,7 +106,7 @@ class SchemaMapBuilder extends AutoService {
     }
     $fieldData = \CRM_Utils_SQL_Select::from('civicrm_custom_field f')
       ->join('custom_group', 'INNER JOIN civicrm_custom_group g ON g.id = f.custom_group_id')
-      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id', 'serialize'])
+      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id', 'serialize', 'fk_entity'])
       ->where('g.extends IN (@entity)', ['@entity' => $customInfo['extends']])
       ->where('g.is_active')
       ->where('f.is_active')
@@ -133,6 +133,12 @@ class SchemaMapBuilder extends AutoService {
       if (!empty($fieldData->is_multiple)) {
         $joinable = new Joinable($baseTable->getName(), $customInfo['column'], AllCoreTables::convertEntityNameToLower($entityName));
         $customTable->addTableLink('entity_id', $joinable);
+      }
+
+      if ($fieldData->data_type === 'EntityReference') {
+        $targetTable = \CRM_Core_BAO_CustomGroup::getTableNameByEntityName($fieldData->fk_entity);
+        $joinable = new Joinable($targetTable, 'id', $fieldData->name);
+        $customTable->addTableLink($fieldData->column_name, $joinable);
       }
 
       if ($fieldData->data_type === 'ContactReference') {


### PR DESCRIPTION
Overview
----------------------------------------
EntityRef custom fields don't work in API4.  The label is always `NULL` and joins are ignored.

Before
----------------------------------------
![Selection_1825](https://user-images.githubusercontent.com/1796012/227632176-ca6568bf-1179-458d-afd0-f95650291e11.png)


After
----------------------------------------
![Selection_1826](https://user-images.githubusercontent.com/1796012/227632481-eef5b2de-3745-4291-b9a9-2f5cdee85c5d.png)

Comments
----------------------------------------
There's a lot that needs following on here for which I lack the capacity at present:
* Needs tests.
* `:label` shouldn't be present on EntityRef fields (it's not present on, say, `employer_id`.  I couldn't find where to configure this.
* Fields still don't display in SearchKit, which needs its own fixes.