### PR TITLE
Authx - Add in new JWT Entity with Create and Validate methods to permi…

### DIFF
--- a/ext/authx/Civi/Api4/Action/JWT/Create.php
+++ b/ext/authx/Civi/Api4/Action/JWT/Create.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\JWT;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Generate a security checksum for anonymous access to CiviCRM.
+ *
+ * @method int getContactId() Get contact ID param (required)
+ * @method $this setContactId(int $contactId) Set the Contact Id
+ * @method $this setTtl(string $ttl) Set TTL param
+ * @method string getTtl() get the TTL param;
+ * @method $this setScope(string $scope) Set the JWT Scope
+ * @method string getScope() get the JWT scopes
+ */
+class Create extends \Civi\Api4\Generic\AbstractAction {
+  /**
+   * ID of contact
+   *
+   * @var int
+   * @required
+   */
+  protected $contactId;
+
+  /**
+   * Expiration time (in seconds). Defaults to 300 seconds
+   *
+   * @var int
+   */
+  protected $ttl = NULL;
+
+
+  /**
+   * Scopes for the JWT
+   *
+   * @var string
+   */
+  protected $scope = NULL;
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $ttl = $this->ttl ?: 300;
+    $scope = $this->scope ?: 'authx';
+
+    $token = \Civi::service('crypto.jwt')->encode([
+      'exp' => time() + $ttl,
+      'sub' => 'cid:' . $this->contactId,
+      'scope' => $scope,
+    ]);
+
+    $result[] = [
+      'token' => $token,
+    ];
+  }
+
+}

--- a/ext/authx/Civi/Api4/Action/JWT/Validate.php
+++ b/ext/authx/Civi/Api4/Action/JWT/Validate.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\JWT;
+
+use Civi\Api4\Generic\Result;
+use Civi\Authx\AuthxException;
+use Civi\Authx\AuthenticatorTarget;
+use Civi\Authx\CheckCredentialEvent;
+
+/**
+ * Validate that a JWT is still valid and can be used in CiviCRM.
+ *
+ * @method int getToken() Get Token to validate (required)
+ * @method setToken(string $token) Get contact ID param (required)
+ */
+class Validate extends \Civi\Api4\Generic\AbstractAction {
+  /**
+   * Token to validate
+   *
+   * @var string
+   * @required
+   */
+  protected $token;
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $tgt = AuthenticatorTarget::create([
+      'flow' => 'script',
+      'cred' => 'Bearer ' . $this->token,
+      'siteKey' => NULL,
+      'useSession' => FALSE,
+    ]);
+    $checkEvent = new CheckCredentialEvent($tgt->cred);
+    \Civi::dispatcher()->dispatch('civi.authx.checkCredential', $checkEvent);
+
+    if ($checkEvent->getRejection()) {
+      throw new AuthxException($checkEvent->getRejection());
+    }
+
+    $result[] = $checkEvent->getPrincipal();
+  }
+
+}

--- a/ext/authx/Civi/Api4/JWT.php
+++ b/ext/authx/Civi/Api4/JWT.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Methods of handling JWTs
+ *
+ * @searchable none
+ * @since 5.62
+ * @package Authx
+ */
+class JWT extends Generic\AbstractEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\JWT\create
+   */
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\JWT\Create(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\JWT\validate
+   */
+  public static function validate($checkPermissions = TRUE) {
+    return (new Action\JWT\Validate(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function() {
+      return [];
+    }))->setCheckPermissions($checkPermissions);
+  }
+
+  public static function permissions() {
+    return [
+      'meta' => ['access CiviCRM'],
+      'default' => ['administer CiviCRM'],
+      'create' => ['generate JWT'],
+      'validate' => [],
+    ];
+  }
+
+}

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -124,6 +124,7 @@ function authx_civicrm_enable() {
 function authx_civicrm_permission(&$permissions) {
   $permissions['authenticate with password'] = E::ts('AuthX: Authenticate to services with password');
   $permissions['authenticate with api key'] = E::ts('AuthX: Authenticate to services with API key');
+  $permissions['generate JWT'] = E::ts('Authx: Permit the generation of JWTs via the API');
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---

--- a/ext/authx/tests/phpunit/api/v4/JwtApiTest.php
+++ b/ext/authx/tests/phpunit/api/v4/JwtApiTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace api\v4\Authx;
+
+use Civi\Api4\JWT;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test JWT API methods
+ * @group headless
+ */
+class JwtApiTest extends TestCase implements HeadlessInterface, TransactionalInterface {
+
+  use \Civi\Test\Api4TestTrait;
+  use \Civi\Test\Api3TestTrait;
+  use \Civi\Test\ContactTestTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testJWTGenrateToken(): void {
+    $this->_apiversion = 4;
+    $contactRecord = $this->createTestRecord('Contact', ['contact_type' => 'Individual']);
+    $this->createLoggedInUser();
+    $this->setPermissions([
+      'access CiviCRM',
+    ]);
+    try {
+      JWT::create()->setContactId($contactRecord['id'])->execute();
+      $this->fail('JWT Should not be created as permission is not granted');
+    }
+    catch (\Exception $e) {
+    }
+    $this->setPermissions([
+      'access CiviCRM',
+      'generate JWT',
+    ]);
+    $jwt = JWT::create()->setContactId($contactRecord['id'])->execute();
+    $this->assertNotEmpty($jwt[0]['token']);
+  }
+
+  public function testJWTValidation(): void {
+    $this->_apiversion = 4;
+    $contactRecord = $this->createTestRecord('Contact', ['contact_type' => 'Individual']);
+    $this->createLoggedInUser();
+    $this->setPermissions([
+      'access CiviCRM',
+      'generate JWT',
+    ]);
+    $jwt = JWT::create()->setContactId($contactRecord['id'])->execute();
+    $validate = JWT::validate()->setToken($jwt[0]['token'])->execute();
+    $this->assertEquals('jwt', $validate[0]['credType']);
+    $this->assertEquals($contactRecord['id'], $validate[0]['contactId']);
+    $this->assertEquals('cid:' . $contactRecord['id'], $validate[0]['jwt']['sub']);
+  }
+
+  /**
+   * Test that the JWT does not validate if expired
+   */
+  public function testExpiredJWTValidation(): void {
+    $this->expectException(\Civi\Authx\AuthxException::class);
+    $this->expectExceptionMessage('Expired token');
+    $this->_apiversion = 4;
+    $contactRecord = $this->createTestRecord('Contact', ['contact_type' => 'Individual']);
+    $this->createLoggedInUser();
+    $this->setPermissions([
+      'access CiviCRM',
+      'generate JWT',
+    ]);
+    $jwt = JWT::create()->setContactId($contactRecord['id'])->setTtl(5)->execute();
+    sleep(10);
+    $validate = JWT::validate()->setToken($jwt[0]['token'])->execute();
+  }
+
+  /**
+   * Set ACL permissions, overwriting any existing ones.
+   *
+   * @param array $permissions
+   *   Array of permissions e.g ['access CiviCRM','access CiviContribute'],
+   */
+  protected function setPermissions(array $permissions): void {
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
+  }
+
+}


### PR DESCRIPTION
…t creation and validation of JWTs via the API

Overview
----------------------------------------
This PR adds in JWT.create and JWT.validate actions to allow 3rd party applications to potentially generate JWTs over APIs when you're in a service principle concept

Before
----------------------------------------
No Methods to create JWT or validate it over the API

After
----------------------------------------
New Methods to do the above

ping @totten @johntwyman 