### PR TITLE
dev/core#4103 Don't show admin only price fields on Registration or Contribution page previews

### DIFF
--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -27,7 +27,7 @@
 
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
-        {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' || $action eq 1024}
+        {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' }
             {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
             <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}


### PR DESCRIPTION
Overview
----------------------------------------
When not logged in, Event Registration or Contribution page previews should not show (part of) admin-only price fields — they should show a preview of what people using the page will see. [See issue](https://lab.civicrm.org/dev/core/-/issues/4103) for steps to replicate.

Before
----------------------------------------
There is an admin-only price field here that has its amount shown when previewing the Registration or Contribution page when not logged in.
<img width="453" alt="image" src="https://user-images.githubusercontent.com/25517556/233806214-3915bad8-937f-45a3-bf8c-081766263021.png">

After
----------------------------------------
Now the price field is not shown.
<img width="461" alt="image" src="https://user-images.githubusercontent.com/25517556/233806262-644afa3b-44f2-43bc-bade-1ce4d2d34e6e.png">

Price field is still shown normally to logged-in users and in the price set preview.
