### PR TITLE
Flush cache that holds schema links information when saving UserJob

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -251,6 +251,7 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
     try {
       unset(Civi::$statics['civiimport_tables']);
       Civi::cache('metadata')->delete('api4.entities.info');
+      Civi::cache('metadata')->delete('api4.schema.map');
       Civi::cache('metadata')->delete('civiimport_tables');
       CRM_Core_DAO_AllCoreTables::flush();
       Managed::reconcile(FALSE)->setModules(['civiimport'])->execute();


### PR DESCRIPTION
Overview
----------------------------------------
Flush cache that holds schema links information when saving UserJob

Before
----------------------------------------
When doing an import with Civi-Import enabled the links to the imported entites do not function as links until the caches are flushed

After
----------------------------------------
The cache that holds the links information is flushed when the other relevant metadata caches are

![image](https://user-images.githubusercontent.com/336308/228727492-02224e4c-63ee-411b-b75c-22db9224594c.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
