### PR TITLE
Clarify `entityID` types in Merger class

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -161,7 +161,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $cmsUser = $mainUfId && $otherUfId;
       $this->assign('user', $cmsUser);
 
-      $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($this->_cid, $this->_oid);
+      $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo((int) $this->_cid, (int) $this->_oid);
       $main = $this->_mainDetails = $rowsElementsAndInfo['main_details'];
       $other = $this->_otherDetails = $rowsElementsAndInfo['other_details'];
 
@@ -311,7 +311,7 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
     $formValues['other_details'] = $this->_otherDetails;
 
     // Check if any rel_tables checkboxes have been de-selected
-    $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo($this->_cid, $this->_oid);
+    $rowsElementsAndInfo = CRM_Dedupe_Merger::getRowsElementsAndInfo((int) $this->_cid, (int) $this->_oid);
     // If rel_tables is not set then initialise with 0 value, required for the check which calls removeContactBelongings in moveAllBelongings
     foreach (array_keys($rowsElementsAndInfo['rel_tables']) as $relTableElement) {
       if (!array_key_exists($relTableElement, $formValues)) {


### PR DESCRIPTION
Overview
----------------------------------------
Clarify `entityID` types in Merger class

Before
----------------------------------------
As a carry over from when the `getTree` function was shared there is a lack of clarity about the type of `$entityID` - this is because in the shared usage it could also be NULL

After
----------------------------------------
The IDs are coming from the `getRowsElementsAndInfo` so I added typing to where that function receives the values & cast the values in all the places that call it (except the tests which will tell us if they are not already the right type...)

![image](https://user-images.githubusercontent.com/336308/229935087-af9f7094-b0b5-42d7-a8d5-0311a0f5ecee.png)

![image](https://user-images.githubusercontent.com/336308/229935585-6248a8d9-2dc1-45da-bd6b-132d6ff013af.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
