### PR TITLE
Remove noisily deprecated code

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -280,10 +280,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->setFormAmountFields($this->_params['priceSetId']);
     }
 
-    if (!empty($this->get('tax_amount'))) {
-      CRM_Core_Error::deprecatedWarning('tax_amount should be not passed in');
-      $this->_params['tax_amount'] = $this->get('tax_amount');
-    }
     $this->_useForMember = $this->get('useForMember');
 
     CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($this->_params);

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1415,7 +1415,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     if ($taxAmount = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_ccid, 'tax_amount')) {
-      $this->set('tax_amount', $taxAmount);
       $this->assign('taxAmount', $taxAmount);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove noisily deprecated code

Before
----------------------------------------
Nearly a year ago @mattwire added noisy deprecation to lines that handle tax_amount in the contribution forms. Tax amount should generally be handled differently (calculated from line items) so this was precautionary. This removes those lines

![image](https://user-images.githubusercontent.com/336308/228997908-752fa696-a211-4a9e-9b24-bdf51cf0dd74.png)

![image](https://user-images.githubusercontent.com/336308/228998070-15f63d3f-4cae-40b3-8db3-79481d5ebaa3.png)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
