### PR TITLE
dev/core#4204 Show the Payment Agreement of the selected processor

### DIFF
--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -62,6 +62,9 @@ class CRM_Core_Payment_ProcessorForm {
 
     $form->assign('currency', $form->getCurrency());
 
+    $form->assign('paymentAgreementTitle', $form->_paymentProcessor['object']->getText('agreementTitle', []));
+    $form->assign('paymentAgreementText', $form->_paymentProcessor['object']->getText('agreementText', []));
+
     // also set cancel subscription url
     if (!empty($form->_paymentProcessor['is_recur']) && !empty($form->_values['is_recur'])) {
       $form->_values['cancelSubscriptionUrl'] = $form->_paymentObject->subscriptionURL(NULL, NULL, 'cancel');

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -287,15 +287,6 @@
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
     </div>
 
-    {if $is_monetary && array_key_exists('bank_account_number', $form)}
-      <div id="payment_notice">
-        <fieldset class="crm-public-form-item crm-group payment_notice-group">
-          <legend>{ts}Agreement{/ts}</legend>
-          {ts}Your account data will be used to charge your bank account via direct debit. While submitting this form you agree to the charging of your bank account via direct debit.{/ts}
-        </fieldset>
-      </div>
-    {/if}
-
     <div id="crm-submit-buttons" class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -39,6 +39,14 @@
         {/foreach}
       </div>
     </fieldset>
+    {if $paymentAgreementTitle}
+      <div id="payment_notice">
+        <fieldset class="crm-public-form-item crm-group payment_notice-group">
+          <legend>{$paymentAgreementTitle}</legend>
+          {ts}Your account data will be used to charge your bank account via direct debit. While submitting this form you agree to the charging of your bank account via direct debit.{/ts}
+        </fieldset>
+      </div>
+    {/if}
   {/if}
   {if $billingDetailsFields|@count && $paymentProcessor.payment_processor_type neq 'PayPal_Express'}
     {if $profileAddressFields && !$ccid}


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4204

The Direct Debit agreement is always/never shown depending on which payment processor is the default.

To reproduce:

- Enable the Credit Card dummy processor
- Enable a Direct Debit processor (such as CiviSepa? or iATS)
- Enable both on a Contribution Page

Depending on which Payment Processor is set as the default, that will influence if the "direct debit agreement" is displayed on the contribution page. It should only be shown if a Direct Debit payment method was selected.

Before
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/227717918-6b396263-5516-4fbd-8379-58537d8b1f86.png)

After
----------------------------------------

![image](https://user-images.githubusercontent.com/254741/227674807-e6f29494-943c-4648-b7b9-28b941d288ac.png)


Technical Details
----------------------------------------

#25910 moved the agreement title and text into the Payment Processor classes, so now it's not so much anyway a factor of whether it's a Debit or Credit payment method, each might have their own agreements. So it should not check for the `bank_account_number` field, for example.

Comments
----------------------------------------

This moves the agreement inside the BillingBlock, so it's higher in the form than it used to be. Previously it was at the footer, before the submit button, and where, admittedly, you would expect the legalese that everyone ignores but we're somehow forced to include anyway.

I mean, who would think that, by submitting this form, you accept that the other party to use that information for the purposes described in the form? Shocking. If only there were details about data retention policies or something more relevant.

I think no one noticed this text until recently, because typically people have Credit and Debit enabled, and Debit is the secondary option, so the agreement was never displayed. Fortunately Word Replacements or CSS can be used to hide it.