### PR TITLE
dev/core#4220 - Remove is_current_revision code that is buggy because it gets overwritten later, and we don't want it anymore anyway

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -456,7 +456,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         $params['is_auto'] = 0;
       }
 
-      // always create a revision of an case activity. CRM-4533
+      // @todo This is called newActParams because it USED TO create new activity revisions. But at the moment just changing the part that is broken.
+      // hidden_custom is always 1, so see above where $params gets merged with the existing activity data every time, including the activity id.
       $newActParams = $params;
 
       // add target contact values in update mode
@@ -484,26 +485,17 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       }
     }
     else {
-      // create a new version of activity if activity was found to
-      // have been modified/created by user
-
-      // since the params we need to set are very few, and we don't want rest of the
-      // work done by bao create method , lets use dao object to make the changes
-      $params = ['id' => $this->_activityId];
-      $params['is_current_revision'] = 0;
-      $activity = new CRM_Activity_DAO_Activity();
-      $activity->copyValues($params);
-      $activity->save();
-
+      // @todo This can go eventually. Just focusing on not creating new
+      // revisions for now. This is still needed to keep it matched up to any
+      // existing older revisions while they are still in the db.
       // set proper original_id
       if (!empty($this->_defaults['original_id'])) {
         $newActParams['original_id'] = $this->_defaults['original_id'];
       }
       else {
-        $newActParams['original_id'] = $activity->id;
+        $newActParams['original_id'] = $this->_activityId;
       }
 
-      //is_current_revision will be set to 1 by default.
       // add attachments if any
       CRM_Core_BAO_File::formatAttachment($newActParams,
         $newActParams,


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4220

Before
----------------------------------------
Activity gets overwritten later, so no new revisions are created anyway.

After
----------------------------------------
Code no longer exists, so no new revisions are created, but it's no longer confusing, because code that doesn't exist usually isn't expected to do anything.

Technical Details
----------------------------------------
Revisions have been known to be broken on this form for a few years. I didn't bother finding out when it broke (probably between 2015 and 2018) because we no longer want revisions to be created at all, but here's why it doesn't work:

1. Note that $params['hidden_custom'] is ALWAYS 1, even if there are no custom fields. Even if that weren't true, this would still be buggy whenever there are custom fields.
2. Note that that means it [always fetches the existing activity from the db and merges in a bunch of params](https://github.com/civicrm/civicrm-core/blob/e111c7be56a383d56b78d1ac0db797cf6428f685/CRM/Case/Form/Activity.php#L420), including the `id`.
3. Note it then sets [$newActParams to $params](https://github.com/civicrm/civicrm-core/blob/e111c7be56a383d56b78d1ac0db797cf6428f685/CRM/Case/Form/Activity.php#L460).
4. So then [lower down after the block we're removing](https://github.com/civicrm/civicrm-core/blob/e111c7be56a383d56b78d1ac0db797cf6428f685/CRM/Case/Form/Activity.php#L517), it then always has the current `id` as a parameter to create(). Hence, it just overwrites.

Comments
----------------------------------------

