### PR TITLE
Use balanceAmount token to remove isset in offline_event_receipt

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1967,6 +1967,26 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   }
 
   /**
+   * Get the contribution ID associated with the participant record.
+   *
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return int|null
+   * @throws \CRM_Core_Exception
+   */
+  public function getContributionID(): ?int {
+    if (!isset($this->contributionID)) {
+      $this->contributionID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment',
+        $this->getParticipantID(), 'contribution_id', 'participant_id'
+      );
+    }
+    return $this->contributionID;
+  }
+
+  /**
    * Get the value for the revenue recognition date field.
    *
    * @return string
@@ -2235,6 +2255,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         'modelProps' => [
           'participantID' => $this->_id,
           'eventID' => $params['event_id'],
+          'contributionId' => $this->getContributionID(),
         ],
       ];
 
@@ -2251,12 +2272,9 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       //send email with pdf invoice
       $template = CRM_Core_Smarty::singleton();
       $taxAmt = $template->get_template_vars('dataArray');
-      $contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment',
-        $this->_id, 'contribution_id', 'participant_id'
-      );
       if (Civi::settings()->get('invoice_is_email_pdf')) {
         $sendTemplateParams['isEmailPdf'] = TRUE;
-        $sendTemplateParams['contributionId'] = $contributionId;
+        $sendTemplateParams['contributionId'] = $this->getContributionID();
       }
       [$mailSent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
       if ($mailSent) {

--- a/CRM/Event/WorkflowMessage/EventExamples.php
+++ b/CRM/Event/WorkflowMessage/EventExamples.php
@@ -61,6 +61,7 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
   private function addExampleData(GenericWorkflowMessage $messageTemplate, $example): void {
     $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
     $messageTemplate->setEventID($example['event_id']);
+    $messageTemplate->setContribution(['total_amount' => 50, 'balance_amount' => 20, 'currency' => 'USD']);
   }
 
   /**

--- a/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
+++ b/CRM/Event/WorkflowMessage/EventOfflineReceipt.php
@@ -21,6 +21,8 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
  */
 class CRM_Event_WorkflowMessage_EventOfflineReceipt extends GenericWorkflowMessage {
   use CRM_Event_WorkflowMessage_ParticipantTrait;
+  use CRM_Contribute_WorkflowMessage_ContributionTrait;
+
   public const WORKFLOW = 'event_offline_receipt';
 
 }

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -323,6 +323,15 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'event.loc_block_id.phone_id.phone_type_id:label:::Mobile',
       'event.loc_block_id.phone_id.phone_ext:::456',
       'event.confirm_email_text::Just do it',
+      'contribution.total_amount:::' . Civi::format()->money(1550.55),
+      'contribution.total_amount|raw:::1550.55',
+      'contribution.paid_amount:::' . Civi::format()->money(1550.55),
+      'contribution.paid_amount|raw:::1550.55',
+      'contribution.balance_amount:::' . Civi::format()->money(0),
+      'contribution.balance_amount|raw is zero:::Yes',
+      'contribution.balance_amount|raw string is zero:::Yes',
+      'contribution.balance_amount|boolean:::No',
+      'contribution.paid_amount|boolean:::Yes',
     ]);
 
     $this->callAPISuccess('Email', 'delete', ['id' => $email['id']]);
@@ -609,7 +618,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'check_number' => 879,
       'payment_instrument_id' => $paymentInstrumentID,
     ]);
