### PR TITLE
[SearchKit] Do not crash on entities without fields

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -188,7 +188,7 @@ class Admin {
   private static function addImplicitFKFields(array $schema):array {
     foreach ($schema as &$entity) {
       if ($entity['searchable'] !== 'bridge') {
-        foreach (array_reverse($entity['fields'], TRUE) as $index => $field) {
+        foreach (array_reverse($entity['fields'] ?? [], TRUE) as $index => $field) {
           if (!empty($field['fk_entity']) && !$field['options'] && !empty($schema[$field['fk_entity']]['label_field'])) {
             $isCustom = strpos($field['name'], '.');
             // Custom fields: append "Contact ID" etc. to original field label


### PR DESCRIPTION
Overview
----------------------------------------
The *SearchKit* admin interface crashes when there are entities without fields (e.g. custom API entities not derived from DAOs).

Before
----------------------------------------
A custom API entity without any fields causes the *SearchKit* admin interface to crash with `TypeError: array_reverse(): Argument #1 ($array) must be of type array, null given in array_reverse()`.

After
----------------------------------------
Entites without fields just don't have fields in *SearchKit*, no crashing.

Technical Details
----------------------------------------
There's an assumption that empty attributes for entities should not be part of the schema at all in `\Civi\Search\Admin::getSchema()`, but *SearchKit* relies on the attribute `fields` being there in `\Civi\Search\Admin::addImplicitFKFields()`.