### PR TITLE
dev/core#3920 Improve footer and support menu

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.63.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.63.alpha1.mysql.tpl
@@ -1,1 +1,14 @@
 {* file to handle db changes in 5.63.alpha1 during upgrade *}
+
+{* https://github.com/civicrm/civicrm-core/pull/24916 *}
+DELETE FROM `civicrm_navigation` WHERE `name` = 'Get started';
+DELETE FROM `civicrm_navigation` WHERE `name` = 'Documentation';
+DELETE FROM `civicrm_navigation` WHERE `name` = 'Ask a question';
+DELETE FROM `civicrm_navigation` WHERE `name` = 'Get expert help';
+
+SELECT @adminHelplastID := `id` FROM `civicrm_navigation` WHERE `name` = 'Support';
+INSERT IGNORE INTO civicrm_navigation
+    ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
+VALUES
+    ( {$domainID}, 'https://docs.civicrm.org/user/?src=iam', '{ts escape="sql" skip="true"}User Guide{/ts}', 'User Guide', NULL, 'AND', @adminHelplastID, '1', NULL, 1 ),
+    ( {$domainID}, 'https://civicrm.org/help?src=iam',       '{ts escape="sql" skip="true"}Get Help{/ts}',   'Get Help',   NULL, 'AND', @adminHelplastID, '1', NULL, 2 );

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -697,8 +697,17 @@ input.crm-form-entityref {
   color: #3e3e3e;
 }
 
+.crm-container .status.crm-status-none {
+  background-color: inherit;
+}
+
 .crm-container .crm-footer {
   font-size: 0.8em;
+}
+
+.crm-footer .status {
+  padding: 4px;
+  border: 0px;
 }
 
 #civicrm-footer {

--- a/templates/CRM/common/footer.tpl
+++ b/templates/CRM/common/footer.tpl
@@ -14,18 +14,17 @@
   {/if}
 
   <div class="crm-footer" id="civicrm-footer">
-    {crmVersion assign=version}
-    {ts}Powered by CiviCRM{/ts} <a href="https://download.civicrm.org/about/{$version}" rel="external" target="_blank">{$version}</a>.
     {if $footer_status_severity}
-      <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
+    <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
       <a href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>
-    </span>
+    </span>&nbsp;
+    {elseif call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+    <span class="status crm-status-none">
+      <a href="{crmURL p='civicrm/a/#/status'}">{ts}System Status{/ts}</a>
+    </span>&nbsp;
     {/if}
-    {ts 1='href="http://www.gnu.org/licenses/agpl-3.0.html" rel="external" target="_blank"'}CiviCRM is openly available under the <a %1>GNU AGPL License</a>.{/ts}<br/>
-    <a href="https://civicrm.org/download" rel="external" target="_blank">{ts}Download CiviCRM.{/ts}</a> &nbsp; &nbsp;
-    <a href="https://lab.civicrm.org/groups/dev/-/issues" rel="external" target="_blank">{ts}View issues and report bugs.{/ts}</a> &nbsp; &nbsp;
-    {capture assign=docUrlText}{ts}Online documentation.{/ts}{/capture}
-    {docURL page="" text=$docUrlText}
+    {crmVersion assign=version}
+    {ts 1='href="http://www.gnu.org/licenses/agpl-3.0.html" rel="external" target="_blank"' 2='href="https://civicrm.org/" rel="external" target="_blank"' 3=$version}Powered by <a %2>CiviCRM</a> %3, free and open source <a %1>AGPLv3</a> software.{/ts}<br/>
   </div>
   {include file="CRM/common/notifications.tpl"}
 {/if}

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -507,18 +507,16 @@ SET @adminHelplastID:=LAST_INSERT_ID();
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
-    ( @domainID, 'https://civicrm.org/get-started?src=iam',        '{ts escape="sql" skip="true"}Get started{/ts}',        'Get started',        NULL, 'AND', @adminHelplastID, '1', NULL, 1 ),
-    ( @domainID, 'https://civicrm.org/documentation?src=iam',      '{ts escape="sql" skip="true"}Documentation{/ts}',      'Documentation',      NULL, 'AND', @adminHelplastID, '1', NULL, 2 ),
-    ( @domainID, 'https://civicrm.org/ask-a-question?src=iam',     '{ts escape="sql" skip="true"}Ask a question{/ts}',     'Ask a question',     NULL, 'AND', @adminHelplastID, '1', NULL, 3 ),
-    ( @domainID, 'https://civicrm.org/experts?src=iam', 		  '{ts escape="sql" skip="true"}Get expert help{/ts}',    'Get expert help',    NULL, 'AND', @adminHelplastID, '1', NULL, 4 ),
-    ( @domainID, 'https://civicrm.org/about?src=iam', 		  '{ts escape="sql" skip="true"}About CiviCRM{/ts}',      'About CiviCRM',      NULL, 'AND', @adminHelplastID, '1', 1, 5 ),
-    ( @domainID, 'https://civicrm.org/register-your-site?src=iam&sid={ldelim}sid{rdelim}', '{ts escape="sql" skip="true"}Register your site{/ts}', 'Register your site', NULL, 'AND', @adminHelplastID, '1', NULL, 6 ),
-    ( @domainID, 'https://civicrm.org/become-a-member?src=iam&sid={ldelim}sid{rdelim}',      '{ts escape="sql" skip="true"}Join CiviCRM{/ts}',       'Join CiviCRM',       NULL, 'AND', @adminHelplastID, '1', NULL, 7 );
+    ( @domainID, 'https://docs.civicrm.org/user/?src=iam',                                 '{ts escape="sql" skip="true"}User Guide{/ts}',         'User Guide',         NULL, 'AND', @adminHelplastID, '1', NULL, 1 ),
+    ( @domainID, 'https://civicrm.org/help?src=iam',                                       '{ts escape="sql" skip="true"}Get Help{/ts}',           'Get Help',           NULL, 'AND', @adminHelplastID, '1', NULL, 2 ),
+    ( @domainID, 'https://civicrm.org/about?src=iam', 		                                 '{ts escape="sql" skip="true"}About CiviCRM{/ts}',      'About CiviCRM',      NULL, 'AND', @adminHelplastID, '1', 1,    3 ),
+    ( @domainID, 'https://civicrm.org/register-your-site?src=iam&sid={ldelim}sid{rdelim}', '{ts escape="sql" skip="true"}Register your Site{/ts}', 'Register your site', NULL, 'AND', @adminHelplastID, '1', NULL, 4 ),
+    ( @domainID, 'https://civicrm.org/become-a-member?src=iam&sid={ldelim}sid{rdelim}',    '{ts escape="sql" skip="true"}Join CiviCRM{/ts}',       'Join CiviCRM',       NULL, 'AND', @adminHelplastID, '1', NULL, 5 );
 
 INSERT INTO civicrm_navigation
 ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
-    ( @domainID, NULL, '{ts escape="sql" skip="true"}Developer{/ts}', 'Developer', 'administer CiviCRM', '', @adminHelplastID, '1', 1, 8 );
+    ( @domainID, NULL, '{ts escape="sql" skip="true"}Developer{/ts}', 'Developer', 'administer CiviCRM', '', @adminHelplastID, '1', 1, 6 );
 
 SET @devellastID:=LAST_INSERT_ID();
 INSERT INTO civicrm_navigation


### PR DESCRIPTION
Overview
----------------------------------------
Replaces #24916

Before
----------------------------------------
Footer is busy and duplicates the support menu.
System Status is only present sometimes and styling is inconsistent depending on status.
![image](https://user-images.githubusercontent.com/25517556/200390561-74a75110-5fa9-4297-b402-352b7d3b3d09.png)

Support menu is redundant with website, includes some, but not all support options.
<img width="220" alt="image" src="https://user-images.githubusercontent.com/25517556/200390749-ad6b6a58-3f9c-406a-ae4c-734cd906be45.png">

After
----------------------------------------
Footer is simpler and does not duplicate support menu.

When System Status is not available due to the vagaries of caching, if you have administer CiviCRM, you'll just see a System Status link, so at least we're consistently showing at least a link here (this one is for @elisseck). The System Status span is now consistently styled, no matter what status it is.
![image](https://user-images.githubusercontent.com/25517556/200391618-90f3b543-ded9-40b9-a417-004d1eaf5b97.png)
With links:
[System Status](http://drupal-test.localhost/civicrm/a/#/status)   Powered by [CiviCRM](https://civicrm.org/) 5.57.alpha1, free and open source [AGPLv3](http://www.gnu.org/licenses/agpl-3.0.html) software.

The support menu is simplified per the discussion in the previous PR, with link to user guide and to [Get Help](https://civicrm.org/help) on website
<img width="176" alt="image" src="https://user-images.githubusercontent.com/25517556/236702118-2dc4578d-1a22-4a1f-83e8-b769cb03808f.png">

Technical Details
----------------------------------------
Also includes SQL to update menu on existing installations.
