### PR TITLE
Use settings::get instead of $config object to retrieve enabled components

### DIFF
--- a/CRM/Admin/Page/Admin.php
+++ b/CRM/Admin/Page/Admin.php
@@ -36,10 +36,7 @@ class CRM_Admin_Page_Admin extends CRM_Core_Page {
       'System Settings' => ts('System Settings'),
     ];
 
-    $config = CRM_Core_Config::singleton();
-
-    foreach ($config->enableComponents as $component) {
-      $comp = CRM_Core_Component::get($component);
+    foreach (CRM_Core_Component::getEnabledComponents() as $comp) {
       $groups[$comp->info['name']] = $comp->info['translatedName'];
     }
 

--- a/CRM/Core/Component.php
+++ b/CRM/Core/Component.php
@@ -421,7 +421,7 @@ class CRM_Core_Component {
    *   Is the component enabled.
    */
   public static function isEnabled(string $component): bool {
-    return in_array($component, CRM_Core_Config::singleton()->enableComponents, TRUE);
+    return in_array($component, Civi::settings()->get('enable_components'), TRUE);
   }
 
 }

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -145,7 +145,7 @@ WHERE  v.option_group_id = g.id
       $query .= ' AND  v.is_active = 1 ';
       // Only show options for enabled components
       $componentClause = ' v.component_id IS NULL ';
-      $enabledComponents = CRM_Core_Config::singleton()->enableComponents;
+      $enabledComponents = Civi::settings()->get('enable_components');
       if ($enabledComponents) {
         $enabledComponents = '"' . implode('","', $enabledComponents) . '"';
         $componentClause .= " OR v.component_id IN (SELECT id FROM civicrm_component WHERE name IN ($enabledComponents)) ";

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -227,8 +227,7 @@ class CRM_Utils_VersionCheck {
    */
   private function getExtensionStats() {
     // Core components
-    $config = CRM_Core_Config::singleton();
-    foreach ($config->enableComponents as $comp) {
+    foreach (Civi::settings()->get('enable_components') as $comp) {
       $this->stats['extensions'][] = [
         'name' => 'org.civicrm.component.' . strtolower($comp),
         'enabled' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
Use new method instead of old method, as suggested by @eileenmcnaughton in https://github.com/civicrm/civicrm-core/pull/26118#issuecomment-1527032263

