### PR TITLE
Fix code handling to pre-5.61 for membership block

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -512,32 +512,29 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
       $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
       // This is always true if this line is reachable - remove along with the upcoming if.
-      $membershipPriceset = (!empty($this->_priceSetId) && $this->isMembershipPriceSet());
+      $membershipPriceset = TRUE;
 
       $allowAutoRenewMembership = $autoRenewOption = FALSE;
       $autoRenewMembershipTypeOptions = [];
 
       $separateMembershipPayment = $this->_membershipBlock['is_separate_payment'] ?? NULL;
 
-      if ($membershipPriceset) {
-        foreach ($this->_priceSet['fields'] as $pField) {
-          if (empty($pField['options'])) {
+      foreach ($this->_priceSet['fields'] as $pField) {
+        if (empty($pField['options'])) {
+          continue;
+        }
+        foreach ($pField['options'] as $opId => $opValues) {
+          if (empty($opValues['membership_type_id'])) {
             continue;
           }
-          foreach ($pField['options'] as $opId => $opValues) {
-            if (empty($opValues['membership_type_id'])) {
-              continue;
-            }
-            $membershipTypeIds[$opValues['membership_type_id']] = $opValues['membership_type_id'];
-          }
+          $membershipTypeIds[$opValues['membership_type_id']] = $opValues['membership_type_id'];
         }
-      }
-      elseif (!empty($this->_membershipBlock['membership_types'])) {
-        $membershipTypeIds = explode(',', $this->_membershipBlock['membership_types']);
       }
 
       if (!empty($membershipTypeIds)) {
         //set status message if wrong membershipType is included in membershipBlock
+        // @todo - this appears to be unreachable - it seems likely it has been broken for
+        // a while so remove may be an OK alternative to fix
         if ($this->getRenewalMembershipID() && !$membershipPriceset) {
           $membershipTypeID = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership',
             $this->getRenewalMembershipID(),


### PR DESCRIPTION
The work for #26170 concluded that membershipPriceset is always TRUE at this point. Since we were pushing out a regression fix I left the variable where it didn't seem to be causing regressions.

However, I think clarifying the variable and
removing the redundant if-else in the rc will set us up well as 1) if there is any further regression we haven't found in 5.61 then people will be able to check on the rc / master 2) if we need to do any further fixes / back-ports the code will be more synced if we do this in the rc

Note there is some further clean up I feel should be done folloiwng what we learnt dealing with #26170 - but I want to let the dust settle so that I'm not creating a hard-to-backport situation
