### PR TITLE
dev/core#4286 APIv4 - Improve export action handling of $match param

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
@@ -34,8 +34,10 @@
         crmApi4(apiCalls)
           .then(function(result) {
             _.each(ctrl.types, function (type) {
-              type.values = _.pluck(_.pluck(_.where(result[0], {entity: type.entity}), 'params'), 'values');
-              type.enabled = !!type.values.length;
+              var params = _.pluck(_.where(result[0], {entity: type.entity}), 'params');
+              type.values = _.pluck(params, 'values');
+              type.match = params[0] && params[0].match;
+              type.enabled = !!params.length;
             });
             // Afforms are not included in the export and are fetched separately
             if (ctrl.afformEnabled) {
@@ -50,10 +52,8 @@
         _.each(ctrl.types, function(type) {
           if (type.enabled) {
             var params = {records: type.values};
-            // Afform always matches on 'name', no need to add it to the API 'save' params
-            if (type.entity !== 'Afform') {
-              // Group and SavedSearch match by 'name', SearchDisplay also matches by 'saved_search_id'.
-              params.match = type.entity === 'SearchDisplay' ? ['name', 'saved_search_id'] : ['name'];
+            if (type.match && type.match.length) {
+              params.match = type.match;
             }
             data.push([type.entity, 'save', params]);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Improves DX when exporting records from the API Explorer.
See [dev/core#4286 Fatal error with managed custom groups containing duplicate field names](https://lab.civicrm.org/dev/core/-/issues/4286)

Before
----------------------------------------
"Match" param not automatically supplied.

After
----------------------------------------
"Match" param automatically set to "name" and augmented for linked entities.

Technical Details
----------------------------------------
If you try exporting a custom field group, it will default to matching on "name". Fields will cascade to matching on "name" + "custom_group_id". Any option groups related to the fields will also match on "name" and their option values will match on "name" + "option_group_id".