### PR TITLE
dev/core#4225 Add test & fix for new regression - contact update fails when relationship exists & CiviMember disabled

### DIFF
--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -85,6 +85,8 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->quickCleanup(['civicrm_relationship', 'civicrm_membership'], TRUE);
     RelationshipType::delete(FALSE)->addWhere('id', '>', ($this->relationshipTypeID - 1))->execute();
     parent::tearDown();
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviMember');
+
   }
 
   /**
@@ -103,6 +105,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * Test Current Employer is correctly set.
    */
   public function testCurrentEmployerRelationship(): void {
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviMember');
     $employerRelationshipID = $this->callAPISuccessGetValue('RelationshipType', [
       'return' => 'id',
       'name_b_a' => 'Employer Of',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4225 Add test & fix for new regression - contact update fails when relationship exists & CiviMember disabled

Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------
Calling apiv4 Member
when CiviMember is not enables gives a hard error

Comments
----------------------------------------
