### PR TITLE
Additional event tokens

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -60,21 +60,85 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'data_type' => 'String',
         'audience' => 'user',
       ],
-      'contact_email' => [
+      'loc_block_id.email_id.email' => [
         'title' => ts('Event Contact Email'),
-        'name' => 'contact_email',
+        'name' => 'loc_block_id.email_id.email',
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'String',
         'audience' => 'user',
       ],
-      'contact_phone' => [
+      'loc_block_id.email_2_id.email' => [
+        'title' => ts('Event Contact Email 2'),
+        'name' => 'loc_block_id.email_2_id.email',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'String',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_id.phone' => [
         'title' => ts('Event Contact Phone'),
-        'name' => 'contact_phone',
+        'name' => 'loc_block_id.phone_id.phone',
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => '',
         'audience' => 'user',
+      ],
+      'loc_block_id.phone_id.phone_type_id' => [
+        'title' => ts('Event Contact Phone'),
+        'name' => 'loc_block_id.phone_id.phone_type_id',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'Int',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_id.phone_type_id:label' => [
+        'title' => ts('Event Contact Phone'),
+        'name' => 'loc_block_id.phone_id.phone_type_id:label',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'String',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_id.phone_ext' => [
+        'title' => ts('Event Contact Phone Extension'),
+        'name' => 'loc_block_id.phone_id.phone_ext',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'String',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_2_id.phone' => [
+        'title' => ts('Event Contact Phone 2'),
+        'name' => 'loc_block_id.phone_2_id.phone',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => '',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_2_id.phone_type_id' => [
+        'title' => ts('Event Contact Phone'),
+        'name' => 'loc_block_id.phone_2_id.phone_type_id',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'Int',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_2_id.phone_type_id:label' => [
+        'title' => ts('Event Contact Phone 2'),
+        'name' => 'loc_block_id.phone_2_id.phone_type_id:label',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'String',
+        'audience' => 'sysadmin',
+      ],
+      'loc_block_id.phone_2_id.phone_ext' => [
+        'title' => ts('Event Contact Phone 2 Extension'),
+        'name' => 'loc_block_id.phone_2_id.phone_ext',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'String',
+        'audience' => 'sysadmin',
       ],
     ];
   }
@@ -118,7 +182,25 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
           'loc_block_id.address_id.state_province_id:label',
           'loc_block_id.address_id.postal_code',
           'loc_block_id.email_id.email',
+          'loc_block_id.email_2_id.email',
           'loc_block_id.phone_id.phone',
+          'loc_block_id.phone_id.phone_type_id',
+          'loc_block_id.phone_id.phone_ext',
+          'loc_block_id.phone_id.phone_type_id:label',
+          'loc_block_id.phone_2_id.phone',
+          'loc_block_id.phone_2_id.phone_type_id',
+          'loc_block_id.phone_2_id.phone_ext',
+          'loc_block_id.phone_2_id.phone_type_id:label',
+          'confirm_email_text',
+          'is_show_location',
+          'is_show_location:label',
+          'is_public',
+          'is_public:label',
+          'is_monetary:label',
+          'event_type_id:label',
+          'event_type_id:name',
+          'pay_later_text',
+          'pay_later_receipt',
           'custom.*',
         ], $this->getExposedFields()))
         ->execute()->first();
