### PR TITLE
Notice fix on isHonor on contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -108,10 +108,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $qParams .= "&amp;pcpId={$pcpId}";
     }
     $this->assign('qParams', $qParams);
-
-    if (!empty($this->_values['footer_text'])) {
-      $this->assign('footer_text', $this->_values['footer_text']);
-    }
+    $this->assign('footer_text', $this->_values['footer_text'] ?? NULL);
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -432,7 +432,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $prms = ['id' => $this->_pcpId];
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $prms, $pcpInfo);
       if ($pcpInfo['is_honor_roll']) {
-        $this->assign('isHonor', TRUE);
         $this->add('checkbox', 'pcp_display_in_roll', ts('Show my contribution in the public honor roll'), NULL, NULL,
           ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"]
         );

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -218,7 +218,7 @@
         {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
       </div>
 
-      {if $isHonor}
+      {if array_key_exists('pcp_display_in_roll', $form)}
         <fieldset class="crm-public-form-item crm-group pcp-group">
           <div class="crm-public-form-item crm-section pcp-section">
             <div class="crm-public-form-item crm-section display_in_roll-section">
@@ -297,8 +297,8 @@
     {/if}
   </div>
   <script type="text/javascript">
-    {if $isHonor}
-    pcpAnonymous();
+    {if array_key_exists('pcp_display_in_roll', $form)}
+      pcpAnonymous();
     {/if}
 
     {literal}


### PR DESCRIPTION
Overview
----------------------------------------
Notice fix on isHonor

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/336308/236735421-8d545c80-93c5-4206-bf56-5b08f2aed413.png)

After
--------------------------------------
--
Still lots
![Uploading image.png…]()

Technical Details
----------------------------------------
These are the only 3 references to `$isHonor`

![image](https://user-images.githubusercontent.com/336308/236735301-329cdec3-7f82-40a6-93fc-1d524d1c2528.png) 

And it is always set in conjunction with adding the pcp_display_in_roll field and always used in conjunction with that field

![image](https://user-images.githubusercontent.com/336308/236735704-52736870-3851-4820-90cf-029fdef4c92c.png)



Comments
----------------------------------------

