### PR TITLE
Update success.tpl CSS (pre/post upgrade messages)

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -178,10 +178,9 @@ class CRM_Upgrade_Incremental_General {
       return sprintf("<li><em>%s</em> - %s</li>", htmlentities($k), htmlentities($v));
     }, array_keys($messages), $messages);
 
-    $message .= '<br />' . ts("The default copies of the message templates listed below will be updated to handle new features or correct a problem. Your installation has customized versions of these message templates, and you will need to apply the updates manually after running this upgrade. <a href='%1' style='color:white; text-decoration:underline; font-weight:bold;' target='_blank'>Click here</a> for detailed instructions. %2", [
-      1 => 'https://docs.civicrm.org/user/en/latest/email/message-templates/#modifying-system-workflow-message-templates',
-      2 => '<ul>' . implode('', $messagesHtml) . '</ul>',
-    ]);
+    $message .= '<br />' . ts("The default copies of the message templates listed below will be updated to handle new features or correct a problem. Your installation has customized versions of these message templates, and you will need to apply the updates manually after running this upgrade. <a %1>View detailed instructions</a>.", [
+      1 => 'href="https://docs.civicrm.org/user/en/latest/email/message-templates/#modifying-system-workflow-message-templates" target="_blank"',
+    ]) . '<ul>' . implode('', $messagesHtml) . '</ul>';
 
     $messageObj->updateTemplates();
   }

--- a/templates/CRM/common/success.tpl
+++ b/templates/CRM/common/success.tpl
@@ -12,42 +12,88 @@
     <h2>{$pageTitle}</h2>
 {/if}
 {if !$upgraded}
-  <div class="crm-container" style="margin-top: 2em; padding: 1em; background-color: #FFFFE3; border: 1px #F8FF00 solid; color: black;">
-    <form method="post">
-        <p>
-          <span class="crm-status-icon info"> </span>
-          {ts 1=$currentVersion 2=$newVersion}The database will be upgraded from %1 to %2.{/ts}
-        </p>
+  <div class="crm-container crm-upgrade-box-outer crm-upgrade-warning">
+    <div class="crm-upgrade-box-inner">
+      <form method="post">
         {if $preUpgradeMessage}
-            <div style="border: 2px solid #E43D2B; background-color: rgba(228, 61, 43, 0.08); padding: 10px; margin-bottom: 15px;">
-              <span class="crm-status-icon"></span>
-              <strong style="vertical-align: middle; font-size: 1.2em;">{ts}Warning:{/ts}</strong>
-              {$preUpgradeMessage}
-            </div>
+          <div class="crm-success-flex">
+            <div><i class="crm-i fa-warning"></i></span></div>
+            <div class="crm-upgrade-large-text"><strong>{ts}Warning{/ts}</strong></div>
+          </div>
+          {$preUpgradeMessage}
         {/if}
         <p><strong>{ts}Back up your database before continuing.{/ts}</strong>
             {ts}This process may change your database structure and values. In case of emergency you may need to revert to a backup.{/ts} {docURL page="sysadmin/upgrade"}</p>
+        <p>{ts 1=$currentVersion 2=$newVersion}The database will be upgraded from %1 to %2.{/ts}</p>
         <input type="hidden" name="action" value="begin" />
-        <button type="submit" class="crm-button" name="upgrade" onclick="return confirm('{ts escape="js"}Are you sure you are ready to upgrade now?{/ts}');" >
-          <i class="crm-i fa-rocket" aria-hidden="true"></i>
-          {ts}Upgrade Now{/ts}
-        </button>&nbsp;&nbsp;
-        <a class="button cancel crm-form-submit" href="{$cancelURL}">
-          <i class="crm-i fa-times" aria-hidden="true"></i>
-          {ts}Cancel{/ts}
-        </a>
-    </form>
+        <div class="crm-submit-buttons">
+          <button type="submit" class="crm-button crm-form-submit"  name="upgrade" onclick="return confirm('{ts escape="js"}Are you sure you are ready to upgrade now?{/ts}');" >
+            <i class="crm-i fa-rocket" aria-hidden="true"></i>
+            {ts}Upgrade Now{/ts}
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
-
 {else}
