### PR TITLE
fixes #4278 - Import fill on email/phone respects location type

### DIFF
--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -397,6 +397,35 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that importing a phone/email with "Fill" strategy respects location type.
+   *
+   * @throws \Exception
+   */
+  public function testImportFillWithLocationType(): void {
+    $anthony = $this->individualCreate();
+    Phone::create()
+      ->addValue('contact_id', $anthony)
+      ->addValue('location_type_id:label', 'Home')
+      ->addValue('phone', '123-456-7890')
+      ->execute();
+    $homeLocationTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'location_type_id', 'Home');
+    $workLocationTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'location_type_id', 'Work');
+    $phoneTypeID = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Phone', 'phone_type_id', 'Phone');
+    $fieldMapping = [
+      ['name' => 'id'],
+      ['name' => 'phone', 'location_type_id' => $workLocationTypeID, 'phone_type_id' => $phoneTypeID],
+    ];
+    $this->runImport([
+      'id' => $anthony,
+      'phone' => '212-555-1212',
+    ], CRM_Import_Parser::DUPLICATE_FILL, FALSE, $fieldMapping);
+    $homePhone = $this->callAPISuccessGetSingle('Phone', ['contact_id' => $anthony, 'location_type_id' => $homeLocationTypeID]);
+    $workPhone = $this->callAPISuccessGetSingle('Phone', ['contact_id' => $anthony, 'location_type_id' => $workLocationTypeID]);
+    $this->assertEquals('123-456-7890', $homePhone['phone']);
+    $this->assertEquals('212-555-1212', $workPhone['phone']);
+  }
+
+  /**
    * Test import parser will fallback to external identifier.
    *
    * In this case no primary match exists (e.g the details are not supplied) so it falls back on external identifier.


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4278
If you use the "Fill" strategy for duplicate records in Contact Import, phone and email will be skipped if any phone/email exists, regardless of location type.  Addresses import correctly. Repro steps in lab.c.o ticket.

Before
----------------------------------------
Phone number/email not imported if *any* phone/email exists.

After
----------------------------------------
Phone number/email only not imported if a phone/email of the same location type exists.

Comments
----------------------------------------
Not as messy as it looks but whitespace issues make that hard to see.
Previously:
* `formatParams()` iterated through each imported value, but skipped `id`, `contact_type`, and `address`.
* after the `foreach` it gave special handling to address fields.

Now:
* We only skip `id` and `contact_type`.
* We set a variable `$checkLocationType` if we're evalutating address/phone/email.
* The address special handling is now within the `foreach`, triggered if `$checkLocationType` is `TRUE`.
