### PR TITLE
Fix regression whereby membership does not submit

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -511,6 +511,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->_currentMemberships = [];
 
       $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
+      // This is always true if this line is reachable - remove along with the upcoming if.
       $membershipPriceset = (!empty($this->_priceSetId) && $this->isMembershipPriceSet());
 
       $allowAutoRenewMembership = $autoRenewOption = FALSE;
@@ -633,28 +634,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       // Assign autorenew option (0:hide,1:optional,2:required) so we can use it in confirmation etc.
       $autoRenewOption = CRM_Price_BAO_PriceSet::checkAutoRenewForPriceSet($this->_priceSetId);
       $this->assign('autoRenewOption', $autoRenewOption);
-
-      if (!$membershipPriceset) {
-        if (!$this->_membershipBlock['is_required']) {
-          $this->assign('showRadioNoThanks', TRUE);
-          $radio['no_thanks'] = NULL;
-          $this->addRadio('selectMembership', NULL, $radio, [], NULL, FALSE, $radioOptAttrs);
-        }
-        elseif ($this->_membershipBlock['is_required'] && count($radio) == 1) {
-          $temp = array_keys($radio);
-          $this->add('hidden', 'selectMembership', $temp[0], ['id' => 'selectMembership']);
-          $this->assign('singleMembership', TRUE);
-          $this->assign('showRadio', FALSE);
-        }
-        else {
-          foreach ($radioOptAttrs as $opt => $attrs) {
-            $attrs['class'] = ' required';
-          }
-          $this->addRadio('selectMembership', NULL, $radio, [], NULL, FALSE, $radioOptAttrs);
-        }
-
-        $this->addRule('selectMembership', ts('Please select one of the memberships.'), 'required');
-      }
 
       if ((!$this->_values['is_pay_later'] || is_array($this->_paymentProcessors)) && ($allowAutoRenewMembership || $autoRenewOption)) {
         if ($autoRenewOption == 2) {
@@ -783,6 +762,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $self->_useForMember
       )
     ) {
+
+      // appears to be unreachable - selectMembership never set...
       $isTest = $self->_action & CRM_Core_Action::PREVIEW;
       $lifeMember = CRM_Member_BAO_Membership::getAllContactMembership($self->_membershipContactID, $isTest, TRUE);
 

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -372,7 +372,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       // build price set form.
       $this->set('priceSetId', $this->_priceSetId);
       if (empty($this->_ccid)) {
-        CRM_Price_BAO_PriceSet::buildPriceSet($this);
+        CRM_Price_BAO_PriceSet::buildPriceSet($this, $this->getMainEntityType());
       }
       if ($this->_values['is_monetary'] &&
         $this->_values['is_recur'] && empty($this->_values['pledge_id'])

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1305,9 +1305,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   protected function isMembershipPriceSet(): bool {
     if ($this->_useForMember === NULL) {
-      if (CRM_Core_Component::isEnabled('CiviMember') &&
-        (!$this->isQuickConfig() || !empty($this->_ccid)) &&
-        (int) CRM_Core_Component::getComponentID('CiviMember') === (int) $this->order->getPriceSetMetadata()['extends']) {
+      if ($this->getMainEntityType() === 'membership' &&
+        !$this->isQuickConfig()) {
         $this->_useForMember = 1;
       }
       else {
@@ -1316,6 +1315,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->set('useForMember', $this->_useForMember);
     }
     return (bool) $this->_useForMember;
+  }
+
+  public function getMainEntityType() {
+    if (CRM_Core_Component::isEnabled('CiviMember') && (int) CRM_Core_Component::getComponentID('CiviMember') === (int) $this->order->getPriceSetMetadata()['extends']) {
+      return 'membership';
+    }
+    return 'contribution';
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -446,6 +446,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->set('values', $this->_values);
       $this->set('fields', $this->_fields);
     }
+    $this->assign('isShowMembershipQuickConfigBlock', $this->isShowMembershipQuickConfigBlock());
     $this->set('membershipBlock', $this->getMembershipBlock());
 
     // Handle PCP
@@ -1315,6 +1316,16 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->set('useForMember', $this->_useForMember);
     }
     return (bool) $this->_useForMember;
+  }
+
+  /**
+   * Should the membership block be displayed.
+   *
+   * This should be shown when the price set is quick config and is a membership price set.
+   * @return bool
+   */
+  protected function isShowMembershipQuickConfigBlock(): bool {
+    return CRM_Core_Component::isEnabled('CiviMember') && $this->getMembershipBlock() && $this->isQuickConfig();
   }
 
   /**

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -791,10 +791,11 @@ WHERE  id = %1";
    * Build the price set form.
    *
    * @param CRM_Core_Form $form
+   * @param string|null $component
    *
    * @return void
    */
-  public static function buildPriceSet(&$form) {
+  public static function buildPriceSet(&$form, $component = NULL) {
     $priceSetId = $form->get('priceSetId');
     if (!$priceSetId) {
       return;
@@ -847,23 +848,19 @@ WHERE  id = %1";
     $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetId;
     $form->assign('priceSet', $form->_priceSet);
 
-    $component = 'contribution';
     if ($className == 'CRM_Member_Form_Membership') {
       $component = 'membership';
     }
 
     if ($className == 'CRM_Contribute_Form_Contribution_Main') {
       $feeBlock = &$form->_values['fee'];
-      if (!empty($form->_useForMember)) {
-        $component = 'membership';
-      }
     }
     else {
       $feeBlock = &$form->_priceSet['fields'];
     }
 
     // Call the buildAmount hook.
-    CRM_Utils_Hook::buildAmount($component, $form, $feeBlock);
+    CRM_Utils_Hook::buildAmount($component ?? 'contribution', $form, $feeBlock);
 
     self::addPriceFieldsToForm($form, $feeBlock, $validFieldsOnly, $className, $validPriceFieldIds);
   }

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -76,7 +76,7 @@
       <div class="help">{ts}You have a current Lifetime Membership which does not need to be renewed.{/ts}</div>
     {/if}
 
-    {if !empty($useForMember) && !$ccid}
+    {if $isShowMembershipQuickConfigBlock && !$ccid}
       <div class="crm-public-form-item crm-section">
         {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl" context="makeContribution"}
       </div>

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -158,6 +158,7 @@
       {foreach from=$membershipTypes item=row}
         <tr {if $context EQ "makeContribution"}class="odd-row" {/if}valign="top">
           {if $showRadio }
+            {* unreachable - show radio is never true *}
             {assign var="pid" value=$row.id}
             <td style="width: 1em;">{$form.selectMembership.$pid.html}</td>
           {else}
@@ -203,7 +204,7 @@
           </td>
         </tr>
       {/if}
-      {if $showRadio}
+      {if $showRadio}{* unreachable *}
         {if $showRadioNoThanks } {* Provide no-thanks option when Membership signup is not required - per membership block configuration. *}
           <tr class="odd-row">
             <td>{$form.selectMembership.no_thanks.html}</td>

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if !empty($useForMember) AND !$is_quick_config}
+{if $isShowMembershipQuickConfigBlock}
   <div id="membership" class="crm-group membership-group">
     {if $context EQ "makeContribution"}
       <div id="priceset">


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression whereby membership does not submit

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4272#note_90443 on 5.61.0 it is not possible to submit a non-quick config membership form as the rule requiring the 'selectMembership' field to be set - however, it is actually never present on the form, having been superceded by the price set fields

After
----------------------------------------
The code that expects it is removed

Technical Details
----------------------------------------
I went back to 5.60 & tested with
- price set with membership
- normal quick config with membership
- quick config with membership and contribution
- quick config with membership and contribution with separate payments

In all these cases `$membershipPriceset` was TRUE and the lines in question were never hit - hence the fix is to remove them


Comments
----------------------------------------
There was  a further possible issue mentioned in chat that I need to check - as a follow up. Also some follow up cleanup is implied by this patch as it implies more bits of code are unreachable