### PR TITLE
Drupal 7, refuse the possibility to execute the REST API with blocked users

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -538,7 +538,7 @@ AND    u.status = 1
 
     if ($uid) {
       $account = user_load($uid);
-      if ($account && $account->uid) {
+      if ($account && $account->uid && $account->status) {
         global $user;
         $user = $account;
         return TRUE;


### PR DESCRIPTION
Refuse the possibility to execute the REST API with blocked users in drupal 7.

Overview
----------------------------------------
Security issue using the REST API.
User blocked can acces to the API by REST.

Before
----------------------------------------
A user blocked in drupal 7 accessing by API REST (.../modules/contrib/civicrm/extern/rest.php?entity=Contact&action=get&json={"s..."}&api_key=FIXME_USER_KEY&key=FIXME_SITE_KEY')
can access to info

After
----------------------------------------
The user is blocked to use the API REST