### PR TITLE
Afform - Fix showing default values for EntityRef fields

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -751,9 +751,16 @@
           };
 
           if (ctrl.ngModel) {
+            var oldValue;
             // Ensure widget is updated when model changes
             ctrl.ngModel.$render = function() {
               element.val(ctrl.ngModel.$viewValue || '');
+              // Trigger change so the Select2 renders the current value,
+              // but only if the value has actually changed (to avoid recursion)
+              if (!angular.equals(ctrl.ngModel.$viewValue, oldValue)) {
+                oldValue = ctrl.ngModel.$viewValue;
+                element.change();
+              }
             };
 
             // Copied from ng-list


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4110](https://lab.civicrm.org/dev/core/-/issues/4110)
Replaces #25465

Before
----------------------------------------
Default values don't load (see #25465 for details)

After
----------------------------------------
Bug fixed without triggering the infinite recursion issue encountered earlier.

Technical Details
----------------------------------------
There was some back-and-forth with this. #25374 removed the change() trigger, which fixed the recursion bug described in https://lab.civicrm.org/dev/core/-/issues/4083 but broke setting defaults, prompting #25465 which proposed to change it back.

This fix walks the line by triggering the change event but only when the value has actually changed.
