### PR TITLE
Duplicate logging not needed for PEAR_Errors anymore

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -950,8 +950,6 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @throws PEAR_Exception
    */
   public static function exceptionHandler($pearError) {
-    CRM_Core_Error::debug_var('Fatal Error Details', self::getErrorDetails($pearError), TRUE, TRUE, '', PEAR_LOG_ERR);
-    CRM_Core_Error::backtrace('backTrace', TRUE);
     if ($pearError instanceof DB_Error) {
       throw new DBQueryException($pearError->getMessage(), $pearError->getCode(), ['exception' => $pearError]);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Unnecessary log entries.

Before
----------------------------------------
One example is the recent status check for db timezone support. Even though there's a try/catch it still logs it in the log.

Another I've seen is related to activities - there's a performance improvement that does a try/catch because the error is expected, but it still makes log entries (e.g. https://github.com/civicrm/civicrm-core/pull/18566#issuecomment-758284009)

After
----------------------------------------
If the exception is later caught, then it's up to that catching code to decide to log/rethrow, as it should be.
If it's not caught later, then it will get logged, as it should. So don't need to log it here.

One way to test this is just add a line like `CRM_Core_DAO::executeQuery('this is bad sql');` or `PEAR::raiseError('boo');` in preprocess() on some form and then visit the form. You'll see it still logs the error.

Technical Details
----------------------------------------
I vaguely remember a few years ago that PEAR errors weren't converted to exceptions, or something like that, so the logging might have been more needed.

Comments
----------------------------------------