-    <div class="crm-container" style="margin-top: 2em; padding: 1em; background-color: #EEFFEE; border: 1px #070 solid; color: black;">
-      <div class="bold" style="padding: 1em; background-color: rgba(255, 255, 255, 0.76);">
-        <p>
-          <img style="display:block; float:left; width:40px; margin-right:10px;" src="{$config->resourceBase}i/logo_lg.png">
-          {ts 1="https://civicrm.org/core-team" 2="https://civicrm.org/contributors" 3="https://civicrm.org/members" 4="https://civicrm.org/partners" 5="https://civicrm.org/become-a-member?src=ug&sid=$sid" 6=$newVersion 7="https://civicrm.org/become-a-partner" 8="https://civicrm.org"}Thank you for upgrading to %6. This release was made possible by the <a href="%1" target="_blank">CiviCRM Core Team</a> and an <a href="%2" target="_blank">incredible group of CiviCRM Contributors</a>. The CiviCRM project could not exist without the continued financial support of <a href="%3" target="_blank">CiviCRM Members</a> and <a href="%4" target="_blank">CiviCRM Partners</a>. We invite you to support CiviCRM by becoming a <a href="%5" target="_blank">CiviCRM Member</a> or <a href="%7" target="_blank">CiviCRM Partner</a> today. Providing financial support ensures that the <a href="%8" target="_blank">CiviCRM project</a> can continue to provide the essential resources and services to support the <a href="%8" target="_blank">CiviCRM community</a>.{/ts}
-        </p>
+    <div class="crm-container crm-upgrade-box-outer crm-upgrade-success">
+      <div class="crm-upgrade-box-inner">
+         <p class="crm-upgrade-large-text">{ts 1=$newVersion}Thank you for upgrading to %1.{/ts}</p>
+         <p class="crm-upgrade-large-text">{ts 1="href='https://civicrm.org/core-team' target='_blank'" 2="href='https://civicrm.org/contributors' target='_blank'" 3="href='https://civicrm.org/civicrm/contribute/transact?reset=1&id=47&src=ug' target='_blank'"}This release was made possible by the <a %1>CiviCRM Core Team</a> and an <a %2>incredible group of CiviCRM Contributors</a>. We are committed to keeping CiviCRM free and open, forever. We depend on your support to help make that happen. <a %3>Support us by making a small donation today</a>.{/ts}</p>
+        <div class="crm-success-flex">
+          <div style="margin: 0 10px;"><i class="crm-i fa-check" aria-hidden="true"></i></div>
+          <div>{$message}</div>
+        </div>
+        <div>
+          <p><a href="{crmURL p='civicrm/a/#/status'}" title="{ts}CiviCRM Status Check{/ts}" style="text-decoration: underline;">{ts}View the CiviCRM System Status{/ts}</a></p>
+          <p><a href="{crmURL p='civicrm/dashboard' q='reset=1'}" title="{ts}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
+        </div>
       </div>
-      <p><span class="crm-status-icon success"> </span>{$message}</p>
-      <p><a href="{crmURL p='civicrm/dashboard' q='reset=1'}" title="{ts}CiviCRM home page{/ts}" style="text-decoration: underline;">{ts}Return to CiviCRM home page.{/ts}</a></p>
     </div>
 {/if}
+{literal}
+<style>
+  /* Temporary inline CSS to be replaced by standard classes if they exist one day */
+  .crm-upgrade-box-outer {
+    margin-top: 2rem;
+    border-radius: 5px;
+    color: black;
+    font-family: sans-serif;
+    font-size: 16px;
+  }
+  .crm-upgrade-box-outer.crm-upgrade-warning {
+    background-color: #FFFFE3;
+    border: 1px #F8FF00 solid;
+  }
+  .crm-upgrade-box-outer.crm-upgrade-success {
+    background-color: #EEFFEE;
+    border: 1px #44cb7e solid;
+  }
+  .crm-upgrade-box-inner {
+    padding: 1rem;
+    background-color: rgba(255, 255, 255, 0.5);
+  }
+  .crm-success-flex {
+    display: flex;
+    padding: 1rem;
+  }
+  .crm-success-flex > div:first-child {
+    width: 50px;
+  }
+  .crm-upgrade-large-text {
+    font-size: 120%;
+  }
+  /* Force link colors because of the success background */
+  .crm-container .crm-upgrade-box-inner a,
+  .crm-container .crm-upgrade-box-inner a:hover,
+  .crm-container .crm-upgrade-box-inner a:active,
+  .crm-container .crm-upgrade-box-inner a:visited {
+    color: #0071bd;
+    text-decoration: underline;
+  }
+  /* Fixes weird visual on Drupal9 */
+  .crm-container summary {
+    color: black;
+  }
+</style>
+{/literal}


### PR DESCRIPTION
Overview
----------------------------------------

Initially I just wanted to add a link to the "CiviCRM System Status", because post-upgrade, I think that's the first thing people should check.

However, after adding the link, it was ugly, just felt like I was adding more clutter, so I went down a rabbit hole attempt to cleanup a bit.

- Pre-upgrade: Hides the "cancel" button, because it's clutter and people know how to use a back button
- Bigger font-size, sans-serif
- Less bold, because it's annoying; replaced by even bigger text, when relevant
- Align icons (mostly on the post-upgrade messages)

Before
----------------------------------------

Before running the upgrade:

![civicrm-preup-before](https://user-images.githubusercontent.com/254741/228918088-bc337f49-0713-43f2-b6a7-686f11a1edbb.png)

After running the upgrade:

![civicrm-finished-before](https://user-images.githubusercontent.com/254741/228918151-b3df24c9-19ff-4720-8091-cc4e94d6af1a.png)

After
----------------------------------------

Before running the upgrade:

![civicrm-preup-after-warnings](https://user-images.githubusercontent.com/254741/228918262-81e57517-1930-4827-b442-fa70d27174cd.png)

Before running the upgrade (if there are no upgrade warnings):

![civicrm-preup-after-nowarnings](https://user-images.githubusercontent.com/254741/228918260-9baebd15-7a11-4490-849a-7ebeb5905363.png)

After running the upgrade:

![civicrm-finished-after](https://user-images.githubusercontent.com/254741/228918263-5684b9c8-7b58-4ab8-9844-ee050b2c25bb.png)

Comments
----------------------------------

Some of the funnyness around buttons is because of Shoreditch and can be ignored.

I think the post-upgrade message should be simplified with a more clear call-to-action (donate), but it would break translations and I was not in the mood.