### PR TITLE
Update a few references to `list()`

### DIFF
--- a/CRM/Activity/Controller/Search.php
+++ b/CRM/Activity/Controller/Search.php
@@ -28,6 +28,9 @@
  */
 class CRM_Activity_Controller_Search extends CRM_Core_Controller {
 
+  /**
+   * @var string
+   */
   protected $entity = 'Activity';
 
   /**

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -373,7 +373,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
 
     $activityTypeDescription = NULL;
     if ($this->_activityTypeId) {
-      list($this->_activityTypeName, $activityTypeDescription) = CRM_Core_BAO_OptionValue::getActivityTypeDetails($this->_activityTypeId);
+      [$this->_activityTypeName, $activityTypeDescription] = CRM_Core_BAO_OptionValue::getActivityTypeDetails($this->_activityTypeId);
     }
 
     // Set activity type name and description to template.

--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -44,11 +44,11 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
 
     foreach ($allTypes as $act) {
       $url = 'civicrm/activity/add';
-      if ($act['name'] == 'Email') {
+      if ($act['name'] === 'Email') {
         if (!CRM_Utils_Mail::validOutBoundMail() || !$contactId) {
           continue;
         }
-        list($name, $email, $doNotEmail, $onHold, $isDeceased) = CRM_Contact_BAO_Contact::getContactDetails($contactId);
+        [, $email, $doNotEmail, , $isDeceased] = CRM_Contact_BAO_Contact::getContactDetails($contactId);
         if (!$doNotEmail && $email && !$isDeceased) {
           $url = 'civicrm/activity/email/add';
           $act['label'] = ts('Send an Email');
@@ -57,7 +57,7 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
           continue;
         }
       }
-      elseif ($act['name'] == 'SMS') {
+      elseif ($act['name'] === 'SMS') {
         if (!$contactId || !CRM_SMS_BAO_Provider::activeProviderCount() || !CRM_Core_Permission::check('send SMS')) {
           continue;
         }

--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -60,7 +60,7 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     CRM_Activity_BAO_Activity::retrieve($params, $defaults);
 
     // Send activity type description to template.
-    list(, $activityTypeDescription) = CRM_Core_BAO_OptionValue::getActivityTypeDetails($defaults['activity_type_id']);
+    [, $activityTypeDescription] = CRM_Core_BAO_OptionValue::getActivityTypeDetails($defaults['activity_type_id']);
     $this->assign('activityTypeDescription', $activityTypeDescription);
 
     if (!empty($defaults['mailingId'])) {

--- a/CRM/Activity/Form/Task/AddToTag.php
+++ b/CRM/Activity/Form/Task/AddToTag.php
@@ -123,7 +123,7 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
     foreach ($allTags as $key => $dnc) {
       $this->_name[] = $this->_tags[$key];
 
-      list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_activityHolderIds, $key,
+      [, $added, $notAdded] = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_activityHolderIds, $key,
         'civicrm_activity', FALSE);
 
       $status = [ts('Activity tagged', ['count' => $added, 'plural' => '%count activities tagged'])];

--- a/CRM/Activity/Form/Task/RemoveFromTag.php
+++ b/CRM/Activity/Form/Task/RemoveFromTag.php
@@ -95,7 +95,7 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
             $tagList[$val] = 1;
           }
           else {
-            list($label, $tagID) = explode(',', $val);
+            [, $tagID] = explode(',', $val);
             $tagList[$tagID] = 1;
           }
         }
@@ -113,7 +113,7 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
     foreach ($allTags as $key => $dnc) {
       $this->_name[] = $this->_tags[$key];
 
-      list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_activityHolderIds,
+      [, $removed, $notRemoved] = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_activityHolderIds,
         $key, 'civicrm_activity', FALSE);
 
       $status = [

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -261,7 +261,7 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
 
       $row['target_contact_name'] = CRM_Activity_BAO_ActivityContact::getNames($row['activity_id'], $targetID);
       $row['assignee_contact_name'] = CRM_Activity_BAO_ActivityContact::getNames($row['activity_id'], $assigneeID);
-      list($row['source_contact_name'], $row['source_contact_id']) = CRM_Activity_BAO_ActivityContact::getNames($row['activity_id'], $sourceID, TRUE);
+      [$row['source_contact_name'], $row['source_contact_id']] = CRM_Activity_BAO_ActivityContact::getNames($row['activity_id'], $sourceID, TRUE);
       $row['source_contact_name'] = implode(',', array_values($row['source_contact_name']));
       $row['source_contact_id'] = implode(',', $row['source_contact_id']);
 

--- a/CRM/Activity/StateMachine/Search.php
+++ b/CRM/Activity/StateMachine/Search.php
@@ -35,7 +35,7 @@ class CRM_Activity_StateMachine_Search extends CRM_Core_StateMachine {
     $this->_pages = [];
 
     $this->_pages['CRM_Activity_Form_Search'] = NULL;
-    list($task) = $this->taskName($controller, 'Search');
+    [$task] = $this->taskName($controller, 'Search');
     $this->_task = $task;
     foreach ($task as $t) {
       $this->_pages[$t] = NULL;

--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -19,6 +19,9 @@
  */
 class CRM_Activity_Task extends CRM_Core_Task {
 
+  /**
+   * @var string
+   */
   public static $objectType = 'activity';
 
   /**

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -427,7 +427,7 @@ class CRM_Contact_Form_Search_Criteria {
     $parseStreetAddress = $addressOptions['street_address_parsing'] ?? 0;
     $form->assign('parseStreetAddress', $parseStreetAddress);
     foreach ($elements as $name => $v) {
-      list($title, $attributes, $select, $multiSelect) = $v;
+      [$title, $attributes, $select, $multiSelect] = $v;
 
       if (in_array($name,
         ['street_number', 'street_name', 'street_unit']

--- a/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
+++ b/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
@@ -24,7 +24,6 @@ trait CRMTraits_PCP_PCPTestTrait {
    *
    * Create the necessary initial objects for a pcpBlock, then return the
    * params needed to create the pcpBlock.
-   *
    */
   public function pcpBlockParams() {
     $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');


### PR DESCRIPTION
Overview
----------------------------------------
Update a few references to `list()`

Before
----------------------------------------
```
list($total, $removed, $notRemoved) = 
```

After
----------------------------------------
```[, $removed, $notRemoved]```

Technical Details
----------------------------------------
After finding myself in a fight with `phpcs` on https://github.com/civicrm/civicrm-core/pull/26002 I figured it made more sense to try to win with a recent version of code - which led me to @michaelmcandrew's efforts - https://packagist.org/packages/michaelmcandrew/civicrm-coding-standards#1.1.1

I'm still tinkering with those but they are throwing up this `list` construct - which we have been replacing anyway so I figured I'd put up a few fixes

Comments
----------------------------------------
