### PR TITLE
Add some weights to menu link items

### DIFF
--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -54,17 +54,20 @@ class CRM_ACL_Page_ACL extends CRM_Core_Page_Basic {
           'name' => ts('Disable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Disable ACL'),
+          'weight' => 40,
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Enable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Enable ACL'),
+          'weight' => 30,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/acl',
           'qs' => 'reset=1&action=delete&id=%%id%%',
           'title' => ts('Delete ACL'),
+          'weight' => 100,
         ],
       ];
     }

--- a/CRM/ACL/Page/EntityRole.php
+++ b/CRM/ACL/Page/EntityRole.php
@@ -54,6 +54,7 @@ class CRM_ACL_Page_EntityRole extends CRM_Core_Page_Basic {
           'name' => ts('Disable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Disable ACL Role Assignment'),
+          'weight' => 40,
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Enable'),

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -206,6 +206,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
           'url' => $url,
           'qs' => $qsView,
           'title' => ts('View Activity'),
+          'weight' => -20,
         ],
       ];
     }
@@ -226,6 +227,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
             'url' => $updateUrl,
             'qs' => $qsUpdate,
             'title' => ts('Update Activity'),
+            'weight' => -10,
           ],
         ];
       }
@@ -257,6 +259,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
           'url' => $delUrl,
           'qs' => $qsDelete,
           'title' => ts('Delete Activity'),
+          'weight' => 100,
         ],
       ];
     }

--- a/CRM/Admin/Page/RelationshipType.php
+++ b/CRM/Admin/Page/RelationshipType.php
@@ -53,28 +53,33 @@ class CRM_Admin_Page_RelationshipType extends CRM_Core_Page_Basic {
           'url' => 'civicrm/admin/reltype/edit',
           'qs' => 'action=view&id=%%id%%&reset=1',
           'title' => ts('View Relationship Type'),
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/admin/reltype/edit',
           'qs' => 'action=update&id=%%id%%&reset=1',
           'title' => ts('Edit Relationship Type'),
+          'weight' => -10,
         ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Disable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Disable Relationship Type'),
+          'weight' => 40,
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Enable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Enable Relationship Type'),
+          'weight' => 30,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/admin/reltype/edit',
           'qs' => 'action=delete&id=%%id%%',
           'title' => ts('Delete Reletionship Type'),
+          'weight' => 100,
         ],
       ];
     }

--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -624,6 +624,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'title' => ts('View'),
           'accessKey' => '',
           'ref' => 'View',
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
@@ -633,6 +634,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'icon' => 'fa-pencil',
           'accessKey' => '',
           'ref' => 'Edit',
+          'weight' => -10,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
@@ -642,6 +644,7 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
           'icon' => 'fa-trash',
           'accessKey' => '',
           'ref' => 'Delete',
+          'weight' => 100,
         ],
         CRM_Core_Action::RENEW => [
           'name' => ts('Restore'),

--- a/CRM/Contact/Page/View/Note.php
+++ b/CRM/Contact/Page/View/Note.php
@@ -236,12 +236,14 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
         'url' => 'civicrm/contact/view/note',
         'qs' => 'action=view&reset=1&cid=%%cid%%&id=%%id%%&selectedChild=note',
         'title' => ts('View Note'),
+        'weight' => -20,
       ],
       CRM_Core_Action::UPDATE => [
         'name' => ts('Edit'),
         'url' => 'civicrm/contact/view/note',
         'qs' => 'action=update&reset=1&cid=%%cid%%&id=%%id%%&selectedChild=note',
         'title' => ts('Edit Note'),
+        'weight' => -10,
       ],
       CRM_Core_Action::ADD => [
         'name' => ts('Comment'),
@@ -254,6 +256,7 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
         'url' => 'civicrm/contact/view/note',
         'qs' => 'action=delete&reset=1&cid=%%cid%%&id=%%id%%&selectedChild=note',
         'title' => ts('Delete Note'),
+        'weight' => 100,
       ],
     ];
   }
