### PR TITLE
CRM_Mailing_Selector_Browse: fix typo in local variable name

### DIFF
--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -615,12 +615,12 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
       $params[5] = [$createdId, 'Integer'];
     }
 
-    $campainIds = $this->_parent->get('campaign_id');
-    if (!CRM_Utils_System::isNull($campainIds)) {
-      if (!is_array($campainIds)) {
+    $campaignIds = $this->_parent->get('campaign_id');
+    if (!CRM_Utils_System::isNull($campaignIds)) {
+      if (!is_array($campaignIds)) {
         $campaignIds = [$campaignIds];
       }
-      $clauses[] = '( campaign_id IN ( ' . implode(' , ', array_values($campainIds)) . ' ) )';
+      $clauses[] = '( campaign_id IN ( ' . implode(' , ', array_values($campaignIds)) . ' ) )';
     }
 
     if ($language = $this->_parent->get('language')) {


### PR DESCRIPTION
Overview
----------------------------------------
There's a typo in a local var name(`$campainIds` vs `$campaignIds`) in `CRM_Mailing_Selector_Browse::whereClause()` and it is used inconsistently. Received campaign_id is checked for a fail-safe: if a single campaign_id is passed in not as an array it is converted to an array and the IN clause will be compiled properly. This mixed use causes this to be ineffective.

As I've tested when I select a single campaign to filter on mails it will be passed as an array, so this check is probably never reached which could be the reason why was it unnoticed. 

Before
----------------------------------------
Fatal error (DB Error: syntax error) if a campaign_id is passed in other than an array.

After
----------------------------------------
No error if a campaign_id is passed in not as an array.

Comments
----------------------------------------
Changing `$campaignIds` to `$campainIds` would make a smaller diff but I've felt that would cement a typo in...
