### PR TITLE
APIv4 - Fix html encoding of rich-text fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -155,6 +155,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField);
 
     CRM_Utils_System::flushCache();
+    CRM_Utils_API_HTMLInputCoder::singleton()->flushCache();
     // Flush caches is not aggressive about clearing the specific cache we know we want to clear
     // so do it manually. Ideally we wouldn't need to clear others...
     Civi::cache('metadata')->clear();
@@ -232,6 +233,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
     }
 
     CRM_Utils_System::flushCache();
+    CRM_Utils_API_HTMLInputCoder::singleton()->flushCache();
     Civi::cache('metadata')->clear();
 
     foreach ($customFields as $index => $customField) {
@@ -2060,6 +2062,7 @@ WHERE  id IN ( %1, %2 )
     $add->save();
 
     CRM_Utils_System::flushCache();
+    CRM_Utils_API_HTMLInputCoder::singleton()->flushCache();
   }
 
   /**

--- a/CRM/Utils/API/AbstractFieldCoder.php
+++ b/CRM/Utils/API/AbstractFieldCoder.php
@@ -27,7 +27,7 @@ abstract class CRM_Utils_API_AbstractFieldCoder implements API_Wrapper {
   /**
    * Get skipped fields.
    *
-   * @return array<string>
+   * @return string[]
    *   List of field names
    */
   public function getSkipFields() {

--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -22,6 +22,9 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
+  /**
+   * @var string[]
+   */
   private $skipFields = NULL;
 
   /**
@@ -40,13 +43,20 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
   }
 
   /**
+   * @return void
+   */
+  public function flushCache(): void {
+    $this->skipFields = NULL;
+  }
+
+  /**
    * Get skipped fields.
    *
-   * @return array<string>
+   * @return string[]
    *   list of field names
    */
   public function getSkipFields() {
-    if ($this->skipFields === NULL) {
+    if (!isset($this->skipFields)) {
       $this->skipFields = [
         'widget_code',
         'html_message',
@@ -118,9 +128,13 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         // Survey entity
         'instructions',
       ];
-      $custom = CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_custom_field WHERE html_type = "RichTextEditor"');
+      $custom = CRM_Core_DAO::executeQuery('
+        SELECT cf.id, cf.name AS field_name, cg.name AS group_name
+        FROM civicrm_custom_field cf, civicrm_custom_group cg
+        WHERE cf.custom_group_id = cg.id AND cf.data_type = "Memo"');
       while ($custom->fetch()) {
         $this->skipFields[] = 'custom_' . $custom->id;
+        $this->skipFields[] = $custom->group_name . '.' . $custom->field_name;
       }
     }
     return $this->skipFields;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the same bug in APIv4 that was fixed for v3 in #12841
See https://chat.civicrm.org/civicrm/pl/oc55t77c3iyetehua71zwbqi5y

Before
----------------------------------------
Rich text custom fields do not display correctly if saved via APIv4.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
In ece8de2d2 this was fixed but only for APIv3, and with no unit test. The previous fix also did not cover fields using "TextArea" as their input type, even though they are allowed to store HTML.
This fixes APIv4 and v3 and adds a test for both.
