### PR TITLE
[REF] dev/core#1777 - Skip checking vendor provided orphaned files if the vendor directory is not within the CiviCRM root

### DIFF
--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -68,7 +68,7 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
    */
   public function findOrphanedFiles() {
     $orphans = [];
-
+    $core_supplied_vendor = Civi::paths()->getPath('[civicrm.root]/vendor');
     foreach ($this->getRemovedFiles() as $file) {
       $path = Civi::paths()->getPath($file);
       if (empty($path) || strpos('[civicrm', $path) !== FALSE) {
@@ -76,6 +76,10 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
           'file' => $file,
           'path' => $path,
         ]);
+      }
+      // If Vendor directory is not within the civicrm module directory (Drupal 8/9/10) etc ignore checks on the vendor paths.
+      if (strpos($file, '.vendor') !== FALSE && !is_dir($core_supplied_vendor)) {
+        continue;
       }
       if (file_exists($path)) {
         $orphans[] = [


### PR DESCRIPTION
…ctory is not within the CiviCRM root

Overview
----------------------------------------
System setting checks for old files in various places including in the vendor directory, This matters in Joomla and Drupal 7 / Backdrop and WordPress to make sure that files that shouldn't be there aren't given that CiviCRM provides the vendor directory but in Drupal 8/9/10 Drupal supplies the vendor directory so we shouldn't be worrying about the vendor file checks in that CMS

