### PR TITLE
SearchKit - Pass entire record into `checkAccess`

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -612,12 +612,13 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       if ($missingRequiredFields->count() || count($vals) === 1) {
         return NULL;
       }
+      $entityValues = $editable['record'];
     }
     // Ensure current user has access
     if ($editable['record']) {
       $access = civicrm_api4($editable['entity'], 'checkAccess', [
         'action' => $editable['action'],
-        'values' => $editable['record'],
+        'values' => $entityValues,
       ], 0)['access'];
       if ($access) {
         // Remove info that's for internal use only


### PR DESCRIPTION
Overview
----------------------------------------
Efficiency tweak for SearchKit

Technical Details
----------------------------------------
For efficiency it's best to pass all available data into the  action to avoid unnecessary db lookups. This ensures the full record is passed in when checking access before enabling in-place edit.