@@ -270,18 +273,21 @@ class CRM_Contact_Page_View_Note extends CRM_Core_Page {
         'url' => 'civicrm/contact/view/note',
         'qs' => 'action=view&reset=1&cid=%%cid%%&id={id}&selectedChild=note',
         'title' => ts('View Comment'),
+        'weight' => -20,
       ],
       CRM_Core_Action::UPDATE => [
         'name' => ts('Edit'),
         'url' => 'civicrm/contact/view/note',
         'qs' => 'action=update&reset=1&cid=%%cid%%&id={id}&parentId=%%pid%%&selectedChild=note',
         'title' => ts('Edit Comment'),
+        'weight' => -10,
       ],
       CRM_Core_Action::DELETE => [
         'name' => ts('Delete'),
         'url' => 'civicrm/contact/view/note',
         'qs' => 'action=delete&reset=1&cid=%%cid%%&id={id}&selectedChild=note',
         'title' => ts('Delete Comment'),
+        'weight' => 100,
       ],
     ];
   }

--- a/CRM/Contact/Page/View/Relationship.php
+++ b/CRM/Contact/Page/View/Relationship.php
@@ -258,28 +258,33 @@ class CRM_Contact_Page_View_Relationship extends CRM_Core_Page {
           'url' => 'civicrm/contact/view/rel',
           'qs' => 'action=view&reset=1&cid=%%cid%%&id=%%id%%&rtype=%%rtype%%&selectedChild=rel',
           'title' => ts('View Relationship'),
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/contact/view/rel',
           'qs' => 'action=update&reset=1&cid=%%cid%%&id=%%id%%&rtype=%%rtype%%',
           'title' => ts('Edit Relationship'),
+          'weight' => -10,
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Enable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Enable Relationship'),
+          'weight' => 30,
         ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Disable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Disable Relationship'),
+          'weight' => 40,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/contact/view/rel',
           'qs' => 'action=delete&reset=1&cid=%%cid%%&id=%%id%%&rtype=%%rtype%%',
           'title' => ts('Delete Relationship'),
+          'weight' => 100,
         ],
         // FIXME: Not sure what to put as the key.
         // We want to use it differently later anyway (see CRM_Contact_BAO_Relationship::getRelationship). NONE should make it hidden by default.

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -262,6 +262,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           'qs' => "reset=1&cid=%%id%%{$searchContext}{$extraParams}",
           'title' => ts('View Contact Details'),
           'ref' => 'view-contact',
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
@@ -270,6 +271,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           'qs' => "reset=1&action=update&cid=%%id%%{$searchContext}{$extraParams}",
           'title' => ts('Edit Contact Details'),
           'ref' => 'edit-contact',
+          'weight' => -10,
         ],
       ];
 
@@ -777,6 +779,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
               'qs' => 'reset=1&cid=%%id%%',
               'class' => 'no-popup',
               'title' => ts('View Contact Details'),
+              'weight' => -20,
             ],
             [
               'name' => ts('Restore'),
@@ -791,6 +794,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
               'url' => 'civicrm/contact/view/delete',
               'qs' => 'reset=1&cid=%%id%%&skip_undelete=1',
               'title' => ts('Permanently Delete Contact'),
+              'weight' => 100,
             ];
           }
           $row['action'] = CRM_Core_Action::formLink(
@@ -952,6 +956,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             'qs' => 'reset=1&cid=%%id%%',
             'class' => 'no-popup',
             'title' => ts('View Contact Details'),
+            'weight' => -20,
           ],
           [
             'name' => ts('Restore'),
@@ -966,6 +971,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             'url' => 'civicrm/contact/view/delete',
             'qs' => 'reset=1&cid=%%id%%&skip_undelete=1',
             'title' => ts('Permanently Delete Contact'),
+            'weight' => 100,
           ];
         }
         $row['action'] = CRM_Core_Action::formLink(

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -405,6 +405,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
         'url' => 'civicrm/contact/view/contribution',
         'qs' => 'reset=1&id=%%contributionid%%&cid=%%contactId%%&action=view&context=contribution&selectedChild=contribute',
         'title' => ts('View related contribution'),
+        'weight' => -20,
       ],
     ];
 

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -55,6 +55,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'title' => ts('View Recurring Payment'),
         'url' => 'civicrm/contact/view/contributionrecur',
         'qs' => "reset=1&id=%%crid%%&cid=%%cid%%&context={$context}",
