### PR TITLE
dev/core#4258 Show next scheduled and cancel / modified date for recurring contributions on contact record

### DIFF
--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -326,6 +326,9 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     foreach ($recurContributions as $recurId => $recurDetail) {
       // API3 does not return "installments" if it is not set. But we need it set to avoid PHP notices on ContributionRecurSelector.tpl
       $recurContributions[$recurId]['installments'] = $recurDetail['installments'] ?? NULL;
+      $recurContributions[$recurId]['next_sched_contribution_date'] = $recurDetail['next_sched_contribution_date'] ?? NULL;
+      $recurContributions[$recurId]['cancel_date'] = $recurDetail['cancel_date'] ?? NULL;
+      $recurContributions[$recurId]['end_date'] = $recurDetail['end_date'] ?? NULL;
       // Is recurring contribution active?
       $recurContributions[$recurId]['is_active'] = !in_array(CRM_Contribute_PseudoConstant::contributionStatus($recurDetail['contribution_status_id'], 'name'), CRM_Contribute_BAO_ContributionRecur::getInactiveStatuses());
       if ($recurContributions[$recurId]['is_active']) {

--- a/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
@@ -13,7 +13,12 @@
     <tr class="columnheader">
       <th scope="col">{ts}Amount{/ts}</th>
       <th scope="col">{ts}Frequency{/ts}</th>
-      <th scope="col">{ts}Start Date{/ts}</th>
+      <th scope="col">
+        {if $recurType EQ 'active'}{ts}Next Scheduled Date{/ts}
+        {elseif $recurType EQ 'inactive'}{ts}End or Modified Date{/ts}
+        {else}{ts}Start Date{/ts}
+        {/if}
+      </th>
       <th scope="col">{ts}Installments{/ts}</th>
       <th scope="col">{ts}Payment Processor{/ts}</th>
       <th scope="col">{ts}Status{/ts}</th>
@@ -25,7 +30,16 @@
       <tr id="contribution_recur-{$row.id}" data-action="cancel" class="crm-entity {cycle values="even-row,odd-row"}{if NOT $row.is_active} disabled{/if}">
         <td>{$row.amount|crmMoney:$row.currency}{if $row.is_test} ({ts}test{/ts}){/if}</td>
         <td>{ts}Every{/ts} {$row.frequency_interval} {$row.frequency_unit} </td>
-        <td>{$row.start_date|crmDate}</td>
+        <td>
+          {if $recurType EQ 'active'}{$row.next_sched_contribution_date|crmDate}
+          {elseif $recurType EQ 'inactive'}
+            {if $row.cancel_date}{$row.cancel_date|crmDate}
+            {elseif $row.end_date}{$row.end_date|crmDate}
+            {else}{$row.modified_date|crmDate}
+            {/if}
+          {else}{$row.start_date|crmDate}
+          {/if}
+        </td>
         <td>{$row.installments}</td>
         <td>{$row.payment_processor}</td>
         <td>{$row.contribution_status}</td>

--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -79,11 +79,11 @@
           {if $recur}
             <div class="crm-block crm-contact-contribute-recur crm-contact-contribute-recur-active">
               <h3>{ts}Active Recurring Contributions{/ts}</h3>
-              {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" recurRows=$activeRecurRows}
+              {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" recurRows=$activeRecurRows recurType='active'}
             </div>
             <div class="crm-block crm-contact-contribute-recur crm-contact-contribute-recur-inactive">
               <h3>{ts}Inactive Recurring Contributions{/ts}</h3>
-              {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" recurRows=$inactiveRecurRows}
+              {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" recurRows=$inactiveRecurRows recurType='inactive'}
             </div>
           {/if}
         </div>


### PR DESCRIPTION
Overview
----------------------------------------
Instead of showing the start date for recurring contributions on the contact record, instead we show the next scheduled for active contributions, which is much more useful, and cancel / end / modified date for inactive contributions.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/25517556/236069252-6d298f26-79f5-4f7d-9268-ba21d68cccb8.png)

After
----------------------------------------
<img width="993" alt="image" src="https://user-images.githubusercontent.com/25517556/236071149-29cfefcf-da3e-4df8-961a-b3d32612778b.png">
For inactive contributions, show cancelled or end date if present, if not show modified date.