### PR TITLE
Add unit test cover for test offline mail receipt

### DIFF
--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -11,7 +11,7 @@
 {capture assign=labelStyle }style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle }style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
 
-  <table id="crm-event_receipt"
+  <table id="crm-membership_receipt"
          style="font-family: Arial, Verdana, sans-serif; text-align: left; width:100%; max-width:700px; padding:0; margin:0; border:0px;">
 
     <!-- BEGIN HEADER -->


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test cover for test offline mail receipt

Before
----------------------------------------
Output of the email, when taxed, not tested

After
----------------------------------------
Test added, also minor cleanup in form to prevent notice 

The form change includes changing the if logic from 

```
if (weShouldSendTheMail) {
  $receiptSend = TRUE;
}

if ($this->getSubmittedValue('send_receipt') && $receiptSend) {
  // send the mail
  $receiptSent = TRUE;
}

if ($receiptSent = TRUE) {
  // set the message
}
```

to

```
if (weShouldSendTheMail && $this->getSubmittedValue('send_receipt')) {
  // send the mail
  // set the message
}
```


Technical Details
----------------------------------------

Comments
----------------------------------------
