### PR TITLE
(dev/core#2855) Preserve pristine ids' for further manipulation via h…

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2612,6 +2612,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    */
   protected function alterStateProvinceID($value, &$row, $selectedfield, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
+    $row[$selectedfield . '_raw'] = $value;
     $row[$selectedfield . '_link'] = $url;
     $row[$selectedfield . '_hover'] = ts("%1 for this state.", [
       1 => $value,


### PR DESCRIPTION
…ooks for reports

Overview
----------------------------------------
Preserve pristine ids' for further manipulation via hooks for reports

Before
----------------------------------------
No pristine id for state province in $rows for hook manipulation

After
----------------------------------------
Pristine id for state province is available in $rows for hook manipulation

Comments
----------------------------------------
Will extend this to other look up fields country, etc once approved. I 've incorporated the feedback from PR #21571
