### PR TITLE
Improve test consistency on capitalisation

### DIFF
--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -227,8 +227,8 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
       'contributionID' => $orderID,
       'module' => 'event',
       'invoice' => 123,
-      'eventID' => $this->ids['event'][0],
-      'participantID' => Participant::get()->addWhere('event_id', '=', $this->ids['event'][0])->addSelect('id')->execute()->first()['id'],
+      'eventID' => $this->ids['Event'][0],
+      'participantID' => Participant::get()->addWhere('event_id', '=', $this->ids['Event'][0])->addSelect('id')->execute()->first()['id'],
       'payment_status' => 'Refunded',
       'processor_id' => $this->createPaymentProcessor(['payment_processor_type_id' => 'PayPal_Standard']),
     ]);
@@ -312,7 +312,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
    * @return int
    */
   protected function getEventID(): int {
-    return $this->ids['event'][0];
+    return $this->ids['Event'][0];
   }
 
   /**
@@ -322,7 +322,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
    * @throws CRM_Core_Exception
    */
   protected function createEventOrder(): int {
-    $this->ids['event'][0] = (int) Event::create()->setValues(['title' => 'Event', 'start_date' => 'tomorrow', 'event_type_id:name' => 'Workshop'])->execute()->first()['id'];
+    $this->ids['Event'][0] = (int) Event::create()->setValues(['title' => 'Event', 'start_date' => 'tomorrow', 'event_type_id:name' => 'Workshop'])->execute()->first()['id'];
     $order = $this->callAPISuccess('Order', 'create', [
       'contact_id' => $this->ids['contact'][0],
       'financial_type_id' => 'Donation',
@@ -340,7 +340,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
           ],
           'params' => [
             'contact_id' => $this->ids['contact'][0],
-            'event_id' => $this->ids['event'][0],
+            'event_id' => $this->ids['Event'][0],
           ],
         ],
       ],

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -345,11 +345,10 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       $event = $this->eventCreate($eventParams);
     }
 
-    $this->ids['contact']['event'] = (int) $this->individualCreate();
     /** @var CRM_Event_Form_Participant $form */
     $form = $this->getFormObject('CRM_Event_Form_Participant');
     $form->_single = TRUE;
-    $form->_contactID = $form->_contactId = $this->ids['contact']['event'];
+    $form->_contactID = $form->_contactId = $this->getContactID();
     $form->setCustomDataTypes();
     $form->_eventId = $event['id'];
     if (!empty($eventParams['is_monetary'])) {
@@ -554,7 +553,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testSubmitPartialPayment($isQuickConfig) {
+  public function testSubmitPartialPayment(bool $isQuickConfig): void {
     $mut = new CiviMailUtils($this, TRUE);
     $form = $this->getForm(['is_monetary' => 1]);
     $this->callAPISuccess('PriceSet', 'create', ['is_quick_config' => $isQuickConfig, 'id' => $this->getPriceSetID('event')]);
@@ -864,7 +863,7 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    * @return int
    */
   protected function getEventID(): int {
-    return $this->ids['Event']['event'];
+    return reset($this->ids['Event']);
   }
 
   /**
@@ -873,7 +872,10 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
    * @return int
    */
   protected function getContactID(): int {
-    return $this->ids['contact']['event'];
+    if (empty($this->ids['Contact']['event'])) {
+      $this->ids['Contact']['event'] = $this->individualCreate([]);
+    }
+    return $this->ids['Contact']['event'];
   }
 
 }

--- a/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
@@ -24,7 +24,7 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
     $minAmt = 100;
     $feeAmt = 1000;
     $event = $this->eventCreate();
-    $form = $this->getEventForm($this->ids['event'][0]);
+    $form = $this->getEventForm($this->ids['Event'][0]);
     $priceSetId = $this->eventPriceSetCreate($feeAmt, $minAmt);
     $priceSet = current(CRM_Price_BAO_PriceSet::getSetDetail($priceSetId));
     $form->_values['fee'] = $form->_feeBlock = $priceSet['fields'];

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -641,7 +641,7 @@ participant.must_wait :
    * @return string
    */
   protected function getExpectedEventTokenOutput(): string {
-    return 'event.id :' . $this->ids['event'][0] . '
+    return 'event.id :' . $this->ids['Event'][0] . '
 event.title :Annual CiviCRM meet
 event.start_date :October 21st, 2008
 event.end_date :October 23rd, 2008
@@ -871,7 +871,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $tokens = array_keys($this->getEventTokens());
     $html = $this->getTokenString($tokens);
     $tokenProcessor->addMessage('html', $html, 'text/plain');
-    $tokenProcessor->addRow(['eventId' => $this->ids['event'][0]]);
+    $tokenProcessor->addRow(['eventId' => $this->ids['Event'][0]]);
     $tokenProcessor->evaluate();
     $this->assertEquals($expectedEventString, $tokenProcessor->getRow(0)->render('html'));
   }
@@ -901,7 +901,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $html = $this->getTokenString(array_keys($this->getEventTokens()));
 
     $tokenProcessor->addMessage('html', $html, 'text/plain');
-    $tokenProcessor->addRow(['eventId' => $this->ids['event'][0]]);
+    $tokenProcessor->addRow(['eventId' => $this->ids['Event'][0]]);
     $tokenProcessor->evaluate();
     $this->assertEquals($expected, $tokenProcessor->getRow(0)->render('html'));
 
@@ -1022,7 +1022,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
         'phone_id' => $phoneID,
       ],
     ])->execute()->first()['id'];
-    $this->ids['event'][0] = $this->eventCreate([
+    $this->ids['Event'][0] = $this->eventCreate([
       'description' => 'event description',
       'end_date' => 20081023,
       'registration_end_date' => 20081015,
@@ -1033,10 +1033,10 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     // this prevents things working just because the id 'happens to be valid'
     $this->participantCreate([
       'register_date' => '2020-01-01',
-      'event_id' => $this->ids['event'][0],
+      'event_id' => $this->ids['Event'][0],
     ]);
     $this->ids['participant'][0] = $this->participantCreate([
-      'event_id' => $this->ids['event'][0],
+      'event_id' => $this->ids['Event'][0],
       'fee_amount' => 50,
       'fee_level' => 'steep',
       $this->getCustomFieldName('participant_int') => '99999',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1039,7 +1039,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       $params['payment_processor'] = is_array($params['payment_processor_id']) ? $params['payment_processor_id'] : [$params['payment_processor_id']];
     }
     $event = Event::create(FALSE)->setValues($params)->execute()->first();
-    $this->ids['event'][] = $event['id'];
+    $this->ids['Event'][] = $event['id'];
     return $event;
   }
 
@@ -1084,7 +1084,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $params = [
       'event_id' => $id,
     ];
-    return $this->callAPISuccess('event', 'delete', $params);
+    return $this->callAPISuccess('Event', 'delete', $params);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Improve test consistency on capitalisation

Before
----------------------------------------
The `ids` property holds ids with the top key being the entity - the capitalisation is inconsistent but is being consolidated on camelCase - event uses lower in one place & camel in another

After
----------------------------------------
Event uses camel

Technical Details
----------------------------------------

Comments
----------------------------------------
