### PR TITLE
SearchKit - Fix handling of new Custom EntityReference fields

### DIFF
--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -105,9 +105,15 @@ class SchemaMapBuilder extends AutoService {
     if (!$customInfo) {
       return;
     }
+    $select = ['f.name', 'f.data_type', 'f.label', 'f.column_name', 'f.option_group_id', 'f.serialize', 'f.fk_entity'];
+    // Prevent errors during upgrade by only selecting fields supported by the current version
+    $supportedFields = \CRM_Utils_Array::prefixKeys(\CRM_Core_BAO_CustomField::getSupportedFields(), 'f.');
+    $select = array_intersect($select, array_keys($supportedFields));
+    // Also select fields from the custom_group table (these fields are so old we don't have to worry about upgrade issues)
+    $select = array_merge(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple'], $select);
     $fieldData = \CRM_Utils_SQL_Select::from('civicrm_custom_field f')
       ->join('custom_group', 'INNER JOIN civicrm_custom_group g ON g.id = f.custom_group_id')
-      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id', 'serialize', 'fk_entity'])
+      ->select($select)
       ->where('g.extends IN (@entity)', ['@entity' => $customInfo['extends']])
       ->where('g.is_active')
       ->where('f.is_active')
@@ -136,8 +142,8 @@ class SchemaMapBuilder extends AutoService {
         $customTable->addTableLink('entity_id', $joinable);
       }
 
-      if ($fieldData->data_type === 'EntityReference') {
-        $targetTable = \CRM_Core_BAO_CustomGroup::getTableNameByEntityName($fieldData->fk_entity);
+      if ($fieldData->data_type === 'EntityReference' && isset($fieldData->fk_entity)) {
+        $targetTable = AllCoreTables::getTableForEntityName($fieldData->fk_entity);
         $joinable = new Joinable($targetTable, 'id', $fieldData->name);
         $customTable->addTableLink($fieldData->column_name, $joinable);
       }

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -107,7 +107,7 @@ class SchemaMapBuilder extends AutoService {
     }
     $fieldData = \CRM_Utils_SQL_Select::from('civicrm_custom_field f')
       ->join('custom_group', 'INNER JOIN civicrm_custom_group g ON g.id = f.custom_group_id')
-      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id', 'serialize'])
+      ->select(['g.name as custom_group_name', 'g.table_name', 'g.is_multiple', 'f.name', 'f.data_type', 'label', 'column_name', 'option_group_id', 'serialize', 'fk_entity'])
       ->where('g.extends IN (@entity)', ['@entity' => $customInfo['extends']])
       ->where('g.is_active')
       ->where('f.is_active')
@@ -134,6 +134,12 @@ class SchemaMapBuilder extends AutoService {
       if (!empty($fieldData->is_multiple)) {
         $joinable = new Joinable($baseTable->getName(), $customInfo['column'], AllCoreTables::convertEntityNameToLower($entityName));
         $customTable->addTableLink('entity_id', $joinable);
+      }
+
+      if ($fieldData->data_type === 'EntityReference') {
+        $targetTable = \CRM_Core_BAO_CustomGroup::getTableNameByEntityName($fieldData->fk_entity);
+        $joinable = new Joinable($targetTable, 'id', $fieldData->name);
+        $customTable->addTableLink($fieldData->column_name, $joinable);
       }
 
       if ($fieldData->data_type === 'ContactReference') {

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -48,7 +48,7 @@ class SpecFormatter {
       $field->setLabel($data['custom_group_id.title'] . ': ' . $data['label']);
       $field->setHelpPre($data['help_pre'] ?? NULL);
       $field->setHelpPost($data['help_post'] ?? NULL);
-      if (self::customFieldHasOptions($data)) {
+      if (\CRM_Core_BAO_CustomField::hasOptions($data)) {
         $field->setOptionsCallback([__CLASS__, 'getOptions']);
         $suffixes = ['label'];
         if (!empty($data['option_group_id'])) {
@@ -101,28 +101,6 @@ class SpecFormatter {
     }
 
     return $field;
-  }
-
-  /**
-   * Does this custom field have options
-   *
-   * @param array $field
-   * @return bool
-   */
-  private static function customFieldHasOptions($field) {
-    // This will include boolean fields with Yes/No options.
-    if (in_array($field['html_type'], ['Radio', 'CheckBox'])) {
-      return TRUE;
-    }
-    // Do this before the "Select" string search because date fields have a "Select Date" html_type
-    // and contactRef fields have an "Autocomplete-Select" html_type - contacts are an FK not an option list.
-    if (in_array($field['data_type'], ['ContactReference', 'Date'])) {
-      return FALSE;
-    }
-    if (strpos($field['html_type'], 'Select') !== FALSE) {
-      return TRUE;
-    }
-    return !empty($field['option_group_id']);
   }
 
   /**

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -191,9 +191,10 @@ class Admin {
         foreach (array_reverse($entity['fields'], TRUE) as $index => $field) {
           if (!empty($field['fk_entity']) && !$field['options'] && !empty($schema[$field['fk_entity']]['label_field'])) {
             $isCustom = strpos($field['name'], '.');
-            // Custom fields: append "Contact ID" to original field label
+            // Custom fields: append "Contact ID" etc. to original field label
             if ($isCustom) {
-              $entity['fields'][$index]['label'] .= ' ' . E::ts('Contact ID');
+              $idField = array_column($schema[$field['fk_entity']]['fields'], NULL, 'name')['id'];
+              $entity['fields'][$index]['label'] .= ' ' . $idField['title'];
             }
             // DAO fields: use title instead of label since it represents the id (title usually ends in ID but label does not)
             else {

--- a/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Custom;
+
+use Civi\Api4\Contact;
+use Civi\Api4\CustomGroup;
+use Civi\Api4\CustomField;
+
+/**
+ * @group headless
+ */
+class CustomEntityReferenceTest extends CustomTestBase {
+
+  /**
+   * Ensure custom fields of type EntityReference show up correctly in getFields metadata.
+   */
+  public function testEntityReferenceCustomField() {
+    CustomGroup::create()->setValues([
+      'title' => 'EntityRefFields',
+      'extends' => 'Individual',
+    ])->execute();
+    CustomField::create()->setValues([
+      'label' => 'TestActivityReference',
+      'custom_group_id.name' => 'EntityRefFields',
+      'html_type' => 'Autocomplete-Select',
+      'data_type' => 'EntityReference',
+      'fk_entity' => 'Activity',
+    ])->execute();
+    $spec = Contact::getFields(FALSE)
+      ->addWhere('name', '=', 'EntityRefFields.TestActivityReference')
+      ->execute()->single();
+    $this->assertNull($spec['suffixes']);
+    $this->assertEquals('EntityRef', $spec['input_type']);
+    $this->assertEquals('Activity', $spec['fk_entity']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Includes the fix from #25914 plus the rest of the issues fixed and a test added.

Before
----------------------------------------
Custom EntityReference fields incorrectly appear to have option lists but no ability to join in SearchKit.

After
----------------------------------------
Option list mirage removed, joins fixed to function correctly and use correct labels. Test added.

Technical Details
----------------------------------------
Removes redundant function `SpecFormatter::customFieldHasOptions` which was completely identical to `CRM_Core_BAO_CustomField::hasOptions` except for one line which was incorrect.