### PR TITLE
Remove unused broken $config->geocodeMethod

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -200,8 +200,6 @@ class CRM_Core_Config_MagicMerge {
       'userFrameworkResourceURL' => ['setting-url'],
 
       // "callback" properties are generated on-demand by calling a function.
-      // @todo remove geocodeMethod. As of Feb 2018, $config->geocodeMethod works but gives a deprecation warning.
-      'geocodeMethod' => ['callback', 'CRM_Utils_Geocode', 'getProviderClass'],
       'defaultCurrencySymbol' => ['callback', 'CRM_Core_BAO_Country', 'getDefaultCurrencySymbol'],
       'wpBasePage' => ['callback', 'CRM_Utils_System_WordPress', 'getBasePage'],
     ];

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -4741,7 +4741,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    *
    */
   public function testContactGetProximity(): void {
-    CRM_Core_Config::singleton()->geocodeMethod = 'CRM_Utils_MockGeocoder';
     $this->individualCreate();
     $contactID = $this->individualCreate();
     $this->callAPISuccess('Address', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Removes a long-deprecated config property which no longer works.

Technical Details
----------------------------------------
This deprecated item in the $config object couldn't possibly work because the class and function it refers to don't exist!