### PR TITLE
Partial fix for API4 Contact.get not returning results for contact subtype

### DIFF
--- a/Civi/Api4/Action/Contact/Get.php
+++ b/Civi/Api4/Action/Contact/Get.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Contact;
+
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * @inheritDoc
+ */
+class Get extends \Civi\Api4\Generic\DAOGetAction {
+
+  public function getWhere(): array {
+    $where = parent::getWhere();
+    foreach ($where as $id => $item) {
+      if ($item[0] === 'contact_sub_type') {
+        // See CRM/Contact/BAO/Query.php: includeContactSubTypes()
+        // $op = str_replace('IN', 'LIKE', $op);
+        // $op = str_replace('=', 'LIKE', $op);
+        // $op = str_replace('!', 'NOT ', $op);
+        if ($item[1] === '=') {
+          $item[1] = 'LIKE';
+          $item[2] = '%' . $item[2] . '%';
+        }
+        $where[$id] = $item;
+      }
+    }
+    return $where;
+  }
+
+}

--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -38,6 +38,15 @@ class Contact extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\Contact\Get
+   */
+  public static function get($checkPermissions = TRUE) {
+    return (new Action\Contact\Get(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\Contact\Update
    */
   public static function update($checkPermissions = TRUE) {


### PR DESCRIPTION
Overview
----------------------------------------
API4 cannot get by contact subtype. Neither could API3 without some comfudgery in the params.

Run API4 Contact.get and specify a contact subtype when a contact has more than one subtype. It won't return any results.

Before
----------------------------------------
Cannot "get" contacts by subtype when contact has more than one subtype.

After
----------------------------------------
Can "get" contacts by subtype when contact has more than one subtype.

Technical Details
----------------------------------------
Contact subtype is stored as a serialized(?) list. The generated SQL query won't match. API3 has some crazyish hack to change from `=/IN` to `LIKE`

Comments
----------------------------------------
Perhaps a more elegant solution could be found than this?
