### PR TITLE
dev/core#4262 - Upgrade message about obsolete civicrm.settings.php setting that generates php warnings

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyTwo.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyTwo.php
@@ -31,6 +31,13 @@ class CRM_Upgrade_Incremental_php_FiveSixtyTwo extends CRM_Upgrade_Incremental_B
         // See also: https://lab.civicrm.org/dev/core/-/issues/3961
         $preUpgradeMessage .= "<p>{$message}</p>";
       }
+
+      if (defined('CIVICRM_SETTINGS_PATH') && CIVICRM_SETTINGS_PATH) {
+        $contents = file_get_contents(CIVICRM_SETTINGS_PATH);
+        if (strpos($contents, 'auto_detect_line_endings') !== FALSE) {
+          $preUpgradeMessage .= '<p>' . ts('Your civicrm.settings.php file contains a line to set the php variable `auto_detect_line_endings`. It is deprecated and the line should be removed from the file.') . '</p>';
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4262

The `auto_detect_line_endings` setting doesn't do anything except on ancient macs. In php 8.1 it starts giving warnings. It was conservatively wrapped in an `if` block for new installs in https://github.com/civicrm/civicrm-core/pull/24092, but older installs always try to set it.

Before
----------------------------------------
warnings

After
----------------------------------------
no warnings

Technical Details
----------------------------------------
I'm not sure if CIVICRM_SETTINGS_PATH gets defined for all cmses, but I can also add a PR for the sysadmin guide for people who miss the upgrade message.

Comments
----------------------------------------
See also https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated
