### PR TITLE
ExtManager - Add failing test to demonstrate non-singleton behavior

### DIFF
--- a/tests/phpunit/CRM/Extension/ManagerTest.php
+++ b/tests/phpunit/CRM/Extension/ManagerTest.php
@@ -38,6 +38,13 @@ class CRM_Extension_ManagerTest extends CiviUnitTestCase {
     $this->mapper = new CRM_Extension_Mapper($this->container);
   }
 
+  public function testManagerInstance() {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    $this->assertTrue($manager === CRM_Extension_System::singleton()->getManager());
+    $manager->install([]);
+    $this->assertTrue($manager === CRM_Extension_System::singleton()->getManager());
+  }
+
   /**
    * Install an extension with an invalid type name.
    */


### PR DESCRIPTION
Overview
----------------
Failing test for discussion with @totten 

Technical Details
----------------------------------------
The behavior of `CRM_Extension_System::singleton()->getManager()` surprised me. Normally, I expect a `singleton()` function to return the same object every time (like a service), but aggressive cache clearing during the extension install/enable/disable process (even if it is a non-op as demonstrated in this test) actually causes the object to be deleted. This feels like a big "gotcha" to me, because as soon as you use it to do something, your local variable is no longer the "real" extension manager, it thinks it is, but it has outdated, possibly incorrect status info, and trying to use it to manage extensions could cause a crash (e.g. when it tries to install an extension that it thinks is not installed but is in fact installed). For example:

```php
$myManager = CRM_Extension_System::singleton()->getManager();
$myManager->install('foo'); // side-effect: deletes and recreates the object returned from `getManager()`, breaking the reference from `$myManager` local var
CRM_Extension_System::singleton()->getManager()->install('bar');
$myManager->getStatus('bar'); // uninstalled
CRM_Extension_System::singleton()->getManager()->getStatus('bar'); // installed
$myManager->install('bar'); // who knows?
```

Comments
----------------
I came across this while debugging tests for #26036 and wanted to document/discuss it in a separate thread so I created this PR.

Note that the first assert passes but the second one fails (after the non-op of installing nothing).