### PR TITLE
(dev/core#4294) Fix mailto links that get converted to traceable urls

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -494,7 +494,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing implements \Civi\C
 
     $patterns = [];
 
-    $protos = '(https?|ftp|mailto)';
+    $protos = '(https?|ftp)';
     $letters = '\w';
     $gunk = '\{\}/#~:.?+=&;%@!\,\-\|\(\)\*';
     $punc = '.:?\-';


### PR DESCRIPTION
Overview
----------------------------------------
mailto links also get converted to trackable urls causing issues. Let's avoid doing that.