### PR TITLE
fix multi-value custom fields on participant import

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -123,21 +123,11 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         throw new CRM_Core_Exception($formatError['error_message']);
       }
 
-      if (!$this->isUpdateExisting()) {
-        $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-          NULL,
-          'Participant'
-        );
-      }
-      else {
+      if ($this->isUpdateExisting()) {
         if (!empty($formatValues['participant_id'])) {
           $dao = new CRM_Event_BAO_Participant();
           $dao->id = $formatValues['participant_id'];
 
-          $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-            $formatValues['participant_id'],
-            'Participant'
-          );
           if ($dao->find(TRUE)) {
             $ids = [
               'participant' => $formatValues['participant_id'],
@@ -276,27 +266,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       // ignore empty values or empty arrays etc
       if (CRM_Utils_System::isNull($value)) {
         continue;
-      }
-
-      // Handling Custom Data
-      if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        $values[$key] = $value;
-        $type = $customFields[$customFieldID]['html_type'];
-        if (CRM_Core_BAO_CustomField::isSerialized($customFields[$customFieldID])) {
-          $values[$key] = self::unserializeCustomValue($customFieldID, $value, $type);
-        }
-        elseif ($type == 'Select' || $type == 'Radio') {
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          foreach ($customOption as $customFldID => $customValue) {
-            $val = $customValue['value'] ?? NULL;
-            $label = $customValue['label'] ?? NULL;
-            $label = strtolower($label);
-            $value = strtolower(trim($value));
-            if (($value == $label) || ($value == strtolower($val))) {
-              $values[$key] = $val;
-            }
-          }
-        }
       }
 
       switch ($key) {

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -143,6 +143,8 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
    */
   public function testImportParticipant() :void {
     $this->eventCreate(['title' => 'Rain-forest Cup Youth Soccer Tournament']);
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Participant'], 'checkbox');
+    $cfName = $this->getCustomFieldName('checkbox');
     $contactID = $this->individualCreate(['external_identifier' => 'ref-77']);
     $this->importCSV('participant_with_ext_id.csv', [
       ['name' => 'event_id'],
@@ -157,6 +159,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
       ['name' => 'status_id'],
       ['name' => 'register_date'],
       ['name' => 'do_not_import'],
+      ['name' => $cfName],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();
@@ -172,6 +175,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     $this->assertEquals('2022-12-07 00:00:00', $result['participant_register_date']);
     $this->assertEquals(['Attendee', 'Volunteer'], $result['participant_role']);
     $this->assertEquals(0, $result['participant_is_pay_later']);
+    $this->assertEquals(['P', 'M'], array_keys($result[$cfName]));
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
@@ -1,2 +1,2 @@
-Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import
-Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,
+Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import,Color
+Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"


### PR DESCRIPTION
Overview
----------------------------------------
Importing multi-value custom fields on "Import Participants" crashes the import.

Before
----------------------------------------
```
PHP Fatal error:  Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, array given in /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Import/Parser.php:1363
```

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
This code in `CRM_Event_Import_Parser_Participant::formatValues()` is duplicative of code in `CRM_Import_Parser::getMappedRow()`.  `formatValues()` is only called once, in `CRM_Event_Import_Parser_Participant::import()`, which always calls `getMappedRow()` first.

Comments
----------------------------------------
This test will fail until https://github.com/civicrm/civicrm-core/pull/25945 is merged, because of the bug with the role_id.

Also, all of `formatValues()` is suspect because it's matching on incorrect array keys (e.g. `participant_event_id` and not `event_id`.
