### PR TITLE
API4: add SQL Function DAYOFWEEK

### DIFF
--- a/Civi/Api4/Query/SqlFunctionDAYOFWEEK.php
+++ b/Civi/Api4/Query/SqlFunctionDAYOFWEEK.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function
+ */
+class SqlFunctionDAYOFWEEK extends SqlFunction {
+
+  protected static $category = self::CATEGORY_DATE;
+
+  protected static $dataType = 'Integer';
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'optional' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Day of Week');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('The day of the week of a date.');
+  }
+
+  /**
+   * @return array
+   */
+  public static function getOptions(): ?array {
+    return [
+      1 => ts('Sunday'),
+      2 => ts('Monday'),
+      3 => ts('Tuesday'),
+      4 => ts('Wednesday'),
+      5 => ts('Thursday'),
+      6 => ts('Friday'),
+      7 => ts('Saturday'),
+    ];
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -236,6 +236,8 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('MONTH(birth_date):label AS month_name')
       ->addSelect('MONTH(birth_date):label')
       ->addSelect('EXTRACT(YEAR_MONTH FROM birth_date) AS year_month')
+      ->addSelect('DAYOFWEEK(birth_date) AS day_number')
+      ->addSelect('DAYOFWEEK(birth_date):label AS day_name')
       ->addWhere('last_name', '=', $lastName)
       ->addOrderBy('id')
       ->execute();
@@ -247,6 +249,8 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('November', $result[0]['month_name']);
     $this->assertEquals('November', $result[0]['MONTH:birth_date:label']);
     $this->assertEquals('200911', $result[0]['year_month']);
+    $this->assertEquals(4, $result[0]['day_number']);
+    $this->assertEquals('Wednesday', $result[0]['day_name']);
 
     $this->assertEquals(0, $result[1]['diff']);
     $this->assertEquals(2010, $result[1]['year']);
@@ -255,6 +259,8 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('January', $result[1]['month_name']);
     $this->assertEquals('January', $result[1]['MONTH:birth_date:label']);
     $this->assertEquals('201001', $result[1]['year_month']);
+    $this->assertEquals(6, $result[1]['day_number']);
+    $this->assertEquals('Friday', $result[1]['day_name']);
   }
 
   public function testIncorrectNumberOfArguments() {


### PR DESCRIPTION
Overview
----------------------------------------
Adds day of week functions as SQL transformation.   Let's you do things like 'find events on Wednesdays'

Before
----------------------------------------
No day of week functions

After
----------------------------------------
Day of week functions. 

Technical Details
----------------------------------------
The SQL function returns 1-7, mapped to day names by the 'getOptions()' function.

Comments
----------------------------------------
Has test!
