### PR TITLE
Add weight to links spec

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -218,18 +218,21 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           'url' => 'civicrm/contact/view/contribution',
           'qs' => "reset=1&id=%%id%%&cid=%%cid%%&action=view&context=%%cxt%%&selectedChild=contribute{$extraParams}",
           'title' => ts('View Contribution'),
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/contact/view/contribution',
           'qs' => "reset=1&action=update&id=%%id%%&cid=%%cid%%&context=%%cxt%%{$extraParams}",
           'title' => ts('Edit Contribution'),
+          'weight' => -10,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/contact/view/contribution',
           'qs' => "reset=1&action=delete&id=%%id%%&cid=%%cid%%&context=%%cxt%%{$extraParams}",
           'title' => ts('Delete Contribution'),
+          'weight' => 100,
         ],
       ];
     }

--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -217,6 +217,10 @@ class CRM_Core_Action {
 
     $url = [];
 
+    usort($seqLinks, static function ($a, $b) {
+      return (int) ((int) ($a['weight'] ?? 0) > (int) ($b['weight'] ?? 0));
+    });
+
     foreach ($seqLinks as $i => $link) {
       if (!$mask || !array_key_exists('bit', $link) || ($mask & $link['bit'])) {
         $extra = isset($link['extra']) ? self::replace($link['extra'], $values) : NULL;

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -178,9 +178,12 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test Assigning a target contact but then the logged in user cannot see the contact
+   * Test Assigning a target contact but then the logged in user cannot see the
+   * contact
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testTargetContactNotavaliable() {
+  public function testTargetContactNotAvaliable(): void {
     $contactId = $this->individualCreate();
     $params = [
       'first_name' => 'liz',
@@ -210,9 +213,9 @@ class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
     $activityGetParams = CRM_Core_Page_AJAX::defaultSortAndPagerParams();
     $activityGetParams += ['contact_id' => $contactId];
     $activities = CRM_Activity_BAO_Activity::getContactActivitySelector($activityGetParams);
-    // Aseert that we have sensible data to display in the contact tab
+    // Assert that we have sensible data to display in the contact tab
     $this->assertEquals('Anderson, Anthony', $activities['data'][0]['source_contact_name']);
-    // Note that becasue there is a target contact but it is not accessable the output is an empty string not n/a
+    // Note that because there is a target contact but it is not accessible the output is an empty string not n/a
     $this->assertEquals('', $activities['data'][0]['target_contact_name']);
     // verify that doing the underlying query shows we get a target contact_id
     $this->assertEquals(1, CRM_Activity_BAO_Activity::getActivities(['contact_id' => $contactId])[1]['target_contact_count']);


### PR DESCRIPTION
Overview
----------------------------------------
This allows a weight to be set & for it to alter the order.



Before
----------------------------------------
Very cumbersome to alter link order in an extension

After
----------------------------------------
Can set 'weight'

Technical Details
----------------------------------------
It is a bit hard to know whether to add weights to existing ones as it would be a lot to do all of them - but I did hear a specific request (can't recall who from) to have Delete last to reduce mis-clicks and with the View & Edit declared in the same place I felt I should add them with low values for some sort of consistency

This would mess with people who have implemented weight in a hook - but probably any change is low impact & an easy-ish fix

Note that I will update docs once agreed


Comments
----------------------------------------
https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/hooks/changes.md
