### PR TITLE
dev/core#4156 Fix employer not carrying over correctly in merge

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -291,7 +291,7 @@ WHERE  id IN ( $idString )
 
     if (!empty($existingRelationship)) {
       if ($existingRelationship['is_active']) {
-        if ($existingRelationship['contact_id_a.organization_name'] !== $existingRelationship['contact_id_b.organization_name']){
+        if ($existingRelationship['contact_id_a.organization_name'] !== $existingRelationship['contact_id_b.organization_name']) {
           self::setCurrentEmployer([$contactID => $employerID]);
         }
         // My work here is done.

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -284,13 +284,16 @@ WHERE  id IN ( $idString )
         ['relationship_type_id', '=', $relationshipTypeID],
         ['is_active', 'IN', [0, 1]],
       ])
-      ->setSelect(['id', 'is_active', 'start_date', 'end_date', 'contact_id_a.employer_id'])
+      ->setSelect(['id', 'is_active', 'start_date', 'end_date', 'contact_id_a.employer_id', 'contact_id_a.organization_name', 'contact_id_b.organization_name'])
       ->addOrderBy('is_active', 'DESC')
       ->setLimit(1)
       ->execute()->first();
 
     if (!empty($existingRelationship)) {
       if ($existingRelationship['is_active']) {
+        if ($existingRelationship['contact_id_a.organization_name'] !== $existingRelationship['contact_id_b.organization_name']){
+          self::setCurrentEmployer([$contactID => $employerID]);
+        }
         // My work here is done.
         return;
       }

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -168,8 +168,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
       $this->assign('contact_type', $main['contact_type']);
       $this->assign('main_name', $main['display_name']);
       $this->assign('other_name', $other['display_name']);
-      $this->assign('main_cid', $main['contact_id']);
-      $this->assign('other_cid', $other['contact_id']);
+      $this->assign('main_cid', $main['id']);
+      $this->assign('other_cid', $other['id']);
       $this->assign('rgid', $this->_rgid);
       $this->assignSummaryRowsToTemplate($contacts);
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2778,8 +2778,12 @@ ORDER BY civicrm_custom_group.weight,
         'id',
         'modified_date',
         'primary_contact_id',
-        'sort_name',
         'user_unique_id',
+        // These are effectively cached / calculated fields
+        'sort_name',
+        'email_greeting_display',
+        'postal_greeting_display',
+        'addressee_display',
       ],
     ];
     return $keysToIgnore[$type];

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2026,34 +2026,6 @@ ORDER BY civicrm_custom_group.weight,
       $removeTables = [];
     }
 
