### PR TITLE
Regression: Fatal error when importing membership

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -326,7 +326,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
           }
           if ($formatted['status_id'] != $calcStatus['id']) {
             //Status Hold" is either NOT mapped or is FALSE
-            throw new CRM_Core_Exception($rowNumber, 'ERROR', 'Status in import row (' . CRM_Utils_Array::value('status_id', $formatValues) . ') does not match calculated status based on your configured Membership Status Rules (' . $calcStatus['name'] . '). Record was not imported.', CRM_Import_Parser::ERROR);
+            throw new CRM_Core_Exception('Status in import row (' . CRM_Utils_Array::value('status_id', $formatValues) . ') does not match calculated status based on your configured Membership Status Rules (' . $calcStatus['name'] . '). Record was not imported.', CRM_Import_Parser::ERROR);
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
When importing membership the import screen freezes resulting in 500 error in php log

2023/05/10 16:08:51 [error] 1107233#1107233: *40097 FastCGI sent in stderr: "PHP message: PHP Warning:  A non-numeric value encountered in /drupal/sites/all/modules/civicrm/CRM/Core/Exception.php on line 52" while reading response header from upstream, client: 192.168.223.90, server: example.com, request: "POST /civicrm/queue/ajax/runNext HTTP/1.1", upstream: "fastcgi://unix:/run/php/php7.4-fpm.sock:", host: "example.com", referrer: "https://example.com/civicrm/queue/runner?reset=1&qrid=user_job_6"


Before
----------------------------------------
500 error

After
----------------------------------------
Import proceeded