### PR TITLE
Clarify return on `BAO_Activity::create`

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -255,11 +255,10 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
    * @param array $params
    *   Associated array of the submitted values.
    *
+   * @return CRM_Activity_DAO_Activity
    * @throws CRM_Core_Exception
-   *
-   * @return CRM_Activity_BAO_Activity|null|object
    */
-  public static function create(&$params) {
+  public static function create(array &$params) {
     // CRM-20958 - These fields are managed by MySQL triggers. Watch out for clients resaving stale timestamps.
     unset($params['created_date']);
     unset($params['modified_date']);
@@ -317,13 +316,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     // start transaction
     $transaction = new CRM_Core_Transaction();
-
     $result = $activity->save();
-
-    if (is_a($result, 'CRM_Core_Error')) {
-      $transaction->rollback();
-      return $result;
-    }
 
     $activityId = $activity->id;
     $activityRecordTypes = [


### PR DESCRIPTION
Overview
----------------------------------------
Clarify return on `BAO_Activity::create`

Before
----------------------------------------
The declared return types from `BAO_Activity::create` are `CRM_Activity_BAO_Activity|null|object` but it only ever returns a `BAO_Activity`

After
----------------------------------------
Declared return type corrected. Legacy handling for error object removed

Technical Details
----------------------------------------
The save function doesn't return an error object - although I believe it did before we made exceptions the consistent error handling method - so I removed that handling

Comments
----------------------------------------
