### PR TITLE
dev/core#398 FormBuilder: add 'Copy' button

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -103,6 +103,7 @@
               item['af-join'] = block.join_entity;
               item['#children'] = [{"#tag": directive}];
               item['af-repeat'] = ts('Add');
+              item['af-copy'] = ts('Copy');
               item.min = '1';
               if (typeof joinEntity.repeat_max === 'number') {
                 item.max = '' + joinEntity.repeat_max;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -127,9 +127,13 @@
           delete ctrl.node.min;
           delete ctrl.node['af-repeat'];
           delete ctrl.node['add-icon'];
+          delete ctrl.node['af-copy'];
+          delete ctrl.node['copy-icon'];
+
         } else {
           ctrl.node.min = '1';
           ctrl.node['af-repeat'] = ts('Add');
+          ctrl.node['af-copy'] = ts('Copy');
           delete ctrl.node.data;
         }
       };
@@ -185,6 +189,12 @@
       $scope.pickAddIcon = function() {
         afGui.pickIcon().then(function(val) {
           ctrl.node['add-icon'] = val;
+        });
+      };
+
+      $scope.pickCopyIcon = function() {
+        afGui.pickIcon().then(function(val) {
+          ctrl.node['copy-icon'] = val;
         });
       };
 

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -46,3 +46,11 @@
     <span crm-ui-editable ng-model="$ctrl.node['af-repeat']">{{ $ctrl.node['af-repeat'] }}</span>
   </button>
 </div>
+<div ng-if="$ctrl.node['af-copy'] || $ctrl.node['af-copy'] === ''" class="af-gui-button">
+  <button type="button" class="btn btn-xs btn-primary disabled">
+    <span class="crm-editable-enabled" ng-click="pickCopyIcon()" >
+      <i class="crm-i {{ $ctrl.node['copy-icon'] || 'fa-copy' }}"></i>
+    </span>
+    <span crm-ui-editable ng-model="$ctrl.node['af-copy']">{{ $ctrl.node['af-copy'] }}</span>
+  </button>
+</div>

--- a/ext/afform/core/ang/af/afRepeat.directive.js
+++ b/ext/afform/core/ang/af/afRepeat.directive.js
@@ -10,7 +10,9 @@
           min: '=',
           max: '=',
           addLabel: '@afRepeat',
-          addIcon: '@'
+          addIcon: '@',
+          copyLabel: '@afCopy',
+          copyIcon: '@'
         },
         templateUrl: '~/af/afRepeat.html',
         link: function($scope, $el, $attr, ctrls) {
@@ -38,6 +40,12 @@
 
           $scope.addItem = function() {
             $scope.getItems().push(getRepeatType() === 'join' ? {} : {fields: {}});
+          };
+
+          $scope.copyItem = function() {
+            var data = $scope.getItems();
+            var last = data[data.length-1];
+            data.push(getRepeatType() === 'join' ? angular.copy(last) : {fields: angular.copy(last.fields)});
           };
 
           $scope.removeItem = function(index) {

--- a/ext/afform/core/ang/af/afRepeat.html
+++ b/ext/afform/core/ang/af/afRepeat.html
@@ -3,3 +3,4 @@
   <button crm-icon="fa-ban" class="btn btn-xs af-repeat-remove-btn" ng-if="canRemove()" ng-click="removeItem($index)"></button>
 </div>
 <button crm-icon="{{ addIcon || 'fa-plus' }}" class="btn btn-sm af-repeat-add-btn" ng-if="canAdd()" ng-click="addItem()">{{ addLabel }}</button>
+<button crm-icon="{{ copyIcon || 'fa-copy' }}" class="btn btn-sm af-repeat-copy-btn" ng-if="canAdd()" ng-click="copyItem()">{{ copyLabel }}</button>


### PR DESCRIPTION
Overview
----------------------------------------
Extend the FormBuilder 'repeat' functionality to add a button to create a new item with a copy of the previous item's values.
https://lab.civicrm.org/dev/core/-/issues/3986

The use case here is for creating a set of similar entities where most values are the same.  

Before
----------------------------------------
Can 'Add' a new item

After
----------------------------------------
Can 'Add' a new item, and also 'Copy' to duplicate the previously entered values:

![image](https://user-images.githubusercontent.com/2730045/232585198-27e223d5-5a7f-45a3-8fed-f42aec125419.png)

**Click Copy**

![image](https://user-images.githubusercontent.com/2730045/232585351-092f849e-c8f7-4652-ba1d-e4f055ad36de.png)

**Then make changes to second entry etc**

Technical Details
----------------------------------------
@colemanw Here's an attempt to produce a 'Copy' button, but it's fairly clueless copy/paste/hack!

~~This seems to work ok for a simple fieldset as in the screenshots.  However, if you create a form for Contact and add the Email block, then the repeat type is 'join' and it fails with duplicates in the `ngRepeat`, which I think is because of `cloneDeep`  Have you come across that before?~~

Also, the 'Copy' button appears whenever the 'Add' one does.  Do you think it need separate configuration to allow form builders to specify whether 'Copy' is enabled?
 

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
