### PR TITLE
[REF][PHP8.2] Declare properties directly on CRM_Core_Form_EntityFormTrait

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -40,25 +40,6 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
   protected $_paymentProcessorType;
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *     Auto-added by setEntityFieldsMetadata unless specified here (use description => '' to hide)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   *  - required
-   *  - is_freeze (field should be frozen).
-   *
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Set entity fields to be assigned to the form.
    */
   protected function setEntityFields() {

--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -25,25 +25,6 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
   protected $_BAOName = 'CRM_Contact_BAO_RelationshipType';
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *     Auto-added by setEntityFieldsMetadata unless specified here (use description => '' to hide)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   *  - required
-   *  - is_freeze (field should be frozen).
-   *
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Set entity fields to be assigned to the form.
    */
   protected function setEntityFields() {

--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -70,21 +70,6 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
   public $_paymentProcessor = [];
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Details of the subscription (recurring contribution) to be altered.
    *
    * @var \CRM_Core_DAO

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -41,6 +41,31 @@ trait CRM_Core_Form_EntityFormTrait {
   protected $deleteMessage;
 
   /**
+   * Fields for the entity to be assigned to the template.
+   *
+   * Fields may have keys
+   *  - name (required to show in tpl from the array)
+   *  - description (optional, will appear below the field)
+   *  - not-auto-addable - this class will not attempt to add the field using addField.
+   *    (this will be automatically set if the field does not have html in it's metadata
+   *    or is not a core field on the form's entity).
+   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
+   *  - template - use a field specific template to render this field
+   *  - required
+   *  - is_freeze (field should be frozen).
+   *
+   * @var array
+   */
+  protected $entityFields = [];
+
+  /**
+   * Metadata from getfields API call for the current entity.
+   *
+   * @var array
+   */
+  protected $metadata = [];
+
+  /**
    * Get entity fields for the entity to be added to the form.
    *
    * @return array

--- a/CRM/Financial/Form/FinancialType.php
+++ b/CRM/Financial/Form/FinancialType.php
@@ -25,13 +25,6 @@ class CRM_Financial_Form_FinancialType extends CRM_Core_Form {
   protected $_BAOName = 'CRM_Financial_BAO_FinancialType';
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -121,24 +121,6 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    */
   protected $_params = [];
 
-  /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   *  - required
-   *  - is_freeze (field should be frozen).
-   *
-   * @var array
-   */
-  protected $entityFields = [];
-
   public function preProcess() {
     // Check for edit permission.
     if (!CRM_Core_Permission::checkActionPermission('CiviMember', $this->_action)) {

--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -37,22 +37,6 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
   }
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (optional) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   *  - required
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Set entity fields to be assigned to the form.
    */
   protected function setEntityFields() {

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -24,24 +24,6 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
   use CRM_Core_Form_EntityFormTrait;
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   *  - required
-   *  - is_freeze (field should be frozen).
-   *
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Set entity fields to be assigned to the form.
    */
   protected function setEntityFields() {

--- a/CRM/Price/Form/Set.php
+++ b/CRM/Price/Form/Set.php
@@ -46,21 +46,6 @@ class CRM_Price_Form_Set extends CRM_Core_Form {
   }
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * Set entity fields to be assigned to the form.
    */
   protected function setEntityFields() {

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -23,24 +23,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
   use CRM_Core_Form_EntityFormTrait;
 
   /**
-   * Fields for the entity to be assigned to the template.
-   *
-   * Fields may have keys
-   *  - name (required to show in tpl from the array)
-   *  - description (optional, will appear below the field)
-   *  - not-auto-addable - this class will not attempt to add the field using addField.
-   *    (this will be automatically set if the field does not have html in it's metadata
-   *    or is not a core field on the form's entity).
-   *  - help (option) add help to the field - e.g ['id' => 'id-source', 'file' => 'CRM/Contact/Form/Contact']]
-   *  - template - use a field specific template to render this field
-   *  - required
-   *  - is_freeze (field should be frozen).
-   *
-   * @var array
-   */
-  protected $entityFields = [];
-
-  /**
    * @var bool
    */
   public $submitOnce = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties directly on `CRM_Core_Form_EntityFormTrait`, rather than (inconsistently) on the classes which use it.

Before
----------------------------------------
The `entityFields` property was declared individually on many classes which use `CRM_Core_Form_EntityFormTrait`, but not all of them. Additionally the large `docblock` was repeated many times, increasing the chance of inconsistent documentation occuring in future.

The `metadata` property was always being written to as a dynamic property, causing tests to fail on PHP 8.2.

After
----------------------------------------
The `entityFields` and `metadata` properties are explicitely declared on the `CRM_Core_Form_EntityFormTrait`.

Comments
----------------------------------------
I think there may be a small backwards compatiability risk here, if third-party extensions are using `CRM_Core_Form_EntityFormTrait`, but have declared `entityFields` or `metadata` as `public` properties (although I've not actually tested what would happen in this scenario)

There is still a `_BAOName` property to tackle, which I'll look at seperately.