### PR TITLE
[REF][PHP8.2] Fix deprecated usage of mb_convert_encoding with HTML-E…

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -371,7 +371,7 @@ class CRM_Afform_ArrayHtml {
    * @return string
    */
   public function replaceUnicodeChars($markup) {
-    return mb_convert_encoding($markup, 'HTML-ENTITIES', 'UTF-8');
+    return htmlspecialchars_decode(htmlentities($markup, ENT_COMPAT, 'utf-8', FALSE));
   }
 
   /**


### PR DESCRIPTION
…ntities

Overview
----------------------------------------
This aims to resolve the following test failure `api\v4\SearchDisplay\SearchAfformTest::testRunWithAfform
mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead` https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=bknix-tmp-edge/lastCompletedBuild/testReport/(root)/api_v4_SearchDisplay_SearchAfformTest/testRunWithAfform/

Before
----------------------------------------
Test fails on PHP8.2 due to deprecation

After
----------------------------------------
Test passes on PHP8.2

ping @demeritcowboy @braders @colemanw 