### PR TITLE
dev/core#4284 Allow deletion of primary email inline on contact

### DIFF
--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -37,12 +37,7 @@
       <td align="center">{$form.email.$blockId.on_hold.html}</td>
       <td align="center" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html}</td>
       <td align="center" class="crm-email-is_primary">{$form.email.$blockId.is_primary.1.html}</td>
-      <td>
-        {if $blockId gt 1}
-          <a title="{ts}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span
-              class="icon delete-icon"></span></a>
-        {/if}
-      </td>
+      <td><a title="{ts}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span class="icon delete-icon"></span></a></td>
     </tr>
   {/section}
 </table>

--- a/templates/CRM/Contact/Page/View/Summary.js
+++ b/templates/CRM/Contact/Page/View/Summary.js
@@ -259,9 +259,14 @@
         //unset and set first as primary
         if ($('[class$=is_primary] input:checked', row).length > 0) {
           $('[class$=is_primary] input', row).prop('checked', false);
-          $('[class$=is_primary] input:first', form).prop('checked', true );
+          $('[class$=is_primary] input:visible:first', form).prop('checked', true );
         }
         $('.add-more-inline', form).show();
+        if ($('[class$=is_primary] input:visible', form).length == 0) {
+          $('.add-more-inline', form).click();
+          $('[class$=is_primary] input:visible:first', form).prop('checked', true );
+        }
+
         e.preventDefault();
       })
       // Delete an address


### PR DESCRIPTION
Overview
----------------------------------------
It's odd that you can't delete a primary email inline on view contact.

Before
----------------------------------------
Primary email cannot be deleted. If you clear the email field, you can save if there is no secondary email, but if there is you must switch the primary from the empty row to the new email before saving or else you'll get a form error.

After
----------------------------------------
Primary email can be deleted. If there are other emails, the next one is set to primary. If there are no other emails, a new empty row is added (with primary already selected).