### PR TITLE
dev/core#4262 - Drop auto_detect_line_endings from civicrm.settings.php.template

### DIFF
--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -601,11 +601,6 @@ if (!defined('CIVICRM_CLEANURL')) {
   }
 }
 
-// force PHP to auto-detect Mac line endings
-if (version_compare(PHP_VERSION, '8.1') < 0) {
-  ini_set('auto_detect_line_endings', '1');
-}
-
 // make sure the memory_limit is at least 64 MB
 $memLimitString = trim(ini_get('memory_limit'));
 $memLimitUnit   = strtolower(substr($memLimitString, -1));


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4262

If the upgrader is telling you to remove it from `civicrm.settings.php` (#26136), then...  we probably don't need it in new copies of `civicrm.settings.php`...

cc @demeritcowboy 

Before
----------------------------------------

Installer generates deprecated configuration clause.

After
----------------------------------------

Installer generates cleaner configuration.

