### PR TITLE
crmMailingAB/services: catch exception, report error and rethrow

### DIFF
--- a/ang/crmMailingAB/services.js
+++ b/ang/crmMailingAB/services.js
@@ -193,6 +193,9 @@
                   return {entity_table: 'civicrm_mailing', entity_id: crmMailingAB.ab['mailing_id_' + mkey]};
                 });
                 return crmMailingAB.attachments[mkey].load();
+              }).catch(function (ex){
+                console.error(ex);
+                throw new Error('Failed to load Mailings');
               });
           }
           else {


### PR DESCRIPTION
Overview
----------------------------------------
If an A/B test's mailing is missing from `civicrm_mailings` (or can't be loaded for any other reason) opening the relevant A/B test on **Mailings >> Manage A/B tests** will fail. 

Before
----------------------------------------
WSOD and an empty console, no hint on error.

After
----------------------------------------
Opening will still fail with a white screen, but there is an error logged to the console, so there is a clue where to start debugging.
