### PR TITLE
Upgrade message for drupal9 sites to advise to clear drupal cache

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyOne.php
@@ -41,6 +41,14 @@ class CRM_Upgrade_Incremental_php_FiveSixtyOne extends CRM_Upgrade_Incremental_B
     }
   }
 
+  public function setPostUpgradeMessage(&$postUpgradeMessage, $rev): void {
+    if ($rev === '5.61.1') {
+      if (defined('CIVICRM_UF') && CIVICRM_UF === 'Drupal8') {
+        $postUpgradeMessage .= '<p>' . ts('You must do a one-time clear of Drupal caches now before visiting CiviCRM pages to rebuild the menu routes to avoid fatal errors. <a %1>Read more</a>.', [1 => 'href="https://civicrm.org/redirect/drupal-5.61" target="_blank"']) . '</p>';
+      }
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *
@@ -69,6 +77,12 @@ class CRM_Upgrade_Incremental_php_FiveSixtyOne extends CRM_Upgrade_Incremental_B
 
     $this->addTask(ts('Drop index %1', [1 => 'civicrm_campaign.UI_campaign_name']), 'dropIndex', 'civicrm_campaign', 'UI_campaign_name');
     $this->addTask(ts('Create index %1', [1 => 'civicrm_campaign.UI_name']), 'addIndex', 'civicrm_campaign', 'name', 'UI');
+  }
+
+  /**
+   * Needs to exist for postUpgradeMessage to get called.
+   */
+  public function upgrade_5_61_1($rev): void {
   }
 
   /**

--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-09</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-02-11</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-01-02</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-11-11</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-08-11</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-05-23</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-12</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/elavon/info.xml
+++ b/ext/elavon/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2022-08-05</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-03</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-07</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-27</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-08-05</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-07-21</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-07-25</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:hidden</tag>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-06-12</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-10-23</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-13</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.61</ver>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -13,7 +13,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-03</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-01-06</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:required</tag>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-01-28</releaseDate>
-  <version>5.61.0</version>
+  <version>5.61.1</version>
   <tags>
     <tag>mgmt:hidden</tag>
   </tags>

--- a/sql/civicrm_generated.mysql
+++ b/sql/civicrm_generated.mysql
@@ -3059,7 +3059,7 @@ UNLOCK TABLES;
 LOCK TABLES `civicrm_domain` WRITE;
 /*!40000 ALTER TABLE `civicrm_domain` DISABLE KEYS */;
 INSERT INTO `civicrm_domain` (`id`, `name`, `description`, `version`, `contact_id`, `locales`, `locale_custom_strings`) VALUES
- (1,'Default Domain Name',NULL,'5.61.0',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
+ (1,'Default Domain Name',NULL,'5.61.1',1,NULL,'a:1:{s:5:\"en_US\";a:0:{}}');
 /*!40000 ALTER TABLE `civicrm_domain` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/test_data_second_domain.mysql
+++ b/sql/test_data_second_domain.mysql
@@ -902,4 +902,4 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, CONCAT('civicrm/report/instance/', @instanceID,'&reset=1'), 'Mailing Detail Report', 'Mailing Detail Report', 'administer CiviMail', 'OR', @reportlastID, '1', NULL, @instanceID+2 );
 UPDATE civicrm_report_instance SET navigation_id = LAST_INSERT_ID() WHERE id = @instanceID;
-UPDATE civicrm_domain SET version = '5.61.0';
+UPDATE civicrm_domain SET version = '5.61.1';

--- a/xml/version.xml
+++ b/xml/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <version>
-  <version_no>5.61.0</version_no>
+  <version_no>5.61.1</version_no>
 </version>


### PR DESCRIPTION
Overview
----------------------------------------

Backport #26159 from 5.62-rc to 5.61-stable.