### PR TITLE
Fix intermittant test fail

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1248,7 +1248,7 @@ Expires: ',
     $this->assertEquals(2, $lineItemResult['count']);
     $discountedItems = 0;
     foreach ($lineItemResult['values'] as $lineItem) {
-      $this->assertEquals($lineItem['line_total'] * .1, $lineItem['tax_amount']);
+      $this->assertEquals(round($lineItem['line_total'] * .1, 2), $lineItem['tax_amount']);
       if (CRM_Utils_String::startsWith($lineItem['label'], 'Long Haired Goat')) {
         $this->assertEquals(15.0, $lineItem['line_total']);
         $this->assertEquals('Long Haired Goat - one leg free!', $lineItem['label']);


### PR DESCRIPTION
Overview
----------------------------------------
Fix intermittant test fail

Before
----------------------------------------
The altered lines consistently fail for me when I run the test in isolation

![image](https://user-images.githubusercontent.com/336308/227746062-f6baec38-40da-44c6-a1dd-648ec50ef955.png)

I'm not sure why it doesn't fail elsewhere but obviously it relates to some difference at the php level

After
----------------------------------------
Fixed to pass

Technical Details
----------------------------------------
The failure relates to the fact that `$expected` has no rounding & what has been saved to the db does have rounding - while this is a topic in it's own right - it's not the intent of this test to have an opinion on rounding - only on the discount having been applied

Comments
----------------------------------------