### PR TITLE
Stop escaping tableHeader in secure smarty mode

### DIFF
--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -44,8 +44,8 @@
         {if !$sections} {* section headers and sticky headers aren't playing nice yet *}
             <thead class="sticky">
             <tr>
-                {$tableHeader}
-        </tr>
+              {$tableHeader|smarty:nodefaults}
+            </tr>
         </thead>
         {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop escaping tableHeader in secure smarty mode

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/236716888-2189bdd2-626b-429e-9398-0db93387cd43.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/236716918-562b5225-f2d3-4325-8fce-e71cb3d25cc1.png)

Technical Details
----------------------------------------
This variable is the result of a smarty capture so it does not make sense to escape it - hence marking as such

Comments
----------------------------------------
