### PR TITLE
Remove "and Time" from registration date label on view Participant

### DIFF
--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -71,7 +71,7 @@
       <td class="label">{ts}Participant Role{/ts}</td>
       <td>{$role}</td></tr>
         <tr class="crm-event-participantview-form-block-register_date">
-      <td class="label">{ts}Registration Date and Time{/ts}</td>
+      <td class="label">{ts}Registration Date{/ts}</td>
       <td>{$register_date|crmDate}&nbsp;</td>
   </tr>
     <tr class="crm-event-participantview-form-block-status">


### PR DESCRIPTION
Overview
----------------------------------------
Every other date and time is simply labelled as a date (including on the edit Participant form), but on view Participant it is  "Registration Date and Time", breaking the label onto two lines. "Registration Date" is more consistent.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/233858000-d296d263-02e4-4363-900f-fa017227e8bc.png)

After
----------------------------------------
<img width="384" alt="image" src="https://user-images.githubusercontent.com/25517556/233857981-f4aa1b98-9901-4d35-87ba-6154a89b5f0c.png">