### PR TITLE
(dev/core#4188) phpunit.xml.dist - Make file compatible with phpunit8 + phpunit9

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,6 @@
-<phpunit backupGlobals="false"
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -11,7 +13,7 @@
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="tests/phpunit/CiviTest/bootstrap.php"
          cacheResult="false"
->
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <testsuites>
     <testsuite name="api_v3_AllTests">
       <directory>./tests/phpunit/api</directory>
@@ -26,20 +28,9 @@
       <directory>./tests/phpunit/WebTest</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./CRM</directory>
-      <directory suffix=".php">./Civi</directory>
-      <directory suffix=".php">./api</directory>
-    </whitelist>
-  </filter>
-
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
-      <arguments></arguments>
+      <arguments/>
     </listener>
   </listeners>
-
 </phpunit>
-


### PR DESCRIPTION
Overview
----------------------------------------

Small update to facilitate running phpunit9.

(Step toward https://lab.civicrm.org/dev/core/-/issues/4188)

Before
----------------------------------------

```
PHPUnit 9.6.5 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

After
----------------------------------------

Warning goes away. File seems to work locally on phpunit 8.5.27 and 9.6.5 without any XML complaints.

Technical Details
----------------------------------------

* To generate this, I ran the suggested command `--migrate-configuration`.
* But it was hard to read the diff -- so then I reformatted whitespace to match older document.
* Then I ran again on phpunit8 to see if it was interoperable. It complained because the [`<filter>`](https://docs.phpunit.de/en/8.5/configuration.html#the-filter-element) had changed to [`<coverage>`](https://docs.phpunit.de/en/9.6/configuration.html#the-coverage-element). These elements seem to be mutually incompatible. However, we don't actually generate code-coverage reports. So I don't need think we need either tag for now.
* After these small touch-ups, it seems to work on both.
