### PR TITLE
[NFC] Remove property declarations that are same as parent

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -857,7 +857,8 @@ DESC limit 1");
    *   & needs rationalising.
    *
    */
-  protected function emailReceipt($form, &$formValues) {
+  protected function emailReceipt(&$formValues) {
+    $form = $this;
     $membership = $this->getMembership();
     // retrieve 'from email id' for acknowledgement
     $receiptFrom = $formValues['from_email_address'] ?? NULL;
@@ -1536,7 +1537,7 @@ DESC limit 1");
     $formValues['contributionType_name'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
       $this->getFinancialTypeID()
     );
-    return $this->emailReceipt($this, $formValues);
+    return $this->emailReceipt($formValues);
   }
 
   /**

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -29,71 +29,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    */
   protected $ids = [];
 
-  protected $_memType = NULL;
-
-  public $_mode;
-
-  public $_contributeMode = 'direct';
-
-  protected $_recurMembershipTypes;
-
   protected $_memTypeSelected;
-
-  /**
-   * Display name of the member.
-   *
-   * @var string
-   */
-  protected $_memberDisplayName = NULL;
-
-  /**
-   * email of the person paying for the membership (used for receipts)
-   * @var string
-   */
-  protected $_memberEmail = NULL;
-
-  /**
-   * Contact ID of the member.
-   *
-   * @var int
-   */
-  public $_contactID = NULL;
-
-  /**
-   * Display name of the person paying for the membership (used for receipts)
-   *
-   * @var string
-   */
-  protected $_contributorDisplayName = NULL;
-
-  /**
-   * Email of the person paying for the membership (used for receipts).
-   *
-   * @var string
-   */
-  protected $_contributorEmail;
-
-  /**
-   * email of the person paying for the membership (used for receipts)
-   *
-   * @var int
-   */
-  protected $_contributorContactID = NULL;
-
-  /**
-   * ID of the person the receipt is to go to.
-   *
-   * @var int
-   */
-  protected $_receiptContactId = NULL;
-
-  /**
-   * Keep a class variable for ALL membership IDs so
-   * postProcess hook function can do something with it
-   *
-   * @var array
-   */
-  protected $_membershipIDs = [];
 
   /**
    * Membership created or edited on this form.


### PR DESCRIPTION
Overview
----------------------------------------
[NFC] Remove property declarations that are same as parent - as highligted by the IDE - it's just words that say nothing - much like those coming out of my son's mouth right now - as he makes the case for crocs...

Before
----------------------------------------
As the IDE highlights - these property declarations 

![image](https://user-images.githubusercontent.com/336308/227744822-e7662e00-8648-4a8b-a057-b4d993795ee4.png)

![image](https://user-images.githubusercontent.com/336308/227744848-5ac73aff-bdf7-49cc-aebe-83ab31365ec1.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------
Most of these were copied to the shared parent but not removed from here

Comments
----------------------------------------
