### PR TITLE
Fix url from just-merged PR

### DIFF
--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -132,7 +132,7 @@ return [
               'label' => E::ts('Import Name'),
               'sortable' => TRUE,
               'link' => [
-                'path' => 'civicrm/contribute/import?reset=1&template_id=[id]',
+                'path' => 'civicrm/import/contribution?reset=1&template_id=[id]',
                 'entity' => '',
                 'action' => '',
                 'join' => '',


### PR DESCRIPTION
The UserJob template search was just merged but in full-release testing I found that the url that was in in pre-dated another PR that was merged - I'm just gonna self-merge this so it doesn't confuse anyone else....