### PR TITLE
Use label, where present for import field labels

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -457,7 +457,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
         continue;
       }
       $childField = [
-        'text' => $field['html']['label'] ?? $field['title'],
+        'text' => $field['label'] ?? ($field['html']['label'] ?? $field['title']),
         'id' => $fieldName,
         'has_location' => !empty($field['hasLocationType']),
         'default_value' => $field['default_value'] ?? '',


### PR DESCRIPTION


Overview
----------------------------------------
Use label, where present for import field labels

Label is preferred over title - when the metadata comes from the DAO it is in html['label'], but if it comes from apiv4 it seems it is mapped higher up...


Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/229409260-58c3201d-a39a-445c-8473-634db8b4fcb8.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/229409116-331871ad-5eef-4e41-af6b-fb24526dc0f0.png)


Technical Details
----------------------------------------
@colemanw 'label' seems consistent in apiv4 derived metadata?

Comments
----------------------------------------
