### PR TITLE
dev/core#1340 - Test + fix for contact get using custom field param + special characters

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -5621,12 +5621,18 @@ civicrm_relationship.start_date > {$today}
    *   Value.
    * @param string $dataType
    *   Data type of the field.
+   * @param bool $isAlreadyEscaped
+   *   Ideally we would be consistent about whether we escape
+   *   before calling this or after, but the code is a fearsome beast
+   *   and poking the sleeping dragon could throw a cat among the
+   *   can of worms. Hence we just schmooze this parameter in
+   *   to prevent double escaping where it is known to occur.
    *
    * @return string
    *   Where clause for the query.
    * @throws \CRM_Core_Exception
    */
-  public static function buildClause($field, $op, $value = NULL, $dataType = NULL) {
+  public static function buildClause($field, $op, $value = NULL, $dataType = 'String', $isAlreadyEscaped = FALSE): string {
     $op = trim($op);
     $clause = "$field $op";
 
@@ -5636,12 +5642,11 @@ civicrm_relationship.start_date > {$today}
         return $clause;
 
       case 'IS EMPTY':
-        $clause = ($dataType == 'Date') ? " $field IS NULL " : " (NULLIF($field, '') IS NULL) ";
+        $clause = ($dataType === 'Date') ? " $field IS NULL " : " (NULLIF($field, '') IS NULL) ";
         return $clause;
 
       case 'IS NOT EMPTY':
-        $clause = ($dataType == 'Date') ? " $field IS NOT NULL " : " (NULLIF($field, '') IS NOT NULL) ";
-        return $clause;
+        return ($dataType === 'Date') ? " $field IS NOT NULL " : " (NULLIF($field, '') IS NOT NULL) ";
 
       case 'RLIKE':
         return " CAST({$field} AS BINARY) RLIKE BINARY '{$value}' ";
@@ -5677,9 +5682,9 @@ civicrm_relationship.start_date > {$today}
         if ($emojiWhere === '0 = 1') {
           $value = $emojiWhere;
         }
-        $value = CRM_Utils_Type::escape($value, $dataType);
+        $value = $isAlreadyEscaped ? $value : CRM_Utils_Type::escape($value, $dataType);
         // if we don't have a dataType we should assume
-        if ($dataType == 'String' || $dataType == 'Text') {
+        if ($dataType === 'String' || $dataType === 'Text') {
           $value = "'" . $value . "'";
         }
         return "$clause $value";

--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -195,8 +195,8 @@ class CRM_Core_BAO_CustomQuery {
         // fix $value here to escape sql injection attacks
         $qillValue = NULL;
         if (!is_array($value)) {
-          $value = CRM_Core_DAO::escapeString(trim($value));
-          $qillValue = CRM_Core_BAO_CustomField::displayValue($value, $id);
+          $escapedValue = CRM_Core_DAO::escapeString(trim($value));
+          $qillValue = CRM_Core_BAO_CustomField::displayValue($escapedValue, $id);
         }
         elseif (count($value) && in_array(key($value), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
           $op = key($value);
@@ -273,7 +273,7 @@ class CRM_Core_BAO_CustomQuery {
               }
               else {
                 //FIX for custom data query fired against no value(NULL/NOT NULL)
-                $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'String');
+                $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'String', TRUE);
               }
               $this->_qill[$grouping][] = $field['label'] . " $qillOp $qillValue";
             }


### PR DESCRIPTION
Overview
----------------------------------------
Brings https://github.com/civicrm/civicrm-core/pull/22786 back to life

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/1340

After
----------------------------------------
The part of this in the test works, not sure if there is more

Technical Details
----------------------------------------
In looking back on old PRs I discovered https://github.com/civicrm/civicrm-core/pull/22786 had a unit test looking for a fix - as the test is the hard part I figured I could pull it up & add the fix.

However, the original test asserts a range of operators that should return a result that I did not agree with

https://github.com/civicrm/civicrm-core/pull/22786/files#diff-547c2b7156c054bbb3e1df3bb55e1c239d311afd179800e73d61fc42da6b4b97R5287-R5297

Specifically this is a text field and operations like `>=`, `<=` and `BETWEEN` are numeric comparisons

I removed those operators from the test but `=` was definitely failing and @iswilson had pointed out the problem was double-escaping. I concluded that it is escaping correctly for query purposes. And it is correct to escape for determining the `displayValue` but escaped version of the value in `displayValue` should be isolated from the value used to escape for the query - to avoid double escaping.

Comments
----------------------------------------
I don't know if there are aspects in the original gitlab not resolved here - I set out to rescue the test from the dead-zone in the PR queue and this definitely fixes an aspect that was verified broken in the test