-    $this->assertPartialPaymentResult($isQuickConfig, $mailUtil);
+    $this->assertPartialPaymentResult($isQuickConfig, $mailUtil, FALSE);
   }
 
   /**
@@ -624,7 +633,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testSubmitPendingAddPayment(bool $isQuickConfig): void {
-    $mut = new CiviMailUtils($this, TRUE);
+    $mailUtil = new CiviMailUtils($this, TRUE);
     $form = $this->getForm(['is_monetary' => 1]);
     $this->callAPISuccess('PriceSet', 'create', ['is_quick_config' => $isQuickConfig, 'id' => $this->getPriceSetID('event')]);
     $paymentInstrumentID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
@@ -635,7 +644,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'check_number' => 879,
       'payment_instrument_id' => $paymentInstrumentID,
     ]);
-    $this->assertPartialPaymentResult($isQuickConfig, $mut, FALSE);
+    $this->assertPartialPaymentResult($isQuickConfig, $mailUtil, FALSE);
   }
 
   /**
@@ -726,8 +735,8 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'Annual CiviCRM meet',
       'Registered Email',
       $isQuickConfig ? $this->formatMoneyInput(1550.55) . ' big - 1' : 'Price Field - big',
-      $isAmountPaidOnForm ? 'Total Paid: $20.00' : ' ',
-      'Balance: $1,530.55',
+      $isAmountPaidOnForm ? 'Total Paid: $20.00' : 'Total Paid: ',
+      $isAmountPaidOnForm ? 'Balance: $1,530.55' : 'Balance: $1,550.55',
       'Financial Type: Event Fee',
       'Paid By: Check',
       'Check Number: 879',

--- a/tests/templates/message_templates/event_offline_receipt_text.tpl
+++ b/tests/templates/message_templates/event_offline_receipt_text.tpl
@@ -19,3 +19,13 @@ participant.participant_role_id:name::{participant.participant_role_id:name}
 participant.status_id:name:::{participant.status_id:name}
 email:::{$email}
 event.pay_later_receipt:::{event.pay_later_receipt}
+contribution.total_amount:::{contribution.total_amount|crmMoney}
+contribution.total_amount|raw:::{contribution.total_amount|raw}
+contribution.balance_amount:::{contribution.balance_amount}
+contribution.balance_amount|raw:::{contribution.balance_amount|raw}
+contribution.paid_amount:::{contribution.paid_amount}
+contribution.paid_amount|raw:::{contribution.paid_amount|raw}
+contribution.balance_amount|raw is zero:::{if {contribution.balance_amount|raw} === 0.00}Yes{/if}
+contribution.balance_amount|raw string is zero:::{if '{contribution.balance_amount|raw}' === '0.00'}Yes{/if}
+contribution.balance_amount|boolean:::{if {contribution.balance_amount|boolean}}Yes{else}No{/if}
+contribution.paid_amount|boolean:::{if {contribution.paid_amount|boolean}}Yes{/if}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -263,28 +263,25 @@
        </tr>
       {/if}
       {if !empty($isPrimary)}
-       <tr>
-        <td {$labelStyle}>
-        {if isset($balanceAmount)}
-           {ts}Total Paid{/ts}
+       {if {contribution.balance_amount|boolean}}
+         <tr>
+           <td {$labelStyle}>{ts}Total Paid{/ts}</td>
+           <td {$valueStyle}>
+             {if {contribution.paid_amount|boolean}}{contribution.paid_amount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+           </td>
+          </tr>
+          <tr>
+           <td {$labelStyle}>{ts}Balance{/ts}</td>
+           <td {$valueStyle}>{contribution.balance_amount}</td>
+         </tr>
         {else}
-           {ts}Total Amount{/ts}
-         {/if}
-        </td>
-        <td {$valueStyle}>
-         {if !empty($totalAmount)}{$totalAmount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
-        </td>
-       </tr>
-      {if isset($balanceAmount)}
-       <tr>
-        <td {$labelStyle}>
-         {ts}Balance{/ts}
-        </td>
-        <td {$valueStyle}>
-         {$balanceAmount|crmMoney}
-        </td>
-       </tr>
-      {/if}
+         <tr>
+           <td {$labelStyle}>{ts}Total Amount{/ts}</td>
+           <td {$valueStyle}>
+               {if {contribution.total_amount|boolean}}{contribution.total_amount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+           </td>
+         </tr>
+       {/if}
        {if !empty($pricesetFieldsCount) }
      <tr>
        <td {$labelStyle}>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -145,10 +145,9 @@
 {/if}
 {if !empty($isPrimary)}
 
-{if !empty($balanceAmount)}{ts}Total Paid{/ts}{else}{ts}Total Amount{/ts}{/if}: {if !empty($totalAmount)}{$totalAmount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
-
-{if !empty($balanceAmount)}
-{ts}Balance{/ts}: {$balanceAmount|crmMoney}
+{if {contribution.balance_amount|boolean}}{ts}Total Paid{/ts}: {if {contribution.paid_amount|boolean}}{contribution.paid_amount}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+{ts}Balance{/ts}: {contribution.balance_amount}
+{else}{ts}Total Amount{/ts}: {if {contribution.total_amount|boolean}}{contribution.total_amount}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 {/if}
 
 {if !empty($pricesetFieldsCount) }


### PR DESCRIPTION
Overview
----------------------------------------
Use balanceAmount token to remove isset in offline_event_receipt

Before
----------------------------------------
The offline receipt relies on complicated (& seemingly inconsistent code) to show the balanceAmount. It only actually shows for the primary receipient so really we just need the balance of the contribution

After
----------------------------------------
The old smarty-assign is deprecated & the contribuiont balance_amount token is used

Technical Details
----------------------------------------
I was looking to tackle https://lab.civicrm.org/dev/core/-/issues/4287 but the `isset` causes fatal errors  if I have smarty secure mode on. The patch for https://lab.civicrm.org/dev/core/-/issues/4287 is in progress & adds tests, including for this, but is starting to get quite big...

Comments
----------------------------------------