### PR TITLE
(dev/core#4188) Update APIv3 tests for phpunit9 compatibility

### DIFF
--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -492,7 +492,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
       'subject' => 'Test followup 123',
       'return' => ['case_id'],
     ]);
-    $this->assertContains($case['id'], $result['case_id']);
+    $this->assertContainsEquals($case['id'], $result['case_id']);
   }
 
   public function testCaseGetByStatus() {

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4553,7 +4553,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     // Ensure they are shown as being in each created group.
     $contact_group_ids = explode(',', $contact_get['values'][$created_contact_id]['groups']);
     foreach ($created_group_ids as $created_group_id) {
-      $this->assertContains($created_group_id, $contact_group_ids);
+      $this->assertContainsEquals($created_group_id, $contact_group_ids);
     }
   }
 

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -602,7 +602,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
     foreach ($groupResult['values'] as $groupValues) {
       $this->assertEquals($contactID, $groupValues['contact_id']);
       $this->assertEquals('Added', $groupValues['status']);
-      $this->assertContains($groupValues['group_id'], $expectedGroups);
+      $this->assertContainsEquals($groupValues['group_id'], $expectedGroups);
 
     }
   }

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1094,7 +1094,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
     $this->assertEquals(2, $result['count']);
     foreach ($result['values'] as $value) {
-      $this->assertContains($value['relationship_type_id'], [$this->relationshipTypeID, $relType3]);
+      $this->assertContainsEquals($value['relationship_type_id'], [$this->relationshipTypeID, $relType3]);
     }
   }
 
@@ -1202,7 +1202,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     // although our contact has more than one relationship we have passed them in as contact_id_a & can't get reciprocal
     $this->assertEquals(1, $result['count']);
     foreach ($result['values'] as $key => $value) {
-      $this->assertContains($value['relationship_type_id'], [$relType1]);
+      $this->assertContainsEquals($value['relationship_type_id'], [$relType1]);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Same issue as #25947, but applied to the `phpunit-api3` suite. These tests failed on phpunit9 because upstream swapped around the semantics of `assertContains()`.

The specific issue is whether an array like `["1","2","3"]` contains the value `2`.

Before
------
* `assertContains()` in phpunit8 says yes => tests pass.
* `assertContains()` in phpunit9 says no => tests fail.

After
------

* `assertContainsEquals()` in both phpunit8+phpunit9 says yes => tests pass.
