### PR TITLE
Minor fixes to Civi-Import screen, populating defaults, missing `ts`

### DIFF
--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -265,7 +265,7 @@
               // For now we just hard-code this - mapping to soft_credit a bit undefined - but
               // we are mimicking getMappingFieldFromMapperInput on the php layer.
               // Could get it from entity_data but .... later.
-              entityConfig = {'soft_credit': $scope.userJob.metadata.entity_configuration[selectedEntity].entity.entity_data};
+              entityConfig = {'soft_credit': $scope.userJob.metadata.entity_configuration[selectedEntity]};
             }
 
             $scope.userJob.metadata.import_mappings.push({

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -56,7 +56,7 @@
         <div ng-if="entity.entity_data && entity.selected.action !== 'ignore'">
           <div ng-repeat="(fieldName, entityField) in entity.entity_data">
             <label>
-              {{ entityField.title }}  <input  class="big" crm-ui-select='{data: entityField.options, required : entityField.is_required}' ng-model="entity.selected.entity.entity_data[fieldName]"/>
+              {{ entityField.title }}  <input  class="big" crm-ui-select='{data: entityField.options, required : entityField.is_required}' ng-model="entity.selected[fieldName]"/>
             </label>
           </div>
         </div>
@@ -142,8 +142,8 @@
 </div>
 
 <div class="crm-submit-buttons">
-  <button class="crm-form-submit cancel crm-button crm-button-type-back crm-button_qf_MapField_back" value="1" type="submit" name="_qf_MapField_back" id="_qf_MapField_back-bottom"><i aria-hidden="true" class="crm-i fa-chevron-left"></i> Previous</button>
-  <button ng-click="save($event)" class="crm-form-submit default validate crm-button crm-button-type-next crm-button_qf_MapField_next" value="1" type="submit" name="_qf_MapField_next" id="_qf_MapField_next-bottom"><i aria-hidden="true" class="crm-i fa-check"></i> Continue</button>
-  <button class="crm-form-submit cancel crm-button crm-button-type-cancel crm-button_qf_MapField_cancel" value="1" type="submit" name="_qf_MapField_cancel" id="_qf_MapField_cancel-bottom"><i aria-hidden="true" class="crm-i fa-times"></i> Cancel</button>
+  <button class="crm-form-submit cancel crm-button crm-button-type-back crm-button_qf_MapField_back" value="1" type="submit" name="_qf_MapField_back" id="_qf_MapField_back-bottom"><i aria-hidden="true" class="crm-i fa-chevron-left"></i>{{:: ts('Previous') }}</button>
+  <button ng-click="save($event)" class="crm-form-submit default validate crm-button crm-button-type-next crm-button_qf_MapField_next" value="1" type="submit" name="_qf_MapField_next" id="_qf_MapField_next-bottom"><i aria-hidden="true" class="crm-i fa-check"></i>{{:: ts('Continue') }}</button>
+  <button class="crm-form-submit cancel crm-button crm-button-type-cancel crm-button_qf_MapField_cancel" value="1" type="submit" name="_qf_MapField_cancel" id="_qf_MapField_cancel-bottom"><i aria-hidden="true" class="crm-i fa-times"></i>{{:: ts('Cancel') }}</button>
 </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Minor fixes to Civi-Import screen, populating defaults, missing `ts`

Before
----------------------------------------
When selecting to import soft credit contacts during contribution import (with Civi-Import) it does not pre-fill the relevant fields

![image](https://user-images.githubusercontent.com/336308/229337973-bcfbed12-9ba7-4229-a031-d967b58e2ef9.png)

This means the fields can easily be left blank - although they are actually required & cannot  be blanked once something is in them. In addition it winds up more confusing that they are blank because then you have to select the contact type before type-specific fields become available. The visual trigger of the wrong type is much more likely to make the user realise the issue than an empty type.

After
----------------------------------------
Defaults filled in, using the default soft credit type id rather than the 'first one' 

Also some translates added

Technical Details
----------------------------------------


Comments
----------------------------------------
