### PR TITLE
[php8] fix Find Cases notices

### DIFF
--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -307,9 +307,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
       $row = [];
       // the columns we are interested in
       foreach (self::$_properties as $property) {
-        if (isset($result->$property)) {
-          $row[$property] = $result->$property;
-        }
+        $row[$property] = $result->$property ?? NULL;
       }
 
       $isDeleted = FALSE;
@@ -358,15 +356,15 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
 
     //retrieve the scheduled & recent Activity type and date for selector
     if (!empty($scheduledInfo)) {
-      $schdeduledActivity = CRM_Case_BAO_Case::getNextScheduledActivity($scheduledInfo, 'upcoming');
-      foreach ($schdeduledActivity as $key => $value) {
-        $rows[$key]['case_scheduled_activity_date'] = $value['date'];
-        $rows[$key]['case_scheduled_activity_type'] = $value['type'];
+      $scheduledActivity = CRM_Case_BAO_Case::getNextScheduledActivity($scheduledInfo, 'upcoming');
+      foreach ($rows as $key => $row) {
+        $rows[$key]['case_scheduled_activity_date'] = $scheduledActivity[$key]['date'] ?? NULL;
+        $rows[$key]['case_scheduled_activity_type'] = $scheduledActivity[$key]['type'] ?? NULL;
       }
       $recentActivity = CRM_Case_BAO_Case::getNextScheduledActivity($scheduledInfo, 'recent');
-      foreach ($recentActivity as $key => $value) {
-        $rows[$key]['case_recent_activity_date'] = $value['date'];
-        $rows[$key]['case_recent_activity_type'] = $value['type'];
+      foreach ($rows as $key => $row) {
+        $rows[$key]['case_recent_activity_date'] = $recentActivity[$key]['date'] ?? NULL;
+        $rows[$key]['case_recent_activity_type'] = $recentActivity[$key]['type'] ?? NULL;
       }
     }
     return $rows;

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -55,7 +55,7 @@
   {$row.case_recent_activity_type}<br />{$row.case_recent_activity_date|crmDate}{else}---{/if}</td>
     <td class="crm-case-case_scheduled_activity_type">{if $row.case_scheduled_activity_type}
   {$row.case_scheduled_activity_type}<br />{$row.case_scheduled_activity_date|crmDate}{else}---{/if}</td>
-    <td>{$row.action|replace:'xx':$row.case_id}{$row.moreActions|replace:'xx':$row.case_id}</td>
+    <td>{$row.action|replace:'xx':$row.case_id}</td>
   {/foreach}
 
     {* Dashboard only lists 10 most recent cases. *}

--- a/templates/CRM/Case/Form/Selector.tpl
+++ b/templates/CRM/Case/Form/Selector.tpl
@@ -33,7 +33,7 @@
   {counter start=0 skip=1 print=false}
   {foreach from=$rows item=row}
 
-  <tr id='rowid{$list}{$row.case_id}' class="{cycle values="odd-row,even-row"} crm-case crm-case-status_{$row.case_status_id} crm-case-type_{$row.case_type_id}">
+  <tr id='rowid{$row.case_id}' class="{cycle values="odd-row,even-row"} crm-case crm-case-status_{$row.case_status_id} crm-case-type_{$row.case_type_id}">
     {if $context eq 'Search' && !$single}
         {assign var=cbName value=$row.checkbox}
         <td>{$form.$cbName.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
1. Create at least one case.
2. Go to Cases - Find Cases
3. Click Search (doesn't matter if you pick some criteria or not)
4. Red box with several errors.

After
----------------------------------------
Less errors.

Technical Details
----------------------------------------
1. The first commit just sets the variables to something instead of not being set at all.
2. The second commit removes a variable that makes no sense in this context and I'm sure was copy/paste from the case dashboard selector, where `$list` means upcoming or recent. But in Find Cases context that doesn't mean anything and it's never assigned.
3. The third commit instead of removing I just guarded it since I'm not as sure. I can't find anywhere it would ever be assigned for this screen, or on the Cases tab of a contact which is the only other place this selector is used.

Comments
----------------------------------------
I have some mink tests on Find Cases searches that started failing when I switched them to run on php 8.1.
