### PR TITLE
Remove form rule for Contribution Page and Event titles preventing /

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -234,10 +234,6 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
   public static function formRule($values, $files, $self) {
     $errors = [];
     $contributionPageId = $self->_id;
-    //CRM-4286
-    if (strstr($values['title'], '/')) {
-      $errors['title'] = ts("Please do not use '/' in Title");
-    }
 
     // ensure on-behalf-of profile meets minimum requirements
     if (!empty($values['is_organization'])) {

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -208,11 +208,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
       $errors[$validateDates['key']] = $validateDates['message'];
     }
 
-    //CRM-4286
-    if (strstr($values['title'], '/')) {
-      $errors['title'] = ts("Please do not use '/' in Event Title.");
-    }
-
     return $errors;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[Past issue.](https://issues.civicrm.org/jira/browse/CRM-4286?page=com.atlassian.streams.streams-jira-plugin:activity-stream-issue-tab)
Looks like Paypal has updated their systems in the last 14 years. I tested with Paypal Payments Standard and had no issue with a `/` or even an emoji.

Before
----------------------------------------
Form rule prevents `/` in title.

After
----------------------------------------
No more rule.

Comments
----------------------------------------
My goal was to remove the weird `Please use only alphanumeric, spaces, hyphens and dashes for event names.` description text, which I will do in another broader PR cleaning up descriptions on these forms, but then I dug into why that text was there and found this old issue.