### PR TITLE
Remove unreachable validation

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -818,15 +818,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
     }
 
-    // validate contribution status for 'Failed'.
-    if ($self->_onlinePendingContributionId && !empty($values['record_contribution']) &&
-      (CRM_Utils_Array::value('contribution_status_id', $values) ==
-        array_search('Failed', CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name'))
-      )
-    ) {
-      $errorMsg['contribution_status_id'] = ts('Please select a valid payment status before updating.');
-    }
-
     // do the amount validations.
     //skip for update mode since amount is freeze, CRM-6052
     if ((!$self->_id && empty($values['total_amount']) &&


### PR DESCRIPTION

Overview
----------------------------------------
Remove unreachable validation

Before
----------------------------------------
Some time ago we fixed it such that only Pending and Completed statuses are in the drop box for contribution_status_id. This fragment of code handles an edge case that is no longer reachable - ie when the value is Failed and some other confusing stuff is true

After
----------------------------------------
poof

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/blob/281d81edcdb71473e4f3ffa1015dce4ff11ecb58/CRM/Event/Form/Participant.php#L1516

Comments
----------------------------------------
