### PR TITLE
dev/core#4217 - Fix file on case search by id and broken entityref pagination

### DIFF
--- a/api/v3/Generic/Getlist.php
+++ b/api/v3/Generic/Getlist.php
@@ -41,7 +41,7 @@ function civicrm_api3_generic_getList($apiRequest) {
 
   $searchResult = _civicrm_api3_generic_getlist_get_result($request, $entity, $meta, $apiRequest);
   $foundIDCount = 0;
-  if ($forceIdSearch && !empty($result['values'])) {
+  if ($forceIdSearch && !empty($result['values']) && isset($idRequest['id'])) {
     $contactSearchID = $idRequest['id'];
     $foundIDCount = 1;
     // Merge id fetch into search result.
@@ -205,7 +205,7 @@ function _civicrm_api3_generic_getList_defaults(string $entity, array &$request,
       // Adding one extra result allows us to see if there are any more
       'limit' => $resultsPerPage + 1,
       // Because sql is zero-based
-      'offset' => ($request['page_num'] - 1) * $resultsPerPage,
+      'offset' => ($request['page_num'] > 1) ? (($request['page_num'] - 1) * $resultsPerPage) : 0,
     ];
   }
 }

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -134,6 +134,25 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     //Only 1 case should be returned.
     $this->assertEquals(count($result['values']), 1);
     $this->assertEquals($result['values'][0]['id'], $case1['id']);
+
+    // For this next part to work we need to make sure we don't have a ton of cases in total.
+    // We expect cases to have ids 1, 2, 3 etc, so the 'input' param below should match one and only one.
+    $this->assertLessThan(10, $this->callAPISuccess('Case', 'getcount'));
+    // These are the same params as the file-on-case widget
+    $getParams = [
+      'input' => '2',
+      'extra' => ['contact_id'],
+      'params' => [
+        'version' => 3,
+        'case_id' => ['!=' => NULL],
+        'case_id.is_deleted' => 0,
+        'case_id.status_id' => ['!=' => "Closed"],
+        'case_id.end_date' => ['IS NULL' => 1],
+      ],
+    ];
+    $result = $this->callAPISuccess('case', 'getlist', $getParams);
+    $this->assertCount(1, $result['values']);
+    $this->assertEquals(2, $result['values'][0]['id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4217

Before
----------------------------------------
1. Can no longer search by case id in file-on-case popup
2. Pagination broken when searching by a number (also for e.g. contact entityref)

After
----------------------------------------


Technical Details
----------------------------------------
`OFFSET -10` isn't valid is the main thing

Comments
----------------------------------------
