### PR TITLE
Fix config is null on hooks

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -433,6 +433,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     // We need to call the config hook again, since we now know
     // all the modules that are listening on it (CRM-8655).
+    $config = CRM_Core_Config::singleton();
     CRM_Utils_Hook::config($config);
 
     if ($loadUser) {

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -288,6 +288,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
     // We need to call the config hook again, since we now know
     // all the modules that are listening on it (CRM-8655).
+    $config = CRM_Core_Config::singleton();
     CRM_Utils_Hook::config($config);
 
     if ($loadUser) {


### PR DESCRIPTION
Overview
----------------------------------------

Encountered error when expecting config to be initialised when using hook_civicrm_config.

Found due to https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/blob/bfa6ec6e0d1906fe9b96e0d364e6a19d7b453331/Civixero.php#L16

which defines the hook as:
`
function civixero_civicrm_config(CRM_Core_Config $config) {
`

Seems like in the D7 code config is initialised but somewhere along the way this didn't make it do D8.

https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/

Before
----------------------------------------
hook_civicrm_config is called with null, resulting in a Fatal error if nz.co.fuzion.civixero extension latest version is installed.

After
----------------------------------------
hook_civicrm_config is called with config object.