+        'weight' => -20,
       ],
     ];
 

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -139,6 +139,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'title' => ts('Cancel'),
         // Only display on-site links in a popup.
         'class' => (stripos($url, 'http') !== FALSE) ? 'no-popup' : '',
+        'weight' => -50,
       ];
     }
 
@@ -152,6 +153,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'url' => $url,
         // Only display on-site links in a popup.
         'class' => (stripos($url, 'http') !== FALSE) ? 'no-popup' : '',
+        'weight' => -15,
       ];
     }
 
@@ -166,6 +168,7 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
         'url' => $url,
         // Only display on-site links in a popup.
         'class' => (stripos($url, 'http') !== FALSE) ? 'no-popup' : '',
+        'weight' => -10,
       ];
     }
     return $links;

--- a/CRM/Custom/Page/Option.php
+++ b/CRM/Custom/Page/Option.php
@@ -68,22 +68,26 @@ class CRM_Custom_Page_Option extends CRM_Core_Page {
           'url' => 'civicrm/admin/custom/group/field/option',
           'qs' => 'action=view&id=%%id%%&fid=%%fid%%',
           'title' => ts('View Multiple Choice Option'),
+          'weight' => -20,
         ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Disable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Disable Multiple Choice Option'),
+          'weight' => 40,
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Enable'),
           'ref' => 'crm-enable-disable',
           'title' => ts('Enable Multiple Choice Option'),
+          'weight' => 30,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/admin/custom/group/field/option',
           'qs' => 'action=delete&id=%%id%%&fid=%%fid%%',
           'title' => ts('Delete Multiple Choice Option'),
+          'weight' => 100,
         ],
       ];
     }

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -215,18 +215,21 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
           'url' => 'civicrm/contact/view/participant',
           'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=view&context=%%cxt%%&selectedChild=event' . $extraParams,
           'title' => ts('View Participation'),
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/contact/view/participant',
           'qs' => 'reset=1&action=update&id=%%id%%&cid=%%cid%%&context=%%cxt%%' . $extraParams,
           'title' => ts('Edit Participation'),
+          'weight' => -10,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/contact/view/participant',
           'qs' => 'reset=1&action=delete&id=%%id%%&cid=%%cid%%&context=%%cxt%%' . $extraParams,
           'title' => ts('Delete Participation'),
+          'weight' => 100,
         ],
       ];
     }

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -243,6 +243,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
         'url' => 'civicrm/contribute/unsubscribe',
         'qs' => 'reset=1&mid=%%id%%&context=%%cxt%%' . $extraParams,
         'title' => ts('Cancel Auto Renew Subscription'),
+        'weight' => 40,
       ];
     }
     elseif (isset(self::$_links['all'][CRM_Core_Action::DISABLE])) {

--- a/CRM/Member/Selector/Search.php
+++ b/CRM/Member/Selector/Search.php
@@ -195,6 +195,7 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
           'url' => 'civicrm/contact/view/membership',
           'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=view&context=%%cxt%%&selectedChild=member' . $extraParams,
           'title' => ts('View Membership'),
+          'weight' => -20,
         ],
       ];
     }
@@ -205,12 +206,14 @@ class CRM_Member_Selector_Search extends CRM_Core_Selector_Base implements CRM_C
           'url' => 'civicrm/contact/view/membership',
           'qs' => 'reset=1&action=update&id=%%id%%&cid=%%cid%%&context=%%cxt%%' . $extraParams,
           'title' => ts('Edit Membership'),
+          'weight' => -10,
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/contact/view/membership',
           'qs' => 'reset=1&action=delete&id=%%id%%&cid=%%cid%%&context=%%cxt%%' . $extraParams,
           'title' => ts('Delete Membership'),
+          'weight' => 100,
         ],
         CRM_Core_Action::RENEW => [
           'name' => ts('Renew'),

--- a/ext/civigrant/CRM/Grant/Selector/Search.php
+++ b/ext/civigrant/CRM/Grant/Selector/Search.php
@@ -174,12 +174,14 @@ class CRM_Grant_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
           'url' => 'civicrm/contact/view/grant',
           'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=view&context=%%cxt%%&selectedChild=grant' . $extraParams,
           'title' => ts('View Grant'),
+          'weight' => -20,
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/contact/view/grant',
           'qs' => 'reset=1&action=update&id=%%id%%&cid=%%cid%%&context=%%cxt%%' . $extraParams,
           'title' => ts('Edit Grant'),
+          'weight' => -10,
         ],
       ];
 
