### PR TITLE
Following PR-25994 and PR-26074

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -372,8 +372,11 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
 
       // get current parents for removal if not in the list anymore
+      $currentParentGroupIDs = [];
       $parents = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $params['id'], 'parents');
-      $currentParentGroupIDs = explode(',', $parents);
+      if (!empty($parents)) {
+        $currentParentGroupIDs = explode(',', $parents);
+      }
     }
 
     // form the name only if missing: CRM-627

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -372,11 +372,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
 
       // get current parents for removal if not in the list anymore
-      $currentParentGroupIDs = [];
       $parents = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $params['id'], 'parents');
-      if (!empty($parents)) {
-        $currentParentGroupIDs = explode(',', $parents);
-      }
+      $currentParentGroupIDs = $parents ? explode(',', $parents) : [];
     }
 
     // form the name only if missing: CRM-627
@@ -451,7 +448,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
       }
 
       // first deal with removed parents
-      if (!empty($params['id']) && !empty($currentParentGroupIDs)) {
+      if (array_key_exists('parents', $params) && !empty($currentParentGroupIDs)) {
         foreach ($currentParentGroupIDs as $parentGroupId) {
           // no more parents or not in the new list, let's remove
           if (empty($params['parents']) || !in_array($parentGroupId, $params['parents'])) {

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -369,16 +369,6 @@ WHERE  title = %1
       $group = CRM_Contact_BAO_Group::create($params);
       // Set the entity id so it is available to postProcess hook consumers
       $this->setEntityId($group->id);
-      //Remove any parent groups requested to be removed
-      if (!empty($this->_groupValues['parents'])) {
-        $parentGroupIds = explode(',', $this->_groupValues['parents']);
-        foreach ($parentGroupIds as $parentGroupId) {
-          if (isset($params["remove_parent_group_$parentGroupId"])) {
-            CRM_Contact_BAO_GroupNesting::remove($parentGroupId, $group->id);
-            $updateNestingCache = TRUE;
-          }
-        }
-      }
 
       CRM_Core_Session::setStatus(ts('The Group \'%1\' has been saved.', array(1 => $group->title)), ts('Group Saved'), 'success');
 
@@ -392,10 +382,6 @@ WHERE  title = %1
       }
     }
 
-    // update the nesting cache
-    if ($updateNestingCache) {
-      CRM_Contact_BAO_GroupNestingCache::update();
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In searchkit, deleting a group parents inline doesn't work.

Finishing the work started in https://github.com/civicrm/civicrm-core/pull/25994 and https://github.com/civicrm/civicrm-core/pull/26074

Before
----------------------------------------
![Peek 17-04-2023 15-33](https://user-images.githubusercontent.com/372004/232591975-73c621d4-c230-4cab-8a97-4663c8b55d4f.gif)

After
----------------------------------------
It works.

Technical Details
----------------------------------------
Move the deletion logic from the group form edit to the `CRM_Contact_BAO_Group::create` function

Not sure if we can assume that if we don't remove a parent, there is no need for cache refresh (assuming no for now) :
```php
      // this is always required, since we don't know when a
      // parent group is removed
      CRM_Contact_BAO_GroupNestingCache::update();
```