### PR TITLE
dev/core#4298 - respond with 400 not 500 errors if wrong params passed to CiviMail urls

### DIFF
--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -50,13 +50,17 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
     $this->_hash = $hash = CRM_Utils_Request::retrieve('h', 'String', $this);
 
     if (!$job_id || !$queue_id || !$hash) {
-      throw new CRM_Core_Exception(ts("Missing input parameters"));
+      CRM_Utils_System::sendResponse(
+        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: missing parameters"))
+      );
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
     if (!$q) {
-      throw new CRM_Core_Exception(ts("There was an error in your request"));
+      CRM_Utils_System::sendResponse(
+        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))
+      );
     }
 
     list($displayName, $email) = CRM_Mailing_Event_BAO_MailingEventQueue::getContactInfo($queue_id);

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -51,13 +51,17 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
     $isConfirm = CRM_Utils_Request::retrieveValue('confirm', 'Boolean', FALSE, FALSE, 'GET');
 
     if (!$job_id || !$queue_id || !$hash) {
-      throw new CRM_Core_Exception(ts('Missing Parameters'));
+      CRM_Utils_System::sendResponse(
+        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: missing parameters"))
+      );
     }
 
     // verify that the three numbers above match
     $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($job_id, $queue_id, $hash);
     if (!$q) {
-      throw new CRM_Core_Exception(ts("There was an error in your request"));
+      CRM_Utils_System::sendResponse(
+        new \GuzzleHttp\Psr7\Response(400, [], ts("Invalid request: bad parameters"))
+      );
     }
 
     list($displayName, $email) = CRM_Mailing_Event_BAO_MailingEventQueue::getContactInfo($queue_id);

--- a/CRM/Mailing/Page/Open.php
+++ b/CRM/Mailing/Page/Open.php
@@ -36,8 +36,9 @@ class CRM_Mailing_Page_Open extends CRM_Core_Page {
       $queue_id = CRM_Utils_Request::retrieveValue('q', 'Positive', NULL, FALSE, 'GET');
     }
     if (!$queue_id) {
-      echo "Missing input parameters\n";
-      exit();
+      CRM_Utils_System::sendResponse(
+        new \GuzzleHttp\Psr7\Response(400, [], ts("Missing input parameters"))
+      );
     }
 
     CRM_Mailing_Event_BAO_MailingEventOpened::open($queue_id);


### PR DESCRIPTION
See: https://lab.civicrm.org/dev/core/-/issues/4298