### PR TITLE
dev/core#3804 - Fix recently performed activities on case dashboard when no upcoming exist

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -588,12 +588,13 @@ HERESQL;
       return $getCount ? 0 : $casesList;
     }
 
+    $type = $params['type'] ?? 'upcoming';
+
     // Return cached value instead of re-running query
-    if (isset(Civi::$statics[__CLASS__]['totalCount']) && $getCount) {
-      return Civi::$statics[__CLASS__]['totalCount'];
+    if (isset(Civi::$statics[__CLASS__]['totalCount'][$type]) && $getCount) {
+      return Civi::$statics[__CLASS__]['totalCount'][$type];
     }
 
-    $type = CRM_Utils_Array::value('type', $params, 'upcoming');
     $userID = CRM_Core_Session::getLoggedInContactID();
 
     // validate access for all cases.
@@ -618,7 +619,7 @@ HERESQL;
     }
     $condition = implode(' AND ', $whereClauses);
 
-    Civi::$statics[__CLASS__]['totalCount'] = $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseActivityCountQuery($type, $userID, $condition));
+    Civi::$statics[__CLASS__]['totalCount'][$type] = $totalCount = CRM_Core_DAO::singleValueQuery(self::getCaseActivityCountQuery($type, $userID, $condition));
     if ($getCount) {
       return $totalCount;
     }


### PR DESCRIPTION
Overview
----------------------------------------
This is the same as https://github.com/civicrm/civicrm-core/pull/24261 but is a reviewer's cut with the added test and requested changes.

https://lab.civicrm.org/dev/core/-/issues/3804

Before
----------------------------------------
1. Make sure there are no upcoming case activities. One way to do this is create a backdated case with a start date 2 years ago, then change the status of any scheduled ones to completed.
2. Create a recent case activity, e.g. backdate it 2 days and mark it completed.
3. Visit the case dashboard. Note it does not show the recent activity.

Unit test fails with `Failed asserting that '0' matches expected 1.`

After
----------------------------------------
Better

Technical Details
----------------------------------------
Count was cached without regard to type.

Comments
----------------------------------------
