### PR TITLE
CustomField - Support filters in EntityReference fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1070,6 +1070,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
         }
         elseif ($field->data_type == 'EntityReference') {
           $fieldAttributes['entity'] = $field->fk_entity;
+          $fieldAttributes['api']['fieldName'] = $field->getEntity() . '.' . $groupName . '.' . $field->name;
           $element = $qf->addAutocomplete($elementName, $label, $fieldAttributes, $useRequired && !$search);
         }
         else {

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2260,8 +2260,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     ];
     $props['api'] += [
       'formName' => 'qf:' . get_class($this),
-      'fieldName' => $name,
     ];
+    // If fieldName is missing and no default entity is set for the form, this will throw an excption.
+    // In that case, you should explicitly supply api.fieldName in the format `EntityName.field_name`
+    // because without it autocompleteSubscribers can't do their job.
+    if (empty($props['api']['fieldName'])) {
+      $props['api']['fieldName'] = $this->getDefaultEntity() . '.' . $name;
+    }
     $props['class'] = ltrim(($props['class'] ?? '') . ' crm-form-autocomplete');
     $props['placeholder'] = $props['placeholder'] ?? self::selectOrAnyPlaceholder($props, $required);
     $props['data-select-params'] = json_encode($props['select']);

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -868,7 +868,9 @@ AND    option_group_id = %2";
         $filter = 'action=lookup&group=' . implode(',', $params['group_id']);
       }
     }
-    $params['filter'] = $filter;
+    if ($params['data_type'] !== 'EntityReference') {
+      $params['filter'] = $filter;
+    }
 
     // fix for CRM-316
     $oldWeight = NULL;

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -621,7 +621,7 @@ SELECT count(*)
       }
     }
 
