### PR TITLE
SearchKit - proper EntityRef joins

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -366,6 +366,24 @@ class Admin {
             }
           }
         }
+        // Custom EntityRef joins
+        foreach ($fields as $field) {
+          if ($field['type'] === 'Custom' && $field['input_type'] === 'EntityRef') {
+            $targetEntity = $allowedEntities[$field['fk_entity']];
+            // Add the EntityRef join
+            [, $bareFieldName] = explode('.', $field['name']);
+            $alias = $entity['name'] . '_' . $field['fk_entity'] . '_' . $bareFieldName;
+            $joins[$entity['name']][] = [
+              'label' => $entity['title'] . ' ' . $field['title'],
+              'description' => $field['description'],
+              'entity' => $field['fk_entity'],
+              'conditions' => self::getJoinConditions($field['name'], $alias . '.id'),
+              'defaults' => [],
+              'alias' => $alias,
+              'multi' => FALSE,
+            ];
+          }
+        }
       }
     }
     return $joins;

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -126,4 +126,22 @@ class AdminTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
     $this->assertCount(1, $optionValueToGroup);
   }
 
+  public function testEntityRefGetJoins(): void {
+    \Civi\Api4\CustomGroup::create()->setValues([
+      'title' => 'EntityRefFields',
+      'extends' => 'Individual',
+    ])->execute();
+    \Civi\Api4\CustomField::create()->setValues([
+      'label' => 'Favorite Nephew',
+      'name' => 'favorite_nephew',
+      'custom_group_id.name' => 'EntityRefFields',
+      'html_type' => 'Autocomplete-Select',
+      'data_type' => 'EntityReference',
+      'fk_entity' => 'Contact',
+    ])->execute();
+    $allowedEntities = Admin::getSchema();
+    $joins = Admin::getJoins($allowedEntities);
+    $this->assertContains('Contact Favorite Nephew', array_column($joins['Contact'], 'label'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
#25927 improved the state of EntityRef custom fields in SearchKit, but didn't allow displaying fields in the joined table other than the primary key.  This allows a proper join to EntityRef records.

To replicate
* create an EntityRef custom field on Contributions referencing a Contact.
* Try to pull in the middle name of the contact, or their membership info.

Before
----------------------------------------
You can see only the ID and pseudoconstant lookup of the EntityRef.
![Selection_1882](https://github.com/civicrm/civicrm-core/assets/1796012/2423bf9b-7dda-495f-8b64-92ad57cfbf76)


After
----------------------------------------
You can join fully to the EntityRef record, and join to the referenced record as usual.
![Selection_1881](https://github.com/civicrm/civicrm-core/assets/1796012/a67a4866-22ad-44f8-ace9-6f3409f7c929)

Comments
----------------------------------------
This join is in one direction only - because I don't see a good way to join to a custom field. You'd have to join from Contact to Contribution, then Contribution to custom field table.