### PR TITLE
dev/core#92 WIP Warn when disabling/deleting groups which feature in smart group criteria

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -241,7 +241,24 @@ class CRM_Admin_Page_AJAX {
           break;
 
         case 'CRM_Contact_BAO_Group':
+          $smartGroupsReferencingThisGroup = CRM_Contact_BAO_Group::getSmartGroupsUsingGroup($recordID);
           $ret['content'] = ts('Are you sure you want to disable this Group?');
+          if (!empty($smartGroupsReferencingThisGroup)) {
+            $ret['content'] .= '<br /><br /><strong>';
+            $ret['content'] .= ts('WARNING this Group is currently referenced by %1 group/s',
+                                  [1 => count($smartGroupsReferencingThisGroup)]);
+            $ret['content'] .= '</strong><ul>';
+
+            foreach ($smartGroupsReferencingThisGroup as $group_id => $group_title) {
+              $ret['content'] .= '<li>' . ts('Group id: %1 title: %2 ', [
+                1 => $group_id,
+                2 => $group_title,
+              ]) . '</li>';
+            }
+            $ret['content'] .= '</ul>';
+            $ret['content'] .= ts('Disabling this group will cause these groups to no longer restrict members based on membership in this group. Please edit and remove this group as a criteria from these smart groups.') . '<br /><br />';
+          }
+
           $ret['content'] .= '<br /><br /><strong>' . ts('WARNING - Disabling this group will disable all the child groups associated if any.') . '</strong>';
           break;
 

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1417,6 +1417,39 @@ WHERE {$whereClause}";
   }
 
   /**
+   * Gets all smart groups that filter based on groupID.
+   *
+   * @param int $groupID
+   *     Group Id to search for.
+   * @return array
+   */
+  public static function getSmartGroupsUsingGroup(int $groupID) {
+    $savedSearches = Group::get(FALSE)
+      ->addSelect('id', 'title', 'saved_search_id', 'saved_search_id.form_values')
+      ->addWhere('saved_search_id', 'IS NOT NULL')
+      ->setLimit(0)
+      ->execute();
+    $failingSmartGroups = [];
+    foreach ($savedSearches as $savedSearch) {
+      // Filter out arrays in Form Values which are group searchs.
+      $groupSearches = array_filter(
+        $savedSearch['saved_search_id.form_values'],
+        function($v) {
+          return ($v[0] == 'group');
+        }
+      );
+      // Check each group search for valid groups.
+      $failingGroups = [];
+      foreach ($groupSearches as $groupSearch) {
+        if (!empty($groupSearch[2]['IN']) && in_array($groupID, $groupSearch[2]['IN'])) {
+          $failingSmartGroups[$savedSearch['id']] = $savedSearch['title'];
+        }
+      }
+    }
+    return $failingSmartGroups;
+  }
+
+  /**
    * @param string $entityName
    * @param string $action
    * @param array $record

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -126,6 +126,8 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
         $this->assign('title', $this->_title);
         try {
           $this->assign('count', CRM_Contact_BAO_Group::memberCount($this->_id));
+          $smartGroupsUsingThisGroup = CRM_Contact_BAO_Group::getSmartGroupsUsingGroup($this->_id);
+          $this->assign('smartGroupsUsingThisGroup', $smartGroupsUsingThisGroup);
         }
         catch (CRM_Core_Exception $e) {
           // If the group is borked the query might fail but delete should be possible.

--- a/templates/CRM/Group/Form/Delete.tpl
+++ b/templates/CRM/Group/Form/Delete.tpl
@@ -17,6 +17,15 @@
     {if $count}
         {ts count=$count plural='This group currently has %count members in it.'}This group currently has one member in it.{/ts}
     {/if}
+
+    {if $smartGroupsUsingThisGroup}
+    <p>Deleting this group will mean the following Smart Groups will no longer restrict based on membership in this group - as they do currently. Please edit and resave these smart groups to remove reference to this group before deleting.</p>
+    <ul>
+    {foreach from=$smartGroupsUsingThisGroup item=v key=k}
+         <li>{$v} <a href='civicrm/group/search?force=1&context=smog&gid={$k}&component_mode=1'>Edit Group</a></li>
+    {/foreach}
+    </ul>
+    {/if}
     {ts}Deleting this group will NOT delete the member contact records. However, all contact subscription information and history for this group will be deleted.{/ts} {ts}If this group is used in CiviCRM profiles, those fields will be reset.{/ts} {ts}This action cannot be undone.{/ts}
     </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Start to address https://lab.civicrm.org/dev/core/-/issues/92 

Before
----------------------------------------
It's not  obvious when disabling or deleting a group that a smart group built from this group will act unpredictably. 

There are warnings about what happens when you disable a group but no reference to dependent smart groups and no indication of which smart groups are involved.

After
----------------------------------------
Adds a warning when user disables/deletes a group listing which groups are potentially problematic.

Disable 
![image](https://user-images.githubusercontent.com/9410526/233483078-c33a739b-fc34-47d1-8e54-550819d190be.png)


Delete
![image](https://user-images.githubusercontent.com/9410526/233483280-d76d8a12-a79c-4f37-9d13-abe7f6265736.png)


Comments
----------------------------------------

To test - Create a static group. Add some contacts. Create a new smart group that includes being in this group as a criteria. Then attempt to disable/delete the first group.
