### PR TITLE
[REF] Refactor location-related BAOs to use `writeRecord`

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1663,7 +1663,7 @@ LEFT JOIN civicrm_option_value contribution_status ON (civicrm_contribution.cont
   public static function createAddress($params, $billingLocationTypeID) {
     [$hasBillingField, $addressParams] = self::getBillingAddressParams($params, $billingLocationTypeID);
     if ($hasBillingField) {
-      $address = CRM_Core_BAO_Address::add($addressParams, FALSE);
+      $address = CRM_Core_BAO_Address::writeRecord($addressParams);
       return $address->id;
     }
     return NULL;

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -20,96 +20,70 @@ use Civi\Api4\Address;
 /**
  * This is class to handle address related functions.
  */
-class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
+class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\HookInterface {
   use CRM_Contact_AccessTrait;
 
   /**
-   * Takes an associative array and creates a address.
+   * @deprecated
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
    * @param bool $fixAddress
-   *   True if you need to fix (format) address values.
-   *                               before inserting in db
-   *
-   * @return array|NULL|self
-   *   array of created address
+   * @return CRM_Core_BAO_Address
+   * @throws CRM_Core_Exception
    */
   public static function create(array &$params, $fixAddress = TRUE) {
-    return self::add($params, $fixAddress);
-  }
-
-  /**
-   * Takes an associative array and adds address.
-   *
-   * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   * @param bool $fixAddress
-   *   True if you need to fix (format) address values.
-   *                               before inserting in db
-   *
-   * @return CRM_Core_BAO_Address|null
-   */
-  public static function add(&$params, $fixAddress = FALSE) {
-
-    $address = new CRM_Core_DAO_Address();
-    $checkPermissions = $params['check_permissions'] ?? TRUE;
-
-    // fixAddress mode to be done
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     if ($fixAddress) {
       CRM_Core_BAO_Address::fixAddress($params);
     }
+    return self::writeRecord($params);
+  }
 
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, 'Address', CRM_Utils_Array::value('id', $params), $params);
+  /**
+   * @deprecated
+   *
+   * @param array $params
+   * @param bool $fixAddress
+   * @return CRM_Core_BAO_Address
+   * @throws CRM_Core_Exception
+   */
+  public static function add(&$params, $fixAddress = FALSE) {
+    return self::create($params, $fixAddress);
+  }
 
-    CRM_Core_BAO_Block::handlePrimary($params, get_class());
-    CRM_Core_BAO_Block::handleBilling($params, get_class());
+  /**
+   * Event fired before modifying an Address.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if (in_array($event->action, ['create', 'edit'])) {
+      CRM_Core_BAO_Block::handlePrimary($event->params, __CLASS__);
+      CRM_Core_BAO_Block::handleBilling($event->params, __CLASS__);
 
-    // (prevent chaining 1 and 3) CRM-21214
-    if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
-      self::fixSharedAddress($params);
+      // (prevent chaining 1 and 3) CRM-21214
+      if (isset($event->params['master_id']) && !CRM_Utils_System::isNull($event->params['master_id'])) {
+        self::fixSharedAddress($event->params);
+      }
     }
+  }
 
-    $address->copyValues($params);
-    $address->save();
-
-    if ($address->id) {
-      // first get custom field from master address if any
-      if (isset($params['master_id']) && !CRM_Utils_System::isNull($params['master_id'])) {
-        $address->copyCustomFields($params['master_id'], $address->id, $hook);
+  /**
+   * Event fired after modifying an Address.
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    // Copy custom data from master address if not supplied
+    if ($event->action === 'create' && !isset($event->params['custom'])) {
+      if (isset($event->params['master_id']) && !CRM_Utils_System::isNull($event->params['master_id'])) {
+        $event->object->copyCustomFields($event->params['master_id'], $event->id, $event->action);
       }
-
-      if (isset($params['custom'])) {
-        $addressCustom = $params['custom'];
-      }
-      else {
-        $customFields = CRM_Core_BAO_CustomField::getFields('Address', FALSE, TRUE, NULL, NULL,
-          FALSE, FALSE, $checkPermissions ? CRM_Core_Permission::EDIT : FALSE);
-
-        if (!empty($customFields)) {
-          $addressCustom = CRM_Core_BAO_CustomField::postProcess($params,
-            $address->id,
-            'Address',
-            FALSE,
-            $checkPermissions
-          );
-        }
-      }
-      if (!empty($addressCustom)) {
-        CRM_Core_BAO_CustomValueTable::store($addressCustom, 'civicrm_address', $address->id, $hook);
-      }
-
+    }
+    if (in_array($event->action, ['create', 'edit'])) {
       // call the function to sync shared address and create relationships
       // if address is already shared, share master_id with all children and update relationships accordingly
       // (prevent chaining 2) CRM-21214
-      self::processSharedAddress($address->id, $params, $hook);
-
-      // lets call the post hook only after we've done all the follow on processing
-      CRM_Utils_Hook::post($hook, 'Address', $address->id, $address);
+      self::processSharedAddress($event->id, $event->params, $event->action);
     }
-
-    return $address;
   }
 
   /**
@@ -1336,7 +1310,6 @@ SELECT is_primary,
       return NULL;
     }
     CRM_Core_BAO_Block::sortPrimaryFirst($params['address']);
-    $contactId = NULL;
 
     $updateBlankLocInfo = CRM_Utils_Array::value('updateBlankLocInfo', $params, FALSE);
     $contactId = $params['contact_id'];
@@ -1386,7 +1359,17 @@ SELECT is_primary,
         $value['manual_geo_code'] = 0;
       }
       $value['contact_id'] = $contactId;
-      $blocks[] = self::add($value, $fixAddress);
+
+      if ($fixAddress) {
+        self::fixAddress($value);
+      }
+
+      // Format custom data
+      if (!isset($value['custom'])) {
+        $value['custom'] = CRM_Core_BAO_CustomField::postProcess($value, $value['id'] ?? NULL, 'Address');
+      }
+
+      $blocks[] = self::writeRecord($value);
     }
     return $blocks;
   }

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -282,7 +282,10 @@ class CRM_Core_BAO_Block {
       }
 
       $blockFields = array_merge($value, $contactFields);
-      $blocks[] = $baoString::create($blockFields);
+      if ($baoString === 'CRM_Core_BAO_Address') {
+        CRM_Core_BAO_Address::fixAddress($blockFields);
+      }
+      $blocks[] = $baoString::writeRecord($blockFields);
     }
 
     return $blocks;

--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -25,13 +25,15 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email implements Civi\Core\HookInt
 
   /**
    * @deprecated
+   *
    * @param array $params
    * @return CRM_Core_BAO_Email
+   * @throws CRM_Core_Exception
    */
   public static function create($params) {
     // FIXME: switch CRM_Core_BAO_Block::create to call writeRecord (once Address, IM, Phone create functions go through it)
     // then this can be uncommented:
-    // CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 
@@ -41,7 +43,7 @@ class CRM_Core_BAO_Email extends CRM_Core_DAO_Email implements Civi\Core\HookInt
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
     if (in_array($event->action, ['create', 'edit'])) {
-      CRM_Core_BAO_Block::handlePrimary($event->params, get_class());
+      CRM_Core_BAO_Block::handlePrimary($event->params, __CLASS__);
 
       if (!empty($event->params['email'])) {
         // lower case email field to optimize queries
@@ -96,8 +98,10 @@ WHERE  contact_id = {$event->params['contact_id']}
 
   /**
    * @deprecated
+   *
    * @param array $params
    * @return CRM_Core_BAO_Email
+   * @throws CRM_Core_Exception
    */
   public static function add($params) {
     CRM_Core_Error::deprecatedFunctionWarning('writeRecord');

--- a/CRM/Core/BAO/IM.php
+++ b/CRM/Core/BAO/IM.php
@@ -18,34 +18,39 @@
 /**
  * This class contain function for IM handling
  */
-class CRM_Core_BAO_IM extends CRM_Core_DAO_IM {
+class CRM_Core_BAO_IM extends CRM_Core_DAO_IM implements Civi\Core\HookInterface {
   use CRM_Contact_AccessTrait;
 
   /**
-   * Create or update IM record.
+   * @deprecated
    *
    * @param array $params
-   *
-   * @return \CRM_Core_DAO|\CRM_Core_DAO_IM
-   * @throws \CRM_Core_Exception
+   * @return CRM_Core_DAO_IM
+   * @throws CRM_Core_Exception
    */
   public static function create($params) {
-    CRM_Core_BAO_Block::handlePrimary($params, __CLASS__);
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 
   /**
-   * Create or update IM record.
-   *
+   * Event fired before modifying an IM.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if (in_array($event->action, ['create', 'edit'])) {
+      CRM_Core_BAO_Block::handlePrimary($event->params, __CLASS__);
+    }
+  }
+
+  /**
    * @deprecated
    *
    * @param array $params
-   *
-   * @return \CRM_Core_DAO|\CRM_Core_DAO_IM
-   * @throws \CRM_Core_Exception
+   * @return CRM_Core_DAO_IM
+   * @throws CRM_Core_Exception
    */
   public static function add($params) {
-    CRM_Core_Error::deprecatedFunctionWarning('use the v4 api');
     return self::create($params);
   }
 

--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -18,35 +18,39 @@
 /**
  * This class contains function for Open Id
  */
-class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID {
+class CRM_Core_BAO_OpenID extends CRM_Core_DAO_OpenID implements Civi\Core\HookInterface {
   use CRM_Contact_AccessTrait;
 
   /**
-   * Create or update OpenID record.
+   * @deprecated
    *
    * @param array $params
-   *
    * @return CRM_Core_DAO_OpenID
-   *
-   * @throws \CRM_Core_Exception
+   * @throws CRM_Core_Exception
    */
   public static function create($params) {
-    CRM_Core_BAO_Block::handlePrimary($params, __CLASS__);
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 
   /**
-   * Create or update OpenID record.
-   *
+   * Event fired before modifying an OpenID.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if (in_array($event->action, ['create', 'edit'])) {
+      CRM_Core_BAO_Block::handlePrimary($event->params, __CLASS__);
+    }
+  }
+
+  /**
    * @deprecated
    *
    * @param array $params
-   *
-   * @return \CRM_Core_DAO|\CRM_Core_DAO_IM
-   * @throws \CRM_Core_Exception
+   * @return CRM_Core_DAO_OpenID
+   * @throws CRM_Core_Exception
    */
   public static function add($params) {
-    CRM_Core_Error::deprecatedFunctionWarning('use the v4 api');
     return self::create($params);
   }
 

--- a/CRM/Core/BAO/Phone.php
+++ b/CRM/Core/BAO/Phone.php
@@ -18,39 +18,39 @@
 /**
  * Class contains functions for phone.
  */
-class CRM_Core_BAO_Phone extends CRM_Core_DAO_Phone {
+class CRM_Core_BAO_Phone extends CRM_Core_DAO_Phone implements Civi\Core\HookInterface {
   use CRM_Contact_AccessTrait;
 
   /**
-   * Create phone object - note that the create function calls 'add' but
-   * has more business logic
+   * @deprecated
    *
    * @param array $params
-   *
-   * @return \CRM_Core_DAO_Phone
-   *
-   * @throws \CRM_Core_Exception
+   * @return CRM_Core_DAO_Phone
+   * @throws CRM_Core_Exception
    */
   public static function create($params) {
-    CRM_Core_BAO_Block::handlePrimary($params, get_class());
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 
   /**
-   * Takes an associative array and adds phone.
-   *
-   * @deprecated use create.
+   * Event fired before modifying a Phone.
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    if (in_array($event->action, ['create', 'edit'])) {
+      CRM_Core_BAO_Block::handlePrimary($event->params, __CLASS__);
+    }
+  }
+
+  /**
+   * @deprecated
    *
    * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
-   * @return object
-   *   CRM_Core_BAO_Phone object on success, null otherwise
-   *
+   * @return CRM_Core_DAO_Phone
    * @throws \CRM_Core_Exception
    */
   public static function add($params) {
-    CRM_Core_Error::deprecatedFunctionWarning('Use the v4 api');
     return self::create($params);
   }
 

--- a/CRM/Core/BAO/Website.php
+++ b/CRM/Core/BAO/Website.php
@@ -22,13 +22,11 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
   use CRM_Contact_AccessTrait;
 
   /**
-   * Create or update Website record.
+   * @deprecated
    *
    * @param array $params
-   *
-   * @deprecated
    * @return CRM_Core_DAO_Website
-   * @throws \CRM_Core_Exception
+   * @throws CRM_Core_Exception
    */
   public static function create($params) {
     CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
@@ -36,16 +34,14 @@ class CRM_Core_BAO_Website extends CRM_Core_DAO_Website {
   }
 
   /**
-   * Create website.
+   * @deprecated
    *
    * @param array $params
-   *
    * @return CRM_Core_DAO_Website
-   * @throws \CRM_Core_Exception
-   * @deprecated
+   * @throws CRM_Core_Exception
    */
   public static function add($params) {
-    CRM_Core_Error::deprecatedFunctionWarning('use apiv4');
+    CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
     return self::writeRecord($params);
   }
 

--- a/Civi/Api4/Action/Address/AddressSaveTrait.php
+++ b/Civi/Api4/Action/Address/AddressSaveTrait.php
@@ -55,7 +55,10 @@ trait AddressSaveTrait {
         $item = array_merge($item, \CRM_Core_BAO_Address::parseStreetAddress($item['street_address']));
       }
       $item['skip_geocode'] = $this->skipGeocode;
-      $saved[] = \CRM_Core_BAO_Address::add($item, $this->fixAddress);
+      if ($this->fixAddress) {
+        \CRM_Core_BAO_Address::fixAddress($item);
+      }
+      $saved[] = \CRM_Core_BAO_Address::writeRecord($item);
     }
     return $saved;
   }

--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -428,6 +428,11 @@ trait Api3TestTrait {
           if ($v4Entity != 'Setting' && !in_array('id', $v4Params['select'])) {
             $v4Params['select'][] = 'id';
           }
+          // Convert 'custom' to 'custom.*'
+          $selectCustom = array_search('custom', $v4Params['select']);
+          if ($selectCustom !== FALSE) {
+            $v4Params['select'][$selectCustom] = 'custom.*';
+          }
         }
         if ($options['limit'] && $v4Entity != 'Setting') {
           $v4Params['limit'] = $options['limit'];

--- a/api/v3/Address.php
+++ b/api/v3/Address.php
@@ -60,22 +60,11 @@ function civicrm_api3_address_create($params) {
     $params['check_permissions'] = 0;
   }
 
-  if (!isset($params['fix_address'])) {
-    $params['fix_address'] = TRUE;
+  if (!isset($params['fix_address']) || $params['fix_address']) {
+    CRM_Core_BAO_Address::fixAddress($params);
   }
 
-  /**
-   * Create array for BAO (expects address params in as an
-   * element in array 'address'
-   */
-  $addressBAO = CRM_Core_BAO_Address::create($params, $params['fix_address']);
-  if (empty($addressBAO)) {
-    return civicrm_api3_create_error("Address is not created or updated ");
-  }
-  else {
-    $values = _civicrm_api3_dao_to_array($addressBAO, $params);
-    return civicrm_api3_create_success($values, $params, 'Address', $addressBAO);
-  }
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'Address');
 }
 
 /**

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1373,7 +1373,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
           'location_type_id' => 1,
           'contact_id' => $contactId,
         ];
-        CRM_Core_BAO_Phone::create($params);
+        CRM_Core_BAO_Phone::writeRecord($params);
         $test->assertDBQuery('202-555-1000',
           'SELECT phone FROM civicrm_phone WHERE contact_id = %1 ORDER BY id DESC LIMIT 1',
           [1 => [$contactId, 'Integer']]

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1565,7 +1565,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'is_billing' => 1,
       'state_province_id' => '3934',
     ];
-    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+    $addAddressA = CRM_Core_BAO_Address::writeRecord($addressParamsA);
 
     $addressParamsB[1] = [
       'contact_id' => $contactIdB,
@@ -1574,7 +1574,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     ];
 
     CRM_Contact_BAO_Contact_Utils::processSharedAddress($addressParamsB);
-    $addAddressB = CRM_Core_BAO_Address::add($addressParamsB[1], FALSE);
+    $addAddressB = CRM_Core_BAO_Address::writeRecord($addressParamsB[1]);
 
     foreach ($addAddressA as $key => $value) {
       if (!in_array($key, ['id', 'contact_id', 'master_id', 'is_primary', 'is_billing', 'location_type_id', 'manual_geo_code'])) {

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -112,7 +112,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    $addAddress = CRM_Core_BAO_Address::add($fixParams, $fixAddress = TRUE);
+    CRM_Core_BAO_Address::fixAddress($fixParams);
+    $addAddress = CRM_Core_BAO_Address::writeRecord($fixParams);
 
     $addParams = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created contact address.'
@@ -216,7 +217,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Address::add($params['address']['1'], $fixAddress = TRUE);
+    CRM_Core_BAO_Address::fixAddress($params['address']['1']);
+    CRM_Core_BAO_Address::writeRecord($params['address']['1']);
 
     // Add address 2
     $params['address']['2'] = [
@@ -236,7 +238,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Address::add($params['address']['2'], $fixAddress = TRUE);
+    CRM_Core_BAO_Address::fixAddress($params['address']['2']);
+    CRM_Core_BAO_Address::writeRecord($params['address']['2']);
 
     $addresses = CRM_Core_BAO_Address::getValues($entityBlock);
 
@@ -281,7 +284,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Address::add($fixParams, $fixAddress = TRUE);
+    CRM_Core_BAO_Address::fixAddress($fixParams);
+    CRM_Core_BAO_Address::writeRecord($fixParams);
 
     $addParams = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created contact address.'
@@ -304,7 +308,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Address::add($fixParams, $fixAddress = TRUE);
+    CRM_Core_BAO_Address::fixAddress($fixParams);
+    CRM_Core_BAO_Address::writeRecord($fixParams);
 
     $addParams = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created contact address.'
@@ -341,7 +346,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Address::add($fixParams, $fixAddress = TRUE);
+    CRM_Core_BAO_Address::fixAddress($fixParams);
+    CRM_Core_BAO_Address::writeRecord($fixParams);
 
     $addParams = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created contact address.'
@@ -585,7 +591,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'is_primary' => '1',
       'contact_id' => $contactIdA,
     ];
-    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+    $addAddressA = CRM_Core_BAO_Address::writeRecord($addressParamsA);
 
     $addressParamsB = [
       'street_address' => '123 Fake St.',
@@ -594,7 +600,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'master_id' => $addAddressA->id,
       'contact_id' => $contactIdB,
     ];
-    $addAddressB = CRM_Core_BAO_Address::add($addressParamsB, FALSE);
+    $addAddressB = CRM_Core_BAO_Address::writeRecord($addressParamsB);
 
     $addressParamsC = [
       'street_address' => '123 Fake St.',
@@ -603,7 +609,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'master_id' => $addAddressB->id,
       'contact_id' => $contactIdC,
     ];
-    $addAddressC = CRM_Core_BAO_Address::add($addressParamsC, FALSE);
+    $addAddressC = CRM_Core_BAO_Address::writeRecord($addressParamsC);
 
     $updatedAddressParamsA = [
       'id' => $addAddressA->id,
@@ -612,7 +618,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'is_primary' => '1',
       'contact_id' => $contactIdA,
     ];
-    $updatedAddressA = CRM_Core_BAO_Address::add($updatedAddressParamsA, FALSE);
+    $updatedAddressA = CRM_Core_BAO_Address::writeRecord($updatedAddressParamsA);
 
     // CRM-21214 - Has Address C been updated with Address A's new values?
     $newAddressC = new CRM_Core_DAO_Address();
@@ -645,7 +651,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'is_primary' => '1',
       'contact_id' => $contactIdA,
     ];
-    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+    $addAddressA = CRM_Core_BAO_Address::writeRecord($addressParamsA);
 
     $addressParamsB = [
       'street_address' => '123 Fake St.',
@@ -653,7 +659,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'is_primary' => '1',
       'contact_id' => $contactIdB,
     ];
-    $addAddressB = CRM_Core_BAO_Address::add($addressParamsB, FALSE);
+    $addAddressB = CRM_Core_BAO_Address::writeRecord($addressParamsB);
 
     $addressParamsC = [
       'street_address' => '123 Fake St.',
@@ -662,7 +668,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'master_id' => $addAddressA->id,
       'contact_id' => $contactIdC,
     ];
-    $addAddressC = CRM_Core_BAO_Address::add($addressParamsC, FALSE);
+    $addAddressC = CRM_Core_BAO_Address::writeRecord($addressParamsC);
 
     $updatedAddressParamsA = [
       'id' => $addAddressA->id,
@@ -672,7 +678,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'master_id' => $addAddressB->id,
       'contact_id' => $contactIdA,
     ];
-    $updatedAddressA = CRM_Core_BAO_Address::add($updatedAddressParamsA, FALSE);
+    $updatedAddressA = CRM_Core_BAO_Address::writeRecord($updatedAddressParamsA);
 
     $updatedAddressParamsB = [
       'id' => $addAddressB->id,
@@ -681,7 +687,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'is_primary' => '1',
       'contact_id' => $contactIdB,
     ];
-    $updatedAddressB = CRM_Core_BAO_Address::add($updatedAddressParamsB, FALSE);
+    $updatedAddressB = CRM_Core_BAO_Address::writeRecord($updatedAddressParamsB);
 
     // CRM-21214 - Has Address C been updated with Address B's new values?
     $newAddressC = new CRM_Core_DAO_Address();
@@ -709,7 +715,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'is_primary' => '1',
       'contact_id' => $contactIdA,
     ];
-    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+    $addAddressA = CRM_Core_BAO_Address::writeRecord($addressParamsA);
 
     $updatedAddressParamsA = [
       'id' => $addAddressA->id,
@@ -719,7 +725,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'master_id' => $addAddressA->id,
       'contact_id' => $contactIdA,
     ];
-    $updatedAddressA = CRM_Core_BAO_Address::add($updatedAddressParamsA, FALSE);
+    $updatedAddressA = CRM_Core_BAO_Address::writeRecord($updatedAddressParamsA);
 
     // CRM-21214 - AdressA shouldn't be master of itself.
     $this->assertEmpty($updatedAddressA->master_id);
@@ -746,8 +752,9 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactIdA,
       $customField => 'this is a custom text field',
     ];
+    $addressParamsA['custom'] = CRM_Core_BAO_CustomField::postProcess($addressParamsA, NULL, 'Address');
 
-    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+    $addAddressA = CRM_Core_BAO_Address::writeRecord($addressParamsA);
 
     // without having the custom field, we should still copy the values from master
     $addressParamsB = [
@@ -757,7 +764,7 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'master_id' => $addAddressA->id,
       'contact_id' => $contactIdB,
     ];
-    $addAddressB = CRM_Core_BAO_Address::add($addressParamsB, FALSE);
+    $addAddressB = CRM_Core_BAO_Address::writeRecord($addressParamsB);
 
     // 1. check if the custom fields values have been copied from master to shared address
     $address = $this->callAPISuccessGetSingle('Address', ['id' => $addAddressB->id, 'return' => $this->getCustomFieldName('text')]);
@@ -766,7 +773,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
     // 2. now, we update addressA custom field to see if it goes into addressB
     $addressParamsA['id'] = $addAddressA->id;
     $addressParamsA[$customField] = 'updated custom text field';
-    $addAddressA = CRM_Core_BAO_Address::add($addressParamsA, FALSE);
+    $addressParamsA['custom'] = CRM_Core_BAO_CustomField::postProcess($addressParamsA, NULL, 'Address');
+    CRM_Core_BAO_Address::writeRecord($addressParamsA);
 
     $address = $this->callAPISuccessGetSingle('Address', ['id' => $addAddressB->id, 'return' => $this->getCustomFieldName('text')]);
     $this->assertEquals($addressParamsA[$customField], $address[$customField]);
@@ -846,7 +854,8 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    $addAddress = CRM_Core_BAO_Address::add($fixParams, TRUE);
+    CRM_Core_BAO_Address::fixAddress($fixParams);
+    $addAddress = CRM_Core_BAO_Address::writeRecord($fixParams);
 
     $addParams = $this->assertDBNotNull('CRM_Core_DAO_Address', $contactId, 'id', 'contact_id',
       'Database check for created contact address.'

--- a/tests/phpunit/CRM/Core/BAO/PhoneTest.php
+++ b/tests/phpunit/CRM/Core/BAO/PhoneTest.php
@@ -21,7 +21,6 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
   public function testAdd() {
     $contactId = $this->individualCreate();
 
-    $params = [];
     $params = [
       'phone' => '(415) 222-1011 x 221',
       'is_primary' => 1,
@@ -30,7 +29,7 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    CRM_Core_BAO_Phone::create($params);
+    CRM_Core_BAO_Phone::writeRecord($params);
 
     $phoneId = $this->assertDBNotNull('CRM_Core_DAO_Phone', $contactId, 'id', 'contact_id',
       'Database check for created phone record.'
@@ -48,7 +47,7 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
       'phone' => '(415) 222-5432',
     ];
 
-    CRM_Core_BAO_Phone::create($params);
+    CRM_Core_BAO_Phone::writeRecord($params);
 
     $this->assertDBCompareValue('CRM_Core_DAO_Phone', $phoneId, 'phone', 'id', '(415) 222-5432',
       "Check if phone field has expected value in updated record ( civicrm_phone.id={$phoneId} )."
@@ -82,13 +81,6 @@ class CRM_Core_BAO_PhoneTest extends CiviUnitTestCase {
     $this->assertEquals(1, $firstPhoneValue[0]['is_primary'], 'Confirm first Phone is primary.');
 
     $this->contactDelete($contactId);
-  }
-
-  /**
-   * AllEntityPhones() method - get all Phones for a location block, with primary Phone first
-   * @todo FIXME: Fixing this test requires add helper functions in CiviTest to create location block and phone and link them to an event. Punting to 3.1 cycle. DGG
-   */
-  public function SKIPPED_testAllEntityPhones() {
   }
 
 }

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -375,9 +375,11 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   }
 
   /**
-   * FIXME: Api4 custom address fields broken?
+   * @param int $version
+   * @dataProvider versionThreeAndFour
    */
-  public function testGetWithCustom() {
+  public function testGetWithCustom($version) {
+    $this->_apiversion = $version;
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
     $params = $this->_params;

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -1184,7 +1184,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'is_primary' => 1,
     ];
     // api requires contact_id - perhaps incorrectly but use add to get past that.
-    $address = CRM_Core_BAO_Address::add($addressParams);
+    $address = CRM_Core_BAO_Address::writeRecord($addressParams);
 
     $location = $this->callAPISuccess('LocBlock', 'create', ['address_id' => $address->id]);
     $this->callAPISuccess('Event', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Updates location BAOs (phone, im, website, email, open id, and address) to use `writeRecord`, noisily deprecate and stop using add/create functions.

Technical Details
--------------------------------
The most challenging was Address which had a lot of extra processing in the `add` function as well as a nonstandard extra `$fixAddress` parameter. Extra processing has been moved to hooks and `fixAddress` to its own function (actually it was already its own function, so never really needed to be a param!).

The `Address::add` function also provided legacy support for custom data in the format `custom_x => 'foo'` mixed into the $params whereas all other BAO create/add functions expect a single key `custom`. I've removed that extra bit and moved it to the `Address::legacyCreate` function which seemed fitting.
