### PR TITLE
Upgrader - Use generic (non-api4) code in upgrader

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyOne.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyOne.php
@@ -9,7 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Api4\Contribution;
 use Civi\Api4\MappingField;
 
 /**
@@ -129,10 +128,11 @@ class CRM_Upgrade_Incremental_php_FiveSixtyOne extends CRM_Upgrade_Incremental_B
       'contribution_check_number' => 'check_number',
       'contribution_campaign_id' => 'campaign_id',
     ];
-    $apiv4 = Contribution::getFields(FALSE)->addWhere('custom_field_id', '>', 0)->execute();
-    foreach ($apiv4 as $apiv4Field) {
-      $fieldMap['custom_' . $apiv4Field['custom_field_id']] = $apiv4Field['name'];
-    }
+    $fieldMap += CRM_Core_DAO::executeQuery('
+      SELECT CONCAT("custom_", fld.id) AS old, CONCAT(grp.name, ".", fld.name) AS new
+      FROM civicrm_custom_field fld, civicrm_custom_group grp
+      WHERE grp.id = fld.custom_group_id AND grp.extends = "Contribution"
+    ')->fetchMap('old', 'new');
 
     // Update the mapped fields.
     foreach ($mappings as $mapping) {


### PR DESCRIPTION
Overview
----------------------------------------
Small chunk extracted from #26208 which fixes a test failure in that PR.

Before
----------------------------------------
Upgrade code uses APIv4

After
----------------------------------------
Same functionality, but without APIv4

Technical Details
----------------------------------------
This was causing issues with https://github.com/civicrm/civicrm-core/pull/26208 because the Contribution API is no longer available without enabling the civi_contribute extension, which doesn't happen until a later upgrade step.
