### PR TITLE
Fix error when importing a soft credit AND a note when currency not provided

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -471,7 +471,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
 
       if (!empty($softCreditParams)) {
         if (empty($contributionParams['total_amount']) || empty($contributionParams['currency'])) {
-          $contributionParams = Contribution::get()->addSelect('total_amount', 'currency')->addWhere('id', '=', $contributionID)->execute()->first();
+          $contributionParams = array_merge($contributionParams, Contribution::get()->addSelect('total_amount', 'currency')->addWhere('id', '=', $contributionID)->execute()->first());
         }
         foreach ($softCreditParams as $softCreditParam) {
           $softCreditParam['contribution_id'] = $contributionID;

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -112,7 +112,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'financial_type_id'],
       ['name' => 'external_identifier'],
       ['name' => 'soft_credit.contact.external_identifier', 'soft_credit_type_id' => 1],
-      ['name' => ''],
+      ['name' => 'note'],
     ];
     $this->importCSV('contributions_amount_validate.csv', $mapping, ['onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix error when importing a soft credit AND a note when currency not provided

Before
----------------------------------------
In order to create the soft credit record there is a lookup on the Contribution record if currency is not known - but this lookup is being assigned to `$contributionParams` rather than merged into it - meaning that `$contributionParams` 'loses track of' the contact_id - which is required to create the note

After
----------------------------------------
Now merged rather than overwrites - test

Technical Details
----------------------------------------

Comments
----------------------------------------
I think this regressed a while back - OK for rc, no need to port to stable