### PR TITLE
Don't show send broken confirmation description if registering multiple contacts

### DIFF
--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -97,10 +97,12 @@
          <tr class="crm-event-eventfees-form-block-send_receipt">
             <td class="label">{if $paid}{ts}Send Confirmation and Receipt{/ts}{else}{ts}Send Confirmation{/ts}{/if}</td>
             <td>{$form.send_receipt.html}<br>
-              {if $paid}
-                <span class="description">{ts 1=$email}Automatically email a confirmation and receipt to %1?{/ts}</span></td>
-              {else}
-                <span class="description">{ts 1=$email}Automatically email a confirmation to %1?{/ts}</span></td>
+              {if $email}
+                {if $paid}
+                  <span class="description">{ts 1=$email}Automatically email a confirmation and receipt to %1?{/ts}</span></td>
+                {else}
+                  <span class="description">{ts 1=$email}Automatically email a confirmation to %1?{/ts}</span></td>
+                {/if}
               {/if}
         </tr>
         <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">


### PR DESCRIPTION
Overview
----------------------------------------
When you register multiple contacts for an event (e.g. from search results or contacts in a group, using `CRM_Event_Task_Register`), the description for the Send Confirmation or Send Confirmation and Receipt checkbox was broken because it was expecting an email. We don't need a description if we don't have a specific email to put in that description, as it would just be 'Send an email confirmation?' or something similarly redundant.

Before
----------------------------------------
<img width="525" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/e18de9b8-d318-479c-a8f6-b7c4197baef1">

After
----------------------------------------
<img width="584" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/871c5ad1-ab43-4154-90fa-0b25e86db2fe">