### PR TITLE
dev/core#4220 - Don't make case activity revisions anymore when file-on-case

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -317,8 +317,7 @@ class CRM_Activity_Page_AJAX {
     $mainActivity->activity_date_time = $actDateTime;
     // Make sure this is current revision.
     $mainActivity->is_current_revision = TRUE;
-    $mainActivity->original_id = $otherActivity->id;
-    $otherActivity->is_current_revision = FALSE;
+    $mainActivity->original_id = $mainActivity->parent_id = NULL;
 
     $mainActivity->save();
     $mainActivityId = $mainActivity->id;

--- a/tests/phpunit/CRM/Activity/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Activity/Page/AJAXTest.php
@@ -69,6 +69,114 @@ class CRM_Activity_Page_AJAXTest extends CiviUnitTestCase {
   }
 
   /**
+   * Similar to testConvertToCaseActivity above but for copy-to-case.
+   */
+  public function testCopyToCase() {
+    $case1 = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->target,
+      'case_type_id' => 'housing_support',
+      'subject' => 'Needs housing',
+    ]);
+    $contact2 = $this->individualCreate([], 1, TRUE);
+    $case2 = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $contact2,
+      'case_type_id' => 'housing_support',
+      'subject' => 'Also needs housing',
+    ]);
+
+    $activity = $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->loggedInUser,
+      'activity_type_id' => 'Meeting',
+      'subject' => 'To be copied to case',
+      'status_id' => 'Completed',
+      'target_id' => $this->target,
+      'case_id' => $case1['id'],
+    ]);
+
+    $params = [
+      'activityID' => $activity['id'],
+      'caseID' => $case2['id'],
+      'mode' => 'copy',
+      'targetContactIds' => $contact2,
+    ];
+    $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($params);
+
+    $this->assertEmpty($result['error_msg']);
+    $newActivityId = $result['newId'];
+
+    $caseActivities = $this->callAPISuccess('Activity', 'get', [
+      'case_id' => $case2['id'],
+      'return' => ['id', 'subject', 'target_contact_id'],
+    ])['values'];
+    $this->assertEquals('To be copied to case', $caseActivities[$newActivityId]['subject']);
+    $this->assertEquals($contact2, $caseActivities[$newActivityId]['target_contact_id'][0]);
+    // This should be a different physical activity, not the same db record as the original.
+    $this->assertNotEquals($activity['id'], $caseActivities[$newActivityId]['id']);
+
+    // original should still be on old case
+    $originalActivity = $this->callAPISuccess('Activity', 'getsingle', [
+      'id' => $activity['id'],
+      'return' => ['is_deleted', 'case_id'],
+    ]);
+    $this->assertEquals(0, $originalActivity['is_deleted']);
+    $this->assertEquals($case1['id'], $originalActivity['case_id'][0]);
+  }
+
+  /**
+   * Similar to testCopyToCase above but for move-to-case.
+   */
+  public function testMoveToCase() {
+    $case1 = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->target,
+      'case_type_id' => 'housing_support',
+      'subject' => 'Needs housing',
+    ]);
+    $contact2 = $this->individualCreate([], 1, TRUE);
+    $case2 = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $contact2,
+      'case_type_id' => 'housing_support',
+      'subject' => 'Also needs housing',
+    ]);
+
+    $activity = $this->callAPISuccess('Activity', 'create', [
+      'source_contact_id' => $this->loggedInUser,
+      'activity_type_id' => 'Meeting',
+      'subject' => 'To be moved to case',
+      'status_id' => 'Completed',
+      'target_id' => $this->target,
+      'case_id' => $case1['id'],
+    ]);
+
+    $params = [
+      'activityID' => $activity['id'],
+      'caseID' => $case2['id'],
+      'mode' => 'move',
+      'targetContactIds' => $contact2,
+    ];
+    $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($params);
+
+    $this->assertEmpty($result['error_msg']);
+    $newActivityId = $result['newId'];
+
+    $caseActivities = $this->callAPISuccess('Activity', 'get', [
+      'case_id' => $case2['id'],
+      'return' => ['id', 'subject', 'target_contact_id'],
+    ])['values'];
+    $this->assertEquals('To be moved to case', $caseActivities[$newActivityId]['subject']);
+    $this->assertEquals($contact2, $caseActivities[$newActivityId]['target_contact_id'][0]);
+    // This should be a different physical activity, not the same db record as the original.
+    $this->assertNotEquals($activity['id'], $caseActivities[$newActivityId]['id']);
+
+    // original should be marked deleted
+    $originalActivity = $this->callAPISuccess('Activity', 'getsingle', [
+      'id' => $activity['id'],
+      'return' => ['is_deleted', 'case_id'],
+    ]);
+    $this->assertEquals(1, $originalActivity['is_deleted']);
+    $this->assertEquals($case1['id'], $originalActivity['case_id'][0]);
+  }
+
+  /**
    * Check if the selected filters are saved.
    */
   public function testPreserveFilters() {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4220

Before
----------------------------------------
1. File on case.
1. A revision is created. This is what we're trying to get rid of.

See lab ticket for more discussion of some side-issues with the current situation.

After
----------------------------------------
This makes it work like it did before 2018, i.e.

| Action | Result |
| ------ | ------ |
| File-on-case | Original is left where it is and the subject is changed to indicate it was filed. A copy is filed on the case. |
| Copy-to-case | Original is left where it is and a copy is filed on the other case. |
| Move-to-case | Original is marked deleted (still current_revision). A copy is filed on the other case. |

So no revisions are created. Some side-issues are resolved but it's maybe not the way everyone would like it.

Technical Details
----------------------------------------
Here "otherActivity" is the original activity, "mainActivity" is the new copy.

Note parent_id isn't related to revisions, it's just clearing it out in case it's set.

Comments
----------------------------------------
I'll look into adding a test. I think there is something already though, and I'm not sure the value of adding a test about revisions.
