### PR TITLE
Fix token boolean filter to work with money & use in templates

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -120,15 +120,11 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       return $row->customToken($entity, \CRM_Core_BAO_CustomField::getKeyID($field), $this->getFieldValue($row, 'id'));
     }
     if ($this->isMoneyField($field)) {
-      $currency = $this->getCurrency($row);
+      $currency = $this->getCurrency($row) ?: \Civi::settings()->get('defaultCurrency');
       if (empty($fieldValue) && !is_numeric($fieldValue)) {
         $fieldValue = 0;
       }
-      if (!$currency) {
-        // too hard basket for now - just do what we always did.
-        return $row->format('text/plain')->tokens($entity, $field,
-          \CRM_Utils_Money::format($fieldValue, $currency));
-      }
+
       return $row->format('text/plain')->tokens($entity, $field,
         Money::of($fieldValue, $currency));
 

--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -479,11 +479,15 @@ class TokenProcessor {
         case 'crmMoney':
           return \Civi::format()->money($value->getAmount(), $value->getCurrency());
 
+        case 'boolean':
+          // We resolve boolean to 0 or 1 or smarty chokes on FALSE.
+          return (int) $value->getAmount()->isGreaterThan(0);
+
         case 'raw':
           return $value->getAmount();
 
         default:
-          throw new \CRM_Core_Exception("Invalid token filter: " . json_encode($filter, JSON_UNESCAPED_SLASHES));
+          throw new \CRM_Core_Exception('Invalid token filter: ' . json_encode($filter, JSON_UNESCAPED_SLASHES));
       }
     }
 

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -96,7 +96,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
       '{participant.register_date}' => 'February 19th, 2007',
       '{participant.source}' => 'Wimbeldon',
       '{participant.fee_level}' => 'low',
