### PR TITLE
APIv4 - Remove incorrect EntityBridge from UFMatch entity

### DIFF
--- a/Civi/Api4/UFMatch.php
+++ b/Civi/Api4/UFMatch.php
@@ -11,13 +11,12 @@
 namespace Civi\Api4;
 
 /**
- * UFMatch entity - links civicrm contacts with users created externally
+ * Matches CiviCRM contacts with their CMS user accounts
  *
  * @searchable secondary
  * @since 5.19
  * @package Civi\Api4
  */
 class UFMatch extends Generic\DAOEntity {
-  use Generic\Traits\EntityBridge;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes SearchKit to allow joins from Contact -> User Account

Before
----------------------------------------
Can join from User Account -> Contact but not the other way. See discussion at https://github.com/civicrm/civicrm-core/pull/23723#issuecomment-1172610283

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
UFJoin cannot work as a bridge because it does not connect two CiviCRM entities with each other. So the trait wasn't doing anything except getting in the way of SearchKit being able to perform joins.