### PR TITLE
dev/core#4248 - Fix missing price-set usage table

### DIFF
--- a/CRM/Price/Page/Field.php
+++ b/CRM/Price/Page/Field.php
@@ -230,12 +230,8 @@ class CRM_Price_Page_Field extends CRM_Core_Page {
     );
 
     if ($this->_sid) {
-      $usedByDefaults = [
-        'civicrm_event' => FALSE,
-        'civicrm_contribution_page' => FALSE,
-      ];
       $usedBy = CRM_Price_BAO_PriceSet::getUsedBy($this->_sid);
-      $this->assign('usedBy', array_intersect_key($usedByDefaults, $usedBy));
+      $this->assign('usedBy', $usedBy);
       $this->_isSetReserved = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_sid, 'is_reserved');
       $this->assign('isReserved', $this->_isSetReserved);
 

--- a/templates/CRM/Price/Page/Field.tpl
+++ b/templates/CRM/Price/Page/Field.tpl
@@ -13,16 +13,14 @@
   {include file="CRM/Price/Form/DeleteField.tpl"}
 {elseif $action eq 1024 }
   {include file="CRM/Price/Form/Preview.tpl"}
-{elseif ($usedBy and $action eq 8) or $usedBy.civicrm_event or $usedBy.civicrm_contribution_page}
+{elseif $usedBy}
   <div id="price_set_used_by" class="messages status no-popup">
     {icon icon="fa-info-circle"}{/icon}
     {if $action eq 8}
       {ts 1=$usedPriceSetTitle}Unable to delete the '%1' Price Field - it is currently in use by one or more active events or contribution pages or contributions  or event templates.{/ts}
     {/if}
 
-    {if $usedBy.civicrm_event or $usedBy.civicrm_contribution_page or $usedBy.civicrm_event_template}
-      {include file="CRM/Price/Page/table.tpl"}
-    {/if}
+    {include file="CRM/Price/Page/table.tpl"}
   </div>
 {/if}
 

--- a/templates/CRM/Price/Page/Set.tpl
+++ b/templates/CRM/Price/Page/Set.tpl
@@ -26,9 +26,7 @@
             {ts 1=$usedPriceSetTitle}Unable to delete the '%1' price set - it is currently in use by one or more active events or contribution pages or contributions or event templates.{/ts}
         {/if}
 
-      {if $usedBy.civicrm_event or $usedBy.civicrm_contribution_page or $usedBy.civicrm_event_template}
-            {include file="CRM/Price/Page/table.tpl"}
-        {/if}
+        {include file="CRM/Price/Page/table.tpl"}
     </div>
     {/if}
 

--- a/templates/CRM/Price/Page/table.tpl
+++ b/templates/CRM/Price/Page/table.tpl
@@ -7,8 +7,11 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{* The price field can be used somewhere but not necessarily in a page/event. In that case we still want to display some message. *}
+{assign var='showGenericMessage' value=true}
 {foreach from=$contexts item=context}
 {if $context EQ "Event"}
+  {assign var='showGenericMessage' value=false}
     {if $action eq 8}
         {ts}If you no longer want to use this price set, click the event title below, and modify the fees for that event.{/ts}
     {else}
@@ -34,6 +37,7 @@
 </table>
 {/if}
 {if $context EQ "Contribution"}
+  {assign var='showGenericMessage' value=false}
     {if $action eq 8}
         {ts}If you no longer want to use this price set, click the contribution page title below, and modify the Amounts or Membership tab configuration.{/ts}
     {else}
@@ -57,6 +61,7 @@
 </table>
 {/if}
 {if $context EQ "EventTemplate"}
+  {assign var='showGenericMessage' value=false}
   {if $action eq 8}
     {ts}If you no longer want to use this price set, click the event template title below, and modify the fees for that event.{/ts}
   {else}
@@ -79,3 +84,9 @@
 </table>
 {/if}
 {/foreach}
+{if $showGenericMessage}
+  {if $action neq 8}
+    {* We don't have to do anything for delete action because the calling tpl already displays something. *}
+    {ts}This price set is used by at least one contribution, but is not used by any active events or contribution pages or event templates.{/ts}
+  {/if}
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4248

Before
----------------------------------------
1. Make a price set.
2. Use it somewhere, e.g. a contribution page.
3. Visit manage price sets and click on View and Edit Price Fields.
4. It's supposed to have a little table at the top telling you where it's used.

After
----------------------------------------
Working again.

Technical Details
----------------------------------------
This reverts parts of both https://github.com/civicrm/civicrm-core/pull/25016 and https://github.com/civicrm/civicrm-core/pull/23046 and instead addresses the undefined vars in the tpls. The first PR was attempting to address them in php, but caused a problem which led to the 2nd PR which then caused this problem.

There is a certain amount of code that expects $usedBy to NOT have the keys and be completely empty when nothing is using the field/set. I felt it was easier and less error-prone to keep it that way rather than try to make sure all the keys are always assigned, and then always have to check every key to see if it's also empty. For example in Field.php just a bit lower down on line 246 where it sets the contexts, and in the tpls there are still other places checking `!$usedBy`.

Comments
----------------------------------------
Additional note that it was buggy regarding usage in event_templates even before the first PR.
