### PR TITLE
Fix dev/core#4240 - Saving entityReference field value via API

### DIFF
--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -57,7 +57,8 @@ class CRM_Core_BAO_CustomValue extends CRM_Core_DAO {
         return CRM_Utils_Rule::boolean($value);
 
       case 'ContactReference':
-        return CRM_Utils_Rule::validContact($value);
+      case 'EntityReference':
+        return CRM_Utils_Rule::positiveInteger($value);
 
       case 'StateProvince':
 

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -205,6 +205,10 @@ class CRM_Core_BAO_CustomValueTable {
 
             case 'EntityReference':
               $type = 'Integer';
+              if ($value == NULL || $value === '') {
+                $type = 'Timestamp';
+                $value = NULL;
+              }
               break;
 
             case 'RichTextEditor':

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -236,6 +236,7 @@ class CRM_Utils_Type {
       case 'Date':
       case 'Timestamp':
       case 'ContactReference':
+      case 'EntityReference':
       case 'MysqlOrderByDirection':
         $validatedData = self::validate($data, $type, $abort);
         if (isset($validatedData)) {
@@ -380,6 +381,7 @@ class CRM_Utils_Type {
       'Date',
       'Timestamp',
       'ContactReference',
+      'EntityReference',
       'MysqlColumnNameOrAlias',
       'MysqlOrderByDirection',
       'MysqlOrderBy',
@@ -435,12 +437,13 @@ class CRM_Utils_Type {
         break;
 
       case 'ContactReference':
+      case 'EntityReference':
         // null is valid
         if (strlen(trim($data)) == 0) {
           return trim($data);
         }
 
-        if (CRM_Utils_Rule::validContact($data)) {
+        if (CRM_Utils_Rule::positiveInteger($data)) {
           return (int) $data;
         }
         break;

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -29,8 +29,6 @@ use Civi\Api4\Entity;
  */
 class CustomValueTest extends CustomTestBase {
 
-  protected $contactID;
-
   /**
    * Test CustomValue::GetFields/Get/Create/Update/Replace/Delete
    */
@@ -40,7 +38,7 @@ class CustomValueTest extends CustomTestBase {
     $group = uniqid('groupc');
     $colorFieldName = uniqid('colorc');
     $multiFieldName = uniqid('chkbx');
-    $textFieldName = uniqid('txt');
+    $refFieldName = uniqid('txt');
 
     $customGroup = CustomGroup::create(FALSE)
       ->addValue('title', $group)
@@ -65,18 +63,21 @@ class CustomValueTest extends CustomTestBase {
       ->addValue('data_type', 'String')
       ->execute()->first();
 
-    $textField = CustomField::create(FALSE)
-      ->addValue('label', $textFieldName)
+    $refField = CustomField::create(FALSE)
+      ->addValue('label', $refFieldName)
       ->addValue('custom_group_id', $customGroup['id'])
-      ->addValue('html_type', 'Text')
-      ->addValue('data_type', 'String')
+      ->addValue('html_type', 'Autocomplete-Select')
+      ->addValue('data_type', 'EntityReference')
+      ->addValue('fk_entity', 'Address')
       ->execute()->first();
 
-    $this->contactID = $this->createTestRecord('Contact', [
+    $cid = $this->createTestRecord('Contact', [
       'first_name' => 'Johann',
       'last_name' => 'Tester',
       'contact_type' => 'Individual',
     ])['id'];
+    $address1 = $this->createTestRecord('Address')['id'];
+    $address2 = $this->createTestRecord('Address')['id'];
 
     // Ensure virtual api entity has been created
     $entity = Entity::get(FALSE)
@@ -121,13 +122,13 @@ class CustomValueTest extends CustomTestBase {
       [
         'custom_group' => $group,
         'type' => 'Field',
-        'name' => $textFieldName,
-        'title' => $textFieldName,
+        'name' => $refFieldName,
+        'title' => $refFieldName,
         'entity' => "Custom_$group",
         'table_name' => $customGroup['table_name'],
-        'column_name' => $textField['column_name'],
-        'data_type' => 'String',
-        'fk_entity' => NULL,
+        'column_name' => $refField['column_name'],
+        'data_type' => 'Integer',
+        'fk_entity' => 'Address',
         'serialize' => 0,
       ],
       [
@@ -163,16 +164,17 @@ class CustomValueTest extends CustomTestBase {
     $created = [
       CustomValue::create($group)
         ->addValue($colorFieldName, 'g')
-        ->addValue("entity_id", $this->contactID)
+        ->addValue($refFieldName, $address1)
+        ->addValue("entity_id", $cid)
         ->execute()->first(),
       CustomValue::create($group)
         ->addValue($colorFieldName . ':label', 'Red')
-        ->addValue("entity_id", $this->contactID)
+        ->addValue("entity_id", $cid)
         ->execute()->first(),
     ];
     // fetch custom values using API4 CustomValue::get
     $result = CustomValue::get($group)
-      ->addSelect('id', 'entity_id', $colorFieldName, $colorFieldName . ':label')
+      ->addSelect('id', 'entity_id', $colorFieldName, $colorFieldName . ':label', $refFieldName)
       ->addOrderBy($colorFieldName, 'ASC')
       ->execute();
 
@@ -183,13 +185,14 @@ class CustomValueTest extends CustomTestBase {
         'id' => 1,
         $colorFieldName => 'g',
         $colorFieldName . ':label' => 'Green',
-        'entity_id' => $this->contactID,
+        $refFieldName => $address1,
+        'entity_id' => $cid,
       ],
       [
         'id' => 2,
         $colorFieldName => 'r',
         $colorFieldName . ':label' => 'Red',
-        'entity_id' => $this->contactID,
+        'entity_id' => $cid,
       ],
     ];
     // match the data
@@ -207,14 +210,16 @@ class CustomValueTest extends CustomTestBase {
     CustomValue::update($group)
       ->addWhere("id", "=", 1)
       ->addValue($colorFieldName . ':label', 'Blue')
+      ->addValue($refFieldName, NULL)
       ->execute();
 
     // ensure that the value is changed for id = 1
-    $color = CustomValue::get($group)
+    $result = CustomValue::get($group)
       ->addWhere("id", "=", 1)
       ->execute()
-      ->first()[$colorFieldName];
-    $this->assertEquals('b', $color);
+      ->first();
+    $this->assertEquals('b', $result[$colorFieldName]);
+    $this->assertEquals(NULL, $result[$refFieldName]);
 
     // CASE 3: Test CustomValue::replace
     // create a second contact which will be used to replace the custom values, created earlier
@@ -226,13 +231,13 @@ class CustomValueTest extends CustomTestBase {
     // Replace all the records which was created earlier with entity_id = first contact
     //  with custom record [$colorField => 'g', 'entity_id' => $secondContactID]
     CustomValue::replace($group)
-      ->setRecords([[$colorFieldName => 'g', $multiFieldName . ':label' => ['Red', 'Green'], 'entity_id' => $secondContactID]])
-      ->addWhere('entity_id', '=', $this->contactID)
+      ->setRecords([[$colorFieldName => 'g', $multiFieldName . ':label' => ['Red', 'Green'], $refFieldName => $address2, 'entity_id' => $secondContactID]])
+      ->addWhere('entity_id', '=', $cid)
       ->execute();
 
     // Check the two records created earlier is replaced by new contact
     $result = CustomValue::get($group)
-      ->addSelect('id', 'entity_id', $colorFieldName, $colorFieldName . ':label', $multiFieldName, $multiFieldName . ':label')
+      ->addSelect('id', 'entity_id', $colorFieldName, $colorFieldName . ':label', $multiFieldName, $multiFieldName . ':label', $refFieldName)
       ->execute();
     $this->assertEquals(1, count($result));
 
@@ -243,6 +248,7 @@ class CustomValueTest extends CustomTestBase {
         $colorFieldName . ':label' => 'Green',
         $multiFieldName => ['r', 'g'],
         $multiFieldName . ':label' => ['Red', 'Green'],
+        $refFieldName => $address2,
         'entity_id' => $secondContactID,
       ],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug described in [dev/core#4240](https://lab.civicrm.org/dev/core/-/issues/4240)

Before
-------------
Cannot save field value for custom data of type EntityReference

After
---------------
Fixed.