### PR TITLE
Serialize 'extends' column in priceSet sample data

### DIFF
--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -1754,8 +1754,8 @@ VALUES
 -- CRM-9714
 
 INSERT INTO `civicrm_price_set` ( `name`, `title`, `is_active`, `extends`, `is_quick_config`, `financial_type_id`, `is_reserved` )
-VALUES ( 'default_contribution_amount', 'Contribution Amount', '1', '2', '1', NULL,1),
-( 'default_membership_type_amount', 'Membership Amount', '1', '3', '1', @financial_type_id_md,1);
+VALUES ( 'default_contribution_amount', 'Contribution Amount', '1', '2', '1', NULL, 1),
+( 'default_membership_type_amount', 'Membership Amount', '1', '3', '1', @financial_type_id_md, 1);
 
 SELECT @setID := max(id) FROM civicrm_price_set WHERE name = 'default_contribution_amount' AND extends = 2 AND is_quick_config = 1 ;
 


### PR DESCRIPTION
Overview
----------------------------------------
This adds `SERIALIZE_BOOKEND` characters to sample data in the `extends` field (which is meant to be serialized).

Technical Details
-------------------
This is a tiny portion of #24765 to help me figure out why those tests are failing.
Note: The invisible characters don't show up in the GitHub diff, but they are there.