### PR TITLE
dev/core#1821 fix custom field option list radio clear link

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -16,30 +16,28 @@
 {/if}
 {if $element.options_per_line}
   <tr class="custom_field-row {$element.element_name}-row">
-    <td
-      class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
+    <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
       {assign var="count" value="1"}
-      <table class="form-layout-compressed" style="margin-top: -0.5em;">
-        <tr>
-          {* sort by fails for option per line. Added a variable to iterate through the element array*}
-          {assign var="index" value="1"}
-          {foreach name=outer key=key item=item from=$formElement}
-          {if $index < 10}
-          {assign var="index" value=$index+1}
-          {else}
-          <td class="labels font-light">{$formElement.$key.html}</td>
+      {* sort by fails for option per line. Added a variable to iterate through the element array*}
+      {assign var="index" value="1"}
+      {foreach name=outer key=key item=item from=$formElement}
+        {if $index < 10}
+          {assign var="index" value=`$index+1`}
+        {else}
+          {$formElement.$key.html}
           {if $count == $element.options_per_line}
-        </tr>
-        <tr>
-          {assign var="count" value="1"}
+            <br />
+            {assign var="count" value="1"}
           {else}
-          {assign var="count" value=$count+1}
+            {assign var="count" value=`$count+1`}
           {/if}
-          {/if}
-          {/foreach}
-        </tr>
-      </table>
+        {/if}
+      {/foreach}
+
+      {if $element.html_type == 'Radio' and $element.is_required == 0}
+        <br /><a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
+      {/if}
     </td>
   </tr>
 {else}


### PR DESCRIPTION
Overview
----------------------------------------
Custom radio fields do not allow both a clear button and a maximum options per line
See https://lab.civicrm.org/dev/core/-/issues/1821

Before
----------------------------------------
When creating a radio type custom field in a custom set that supports multiple rows, the option to clear the selection is not present.

After
----------------------------------------
Option is present.
