### PR TITLE
Fix invoice being sent instead of receipt if contribution 'is_pay_later' is true

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -4234,7 +4234,7 @@ LIMIT 1;";
         );
 
         unset($dates['end_date']);
-        $membershipParams['status_id'] = CRM_Utils_Array::value('id', $calcStatus, 'New');
+        $membershipParams['status_id'] = $calcStatus['id'] ?? 'New';
       }
       //we might be renewing membership,
       //so make status override false.

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2598,6 +2598,16 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if ($this->is_test) {
         $isTest = TRUE;
       }
+
+      // "is_pay_later" is used by contribution and membership online receipt to decide if "invoice" or "receipt" is sent:
+      // {if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if}
+      // But is_pay_later does not change when the contribution is Completed.
+      // Set it here only if contribution = Pending
+      if ($this->contribution_status_id == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')
+        && $this->is_pay_later == 1) {
+        $values['is_pay_later'] = 1;
+      }
+
       if (!empty($this->_relatedObjects['membership'])) {
         foreach ($this->_relatedObjects['membership'] as $membership) {
           if ($membership->id) {
@@ -2761,8 +2771,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
     $values['customGroup'] = $customGroup;
-
-    $values['is_pay_later'] = $this->is_pay_later;
 
     return $values;
   }

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -291,7 +291,6 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
         ],
       ],
       'customGroup' => [],
-      'is_pay_later' => '0',
     ], $gathered_values);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This was found using the accountsync/xero integration. When a payment is recorded in Xero and synced back to CiviCRM a second invoice gets sent instead of a receipt.
This can be reproduced easily just by using the Payment.create API call.

To reproduce:
1. Create a contribution page with a membership and pay later enabled.
2. Submit the form selecting pay later.
3. Use payment.create to simulate a payment being recorded specifying `contribution_id`, `payment_amount` and `payment_date`. It defaults to sending a receipt.

Before
----------------------------------------
Invoice sent when payment received.

After
----------------------------------------
Receipt sent when payment received.

Technical Details
----------------------------------------
Related: https://github.com/civicrm/civicrm-core/commit/dbacb875394fb134588f4b79f9b631060c6cd1f1

Comments
----------------------------------------
Longer term this should probably be refactored to not rely on "is_pay_later" in the template to control if it is an invoice/receipt.
