### PR TITLE
Deprecate unused 'validContact' function

### DIFF
--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -878,12 +878,14 @@ class CRM_Utils_Rule {
   }
 
   /**
+   * @deprecated
    * @param mixed $value
    * @param mixed $actualElementValue
    *
    * @return bool
    */
   public static function validContact($value, $actualElementValue = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('positiveInteger');
     if ($actualElementValue) {
       $value = $actualElementValue;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate unused redundant function.

Before
----------------
Unused `validContact` function redundant with `positiveInteger`.

After
-------------
Deprecated