### PR TITLE
Remove traces of preferred mail format from communication preferences

### DIFF
--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -172,14 +172,6 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
       $defaults['communication_style_id'] = array_pop(CRM_Core_OptionGroup::values('communication_style', TRUE, NULL, NULL, 'AND is_default = 1'));
     }
 
-    // CRM-17778 -- set preferred_mail_format to default if unset
-    if (empty($defaults['preferred_mail_format'])) {
-      $defaults['preferred_mail_format'] = 'Both';
-    }
-    else {
-      $defaults['preferred_mail_format'] = array_search($defaults['preferred_mail_format'], CRM_Core_SelectValues::pmf());
-    }
-
     //set default from greeting types CRM-4575, CRM-9739
     if ($form->_action & CRM_Core_Action::ADD) {
       foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {

--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -44,9 +44,6 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
 
     // CRM-19135: where CRM_Core_BAO_Contact::getValues() set label as a default value instead of reserved 'value',
     // the code is to ensure we always set default to value instead of label
-    if (!empty($defaults['preferred_mail_format'])) {
-      $defaults['preferred_mail_format'] = array_search($defaults['preferred_mail_format'], CRM_Core_SelectValues::pmf());
-    }
 
     if (empty($defaults['communication_style_id'])) {
       $defaults['communication_style_id'] = array_pop(CRM_Core_OptionGroup::values('communication_style', TRUE, NULL, NULL, 'AND is_default = 1'));

--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -45,18 +45,6 @@
         </div>
       </div>
 
-      {if !empty($form.preferred_mail_format)}
-      <div class="crm-summary-row">
-        <div class="crm-label">
-          {$form.preferred_mail_format.label}
-          {help id="id-emailFormat" file="CRM/Contact/Form/Contact.hlp"}
-        </div>
-        <div class="crm-content">
-          {$form.preferred_mail_format.html}
-        </div>
-      </div>
-      {/if}
-
       {if !empty($form.communication_style_id)}
       <div class="crm-summary-row">
         <div class="crm-label">


### PR DESCRIPTION
Overview
----------------------------------------
Preferred mail format was removed from the form in https://github.com/civicrm/civicrm-core/commit/af77aafafdd0a3383523ac9a7f450a81cac66721 but still has traces
