### PR TITLE
Remove upgrade custom field handling from Dedupe code - previously shared function

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1752,7 +1752,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     // create a new tree
 
     // legacy hardcoded list of data to return
-    $tableData = [
+    $toReturn = [
       'custom_field' => [
         'id',
         'name',
@@ -1773,6 +1773,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         'time_format',
         'option_group_id',
         'in_selector',
+        'serialize',
       ],
       'custom_group' => [
         'id',
@@ -1788,19 +1789,9 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         'extends_entity_column_id',
         'extends_entity_column_value',
         'max_multiple',
+        'is_public',
       ],
     ];
-    $current_db_version = CRM_Core_BAO_Domain::version();
-    $is_public_version = version_compare($current_db_version, '4.7.19', '>=');
-    $serialize_version = version_compare($current_db_version, '5.27.alpha1', '>=');
-    if ($is_public_version) {
-      $tableData['custom_group'][] = 'is_public';
-    }
-    if ($serialize_version) {
-      $tableData['custom_field'][] = 'serialize';
-    }
-
-    $toReturn = $tableData;
 
     // create select
     $select = [];
@@ -1809,17 +1800,17 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         $select[] = "civicrm_{$tableName}.{$columnName} as civicrm_{$tableName}_{$columnName}";
       }
     }
-    $strSelect = "SELECT " . implode(', ', $select);
+    $strSelect = 'SELECT ' . implode(', ', $select);
 
     // from, where, order by
-    $strFrom = "
+    $strFrom = '
 FROM     civicrm_custom_group
 LEFT JOIN civicrm_custom_field ON (civicrm_custom_field.custom_group_id = civicrm_custom_group.id)
-";
+';
 
     // if entity is either individual, organization or household pls get custom groups for 'contact' too.
-    if ($entityType == "Individual" || $entityType == 'Organization' ||
-      $entityType == 'Household'
+    if ($entityType === 'Individual' || $entityType === 'Organization' ||
+      $entityType === 'Household'
     ) {
       $in = "'$entityType', 'Contact'";
     }


### PR DESCRIPTION
Overview
----------------------------------------
Remove upgrade custom field handling from Dedupe code - previously shared function

Before
----------------------------------------
Previously shared code has handling to not crash when the db upgrade has not yet been done - but we don't really need to handle that in the dedupe code - we can reasonably assume deduping stops during upgrade (as opposed to code that might render the site unusable / make the upgrade unaccessible

After
----------------------------------------
poof

Technical Details
----------------------------------------
We will probably replace the whole lot with an api call or 2 once it is cleaned up to that point

Comments
----------------------------------------
