### PR TITLE
dev/core#4249 Ensure that no deprecation logging occurs from groupPer…

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -196,7 +196,7 @@ class CRM_ACL_API {
 
     $key = "{$tableName}_{$type}_{$contactID}";
     if (!array_key_exists($key, Civi::$statics[__CLASS__]['group_permission'])) {
-      Civi::$statics[__CLASS__]['group_permission'][$key] = self::group($type, $contactID, $tableName, $allGroups, $includedGroups);
+      Civi::$statics[__CLASS__]['group_permission'][$key] = self::group($type, $contactID, $tableName, $allGroups, $includedGroups ?? []);
     }
 
     return in_array($groupID, Civi::$statics[__CLASS__]['group_permission'][$key]);


### PR DESCRIPTION
…mission having includeGroups as NULL rather than an empty array

Overview
----------------------------------------
This aims to stop unnecessary deprecation logging because $includeGroups in groupPermission function is NULL not an empty array

Before
----------------------------------------
if groupPermission is called with $includeGroups as NULL it is passed onto group() as NULL causing the deprecation warning

After
----------------------------------------
No unnecessary deprecation warning generated

ping @eileenmcnaughton 