### PR TITLE
Further separate register task from participant form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -895,50 +895,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
       return;
     }
-    // When adding a single contact, the formRule prevents you from adding duplicates
-    // (See above in formRule()). When adding more than one contact, the duplicates are
-    // removed automatically and the user receives one notification.
-    if ($this->_action & CRM_Core_Action::ADD) {
-      $event_id = $this->_eventId;
-      if (empty($event_id) && !empty($params['event_id'])) {
-        $event_id = $params['event_id'];
-      }
-      if (!$this->_single && !empty($event_id)) {
-        $duplicateContacts = 0;
-        foreach ($this->_contactIds as $k => $dupeCheckContactId) {
-          // Eliminate contacts that have already been assigned to this event.
-          $dupeCheck = new CRM_Event_BAO_Participant();
-          $dupeCheck->contact_id = $dupeCheckContactId;
-          $dupeCheck->event_id = $event_id;
-          $dupeCheck->find(TRUE);
-          if (!empty($dupeCheck->id)) {
-            $duplicateContacts++;
-            unset($this->_contactIds[$k]);
-          }
-        }
-        if ($duplicateContacts > 0) {
-          $msg = ts(
-            "%1 contacts have already been assigned to this event. They were not added a second time.",
-            [1 => $duplicateContacts]
-          );
-          CRM_Core_Session::setStatus($msg);
-        }
-        if (count($this->_contactIds) == 0) {
-          CRM_Core_Session::setStatus(ts("No participants were added."));
-          return;
-        }
-        // We have to re-key $this->_contactIds so each contact has the same
-        // key as their corresponding record in the $participants array that
-        // will be created below.
-        $this->_contactIds = array_values($this->_contactIds);
-      }
-    }
 
     $statusMsg = $this->submit($params);
     CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
     $session = CRM_Core_Session::singleton();
     $buttonName = $this->controller->getButtonName();
-    if ($this->_context == 'standalone') {
+    if ($this->_context === 'standalone') {
       if ($buttonName == $this->getButtonName('upload', 'new')) {
         $urlParams = 'reset=1&action=add&context=standalone';
         if ($this->_mode) {

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -25,7 +25,6 @@
  */
 class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
 
-
   /**
    * Are we operating in "single mode", i.e. adding / editing only
    * one participant record, or is this a batch add operation
@@ -77,6 +76,53 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     $this->assign('participantQfKey', $key);
     $this->assign('participantAction', CRM_Core_Action::ADD);
     $this->assign('urlPathVar', "_qf_Participant_display=true&context=search");
+  }
+
+  /**
+   * Process the form submission.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function postProcess(): void {
+    $params = $this->controller->exportValues($this->_name);
+    // When adding more than one contact, the duplicates are
+    // removed automatically and the user receives one notification.
+    $event_id = $this->_eventId;
+    if (!$event_id && !empty($params['event_id'])) {
+      $event_id = $params['event_id'];
+    }
+    if (!empty($event_id)) {
+      $duplicateContacts = 0;
+      foreach ($this->_contactIds as $k => $dupeCheckContactId) {
+        // Eliminate contacts that have already been assigned to this event.
+        $dupeCheck = new CRM_Event_BAO_Participant();
+        $dupeCheck->contact_id = $dupeCheckContactId;
+        $dupeCheck->event_id = $event_id;
+        $dupeCheck->find(TRUE);
+        if (!empty($dupeCheck->id)) {
+          $duplicateContacts++;
+          unset($this->_contactIds[$k]);
+        }
+      }
+      if ($duplicateContacts > 0) {
+        $msg = ts(
+          '%1 contacts have already been assigned to this event. They were not added a second time.',
+          [1 => $duplicateContacts]
+        );
+        CRM_Core_Session::setStatus($msg);
+      }
+      if (count($this->_contactIds) === 0) {
+        CRM_Core_Session::setStatus(ts('No participants were added.'));
+        return;
+      }
+      // We have to re-key $this->_contactIds so each contact has the same
+      // key as their corresponding record in the $participants array that
+      // will be created below.
+      $this->_contactIds = array_values($this->_contactIds);
+    }
+
+    $statusMsg = $this->submit($params);
+    CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The process of separating the search action from the participant form started a long time back - see https://github.com/civicrm/civicrm-core/pull/18464

This extends the separation to the `postProcess` function to make it less difficult to figure out what is going on :-)

The only place the `CRM_Event_Task_Register` form is called form is [contact seach actions](https://github.com/civicrm/civicrm-core/pull/18464/files#diff-dd1c0fdd3c4b581995b6000f11be86dc6b195b87aa4c687bc475d98ec7155732R237)  - ie by doing a contact search & selecting one or more contacts & then register participant

Before
----------------------------------------
Both the Participant form and the register task share a `postProcess` function but almost none of the code within it is shared

After
----------------------------------------
The `CRM_Event_Task_Register` has it's own `postProcess` and the logic is divied up appropriately

Technical Details
----------------------------------------
In the case of `CRM_Event_Task_Register`
- `$this->_single` is always FALSE
- the action is always CRM_Core_Action::ADD
- the context is never standalone  (the url looks like https://dmaster.localhost:32353/civicrm/contact/search?_qf_Register_display=true&qfKey=CRMContactControllerSearch4eiq2vqlvkiso4kwogo4g0s8kogk4g4sgwgookkscgw8swkcwk_9637)
- the button is `qf_Register`

In the case of `CRM_Event_Form_Participant`
- `$this->_single` is always true
-  the portion of the `if ($this->_action & CRM_Core_Action::ADD) {` that is not depending on `$this->_single` being false just sets a variable that is only used in that if


Comments
----------------------------------------