### PR TITLE
(dev/core#4188) Update CRM tests for phpunit9 compatibility

### DIFF
--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -203,13 +203,13 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
       ],
     ]);
     $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
-    $this->assertContains('6', array_keys($savedSearch['form_values']));
+    $this->assertContainsEquals('6', array_keys($savedSearch['form_values']));
     $this->assertEquals('membership_join_date_relative', $savedSearch['form_values'][6][0]);
     $this->assertEquals('this.day', $savedSearch['form_values'][6][2]);
-    $this->assertContains('7', array_keys($savedSearch['form_values']));
+    $this->assertContainsEquals('7', array_keys($savedSearch['form_values']));
     $this->assertEquals('membership_start_date_relative', $savedSearch['form_values'][7][0]);
     $this->assertEquals('this.week', $savedSearch['form_values'][7][2]);
-    $this->assertContains('8', array_keys($savedSearch['form_values']));
+    $this->assertContainsEquals('8', array_keys($savedSearch['form_values']));
     $this->assertEquals('membership_end_date_relative', $savedSearch['form_values'][8][0]);
     $this->assertEquals('this.week', $savedSearch['form_values'][8][2]);
   }


### PR DESCRIPTION
Overview
----------------------------------------

These tests failed on phpunit9 because upstream swapped around the semantics of `assertContains()`.

Same issue as #25947 but applied to the phpunit-crm suite.