-      '{participant.fee_amount}' => '$ 0.00',
+      '{participant.fee_amount}' => '$0.00',
       '{participant.registered_by_id}' => NULL,
       '{participant.transferred_to_contact_id}' => NULL,
       '{participant.role_id:label}' => 'Attendee',

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -476,6 +476,24 @@ contribution_recur.payment_instrument_id:name :Check
   }
 
   /**
+   * Test balance token works can be rendered as raw & boolean.
+   *
+   * This is a stand in for money tokens in general but as a pseudo-field
+   * it has some added charm.
+   */
+  public function testContributionBalanceToken(): void {
+    $contributionID = $this->contributionCreate(['contact_id' => $this->individualCreate(), 'contribution_status_id' => 'Pending']);
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $contributionID,
+      'total_amount' => 1,
+    ]);
+    $text = $this->renderText(['contributionId' => $contributionID],
+      '{contribution.balance_amount} {contribution.balance_amount|raw} {contribution.balance_amount|boolean} {contribution.tax_amount|boolean}'
+    );
+    $this->assertEquals('$99.00 99.00 1 0', $text);
+  }
+
+  /**
    * Test that membership tokens are consistently rendered.
    *
    * @throws \CRM_Core_Exception

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -63,7 +63,7 @@
            <th>{ts}Item{/ts}</th>
            <th>{ts}Qty{/ts}</th>
            <th>{ts}Each{/ts}</th>
-           {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+           {if $isShowTax && {contribution.tax_amount|boolean}}
              <th>{ts}Subtotal{/ts}</th>
              <th>{ts}Tax Rate{/ts}</th>
              <th>{ts}Tax Amount{/ts}</th>
@@ -81,7 +81,7 @@
             <td>
              {$line.unit_price|crmMoney:'{contribution.currency}'}
             </td>
-            {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+            {if $isShowTax && {contribution.tax_amount|boolean}}
               <td>
                 {$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'}
               </td>
@@ -107,7 +107,7 @@
        </tr>
 
      {/if}
-     {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+     {if $isShowTax && {contribution.tax_amount|boolean}}
        <tr>
          <td {$labelStyle}>
            {ts} Amount before Tax : {/ts}

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -17,21 +17,21 @@
 {capture assign=ts_item}{ts}Item{/ts}{/capture}
 {capture assign=ts_qty}{ts}Qty{/ts}{/capture}
 {capture assign=ts_each}{ts}Each{/ts}{/capture}
-{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+{if $isShowTax && {contribution.tax_amount|boolean}}
 {capture assign=ts_subtotal}{ts}Subtotal{/ts}{/capture}
 {capture assign=ts_taxRate}{ts}Tax Rate{/ts}{/capture}
 {capture assign=ts_taxAmount}{ts}Tax Amount{/ts}{/capture}
 {/if}
 {capture assign=ts_total}{ts}Total{/ts}{/capture}
-{$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
+{$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
 ----------------------------------------------------------
 {foreach from=$lineItems item=line}
-{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}{$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""} {$line.tax_rate|string_format:"%.2f"} %   {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"} {else}                  {/if} {/if}   {$line.line_total+$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}
+{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}}{$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""} {$line.tax_rate|string_format:"%.2f"} %   {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"} {else}                  {/if} {/if}   {$line.line_total+$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}
 {/foreach}
 {/if}
 
 
-{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+{if $isShowTax && {contribution.tax_amount|boolean}}
 {ts}Amount before Tax{/ts} : {$formValues.total_amount-$totalTaxAmount|crmMoney:$currency}
 {/if}
 {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -33,7 +33,7 @@
   </tr>
 </table>
 <table style="width:100%; max-width:500px; border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse;">
-  {if '{contribution.total_amount|raw}' !== '0.00'}
+  {if {contribution.total_amount|boolean}}
     <tr>
       <th {$headerStyle}>
         {ts}Contribution Information{/ts}
@@ -48,7 +48,7 @@
               <th>{ts}Item{/ts}</th>
               <th>{ts}Qty{/ts}</th>
               <th>{ts}Each{/ts}</th>
-              {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+              {if $isShowTax && {contribution.tax_amount|boolean}}
                 <th>{ts}Subtotal{/ts}</th>
                 <th>{ts}Tax Rate{/ts}</th>
                 <th>{ts}Tax Amount{/ts}</th>
@@ -60,7 +60,7 @@
                 <td>{$line.title}</td>
                 <td>{$line.qty}</td>
                 <td>{$line.unit_price|crmMoney:$currency}</td>
-                {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+                {if $isShowTax && {contribution.tax_amount|boolean}}
                   <td>{$line.unit_price*$line.qty|crmMoney:$currency}</td>
                   {if $line.tax_rate || $line.tax_amount != ""}
                     <td>{$line.tax_rate|string_format:"%.2f"}%</td>
@@ -79,7 +79,7 @@
         </td>
       </tr>
 
-      {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+      {if $isShowTax && {contribution.tax_amount|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts} Amount before Tax : {/ts}
@@ -116,7 +116,7 @@
         </td>
       </tr>
     {else}
-      {if '{contribution.tax_amount|raw}' !== '0.00'}
+      {if {contribution.tax_amount|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}Total Tax Amount{/ts}

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -9,7 +9,7 @@
 ===========================================================
 {/if}
 
-{if '{contribution.total_amount|raw}' !== '0.00'}
+{if {contribution.total_amount|boolean}}
 ===========================================================
 {ts}Contribution Information{/ts}
 
@@ -20,19 +20,19 @@
 {capture assign=ts_item}{ts}Item{/ts}{/capture}
 {capture assign=ts_qty}{ts}Qty{/ts}{/capture}
 {capture assign=ts_each}{ts}Each{/ts}{/capture}
-{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+{if $isShowTax && {contribution.tax_amount|boolean}}
 {capture assign=ts_subtotal}{ts}Subtotal{/ts}{/capture}
 {capture assign=ts_taxRate}{ts}Tax Rate{/ts}{/capture}
 {capture assign=ts_taxAmount}{ts}Tax Amount{/ts}{/capture}
 {/if}
 {capture assign=ts_total}{ts}Total{/ts}{/capture}
-{$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
+{$ts_item|string_format:"%-30s"} {$ts_qty|string_format:"%5s"} {$ts_each|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate} {$ts_taxAmount|string_format:"%10s"} {/if} {$ts_total|string_format:"%10s"}
 ----------------------------------------------------------
 {foreach from=$lineItems item=line}
-{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
+{capture assign=ts_item}{$line.title}{/capture}{$ts_item|truncate:30:"..."|string_format:"%-30s"} {$line.qty|string_format:"%5s"} {$line.unit_price|crmMoney:$currency|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}}{$line.unit_price*$line.qty|crmMoney:$currency|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:$currency|string_format:"%10s"} {else}                  {/if}  {/if} {$line.line_total+$line.tax_amount|crmMoney:$currency|string_format:"%10s"}
 {/foreach}
 
-{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+{if $isShowTax && {contribution.tax_amount|boolean}}
 {ts}Amount before Tax:{/ts} {$amount-$totalTaxAmount|crmMoney:$currency}
   {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
     {if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if} : {$taxDetail.amount|crmMoney:'{contribution.currency}'}

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -67,7 +67,7 @@
                 </td>
               </tr>
             {/if}
-            {if '{contribution.total_amount|raw}' !== '0.00'}
+            {if {contribution.total_amount|boolean}}
               <tr>
                 <th {$headerStyle}>
                   {ts}Membership Fee{/ts}
@@ -91,7 +91,7 @@
                         <tr>
                           <th>{ts}Item{/ts}</th>
                           <th>{ts}Fee{/ts}</th>
-                          {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+                          {if $isShowTax && {contribution.tax_amount|boolean}}
                             <th>{ts}SubTotal{/ts}</th>
                             <th>{ts}Tax Rate{/ts}</th>
                             <th>{ts}Tax Amount{/ts}</th>
@@ -106,7 +106,7 @@
                             <td>
                               {$line.line_total|crmMoney}
                             </td>
-                            {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+                            {if $isShowTax && {contribution.tax_amount|boolean}}
                               <td>
                                 {$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'}
                               </td>
@@ -137,7 +137,7 @@
                     </td>
                   </tr>
 
-                {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+                {if $isShowTax && {contribution.tax_amount|boolean}}
                   <tr>
                     <td {$labelStyle}>
                         {ts}Amount Before Tax:{/ts}
@@ -154,7 +154,7 @@
                   {/foreach}
                 {/if}
               {/if}
-              {if '{contribution.tax_amount|raw}' !== '0.00'}
+              {if {contribution.tax_amount|boolean}}
                 <tr>
                   <td {$labelStyle}>
                     {ts}Total Tax Amount{/ts}

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -17,7 +17,7 @@
 {ts}Membership Expiration Date{/ts}: {membership.end_date|crmDate:"Full"}
 {/if}
 
-{if '{contribution.total_amount|raw}' !== '0.00'}
+{if {contribution.total_amount|boolean}}
 ===========================================================
 {ts}Membership Fee{/ts}
 
@@ -28,7 +28,7 @@
 {if $isShowLineItems}
 {capture assign=ts_item}{ts}Item{/ts}{/capture}
 {capture assign=ts_total}{ts}Fee{/ts}{/capture}
-{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+{if $isShowTax && '{contribution.tax_amount|boolean}'}
 {capture assign=ts_subtotal}{ts}Subtotal{/ts}{/capture}
 {capture assign=ts_taxRate}{ts}Tax Rate{/ts}{/capture}
 {capture assign=ts_taxAmount}{ts}Tax Amount{/ts}{/capture}
@@ -36,14 +36,14 @@
 {/if}
 {capture assign=ts_start_date}{ts}Membership Start Date{/ts}{/capture}
 {capture assign=ts_end_date}{ts}Membership Expiration Date{/ts}{/capture}
-{$ts_item|string_format:"%-30s"} {$ts_total|string_format:"%10s"} {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate|string_format:"%10s"} {$ts_taxAmount|string_format:"%10s"} {$ts_total|string_format:"%10s"} {/if} {$ts_start_date|string_format:"%20s"} {$ts_end_date|string_format:"%20s"}
+{$ts_item|string_format:"%-30s"} {$ts_total|string_format:"%10s"} {if $isShowTax && {contribution.tax_amount|boolean}} {$ts_subtotal|string_format:"%10s"} {$ts_taxRate|string_format:"%10s"} {$ts_taxAmount|string_format:"%10s"} {$ts_total|string_format:"%10s"} {/if} {$ts_start_date|string_format:"%20s"} {$ts_end_date|string_format:"%20s"}
 --------------------------------------------------------------------------------------------------
 
 {foreach from=$lineItems item=line}
-{line.title} {$line.line_total|crmMoney|string_format:"%10s"}  {if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'} {$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}  {else}                  {/if}   {$line.line_total+$line.tax_amount|crmMoney|string_format:"%10s"} {/if} {$line.membership.start_date|string_format:"%20s"} {$line.membership.end_date|string_format:"%20s"}
+{line.title} {$line.line_total|crmMoney|string_format:"%10s"}  {if $isShowTax && {contribution.tax_amount|boolean}} {$line.unit_price*$line.qty|crmMoney:'{contribution.currency}'|string_format:"%10s"} {if $line.tax_rate || $line.tax_amount != ""}  {$line.tax_rate|string_format:"%.2f"} %  {$line.tax_amount|crmMoney:'{contribution.currency}'|string_format:"%10s"}  {else}                  {/if}   {$line.line_total+$line.tax_amount|crmMoney|string_format:"%10s"} {/if} {$line.membership.start_date|string_format:"%20s"} {$line.membership.end_date|string_format:"%20s"}
 {/foreach}
 
-{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
+{if $isShowTax && {contribution.tax_amount|boolean}}
 {ts}Amount before Tax:{/ts} {contribution.tax_exclusive_amount}
 
 {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
@@ -53,7 +53,7 @@
 --------------------------------------------------------------------------------------------------
 {/if}
 
-{if '{contribution.tax_amount|raw}' !== '0.00'}
+{if {contribution.tax_amount|boolean}}
 {ts}Total Tax Amount{/ts}: {contribution.tax_amount}
 {/if}
 


### PR DESCRIPTION


Overview
----------------------------------------
Fix token boolean filter to work with money & use in templates

Before
----------------------------------------
Templates need to use this construct

```
{if $isShowTax && '{contribution.tax_amount|raw}' !== '0.00'}
```

After
----------------------------------------
```
{if $isShowTax && {contribution.tax_amount|boolean}}
```

Technical Details
----------------------------------------
The |raw comparison is quite confusing because it compares to 0.00 & we need quotes. We are otherwise using the |boolean increasingly so there is some consistency there.

Comments
----------------------------------------
Note that a bunch of the changed templates are in tests & I feel pretty sure all the templates have test cover on this

I won't do any pro-active template updates here 
