### PR TITLE
Fix PHP8 warnings for AddToGroup

### DIFF
--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -109,10 +109,6 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
 
     if ($this->_context === 'amtg') {
       $groupElement->freeze();
-
-      // also set the group title
-      $groupValues = ['id' => $this->_id, 'title' => $this->_title];
-      $this->assign_by_ref('group', $groupValues);
     }
 
     // Set dynamic page title for 'Add Members Group (confirm)'

--- a/templates/CRM/Contact/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToGroup.tpl
@@ -9,7 +9,7 @@
 *}
 <div class="crm-block crm-form-block crm-contact-task-addtogroup-form-block">
 <table class="form-layout">
-    {if $group.id}
+    {if $form.group_id.value}
        <tr class="crm-contact-task-addtogroup-form-block-group_id">
           <td class="label">{ts}Group{/ts}</td>
           <td>{$form.group_id.html}</td>
@@ -54,7 +54,7 @@
 </div>
 {include file="CRM/common/showHide.tpl"}
 
-{if !$group.id}
+{if !$form.group_id.value}
 {literal}
 <script type="text/javascript">
 showElements();


### PR DESCRIPTION
Before
----------------------------------------
Warnings when not in amtg context.
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/25517556/236655987-764234af-867d-4a55-ba3c-fd809405f1cc.png">

After
----------------------------------------
Fewer warnings (still some for showHide.tpl).
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/25517556/236655965-025ba0df-9073-48e2-95f2-6a68448bb5d6.png">

Technical Details
----------------------------------------
Was able to simplify as {$group.title} was not actually used and we already had {$group.id} in {$form.group_id.value}.