### PR TITLE
Report on the most recent membership contribution, not the oldest

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -294,10 +294,15 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
 
     //used when contribution field is selected.
     if ($this->isTableSelected('civicrm_contribution')) {
+      // if we're grouping (by membership), we need to make sure the inner join picks the most recent contribution.
+      $groupedBy = !empty($this->_params['group_bys']['id']);
       $this->_from .= "
              LEFT JOIN civicrm_membership_payment cmp
-                 ON ({$this->_aliases['civicrm_membership']}.id = cmp.membership_id
-                 AND cmp.id = (SELECT MAX(id) FROM civicrm_membership_payment WHERE civicrm_membership_payment.membership_id = {$this->_aliases['civicrm_membership']}.id))
+                 ON ({$this->_aliases['civicrm_membership']}.id = cmp.membership_id";
+      $this->_from .= $groupedBy ? "
+                 AND cmp.id = (SELECT MAX(id) FROM civicrm_membership_payment WHERE civicrm_membership_payment.membership_id = {$this->_aliases['civicrm_membership']}.id))"
+                 : ")";
+      $this->_from .= "
              LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
                  ON cmp.contribution_id={$this->_aliases['civicrm_contribution']}.id\n";
     }

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -296,7 +296,8 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
     if ($this->isTableSelected('civicrm_contribution')) {
       $this->_from .= "
              LEFT JOIN civicrm_membership_payment cmp
-                 ON {$this->_aliases['civicrm_membership']}.id = cmp.membership_id
+                 ON ({$this->_aliases['civicrm_membership']}.id = cmp.membership_id
+                 AND cmp.id = (SELECT MAX(id) FROM civicrm_membership_payment WHERE civicrm_membership_payment.membership_id = {$this->_aliases['civicrm_membership']}.id))
              LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
                  ON cmp.contribution_id={$this->_aliases['civicrm_contribution']}.id\n";
     }


### PR DESCRIPTION
Overview
----------------------------------------
As per https://lab.civicrm.org/dev/core/-/issues/4261

Before
----------------------------------------
When grouping by membership, the membership detail report reports on the oldest contribution associated with a membership.

After
----------------------------------------
The membership detail report (when grouping by membership) reports on the most recently assigned contribution associated with a membership.

Technical Details
----------------------------------------
Inspired by https://stackoverflow.com/questions/725153/most-recent-record-in-a-left-join

Comments
----------------------------------------
There may be some edge cases where the contribution with the max id in the membership payment table isn't the newest, but the sql to sort on the contribution receive date would be considerably uglier and not worthwhile, IMHO.

This change won't affect the report when grouping is not chosen.
