### PR TITLE
(dev/core#4188) Update APIv4 tests for phpunit9 compatibility

### DIFF
--- a/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
+++ b/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
@@ -124,9 +124,9 @@ class ContactDuplicatesTest extends CustomTestBase {
       ->execute()->column('id');
 
     $this->assertCount(3, $found);
-    $this->assertContains($testContacts[0], $found);
-    $this->assertContains($testContacts[1], $found);
-    $this->assertContains($testContacts[3], $found);
+    $this->assertContainsEquals($testContacts[0], $found);
+    $this->assertContainsEquals($testContacts[1], $found);
+    $this->assertContainsEquals($testContacts[3], $found);
 
     $found = Contact::getDuplicates(FALSE)
       ->setDedupeRule('customRule')
@@ -136,8 +136,8 @@ class ContactDuplicatesTest extends CustomTestBase {
       ->execute()->column('id');
 
     $this->assertCount(2, $found);
-    $this->assertContains($testContacts[2], $found);
-    $this->assertContains($testContacts[4], $found);
+    $this->assertContainsEquals($testContacts[2], $found);
+    $this->assertContainsEquals($testContacts[4], $found);
   }
 
   public function testMergeDuplicates():void {

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -589,7 +589,7 @@ class BasicCustomFieldTest extends CustomTestBase {
         ->addValue('html_type', 'Text')
       )
       ->execute()->single();
-    $this->assertContains($financialType['id'], $contributionGroup['extends_entity_column_value']);
+    $this->assertContainsEquals($financialType['id'], $contributionGroup['extends_entity_column_value']);
 
     $getFieldsWithTestType = Contribution::getFields(FALSE)
       ->addValue('financial_type_id:name', 'Test_Type')


### PR DESCRIPTION
Overview
----------------------------------------

These tests failed on `phpunit9` because upstream swapped around the semantics of `assertContains()`.

The specific issue is whether an array like `["1","2","3"]` contains the value `2`.

Before
----------------------------------------

* `assertContains()` in phpunit8 says yes => tests pass.
* `assertContains()` in phpunit9 says no => tests fail.

After
----------------------------------------

* `assertContainsEquals()` in both phpunit8+phpunit9 says yes => tests pass.

