### PR TITLE
Use purify rather than escape to preserve currency

### DIFF
--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -763,6 +763,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
       $statistics['counts']['count'] = [
         'title' => ts('Total Contributions'),
         'value' => $count,
+        'type' => CRM_Utils_Type::T_INT,
       ];
       $statistics['counts']['avg'] = [
         'title' => ts('Average'),
@@ -789,6 +790,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
       $statistics['counts']['soft_count'] = [
         'title' => ts('Total Soft Credits'),
         'value' => $softCount,
+        'type' => CRM_Utils_Type::T_INT,
       ];
       $statistics['counts']['soft_avg'] = [
         'title' => ts('Average Soft Credit'),

--- a/templates/CRM/Report/Form/Statistics.tpl
+++ b/templates/CRM/Report/Form/Statistics.tpl
@@ -40,7 +40,7 @@
             {if $row.type eq 1024}
               {$row.value|crmMoney|escape}
             {elseif $row.type eq 2}
-              {$row.value|escape}
+              {$row.value|purify}
             {else}
                {$row.value|crmNumberFormat|escape}
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Use purify rather than escape to preserve currency

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/235383034-ef9aa84a-80d7-4279-98c9-0140ab0bef55.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/235383065-0474c23c-f51b-4bcf-94cd-87bb3a78a890.png)

Technical Details
----------------------------------------
This is probably a double escapting due to escape on output but seems ok to just purify here 

Comments
----------------------------------------
