### PR TITLE
dev/financial#215 : Incorrect membership status on payment failure

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1538,6 +1538,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         // Save the contribution ID so that I can be used in email receipts
         // For example, if you need to generate a tax receipt for the donation only.
         $form->_values['contribution_other_id'] = $membershipContribution->id;
+
+        if ($paymentResult['contribution']->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending') && empty($paymentResult['contribution']->trxn_id)) {
+          $pending = TRUE;
+        }
+      }
+      elseif (!empty($paymentResult['is_payment_failure'])) {
+        $pending = TRUE;
       }
     }
 
@@ -1625,7 +1632,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           ) {
             $pending = TRUE;
           }
-          $pending = FALSE;
+          $pending = $pending ?: FALSE;
         }
 
         [$membership, $renewalMode, $dates] = self::legacyProcessMembership(
@@ -2923,7 +2930,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $memParams = array_merge([
           'id' => $currentMembership['id'],
           'contribution' => $contribution,
-          'status_id' => $currentMembership['status_id'],
+          'status_id' => $pending ? array_search('Pending', $allStatus) : $currentMembership['status_id'],
           'start_date' => $currentMembership['start_date'],
           'end_date' => $currentMembership['end_date'],
           'line_item' => $lineItems,


### PR DESCRIPTION
Overview
----------------------------------------
If there is an active membership A and the user selects & renews for a different membership B, then on payment failure membership B retain the old membership status (current/new) instead of pending.

Reproduction steps
----------------------------------------
1. A user has active membership A
1. User made a live donation for membership B (that belongs to the same membership org)
1. Payment fails due to some reason.

Current behaviour
----------------------------------------
The user has an active membership B linked with a Pending (Incomplete transaction) contribution.


Expected behaviour
----------------------------------------
The membership status should be set to Pending

Environment information
----------------------------------------


* __Browser:__ _Firefox 59.0.1/Chrome 78.0.3904/Safari 13_
* __CiviCRM:__ _Master_
* __PHP:__ __8.0_
* __CMS:__ _Drupal 8_
* __Database:__ _MariaDB 10.4_
* __Web Server:__ _Apache 2.4_