### PR TITLE
Fix invoice being sent instead of receipt if contribution 'is_pay_later' is true

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}
+{if '{contribution.contribution_status_id:name}' === 'Pending'}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}

--- a/xml/templates/message_templates/membership_online_receipt_subject.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_subject.tpl
@@ -1,1 +1,1 @@
-{if $is_pay_later}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}
+{if '{contribution.contribution_status_id:name}' === 'Pending'}{ts}Invoice{/ts}{else}{ts}Receipt{/ts}{/if} - {$title} - {contact.display_name}


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to #26207

This changes the messagetemplate to use a more sensible variable to decide if subject should be receipt or invoice.

Before
----------------------------------------
Invoice sent twice

After
----------------------------------------
Invoice sent if contribution not "Completed". Receipt sent if contribution = "Completed".

Technical Details
----------------------------------------
See #26207 for discussion / more detail.

Comments
----------------------------------------
@eileenmcnaughton 
