### PR TITLE
flexmailer remove cruft code

### DIFF
--- a/ext/flexmailer/flexmailer.php
+++ b/ext/flexmailer/flexmailer.php
@@ -42,41 +42,9 @@ function flexmailer_civicrm_enable() {
 }
 
 /**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
- */
-function flexmailer_civicrm_navigationMenu(&$menu) {
-  _flexmailer_civix_insert_navigation_menu($menu, 'Administer/CiviMail', [
-    'label' => E::ts('Flexmailer Settings'),
-    'name' => 'flexmailer_settings',
-    'permission' => 'administer CiviCRM',
-    'child' => [],
-    'operator' => 'AND',
-    'separator' => 0,
-    'url' => CRM_Utils_System::url('civicrm/admin/setting/flexmailer', 'reset=1', TRUE),
-  ]);
-  _flexmailer_civix_navigationMenu($menu);
-}
-
-/**
  * Implements hook_civicrm_container().
  */
 function flexmailer_civicrm_container($container) {
   $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
   \Civi\FlexMailer\Services::registerServices($container);
-}
-
-/**
- * Get a list of delivery options for traditional mailings.
- *
- * @return array
- *   Array (string $machineName => string $label).
- */
-function _flexmailer_traditional_options() {
-  return array(
-    'auto' => E::ts('Automatic'),
-    'bao' => E::ts('CiviMail BAO'),
-    'flexmailer' => E::ts('Flexmailer Pipeline'),
-  );
 }


### PR DESCRIPTION
flexmailer is required now, the flexmailer settings still appears to be in navigation menu, on click redirects to civicrm/admin page