### PR TITLE
Permit ACL rules that negate (deny) access

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -160,6 +160,10 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     $this->add('select', 'event_id', ts('Event'), $event);
 
     $this->add('checkbox', 'is_active', ts('Enabled?'));
+    $this->addRadio('deny', ts('Mode'), [
+      0 => ts('Allow'),
+      1 => ts('Deny'),
+    ]);
 
     $this->addFormRule(['CRM_ACL_Form_ACL', 'formRule']);
   }
@@ -253,7 +257,6 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     else {
       $params = $this->controller->exportValues($this->_name);
       $params['is_active'] = CRM_Utils_Array::value('is_active', $params, FALSE);
-      $params['deny'] = 0;
       $params['entity_table'] = 'civicrm_acl_role';
 
       // Figure out which type of object we're permissioning on and set object_table and object_id.

--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -136,6 +136,7 @@ ORDER BY entity_id
       $acl[$dao->id]['object_table'] = $dao->object_table;
       $acl[$dao->id]['object_id'] = $dao->object_id;
       $acl[$dao->id]['is_active'] = $dao->is_active;
+      $acl[$dao->id]['deny'] = $dao->deny;
 
       if ($acl[$dao->id]['entity_id']) {
         $acl[$dao->id]['entity'] = $roles[$acl[$dao->id]['entity_id']] ?? NULL;

--- a/templates/CRM/ACL/Form/ACL.tpl
+++ b/templates/CRM/ACL/Form/ACL.tpl
@@ -32,7 +32,7 @@
      <tr class="crm-acl-form-block-operation">
          <td class="label">{$form.operation.label}</td>
          <td>{$form.operation.html}<br />
-            <span class="description">{ts}What type of operation (action) is being permitted?{/ts}</span>
+            <span class="description">{ts}What type of operation (action) is being referenced?{/ts}</span>
          </td>
      </tr>
      <tr class="crm-acl-form-block-object_type">
@@ -44,6 +44,10 @@
         {if $config->userSystem->is_drupal EQ '1'}
            <div class="status description">{ts}IMPORTANT: The Drupal permissions for 'access all custom data' and 'profile listings and forms' override and disable specific ACL settings for custom field groups and profiles respectively. Do not enable those Drupal permissions for a Drupal role if you want to use CiviCRM ACL's to control access.{/ts}</div></td>
         {/if}
+     </tr>
+     <tr class="crm-acl-form-block-deny">
+       <td class="label">{$form.deny.label}</td>
+       <td>{$form.deny.html}</td>
      </tr>
   </table>
   <div id="id-group-acl">

--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -30,6 +30,7 @@
               <th>{ts}Which Data{/ts}</th>
               <th>{ts}Description{/ts}</th>
               <th>{ts}Enabled?{/ts}</th>
+              <th>{ts}Mode{/ts}</th>
               <th></th>
             </tr>
             </thead>
@@ -42,6 +43,7 @@
                 <td class="crm-acl-object" >{$row.object}</td>
                 <td class="crm-acl-name crm-editable" data-field="name">{$row.name}</td>
                 <td class="crm-acl-is_active" id="row_{$aclID}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+                <td class="crm-acl-deny" id="row_{$aclID}_deny">{if $row.deny eq 1} {ts}Deny{/ts} {else} {ts}allow{/ts} {/if}</td>
                 <td>{$row.action|replace:'xx':$aclID}</td>
               </tr>
             {/foreach}

--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -43,7 +43,7 @@
                 <td class="crm-acl-object" >{$row.object}</td>
                 <td class="crm-acl-name crm-editable" data-field="name">{$row.name}</td>
                 <td class="crm-acl-is_active" id="row_{$aclID}_status">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
-                <td class="crm-acl-deny" id="row_{$aclID}_deny">{if $row.deny eq 1} {ts}Deny{/ts} {else} {ts}allow{/ts} {/if}</td>
+                <td class="crm-acl-deny" id="row_{$aclID}_deny">{if $row.deny}{ts}Deny{/ts}{else}{ts}Allow{/ts}{/if}</td>
                 <td>{$row.action|replace:'xx':$aclID}</td>
               </tr>
             {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Permit Administrative users to create rules to deny access to custom groups / groups of contacts

See https://lab.civicrm.org/dev/core/-/issues/3753

Before
----------------------------------------
Only permit deny actions via hooks

After
----------------------------------------
Can use UI to create ACL rules to deny access to events, contacts, custom groups as needed
