### PR TITLE
Civi-Import - improvements to the search display for imported rows

### DIFF
--- a/ext/civiimport/Civi/Api4/Import.php
+++ b/ext/civiimport/Civi/Api4/Import.php
@@ -10,7 +10,7 @@
  */
 namespace Civi\Api4;
 
-use Civi\Api4\Generic\CheckAccessAction;
+use Civi\Api4\Import\CheckAccessAction;
 use Civi\Api4\Generic\DAOGetAction;
 use Civi\Api4\Generic\DAOGetFieldsAction;
 use Civi\Api4\Action\GetActions;

--- a/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
+++ b/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
@@ -12,8 +12,6 @@
 
 namespace Civi\Api4\Import;
 
-use Civi\API\Exception\UnauthorizedException;
-use Civi\API\Request;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
 use Civi\Api4\Generic\Traits\GetSetValueTrait;

--- a/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
+++ b/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
@@ -12,39 +12,23 @@
 
 namespace Civi\Api4\Import;
 
-use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
-use Civi\Api4\Generic\Traits\GetSetValueTrait;
 use Civi\Api4\Utils\CoreUtil;
 
 /**
- * Check if current user is authorized to perform specified action on a given $ENTITY.
+ * Check if current user is authorized to perform specified action on the given import.
  *
- * @method $this setAction(string $action)
- * @method string getAction()
- * @method $this setValues(array $values)
- * @method array getValues()
+ * This is overridden to implement a permission on editing imported rows, mostly
+ * to make it less confusing as there is no meaning to importing edited rows.
  */
-class CheckAccessAction extends AbstractAction {
-
-  use GetSetValueTrait;
-
-  /**
-   * @var string
-   * @required
-   */
-  protected $action;
-
-  /**
-   * @var array
-   * @required
-   */
-  protected $values = [];
+class CheckAccessAction extends \Civi\Api4\Generic\CheckAccessAction {
 
   /**
    * @param \Civi\Api4\Generic\Result $result
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function _run(Result $result) {
+  public function _run(Result $result): void {
     // Prevent circular checks
     $action = $this->action;
     $entity = $this->getEntityName();
@@ -65,15 +49,6 @@ class CheckAccessAction extends AbstractAction {
       $granted = \Civi::$statics[__CLASS__ . $entity][$action][$userID] = CoreUtil::checkAccessDelegated($entity, $action, $this->values, $userID);
     }
     $result->exchangeArray([['access' => $granted]]);
-  }
-
-  /**
-   * This action is always allowed
-   *
-   * @return bool
-   */
-  public function isAuthorized(): bool {
-    return TRUE;
   }
 
 }

--- a/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
+++ b/ext/civiimport/Civi/Api4/Import/CheckAccessAction.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Import;
+
+use Civi\API\Exception\UnauthorizedException;
+use Civi\API\Request;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\Traits\GetSetValueTrait;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Check if current user is authorized to perform specified action on a given $ENTITY.
+ *
+ * @method $this setAction(string $action)
+ * @method string getAction()
+ * @method $this setValues(array $values)
+ * @method array getValues()
+ */
+class CheckAccessAction extends AbstractAction {
+
+  use GetSetValueTrait;
+
+  /**
+   * @var string
+   * @required
+   */
+  protected $action;
+
+  /**
+   * @var array
+   * @required
+   */
+  protected $values = [];
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    // Prevent circular checks
+    $action = $this->action;
+    $entity = $this->getEntityName();
+    $userID = \CRM_Core_Session::getLoggedInContactID() ?: 0;
+    if ($action === 'checkAccess') {
+      $granted = TRUE;
+    }
+    elseif (isset(\Civi::$statics[__CLASS__ . $entity][$action][$userID])) {
+      $granted = \Civi::$statics[__CLASS__ . $entity][$action][$userID];
+    }
+    // If _status is not passed we could do a look up - but this permission is more of a
+    // UI thing than a true permission - ie the point is not to confuse the user
+    // with a meaningless option to edit-in-place in the search so it's kinda optional.
+    elseif (in_array($this->getValue('_status'), ['soft_credit_imported', 'pledge_payment_imported', 'IMPORTED'])) {
+      $granted = \Civi::$statics[__CLASS__ . $entity][$action][$userID] = FALSE;
+    }
+    else {
+      $granted = \Civi::$statics[__CLASS__ . $entity][$action][$userID] = CoreUtil::checkAccessDelegated($entity, $action, $this->values, $userID);
+    }
+    $result->exchangeArray([['access' => $granted]]);
+  }
+
+  /**
+   * This action is always allowed
+   *
+   * @return bool
+   */
+  public function isAuthorized(): bool {
+    return TRUE;
+  }
+
+}

--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -7,7 +7,7 @@ $managedEntities = [];
 $importEntities = Import::getImportTables();
 foreach ($importEntities as $importEntity) {
   try {
-    $fields = array_merge(['_id' => TRUE, '_status' => TRUE, '_status_message' => TRUE, '_entity_id' => TRUE], Import::getFieldsForUserJobID($importEntity['user_job_id'], FALSE));
+    $fields = array_merge(['_id' => TRUE, '_status' => TRUE, '_entity_id' => TRUE, '_status_message' => TRUE], Import::getFieldsForUserJobID($importEntity['user_job_id'], FALSE));
   }
   catch (CRM_Core_Exception $e) {
     continue;


### PR DESCRIPTION
Overview
----------------------------------------
Civi-Import - improvements to the search display for imported rows

Before
----------------------------------------
After importing contributions  there is a link to the table with the import rows. However, when tested @aydun found this confusing for 2 reasons

1) there was a caching bug so the most useful thing about this - being able to click through to the imported contribution wasn't working (this is now fixed in master)
2) absent that useful thing being apparent the focus became 'what is the point of being able to edit these rows? The answer to that is that it is only useful to be able to edit when the rows have failed to import & you want to try again

![image](https://user-images.githubusercontent.com/336308/229329459-07c08cdd-97af-4888-a87c-b4c90da7f786.png)


After
----------------------------------------
- edit in place does not appear on imported rows - only rows that have failed to import
- I re-orded the contribution ID to be before the status message - as the status message could be long & would push the contribution ID out of view

![image](https://user-images.githubusercontent.com/336308/229329497-0b661988-ac27-4f86-b972-0c108d8f921a.png)


Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw 