### PR TITLE
Avoid potentially undefined var

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -57,10 +57,8 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship implemen
     }
     $params = $extendedParams;
     // Check if this is a "simple" disable relationship. If it is don't check the relationshipType
-    if (!empty($params['id']) && array_key_exists('is_active', $params) && empty($params['is_active'])) {
-      $disableRelationship = TRUE;
-    }
-    if (empty($disableRelationship) && !CRM_Contact_BAO_Relationship::checkRelationshipType($params['contact_id_a'], $params['contact_id_b'], $params['relationship_type_id'])) {
+    $disableRelationship = !empty($params['id']) && array_key_exists('is_active', $params) && empty($params['is_active']);
+    if (!$disableRelationship && !CRM_Contact_BAO_Relationship::checkRelationshipType($params['contact_id_a'], $params['contact_id_b'], $params['relationship_type_id'])) {
       throw new CRM_Core_Exception('Invalid Relationship');
     }
     $relationship = self::add($params);


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/25647#discussion_r1151285735

Before
----------------------------------------
While php doesn't complain, it seems better to make sure the variable is defined since it can be undefined at line 63. Some fancy IDEs might warn about it.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

