### PR TITLE
Fix locale leaking into tokens

### DIFF
--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -72,7 +72,7 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
       foreach ($e->context['smartyTokenAlias'] ?? [] as $smartyName => $tokenName) {
         $tokenParts = explode('|', $tokenName);
         $modifier = $tokenParts[1] ?? '';
-        $smartyVars[$smartyName] = \CRM_Utils_Array::pathGet($e->row->tokens, explode('.', $tokenParts[0]), $e->context['locale'] ?? NULL);
+        $smartyVars[$smartyName] = \CRM_Utils_Array::pathGet($e->row->tokens, explode('.', $tokenParts[0]), '');
         if ($smartyVars[$smartyName] instanceof \Brick\Money\Money) {
           // TODO: We should reuse the filters from TokenProcessor::filterTokenValue()
           if ($modifier === 'crmMoney') {


### PR DESCRIPTION
Overview
----------------------------------------
Fix locale leaking into tokens

Before

----------------------------------------
I'm trying to convert some code that uses our own message template stuff to call the core `CRM_Core_BAO_MessageTemplate::render()` function - while this isn't an api we don't have an equivalent at the moment & as our code is heavily tested I feel OK taking the risk calling it from outside of core. (Whether I can figure out the parameters is TBD) 

However, what I'm finding is that I have

```
  protected function exportExtraTokenContext(array &$export): void {
    $export['smartyTokenAlias']['first_name'] = 'contact.first_name';
```

When the name is NOT provided the call to `pathGet` is using the default it is passed .... the locale - so I wind up with 'Dear en_US'

After
----------------------------------------
I get Dear  as I would expect when first_name is not provided


Technical Details
----------------------------------------
I'm still deep in the struggling part of this bit of work so I struggle to articulate much but looking at the function signature of pathGet I can't see any reason why the locale rather than an empty string would be passed. I suspect NULL is OK too - but I'm scared to use NULL within token code code it has a history of breaking things


Comments
----------------------------------------
@totten 
