### PR TITLE
Afform - Consistently save 'contact_summary' = null

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -330,7 +330,7 @@
 
       this.toggleContactSummary = function() {
         if (editor.afform.contact_summary) {
-          editor.afform.contact_summary = false;
+          editor.afform.contact_summary = null;
           _.each(editor.searchDisplays, function(searchDisplay) {
             delete searchDisplay.element.filters;
           });


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4206](https://lab.civicrm.org/dev/core/-/issues/4206)

Before
----------------------------------------
Value of `contact_summary` is initially `null` but the GUI re-saves it as `0` when toggled.

After
----------------------------------------
Consistently `null`.