### PR TITLE
Use payment create rather than transitionComponents

### DIFF
--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1109,7 +1109,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
     // Check if Membership is updated to New.
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
-    $this->assertEquals($membership['status_id'], array_search('New', $memStatus));
+    $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']));
   }
 
   /**


### PR DESCRIPTION
@seamuslee001 I've pushed this up because I think tests will fail & it will highlight the difference between the `transitionComponents` and `Payment.create` handling - the intension is to get rid of `transitionComponents` but I never quite got to the bottom of this difference.

The first commit is a clean up we should merge to make this easier - will put up a separate PR