### PR TITLE
Importer - Ensure mapping ID is set in all places using import templates

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -221,6 +221,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       // Unset fields that should not be copied over.
       unset($userJob['id'], $userJob['name'], $userJob['created_date'], $userJob['is_template'], $userJob['queue_id'], $userJob['start_date'], $userJob['end_date']);
       $userJob['metadata']['template_id'] = $templateID;
+      $userJob['metadata']['Template']['mapping_id'] = $mappingID;
       $userJob['created_id'] = CRM_Core_Session::getLoggedInContactID();
       $userJob['expires_date'] = '+1 week';
       $userJobID = UserJob::create(FALSE)->setValues($userJob)->execute()->first()['id'];


### PR DESCRIPTION
This fixes the missing update saved mapping option when using a template

I think I changed the way the metadata was a few times & so it is a bit confusing - but this ensures it is set in the place MapField is expecting it to be


- against 5.61 as the rest of import templates is in there - this is just an issue we hit in live testing
