### PR TITLE
BAO - deprecate create for writeRecord: SubscriptionHistory

### DIFF
--- a/CRM/Contact/BAO/SubscriptionHistory.php
+++ b/CRM/Contact/BAO/SubscriptionHistory.php
@@ -16,25 +16,30 @@
  */
 
 /**
- * BAO object for crm_email table.
+ * BAO object for civicrm_subscription_history table.
  */
-class CRM_Contact_BAO_SubscriptionHistory extends CRM_Contact_DAO_SubscriptionHistory {
+class CRM_Contact_BAO_SubscriptionHistory extends CRM_Contact_DAO_SubscriptionHistory implements \Civi\Core\HookInterface {
 
   /**
-   * Create a new subscription history record.
-   *
+   * @deprecated
    * @param array $params
-   *   Values for the new history record.
-   *
-   * @return object
-   *   $history  The new history object
+   * @return CRM_Contact_DAO_SubscriptionHistory
    */
   public static function create($params) {
-    $history = new CRM_Contact_BAO_SubscriptionHistory();
-    $history->date = date('YmdHis');
-    $history->copyValues($params);
-    $history->save();
-    return $history;
+    return self::writeRecord($params);
+  }
+
+  /**
+   * Callback for hook_civicrm_pre().
+   *
+   * @param \Civi\Core\Event\PreEvent $event
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event): void {
+    if ($event->action === 'create' || $event->action === 'edit') {
+      $event->params['date'] = date('YmdHis');
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Part of an ongoing cleanup effort to standardize BAO write functions.