### PR TITLE
Expire notifications for adding and removing groups, tags and relationships

### DIFF
--- a/CRM/Activity/Form/Task/AddToTag.php
+++ b/CRM/Activity/Form/Task/AddToTag.php
@@ -134,7 +134,7 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
         ]);
       }
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success', ['expires' => 0]);
+      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
     }
 
   }

--- a/CRM/Activity/Form/Task/RemoveFromTag.php
+++ b/CRM/Activity/Form/Task/RemoveFromTag.php
@@ -129,7 +129,7 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
         ]);
       }
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success', ['expires' => 0]);
+      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
     }
   }
 

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -219,7 +219,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
       1 => $groupName,
       'count' => $added,
       'plural' => 'Added Contacts to %1',
-    ]), 'success', ['expires' => 0]);
+    ]), 'success');
 
     if ($this->_context === 'amtg') {
       CRM_Core_Session::singleton()

--- a/CRM/Contact/Form/Task/AddToParentClass.php
+++ b/CRM/Contact/Form/Task/AddToParentClass.php
@@ -146,7 +146,7 @@ class CRM_Contact_Form_Task_AddToParentClass extends CRM_Contact_Form_Task {
     CRM_Core_Session::setStatus($status, ts('Relationship created.', [
       'count' => $outcome['valid'],
       'plural' => 'Relationships created.',
-    ]), 'success', ['expires' => 0]);
+    ]), 'success');
 
   }
 

--- a/CRM/Contact/Form/Task/AddToTag.php
+++ b/CRM/Contact/Form/Task/AddToTag.php
@@ -131,7 +131,7 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
         ]);
       }
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success', ['expires' => 0]);
+      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
     }
 
   }

--- a/CRM/Contact/Form/Task/RemoveFromGroup.php
+++ b/CRM/Contact/Form/Task/RemoveFromGroup.php
@@ -76,7 +76,7 @@ class CRM_Contact_Form_Task_RemoveFromGroup extends CRM_Contact_Form_Task {
     CRM_Core_Session::setStatus($status, ts("Removed Contact From Group", [
       'plural' => "Removed Contacts From Group",
       'count' => $removed,
-    ]), 'success', ['expires' => 0]);
+    ]), 'success');
   }
 
 }

--- a/CRM/Contact/Form/Task/RemoveFromTag.php
+++ b/CRM/Contact/Form/Task/RemoveFromTag.php
@@ -124,7 +124,7 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
         ]);
       }
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success', ['expires' => 0]);
+      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
     }
   }
 

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -232,7 +232,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
       1 => $groupName,
       'count' => $added,
       'plural' => 'Added Contacts to %1',
-    ]), 'success', ['expires' => 0]);
+    ]), 'success');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Some non-critical notifications were set to never expire. I don't think we need the notification that we added some contacts to a group to hang around forever. This is especially annoying when you are working in SearchKit and the notifications pile up and cover part of your query.

Before
----------------------------------------
Notifications for adding and removing contacts to a group, adding and removing tags from contacts and activities, and adding relationships did not expire.

After
----------------------------------------
Now they expire after the default 10s.