### PR TITLE
[NFC] Don't have null values for required fields in Case test fixture

### DIFF
--- a/tests/fixtures/case.json
+++ b/tests/fixtures/case.json
@@ -3,7 +3,9 @@
         {
             "id": 1,
             "case_type_id": 1,
-            "status_id": 1
+            "status_id": 1,
+            "start_date": "2023-01-02",
+            "subject": "test case"
         }
     ]
 }


### PR DESCRIPTION
Overview
----------------------------------------
The fields get created as NULL, which doesn't make sense for start_date, and at least on the form subject is required.

I don't think this is used much - tests generally create their own case - but this is more realistic data.