### PR TITLE
CiviGrant - Fix upgrade to work on multiple domains

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -310,8 +310,8 @@ class CRM_Core_BAO_ConfigSetting {
    */
   public static function enableComponent($componentName) {
     $enabledComponents = Civi::settings()->get('enable_components');
-    if (in_array($componentName, $enabledComponents)) {
-      // component is already enabled
+    if (in_array($componentName, $enabledComponents, TRUE)) {
+      // Component is already enabled
       return TRUE;
     }
 
@@ -346,20 +346,13 @@ class CRM_Core_BAO_ConfigSetting {
    * @return bool
    */
   public static function disableComponent($componentName) {
-    $config = CRM_Core_Config::singleton();
-    if (!in_array($componentName, $config->enableComponents) ||
-      !array_key_exists($componentName, CRM_Core_Component::getComponents())
-    ) {
-      // Post-condition is satisfied.
+    $enabledComponents = Civi::settings()->get('enable_components');
+    if (!in_array($componentName, $enabledComponents, TRUE)) {
+      // Component is already disabled.
       return TRUE;
     }
 
-    // get enabled-components from DB and add to the list
-    $enabledComponents = Civi::settings()->get('enable_components');
-    $enabledComponents = array_diff($enabledComponents, [$componentName]);
-
-    self::setEnabledComponents($enabledComponents);
-
+    self::setEnabledComponents(array_diff($enabledComponents, [$componentName]));
     return TRUE;
   }
 
@@ -369,8 +362,7 @@ class CRM_Core_BAO_ConfigSetting {
    * @param array $enabledComponents
    */
   public static function setEnabledComponents($enabledComponents) {
-    // The on_change trigger on this setting will trigger a cache flush
-    Civi::settings()->set('enable_components', $enabledComponents);
+    Civi::settings()->set('enable_components', array_values($enabledComponents));
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -101,9 +101,11 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
    */
   public static function migrateCiviGrant(CRM_Queue_TaskContext $ctx): bool {
     $civiGrantEnabled = CRM_Core_Component::isEnabled('CiviGrant');
-    if ($civiGrantEnabled) {
-      CRM_Core_BAO_ConfigSetting::disableComponent('CiviGrant');
-    }
+    // This was failing on multi-domain setups. See  https://github.com/civicrm/civicrm-core/pull/26043
+    // Instead, we'll handle it in FiveSixtyTwo::consolidateComponents.
+    //  if ($civiGrantEnabled) {
+    //    CRM_Core_BAO_ConfigSetting::disableComponent('CiviGrant');
+    //  }
     $civiGrantId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Component', 'CiviGrant', 'id', 'name');
     if ($civiGrantId) {
       foreach (['civicrm_menu', 'civicrm_option_value'] as $table) {

--- a/CRM/Upgrade/Incremental/php/FiveSixtyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyTwo.php
@@ -63,6 +63,10 @@ class CRM_Upgrade_Incremental_php_FiveSixtyTwo extends CRM_Upgrade_Incremental_B
 
   public static function consolidateComponents($ctx): bool {
     $final = static::findAllEnabledComponents();
+    // Ensure CiviGrant is removed from the setting, as this may have been incomplete in a previous upgrade.
+    // @see FiveFortySeven::migrateCiviGrant
+    $final = array_values(array_diff($final, ['CiviGrant']));
+
     $lowestDomainId = CRM_Core_DAO::singleValueQuery('SELECT min(domain_id) FROM civicrm_setting WHERE name = "enable_components"');
     if (!is_numeric($lowestDomainId)) {
       return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Ensures CiviGrant component is completely removed by the upgrader.

Before
----------------------------------------
In certain conditions, such as multi-domain, CiviGrant setting was not completely removed by the upgrader step. This is pretty harmless except it was causing problems with #26036.

After
----------------------------------------
Component enable/disable functions cleaned up. Upgrader fixed.

Technical Details
----------------------------------------
The `CRM_Core_BAO_ConfigSetting::disableComponent()` wasn't working as expected by the upgrader because

1. It's not multi-domain aware
2. It was short-circuiting on non-existent components, and CiviGrant no longer exists as a component.
3. Domain settings for components have been consolidated by #26043