### PR TITLE
[REF][PHP8.2] Add cookieExpire property to CRM_Campaign_BAO_Petition

### DIFF
--- a/CRM/Campaign/BAO/Petition.php
+++ b/CRM/Campaign/BAO/Petition.php
@@ -17,6 +17,13 @@
 class CRM_Campaign_BAO_Petition extends CRM_Campaign_BAO_Survey {
 
   /**
+   * Length of the cookie's created by this class
+   *
+   * @var int
+   */
+  protected $cookieExpire;
+
+  /**
    * Class constructor.
    */
   public function __construct() {


### PR DESCRIPTION
Overview
----------------------------------------
Add cookieExpire property to CRM_Campaign_BAO_Petition.

Before
----------------------------------------
`cookieExpire` was a dynamic property. Dynamic properties are no longer supported in PHP 8.2.

After
----------------------------------------
`cookieExpire` is no longer dynamic.

Comments
----------------------------------------
This could have been a const, but keeping it as a property, means the maths can still be written out `(1 * 60 * 60 * 24)`
