### PR TITLE
Stop passing `$this` as `$form` to previously shared, non-static, function

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -908,12 +908,8 @@ DESC limit 1");
   /**
    * Send email receipt.
    *
-   * @param CRM_Core_Form $form
-   *   Form object.
    * @param array $formValues
    *
-   * @return bool
-   *   true if mail was sent successfully
    * @throws \CRM_Core_Exception
    *
    * @deprecated
@@ -921,7 +917,7 @@ DESC limit 1");
    *   & needs rationalising.
    *
    */
-  protected function emailReceipt($form, &$formValues) {
+  protected function emailReceipt($formValues) {
     $membership = $this->getMembership();
     // retrieve 'from email id' for acknowledgement
     $receiptFrom = $formValues['from_email_address'] ?? NULL;
@@ -932,45 +928,45 @@ DESC limit 1");
       $formValues['paidBy'] = $paymentInstrument[$formValues['payment_instrument_id']];
     }
 
-    $form->assign('module', 'Membership');
+    $this->assign('module', 'Membership');
 
     if (!empty($formValues['contribution_id'])) {
-      $form->assign('currency', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $formValues['contribution_id'], 'currency'));
+      $this->assign('currency', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $formValues['contribution_id'], 'currency'));
     }
     else {
-      $form->assign('currency', CRM_Core_Config::singleton()->defaultCurrency);
+      $this->assign('currency', CRM_Core_Config::singleton()->defaultCurrency);
     }
 
     if (!empty($formValues['contribution_status_id'])) {
-      $form->assign('contributionStatusID', $formValues['contribution_status_id']);
-      $form->assign('contributionStatus', CRM_Contribute_PseudoConstant::contributionStatus($formValues['contribution_status_id'], 'name'));
+      $this->assign('contributionStatusID', $formValues['contribution_status_id']);
+      $this->assign('contributionStatus', CRM_Contribute_PseudoConstant::contributionStatus($formValues['contribution_status_id'], 'name'));
     }
 
     if (!empty($formValues['is_renew'])) {
-      $form->assign('receiptType', 'membership renewal');
+      $this->assign('receiptType', 'membership renewal');
     }
     else {
-      $form->assign('receiptType', 'membership signup');
+      $this->assign('receiptType', 'membership signup');
     }
-    $form->assign('receive_date', CRM_Utils_Array::value('receive_date', $formValues));
-    $form->assign('formValues', $formValues);
+    $this->assign('receive_date', CRM_Utils_Array::value('receive_date', $formValues));
+    $this->assign('formValues', $formValues);
 
-    $form->assign('mem_start_date', CRM_Utils_Date::formatDateOnlyLong($membership['start_date']));
+    $this->assign('mem_start_date', CRM_Utils_Date::formatDateOnlyLong($membership['start_date']));
     if (!CRM_Utils_System::isNull($membership['end_date'])) {
-      $form->assign('mem_end_date', CRM_Utils_Date::formatDateOnlyLong($membership['end_date']));
+      $this->assign('mem_end_date', CRM_Utils_Date::formatDateOnlyLong($membership['end_date']));
     }
-    $form->assign('membership_name', CRM_Member_PseudoConstant::membershipType($membership['membership_type_id']));
+    $this->assign('membership_name', CRM_Member_PseudoConstant::membershipType($membership['membership_type_id']));
 
-    if ((empty($form->_contributorDisplayName) || empty($form->_contributorEmail))) {
+    if ((empty($this->_contributorDisplayName) || empty($this->_contributorEmail))) {
       // in this case the form is being called statically from the batch editing screen
       // having one class in the form layer call another statically is not greate
       // & we should aim to move this function to the BAO layer in future.
       // however, we can assume that the contact_id passed in by the batch
       // function will be the recipient
-      [$form->_contributorDisplayName, $form->_contributorEmail]
+      [$this->_contributorDisplayName, $this->_contributorEmail]
         = CRM_Contact_BAO_Contact_Location::getEmailDetails($formValues['contact_id']);
-      if (empty($form->_receiptContactId)) {
-        $form->_receiptContactId = $formValues['contact_id'];
+      if (empty($this->_receiptContactId)) {
+        $this->_receiptContactId = $formValues['contact_id'];
       }
     }
 
@@ -978,21 +974,19 @@ DESC limit 1");
       [
         'workflow' => 'membership_offline_receipt',
         'from' => $receiptFrom,
-        'toName' => $form->_contributorDisplayName,
-        'toEmail' => $form->_contributorEmail,
+        'toName' => $this->_contributorDisplayName,
+        'toEmail' => $this->_contributorEmail,
         'PDFFilename' => ts('receipt') . '.pdf',
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
-        'isTest' => (bool) ($form->_action & CRM_Core_Action::PREVIEW),
+        'isTest' => (bool) ($this->_action & CRM_Core_Action::PREVIEW),
         'modelProps' => [
           'receiptText' => $this->getSubmittedValue('receipt_text'),
           'contributionId' => $formValues['contribution_id'],
-          'contactId' => $form->_receiptContactId,
+          'contactId' => $this->_receiptContactId,
           'membershipId' => $this->getMembershipID(),
         ],
       ]
     );
-
-    return TRUE;
   }
 
   /**
@@ -1600,7 +1594,8 @@ DESC limit 1");
     $formValues['contributionType_name'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
       $this->getFinancialTypeID()
     );
-    return $this->emailReceipt($this, $formValues);
+    $this->emailReceipt($formValues);
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing `$this` as `$form` to previously shared, non-static, function

Before
----------------------------------------
`$this` is passed as `$form` - which would have made sense when the function was shared & static but now is just worth a cleanup.

Also `$formValues` is passed by reference - but the (only) function that calls it returns immediately afterwards & does not return `$formValues` to it's calling function, and did not receive it by reference.

The function Always returns `TRUE `- so I removed the return too

```
return $this->emailReceipt($this, $formValues);
    $this->emailReceipt($formValues);



protected function emailReceipt($form, &$formValues) {
```

After
----------------------------------------

```
protected function emailReceipt($formValues) {
```


Technical Details
----------------------------------------
The intent is probably to fold this back into the parent - & this change would make that code-move an easy read

Comments
----------------------------------------