### PR TITLE
dev/core#4295 SearchKit: check controller class for qfKey when loading legacy search actions for contributions 

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -193,7 +193,10 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       // FIXME: tasks() function always checks permissions, should respect `$this->checkPermissions`
       foreach (\CRM_Contribute_Task::tasks() as $id => $task) {
         if (!empty($task['url'])) {
-          $key = \CRM_Core_Key::get('CRM_Contribute_Controller_Task', TRUE);
+          $path = explode('?', $task['url'], 2)[0];
+          $menu = \CRM_Core_Menu::get($path);
+          $key = \CRM_Core_Key::get($menu['page_callback'], TRUE);
+
           $tasks[$entity['name']]['contribution.' . $id] = [
             'title' => $task['title'],
             'icon' => $task['icon'] ?? 'fa-gear',


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/4295

Before
----------------------------------------
Legacy search actions for contributions don't work if they aren't going through `CRM_Contribute_Controller_Task`

For example: https://lab.civicrm.org/ufundo/ukgiftaid/-/tree/searchkit-actions

After
----------------------------------------
They work :)

Technical Details
----------------------------------------
At first I tried using the `$task['class']` for the qfKey, but this required modifying the core qfKey validation. An attempt going down that route here https://github.com/ufundo/civicrm-core/tree/task-controller-qfkey-name 

I think this is probably much safer!
