### PR TITLE
Update BillingBlock.tpl - Error with CiviDiscount + Patch Issue #24781

### DIFF
--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -9,7 +9,7 @@
 *}
 {crmRegion name="billing-block"}
 <div id="payment_information">
-  {if $paymentFields|@count}
+  {if $paymentFields}
     <fieldset class="billing_mode-group {$paymentTypeName}_info-group">
       <legend>
         {$paymentTypeLabel}
@@ -48,7 +48,7 @@
       </div>
     {/if}
   {/if}
-  {if $billingDetailsFields|@count && $paymentProcessor.payment_processor_type neq 'PayPal_Express'}
+  {if $billingDetailsFields && $paymentProcessor.payment_processor_type neq 'PayPal_Express'}
     {if $profileAddressFields && !$ccid}
       <input type="checkbox" id="billingcheckbox" value="0">
       <label for="billingcheckbox">{ts}My billing address is the same as above{/ts}</label>


### PR DESCRIPTION
Fixes a bug where @count is an expecting an array to count but may not be given one in every case. when using CiviDiscount with the patch from issue https://github.com/civicrm/civicrm-core/pull/24781 

Overview
----------------------------------------
An error, introduced when using the Stripe payment processor along with multi-participant registration, was fixed with a patch moving the payment block to the review page.  However, this, when mixed with CiviDiscount, caused an error with the BillingBlock.tpl file. This simple addition checks to see if the variable is set before attempting to count it. 

Before
----------------------------------------
Immediately begins to check $paymentFields|@count & $billingDetailFields|@count. 

After
----------------------------------------
Checks the validity of $paymentFields -> proceeds to $paymentFields|@count || same with $billingDetailFields -> moves to $billingDetailFields|@count. 

Technical Details
----------------------------------------
Minimal change, prevents an error being thrown and TPL breaking when the discount button is clicked. 

Comments
----------------------------------------
This has to do with the issue: issue #24781 
