### PR TITLE
Remove unnecessary count() from smarty conditionals

### DIFF
--- a/templates/CRM/Form/body.tpl
+++ b/templates/CRM/Form/body.tpl
@@ -15,7 +15,7 @@
   <div>{$form.hidden}</div>
 {/if}
 
-{if ($snippet !== 'json') and !$suppressForm and $form.errors !== NULL && count($form.errors) gt 0}
+{if ($snippet !== 'json') and !$suppressForm and $form.errors}
    <div class="messages crm-error">
        <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>
      {ts}Please correct the following errors in the form fields below:{/ts}

--- a/templates/CRM/common/SectionNav.tpl
+++ b/templates/CRM/common/SectionNav.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {* Navigation template for multi-section Wizards *}
-{if count( $category.steps ) > 0}
+{if $category.steps}
 <div id="wizard-steps">
    <ul class="section-list">
     {foreach from=$category.steps item=step}

--- a/templates/CRM/common/displaySearchCriteria.tpl
+++ b/templates/CRM/common/displaySearchCriteria.tpl
@@ -11,7 +11,7 @@
 {foreach from=$qill name=sets key=setKey item=orClauses}
     {if $smarty.foreach.sets.total > 2}
         {* We have multiple criteria sets, so display AND'd items in each set on the same line. *}
-        {if count($orClauses) gt 0}
+        {if $orClauses}
         <ul>
         <li>
         {foreach from=$orClauses name=criteria item=item}


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #26064 this removes some more unnecessary counts.

Before
----------------------------------------
Variable is counted and then cast to boolean by the conditional.

After
----------------------------------------
Variable is cast to boolean by the conditional.