### PR TITLE
Strictness cleanups in test class

### DIFF
--- a/Civi/Test/DbTestTrait.php
+++ b/Civi/Test/DbTestTrait.php
@@ -25,9 +25,8 @@ trait DbTestTrait {
    * @param $id
    * @param $match
    * @param bool $delete
-   * @throws \PHPUnit_Framework_AssertionFailedError
    */
-  public function assertDBState($daoName, $id, $match, $delete = FALSE) {
+  public function assertDBState($daoName, $id, $match, $delete = FALSE): void {
     if (empty($id)) {
       // adding this here since developers forget to check for an id
       // and hence we get the first value in the db
@@ -170,14 +169,15 @@ trait DbTestTrait {
    * Example: $this->assertSql(2, 'select count(*) from foo where foo.bar like "%1"',
    * array(1 => array("Whiz", "String")));
    *
-   * @param $expected
-   * @param $query
+   * @param string|null $expected
+   * @param string $query
    * @param array $params
    * @param string $message
    *
-   * @throws \CRM_Core_Exception
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
    */
-  public function assertDBQuery($expected, $query, $params = [], $message = '') {
+  public function assertDBQuery(?string $expected, string $query, array $params = [], string $message = ''): void {
     if ($message) {
       $message .= ': ';
     }

--- a/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/ext/flexmailer/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -10,8 +10,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
 
   protected $_groupID;
   protected $_email;
-  protected $_apiversion = 3;
-  protected $_params = array();
+  protected $_params = [];
   protected $_entity = 'Mailing';
   protected $_contactID;
 

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -1364,7 +1364,7 @@ civicrm_relationship.is_active = 1 AND
    *
    * @return array
    */
-  public function relativeDateFilters() {
+  public function relativeDateFilters(): array {
     $dataProvider[] = ['this.year', "WHERE  ( contact_a.created_date BETWEEN 'date0' AND 'date1' )  AND (contact_a.is_deleted = 0)"];
     $dataProvider[] = ['greater.day', "WHERE  ( contact_a.created_date >= 'date0' )  AND (contact_a.is_deleted = 0)"];
     $dataProvider[] = ['earlier.week', "WHERE  ( contact_a.created_date <= 'date1' )  AND (contact_a.is_deleted = 0)"];
@@ -1382,10 +1382,8 @@ civicrm_relationship.is_active = 1 AND
    * Donation           |NULL                | 300.00     |SSF         | Donation,Donation         | 2                | 200.00,100.00
    * Donation           |2019-02-13 00:00:00 | 50.00      |SSF         | Donation                  | 1                | 50.00
    * Member Dues        |2019-02-13 00:00:00 | 50.00      |SSF         | Member Dues               | 1                | 50.00
-   *
-   * @throws \CRM_Core_Exception
    */
-  protected function createContributionsForSummaryQueryTests() {
+  protected function createContributionsForSummaryQueryTests(): void {
     $contactID = $this->individualCreate();
     $this->contributionCreate(['contact_id' => $contactID]);
     $this->contributionCreate([
@@ -1398,15 +1396,15 @@ civicrm_relationship.is_active = 1 AND
     $this->createContributionWithTwoLineItemsAgainstPriceSet(['contact_id' => $contactID, 'source' => 'SSF'], [
       CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
       $eventFeeType,
-    ]);
+    ], 'event_fee');
     $this->createContributionWithTwoLineItemsAgainstPriceSet(['contact_id' => $contactID, 'source' => 'SSF'], [
       CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
       CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
-    ]);
+    ], 'two_donations');
     $this->createContributionWithTwoLineItemsAgainstPriceSet(['contact_id' => $contactID, 'source' => 'SSF', 'financial_type_id' => $eventFeeType], [
       CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
       CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Donation'),
-    ]);
+    ], 'two_more_donations');
     $this->contributionCreate([
       'contact_id' => $contactID,
       'total_amount' => 50,
@@ -1438,7 +1436,7 @@ civicrm_relationship.is_active = 1 AND
    *
    * @throws \CRM_Core_Exception
    */
-  public function testGenericWhereHandling() {
+  public function testGenericWhereHandling(): void {
     $query = new CRM_Contact_BAO_Query([['suffix_id', '=', 2, 0]]);
     $this->assertEquals('contact_a.suffix_id = 2', $query->_where[0][0]);
     $this->assertEquals('Individual Suffix = Sr.', $query->_qill[0][0]);

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -746,13 +746,11 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
   /**
    * Test allowUpdateRevenueRecognitionDate.
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function testAllowUpdateRevenueRecognitionDate() {
-    $contactId = $this->individualCreate();
+  public function testAllowUpdateRevenueRecognitionDate(): void {
+    $contactID = $this->individualCreate();
     $params = [
-      'contact_id' => $contactId,
+      'contact_id' => $contactID,
       'receive_date' => '2010-01-20',
       'total_amount' => 100,
       'financial_type_id' => 4,
@@ -764,10 +762,10 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
     $event = $this->eventCreate();
     $params = [
-      'contact_id' => $contactId,
+      'contact_id' => $contactID,
       'receive_date' => '2010-01-20',
       'total_amount' => 300,
-      'financial_type_id' => $this->getFinancialTypeId('Event Fee'),
+      'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Price_BAO_PriceSet', 'financial_type_id', 'Event Fee'),
       'contribution_status_id' => 'Pending',
     ];
     $priceFields = $this->createPriceSet('event', $event['id']);
@@ -787,7 +785,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $params['line_items'][] = [
       'line_item' => $lineItems,
       'params' => [
-        'contact_id' => $contactId,
+        'contact_id' => $contactID,
         'event_id' => $event['id'],
         'status_id' => 1,
         'role_id' => 1,
@@ -800,14 +798,14 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $this->assertFalse($allowUpdate);
 
     $params = [
-      'contact_id' => $contactId,
+      'contact_id' => $contactID,
       'receive_date' => '2010-01-20',
       'total_amount' => 200,
       'financial_type_id' => $this->getFinancialTypeId('Member Dues'),
       'contribution_status_id' => 'Pending',
     ];
     $membershipType = $this->membershipTypeCreate();
-    $priceFields = $this->createPriceSet();
+    $priceFields = $this->createPriceSet('contribution_page', NULL, [], 'membership');
     $lineItems = [];
     foreach ($priceFields['values'] as $key => $priceField) {
       $lineItems[$key] = [
@@ -826,7 +824,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $params['line_items'][] = [
       'line_item' => [array_pop($lineItems)],
       'params' => [
-        'contact_id' => $contactId,
+        'contact_id' => $contactID,
         'membership_type_id' => $membershipType,
         'join_date' => '2006-01-21',
         'start_date' => '2006-01-21',
@@ -843,10 +841,8 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
 
   /**
    * Test recording of amount with comma separator.
-   *
-   * @throws \CRM_Core_Exception
    */
-  public function testCommaSeparatorAmount() {
+  public function testCommaSeparatorAmount(): void {
     $contactId = $this->individualCreate();
 
     $params = [

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -54,7 +54,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       0 => [
         13 => [
           'price_field_id' => $this->getPriceFieldID(),
-          'price_field_value_id' => $this->_ids['price_field_value'][0],
+          'price_field_value_id' => $this->ids['PriceFieldValue']['price_field'],
           'label' => 'Tiny-tots (ages 5-8)',
           'field_title' => 'Tournament Fees',
           'description' => NULL,
@@ -81,7 +81,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'role_id' => 1,
       'event_id' => $form->_eventId,
       'priceSetId' => $this->getPriceSetID('event'),
-      $this->getPriceFieldKey() => $this->_ids['price_field_value'][0],
+      $this->getPriceFieldKey() => $this->ids['PriceFieldValue']['price_field'],
       'is_pay_later' => 1,
       'amount_level' => 'Too much',
       'fee_amount' => 55,
@@ -212,7 +212,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'line_total' => 1550.55,
       'participant_count' => 0,
       'price_field_id' => $this->getPriceFieldID(),
-      'price_field_value_id' => $this->_ids['price_field_value'][1],
+      'price_field_value_id' => $this->ids['PriceFieldValue']['big'],
       'tax_amount' => 0,
       // Interestingly the financial_type_id set in this test is ignored but currently locking in what is happening with this test so setting to 'actual'
       'financial_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Event Fee'),
@@ -768,7 +768,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    * @return int
    */
   protected function getPriceFieldValueID(): int {
-    return (int) $this->_ids['price_field_value'][1];
+    return (int) $this->ids['PriceFieldValue']['big'];
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Event/Form/SearchTest.php
@@ -19,7 +19,7 @@ class CRM_Event_Form_SearchTest extends CiviUnitTestCase {
     parent::setUp();
     $this->individualID = $this->individualCreate();
     $event = $this->eventCreate();
-    $priceFieldValues = $this->createPriceSet('event', $event, [
+    $priceFieldValues = $this->createPriceSet('event', $event['id'], [
       'html_type'    => 'Radio',
       'option_label' => ['1' => 'Radio Label A (inc. GST)', '2' => 'Radio Label B (inc. GST)'],
       'option_name'  => ['1' => 'Radio Label A', '2' => 'Radio Label B'],

--- a/tests/phpunit/CRM/Price/Form/OptionTest.php
+++ b/tests/phpunit/CRM/Price/Form/OptionTest.php
@@ -24,7 +24,12 @@ class CRM_Price_Form_OptionTest extends CiviUnitTestCase {
     ]);
   }
 
-  public function testChangingUniquePublicOptionOnPublicFieldIsNotAllowed() {
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+  public function testChangingUniquePublicOptionOnPublicFieldIsNotAllowed(): void {
     $this->setUpPriceSet([
       'html_type' => 'Select',
       'visibility_id' => $this->visibilityOptionsKeys['public'],
@@ -51,7 +56,7 @@ class CRM_Price_Form_OptionTest extends CiviUnitTestCase {
     $this->assertTrue(array_key_exists('visibility_id', $validationResult));
   }
 
-  public function testAddingPublicOptionToAdminFieldIsNotAllowed() {
+  public function testAddingPublicOptionToAdminFieldIsNotAllowed(): void {
     $this->setUpPriceSet([
       'html_type' => 'Select',
       'visibility_id' => $this->visibilityOptionsKeys['admin'],

--- a/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/DeleteTest.php
@@ -39,15 +39,4 @@ class CRM_Utils_SQL_DeleteTest extends CiviUnitTestCase {
     $this->assertLike('DELETE FROM foo WHERE (foo IS NULL) AND (nonexistent IS @nonexistent) AND (morenonexistent IS @nonexistent) AND (bar IS "null")', $del->toSQL());
   }
 
-  /**
-   * @param $expected
-   * @param $actual
-   * @param string $message
-   */
-  public function assertLike($expected, $actual, $message = '') {
-    $expected = trim((preg_replace('/[ \r\n\t]+/', ' ', $expected)));
-    $actual = trim((preg_replace('/[ \r\n\t]+/', ' ', $actual)));
-    $this->assertEquals($expected, $actual, $message);
-  }
-
 }

--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -364,15 +364,4 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
     $this->assertLike('INSERT INTO bar (name, first, second) SELECT foo.name, concat(foo.one, " and on and on"), foo.two FROM foo WHERE (foo.whiz = 100) ON DUPLICATE KEY UPDATE first = concat(foo.one, " and on and on"), second = foo.two', $select->toSQL());
   }
 
-  /**
-   * @param $expected
-   * @param $actual
-   * @param string $message
-   */
-  public function assertLike($expected, $actual, $message = '') {
-    $expected = trim((preg_replace('/[ \r\n\t]+/', ' ', $expected)));
-    $actual = trim((preg_replace('/[ \r\n\t]+/', ' ', $actual)));
-    $this->assertEquals($expected, $actual, $message);
-  }
-
 }

--- a/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/FinancialACLTrait.php
@@ -82,7 +82,7 @@ trait CRMTraits_Financial_FinancialACLTrait {
    * @param array $permissions
    *   Array of permissions e.g ['access CiviCRM','access CiviContribute'],
    */
-  protected function setPermissions($permissions) {
+  protected function setPermissions(array $permissions): void {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
     if (isset(\Civi::$statics['CRM_Financial_BAO_FinancialType'])) {
       unset(\Civi::$statics['CRM_Financial_BAO_FinancialType']);

--- a/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/PriceSetTrait.php
@@ -36,12 +36,14 @@ trait CRMTraits_Financial_PriceSetTrait {
    *
    * This works for quick config pages with only one option.
    *
+   * @param int $contributionPageID
+   *
    * @return string
    *
    * @noinspection PhpUnhandledExceptionInspection
    * @noinspection PhpDocMissingThrowsInspection
    */
-  protected function getPriceFieldLabelForContributionPage($contributionPageID): string {
+  protected function getPriceFieldLabelForContributionPage(int $contributionPageID): string {
     $this->ids['PriceSet']['contribution_page' . $contributionPageID] = (int) PriceSetEntity::get(FALSE)
       ->addWhere('entity_id', '=', $contributionPageID)
       ->addWhere('entity_table', '=', 'civicrm_contribution_page')
@@ -70,14 +72,16 @@ trait CRMTraits_Financial_PriceSetTrait {
    * @param $params
    * @param array $lineItemFinancialTypes
    *   Financial Types, if an override is intended.
+   * @param string $identifier
+   *   Name to to identify price set.
    */
-  protected function createContributionWithTwoLineItemsAgainstPriceSet($params, array $lineItemFinancialTypes = []): void {
+  protected function createContributionWithTwoLineItemsAgainstPriceSet($params, array $lineItemFinancialTypes = [], string $identifier = 'Donation'): void {
     $params = (array) array_merge([
       'total_amount' => 300,
       'financial_type_id' => 'Donation',
       'contribution_status_id' => 'Pending',
     ], $params);
-    $priceFields = $this->createPriceSet('contribution');
+    $priceFields = $this->createPriceSet('contribution', NULL, [], $identifier);
     foreach ($priceFields['values'] as $key => $priceField) {
       $financialTypeID = (!empty($lineItemFinancialTypes) ? array_shift($lineItemFinancialTypes) : $priceField['financial_type_id']);
       $params['line_items'][]['line_item'][$key] = [


### PR DESCRIPTION
Overview
----------------------------------------
Strictness cleanups in test class

Before
----------------------------------------
In strict mode we see

![image](https://user-images.githubusercontent.com/336308/229943168-4fea9878-9f51-4801-9520-4926a5a03124.png)


After
----------------------------------------
I removed the sha bit - that randomisation is just a work-around for sloppy cleanup anyway - if the cleanup is done between tests we don't need to randomise

Technical Details
----------------------------------------
Various other minor cleanups

Comments
----------------------------------------

