### PR TITLE
dev/core#4281 - Fix help bubbles on windows when file param not specified

### DIFF
--- a/CRM/Core/Page/Inline/Help.php
+++ b/CRM/Core/Page/Inline/Help.php
@@ -22,6 +22,8 @@ class CRM_Core_Page_Inline_Help {
   public function run() {
     $args = $_REQUEST;
     $file = (string) ($args['file'] ?? '');
+    // windows - just replace so the regex can match
+    $file = str_replace('\\', '/', $file);
     if (preg_match('@^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)*$@', $file)) {
       $additionalTPLFile = "$file.extra.hlp";
       $file .= '.hlp';


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4281

Before
----------------------------------------
1. On windows, click the help bubble for a field where the `{help}` tag has not specified the `file` param. An example is for the assignee on activities.
2. Error: cannot load help file.

After
----------------------------------------
Loads

Technical Details
----------------------------------------
Technically a regression from 5.57 https://github.com/civicrm/civicrm-core/commit/d80e8fa62cad6661a0882753a8babf5512f9bb12 but I didn't bother backporting.

The regex doesn't match because it contains `\` instead.

Comments
----------------------------------------