@@ -190,6 +192,7 @@ class CRM_Grant_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
             'url' => 'civicrm/contact/view/grant',
             'qs' => 'action=delete&reset=1&cid=%%cid%%&id=%%id%%&selectedChild=grant' . $extraParams,
             'title' => ts('Delete Grant'),
+            'weight' => 100,
           ],
         ];
         self::$_links = self::$_links + $delLink;

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -34,7 +34,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'receipt_from_name' => 'Pachamama',
       'is_email_receipt' => TRUE,
     ]);
-    $this->_contributionPageID = $contributionPage['id'];
+    $this->_contributionPageID = $this->ids['ContributionPage'][0] = $contributionPage['id'];
   }
 
   public function tearDown(): void {

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -119,7 +119,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testIPNPaymentRecurSuccess(): void {
-    $this->setupRecurringPaymentProcessorTransaction([], ['total_amount' => '15.00', 'contribution_page_id' => $this->_contributionPageID]);
+    $this->setupRecurringPaymentProcessorTransaction([], ['total_amount' => '15.00', 'contribution_page_id' => $this->ids['ContributionPage'][0] ?? NULL]);
     $mut = new CiviMailUtils($this, TRUE);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
     $paypalIPN->main();

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -21,7 +21,6 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
   protected $_financialTypeID = 1;
   protected $_contactID;
   protected $_contributionRecurID;
-  protected $_contributionPageID;
   protected $_paymentProcessorID;
 
   /**
@@ -37,7 +36,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'currency' => 'USD',
       'payment_processor' => $this->_paymentProcessorID,
     ]);
-    $this->_contributionPageID = $contributionPage['id'];
+    $this->ids['ContributionPage'][0] = $contributionPage['id'];
   }
 
   /**
@@ -267,7 +266,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       'payment_status' => 'Completed',
       'product_name' => '5 Per 1 month',
       'charset' => 'windows-1252',
-      'rp_invoice_id' => 'i=xyz&m=&c=&r=&b=&p=' . $this->_contributionPageID,
+      'rp_invoice_id' => 'i=xyz&m=&c=&r=&b=&p=' . $this->ids['ContributionPage'][0],
       'recurring_payment_id' => 'I-3EEUC094KYQW',
       'address_zip' => '90210',
       'first_name' => 'Alanna',
@@ -392,7 +391,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
       . '&m=&c=' . $this->_contributionID
       . '&r=' . $this->_contributionRecurID
       . '&b=' . $this->_contactID
-      . '&p=' . $this->_contributionPageID,
+      . '&p=' . $this->ids['ContributionPage'][0],
       'currency_code' => 'GBP',
       'time_created' => '12:39:01 May 09, 2018 PDT',
       'verify_sign' => 'AUg223oCjn4HgJXKkrICawXQ3fyUA2gAd1.f1IPJ4r.9sln-nWcB-EJG',

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -220,7 +220,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
 
     $row = $this->csv->fetchOne();
     $expected = [
-      'Contact ID' => $this->contactIDs[0],
+      'Contact ID' => $membership['contact_id'],
       'Contact Type' => 'Individual',
       'Contact Subtype' => '',
       'Do Not Email' => '',
@@ -427,7 +427,6 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $this->contactMembershipCreate(['contact_id' => $this->contactIDs[0]]);
 
     $this->_contactID = $this->contactIDs[0];
-    $this->_contributionPageID = NULL;
     $this->_paymentProcessorID = $this->paymentProcessorCreate();
     $this->setupMembershipRecurringPaymentProcessorTransaction();
 
@@ -495,7 +494,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
     $params['is_primary'] = 0;
     $params['location_type_id'] = 'Work';
     $this->callAPISuccess('address', 'create', $params);
-    $this->contactIDs[] = $contactB = $this->individualCreate();
+    $this->contactIDs[] = $contactB = $this->individualCreate([], 1);
 
     $this->callAPISuccess('address', 'create', [
       'contact_id' => $contactB,
@@ -2988,12 +2987,12 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
         'Home-email' => 'home@example.com',
       ],
       [
-        'first_name' => 'Anthony',
-        'last_name' => 'Anderson',
+        'first_name' => 'Joe',
+        'last_name' => 'Miller',
         'Home-street_address' => '',
         'Home-city' => '',
         'Home-country' => '',
-        'Home-email' => 'anthony_anderson@civicrm.org',
+        'Home-email' => 'joe_miller@civicrm.org',
       ],
     ], $result);
   }

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -18,23 +18,20 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
 
   /**
    * Test results from getRows.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testSelectorGetRows(): void {
-    $this->_contactID = $this->individualCreate();
-    $this->_contributionPageID = NULL;
+    $contactID = $this->individualCreate();
     $this->_paymentProcessorID = $this->paymentProcessorCreate();
     $this->setupMembershipRecurringPaymentProcessorTransaction();
-    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_contactID]);
-    $membershipID = $membership['id'];
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $contactID]);
+    $membershipID = (int) $membership['id'];
     $params = [];
     $selector = new CRM_Member_Selector_Search($params);
     $rows = $selector->getRows(CRM_Core_Permission::VIEW, 0, 25, NULL);
     $this->assertEquals([
-      'contact_id' => $this->_contactID,
+      'contact_id' => $contactID,
       'membership_id' => $membershipID,
-      'contact_type' => '<a href="/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $this->_contactID . '" data-tooltip-url="/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=' . $this->_contactID . '&amp;snippet=4&amp;is_show_email_task=1" class="crm-summary-link"><i class="crm-i fa-fw fa-user" title=""></i></a>',
+      'contact_type' => '<a href="/index.php?q=civicrm/contact/view&amp;reset=1&amp;cid=' . $contactID . '" data-tooltip-url="/index.php?q=civicrm/profile/view&amp;reset=1&amp;gid=7&amp;id=' . $contactID . '&amp;snippet=4&amp;is_show_email_task=1" class="crm-summary-link"><i class="crm-i fa-fw fa-user" title=""></i></a>',
       'sort_name' => 'Anderson, Anthony',
       'membership_type' => 'General',
       'membership_join_date' => date('Y-m-d'),
@@ -48,7 +45,7 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
       'campaign' => NULL,
       'campaign_id' => NULL,
       'checkbox' => 'mark_x_1',
-      'action' => '<span><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;id=1&amp;cid=' . $this->_contactID . '&amp;action=view&amp;context=search&amp;selectedChild=member&amp;compContext=membership" class="action-item crm-hover-button" title=\'View Membership\' >View</a><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=update&amp;id=' . $membershipID . '&amp;cid=' . $this->_contactID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Edit Membership\' >Edit</a></span><span class=\'btn-slide crm-hover-button\'>Renew...<ul class=\'panel\'><li><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=delete&amp;id=' . $membershipID . '&amp;cid=' . $this->_contactID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button small-popup" title=\'Delete Membership\' >Delete</a></li><li><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=renew&amp;id=' . $membershipID . '&amp;cid=' . $this->_contactID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Renew Membership\' >Renew</a></li><li><a href="/index.php?q=civicrm/contribute/unsubscribe&amp;reset=1&amp;mid=' . $membershipID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Cancel Auto Renew Subscription\' >Cancel Auto-renewal</a></li></ul></span>',
+      'action' => '<span><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;id=1&amp;cid=' . $this->ids['Contact']['individual_0'] . '&amp;action=view&amp;context=search&amp;selectedChild=member&amp;compContext=membership" class="action-item crm-hover-button" title=\'View Membership\' >View</a><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=update&amp;id=' . $membershipID . '&amp;cid=' . $this->ids['Contact']['individual_0'] . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Edit Membership\' >Edit</a></span><span class=\'btn-slide crm-hover-button\'>Renew...<ul class=\'panel\'><li><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=renew&amp;id=' . $membershipID . '&amp;cid=' . $this->ids['Contact']['individual_0'] . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Renew Membership\' >Renew</a></li><li><a href="/index.php?q=civicrm/contribute/unsubscribe&amp;reset=1&amp;mid=' . $membershipID . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button" title=\'Cancel Auto Renew Subscription\' >Cancel Auto-renewal</a></li><li><a href="/index.php?q=civicrm/contact/view/membership&amp;reset=1&amp;action=delete&amp;id=' . $membershipID . '&amp;cid=' . $this->ids['Contact']['individual_0'] . '&amp;context=search&amp;compContext=membership" class="action-item crm-hover-button small-popup" title=\'Delete Membership\' >Delete</a></li></ul></span>',
       'auto_renew' => 1,
     ], $rows[0]);
     $this->assertCount(1, $rows);

--- a/tests/phpunit/CRMTraits/Financial/OrderTrait.php
+++ b/tests/phpunit/CRMTraits/Financial/OrderTrait.php
@@ -48,7 +48,7 @@ trait CRMTraits_Financial_OrderTrait {
       'financial_type_id' => 'Donation',
       'source' => 'Online Contribution: form payment',
       'contact_id' => $this->_contactID,
-      'contribution_page_id' => $this->_contributionPageID,
+      'contribution_page_id' => $this->ids['ContributionPage'][0] ?? NULL,
       'payment_processor_id' => $this->_paymentProcessorID,
       'is_test' => 0,
       'receive_date' => '2019-07-25 07:34:23',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2299,8 +2299,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'total_amount' => '200',
       'invoice_id' => 'xyz',
       'financial_type_id' => 'Donation',
-      'contact_id' => $this->_contactID,
-      'contribution_page_id' => $this->_contributionPageID,
+      'contact_id' => $this->ids['Contact']['individual_0'],
+      'contribution_page_id' => $this->ids['ContributionPage'][0] ?? NULL,
       'payment_processor_id' => $this->_paymentProcessorID,
       'receive_date' => '2019-07-25 07:34:23',
       'skipCleanMoney' => TRUE,
@@ -2309,7 +2309,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'source' => 'Online Contribution: Page name',
     ], $contributionParams);
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
-      'contact_id' => $this->_contactID,
+      'contact_id' => $this->ids['Contact']['individual_0'],
       'amount' => 1000,
       'sequential' => 1,
       'installments' => 5,
@@ -2319,7 +2319,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'invoice_id' => $contributionParams['invoice_id'],
       'payment_processor_id' => $this->_paymentProcessorID,
       // processor provided ID - use contact ID as proxy.
-      'processor_id' => $this->_contactID,
+      'processor_id' => $this->ids['Contact']['individual_0'],
       'api.Order.create' => $contributionParams,
     ], $recurParams))['values'][0];
     $this->_contributionRecurID = $contributionRecur['id'];
@@ -2349,7 +2349,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     //create a contribution so our membership & contribution don't both have id = 1
     if ($this->callAPISuccess('Contribution', 'getcount', []) === 0) {
       $this->contributionCreate([
-        'contact_id' => $this->_contactID,
+        'contact_id' => $this->ids['Contact']['individual_0'],
         'is_test' => 1,
         'financial_type_id' => 1,
         'invoice_id' => 'abcd',
@@ -2372,7 +2372,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
             ],
           ],
           'params' => [
-            'contact_id' => $this->_contactID,
+            'contact_id' => $this->ids['Contact']['individual_0'],
             'membership_type_id' => $this->ids['membership_type'],
             'source' => 'Payment',
           ],


### PR DESCRIPTION
Overview
----------------------------------------
This builds on https://github.com/civicrm/civicrm-core/pull/26233 by adding some weights to core menu items. The added weights are well spread out to allow people to add between them. This does not cover all of them - it's abit tedious so I'll do some more once merged

I have been trying to consistently assign the following values to links that appear near the beginning & end respectively

- `CRM_Core_Action::VIEW` -20 
- `CRM_Core_Action::UPDATE`  -10
- `CRM_Core_Action::ENABLE` 30
- `CRM_Core_Action::DISABLE` 40
- `CRM_Core_Action::DELETE` 100

Before
----------------------------------------
No weights

After
----------------------------------------
some

Technical Details
----------------------------------------

Comments
----------------------------------------
Docs https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/hooks/hook_civicrm_links.md