### PR TITLE
Simplify messaging for event confirm page

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -15,20 +15,22 @@
 
 <div class="crm-event-id-{$event.id} crm-block crm-event-confirm-form-block">
     {if $isOnWaitlist}
-        <div class="help">
-            {ts}Please verify the information below. <span class="bold">Then click 'Register' to be added to the WAIT LIST for this event</span>. If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
+        <div class="messages status section continue_message-section">
+            {ts}Please verify the information below.{/ts} <span class="bold">{ts}If space becomes available you will receive an email with a link to complete your registration.{/ts}</span>
+            {ts}Click <strong>Register</strong> to be added to the WAIT LIST for this event.{/ts}
         </div>
     {elseif $isRequireApproval}
-        <div class="help">
-            {ts}Please verify the information below. Then click 'Register' to submit your registration. <span class="bold">Once approved, you will receive an email with a link to a web page where you can complete the registration process.</span>{/ts}
+        <div class="messages status section continue_message-section">
+            {ts}Please verify the information below.{/ts} <span class="bold">{ts}Once approved, you will receive an email with a link to complete the registration process.{/ts}</span>
+            {ts}Click <strong>Register</strong> to submit your registration.{/ts}
         </div>
     {else}
-        <div class="help">
-        {ts}Please verify the information below. Click the <strong>Go Back</strong> button below if you need to make changes.{/ts}
-        {if $contributeMode EQ 'notify' and !$is_pay_later and ! $isAmountzero }
-          {ts 1=$paymentProcessor.name}Click the <strong>Register</strong> button to checkout to %1, where you will select your payment method and complete the registration.{/ts}
+        <div class="messages status section continue_message-section">
+            {ts}Please verify the information below.{/ts}
+        {if $contributeMode EQ 'notify' and !$is_pay_later and !$isAmountzero}
+            {ts 1=$paymentProcessor.frontend_title}Click <strong>Register</strong> to checkout to %1, where you will select your payment method and complete the registration.{/ts}
         {else}
-            {ts}Otherwise, click the <strong>Register</strong> button below to complete your registration.{/ts}
+            {ts}Click <strong>Register</strong> to complete your registration.{/ts}
         {/if}
         </div>
         {if $is_pay_later and !$isAmountzero}
@@ -182,14 +184,6 @@
             {include file="CRM/Event/Form/Registration/EventInfoBlock.tpl"}
         </div>
     </div>
-
-    {if $contributeMode NEQ 'notify'} {* In 'notify mode, contributor is taken to processor payment forms next *}
-    <div class="messages status section continue_message-section">
-        <p>
-        {ts}Your registration will not be submitted until you click the <strong>Register</strong> button. Please click the button one time only. If you need to change any details, click the Go Back button below to return to the previous screen.{/ts}
-        </p>
-    </div>
-    {/if}
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
Overview
----------------------------------------
The text on the confirm page hasn't changed for at least 10 years and there is a lot of it! This PR removes some and simplifies the rest to make it quicker / easier to read and hopefully clearer.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/731bf46f-e6a2-4a0e-9eaf-737d40c1e860)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/49b1a221-c227-4f63-af01-e2e165538ac0)

Removes bottom block of text explaining how to use buttons.
Text at the top is shortened and simplified.


Technical Details
----------------------------------------


Comments
----------------------------------------