-    // FIXME: fix gender, prefix and postfix, so they're edible by createProfileContact()
-    $names['gender'] = ['newName' => 'gender_id', 'groupName' => 'gender'];
-    $names['individual_prefix'] = [
-      'newName' => 'prefix_id',
-      'groupName' => 'individual_prefix',
-    ];
-    $names['individual_suffix'] = [
-      'newName' => 'suffix_id',
-      'groupName' => 'individual_suffix',
-    ];
-    $names['communication_style'] = [
-      'newName' => 'communication_style_id',
-      'groupName' => 'communication_style',
-    ];
-    $names['addressee'] = [
-      'newName' => 'addressee_id',
-      'groupName' => 'addressee',
-    ];
-    $names['email_greeting'] = [
-      'newName' => 'email_greeting_id',
-      'groupName' => 'email_greeting',
-    ];
-    $names['postal_greeting'] = [
-      'newName' => 'postal_greeting_id',
-      'groupName' => 'postal_greeting',
-    ];
-    CRM_Core_OptionGroup::lookupValues($submitted, $names, TRUE);
-
     if (!isset($submitted)) {
       $submitted = [];
     }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1546,7 +1546,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       $rows["move_$field"] = [
         'main' => self::getFieldValueAndLabel($field, $main)['label'],
         'other' => self::getFieldValueAndLabel($field, $other)['label'],
-        'title' => $fields[$field]['html']['label'] ?? $fields[$field]['title'],
+        'title' => $fields[$field]['label'],
       ];
 
       $value = self::getFieldValueAndLabel($field, $other)['value'];

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1469,6 +1469,27 @@ WHERE
   public function testMergeWithEmployer(): void {
     $organizationToRemoveID = $this->organizationCreate(['organization_name' => 'remove']);
     $organizationToKeepID = $this->organizationCreate(['organization_name' => 'keep']);
+    $individualToKeepID = $this->createContactWithEmployerRelationship([
+      'contact_id_b' => $organizationToRemoveID,
+    ]);
+    $individualToRemoveID = $this->createContactWithEmployerRelationship([
+      'contact_id_b' => $organizationToKeepID,
+    ]);
+    $employerName = Contact::get()->addSelect('organization_name')->addWhere('id', '=', $individualToKeepID)->execute()->first()['organization_name'];
+    $this->assertEquals('remove', $employerName);
+    $this->mergeContacts($individualToKeepID, $individualToRemoveID, ['move_employer_id' => $organizationToKeepID, 'move_rel_table_relationships' => TRUE]);
+    $employerName = Contact::get()->addSelect('organization_name')->addWhere('id', '=', $individualToKeepID)->execute()->first()['organization_name'];
+    $this->assertEquals('keep', $employerName);
+  }
+
+  /**
+   * Test that organization name is updated for employees of merged organizations..
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMergeWithEmployee(): void {
+    $organizationToRemoveID = $this->organizationCreate(['organization_name' => 'remove']);
+    $organizationToKeepID = $this->organizationCreate(['organization_name' => 'keep']);
     $individualID = $this->createContactWithEmployerRelationship([
       'contact_id_b' => $organizationToRemoveID,
     ]);

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -35,6 +35,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'civicrm_group_contact',
       'civicrm_group',
       'civicrm_prevnext_cache',
+      'civicrm_relationship',
     ]);
     if ($this->hookClass) {
       // Do this here to flush the entityTables cache on teardown.

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -59,8 +59,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
   public function tearDown(): void {
     $this->resetHooks();
     $this->quickCleanUpFinancialEntities();
-    $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_website', 'civicrm_phone', 'civicrm_job', 'civicrm_action_log', 'civicrm_action_schedule', 'civicrm_group', 'civicrm_group_contact'], TRUE);
-    $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_website', 'civicrm_phone'], TRUE);
+    $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_relationship', 'civicrm_website', 'civicrm_phone', 'civicrm_job', 'civicrm_action_log', 'civicrm_action_schedule', 'civicrm_group', 'civicrm_group_contact'], TRUE);
     foreach ($this->originalValues as $entity => $entities) {
       foreach ($entities as $values) {
         $this->callAPISuccess($entity, 'create', $values);

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -1389,7 +1389,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
           ],
         ],
       ],
-      [
+      'deceased_no_merge' => [
         [
           'mode' => 'safe',
           'contacts' => [


### PR DESCRIPTION


Overview
----------------------------------------
Fix employer not carrying over correctly in merge

This addresses a deduper bug where selecting the employer_id to carry over in the form does NOT result in the newly merged contact having that organization's name
in it's organization_name field


Before
----------------------------------------
When merging a contact with an employer to a contact without an employer the employer_id is not carried over

After
----------------------------------------
Now it is

Technical Details
----------------------------------------
We did an earlier fix on this - but I'm not quite sure if it made it worse as this seems more broken than I though we left it - hence I'm targetting the rc

The gitlab was reported as a regression.

This is quite a lot of code change but what it does is consolidates the contact metadata handling a bit & switches to using apiv4 rather than the `DAO::fields`. This means we stop getitng 'special' names for

- is_deleted
- prefix_id
- suffix_id
- id
- employer_id
- email_greeing_id, postal_greeing_id, addressee_id
- gender
 
At the dedupe level many of these are already translated anyway & we have a pretty solid swag of tests (which might yet fail on this :-) - 

I did strip out some code that loads the suffix & prefix if not changed - as the `BAO` has handled that for some time

Comments
----------------------------------------
This should be a more solid fix than the previous one as it is standardising metadata onto apiv4