### PR TITLE
fix import of participant role ID

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1893,6 +1893,17 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
    * @throws CRM_Core_Exception
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
+    // Set the default role ID on create.
+    if ($event->entity === 'Participant' && $event->action === 'create' && empty($event->params['role_id'])) {
+      if (!empty($event->params['event_id'])) {
+        $event->params['role_id'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $event->params['event_id'], 'default_role_id');
+      }
+      else {
+        $params['role_id'] = CRM_Core_DAO::singleValueQuery('SELECT default_role_id FROM civicrm_event WHERE id = %1', [
+          1 => [$event->params['event_id'], 'Integer'],
+        ]);
+      }
+    }
     if ($event->entity === 'Participant' && $event->action === 'create' && empty($event->params['created_id'])) {
       // Set the "created_id" field if not already set.
       // The created_id should always be the person that actually did the registration.

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -108,18 +108,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       // don't add to recent items, CRM-4399
       $formatted['skipRecentView'] = TRUE;
 
-      if (!(!empty($params['participant_role_id']) || !empty($params['participant_role']))) {
-        if (!empty($params['event_id'])) {
-          $params['participant_role_id'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $params['event_id'], 'default_role_id');
-        }
-        else {
-          $eventTitle = $params['event_title'];
-          $params['participant_role_id'] = CRM_Core_DAO::singleValueQuery('SELECT default_role_id FROM civicrm_event WHERE title = %1', [
-            1 => [$eventTitle, 'String'],
-          ]);
-        }
-      }
-
       $formatValues = [];
       foreach ($params as $key => $field) {
         if ($field == NULL || $field === '') {

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -139,6 +139,42 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that imports work generally.
+   */
+  public function testImportParticipant() :void {
+    $this->eventCreate(['title' => 'Rain-forest Cup Youth Soccer Tournament']);
+    $contactID = $this->individualCreate(['external_identifier' => 'ref-77']);
+    $this->importCSV('participant_with_ext_id.csv', [
+      ['name' => 'event_id'],
+      ['name' => 'do_not_import'],
+      ['name' => 'external_identifier'],
+      ['name' => 'fee_amount'],
+      ['name' => 'fee_currency'],
+      ['name' => 'fee_level'],
+      ['name' => 'is_pay_later'],
+      ['name' => 'role_id'],
+      ['name' => 'source'],
+      ['name' => 'status_id'],
+      ['name' => 'register_date'],
+      ['name' => 'do_not_import'],
+    ]);
+    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
+    $row = $dataSource->getRow();
+    $result = $this->callAPISuccess('Participant', 'get', [
+      'contact_id' => $contactID,
+      'sequential' => TRUE,
+    ])['values'][0];
+
+    $this->assertEquals($row['event_title'], $result['event_title']);
+    $this->assertEquals($row['fee_amount'], $result['participant_fee_amount']);
+    $this->assertEquals($row['participant_source'], $result['participant_source']);
+    $this->assertEquals($row['participant_status'], $result['participant_status']);
+    $this->assertEquals('2022-12-07 00:00:00', $result['participant_register_date']);
+    $this->assertEquals(['Attendee', 'Volunteer'], $result['participant_role']);
+    $this->assertEquals(0, $result['participant_is_pay_later']);
+  }
+
+  /**
    * @param array $submittedValues
    *
    * @return int


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4082

When importing participant data, the role ID in the CSV is ignored, and the default role is always assigned.

Before
----------------------------------------
Default role for everyone.

After
----------------------------------------
Role can be set in the import data.

Comments
----------------------------------------
* This is a regression, but I have no idea how far back it goes. I can rebase against the RC if it's preferred.
* It's not clear to me if we still need to be checking `participant_role_id` and `participant_role`.
