### PR TITLE
AbstractAction: Drop `@throws` from phpdoc of `__construct()` because it's not thrown

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -151,7 +151,6 @@ abstract class AbstractAction implements \ArrayAccess {
    *
    * @param string $entityName
    * @param string $actionName
-   * @throws \CRM_Core_Exception
    */
   public function __construct($entityName, $actionName) {
     // If a namespaced class name is passed in


### PR DESCRIPTION
Overview
----------------------------------------
`@throws` is removed from phpdoc of `AbstractAction::__construct()`.

Before
----------------------------------------
The phpdoc says `\CRM_Core_Exception` is thrown, but it isn't.

After
----------------------------------------
No `@throws` in phpdoc.