-    if ($dataType === 'EntityReference') {
+    if ($dataType === 'EntityReference' && $self->_action == CRM_Core_Action::ADD) {
       if (empty($fields['fk_entity'])) {
         $errors['fk_entity'] = ts('Selecting an entity is required');
       }
@@ -813,7 +813,8 @@ AND    option_group_id = %2";
     }
 
     // If switching to a new option list, validate existing data
-    if (empty($errors) && $self->_id && in_array($htmlType, self::$htmlTypesWithOptions)) {
+    if (empty($errors) && $self->_id && in_array($htmlType, self::$htmlTypesWithOptions) &&
+      !in_array($dataType, ['Boolean', 'Country', 'StateProvince', 'ContactReference', 'EntityReference'])) {
       $oldHtmlType = $self->_values['html_type'];
       $oldOptionGroup = $self->_values['option_group_id'];
       if ($oldHtmlType === 'Text' || $oldOptionGroup != $fields['option_group_id'] || $fields['option_type'] == 1) {

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -262,7 +262,7 @@ class SpecFormatter {
     $inputType = $data['html']['type'] ?? $data['html_type'] ?? NULL;
     $inputAttrs = $data['html'] ?? [];
     unset($inputAttrs['type']);
-    // Custom field contact ref filters
+    // Custom field EntityRef or ContactRef filters
     if (is_string($data['filter'] ?? NULL) && strpos($data['filter'], '=')) {
       $filters = explode('&', $data['filter']);
       $inputAttrs['filter'] = $filters;
@@ -315,7 +315,8 @@ class SpecFormatter {
         $filters = [];
         foreach ($val as $filter) {
           [$k, $v] = explode('=', $filter);
-          $filters[$k] = $v;
+          // Explode comma-separated values
+          $filters[$k] = strpos($v, ',') ? explode(',', $v) : $v;
         }
         // Legacy APIv3 custom field stuff
         if ($dataTypeName === 'ContactReference') {

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -66,9 +66,20 @@
       <td class="label">{$form.filter.label}</td>
       <td class="html-adjust">
         {$form.filter.html}
-        &nbsp;&nbsp;<span><a class="crm-hover-button toggle-contact-ref-mode" href="#Group">{ts}Filter by Group{/ts}</a></span>
+        <span class="api3-filter-info"><a class="crm-hover-button toggle-contact-ref-mode" href="#Group">{ts}Filter by Group{/ts}</a></span>
         <br />
-        <span class="description">{ts}Filter contact search results for this field using Contact get API parameters. EXAMPLE: To list Students in group 3:{/ts} "action=get&group=3&contact_sub_type=Student" {docURL page="dev/api"}</span>
+        <span class="description api3-filter-info">
+          {ts}Filter contact search results for this field using Contact get API parameters. EXAMPLE: To list Students in group 3:{/ts}
+          <code>action=get&group=3&contact_sub_type=Student</code>
+          {docURL page="dev/api"}
+        </span>
+        <span class="description api4-filter-info">
+          {ts}Filter search results for this field using API-style parameters{/ts}
+          (<code>field=value&another_field=val1,val2</code>).<br>
+          {ts}EXAMPLE (Contact entity): To list Students in "Volunteers" or "Supporters" groups:{/ts}
+          <code>contact_sub_type=Student&groups:name=Volunteers,Supporters</code>
+          {docURL page="dev/api"}
+        </span>
       </td>
     </tr>
     <tr class="crm-custom-field-form-block-options_per_line" id="optionsPerLine">
@@ -229,8 +240,8 @@
         $('#filter_selected').val(setSelected.slice(1));
       }
       if (setSelected == '#Advance') {
-        $('#contact_reference_group').hide( );
-        $('#field_advance_filter').show( );
+        $('#contact_reference_group, .api4-filter-info').hide();
+        $('#field_advance_filter, .api3-filter-info').show();
       } else {
         $('#field_advance_filter').hide( );
         $('#contact_reference_group').show( );
@@ -249,6 +260,9 @@
 
       if (dataType === 'ContactReference') {
         toggleContactRefFilter();
+      } else if (dataType === 'EntityReference') {
+        $('#field_advance_filter, .api4-filter-info').show();
+        $('#contact_reference_group, .api3-filter-info').hide();
       } else {
         $('#field_advance_filter, #contact_reference_group', $form).hide();
       }

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -25,7 +25,6 @@ use Civi\Api4\Contact;
 use Civi\Api4\MockBasicEntity;
 use Civi\Api4\SavedSearch;
 use Civi\Core\Event\GenericHookEvent;
-use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
@@ -53,11 +52,6 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     if ($this->hookCallback && is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
       ($this->hookCallback)($apiRequest);
     }
-  }
-
-  public function setUpHeadless(): CiviEnvBuilder {
-    // TODO: search_kit should probably be part of the 'headless()' baseline.
-    return \Civi\Test::headless()->install(['org.civicrm.search_kit'])->apply();
   }
 
   public function setUp(): void {

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -46,7 +46,8 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
   }
 
   public function setUpHeadless(): CiviEnvBuilder {
-    return Test::headless()->apply();
+    // TODO: search_kit should probably be part of the 'headless()' baseline.
+    return Test::headless()->install(['org.civicrm.search_kit'])->apply();
   }
 
   /**

--- a/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomEntityReferenceTest.php
@@ -17,6 +17,7 @@
 
 namespace api\v4\Custom;
 
+use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomField;
@@ -27,26 +28,47 @@ use Civi\Api4\CustomField;
 class CustomEntityReferenceTest extends CustomTestBase {
 
   /**
-   * Ensure custom fields of type EntityReference show up correctly in getFields metadata.
+   * Ensure custom fields of type EntityReference correctly apply filters
    */
   public function testEntityReferenceCustomField() {
+    $subject = uniqid();
     CustomGroup::create()->setValues([
       'title' => 'EntityRefFields',
       'extends' => 'Individual',
     ])->execute();
-    CustomField::create()->setValues([
+    $field = CustomField::create()->setValues([
       'label' => 'TestActivityReference',
       'custom_group_id.name' => 'EntityRefFields',
       'html_type' => 'Autocomplete-Select',
       'data_type' => 'EntityReference',
       'fk_entity' => 'Activity',
-    ])->execute();
+      'filter' => "subject=$subject",
+    ])->execute()->single();
+    // Check metadata
     $spec = Contact::getFields(FALSE)
       ->addWhere('name', '=', 'EntityRefFields.TestActivityReference')
       ->execute()->single();
     $this->assertNull($spec['suffixes']);
     $this->assertEquals('EntityRef', $spec['input_type']);
     $this->assertEquals('Activity', $spec['fk_entity']);
+    $this->assertEquals($subject, $spec['input_attrs']['filter']['subject']);
+    // Check results
+    $activities = $this->saveTestRecords('Activity', [
+      'records' => [
+        ['subject' => $subject],
+        ['subject' => 'wrong one'],
+        ['subject' => $subject],
+      ],
+    ]);
+    // Filter using field name
+    $result = Activity::autocomplete(FALSE)
+      ->setFieldName("Contact.EntityRefFields.TestActivityReference")
+      ->execute();
+    $this->assertCount(2, $result);
+    // No filter
+    $result = Activity::autocomplete(FALSE)
+      ->execute();
+    $this->assertGreaterThan(2, $result->countFetched());
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -102,7 +102,8 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
    * @return array
    */
   public function getEntitiesLotech(): array {
-    $manual['add'] = [];
+    // TODO: Auto-scan required core extensions like search_kit
+    $manual['add'] = ['SearchDisplay', 'SearchSegment'];
     $manual['remove'] = ['CustomValue'];
     $manual['transform'] = ['CiviCase' => 'Case'];
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds basic support for *filters* on the new custom field type *EntityReference*.

Before
----------------------------------------
Filters supported on the old *ContactReference* custom field type, but not for the new *EntityReference*.
![image](https://user-images.githubusercontent.com/2874912/228901761-82103843-8bc6-4375-bbf5-2eb03cfe8075.png)

After
----------------------------------------
Filters now work for EntityReference forms. Minimalist "Advanced Filter" textfield now shown for *EntityReference* as well as *ContactReference* fields:
![image](https://user-images.githubusercontent.com/2874912/229260223-820eef7f-55b1-469f-b5e3-8fed3bafb408.png)


Technical Details
--------------------------------------
As of e9fe23ef3a8ee33ee89125b0a9fc3d93e7afa094 APIv4 started passing anything stored in the `CustomField.filter` column to the `getFields` metadata. This completes that work by ensuring the filters are applied at runtime for all forms (both Quickform and Afform), and exposing the filters to the create/edit custom field form.

Comments
------------------
This is not a great UX but it's a start. SearchKit-style field selectors would be an improvement but would require mixing Angular code into the create/edit custom field form which is QuickForm-based. Adding Angular code to that form would be a little tricky but not impossible.