### PR TITLE
Log sending of Scheduled Reminders

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -252,6 +252,10 @@ FROM civicrm_action_schedule cas
         [1 => [$actionSchedule->id, 'Integer']]
       );
 
+      if ($dao->N > 0) {
+        Civi::log()->info("Sending Scheduled Reminder {$actionSchedule->id} to {$dao->N} recipients");
+      }
+
       $multilingual = CRM_Core_I18n::isMultilingual();
       $tokenProcessor = self::createTokenProcessor($actionSchedule, $mapping);
       while ($dao->fetch()) {


### PR DESCRIPTION
Overview
----------------------------------------

Somewhat related to: https://lab.civicrm.org/dev/core/-/issues/2775

When Scheduled Reminders fail to send, they can be a real pain to debug. The CiviCRM Status Check kindly informs us that Reminders are failings, but we cannot easily know which reminder is failing. On some installations, there can be many dozen reminders.

For example, the Scheduled Job log had this:

> Finished execution of Scheduled reminders sender with result: Failure, Error message: Message was not parsed due to invalid smarty syntax : Smarty error: [in evaluated template line 4]: syntax error: unrecognized tag: height: auto !important; (Smarty_Compiler.class.php, line 440)

This PR adds a log line to know which was the last Reminder that was being processed.

Before
----------------------------------------

No CiviCRM (ConfigAndLog) logs.

After
----------------------------------------

Example log:

```
Mar 27 12:18:00  [info] Sending Scheduled Reminder: 138 to 1 recipients
```
