### PR TITLE
dev/core#4029 Ensure that Pan Truncation and card type id is recorded…

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1728,8 +1728,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
                 'is_transactional' => FALSE,
                 'fee_amount' => $result['result']['fee_amount'] ?? NULL,
                 'receive_date' => $result['result']['receive_date'] ?? NULL,
-                'card_type_id' => $result['result']['card_type_id'] ?? NULL,
-                'pan_truncation' => $result['result']['pan_truncation'] ?? NULL,
+                'card_type_id' => $paymentParams['card_type_id'] ?? NULL,
+                'pan_truncation' => $paymentParams['pan_truncation'] ?? NULL,
               ]);
             }
             catch (CRM_Core_Exception $e) {
@@ -2407,8 +2407,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
               'is_transactional' => FALSE,
               'fee_amount' => $result['fee_amount'] ?? NULL,
               'receive_date' => $result['receive_date'] ?? NULL,
-              'card_type_id' => $result['card_type_id'] ?? NULL,
-              'pan_truncation' => $result['pan_truncation'] ?? NULL,
+              'card_type_id' => $paymentParams['card_type_id'] ?? NULL,
+              'pan_truncation' => $paymentParams['pan_truncation'] ?? NULL,
             ]);
           }
           catch (CRM_Core_Exception $e) {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -227,6 +227,12 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $form->preProcess();
     $form->buildQuickForm();
     $form->postProcess();
+    $financialTrxnId = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['entity_id' => $form->_contributionID, 'entity_table' => 'civicrm_contribution', 'sequential' => 1])['values'][0]['financial_trxn_id'];
+    $financialTrxn = $this->callAPISuccess('FinancialTrxn', 'get', [
+      'id' => $financialTrxnId,
+    ])['values'][$financialTrxnId];
+    $this->assertEquals('1111', $financialTrxn['pan_truncation']);
+    $this->assertEquals(1, $financialTrxn['card_type_id']);
     $assignedVariables = $form->get_template_vars();
     $this->assertTrue($assignedVariables['is_separate_payment']);
   }


### PR DESCRIPTION
… when processing front end contributions

Overview
----------------------------------------
This fixes an issue where on front end Contribution form the Card Type ID and Pan Truncation were not being stored since about 5.49

Before
----------------------------------------
Card details not stored

After
----------------------------------------
Card details are stored

Technical Details
----------------------------------------
This seemed to be assuming that the original params would be returned with the payment processor result added in but that I think has changed and is not consistent with https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/Confirm.php#L921 and https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Contribution.php#L1185

ping @Stoob @eileenmcnaughton 