### PR TITLE
Uncheck is_email_receipt when hidden on New Contribution

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -397,6 +397,7 @@
                 else {
                   CRM.alert(ts("No email receipt can be sent as the contact's primary email address is on hold or they are set to do not email."), ts("Cannot send email receipt"));
                   $("#email-receipt", $form).hide();
+                  $("#is_email_receipt", $form).removeAttr('checked');
                 }
               }, function(failure) {
                 $("#email-receipt", $form).show();
@@ -405,11 +406,11 @@
             }
             else {
               $("#email-receipt", $form).hide();
+              $("#is_email_receipt", $form).removeAttr('checked');
             }
-          }
-
           showHideByValue('is_email_receipt', '', 'receiptDate', 'table-row', 'radio', true);
           showHideByValue('is_email_receipt', '', 'fromEmail', 'table-row', 'radio', false);
+          }
         });
 
         {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
A small follow up to #25403

Before
----------------------------------------
On the New Contribution form, if you select a contact that has a valid email, then check Send Receipt?, then change to a different contact who does not have a valid email, Send Receipt? is hidden but remains checked. Also, From Email is still shown, but it should be switched out with Receipt Date.

After
----------------------------------------
Send Receipt? is unchecked when hidden and From Email and Receipt Date are switched along with Send Receipt?