### PR TITLE
Speed up Download Spreadsheet from SearchKit results

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -54,6 +54,13 @@ class Download extends AbstractRunAction {
     $apiParams =& $this->_apiParams;
     $settings = $this->display['settings'];
 
+    // checking permissions for menu, link or button columns is costly, so remove them early
+    foreach ($this->display['settings']['columns'] as $index => $col) {
+      if (empty($col['key'])) {
+        unset($this->display['settings']['columns'][$index]);
+      }
+    }
+
     // Displays are only exportable if they have actions enabled
     if (empty($settings['actions'])) {
       \CRM_Utils_System::permissionDenied();
@@ -75,9 +82,7 @@ class Download extends AbstractRunAction {
     $columns = [];
     foreach ($this->display['settings']['columns'] as $index => $col) {
       $col += ['type' => NULL, 'label' => '', 'rewrite' => FALSE];
-      if (!empty($col['key'])) {
-        $columns[$index] = $col;
-      }
+      $columns[$index] = $col;
       // Convert html to plain text
       if ($col['type'] === 'html') {
         foreach ($rows as $i => $row) {


### PR DESCRIPTION
Overview
----------------------------------------
Downloading a spreadsheet from SearchKit results is often slow when you have even a thousand rows. Timeouts are common, depending on your environment, with a few thousand rows.

It turns out that almost all the execution time was being used to generate the menu column, which of course isn't included in the spreadsheet download, so doesn't need to be generated. I suspect there is also some work to be done to make that faster in general to speed up results in SearchKit (not a big deal with 50 rows, but if you increase the page size it gets slower).

Related [issue.](https://lab.civicrm.org/dev/core/-/issues/4085)

Before
----------------------------------------
Slow! Timeouts! Can't download more than a couple thousand rows.

After
----------------------------------------
At least an order of magnitude faster, for simple rows. Timeouts much less likely.
Can download 10,000 plus rows (I was hitting memory limits while testing, rather than timeouts).