### PR TITLE
Let unset weights give an e-notice

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -315,7 +315,7 @@ class CRM_Core_Action {
     $url = [];
 
     usort($seqLinks, static function ($a, $b) {
-      return (int) ((int) ($a['weight'] ?? 0) > (int) ($b['weight'] ?? 0));
+      return (int) ((int) ($a['weight']) > (int) ($b['weight']));
     });
 
     foreach ($seqLinks as $i => $link) {


### PR DESCRIPTION
Overview
----------------------------------------
Let unset weights give an e-notice

Before
----------------------------------------
`weight` should now be set on links - but where it isn't it is invisible

After
----------------------------------------
missing weights will show an e-notice. This will not show on properly configured production sites (with `error_level` set appropriately in php settings ) but will show on most dev sites

Technical Details
----------------------------------------

Comments
----------------------------------------
