### PR TITLE
Fix PHP8 warnings in Participant.tpl

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1740,7 +1740,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
     $form->assign('onlinePendingContributionId', $form->get('onlinePendingContributionId'));
 
-    $form->assign('paid', $form->_isPaidEvent);
+    $form->assign('paid', $form->_isPaidEvent ?? NULL);
 
     $form->addElement('checkbox',
       'send_receipt',
@@ -2266,6 +2266,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    */
   protected function assignUrlPath() {
     $this->assign('urlPath', 'civicrm/contact/view/participant');
+    $this->assign('urlPathVar', NULL);
     if (!$this->_id && !$this->_contactId) {
       $breadCrumbs = [
         [

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -15,7 +15,7 @@
 {* Main event form template *}
 {else}
   <div class="crm-block crm-form-block crm-participant-form-block">
-    {if $newCredit AND $action EQ 1 AND $participantMode EQ null}
+    {if $action EQ 1 AND ($context EQ 'participant' OR $context EQ 'standalone') AND $newCredit AND $participantMode EQ null}
       <div class="action-link css_right crm-link-credit-card-mode">
         {if $contactId}
           {capture assign=ccModeLink}{crmURL p='civicrm/contact/view/participant' q="reset=1&action=add&cid=`$contactId`&context=`$context`&mode=live"}{/capture}
@@ -32,13 +32,6 @@
         </div>
       {/if}
       <div id="eventFullMsg" class="messages status no-popup" style="display:none;"></div>
-
-
-      {if $action eq 1 AND $paid}
-        <div class="help">
-          {ts}If you are accepting offline payment from this participant, check <strong>Record Payment</strong>. You will be able to fill in the payment information, and optionally send a receipt.{/ts}
-        </div>
-      {/if}
 
       {if $action eq 8} {* If action is Delete *}
         <div class="crm-participant-form-block-delete messages status no-popup">
@@ -58,10 +51,12 @@
         {else} {* If action is other than Delete *}
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
         <table class="form-layout-compressed">
-          <tr class="crm-participant-form-contact-id">
-            <td class="label">{$form.contact_id.label}</td>
-            <td>{$form.contact_id.html}</td>
-          </tr>
+          {if $context EQ 'standalone' OR $context EQ 'participant' OR $action EQ 2}
+            <tr class="crm-participant-form-contact-id">
+              <td class="label">{$form.contact_id.label}</td>
+              <td>{$form.contact_id.html}</td>
+            </tr>
+          {/if}
           {if $action EQ 2}
             {if $additionalParticipants} {* Display others registered by this participant *}
               <tr class="crm-participant-form-block-additionalParticipants">
@@ -85,12 +80,7 @@
           {/if}
           <tr class="crm-participant-form-block-event_id">
             <td class="label">{$form.event_id.label}</td>
-            <td class="view-value">
-              {$form.event_id.html}
-              {if $is_test}
-                {ts}(test){/ts}
-              {/if}
-            </td>
+            <td class="view-value">{$form.event_id.html}</td>
           </tr>
 
         {* CRM-7362 --add campaign *}
@@ -148,7 +138,7 @@
         </div>
       {/if}
 
-      {if $accessContribution and $action eq 2 and $rows.0.contribution_id}
+      {if $action eq 2 and $accessContribution and $rows.0.contribution_id}
       {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
       {/if}
 
@@ -274,25 +264,25 @@
 
   {/if}
 
+  {if $action NEQ 8}
+  <script type="text/javascript">
+    {literal}
 
-<script type="text/javascript">
-  {literal}
-
-  sendNotification();
-  function sendNotification() {
-    var notificationStatusIds = {/literal}"{$notificationStatusIds}"{literal};
-    notificationStatusIds = notificationStatusIds.split(',');
-    if (cj.inArray(cj('.crm-participant-form-block-status_id select#status_id option:selected').val(), notificationStatusIds) > -1) {
-      cj("#notify").show();
-      cj("#is_notify").prop('checked', false);
+    sendNotification();
+    function sendNotification() {
+      var notificationStatusIds = {/literal}"{$notificationStatusIds}"{literal};
+      notificationStatusIds = notificationStatusIds.split(',');
+      if (cj.inArray(cj('.crm-participant-form-block-status_id select#status_id option:selected').val(), notificationStatusIds) > -1) {
+        cj("#notify").show();
+      }
+      else {
+        cj("#notify").hide();
+        cj("#is_notify").prop('checked', false);
+      }
     }
-    else {
-      cj("#notify").hide();
-      cj("#is_notify").prop('checked', false);
-    }
-  }
 
-  {/literal}
-</script>
+    {/literal}
+  </script>
+  {/if}
 
 {/if} {* end of main event block*}

--- a/templates/CRM/Event/Page/Tab.tpl
+++ b/templates/CRM/Event/Page/Tab.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $action eq 1 or $action eq 2 or $action eq 8} {* add, update or view *}
+{if $action eq 1 or $action eq 2 or $action eq 8} {* add, update or delete *}
     {include file="CRM/Event/Form/Participant.tpl"}
 {elseif $action eq 4}
     {include file="CRM/Event/Form/ParticipantView.tpl"}


### PR DESCRIPTION
Before
----------------------------------------
Lots of warnings on: standalone New Event Registration, Actions - Register participants for event when selecting contacts, New Event Registration for Contact (both live credit card and regular), Delete Event Registration and Edit Event Registration.

Send Notification was not being hidden as intended due to the div having id `notify`, which something else was targeting, at least for me.

After
----------------------------------------
No more warnings.

Send Notification hidden and shown as intended.

Technical Details
----------------------------------------
Some of this maybe isn't the prettiest, but I think better to check the context in the template rather than, for example, dealing with the three different variables for contact id that may or may not be present across three different classes.