### PR TITLE
empty pseudoconstant string on create causes an error

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -240,14 +240,14 @@ trait DAOActionTrait {
         continue;
       }
 
-      // Null and empty string are interchangeable as far as the custom bao understands
-      if (NULL === $value) {
-        $value = '';
-      }
-
       if ($field['suffix']) {
         $options = FormattingUtil::getPseudoconstantList($field, $name, $params, $this->getActionName());
         $value = FormattingUtil::replacePseudoconstant($options, $value, TRUE);
+      }
+
+      // Null and empty string are interchangeable as far as the custom bao understands
+      if (NULL === $value) {
+        $value = '';
       }
 
       if ($field['html_type'] === 'CheckBox') {

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -419,6 +419,36 @@ class BasicCustomFieldTest extends CustomTestBase {
     $this->assertEquals($optionGroupCount, OptionGroup::get(FALSE)->selectRowCount()->execute()->count());
   }
 
+  /**
+   * Pseudoconstant lookups that are passed an empty string return NULL, not an empty string.
+   * @throws \CRM_Core_Exception
+   */
+  public function testPseudoConstantCreate(): void {
+    $optionGroupId = $this->createTestRecord('OptionGroup')['id'];
+    $this->createTestRecord('OptionValue', ['option_group_id' => $optionGroupId]);
+
+    $customGroup = CustomGroup::create(FALSE)
+      ->addValue('title', 'MyIndividualFields')
+      ->addValue('extends', 'Individual')
+      ->execute()
+      ->first();
+
+    CustomField::create(FALSE)
+      ->addValue('label', 'FavMovie')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Select')
+      ->addValue('data_type', 'String')
+      ->addValue('option_group_id', $optionGroupId)
+      ->execute();
+
+    Contact::create(FALSE)
+      ->addValue('first_name', 'Johann')
+      ->addValue('last_name', 'Tester')
+      ->addValue('contact_type', 'Individual')
+      ->addValue('MyIndividualFields.FavMovie:label', '')
+      ->execute();
+  }
+
   public function testUpdateWeights() {
     $getValues = function($groupName) {
       return CustomField::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
When using API4 `Create` action, you can't pass a pseudoconstant (e.g. `MyCustomGroup.MyField:label`) an empty string, you'll hit an exception: `CRM_Core_Exception:  is not of type String`.

You can replicate this against a demo site with:
```shell
cv api4 Contact.create '{"values":{"first_name":"f","last_name":"l","constituent_information.Marital_Status:label":""}}'
```

Before
----------------------------------------
`CRM_Core_Exception:  is not of type String`

After
----------------------------------------
Value is saved correctly as empty.

Technical Details
----------------------------------------
The blank string comes in as `NULL`, and there's a bit of code  (the one I moved) that changes it to an empty string, and I assume that's to address this issue for non-pseudoconstant values.  By moving it after the pseudoconstant lookup it works on that too.

Comments
----------------------------------------
This is a spiritual cousin of #25028.
