### PR TITLE
Use `mb_strtolower` rathter than `strtolower` to compare translated strings

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -223,7 +223,7 @@ class CRM_Core_BAO_CustomQuery {
             else {
               // fix $value here to escape sql injection attacks
               if (!is_array($value)) {
-                if ($field['data_type'] == 'String') {
+                if ($field['data_type'] === 'String') {
                   $value = CRM_Utils_Type::escape($value, 'String');
                 }
                 elseif ($value) {
@@ -242,7 +242,7 @@ class CRM_Core_BAO_CustomQuery {
                 foreach ($value as $key => $val) {
                   $value[$key] = str_replace(['[', ']', ','], ['\[', '\]', '[:comma:]'], $val);
                   $value[$key] = str_replace('|', '[:separator:]', $value[$key]);
-                  if ($field['data_type'] == 'String') {
+                  if ($field['data_type'] === 'String') {
                     $value[$key] = CRM_Utils_Type::escape($value[$key], 'String');
                   }
                   elseif ($value) {
@@ -281,12 +281,12 @@ class CRM_Core_BAO_CustomQuery {
 
           case 'Int':
             $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'Integer');
-            $this->_qill[$grouping][] = ts("%1 %2 %3", [1 => $field['label'], 2 => $qillOp, 3 => $qillValue]);
+            $this->_qill[$grouping][] = ts('%1 %2 %3', [1 => $field['label'], 2 => $qillOp, 3 => $qillValue]);
             break;
 
           case 'Boolean':
             if (!is_array($value)) {
-              if (strtolower($value) == 'yes' || strtolower($value) == strtolower(ts('Yes'))) {
+              if (mb_strtolower($value) === 'yes' || mb_strtolower($value) === mb_strtolower(ts('Yes'))) {
                 $value = 1;
               }
               else {


### PR DESCRIPTION
Overview
----------------------------------------
Use `mb_strtolower` rathter than `strtolower` to compare translated strings

Before
----------------------------------------
`strtolower`  used with `ts`

After
----------------------------------------
 `mb_strtolower` 

Technical Details
----------------------------------------
I didn't actually hit this issue but the comparison leapt out at me as being incorrect for languages that use special characters. Perhaps less common to hit special characters that require `mb_strtolower` on the word `Yes` since this hasn't been user-raised. (Or maybe just an obscure file path)

Comments
----------------------------------------
One of those IDE things