### PR TITLE
[REF][PHP8.2] Remove unused dyanamic property

### DIFF
--- a/tests/phpunit/api/v3/UFGroupTest.php
+++ b/tests/phpunit/api/v3/UFGroupTest.php
@@ -38,12 +38,11 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
       'title' => 'Test Profile',
     ]);
     $this->_ufGroupId = $ufGroup['id'];
-    $ufMatch = $this->callAPISuccess('uf_match', 'create', [
+    $this->callAPISuccess('uf_match', 'create', [
       'contact_id' => $this->_contactId,
       'uf_id' => 42,
       'uf_name' => 'email@mail.com',
     ]);
-    $this->_ufMatchId = $ufMatch['id'];
     $this->params = [
       'add_captcha' => 1,
       'add_contact_to_group' => $this->_groupId,


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused dyanamic property `_ufMatchId`.

Before
----------------------------------------
`_ufMatchId` declared dyanmically, despite not being used anywhere:

<img width="512" alt="Screenshot 2023-03-25 at 16 06 17" src="https://user-images.githubusercontent.com/1931323/227729048-e0a43b20-cea8-40fd-8c8e-b8363d7ca778.png">

Remember, dyanmic properties are deprecated in PHP 8.2.

After
----------------------------------------
Property removed. As a result the `$ufMatch` variable is no longer required.