### PR TITLE
Use label from schema instead of title for selects on QuickForms

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1688,7 +1688,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
           break;
         }
       }
-      $label = $props['label'] ?? $fieldSpec['title'];
+      $label = $props['label'] ?? $fieldSpec['html']['label'] ?? $fieldSpec['title'];
       if (CRM_Utils_Array::value('context', $props) != 'search') {
         $props['data-option-edit-path'] = array_key_exists('option_url', $props) ? $props['option_url'] : CRM_Core_PseudoConstant::getOptionEditUrl($fieldSpec);
       }
@@ -1785,8 +1785,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // Core field - get metadata.
     $fieldSpec = civicrm_api3($props['entity'], 'getfield', $props);
     $fieldSpec = $fieldSpec['values'];
-    $fieldSpecLabel = $fieldSpec['html']['label'] ?? CRM_Utils_Array::value('title', $fieldSpec);
-    $label = CRM_Utils_Array::value('label', $props, $fieldSpecLabel);
+    $label = $props['label'] ?? $fieldSpec['html']['label'] ?? $fieldSpec['title'];
 
     $widget = $props['type'] ?? $fieldSpec['html']['type'];
     if ($widget == 'TextArea' && $context == 'search') {


### PR DESCRIPTION
Overview
----------------------------------------
This change was made for fields in general many years ago, but not for selects, which are handled separately.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/233858890-f4e69647-9dff-44fb-90d8-1f95ace2123f.png)
Participant Role ID and Status ID are the titles, but the labels are Participant Role and Status.

After
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/233858911-ebfde23c-8c07-4e9a-bd6a-d9e1c717c7a5.png)
Labels from schema are used when present, fallback is title as before. Confirmed still works for fields that only have a title.