@@ -133,10 +215,11 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
       $tokens['registration_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/register', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
       $tokens['start_date']['text/html'] = !empty($event['start_date']) ? new DateTime($event['start_date']) : '';
       $tokens['end_date']['text/html'] = !empty($event['end_date']) ? new DateTime($event['end_date']) : '';
-      $tokens['event_type_id:label']['text/html'] = CRM_Core_PseudoConstant::getLabel('CRM_Event_BAO_Event', 'event_type_id', $event['event_type_id']);
-      $tokens['event_type_id:name']['text/html'] = CRM_Core_PseudoConstant::getName('CRM_Event_BAO_Event', 'event_type_id', $event['event_type_id']);
-      $tokens['contact_phone']['text/html'] = $event['loc_block_id.phone_id.phone'];
       $tokens['contact_email']['text/html'] = $event['loc_block_id.email_id.email'];
+      $tokens['contact_phone']['text/html'] = $event['loc_block_id.phone_id.phone'];
+      // We use text/plain for fields which should be converted to html when used in html content.
+      $tokens['confirm_email_text']['text/plain'] = $event['confirm_email_text'];
+      $tokens['pay_later_text']['text/plain'] = $event['pay_later_text'];
 
       foreach ($this->getTokenMetadata() as $fieldName => $fieldSpec) {
         if (!isset($tokens[$fieldName])) {
@@ -168,6 +251,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
   protected function getExposedFields(): array {
     return [
       'event_type_id',
+      'event_type_id:label',
       'title',
       'id',
       'pay_later_receipt',
@@ -175,6 +259,47 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
       'end_date',
       'summary',
       'description',
+      'is_show_location',
+      'is_public',
+      'confirm_email_text',
+      'is_monetary',
+    ];
+  }
+
+  /**
+   * Get any overrides for token metadata.
+   *
+   * This is most obviously used for setting the audience, which
+   * will affect widget-presence.
+   *
+   * Changing the audience is done in order to simplify the
+   * UI for more general users.
+   *
+   * @return \string[][]
+   */
+  protected function getTokenMetadataOverrides(): array {
+    return [
+      'is_public' => ['audience' => 'sysadmin'],
+      'is_show_location' => ['audience' => 'sysadmin'],
+      'is_monetary' => ['audience' => 'sysadmin'],
+    ];
+  }
+
+  /**
+   * These tokens still work but we don't advertise them.
+   *
+   * We will actively remove from the following places
+   * - scheduled reminders
+   * - add to 'blocked' on pdf letter & email
+   *
+   * & then at some point start issuing warnings for them.
+   *
+   * @return string[]
+   */
+  protected function getDeprecatedTokens(): array {
+    return [
+      'contact_phone' => 'loc_block_id.phone_id.phone',
+      'contact_email' => 'loc_block_id.email_id.email',
     ];
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -647,8 +647,8 @@ event.start_date :October 21st, 2008
 event.end_date :October 23rd, 2008
 event.event_type_id:label :Conference
 event.summary :If you have any CiviCRM related issues or want to track where CiviCRM is heading, Sign up now
-event.contact_email :event@example.com
-event.contact_phone :456 789
+event.loc_block_id.email_id.email :event@example.com
+event.loc_block_id.phone_id.phone :456 789
 event.description :event description
 event.location :15 Walton St
 Emerald City, Maine 90210
@@ -657,6 +657,7 @@ event.info_url :' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&
 event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1
 event.pay_later_receipt :
 event.custom_1 :my field
+event.confirm_email_text :
 ';
   }
 
@@ -946,14 +947,15 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{event.end_date}' => 'Event End Date',
       '{event.event_type_id:label}' => 'Type',
       '{event.summary}' => 'Event Summary',
-      '{event.contact_email}' => 'Event Contact Email',
-      '{event.contact_phone}' => 'Event Contact Phone',
+      '{event.loc_block_id.email_id.email}' => 'Event Contact Email',
+      '{event.loc_block_id.phone_id.phone}' => 'Event Contact Phone',
       '{event.description}' => 'Event Description',
       '{event.location}' => 'Event Location',
       '{event.info_url}' => 'Event Info URL',
       '{event.registration_url}' => 'Event Registration URL',
       '{event.pay_later_receipt}' => 'Pay Later Receipt Text',
       '{event.' . $this->getCustomFieldName('text') . '}' => 'Enter text here :: Group with field text',
+      '{event.confirm_email_text}' => 'Confirmation Email Text',
     ];
   }
 

--- a/tests/templates/message_templates/event_offline_receipt_text.tpl
+++ b/tests/templates/message_templates/event_offline_receipt_text.tpl
@@ -5,6 +5,17 @@ contact.id:::{contact.id}
 event.id:::{event.id}
 participant.id:::{participant.id}
 event.title:::{event.title}
+event.end_date|crmDate:"%Y%m%d"::{event.end_date|crmDate:"%Y%m%d"}
+event.loc_block_id.phone_id.phone:::{event.loc_block_id.phone_id.phone}
+event.loc_block_id.phone_id.phone_type_id:label:::{event.loc_block_id.phone_id.phone_type_id:label}
+event.loc_block_id.phone_id.phone_ext:::{event.loc_block_id.phone_id.phone_ext}
+event.loc_block_id.phone_2_id.phone:::{event.loc_block_id.phone_id.phone_2}
+event.loc_block_id.phone_2_id.phone_type_id:label:::{event.loc_block_id.phone_id.phone_type_id_2:label}
+event.loc_block_id.phone_2_id.phone_ext:::{event.loc_block_id.phone_id.phone_ext_2}
+event.confirm_email_text::{event.confirm_email_text}
+event.is_show_location|boolean::{event.is_show_location|boolean}
+event.is_public|boolean::{event.is_public|boolean}
+participant.participant_role_id:name::{participant.participant_role_id:name}
 participant.status_id:name:::{participant.status_id:name}
 email:::{$email}
 event.pay_later_receipt:::{event.pay_later_receipt}


### PR DESCRIPTION
Overview
----------------------------------------
Additional event tokens

Before
----------------------------------------
We don't have tokens to deal with the notices in 
https://lab.civicrm.org/dev/core/-/issues/4287

After
----------------------------------------
Tokens added - note that I~followed~ deprecated the existing `{event.contact_phone}` & added a bunch more rather than `{event.loc_block_id.phone_id.phone}` which would be more correct. I'm on the fence here about switching over (& deprecating the existing format)

Technical Details
----------------------------------------

Comments
----------------------------------------
