### PR TITLE
Upgrader - Fix upgrade step to remove CiviGrant from component list

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveFortySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveFortySeven.php
@@ -102,7 +102,7 @@ class CRM_Upgrade_Incremental_php_FiveFortySeven extends CRM_Upgrade_Incremental
   public static function migrateCiviGrant(CRM_Queue_TaskContext $ctx): bool {
     $civiGrantEnabled = CRM_Core_Component::isEnabled('CiviGrant');
     // This was failing on multi-domain setups. See  https://github.com/civicrm/civicrm-core/pull/26043
-    // Instead, we'll handle it in FiveSixtyTwo::consolidateComponents.
+    // Instead, we'll handle it in FiveSixtyTwo::upgrade_5_62_beta1.
     //  if ($civiGrantEnabled) {
     //    CRM_Core_BAO_ConfigSetting::disableComponent('CiviGrant');
     //  }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the upgrade step in #26118 in attempt to clear the test failure in #26036.

Before
----------------------------------------
Step doesn't seem to successfully remove CiviGrant from the components list.

After
----------------------------------------
Moved to its own step.

Technical Details
-----------
I'm not entirely sure why, but the previous attempt didn't seem to work, per the test failure in #26036, so I've moved it to its own step to see if that clears it up.