### PR TITLE
Ensure counties are properly imported even if ambiguous

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
+++ b/tests/phpunit/CRM/Contact/Import/Form/data/individual_country_state_county_with_related.csv
@@ -4,6 +4,6 @@ Susie,Jones,susie@example.com,,,,,,,,Mum,Jones,mum@example.com,NSW,ABC,Farnell,,
 Susie,Jones,susie@example.com,farnell,Australia,NSW,NSW,Australia,Australia,NSW,Mum,Jones,mum@example.com,NSW,Australia,Farnell,Australia,NSW,Australia,NSW,Valid,
 Susie,Jones,susie@example.com,farnell,AU,New South Wales,New South Wales,AU,AU,New South Wales,Mum,Jones,mum@example.com,New South Wales,AU,Farnell,AU,New South Wales,Australia,New South Wales,Valid,
 Susie,Jones,susie@example.com,FARNELL,1013,New South Wales,,1013,1013,New South Wales,Mum,Jones,mum@example.com,New South Wales,1013,Farnell,1013,New South Wales,1013,New South Wales,Valid,
-Susie,Jones,susie@example.com,Farnell,AUSTRALIA,,,,,,Mum,Jones,mum@example.com,,austRalia,Farnell,,,,,Valid,
+Susie,Jones,susie@example.com,Farnell,AUSTRALIA,NSW,,,,,Mum,Jones,mum@example.com,NSW,austRalia,Farnell,,,,,Valid,
 Susie,Jones,susie@example.com,Farnell,AU,NEW South Wales,NEW South Wales,AU,AU,NEW South Wales,Mum,Jones,mum@example.com,NEW South Wales,AU,Farnell,AU,NEW South Wales,Australia,NEW South Wales,Valid,
 Susie,Jones,susie@example.com,,AU,My own personal fiefdom,My own personal fiefdom,AU,AU,My own personal fiefdom,Mum,Jones,mum@example.com,My own personal fiefdom,AU,Farnell,AU,My own personal fiefdom,Australia,My own personal fiefdom,Invalid,rando

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -65,6 +65,7 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     $this->quickCleanup(['civicrm_address', 'civicrm_phone', 'civicrm_openid', 'civicrm_email', 'civicrm_user_job', 'civicrm_relationship', 'civicrm_im', 'civicrm_website', 'civicrm_queue', 'civicrm_queue_item'], TRUE);
     RelationshipType::delete()->addWhere('name_a_b', '=', 'Dad to')->execute();
     ContactType::delete()->addWhere('name', '=', 'baby')->execute();
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_setting WHERE name = "defaultContactCountry"');
     parent::tearDown();
   }
 
@@ -1348,11 +1349,19 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testImportCountryStateCounty(): void {
+    \Civi::settings()->set('defaultContactCountry', 1013);
     $countyID = County::create()->setValues([
       'name' => 'Farnell',
       'abbreviation' => '',
       'state_province_id' => 1640,
     ])->execute()->first()['id'];
+    // What if there are two counties with the same name?
+    County::create()->setValues([
+      'name' => 'Farnell',
+      'abbreviation' => '',
+      'state_province_id' => 1641,
+    ])->execute()->first()['id'];
+
     $childKey = $this->getRelationships()['Child of']['id'] . '_a_b';
     $addressCustomGroupID = $this->createCustomGroup(['extends' => 'Address', 'name' => 'Address']);
     $contactCustomGroupID = $this->createCustomGroup(['extends' => 'Contact', 'name' => 'Contact']);


### PR DESCRIPTION
If a county has a unique name, you can import it by name.

But, if there is one or more counties with the same name, the county is not properly converted to an id, and we get a foreign constraint error and/or a invalid value error.

@jmcclelland  - proposed replacement for https://github.com/civicrm/civicrm-core/pull/25116