### PR TITLE
Nasty fail

### DIFF
--- a/ext/civigrant/sql/auto_install.sql
+++ b/ext/civigrant/sql/auto_install.sql
@@ -36,7 +36,7 @@ SET FOREIGN_KEY_CHECKS=1;
 CREATE TABLE `civicrm_grant` (
   `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Grant id',
   `contact_id` int unsigned NOT NULL COMMENT 'Contact ID of contact record given grant belongs to.',
-  `application_received_date` date COMMENT 'Date on which grant application was received by donor.',
+  `application_received_date` dateCOMMENT 'Date on which grant application was received by donor.',
   `decision_date` date COMMENT 'Date on which grant decision was made.',
   `money_transfer_date` date COMMENT 'Date on which grant money transfer was made.',
   `grant_due_date` date COMMENT 'Date on which grant report is due.',


### PR DESCRIPTION
this should fail - but in a meaningful way - not

Could not find the permission: access CiviGrant

CRM_Utils_File::runSqlQuery

looks like it should work - but it swallows the error

side question - why can't it use `CRM_Core_DAO::executeQuery ` calling `query()` is something we have been trying to ditch - mostly cos it doesn't free memory properly which `excuteQuery` does. That is probably less relevant here but we have established `CRM_Core_DAO::executeQuery `  as best practice
