### PR TITLE
Issue #4249: Eliminate deprecated warning in CRM_ACL_API::groupPermission

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -183,7 +183,7 @@ class CRM_ACL_API {
     $contactID = NULL,
     $tableName = 'civicrm_saved_search',
     $allGroups = NULL,
-    $includedGroups = NULL
+    $includedGroups = []
   ) {
 
     if (!isset(Civi::$statics[__CLASS__]) || !isset(Civi::$statics[__CLASS__]['group_permission'])) {


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/4249.

Overview
----------------------------------------
Eliminates a warning when viewing Profile after login:

pass an array for included groups Caller: CRM_ACL_API::groupPermission Array ( [civi.tag] => deprecated )

Before
----------------------------------------
Logging in a user with a Profile resulted in the above warning being posted twice to the dblog.

After
----------------------------------------
No more warning.
