### PR TITLE
dev/core#3961 Create stub extensions for all components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,14 @@
 !/ext/ckeditor4
 !/ext/legacycustomsearches
 !/ext/civiimport
+!/ext/civi_campaign
+!/ext/civi_case
+!/ext/civi_contribute
+!/ext/civi_event
+!/ext/civi_mail
+!/ext/civi_member
+!/ext/civi_pledge
+!/ext/civi_report
 backdrop/
 bower_components
 CRM/Case/xml/configuration

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -362,6 +362,7 @@ class CRM_Core_BAO_ConfigSetting {
    * @param array $enabledComponents
    */
   public static function setEnabledComponents($enabledComponents) {
+    // The post_change trigger on this setting will sync component extensions, which will also flush caches
     Civi::settings()->set('enable_components', array_values($enabledComponents));
   }
 

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -116,15 +116,6 @@ class CRM_Core_Component {
   }
 
   /**
-   * Triggered by on_change callback of the 'enable_components' setting.
-   */
-  public static function flushEnabledComponents() {
-    unset(Civi::$statics[__CLASS__]);
-    CRM_Core_BAO_Navigation::resetNavigation();
-    Civi::cache('metadata')->clear();
-  }
-
-  /**
    * @param bool $translated
    *
    * @return array

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -428,6 +428,9 @@ class CRM_Core_Component {
    * @throws \CRM_Core_Exception.
    */
   public static function onToggleComponents($oldValue, $newValue): void {
+    if (CRM_Core_Config::isUpgradeMode()) {
+      return;
+    }
     $manager = CRM_Extension_System::singleton()->getManager();
     $toEnable = $toDisable = [];
     foreach (self::getComponents() as $component) {

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -424,4 +424,38 @@ class CRM_Core_Component {
     return in_array($component, Civi::settings()->get('enable_components'), TRUE);
   }
 
+  /**
+   * Callback for the "enable_components" setting
+   *
+   * When a component is enabled or disabled, ensure the corresponding module-extension is also enabled/disabled.
+   *
+   * @param array $oldValue
+   *   List of component names.
+   * @param array $newValue
+   *   List of component names.
+   *
+   * @throws \CRM_Core_Exception.
+   */
+  public static function onToggleComponents($oldValue, $newValue): void {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    $toEnable = $toDisable = [];
+    foreach (self::getComponents() as $component) {
+      $componentEnabled = in_array($component->name, $newValue);
+      $extName = $component->getExtensionName();
+      $extensionEnabled = $manager->getStatus($extName) === $manager::STATUS_INSTALLED;
+      if ($componentEnabled && !$extensionEnabled) {
+        $toEnable[] = $extName;
+      }
+      elseif (!$componentEnabled && $extensionEnabled) {
+        $toDisable[] = $extName;
+      }
+    }
+    if ($toEnable) {
+      CRM_Extension_System::singleton()->getManager()->install($toEnable);
+    }
+    if ($toDisable) {
+      CRM_Extension_System::singleton()->getManager()->disable($toDisable);
+    }
+  }
+
 }

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -63,7 +63,7 @@ abstract class CRM_Core_Component_Info {
   /**
    * Component settings as key/value pairs.
    *
-   * @var array
+   * @var array{name: string, translatedName: string, title: string, search: bool, showActivitiesInCore: bool, url: string}
    */
   public $info;
 
@@ -119,6 +119,14 @@ abstract class CRM_Core_Component_Info {
    */
   public function getAngularModules() {
     return [];
+  }
+
+  /**
+   * Name of the module-extension coupled with this component
+   * @return string
+   */
+  public function getExtensionName(): string {
+    return CRM_Utils_String::convertStringToSnakeCase($this->name);
   }
 
   /**

--- a/CRM/Extension/Upgrader/Component.php
+++ b/CRM/Extension/Upgrader/Component.php
@@ -1,0 +1,33 @@
+<?php
+use CRM_AfformAdmin_ExtensionUtil as E;
+
+/**
+ * Upgrader base class ONLY for core component extensions (e.g. `civi_mail`, `civi_event`).
+ *
+ * Can be used directly from the extensions' info.xml or can be extended for
+ * additional install/uninstall/upgrade functionality in the extension.
+ */
+class CRM_Extension_Upgrader_Component extends CRM_Extension_Upgrader_Base {
+
+  public function install() {
+    CRM_Core_BAO_ConfigSetting::enableComponent($this->getComponentName());
+  }
+
+  public function enable() {
+    CRM_Core_BAO_ConfigSetting::enableComponent($this->getComponentName());
+  }
+
+  public function disable() {
+    CRM_Core_BAO_ConfigSetting::disableComponent($this->getComponentName());
+  }
+
+  /**
+   * Get of component (e.g. CiviMail)
+   *
+   * @return string
+   */
+  protected function getComponentName(): string {
+    return CRM_Utils_String::convertStringToCamel($this->extensionName);
+  }
+
+}

--- a/CRM/Extension/Upgrader/Component.php
+++ b/CRM/Extension/Upgrader/Component.php
@@ -9,7 +9,7 @@ use CRM_AfformAdmin_ExtensionUtil as E;
  */
 class CRM_Extension_Upgrader_Component extends CRM_Extension_Upgrader_Base {
 
-  public function install() {
+  public function postInstall() {
     CRM_Core_BAO_ConfigSetting::enableComponent($this->getComponentName());
   }
 

--- a/CRM/Upgrade/Incremental/php/FiveSixtyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyThree.php
@@ -29,6 +29,10 @@ class CRM_Upgrade_Incremental_php_FiveSixtyThree extends CRM_Upgrade_Incremental
    */
   public function upgrade_5_63_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+
+    $enabledComponents = Civi::settings()->get('enable_components');
+    $extensions = array_map(['CRM_Utils_String', 'convertStringToSnakeCase'], $enabledComponents);
+    $this->addExtensionTask('Enable component extensions', $extensions);
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/FiveSixtyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyTwo.php
@@ -94,6 +94,8 @@ class CRM_Upgrade_Incremental_php_FiveSixtyTwo extends CRM_Upgrade_Incremental_B
       1 => [$lowestDomainId, 'Positive'],
       2 => ['enable_components', 'String'],
     ]);
+    // Flush the settings cache after updating the `enable_components` setting.
+    \Civi\Core\Container::getBootService('settings_manager')->flush();
 
     return TRUE;
   }

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -379,6 +379,7 @@ class SettingsBag {
       $dao->domain_id = $this->domainId;
     }
     $dao->find(TRUE);
+    $oldValue = \CRM_Utils_String::unserialize($dao->value);
 
     // Call 'on_change' listeners. It would be nice to only fire when there's
     // a genuine change in the data. However, PHP developers have mixed
@@ -388,7 +389,7 @@ class SettingsBag {
       foreach ($metadata['on_change'] as $callback) {
         call_user_func(
           \Civi\Core\Resolver::singleton()->get($callback),
-          \CRM_Utils_String::unserialize($dao->value),
+          $oldValue,
           $value,
           $metadata,
           $this->domainId
@@ -424,6 +425,20 @@ class SettingsBag {
       // Cannot use $dao->save(); in upgrade mode (eg WP + Civi 4.4=>4.7), the DAO will refuse
       // to save the field `group_name`, which is required in older schema.
       \CRM_Core_DAO::executeQuery(\CRM_Utils_SQL_Insert::dao($dao)->toSQL());
+    }
+
+    // Call 'post_change' listeners after the value has been saved.
+    // Unlike 'on_change', this will only fire if the oldValue and newValue are not equivalent (using == comparison)
+    if ($value != $oldValue && !empty($metadata['post_change'])) {
+      foreach ($metadata['post_change'] as $callback) {
+        call_user_func(
+          \Civi\Core\Resolver::singleton()->get($callback),
+          $oldValue,
+          $value,
+          $metadata,
+          $this->domainId
+        );
+      }
     }
   }
 

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -248,8 +248,6 @@ class SettingsBag {
       return $this;
     }
     $this->setDb($key, $value);
-    $this->values[$key] = $value;
-    $this->combined = NULL;
     return $this;
   }
 
@@ -426,6 +424,9 @@ class SettingsBag {
       // to save the field `group_name`, which is required in older schema.
       \CRM_Core_DAO::executeQuery(\CRM_Utils_SQL_Insert::dao($dao)->toSQL());
     }
+
+    $this->values[$name] = $value;
+    $this->combined = NULL;
 
     // Call 'post_change' listeners after the value has been saved.
     // Unlike 'on_change', this will only fire if the oldValue and newValue are not equivalent (using == comparison)

--- a/api/v3/examples/Setting/GetFields.ex.php
+++ b/api/v3/examples/Setting/GetFields.ex.php
@@ -1216,8 +1216,6 @@ function setting_getfields_expectedresult() {
         'help_text' => '',
         'on_change' => [
           '0' => 'CRM_Case_Info::onToggleComponents',
-          '1' => 'CRM_Core_Component::flushEnabledComponents',
-          '2' => 'call://resources/resetCacheCode',
         ],
         'pseudoconstant' => [
           'callback' => 'CRM_Core_SelectValues::getComponentSelectValues',

--- a/distmaker/core-ext.txt
+++ b/distmaker/core-ext.txt
@@ -24,3 +24,11 @@ search_kit
 sequentialcreditnotes
 legacycustomsearches
 elavon
+civi_campaign
+civi_case
+civi_contribute
+civi_event
+civi_mail
+civi_member
+civi_pledge
+civi_report

--- a/ext/civi_campaign/civi_campaign.civix.php
+++ b/ext/civi_campaign/civi_campaign.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviCampaign_ExtensionUtil {
+  const SHORT_NAME = 'civi_campaign';
+  const LONG_NAME = 'civi_campaign';
+  const CLASS_PREFIX = 'CRM_CiviCampaign';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviCampaign_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_campaign_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_campaign_civix_civicrm_install() {
+  _civi_campaign_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_campaign_civix_civicrm_enable(): void {
+  _civi_campaign_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_campaign_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_campaign_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_campaign_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_campaign_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_campaign_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_campaign_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_campaign_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_campaign_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_campaign/civi_campaign.php
+++ b/ext/civi_campaign/civi_campaign.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_campaign.civix.php';
+// phpcs:disable
+use CRM_CiviCampaign_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_campaign" type="module">
+  <file>civi_campaign</file>
+  <name>CiviCampaign</name>
+  <description>CiviCampaign can link together events, mailings, activities, and contributions with campaigns.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/campaign/what-is-civicampaign/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviCampaign</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviCampaign</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_case/civi_case.civix.php
+++ b/ext/civi_case/civi_case.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviCase_ExtensionUtil {
+  const SHORT_NAME = 'civi_case';
+  const LONG_NAME = 'civi_case';
+  const CLASS_PREFIX = 'CRM_CiviCase';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviCase_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_case_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_case_civix_civicrm_install() {
+  _civi_case_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_case_civix_civicrm_enable(): void {
+  _civi_case_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_case_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_case_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_case_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_case_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_case_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_case_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_case_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_case_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_case.civix.php';
+// phpcs:disable
+use CRM_CiviCase_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_case" type="module">
+  <file>civi_case</file>
+  <name>CiviCase</name>
+  <description>CiviCase is a tool for tracking and managing sequences of activities.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/case-management/what-is-civicase/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviCase</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviCase</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_contribute/civi_contribute.civix.php
+++ b/ext/civi_contribute/civi_contribute.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviContribute_ExtensionUtil {
+  const SHORT_NAME = 'civi_contribute';
+  const LONG_NAME = 'civi_contribute';
+  const CLASS_PREFIX = 'CRM_CiviContribute';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviContribute_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_contribute_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_contribute_civix_civicrm_install() {
+  _civi_contribute_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_contribute_civix_civicrm_enable(): void {
+  _civi_contribute_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_contribute_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_contribute_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_contribute_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_contribute_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_contribute_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_contribute_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_contribute_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_contribute_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_contribute/civi_contribute.php
+++ b/ext/civi_contribute/civi_contribute.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_contribute.civix.php';
+// phpcs:disable
+use CRM_CiviContribute_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_contribute" type="module">
+  <file>civi_contribute</file>
+  <name>CiviContribute</name>
+  <description>CiviContribute records and reports on financial and in-kind contributions.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/contributions/what-is-civicontribute/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviContribute</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviContribute</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_event/civi_event.civix.php
+++ b/ext/civi_event/civi_event.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviEvent_ExtensionUtil {
+  const SHORT_NAME = 'civi_event';
+  const LONG_NAME = 'civi_event';
+  const CLASS_PREFIX = 'CRM_CiviEvent';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviEvent_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_event_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_event_civix_civicrm_install() {
+  _civi_event_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_event_civix_civicrm_enable(): void {
+  _civi_event_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_event_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_event_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_event_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_event_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_event_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_event_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_event_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_event_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_event/civi_event.php
+++ b/ext/civi_event/civi_event.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_event.civix.php';
+// phpcs:disable
+use CRM_CiviEvent_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_event" type="module">
+  <file>civi_event</file>
+  <name>CiviEvent</name>
+  <description>Event management functionality for CiviCRM</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/events/what-is-civievent</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviEvent</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviEvent</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_mail/civi_mail.civix.php
+++ b/ext/civi_mail/civi_mail.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviMail_ExtensionUtil {
+  const SHORT_NAME = 'civi_mail';
+  const LONG_NAME = 'civi_mail';
+  const CLASS_PREFIX = 'CRM_CiviMail';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviMail_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_mail_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_mail_civix_civicrm_install() {
+  _civi_mail_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_mail_civix_civicrm_enable(): void {
+  _civi_mail_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_mail_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_mail_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_mail_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_mail_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_mail_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_mail_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_mail_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_mail_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_mail/civi_mail.php
+++ b/ext/civi_mail/civi_mail.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_mail.civix.php';
+// phpcs:disable
+use CRM_CiviMail_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_mail" type="module">
+  <file>civi_mail</file>
+  <name>CiviMail</name>
+  <description>CiviMail is a sophisticated tool for handling mass email campaigns.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/email/what-is-civimail/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviMail</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviMail</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_member/civi_member.civix.php
+++ b/ext/civi_member/civi_member.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviMember_ExtensionUtil {
+  const SHORT_NAME = 'civi_member';
+  const LONG_NAME = 'civi_member';
+  const CLASS_PREFIX = 'CRM_CiviMember';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviMember_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_member_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_member_civix_civicrm_install() {
+  _civi_member_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_member_civix_civicrm_enable(): void {
+  _civi_member_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_member_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_member_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_member_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_member_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_member_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_member_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_member_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_member_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_member/civi_member.php
+++ b/ext/civi_member/civi_member.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_member.civix.php';
+// phpcs:disable
+use CRM_CiviMember_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_member" type="module">
+  <file>civi_member</file>
+  <name>CiviMember</name>
+  <description>CiviMember provides functionality to support and automate the management of memberships.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/membership/what-is-civimember/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviMember</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviMember</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_pledge/civi_pledge.civix.php
+++ b/ext/civi_pledge/civi_pledge.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviPledge_ExtensionUtil {
+  const SHORT_NAME = 'civi_pledge';
+  const LONG_NAME = 'civi_pledge';
+  const CLASS_PREFIX = 'CRM_CiviPledge';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviPledge_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_pledge_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_pledge_civix_civicrm_install() {
+  _civi_pledge_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_pledge_civix_civicrm_enable(): void {
+  _civi_pledge_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_pledge_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_pledge_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_pledge_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_pledge_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_pledge_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_pledge_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_pledge_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_pledge_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_pledge/civi_pledge.php
+++ b/ext/civi_pledge/civi_pledge.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_pledge.civix.php';
+// phpcs:disable
+use CRM_CiviPledge_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_pledge" type="module">
+  <file>civi_pledge</file>
+  <name>CiviPledge</name>
+  <description>A Pledge is the promise to give a donation at a pre-arranged time in the future.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/pledges/what-is-civipledge/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviPledge</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviPledge</angularModule>
+  </civix>
+</extension>

--- a/ext/civi_report/civi_report.civix.php
+++ b/ext/civi_report/civi_report.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviReport_ExtensionUtil {
+  const SHORT_NAME = 'civi_report';
+  const LONG_NAME = 'civi_report';
+  const CLASS_PREFIX = 'CRM_CiviReport';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviReport_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _civi_report_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _civi_report_civix_civicrm_install() {
+  _civi_report_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _civi_report_civix_civicrm_enable(): void {
+  _civi_report_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _civi_report_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _civi_report_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _civi_report_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _civi_report_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _civi_report_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _civi_report_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _civi_report_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _civi_report_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/civi_report/civi_report.php
+++ b/ext/civi_report/civi_report.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'civi_report.civix.php';
+// phpcs:disable
+use CRM_CiviReport_ExtensionUtil as E;
+// phpcs:enable

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -19,6 +19,7 @@
     <ver>5.62</ver>
   </compatibility>
   <comments>Core Component</comments>
+  <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<extension key="civi_report" type="module">
+  <file>civi_report</file>
+  <name>CiviReport</name>
+  <description>The original reporting component for CiviCRM, which is being phased out by SearchKit.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/user/en/latest/reporting/what-is-civireport/</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-04-08</releaseDate>
+  <version>5.62.alpha1</version>
+  <develStage>stable</develStage>
+  <compatibility>
+    <ver>5.62</ver>
+  </compatibility>
+  <comments>Core Component</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/CiviReport</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmCiviReport</angularModule>
+  </civix>
+</extension>

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -801,6 +801,9 @@ return [
       'CRM_Core_Component::flushEnabledComponents',
       'call://resources/resetCacheCode',
     ],
+    'post_change' => [
+      'CRM_Core_Component::onToggleComponents',
+    ],
     'pseudoconstant' => [
       'callback' => 'CRM_Core_SelectValues::getComponentSelectValues',
     ],

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -798,8 +798,6 @@ return [
     'help_text' => NULL,
     'on_change' => [
       'CRM_Case_Info::onToggleComponents',
-      'CRM_Core_Component::flushEnabledComponents',
-      'call://resources/resetCacheCode',
     ],
     'post_change' => [
       'CRM_Core_Component::onToggleComponents',

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -410,7 +410,11 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $this->setShowCaseActivitiesInCore(FALSE);
     $this->setUpForActivityDashboardTests();
     $this->addCaseWithActivity();
-    CRM_Core_Config::singleton()->userPermissionClass->permissions[] = 'access all cases and activities';
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'view all contacts',
+      'access all cases and activities',
+    ];
 
     $activityCount = CRM_Activity_BAO_Activity::getActivitiesCount($this->_params);
     $this->assertEquals(8, $activityCount);

--- a/tests/phpunit/CRM/Core/BAO/NavigationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NavigationTest.php
@@ -297,6 +297,7 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
 
     CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'access CiviContribute'];
     $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
 
     CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
@@ -307,6 +308,7 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
 
     CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviContribute'];
     $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
 
     CRM_Core_BAO_ConfigSetting::enableComponent('CiviMail');
@@ -322,10 +324,9 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $this->assertTrue(CRM_Core_BAO_Navigation::checkPermission($menuItem));
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
     $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
-    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviMail', 'delete in CiviMail'];
     CRM_Core_BAO_ConfigSetting::disableComponent('CiviMail');
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviMail', 'delete in CiviMail'];
     $this->assertFalse(CRM_Core_BAO_Navigation::checkPermission($menuItem));
-    CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
   }
 
 }

--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -467,6 +467,18 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
     $this->assertDBQuery('newextension', 'SELECT file FROM civicrm_extension WHERE full_name ="test.whiz.bang"');
   }
 
+  public function testComponentExtensionSync() {
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviCampaign');
+    $this->assertEquals(CRM_Extension_Manager::STATUS_INSTALLED, CRM_Extension_System::singleton()->getManager()->getStatus('civi_campaign'));
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviCampaign');
+    $this->assertEquals(CRM_Extension_Manager::STATUS_DISABLED, CRM_Extension_System::singleton()->getManager()->getStatus('civi_campaign'));
+    $this->assertFalse(CRM_Core_Component::isEnabled('CiviCampaign'));
+    CRM_Extension_System::singleton()->getManager()->install('civi_campaign');
+    $this->assertTrue(CRM_Core_Component::isEnabled('CiviCampaign'));
+    CRM_Extension_System::singleton()->getManager()->disable('civi_campaign');
+    $this->assertFalse(CRM_Core_Component::isEnabled('CiviCampaign'));
+  }
+
   /**
    * Install a module and then delete (leaving stale DB info); restore
    * the module by downloading new code.

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -488,6 +488,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   protected function assertPostConditions(): void {
     // Reset to version 3 as not all (e.g payments) work on v4
     $this->_apiversion = 3;
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
     if ($this->isLocationTypesOnPostAssert) {
       $this->assertLocationValidity();
     }

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -55,6 +55,7 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
+    CRM_Core_BAO_ConfigSetting::enableAllComponents();
     CRM_Core_DAO::createTestObject('CRM_Pledge_BAO_Pledge', [], 1, 0);
     $this->callAPISuccess('Phone', 'create', ['id' => $this->individualCreate(['email' => '']), 'phone' => '911', 'location_type_id' => 'Home']);
     $this->prepareForACLs();
@@ -748,7 +749,6 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
    */
   public function testGetActivityCheckPermissionsByCaseComponent(int $version): void {
     $this->_apiversion = $version;
-    CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
     $activity = $this->activityCreate(['activity_type_id' => 'Open Case']);
     $activity2 = $this->activityCreate(['activity_type_id' => 'Pledge Reminder']);
     $this->hookClass->setHook('civicrm_aclWhereClause', [

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -93,18 +93,20 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
   public function testExtensionGetByStatus() {
     $installed = $this->callAPISuccess('extension', 'get', ['status' => 'installed', 'options' => ['limit' => 0]]);
     $uninstalled = $this->callAPISuccess('extension', 'get', ['status' => 'uninstalled', 'options' => ['limit' => 0]]);
+    $disabled = $this->callAPISuccess('extension', 'get', ['status' => 'disabled', 'options' => ['limit' => 0]]);
 
     // If the filter works, then results should be strictly independent.
     $this->assertEquals(
       [],
       array_intersect(
         CRM_Utils_Array::collect('key', $installed['values']),
-        CRM_Utils_Array::collect('key', $uninstalled['values'])
+        CRM_Utils_Array::collect('key', $uninstalled['values']),
+        CRM_Utils_Array::collect('key', $disabled['values'])
       )
     );
 
     $all = $this->callAPISuccess('extension', 'get', ['options' => ['limit' => 0]]);
-    $this->assertEquals($all['count'], $installed['count'] + $uninstalled['count']);
+    $this->assertEquals($all['count'], $installed['count'] + $uninstalled['count'] + $disabled['count']);
   }
 
   public function testGetMultipleExtensions() {

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -44,6 +44,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
+    // Enable components BEFORE starting the transaction or the cache clearing will break the transaction
+    CRM_Core_BAO_ConfigSetting::enableAllComponents();
     $this->useTransaction();
     // DGW
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
@@ -84,7 +86,6 @@ class api_v3_MailingTest extends CiviUnitTestCase {
    */
   public function testMailerCreateSuccess(int $version): void {
     $this->_apiversion = $version;
-    $this->enableCiviCampaign();
     $this->callAPISuccess('Campaign', 'create', ['name' => 'big campaign', 'title' => 'abc']);
     $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign'], __FUNCTION__, __FILE__);
     $jobs = $this->callAPISuccess('MailingJob', 'get', ['mailing_id' => $result['id']]);


### PR DESCRIPTION
Overview
----------------------------------------
Implements [dev/core#3961 proposal to create a stub extension for all components](https://lab.civicrm.org/dev/core/-/issues/3961).

Before
----------------------------------------
There are 8 components in CiviCRM (_CiviMail_, _CiviEvent_, _CiviContribute_, etc)

After
----------------------------------------
Now there are also 8 new extensions (`civi_mail`, `civi_event`, `civi_contribute`, etc). The extensions do nothing (yet), but are enabled/disabled in-sync with their corresponding components.

Technical Details
----------------------------------------
- **Naming convention:** Is a simple conversion from `CamelCase` to `snake_case`. (e.g. `CiviCase` component == `civi_case` extension). This is easy to convert, doesn't require any extra mapping, and avoids conflicts with other extensions in the civi-universe, (namely the `civicase` extension which would conflict if we didn't use an underscore in our name).
- **Status-sync:** 2-way syncing: enabling the extension will trigger the component to be enabled, and vice-versa.
- **Upgrader:** This uses the [2nd variant](https://lab.civicrm.org/dev/core/-/issues/3961#note_84070) suggested by @totten, which is a module-extension with shared upgrader class to manage the enable/disable logic.

Next Steps
-------------------
This PR is a baby step to add the stub extensions with no functionality, just so we can work the kinks out of the install-sync mechanisms. Once that's done and this PR is merged, a lot of possibilities open up such as:
- Getting rid of the *Enable Components* screen
- Packaging SearchKit searches with components
- Migrating code out of core and into the extensions