### PR TITLE
Declare strict types in CiviUnitTestCase

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -25,7 +25,7 @@
  *   License along with this program.  If not, see
  *   <http://www.gnu.org/licenses/>.
  */
-
+declare(strict_types = 1);
 use Civi\Api4\Address;
 use Civi\Api4\Contribution;
 use Civi\Api4\CustomField;


### PR DESCRIPTION
Overview
----------------------------------------
Declare strict types in CiviUnitTestCase

Before
----------------------------------------
Strict types not declared in unit tests

After
----------------------------------------
Strict types declared on main base class

Technical Details
----------------------------------------
My reading of 
https://www.phptutorial.net/php-tutorial/php-strict_types/

is that
1) declaring strict type declarations in tests might help us pick up bugs we would otherwise miss and
2) I *believe* that we would have to declare it in EVERY test file, rather than it inheritting to child classes

Comments
----------------------------------------
Let's see what this throws up...