### PR TITLE
dev/core#1321 - SearchKit - Limit operator list for array fields

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
@@ -64,6 +64,9 @@
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];
         }
+        if (!allowedOps && (field.data_type === 'Array' || field.serialize)) {
+          allowedOps = ['CONTAINS', 'IS EMPTY', 'IS NOT EMPTY'];
+        }
         if (!allowedOps) {
           return CRM.crmSearchAdmin.operators;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Implements suggestion from https://lab.civicrm.org/dev/core/-/issues/1321#note_58735 to limit operators in SearchKit for fields that store array data.

Before
----------------------------------------
Searching on an array field like "Contact Subtype" is confusing in SearchKit, as the default `"="` operator doesn't work as expected.

After
----------------------------------------
Default is now `"CONTAINS"` which correctly searches within arrays. Only sensible operators are available.

![image](https://user-images.githubusercontent.com/2874912/232253122-778ddfae-107e-489b-9855-451c2b872c0b.png)
