### PR TITLE
Fix enotice when using Civi-import

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -224,8 +224,19 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    * @throws \CRM_Core_Exception
    */
   protected function saveMappingField(int $mappingID, int $columnNumber, bool $isUpdate = FALSE): void {
-    $fieldMapping = (array) $this->getSubmittedValue('mapper')[$columnNumber];
-    $mappedField = $this->getMappedField($fieldMapping, $mappingID, $columnNumber);
+    if (!empty($this->userJob['metadata']['import_mappings'])) {
+      // In this case Civi-Import has already saved the mapping to civicrm_user_job.metadata
+      // and the code here is just keeping civicrm_mapping_field in sync.
+      // Eventually we hope to phase out the use of the civicrm_mapping data &
+      // just use UserJob and Import Templates (UserJob records with 'is_template' = 1
+      $mappedFieldData = $this->userJob['metadata']['import_mappings'][$columnNumber];
+      $mappedField = array_intersect_key(array_fill_keys(['name', 'column_number', 'entity_data'], TRUE), $mappedFieldData);
+      $mappedField['mapping_id'] = $mappingID;
+    }
+    else {
+      $fieldMapping = (array) $this->getSubmittedValue('mapper')[$columnNumber];
+      $mappedField = $this->getMappedField($fieldMapping, $mappingID, $columnNumber);
+    }
     if (empty($mappedField['name'])) {
       $mappedField['name'] = 'do_not_import';
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotice when using Civi-import

Before
----------------------------------------
When Civi-import is enabled and the there is an attempt to save an import configuration which includes Soft Credit fields e-notices appear and the Soft credit fields are not saved to `civicrm_mapping_field`. This is actually a cosmetic rather than functional issue as the values in  `civicrm_mapping_field` and not the primary information source for mappings when Civi-Import is enabled. They are synced to the primary source - which is the `import_mappings`  key in the `civicrm_user_job.metadata` field. We don't necessary want to keep this sync forever - but while it exists it should work....

After
----------------------------------------
E-notices fixed, it saves

Technical Details
----------------------------------------
The underlying problem we are hacking around is that we use api syntax (with dots between entity & field names) with the import code but the QuickForm hierarchical Select element does not support the dots (which I think break it's js). On the QuickForm layer we swap them out for `__` & then back again but on the angular layer we keep the dots & save the values to the more sophisticated data structure in the metadata

Comments
----------------------------------------
Not new to this PR but I do wonder if my js structure [here](https://github.com/civicrm/civicrm-core/blob/6b0a7c820050e99b7fe508be1ac1941afec3f816/ext/civiimport/ang/crmCiviimport/Import.html#L146) and [here](https://github.com/civicrm/civicrm-core/blob/6b0a7c820050e99b7fe508be1ac1941afec3f816/ext/civiimport/ang/crmCiviimport.js#L255-L280) is at risk of Quickform submit starting before the js has saved the job. Recommendations welcome on it