### PR TITLE
Allow backend transfer or cancel for all participant statuses

### DIFF
--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -551,6 +551,15 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'isBackOffice' => TRUE,
       'successExpected' => TRUE,
     ];
+    // Update from back office when participant status is Attended
+    $scenarios[] = [
+      'selfSvcEnabled' => 0,
+      'selfSvcHours' => 12,
+      'hoursToEvent' => 16,
+      'participantStatusId' => 2,
+      'isBackOffice' => TRUE,
+      'successExpected' => TRUE,
+    ];
     return $scenarios;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
From the backend, we should be able to use Transfer or Cancel for a participant of any status.

Before
----------------------------------------
If you tried to use Transfer or Cancel on the backend for a participant whose status was not one of Registered, Pending from pay later or On waitlist, a nonsensical error message popped up and you could not proceed.
![image](https://github.com/civicrm/civicrm-core/assets/25517556/98ec075b-1add-401d-b774-05474f70424e)

After
----------------------------------------
On the backend, participant status is not checked before allowing cancel or transfer.