### PR TITLE
dev/core#4031 Export dates from SearchKit to spreadsheet in SQL format

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -207,7 +207,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           $out['val'] = $this->rewrite($column, $data);
         }
         else {
-          $out['val'] = $this->formatViewValue($column['key'], $rawValue, $data);
+          $dataType = $this->getSelectExpression($column['key'])['dataType'] ?? NULL;
+          $out['val'] = $this->formatViewValue($column['key'], $rawValue, $data, $dataType);
         }
         if ($this->hasValue($column['label']) && (!empty($column['forceLabel']) || $this->hasValue($out['val']))) {
           $out['label'] = $this->replaceTokens($column['label'], $data, 'view');
@@ -736,7 +737,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       foreach ($this->getTokens($tokenExpr) as $token) {
         $val = $data[$token] ?? NULL;
         if (isset($val) && $format === 'view') {
-          $val = $this->formatViewValue($token, $val, $data);
+          $dataType = $this->getSelectExpression($token)['dataType'] ?? NULL;
+          $val = $this->formatViewValue($token, $val, $data, $dataType);
         }
         if (!(is_null($index))) {
           $replacement = is_array($val) ? $val[$index] ?? '' : $val;
@@ -759,16 +761,15 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @param string $key
    * @param mixed $rawValue
    * @param array $data
+   * @param string $dataType
    * @return array|string
    */
-  protected function formatViewValue($key, $rawValue, $data) {
+  protected function formatViewValue($key, $rawValue, $data, $dataType) {
     if (is_array($rawValue)) {
       return array_map(function($val) use ($key, $data) {
         return $this->formatViewValue($key, $val, $data);
-      }, $rawValue);
+      }, $rawValue, $dataType);
     }
-
-    $dataType = $this->getSelectExpression($key)['dataType'] ?? NULL;
 
     $formatted = $rawValue;
 
@@ -787,9 +788,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
       case 'Date':
       case 'Timestamp':
-        if (!(isset($this->format) && in_array($this->format, ['csv', 'xlsx', 'ods']))) {
-          $formatted = \CRM_Utils_Date::customFormat($rawValue);
-        }
+        $formatted = \CRM_Utils_Date::customFormat($rawValue);
     }
 
     return $formatted;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -766,9 +766,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    */
   protected function formatViewValue($key, $rawValue, $data, $dataType) {
     if (is_array($rawValue)) {
-      return array_map(function($val) use ($key, $data) {
-        return $this->formatViewValue($key, $val, $data);
-      }, $rawValue, $dataType);
+      return array_map(function($val) use ($key, $data, $dataType) {
+        return $this->formatViewValue($key, $val, $data, $dataType);
+      }, $rawValue);
     }
 
     $formatted = $rawValue;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -787,7 +787,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
       case 'Date':
       case 'Timestamp':
-        $formatted = \CRM_Utils_Date::customFormat($rawValue);
+        if (!(isset($this->format) && in_array($this->format, ['csv', 'xlsx', 'ods']))) {
+          $formatted = \CRM_Utils_Date::customFormat($rawValue);
+        }
     }
 
     return $formatted;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -112,6 +112,23 @@ class Download extends AbstractRunAction {
   }
 
   /**
+   * Return raw value if it is a single date, otherwise return parent
+   * {@inheritDoc}
+   */
+  protected function formatViewValue($key, $rawValue, $data, $dataType) {
+    if (is_array($rawValue)) {
+      return parent::formatViewValue($key, $rawValue, $data, $dataType);
+    }
+
+    if (($dataType === 'Date' || $dataType === 'Timestamp') && in_array($this->format, ['csv', 'xlsx', 'ods'])) {
+      return $rawValue;
+    }
+    else {
+      return parent::formatViewValue($key, $rawValue, $data, $dataType);
+    }
+  }
+
+  /**
    * Outputs headers and CSV directly to browser for download
    * @param array $rows
    * @param array $columns


### PR DESCRIPTION
Before
----------------------------------------
From SearchKit Download Spreadsheet, dates are formatted in Complete Date and Time format. The default for this format is not readily recognized as a date in spreadsheets.

After
----------------------------------------
Dates are formatted in SQL DATETIME or DATE format for csv, xlxs and ods downloads. No change in pdfs, SearchKit itself or for dates that have been re-written in a Display.