### PR TITLE
[REF] CoreComponent - Standardize on isEnabled function and remove unused code

### DIFF
--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -89,10 +89,12 @@ class CRM_Core_Component {
   }
 
   /**
+   * @deprecated
    * @return array
    *   Array(string $name => int $id).
    */
   public static function &getComponentIDs() {
+    CRM_Core_Error::deprecatedFunctionWarning('getComponents');
     $componentIDs = [];
 
     $cr = new CRM_Core_DAO_Component();
@@ -193,32 +195,28 @@ class CRM_Core_Component {
   /**
    * @param string $componentName
    *
-   * @return mixed
+   * @return int|null
    */
   public static function getComponentID($componentName) {
-    $info = self::_info();
+    $info = self::getComponents();
     if (!empty($info[$componentName])) {
       return $info[$componentName]->componentID;
     }
+    return NULL;
   }
 
   /**
    * @param int $componentID
    *
-   * @return int|null|string
+   * @return string|null
    */
   public static function getComponentName($componentID) {
-    $info = self::_info();
-
-    $componentName = NULL;
-    foreach ($info as $compName => $component) {
+    foreach (self::getComponents() as $compName => $component) {
       if ($component->componentID == $componentID) {
-        $componentName = $compName;
-        break;
+        return $compName;
       }
     }
-
-    return $componentName;
+    return NULL;
   }
 
   /**

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -527,7 +527,7 @@ class CRM_Core_Permission {
     // if component_id is present, ensure it is enabled
     if (!empty($item['component_id'])) {
       $componentName = CRM_Core_Component::getComponentName($item['component_id']);
-      if (!CRM_Core_Component::isEnabled($componentName)) {
+      if (!$componentName || !CRM_Core_Component::isEnabled($componentName)) {
         return FALSE;
       }
     }

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -525,17 +525,9 @@ class CRM_Core_Permission {
     }
 
     // if component_id is present, ensure it is enabled
-    if (isset($item['component_id']) && $item['component_id']) {
-      if (!isset(Civi::$statics[__CLASS__]['componentNameId'])) {
-        Civi::$statics[__CLASS__]['componentNameId'] = array_flip(CRM_Core_Component::getComponentIDs());
-      }
-      $componentName = Civi::$statics[__CLASS__]['componentNameId'][$item['component_id']];
-
-      $config = CRM_Core_Config::singleton();
-      if (is_array($config->enableComponents) && in_array($componentName, $config->enableComponents)) {
-        // continue with process
-      }
-      else {
+    if (!empty($item['component_id'])) {
+      $componentName = CRM_Core_Component::getComponentName($item['component_id']);
+      if (!CRM_Core_Component::isEnabled($componentName)) {
         return FALSE;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Code cleanup to consistently use `CRM_Core_Component::isEnabled()` function instead of directly accessing the `$config->enableComponents` setting, following on [#22567](https://github.com/civicrm/civicrm-core/pull/22567). 

Also removes some unused code.