### PR TITLE
SearchKit - Display option values for field transformations

### DIFF
--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -88,7 +88,7 @@ abstract class SqlExpression {
       $className = 'SqlEquation';
     }
     // If there are brackets but not the first character, we have a function
-    elseif ($bracketPos && $lastChar === ')') {
+    elseif ($bracketPos && preg_match('/^\w+\(.*\)(:[a-z]+)?$/', $expr)) {
       $fnName = substr($expr, 0, $bracketPos);
       if ($fnName !== strtoupper($fnName)) {
         throw new \CRM_Core_Exception('Sql function must be uppercase.');

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -181,10 +181,12 @@
         return {field: field, join: join};
       }
       function parseFnArgs(info, expr) {
-        var fnName = expr.split('(')[0],
-          argString = expr.substr(fnName.length + 1, expr.length - fnName.length - 2);
+        var matches = /([_A-Z]+)\((.*)\)(:[a-z]+)?$/.exec(expr),
+          fnName = matches[1],
+          argString = matches[2];
         info.fn = _.find(CRM.crmSearchAdmin.functions, {name: fnName || 'e'});
         info.data_type = (info.fn && info.fn.data_type) || null;
+        info.suffix = matches[3];
 
         function getKeyword(whitelist) {
           var keyword;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -186,6 +186,10 @@
           ctrl.expr += args.join('');
           ctrl.expr += ')';
           if (ctrl.mode === 'select') {
+            // Add pseudoconstant suffix if function has an option list
+            if (ctrl.fn.options) {
+              ctrl.expr += ':label';
+            }
             ctrl.expr += ' AS ' + makeAlias();
           }
         } else {

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -233,6 +233,8 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->addSelect('YEAR(birth_date) AS year')
       ->addSelect('QUARTER(birth_date) AS quarter')
       ->addSelect('MONTH(birth_date) AS month')
+      ->addSelect('MONTH(birth_date):label AS month_name')
+      ->addSelect('MONTH(birth_date):label')
       ->addSelect('EXTRACT(YEAR_MONTH FROM birth_date) AS year_month')
       ->addWhere('last_name', '=', $lastName)
       ->addOrderBy('id')
@@ -242,12 +244,16 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(2009, $result[0]['year']);
     $this->assertEquals(4, $result[0]['quarter']);
     $this->assertEquals(11, $result[0]['month']);
+    $this->assertEquals('November', $result[0]['month_name']);
+    $this->assertEquals('November', $result[0]['MONTH:birth_date:label']);
     $this->assertEquals('200911', $result[0]['year_month']);
 
     $this->assertEquals(0, $result[1]['diff']);
     $this->assertEquals(2010, $result[1]['year']);
     $this->assertEquals(1, $result[1]['quarter']);
     $this->assertEquals(1, $result[1]['month']);
+    $this->assertEquals('January', $result[1]['month_name']);
+    $this->assertEquals('January', $result[1]['MONTH:birth_date:label']);
     $this->assertEquals('201001', $result[1]['year_month']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This takes advantage of function option lists in SearchKit output, e.g. this will show Janurary instead of 1 for the Month-Only transformation.

![image](https://user-images.githubusercontent.com/2874912/232245870-ca6eb977-5a88-403a-a899-e6711bc1fea5.png)
