### PR TITLE
🥚 Payment API creates Activity with subject: "$x Offline Payment for Contribution" even when a payment was captured online

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3522,7 +3522,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public static function addActivityForPayment($targetCid, $activityType, $title, $contributionId, $totalAmount, $currency, $trxn_date) {
     $paymentAmount = CRM_Utils_Money::format($totalAmount, $currency);
-    $subject = "{$paymentAmount} - Offline {$activityType} for {$title}";
+    $subject = "{$paymentAmount} - {$activityType} for {$title}";
     $date = CRM_Utils_Date::isoToMysql($trxn_date);
     // source record id would be the contribution id
     $srcRecId = $contributionId;

--- a/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/AdditionalPaymentTest.php
@@ -179,8 +179,8 @@ class CRM_Contribute_Form_AdditionalPaymentTest extends CiviUnitTestCase {
       'return' => ['target_contact_id', 'assignee_contact_id', 'subject'],
     ])['values'];
     $this->assertCount(3, $activities);
-    $this->assertEquals('$ 50.00 - Offline Payment for Contribution', $activities[1]['subject']);
-    $this->assertEquals('$ 20.00 - Offline Payment for Contribution', $activities[2]['subject']);
+    $this->assertEquals('$ 50.00 - Payment for Contribution', $activities[1]['subject']);
+    $this->assertEquals('$ 20.00 - Payment for Contribution', $activities[2]['subject']);
     $this->assertEquals(CRM_Core_Session::singleton()->getLoggedInContactID(), $activities[0]['source_contact_id']);
     $this->assertEquals([$this->_individualId], $activities[0]['target_contact_id']);
     $this->assertEquals([], $activities[0]['assignee_contact_id']);


### PR DESCRIPTION
Overview
----------------------------------------
Payment API creates Activity with subject: "$x Offline Payment for Contribution" even when a payment was captured online.

This change simply removes the word "Offline" so that it works for describing both online and offline payments.

Before
----------------------------------------
When the recordPaymentActivity function is called, the addActivityForPayment function has the word "Offline" hard coded for the Activity subject, irrespective of how the payment was created.

![image](https://user-images.githubusercontent.com/58866555/229701283-bde43a3f-be3f-41df-98e9-ee84d26017b3.png)


After
----------------------------------------
The word "Offline" is removed, so when the Activity is created it still describes both online and offline payments.

Technical Details
----------------------------------------

Comments
----------------------------------------
Ideally the generic "Contribution" would also be set in recordPaymentActivity to refer to Membership, Event or Contribution. For Events, it will use the Event Title but for everything else just uses: "Contribution".

Agileware Ref: CIVICRM-2120
