### PR TITLE
(REF) CRM_Core_Config  - Simplify dependencies between MagicMerge and Runtime

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -402,7 +402,6 @@ class CRM_Core_Config_MagicMerge {
         'inCiviCRM' => FALSE,
         'doNotResetCache' => 0,
         'keyDisable' => FALSE,
-        'initialized' => FALSE,
         'userFrameworkFrontend' => FALSE,
         'userPermissionTemp' => NULL,
       ];

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -16,7 +16,7 @@
  * the DSN, CMS type, CMS URL, etc. Generally, runtime properties must be
  * determined externally (before loading CiviCRM).
  */
-class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
+class CRM_Core_Config_Runtime {
 
   public $dsn;
 
@@ -62,6 +62,11 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
    * @var string
    */
   public $templateDir;
+
+  /**
+   * @var bool
+   */
+  public $initialized;
 
   /**
    * @param bool $loadFromDB
@@ -117,7 +122,7 @@ class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge {
   public function includeCustomPath() {
     $customProprtyName = ['customPHPPathDir', 'customTemplateDir'];
     foreach ($customProprtyName as $property) {
-      $value = $this->getSettings()->get($property);
+      $value = Civi::settings()->get($property);
       if (!empty($value)) {
         $customPath = Civi::paths()->getPath($value);
         set_include_path($customPath . PATH_SEPARATOR . get_include_path());


### PR DESCRIPTION
Overview
--------

* `CRM_Core_Config_MagicMerge` is a property-map -- you ask for a property "X", and it figures where to forward the request (e.g. to the "settings" subsystem, the "runtime" subsystem, or somewhere else).
* Specifically, it forwards some requests to `CRM_Core_Config_Runtime`. The class defines a set of properties inferred from the local environment.
* This was originally a 1-way dependency. (_`MagicMerge` delegates to `Runtime`._) In 1b81ed503682ef2d88f65673b0dce9f112078000, it became a 2-way dependency.
* The patch reduces it back to the simpler 1-way dependency -- while preserving other parts of 1b81ed503682ef2d88f65673b0dce9f112078000 that had more behavioral effects.

Before
------

There is a bi-directional dependency:

```php
class CRM_Core_Config_MagicMerge {
    ... \Civi\Core\Container::getBootService('runtime')->{$name} ... 
}
class CRM_Core_Config_Runtime extends CRM_Core_Config_MagicMerge { ... }
```

Additionally, within the `runtime` object, there is a secondary copy of the `MagicMerge` properties (e.g. `$this->map`, `$this->local`, `$this->cache`) and methods (`__get()`, `__set()`, `getSettings()`, etc). This is not used for anything except for calling `getSettings()` and storing `$this->cache['initialized']`. 

After
-----

Less magic. The dependencies flow in one direction (`MagicMerge` => `Runtime`).

`Runtime` does not duplicate anything from `MagicMerge` (i.e. there is no `$this->map`, `$this->local`, `$this->cache`, `__get()`, `__set()`, `getSettings()`, etc).

These are replaced by simpler references to `Civi::settings()` and plain properties (`$this>initialized`).

Technical Details
-----------------

I suspect that 1b81ed503682ef2d88f65673b0dce9f112078000 was aiming to use `getSettings()`. But that is really just a wrapper for `Civi::settings()`. (*`getSettings()` is a micro-optimization to serve that bazillion settings in `MagicMerge`. `Runtime` doesn't need that micro-optimization.*)

For QA, I wanted to ensure that `$config->initialized` behaved the same way before+after. To do this, I hacked some log statements:

```diff
diff --git a/Civi/Core/Container.php b/Civi/Core/Container.php
index 5b983fb637..4953a2c25c 100644
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -598,7 +598,9 @@ class Container {
     \Civi::$statics[__CLASS__]['boot'] = &$bootServices;

     $bootServices['runtime'] = $runtime = new \CRM_Core_Config_Runtime();
+    var_export(['line' => __LINE__, 'via runtime' => $runtime->initialized, 'via config' => \CRM_Core_Config::singleton()->initialized]);
     $runtime->initialize($loadFromDB);
+    var_export(['line' => __LINE__, 'via runtime' => $runtime->initialized, 'via config' => \CRM_Core_Config::singleton()->initialized]);

     $bootServices['paths'] = new \Civi\Core\Paths();
```

and executed

```bash
cv ev 'return CRM_Core_Config::singleton()->initialized;'
```

The behavior is unchanged -- both before+after, the value of `$initialized` evolves from `null` to `1`. (Actually, it's a little better - it's less likely to provoke warnings now because `$initialized` has been cleanly declared upfront.)
