### PR TITLE
tell search engines not to index click-through URLs

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -62,6 +62,7 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
       'for' => 'civicrm/mailing/url',
       'queue_id' => $queue_id,
       'url_id' => $url_id,
+      'noindex' => TRUE,
     ]);
   }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -545,7 +545,9 @@ class CRM_Utils_System {
     $url = str_replace('&amp;', '&', $url);
 
     $context['output'] = $_GET['snippet'] ?? NULL;
-
+    if ($context['noindex'] ?? FALSE) {
+      self::setHttpHeader('X-Robots-Tag', 'noindex');
+    }
     $parsedUrl = CRM_Utils_Url::parseUrl($url);
     CRM_Utils_Hook::alterRedirect($parsedUrl, $context);
     $url = CRM_Utils_Url::unparseUrl($parsedUrl);

--- a/extern/url.php
+++ b/extern/url.php
@@ -54,5 +54,6 @@ if (strlen($query_string) > 0) {
 $url = str_replace('&amp;', '&', $url);
 
 // CRM-17953 - The CMS is not bootstrapped so cannot use CRM_Utils_System::redirect
+header('X-Robots-Tag', 'noindex');
 header('Location: ' . $url);
 CRM_Utils_System::civiExit();


### PR DESCRIPTION
Overview
----------------------------------------
Currently, URLs like `http://mysite.org/civicrm/mailing/url?u=2&qid=4` or `https://mysite.org/vendor/civicrm/civicrm-core/extern/url.php?u=4606&qid=1774948` can be indexed by Google, leading to page indexing warnings in Google Search Console.

Before
----------------------------------------
Search engines attempt to index click-through URLs.

After
----------------------------------------
Search engines don't attempt to index click-through URLs.

Comments
----------------------------------------
I wonder what other pages we want to apply a `noindex` header to, if any.
