### PR TITLE
dev/core#4279 - Add support for ECMAScript Modules (ESM, part 1)

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -88,7 +88,10 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
           break;
 
         case 'scriptUrl':
-          if (!$allowCmsOverride || !$cms->addScriptUrl($snippet['scriptUrl'], $this->_name)) {
+          if (!empty($snippet['esm'])) {
+            $html .= sprintf("<script type=\"module\" src=\"%s\">\n</script>\n", $snippet['scriptUrl']);
+          }
+          elseif (!$allowCmsOverride || !$cms->addScriptUrl($snippet['scriptUrl'], $this->_name)) {
             $html .= sprintf("<script type=\"text/javascript\" src=\"%s\">\n</script>\n", $snippet['scriptUrl']);
           }
           break;
@@ -107,7 +110,10 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
           break;
 
         case 'script':
-          if (!$allowCmsOverride || !$cms->addScript($snippet['script'], $this->_name)) {
+          if (!empty($snippet['esm'])) {
+            $html .= sprintf("<script type=\"module\">\n%s\n</script>\n", $snippet['script']);
+          }
+          elseif (!$allowCmsOverride || !$cms->addScript($snippet['script'], $this->_name)) {
             $html .= sprintf("<script type=\"text/javascript\">\n%s\n</script>\n", $snippet['script']);
           }
           break;

--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -88,6 +88,7 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
           break;
 
         case 'scriptUrl':
+          // ECMAScript Modules (ESMs) are basically Javascript files, but they require a slightly different incantation.
           if (!empty($snippet['esm'])) {
             $html .= sprintf("<script type=\"module\" src=\"%s\">\n</script>\n", $snippet['scriptUrl']);
           }
@@ -110,6 +111,7 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
           break;
 
         case 'script':
+          // ECMAScript Modules (ESMs) are basically Javascript files, but they require a slightly different incantation.
           if (!empty($snippet['esm'])) {
             $html .= sprintf("<script type=\"module\">\n%s\n</script>\n", $snippet['script']);
           }

--- a/CRM/Core/Resources/CollectionAdderInterface.php
+++ b/CRM/Core/Resources/CollectionAdderInterface.php
@@ -45,7 +45,7 @@ interface CRM_Core_Resources_CollectionAdderInterface {
   public function addMarkup(string $markup, ...$options);
 
   /**
-   * Add an ECMAScript module to the current page (<SCRIPT TYPE=MODULE>).
+   * Add an ECMAScript Module (ESM) to the current page (<SCRIPT TYPE=MODULE>).
    *
    * Ex: addScript('alert("Hello world");', ['weight' => 123]);
    *
@@ -60,7 +60,7 @@ interface CRM_Core_Resources_CollectionAdderInterface {
   public function addModule(string $code, ...$options);
 
   /**
-   * Add an ECMAScript Module from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   * Add an ECMAScript Module (ESM) from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
    *
    * Ex: addScriptFile('myextension', 'myscript.js', ['weight' => 123]);
    *
@@ -77,7 +77,7 @@ interface CRM_Core_Resources_CollectionAdderInterface {
   public function addModuleFile(string $ext, string $file, ...$options);
 
   /**
-   * Add an ECMAScript Module by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   * Add an ECMAScript Module (ESM) by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
    *
    * Ex: addScriptUrl('http://example.com/foo.js', ['weight' => 123])
    *

--- a/CRM/Core/Resources/CollectionAdderInterface.php
+++ b/CRM/Core/Resources/CollectionAdderInterface.php
@@ -45,6 +45,52 @@ interface CRM_Core_Resources_CollectionAdderInterface {
   public function addMarkup(string $markup, ...$options);
 
   /**
+   * Add an ECMAScript module to the current page (<SCRIPT TYPE=MODULE>).
+   *
+   * Ex: addScript('alert("Hello world");', ['weight' => 123]);
+   *
+   * @param string $code
+   *   JavaScript source code.
+   * @param array $options
+   *   Open-ended list of key-value options. See CollectionInterface docs.
+   *   Positional equivalence: addScript(string $code, int $weight, string $region).
+   * @return static
+   * @see CRM_Core_Resources_CollectionInterface
+   */
+  public function addModule(string $code, ...$options);
+
+  /**
+   * Add an ECMAScript Module from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   *
+   * Ex: addScriptFile('myextension', 'myscript.js', ['weight' => 123]);
+   *
+   * @param string $ext
+   *   Extension name; use 'civicrm' for core.
+   * @param string $file
+   *   File path -- relative to the extension base dir.
+   * @param array $options
+   *   Open-ended list of key-value options. See CollectionInterface docs.
+   *   Positional equivalence: addScriptFile(string $code, int $weight, string $region, mixed $translate).
+   * @return static
+   * @see CRM_Core_Resources_CollectionInterface
+   */
+  public function addModuleFile(string $ext, string $file, ...$options);
+
+  /**
+   * Add an ECMAScript Module by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   *
+   * Ex: addScriptUrl('http://example.com/foo.js', ['weight' => 123])
+   *
+   * @param string $url
+   * @param array $options
+   *   Open-ended list of key-value options. See CollectionInterface docs.
+   *   Positional equivalence: addScriptUrl(string $url, int $weight, string $region).
+   * @return static
+   * @see CRM_Core_Resources_CollectionInterface
+   */
+  public function addModuleUrl(string $url, ...$options);
+
+  /**
    * Export permission data to the client to enable smarter GUIs.
    *
    * Note: Application security stems from the server's enforcement

--- a/CRM/Core/Resources/CollectionAdderTrait.php
+++ b/CRM/Core/Resources/CollectionAdderTrait.php
@@ -62,7 +62,7 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
-   * Add an ECMAScript module to the current page (<SCRIPT TYPE=MODULE>).
+   * Add an ECMAScript module (esm) to the current page (<SCRIPT TYPE=MODULE>).
    *
    * Ex: addModule('alert("Hello world");', ['weight' => 123]);
    *
@@ -84,7 +84,7 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
-   * Add an ECMAScript Module from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   * Add an ECMAScript Module (esm) from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
    *
    * Ex: addModuleFile('myextension', 'myscript.js', ['weight' => 123]);
    *
@@ -111,7 +111,7 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
-   * Add an ECMAScript Module by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   * Add an ECMAScript Module (esm) by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
    *
    * Ex: addModuleUrl('http://example.com/foo.js', ['weight' => 123])
    *

--- a/CRM/Core/Resources/CollectionAdderTrait.php
+++ b/CRM/Core/Resources/CollectionAdderTrait.php
@@ -62,6 +62,79 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
+   * Add an ECMAScript module to the current page (<SCRIPT TYPE=MODULE>).
+   *
+   * Ex: addModule('alert("Hello world");', ['weight' => 123]);
+   *
+   * @param string $code
+   *   JavaScript source code.
+   * @param array $options
+   *   Open-ended list of key-value options. See CollectionInterface docs.
+   *   Positional equivalence: addModule(string $code, int $weight, string $region).
+   * @return static
+   * @see CRM_Core_Resources_CollectionInterface
+   * @see CRM_Core_Resources_CollectionAdderInterface::addModule()
+   */
+  public function addModule(string $code, ...$options) {
+    $this->add(self::mergeStandardOptions($options, [
+      'esm' => TRUE,
+      'script' => $code,
+    ]));
+    return $this;
+  }
+
+  /**
+   * Add an ECMAScript Module from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   *
+   * Ex: addModuleFile('myextension', 'myscript.js', ['weight' => 123]);
+   *
+   * @param string $ext
+   *   Extension name; use 'civicrm' for core.
+   * @param string $file
+   *   File path -- relative to the extension base dir.
+   * @param array $options
+   *   Open-ended list of key-value options. See CollectionInterface docs.
+   *   Positional equivalence: addModuleFile(string $code, int $weight, string $region, mixed $translate).
+   * @return static
+   * @see CRM_Core_Resources_CollectionInterface
+   * @see CRM_Core_Resources_CollectionAdderInterface::addModuleFile()
+   */
+  public function addModuleFile(string $ext, string $file, ...$options) {
+    $this->add(self::mergeStandardOptions($options, [
+      'esm' => TRUE,
+      'scriptFile' => [$ext, $file],
+      'name' => "$ext:$file",
+      // Setting the name above may appear superfluous, but it preserves a historical quirk
+      // where Region::add() and Resources::addScriptFile() produce slightly different orderings.
+    ]));
+    return $this;
+  }
+
+  /**
+   * Add an ECMAScript Module by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   *
+   * Ex: addModuleUrl('http://example.com/foo.js', ['weight' => 123])
+   *
+   * @param string $url
+   * @param array $options
+   *   Open-ended list of key-value options. See CollectionInterface docs.
+   *   Positional equivalence: addModuleUrl(string $url, int $weight, string $region).
+   * @return static
+   * @see CRM_Core_Resources_CollectionInterface
+   * @see CRM_Core_Resources_CollectionAdderInterface::addModuleUrl()
+   */
+  public function addModuleUrl(string $url, ...$options) {
+    $this->add(self::mergeStandardOptions($options, [
+      'esm' => TRUE,
+      'scriptUrl' => $url,
+      'name' => $url,
+      // Setting the name above may appear superfluous, but it preserves a historical quirk
+      // where Region::add() and Resources::addScriptUrl() produce slightly different orderings.
+    ]));
+    return $this;
+  }
+
+  /**
    * Export permission data to the client to enable smarter GUIs.
    *
    * @param string|iterable $permNames

--- a/CRM/Core/Resources/CollectionAdderTrait.php
+++ b/CRM/Core/Resources/CollectionAdderTrait.php
@@ -62,7 +62,7 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
-   * Add an ECMAScript module (esm) to the current page (<SCRIPT TYPE=MODULE>).
+   * Add an ECMAScript module (ESM) to the current page (<SCRIPT TYPE=MODULE>).
    *
    * Ex: addModule('alert("Hello world");', ['weight' => 123]);
    *
@@ -84,7 +84,7 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
-   * Add an ECMAScript Module (esm) from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   * Add an ECMAScript Module (ESM) from file to the current page (<SCRIPT TYPE=MODULE SRC=...>).
    *
    * Ex: addModuleFile('myextension', 'myscript.js', ['weight' => 123]);
    *
@@ -111,7 +111,7 @@ trait CRM_Core_Resources_CollectionAdderTrait {
   }
 
   /**
-   * Add an ECMAScript Module (esm) by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
+   * Add an ECMAScript Module (ESM) by URL to the current page (<SCRIPT TYPE=MODULE SRC=...>).
    *
    * Ex: addModuleUrl('http://example.com/foo.js', ['weight' => 123])
    *

--- a/CRM/Core/Resources/CollectionInterface.php
+++ b/CRM/Core/Resources/CollectionInterface.php
@@ -57,6 +57,7 @@
  *     not guaranteed among versions/implementations.)
  *   - disabled: int, default=0
  *   - region: string
+ *   - esm: bool; for "script","scriptFile","scriptUrl", the "esm" flag enables Ecmascript 5 Module support
  *   - translate: bool|string, Autoload translations. (Only applies to 'scriptFile')
  *       - FALSE: Do not load translated strings.
  *       - TRUE: Load translated strings. Use the $ext's default domain.

--- a/CRM/Core/Resources/CollectionInterface.php
+++ b/CRM/Core/Resources/CollectionInterface.php
@@ -57,7 +57,7 @@
  *     not guaranteed among versions/implementations.)
  *   - disabled: int, default=0
  *   - region: string
- *   - esm: bool; for "script","scriptFile","scriptUrl", the "esm" flag enables Ecmascript 5 Module support
+ *   - esm: bool, enable ECMAScript Module (ESM) support for "script","scriptFile","scriptUrl"
  *   - translate: bool|string, Autoload translations. (Only applies to 'scriptFile')
  *       - FALSE: Do not load translated strings.
  *       - TRUE: Load translated strings. Use the $ext's default domain.

--- a/tests/phpunit/CRM/Core/RegionTest.php
+++ b/tests/phpunit/CRM/Core/RegionTest.php
@@ -114,6 +114,14 @@ class CRM_Core_RegionTest extends CiviUnitTestCase {
       'jquery' => '$("div");',
     ]);
     CRM_Core_Region::instance('testAllTypes')->add([
+      'scriptUrl' => '/my%20module.mjs',
+      'esm' => TRUE,
+    ]);
+    CRM_Core_Region::instance('testAllTypes')->add([
+      'script' => 'import foo from "./foobar.mjs";',
+      'esm' => TRUE,
+    ]);
+    CRM_Core_Region::instance('testAllTypes')->add([
       'styleUrl' => '/foo%20bar.css',
     ]);
     CRM_Core_Region::instance('testAllTypes')->add([
@@ -131,6 +139,8 @@ class CRM_Core_RegionTest extends CiviUnitTestCase {
       . "<script type=\"text/javascript\" src=\"/foo%20bar.js\">\n</script>\n"
       . "<script type=\"text/javascript\">\nalert(\"hi\");\n</script>\n"
       . "<script type=\"text/javascript\">\nCRM.\$(function(\$) {\n\$(\"div\");\n});\n</script>\n"
+      . "<script type=\"module\" src=\"/my%20module.mjs\">\n</script>\n"
+      . "<script type=\"module\">\nimport foo from \"./foobar.mjs\";\n</script>\n"
       . "<link href=\"/foo%20bar.css\" rel=\"stylesheet\" type=\"text/css\"/>\n"
       . "<style type=\"text/css\">\nbody { background: black; }\n</style>\n";
     $this->assertEquals($expected, $actual);

--- a/tests/phpunit/CRM/Core/Resources/CollectionTestTrait.php
+++ b/tests/phpunit/CRM/Core/Resources/CollectionTestTrait.php
@@ -128,6 +128,21 @@ trait CRM_Core_Resources_CollectionTestTrait {
 
     $addCases(
       [
+        'add(scriptUrl,esm)' => ['add', ['scriptUrl' => 'http://example.com/foo.js', 'esm' => TRUE]],
+        'addModuleUrl()' => ['addModuleUrl', 'http://example.com/foo.js'],
+      ],
+      [
+        'name' => 'http://example.com/foo.js',
+        'disabled' => FALSE,
+        'weight' => 1,
+        'type' => 'scriptUrl',
+        'scriptUrl' => 'http://example.com/foo.js',
+        'esm' => TRUE,
+      ]
+    );
+
+    $addCases(
+      [
         'add(styleFile)' => ['add', ['styleFile' => ['civicrm', 'css/civicrm.css']]],
         'addStyleFile()' => ['addStyleFile', 'civicrm', 'css/civicrm.css'],
       ],
@@ -152,6 +167,15 @@ trait CRM_Core_Resources_CollectionTestTrait {
         Civi::paths()->getUrl('[civicrm.root]/js/foo.js?r=XXXX'),
       ],
     ];
+
+    $addCases(
+      [
+        'add(scriptFile): esm' => ['add', ['scriptFile' => ['civicrm', 'js/foo.js'], 'esm' => TRUE]],
+        'addScriptFile(): esm' => ['addModuleFile', 'civicrm', 'js/foo.js', ['esm' => TRUE]],
+        'addModuleFile(): dfl' => ['addModuleFile', 'civicrm', 'js/foo.js'],
+      ],
+      $basicFooJs + ['weight' => 1, 'translate' => TRUE, 'esm' => TRUE]
+    );
 
     $addCases(
       [
@@ -192,6 +216,22 @@ trait CRM_Core_Resources_CollectionTestTrait {
         'weight' => 1,
         'type' => 'script',
         'script' => 'window.alert("Boo!");',
+      ]
+    );
+
+    $addCases(
+      [
+        'add(script): esm' => ['add', ['script' => 'window.alert("Boo!");', 'esm' => TRUE]],
+        'addScript(): esm' => ['addScript', 'window.alert("Boo!");', ['esm' => TRUE]],
+        'addModule(): dfl' => ['addModule', 'window.alert("Boo!");'],
+      ],
+      [
+        'name' => 1 + $defaultCount,
+        'disabled' => FALSE,
+        'weight' => 1,
+        'type' => 'script',
+        'script' => 'window.alert("Boo!");',
+        'esm' => TRUE,
       ]
     );
 


### PR DESCRIPTION
Overview
----------------------------------------

This adds support for loading ECMAScript 6 Modules (ESM's). ESMs are Javascript files with additional support for the keywords `import` and `export`. Basic ESM support has been [provided by most web-browsers since ~2017](https://caniuse.com/es6-module).

(*This is the first part of https://lab.civicrm.org/dev/core/-/issues/4279. The second part will be a subsequent PR.*)

Before
----------------------------------------

You can add basic Javascript files:

```php
Civi::resources()->addScript('doStuff();');
Civi::resources()->addScriptFile('my_extension', 'js/foo.js');
Civi::resources()->addScriptUrl('https://example.com/bar.js');
```

But this will not work with ESMs.

After
----------------------------------------

You can use the `addModule()` methods for ESMs:

```php
Civi::resources()->addModule('import doStuff from \'./do-stuff.js\'; doStuff();');
Civi::resources()->addModuleFile('my_extension', 'js/foo.js');
Civi::resources()->addModuleUrl('https://example.com/bar.js');
```

Additionally, since an ESM is a special kind of Javascript file, you can also use the `addScript()` method. However, this requires the flag `['esm' => TRUE]`.

```php
Civi::resources()->addScript('import doStuff from \'./do-stuff.js\'; doStuff();', ['esm' => TRUE]);
Civi::resources()->addScriptFile('my_extension', 'js/foo.js', ['esm' => TRUE]);
Civi::resources()->addScriptUrl('https://example.com/bar.js', ['esm' => TRUE]);
```

Comments
----------------------------------------

I've included some basic unit-tests for `addModule()`, etc.

To see them in action, you can use this example extension: https://github.com/totten/esmdemo/
