### PR TITLE
dev/core#3961 - Modify psr-0 namespaces of component extensions to match core

### DIFF
--- a/ext/civi_campaign/civi_campaign.civix.php
+++ b/ext/civi_campaign/civi_campaign.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviCampaign_ExtensionUtil {
+class CRM_Campaign_ExtensionUtil {
   const SHORT_NAME = 'civi_campaign';
   const LONG_NAME = 'civi_campaign';
-  const CLASS_PREFIX = 'CRM_CiviCampaign';
+  const CLASS_PREFIX = 'CRM_Campaign';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviCampaign_ExtensionUtil {
 
 }
 
-use CRM_CiviCampaign_ExtensionUtil as E;
+use CRM_Campaign_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_campaign/civi_campaign.php
+++ b/ext/civi_campaign/civi_campaign.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_campaign.civix.php';
-// phpcs:disable
-use CRM_CiviCampaign_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviCampaign</namespace>
+    <namespace>CRM/Campaign</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviCampaign</angularModule>
+    <angularModule>civiCampaign</angularModule>
   </civix>
 </extension>

--- a/ext/civi_case/civi_case.civix.php
+++ b/ext/civi_case/civi_case.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviCase_ExtensionUtil {
+class CRM_Case_ExtensionUtil {
   const SHORT_NAME = 'civi_case';
   const LONG_NAME = 'civi_case';
-  const CLASS_PREFIX = 'CRM_CiviCase';
+  const CLASS_PREFIX = 'CRM_Case';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviCase_ExtensionUtil {
 
 }
 
-use CRM_CiviCase_ExtensionUtil as E;
+use CRM_Case_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_case.civix.php';
-// phpcs:disable
-use CRM_CiviCase_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviCase</namespace>
+    <namespace>CRM/Case</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviCase</angularModule>
+    <angularModule>civiCase</angularModule>
   </civix>
 </extension>

--- a/ext/civi_contribute/civi_contribute.civix.php
+++ b/ext/civi_contribute/civi_contribute.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviContribute_ExtensionUtil {
+class CRM_Contribute_ExtensionUtil {
   const SHORT_NAME = 'civi_contribute';
   const LONG_NAME = 'civi_contribute';
-  const CLASS_PREFIX = 'CRM_CiviContribute';
+  const CLASS_PREFIX = 'CRM_Contribute';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviContribute_ExtensionUtil {
 
 }
 
-use CRM_CiviContribute_ExtensionUtil as E;
+use CRM_Contribute_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_contribute/civi_contribute.php
+++ b/ext/civi_contribute/civi_contribute.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_contribute.civix.php';
-// phpcs:disable
-use CRM_CiviContribute_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviContribute</namespace>
+    <namespace>CRM/Contribute</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviContribute</angularModule>
+    <angularModule>civiContribute</angularModule>
   </civix>
 </extension>

--- a/ext/civi_event/civi_event.civix.php
+++ b/ext/civi_event/civi_event.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviEvent_ExtensionUtil {
+class CRM_Event_ExtensionUtil {
   const SHORT_NAME = 'civi_event';
   const LONG_NAME = 'civi_event';
-  const CLASS_PREFIX = 'CRM_CiviEvent';
+  const CLASS_PREFIX = 'CRM_Event';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviEvent_ExtensionUtil {
 
 }
 
-use CRM_CiviEvent_ExtensionUtil as E;
+use CRM_Event_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_event/civi_event.php
+++ b/ext/civi_event/civi_event.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_event.civix.php';
-// phpcs:disable
-use CRM_CiviEvent_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviEvent</namespace>
+    <namespace>CRM/Event</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviEvent</angularModule>
+    <angularModule>civiEvent</angularModule>
   </civix>
 </extension>

--- a/ext/civi_mail/civi_mail.civix.php
+++ b/ext/civi_mail/civi_mail.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviMail_ExtensionUtil {
+class CRM_Mailing_ExtensionUtil {
   const SHORT_NAME = 'civi_mail';
   const LONG_NAME = 'civi_mail';
-  const CLASS_PREFIX = 'CRM_CiviMail';
+  const CLASS_PREFIX = 'CRM_Mailing';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviMail_ExtensionUtil {
 
 }
 
-use CRM_CiviMail_ExtensionUtil as E;
+use CRM_Mailing_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_mail/civi_mail.php
+++ b/ext/civi_mail/civi_mail.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_mail.civix.php';
-// phpcs:disable
-use CRM_CiviMail_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviMail</namespace>
+    <namespace>CRM/Mailing</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviMail</angularModule>
+    <angularModule>civiMail</angularModule>
   </civix>
 </extension>

--- a/ext/civi_member/civi_member.civix.php
+++ b/ext/civi_member/civi_member.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviMember_ExtensionUtil {
+class CRM_Member_ExtensionUtil {
   const SHORT_NAME = 'civi_member';
   const LONG_NAME = 'civi_member';
-  const CLASS_PREFIX = 'CRM_CiviMember';
+  const CLASS_PREFIX = 'CRM_Member';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviMember_ExtensionUtil {
 
 }
 
-use CRM_CiviMember_ExtensionUtil as E;
+use CRM_Member_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_member/civi_member.php
+++ b/ext/civi_member/civi_member.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_member.civix.php';
-// phpcs:disable
-use CRM_CiviMember_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviMember</namespace>
+    <namespace>CRM/Member</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviMember</angularModule>
+    <angularModule>civiMember</angularModule>
   </civix>
 </extension>

--- a/ext/civi_pledge/civi_pledge.civix.php
+++ b/ext/civi_pledge/civi_pledge.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviPledge_ExtensionUtil {
+class CRM_Pledge_ExtensionUtil {
   const SHORT_NAME = 'civi_pledge';
   const LONG_NAME = 'civi_pledge';
-  const CLASS_PREFIX = 'CRM_CiviPledge';
+  const CLASS_PREFIX = 'CRM_Pledge';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviPledge_ExtensionUtil {
 
 }
 
-use CRM_CiviPledge_ExtensionUtil as E;
+use CRM_Pledge_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_pledge/civi_pledge.php
+++ b/ext/civi_pledge/civi_pledge.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_pledge.civix.php';
-// phpcs:disable
-use CRM_CiviPledge_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviPledge</namespace>
+    <namespace>CRM/Pledge</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviPledge</angularModule>
+    <angularModule>civiPledge</angularModule>
   </civix>
 </extension>

--- a/ext/civi_report/civi_report.civix.php
+++ b/ext/civi_report/civi_report.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_CiviReport_ExtensionUtil {
+class CRM_Report_ExtensionUtil {
   const SHORT_NAME = 'civi_report';
   const LONG_NAME = 'civi_report';
-  const CLASS_PREFIX = 'CRM_CiviReport';
+  const CLASS_PREFIX = 'CRM_Report';
 
   /**
    * Translate a string using the extension's domain.
@@ -77,7 +77,7 @@ class CRM_CiviReport_ExtensionUtil {
 
 }
 
-use CRM_CiviReport_ExtensionUtil as E;
+use CRM_Report_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().

--- a/ext/civi_report/civi_report.php
+++ b/ext/civi_report/civi_report.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once 'civi_report.civix.php';
-// phpcs:disable
-use CRM_CiviReport_ExtensionUtil as E;
-// phpcs:enable

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -25,8 +25,8 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/CiviReport</namespace>
+    <namespace>CRM/Report</namespace>
     <format>23.02.1</format>
-    <angularModule>crmCiviReport</angularModule>
+    <angularModule>civiReport</angularModule>
   </civix>
 </extension>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a naming conflict between the new stub extensions added in #26036 and the existing Compucorp CiviCase extension by aligning the new extensions with the naming pattern of core components.

Before
----------------------------------------
`Fatal error: Cannot declare class CRM_Civicase_ExtensionUtil, because the name is already in use`

After
----------------------------------------
No error, code is better aligned with existing components.

Technical Details
----------------------------------------
I went ahead and made this change to all the stub extensions, because I like consistency and it might simplify the process of moving CRM_* files into the extensions.