### PR TITLE
Import help text gone missing

### DIFF
--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -73,7 +73,7 @@
       {if array_key_exists('onDuplicate', $form)}
         <tr class="crm-import-uploadfile-from-block-onDuplicate">
           <td class="label">{$form.onDuplicate.label}</td>
-          <td>{$form.onDuplicate.html} {help id="id-onDuplicate"}</td>
+          <td>{$form.onDuplicate.html} {help id="dupes"}</td>
         </tr>
       {/if}
       {if array_key_exists('dedupe_rule_id', $form)}


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
1. Go to contact import.
2. Click on the help icon for the update/fill radio field.
3. Very uninformative empty help box when you click on the help, although I suppose it makes it easy to translate...

After
----------------------------------------
Better

Technical Details
----------------------------------------
Went missing in https://github.com/civicrm/civicrm-core/commit/3bdb54e6ebcabd4ba6aa17356e4c86a084186e0f

Comments
----------------------------------------

