### PR TITLE
htxt undetected opening tag

### DIFF
--- a/templates/CRM/SMS/Form/Group.hlp
+++ b/templates/CRM/SMS/Form/Group.hlp
@@ -47,10 +47,10 @@
 <p>{ts}If you have sent other Mass SMS - you can additionally Include (or Exclude) contacts who received those Mass SMS. CiviCRM will eliminate any duplications so that contacts who are in an Included Group AND were recipients of an Included Mailing will only be sent one copy of this SMS.{/ts}</p>
 {/htxt}
 
-{htxt id ="id-sms_provider-title"}
+{htxt id="id-sms_provider-title"}
   {ts}SMS Provider{/ts}
 {/htxt}
-{htxt id ="id-sms_provider"}
+{htxt id="id-sms_provider"}
 <p>{ts}Select the SMS provider for this mass message from the dropdown list.{/ts}</p>
 {if $params.isAdmin}
     {capture assign="fromConfig"}{crmURL p="civicrm/admin/sms/provider" q="reset=1"}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
In the page /civicrm/sms/send?reset=1, we get the following error:

![ksnip_20230419-101245](https://user-images.githubusercontent.com/372004/233102533-3bc0b568-e9c9-4397-acdb-fea08970e8cd.png)

Before
----------------------------------------
Error message

After
----------------------------------------
No more errors

Technical Details
----------------------------------------
Smarty smarty_prefilter_htxtFilter doesn't work if we put a space between `{htxt id` and `=`

