### PR TITLE
Fix broken wysiwyg fields in Afforms due to timing issue

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -399,24 +399,28 @@
         require: '?ngModel',
         link: function (scope, elm, attr, ngModel) {
 
-          var editor = CRM.wysiwyg.create(elm);
-          if (!ngModel) {
-            return;
-          }
+          // Wait for #id to stabilize so the wysiwyg doesn't init with an id like `cke_{{:: fieldId }}`
+          $timeout(function() {
+            var editor = CRM.wysiwyg.create(elm);
 
-          if (attr.ngBlur) {
-            $(elm).on('blur', function() {
-              $timeout(function() {
-                scope.$eval(attr.ngBlur);
+            if (!ngModel) {
+              return;
+            }
+
+            if (attr.ngBlur) {
+              $(elm).on('blur', function() {
+                $timeout(function() {
+                  scope.$eval(attr.ngBlur);
+                });
               });
-            });
-          }
+            }
 
-          ngModel.$render = function(value) {
-            editor.done(function() {
-              CRM.wysiwyg.setVal(elm, ngModel.$viewValue || '');
-            });
-          };
+            ngModel.$render = function(value) {
+              editor.done(function() {
+                CRM.wysiwyg.setVal(elm, ngModel.$viewValue || '');
+              });
+            };
+          });
         }
       };
     })


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug when pre-filling wysiwyg fields in a popup.

Before
----------------------------------------
Create a wysiwyg field with a default value. Load the afform in a popup. It may work the first time, but close the dialog and try again. The second time will fail to populate the value.

After
----------------------------------------
Works every time

Technical Details
----------------------------------------
This was a timing issue. We need to wait for the `textarea` to be completely rendered by Angular before we can make it into a wysiwyg.