### PR TITLE
Fix authorization failed on self-service participant transfer

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -465,7 +465,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function transferParticipantRegistration($toContactID, $fromParticipantID) {
-    $toParticipantValues = \Civi\Api4\Participant::get()
+    $toParticipantValues = \Civi\Api4\Participant::get(FALSE)
       ->addWhere('id', '=', $fromParticipantID)
       ->execute()
       ->first();


### PR DESCRIPTION
Before
----------------------------------------
Self-service participant transfer fails with `Authorization Failed` error.

After
----------------------------------------
Works as intended. 

We don't check permissions while getting the participant, as the user is likely anonymous. I guess this doesn't get used much because it looks like it has been broken for three years.
