### PR TITLE
dev/core#5903 Standardize when emails aren't sent for email on hold, do not email & deceased

### DIFF
--- a/CRM/Activity/Form/ActivityLinks.php
+++ b/CRM/Activity/Form/ActivityLinks.php
@@ -48,8 +48,8 @@ class CRM_Activity_Form_ActivityLinks extends CRM_Core_Form {
         if (!CRM_Utils_Mail::validOutBoundMail() || !$contactId) {
           continue;
         }
-        [, $email, $doNotEmail, , $isDeceased] = CRM_Contact_BAO_Contact::getContactDetails($contactId);
-        if (!$doNotEmail && $email && !$isDeceased) {
+        [, $email, $doNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($contactId);
+        if (!$doNotEmail && $email) {
           $url = 'civicrm/activity/email/add';
           $act['label'] = ts('Send an Email');
         }

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -592,7 +592,7 @@ FROM civicrm_action_schedule cas
   protected static function sendReminderEmail($tokenRow, $schedule, $toContactID): array {
     $toEmail = CRM_Contact_BAO_Contact::getPrimaryEmail($toContactID, TRUE);
     if (!$toEmail) {
-      return ['email_missing' => "Couldn't find recipient's email address."];
+      return ['email_missing' => "Recipient has no email or should not be emailed."];
     }
 
     // set up the parameters for CRM_Utils_Mail::send

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1062,7 +1062,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
     $compareParams = [
       $params['first_name'] . ' ' . $params['last_name'],
       CRM_Utils_Array::value('email', $params['email'][1]),
-      (bool ) $params['privacy']['do_not_email'],
+      (bool ) ($params['privacy']['do_not_email'] || $params['email'][1]['on_hold'] || $params['is_deceased']),
     ];
     //Now check the contact details
     $this->assertAttributesEquals($compareParams, $contactDetails);
@@ -1275,6 +1275,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
       'location_type_id' => 1,
       'is_primary' => 1,
       'email' => 'john.smith@example.org',
+      'on_hold' => 1,
     ];
 
     $params['phone'] = [];


### PR DESCRIPTION
Overview
----------------------------------------
I've found that when we are sending transactional emails, what we check before sending is inconsistent. Sometimes we send transactional emails to contact with do not email, sometimes we send them to contacts with primary email on hold, sometimes we send them to deceased contacts.

This is a first step to making this more consistent and not sending emails to contacts that are do not email, on hold or deceased. This PR updates the two functions that are used for this purpose (though they aren't much used and I intend to follow up to put them to use in other places).

Before
----------------------------------------
`getContactDetails` returns bools for each of on hold, do not email and deceased, but this is not fully used anywhere at all. Most uses, if they do anything beyond just getting the email, only use do_not_email.
`getPrimaryEmail($contactID, polite = TRUE)` does not return on hold or do not email, but does return emails for deceased contacts. 

After
----------------------------------------
`getContactDetails` returns one bool for if the person should not be emailed that accounts for all three values. Since this third param returned by the function was the one mostly used in the past (it looks like the others were added later), this requires very little cleanup, only in one place.
`getPrimaryEmail($contactID, polite = TRUE)` no longer returns emails for deceased contacts. This was only actually used in one place and only requires updating some error text.

Technical Details
----------------------------------------
I have also grepped `universe` for these functions. There are two uses that will requires updates outside of core, one in [CiviMobile](https://lab.civicrm.org/extensions/civimobileapi/-/blob/master/CRM/CiviMobileAPI/Utils/ActivityType.php#L83) and one in [CDN Tax Receipts](https://lab.civicrm.org/extensions/cdntaxreceipts/-/blob/master/cdntaxreceipts.functions.inc#L1099). I will make PRs for both of these once this is merged, both will be minor changes.

Test updated.
