### PR TITLE
Show/hide billing name/address on event confirm based on if they're set instead of a magical collection of booleans

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -131,7 +131,7 @@
 
     {include file="CRM/Event/Form/Registration/DisplayProfile.tpl"}
 
-    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $paidEvent and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+    {if $billingName or $address}
       <div class="crm-group billing_name_address-group">
             <div class="header-dark">
                 {ts}Billing Name and Address{/ts}

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -156,7 +156,7 @@
     {/if}
 
     {include file="CRM/Event/Form/Registration/DisplayProfile.tpl"}
-    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $paidEvent and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+    {if $billingName or $address}
         <div class="crm-group billing_name_address-group">
             <div class="header-dark">
                 {ts}Billing Name and Address{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
If we have data for billing name/address then it should be fine to display independently of any billing mode / paylater etc. If we don't have billing data we shouldn't show an empty header.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/999f8dde-b88d-4db6-974c-26bf3f013662)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/19689b90-40ea-4aa1-b827-1a68033e8825)


Technical Details
----------------------------------------


Comments
----------------------------------------
