### PR TITLE
dev/core#4227 Fix import to not blank birth_date etc on update

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -306,6 +306,7 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if ($customFieldID &&
         !array_key_exists($customFieldID, $addressCustomFields)
       ) {
+        // @todo - this can probably go....
         if ($customFields[$customFieldID]['data_type'] == 'Boolean') {
           if (empty($val) && !is_numeric($val) && $this->isFillDuplicates()) {
             //retain earlier value when Import mode is `Fill`
@@ -816,12 +817,10 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
           }
         }
       }
-      if (in_array($key, ['nick_name', 'job_title', 'middle_name', 'birth_date', 'gender_id', 'current_employer', 'prefix_id', 'suffix_id'])
-        && ($value == '' || !isset($value)) &&
-        ($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 ||
-        ($key === 'current_employer' && empty($params['current_employer']))) {
-        // CRM-10128: if auth source is not checksum / login && $value is blank, do not fill $data with empty value
-        // to avoid update with empty values
+      // Why only these fields...?
+      if ($value === '' && in_array($key, ['nick_name', 'job_title', 'middle_name', 'birth_date', 'gender_id', 'current_employer', 'prefix_id', 'suffix_id'], TRUE)
+        ) {
+        // CRM-10128: if $value is blank, do not fill $data with empty value
         continue;
       }
       else {

--- a/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Parser/ContactTest.php
@@ -434,11 +434,9 @@ class CRM_Contact_Import_Parser_ContactTest extends CiviUnitTestCase {
     [$originalValues, $result] = $this->setUpBaseContact([
       'external_identifier' => '',
       'email' => NULL,
+      'birth_date' => '2008-01-07',
     ]);
-    $updateValues = ['id' => $result['id'], 'email' => 'bill@example.com'];
-    // This is some deep weirdness - this sets a flag for updatingBlankLocinfo - allowing input to be blanked
-    // (which IS a good thing but it's pretty weird & all to do with legacy profile stuff).
-    CRM_Core_Session::singleton()->set('authSrc', CRM_Core_Permission::AUTH_SRC_CHECKSUM);
+    $updateValues = ['id' => (int) $result['id'], 'email' => 'bill@example.com', 'birth_date' => ''];
     $this->runImport($updateValues, CRM_Import_Parser::DUPLICATE_UPDATE, CRM_Import_Parser::VALID);
     $originalValues['id'] = $result['id'];
     $this->callAPISuccessGetSingle('Email', ['contact_id' => $originalValues['id'], 'is_primary' => 1]);


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4227 Fix import to not blank birth_date etc on update

Before
----------------------------------------
per 
https://lab.civicrm.org/dev/core/-/issues/4227

After
----------------------------------------
Fixed according to the parameters of https://lab.civicrm.org/dev/core/-/issues/4227

Technical Details
----------------------------------------
This is some weird dark code. However, @bjendres has pin pointed that there was a behaviour change & the code is way clearer with this removed.

I initially worried that there might be an expectation at some point that the fields be blanked - but the fact an allowList is specifically configured makes it seem unlikely that this is anything other than a regression from the intended behaviour

Interestingly the test had that value set in the test.

Comments
----------------------------------------
