### PR TITLE
This doesn't belong here

### DIFF
--- a/templates/CRM/Case/Form/Activity/ChangeCaseStartDate.tpl
+++ b/templates/CRM/Case/Form/Activity/ChangeCaseStartDate.tpl
@@ -7,12 +7,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Template for "Change Case Type" activities *}
+{* Template for "Change Case Start Date" activities *}
    <div class="crm-block crm-form-block crm-case-changecasestartdate-form-block">
-    <tr class="crm-case-changecasestartdate-form-block-case_type_id">
-  <td class="label">{$form.case_type_id.label}</td>
-  <td>{$form.case_type_id.html}</td>
-    </tr>
     <tr class="crm-case-changecasestartdate-form-block-current_start_date">
   <td class="label">{ts}Current Start Date{/ts}</td>
         <td>{$current_start_date|crmDate}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Clearly copy/paste from the change case type tpl. It's been here since day 1.

Before
----------------------------------------
`Warning: Undefined array key "case_type_id" in include() (line 7 of .../templates_c/en_US/%%CA/CA3/CA3F5685%%ChangeCaseStartDate.tpl.php).`
`Warning: Trying to access array offset on value of type null in include() (line 7 of .../templates_c/en_US/%%CA/CA3/CA3F5685%%ChangeCaseStartDate.tpl.php).`

After
----------------------------------------


Technical Details
----------------------------------------
This is change start date - nothing to do with change case type.

Comments
----------------------------------------
I'm ignoring that there's a div around the tr's. Maybe in a followup PR. The div ends up being outside the table and empty because, well, it doesn't belong where it is. But maybe somebody is targeting it to insert or move stuff. It's not related to what I'm currently trying to fix.
