### PR TITLE
APIv4 Explorer - Translate localizable strings in php output

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -347,6 +347,11 @@ class BasicGetFieldsAction extends BasicGetAction {
         'data_type' => 'String',
       ],
       [
+        'name' => 'localizable',
+        'data_type' => 'Boolean',
+        'default_value' => FALSE,
+      ],
+      [
         'name' => 'readonly',
         'data_type' => 'Boolean',
         'description' => 'True for auto-increment, calculated, or otherwise non-editable fields.',

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -66,6 +66,7 @@ class SpecFormatter {
       $field->setRequired(!empty($data['required']) && empty($data['default']));
       $field->setTitle($data['title'] ?? NULL);
       $field->setLabel($data['html']['label'] ?? NULL);
+      $field->setLocalizable($data['localizable'] ?? FALSE);
       if (!empty($data['pseudoconstant'])) {
         // Do not load options if 'prefetch' is explicitly FALSE
         if (!isset($data['pseudoconstant']['prefetch']) || $data['pseudoconstant']['prefetch'] === FALSE) {

--- a/Civi/Schema/Traits/GuiSpecTrait.php
+++ b/Civi/Schema/Traits/GuiSpecTrait.php
@@ -38,6 +38,13 @@ trait GuiSpecTrait {
   public $inputType;
 
   /**
+   * Can the field be translated.
+   *
+   * @var bool
+   */
+  public $localizable = FALSE;
+
+  /**
    * @var array
    */
   public $inputAttrs = [];
@@ -90,6 +97,23 @@ trait GuiSpecTrait {
    */
   public function setInputAttrs($inputAttrs) {
     $this->inputAttrs = $inputAttrs;
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getLocalizable() {
+    return $this->localizable;
+  }
+
+  /**
+   * @param bool $localizable
+   *
+   * @return $this
+   */
+  public function setLocalizable(bool $localizable) {
+    $this->localizable = $localizable;
     return $this;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Displays localizable strings wrapped in `E::ts()` when using PHP output in the APIv4 explorer. This is especially helpful for the Export action.

![image](https://user-images.githubusercontent.com/2874912/231567993-42896f5c-6e83-4255-937b-f25e10952ef9.png)
