### PR TITLE
Send SMS: fix invalid htxt tag error

### DIFF
--- a/templates/CRM/Mailing/MailingUI.hlp
+++ b/templates/CRM/Mailing/MailingUI.hlp
@@ -15,7 +15,7 @@
 </p>
 {/htxt}
 
-{htxt id ="from_email"}
+{htxt id="from_email"}
   <p>{ts}Select the "FROM" Email Address for this mailing from the dropdown list. Available email addresses are configurable by users with Administer CiviCRM permission. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
 {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') }
   {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/from_email_address" q="reset=1"}{/capture}

--- a/templates/CRM/SMS/Form/Group.hlp
+++ b/templates/CRM/SMS/Form/Group.hlp
@@ -47,10 +47,10 @@
 <p>{ts}If you have sent other Mass SMS - you can additionally Include (or Exclude) contacts who received those Mass SMS. CiviCRM will eliminate any duplications so that contacts who are in an Included Group AND were recipients of an Included Mailing will only be sent one copy of this SMS.{/ts}</p>
 {/htxt}
 
-{htxt id ="id-sms_provider-title"}
+{htxt id="id-sms_provider-title"}
   {ts}SMS Provider{/ts}
 {/htxt}
-{htxt id ="id-sms_provider"}
+{htxt id="id-sms_provider"}
 <p>{ts}Select the SMS provider for this mass message from the dropdown list.{/ts}</p>
 {if $params.isAdmin}
     {capture assign="fromConfig"}{crmURL p="civicrm/admin/sms/provider" q="reset=1"}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------

When sending an SMS mailing on 5.60 RC, we ran into this bug:

![image](https://user-images.githubusercontent.com/254741/230186656-2f476dc1-1ddf-4538-b963-0e27b3f98f3a.png)

Of course, this help file hasn't changed in a while, I don't know if it's related to a Smarty upgrade?

Fixing the whitespace in the hlp file fixes the issue :shrug: 

(the fix in `templates/CRM/Mailing/MailingUI.hlp` is only as a precaution, it was the only other misformatted tag that I found)