### PR TITLE
dev/core#4220 - Make activity original_id consistent

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -493,7 +493,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         $newActParams['original_id'] = $this->_defaults['original_id'];
       }
       else {
-        $newActParams['original_id'] = $this->_activityId;
+        $newActParams['original_id'] = NULL;
       }
 
       // add attachments if any


### PR DESCRIPTION
Overview
----------------------------------------
Recently in https://github.com/civicrm/civicrm-core/pull/26037 some changes were made to remove activity revisioning. But we still have older revisions in the db because people need time to decide how to archive them if desired. So in the meantime original_id still needs to match to up to old revisions.

In that PR it inconsistently sets original_id to the current_activity when there are no existing revisions. But it should be null.

Before
----------------------------------------
Incorrect original_id

After
----------------------------------------
Correct

Technical Details
----------------------------------------


Comments
----------------------------------------
In practice it's difficult to see the difference, because on the List All Revisions tab it still works out anyway. But it should be the correct id. The later change in ChangeCaseStartDate was correct so can stay as-is.
