### PR TITLE
Preserve participant status when transferring

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -475,7 +475,6 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     ])['values'];
     unset($toParticipantValues['id']);
     $toParticipantValues['contact_id'] = $toContactID;
-    $toParticipantValues['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Registered');
     $toParticipantValues['register_date'] = date("Y-m-d");
     //first create the new participant row -don't set registered_by yet or email won't be sent
     $participant = CRM_Event_BAO_Participant::create($toParticipantValues);


### PR DESCRIPTION
Before
----------------------------------------
Whenever a registration was transferred, the status was set to Registered, which is definitely not what should happen if the status was On Waitlist or Pending (Pay Later) or others.

After
----------------------------------------
On transfer, status maintained.

Comments
----------------------------------------
In general, transferring seems fairly buggy to me, but I don't think this changes anything one way or another as far as when transferring works or fails for unknown reasons.