### PR TITLE
setup - Fix uninstall on MySQL 8.0

### DIFF
--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -311,8 +311,8 @@ class DbUtil {
     $sql = sprintf("SELECT table_name FROM information_schema.TABLES  WHERE TABLE_SCHEMA='%s' AND TABLE_TYPE = 'BASE TABLE'",
       $conn->escape_string($databaseName));
 
-    return array_map(function($arr) {
-      return $arr['table_name'];
+    return array_map(function ($arr) {
+      return $arr['table_name'] ?? $arr['TABLE_NAME'];
     }, self::fetchAll($conn, $sql));
   }
 


### PR DESCRIPTION
Overview
--------

Fix a bug with uninstalling or reinstalling via cv (`cv core:uninstall` or `cv core:install -f`) on MySQL 8.0.

Before
------

On MySQL 8.0, it fails - because all table-names appear as null.

It's looking for a result column named `table_name` but actually receives `TABLE_NAME`.

After
-----

Doesn't matter if the column is called `table_name` or `TABLE_NAME`.

Comments
-----------

This branch should amenable to merging on either `5.62` or `master`.