### PR TITLE
dev/core#4247 Ensure that Membership values are populated to prevent …

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -927,7 +927,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
   protected function emailReceipt($form, &$formValues): bool {
     $membership = new CRM_Member_BAO_Membership();
     $membership->id = $this->getCurrentRowMembershipID();
-    $membership->fetch();
+    $membership->find(TRUE);
     // @todo figure out how much of the stuff below is genuinely shared with the batch form & a logical shared place.
     if (!empty($formValues['payment_instrument_id'])) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();


### PR DESCRIPTION
…fatal error on formatting start date

Overview
----------------------------------------
This fixes a fatal type error on passing NULL into the date function when it expects a string

Before
----------------------------------------
Fatal error on processing a batch

After
----------------------------------------
No Fatal error

ping @eileenmcnaughton 