### PR TITLE
Add default payment method for additional payment or refund

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -161,6 +161,12 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     // Set $newCredit variable in template to control whether link to credit card mode is included
     $this->assign('newCredit', CRM_Core_Config::isEnabledBackOfficeCreditCardPayments());
+
+    $defaults['payment_instrument_id'] = \Civi\Api4\Contribution::get(FALSE)
+      ->addSelect('payment_instrument_id')
+      ->addWhere('id', '=', $this->_contributionId)
+      ->execute()->first()['payment_instrument_id'];
+
     return $defaults;
   }
 

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -84,9 +84,7 @@
         <table class="form-layout-compressed" >
           <tr class="crm-payment-form-block-trxn_date">
             <td class="label">{$form.trxn_date.label}</td>
-            <td>{$form.trxn_date.html}<br />
-              <span class="description">{ts}The date this payment was received.{/ts}</span>
-            </td>
+            <td>{$form.trxn_date.html}</td>
           </tr>
           <tr class="crm-payment-form-block-payment_instrument_id">
             <td class="label">{$form.payment_instrument_id.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
When you want to add an additional payment or record a refund for a contribution, it is very likely that the payment method will be the same as the original. For example, if you're refunding something paid with a credit card, the refund is very likely to be to the credit card. So it makes sense to load the payment method for the contribution as the default method on the form for the additional payment or refund.

Before
----------------------------------------
No default payment method for additional payment.
<img width="401" alt="image" src="https://user-images.githubusercontent.com/25517556/234920686-15e031c4-e61a-426e-b693-1e803a6dd590.png">

After
----------------------------------------
Default payment method is set based on contribution.
<img width="402" alt="image" src="https://user-images.githubusercontent.com/25517556/234920438-db9265dc-0dda-4031-93b5-4c9afe9b26c5.png">
I removed the description of the Date Received / Refund Date. I was going to add a conditional to change the text for refunds to something that made sense, but noted that this description added no information, so wasn't really needed.
