### PR TITLE
Remove unneeded descriptions or replace with help text from Edit Contribution Page & Event

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -145,9 +145,11 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       $this->assign('price', TRUE);
     }
 
-    $this->addField('price_set_id', [
-      'entity' => 'PriceField',
+    $this->addSelect('price_set_id', [
+      'entity' => 'PriceSet',
+      'option_url' => 'civicrm/admin/price',
       'options' => $price,
+      'label' => 'Price Set',
       'onchange' => "showHideAmountBlock( this.value, 'price_set_id' );",
     ]);
 

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.hlp
@@ -1,0 +1,58 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="id-is_monetary-title"}
+  {ts}Execute real-time monetary transactions{/ts}
+{/htxt}
+{htxt id="id-is_monetary"}
+{ts}Uncheck this box if you are using this contribution page for free membership signup ONLY, or to solicit in-kind / non-monetary donations such as furniture, equipment.. etc.{/ts}
+{/htxt}
+
+{htxt id="id-pay_later_receipt-title"}
+  {ts}Pay Later Instructions{/ts}
+{/htxt}
+{htxt id="id-pay_later_receipt"}
+{ts}Instructions added to Confirmation and Thank-you pages, as well as the confirmation email, when the user selects the 'pay later' option (e.g. 'Mail your check to ... within 3 business days.').{/ts}
+{/htxt}
+
+{htxt id="id-is_billing_required-title"}
+  {ts}Billing address required{/ts}
+{/htxt}
+{htxt id="id-is_billing_required"}
+{ts}Check this box to require users who select the pay later option to provide billing name and address.{/ts}
+{/htxt}
+
+{htxt id="id-amount_block_is_active-title"}
+  {ts}Recurring Contributions{/ts}
+{/htxt}
+{htxt id="id-amount_block_is_active"}
+{ts}Uncheck this box if you are using this contribution page for membership signup and renewal only &ndash; and you do NOT want users to select or enter any additional contribution amounts.{/ts}
+{/htxt}
+
+{htxt id="id-is_recur-title"}
+  {ts}Recurring Contributions{/ts}
+{/htxt}
+{htxt id="id-is_recur"}
+{ts}Check this box if you want to give users the option to make recurring contributions. This feature requires that you use a payment processor which supports recurring billing / subscriptions functionality.{/ts} {docURL page="user/contributions/payment-processors"}
+{/htxt}
+
+{htxt id="id-is_pledge_active-title"}
+  {ts}Pledges{/ts}
+{/htxt}
+{htxt id="id-is_pledge_active"}
+{ts}Check this box if you want to give users the option to make a Pledge (a commitment to contribute a fixed amount on a recurring basis).{/ts}
+{/htxt}
+
+{htxt id="id-is_allow_other_amount-title"}
+  {ts}Allow other amounts{/ts}
+{/htxt}
+{htxt id="id-is_allow_other_amount"}
+{ts}Check this box if you want to give users the option to enter their own contribution amount. Your page will then include a text field labeled <strong>Other Amount</strong>.{/ts} {ts}You can also set minimum and maximum amounts that users are allowed to enter.{/ts}
+{/htxt}
+

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -22,18 +22,16 @@
         </div>
     {/if}
     <table class="form-layout-compressed">
-        <tr class="crm-contribution-contributionpage-amount-form-block-is_monetary"><td scope="row" class="label" width="20%">{$form.is_monetary.label}</td>
-          <td>{$form.is_monetary.html}<br />
-          <span class="description">{ts}Uncheck this box if you are using this contribution page for free membership signup ONLY, or to solicit in-kind / non-monetary donations such as furniture, equipment.. etc.{/ts}</span></td>
+        <tr class="crm-contribution-contributionpage-amount-form-block-is_monetary">
+            <td scope="row" class="label" width="20%">{$form.is_monetary.label} {help id="id-is_monetary"}</td>
+            <td>{$form.is_monetary.html}</td>
         </tr>
         <tr class="crm-contribution-contributionpage-amount-form-block-currency"><td scope="row" class="label" width="20%">{$form.currency.label}</td>
-          <td>{$form.currency.html}<br />
-          <span class="description">{ts}Select the currency to be used for contributions submitted from this contribution page.{/ts}</span></td>
+          <td>{$form.currency.html}</td>
         </tr>
         {if $paymentProcessor}
           <tr class="crm-contribution-contributionpage-amount-form-block-payment_processor"><td scope="row" class="label" width="20%">{$form.payment_processor.label}</td>
-            <td>{$form.payment_processor.html}<br />
-            <span class="description">{ts}Select the payment processor to be used for contributions submitted from this contribution page (unless you are soliciting non-monetary / in-kind contributions only).{/ts} {docURL page="user/contributions/payment-processors"}</span></td>
+            <td>{$form.payment_processor.html}</td>
           </tr>
         {/if}
         <tr class="crm-contribution-contributionpage-amount-form-block-is_pay_later"><td scope="row" class="label">{$form.is_pay_later.label}</td>
@@ -43,32 +41,33 @@
         <tr id="payLaterFields" class="crm-contribution-form-block-payLaterFields"><td>&nbsp;</td>
             <td>
             <table class="form-layout">
-                <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_text"><td scope="row" class="label">{$form.pay_later_text.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_text' id=$contributionPageID}{/if}</td>
-                <td>{$form.pay_later_text.html|crmAddClass:big}<br />
-                    <span class="description">{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}</span></td></tr>
-                <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_receipt"><td scope="row" class="label">{$form.pay_later_receipt.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_receipt' id=$contributionPageID}{/if}</td>
-                <td>{$form.pay_later_receipt.html|crmAddClass:big}<br />
-                  <span class="description">{ts}Instructions added to Confirmation and Thank-you pages, as well as the confirmation email, when the user selects the 'pay later' option (e.g. 'Mail your check to ... within 3 business days.').{/ts}</span></td></tr>
-
-                <tr><td scope="row" class="label">{$form.is_billing_required.label}</td>
-                <td>{$form.is_billing_required.html}<br />
-                    <span class="description">{ts}Check this box to require users who select the pay later option to provide billing name and address.{/ts}</span>
-                </td></tr>
+                <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_text">
+                    <td scope="row" class="label">{$form.pay_later_text.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_text' id=$contributionPageID}{/if}</td>
+                    <td>{$form.pay_later_text.html|crmAddClass:big}</td>
+                </tr>
+                <tr class="crm-contribution-contributionpage-amount-form-block-pay_later_receipt">
+                    <td scope="row" class="label">
+                        {$form.pay_later_receipt.label}
+                        <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span>
+                        {help id="id-pay_later_receipt"}
+                        {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='pay_later_receipt' id=$contributionPageID}{/if}
+                    </td>
+                    <td>{$form.pay_later_receipt.html|crmAddClass:big}</td>
+                </tr>
+                <tr>
+                    <td scope="row" class="label">{$form.is_billing_required.label} {help id="id-is_billing_required"}</td>
+                    <td>{$form.is_billing_required.html}</td>
+                </tr>
             </table>
             </td>
         </tr>
         <tr class="crm-contribution-contributionpage-amount-form-block-amount_block_is_active">
-          <td scope="row" class="label">{$form.amount_block_is_active.label}</td>
-          <td>{$form.amount_block_is_active.html}<br />
-          <span class="description">{ts}Uncheck this box if you are using this contribution page for membership signup and renewal only &ndash; and you do NOT want users to select or enter any additional contribution amounts.{/ts}</span></td>
+          <td scope="row" class="label">{$form.amount_block_is_active.label} {help id="id-amount_block_is_active"}</td>
+          <td>{$form.amount_block_is_active.html}</td>
         </tr>
         <tr id="priceSet" class="crm-contribution-contributionpage-amount-form-block-priceSet">
-          <td scope="row" class="label">{$form.price_set_id.label}</td>
-          {if $price eq true}
-             <td>{$form.price_set_id.html}<br /><span class="description">{ts 1=$adminPriceSets}Select a pre-configured Price Set to offer multiple individually priced options for contributions. Otherwise, select &quot;-none-&quot; and enter one or more fixed contribution options in the table below. Create or edit Price Sets <a href='%1'>here</a>.{/ts}</span></td>
-          {else}
-            <td><div class="status message">{ts 1=$adminPriceSets}No Contribution Price Sets have been configured / enabled for your site. Price sets allow you to configure more complex contribution options (e.g. "Contribute $25 more to receive our monthly magazine."). Click <a href='%1'>here</a> if you want to configure price sets for your site.{/ts}</div></td>
-          {/if}
+            <td scope="row" class="label">{$form.price_set_id.label}</td>
+            <td>{$form.price_set_id.html} <br /><span class="description">{ts}Select a Price Set to offer more complex amount options. Otherwise, leave this empty and enter fixed contribution options below.{/ts}</span></td>
         </tr>
     </table>
 
@@ -77,17 +76,15 @@
 
 
   {if $recurringPaymentProcessor}
-        <tr id="recurringContribution" class="crm-contribution-form-block-is_recur"><td scope="row" class="label" width="20%">{$form.is_recur.label}</td>
-               <td>{$form.is_recur.html}<br />
-                  <span class="description">{ts}Check this box if you want to give users the option to make recurring contributions. This feature requires that you use a payment processor which supports recurring billing / subscriptions functionality.{/ts} {docURL page="user/contributions/payment-processors"}</span>
-               </td>
+        <tr id="recurringContribution" class="crm-contribution-form-block-is_recur"><td scope="row" class="label" width="20%">{$form.is_recur.label} {help id="id-is_recur"}</td>
+               <td>{$form.is_recur.html}</td>
         </tr>
         <tr id="recurFields" class="crm-contribution-form-block-recurFields"><td>&nbsp;</td>
                <td>
                   <table class="form-layout-compressed">
-            <tr class="crm-contribution-form-block-recur_frequency_unit"><td scope="row" class="label">{$form.recur_frequency_unit.label}<span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
-                        <td>{$form.recur_frequency_unit.html}<br />
-                        <span class="description">{ts}Select recurring units supported for recurring payments.{/ts}</span></td>
+                    <tr class="crm-contribution-form-block-recur_frequency_unit">
+                        <td scope="row" class="label">{$form.recur_frequency_unit.label} <span class="crm-marker" title="{ts}This field is required.{/ts}">*</span></td>
+                        <td>{$form.recur_frequency_unit.html}</td>
                     </tr>
                     <tr class="crm-contribution-form-block-is_recur_interval"><td scope="row" class="label">{$form.is_recur_interval.label}</td>
                         <td>{$form.is_recur_interval.html}<br />
@@ -106,7 +103,7 @@
     </div>
 {if $futurePaymentProcessor}
     <span id="pledge_calendar_date_field">&nbsp;&nbsp;{$form.pledge_calendar_date.html}</span>
-    <span id="pledge_calendar_month_field">&nbsp;&nbsp;{$form.pledge_calendar_month.html}<br/><span class="description">{ts}Recurring payment will be processed this day of the month following submission of this contribution page.{/ts}</span></span>
+    <span id="pledge_calendar_month_field">&nbsp;&nbsp;{$form.pledge_calendar_month.html}</span>
 {/if}
 
 
@@ -114,16 +111,13 @@
         <table class="form-layout-compressed">
             {* handle CiviPledge fields *}
             {if $civiPledge}
-            <tr class="crm-contribution-form-block-is_pledge_active"><td scope="row" class="label" width="20%">{$form.is_pledge_active.label}</td>
-                <td>{$form.is_pledge_active.html}<br />
-                    <span class="description">{ts}Check this box if you want to give users the option to make a Pledge (a commitment to contribute a fixed amount on a recurring basis).{/ts}</span>
-                </td>
+            <tr class="crm-contribution-form-block-is_pledge_active"><td scope="row" class="label" width="20%">{$form.is_pledge_active.label} {help id="id-is_pledge_active"}</td>
+                <td>{$form.is_pledge_active.html}</td>
             </tr>
             <tr id="pledgeFields" class="crm-contribution-form-block-pledgeFields"><td></td><td>
                 <table class="form-layout-compressed">
                     <tr class="crm-contribution-form-block-pledge_frequency_unit"><td scope="row" class="label">{$form.pledge_frequency_unit.label}<span class="crm-marker"> *</span></td>
-                        <td>{$form.pledge_frequency_unit.html}<br />
-                            <span class="description">{ts}Which frequencies can the user pick from (e.g. every 'week', every 'month', every 'year')?{/ts}</span></td>
+                        <td>{$form.pledge_frequency_unit.html}</td>
                     </tr>
                     <tr class="crm-contribution-form-block-is_pledge_interval"><td scope="row" class="label">{$form.is_pledge_interval.label}</td>
                         <td>{$form.is_pledge_interval.html}<br />
@@ -170,17 +164,17 @@
               <td scope="row" class="label" width="20%">{$form.amount_label.label}<span class="crm-marker"> *</span></td>
         <td>{$form.amount_label.html}</td>
       </tr>
-            <tr class="crm-contribution-form-block-is_allow_other_amount"><td scope="row" class="label" width="20%">{$form.is_allow_other_amount.label}</td>
-            <td>{$form.is_allow_other_amount.html}<br />
-            <span class="description">{ts}Check this box if you want to give users the option to enter their own contribution amount. Your page will then include a text field labeled <strong>Other Amount</strong>.{/ts}</span></td></tr>
+            <tr class="crm-contribution-form-block-is_allow_other_amount">
+                <td scope="row" class="label" width="20%">{$form.is_allow_other_amount.label} {help id="id-is_allow_other_amount"}</td>
+                <td>{$form.is_allow_other_amount.html}</td>
+            </tr>
 
             <tr id="minMaxFields" class="crm-contribution-form-block-minMaxFields"><td>&nbsp;</td><td>
                <table class="form-layout-compressed">
                 <tr class="crm-contribution-form-block-min_amount"><td scope="row" class="label">{$form.min_amount.label}</td>
                 <td>{$form.min_amount.html}</td></tr>
                 <tr class="crm-contribution-form-block-max_amount"><td scope="row" class="label">{$form.max_amount.label}</td>
-                <td>{$form.max_amount.html}<br />
-                <span class="description">{ts 1=5|crmMoney}If you have chosen to <strong>Allow Other Amounts</strong>, you can use the fields above to control minimum and/or maximum acceptable values (e.g. don't allow contribution amounts less than %1).{/ts}</span></td></tr>
+                <td>{$form.max_amount.html}</td></tr>
                </table>
             </td></tr>
 

--- a/templates/CRM/Contribute/Form/ContributionPage/Custom.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Custom.tpl
@@ -15,18 +15,14 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout-compressed">
     <tr class="crm-contribution-contributionpage-custom-form-block-custom_pre_id">
-       <td class="label">{$form.custom_pre_id.label}
-       </td>
+       <td class="label">{$form.custom_pre_id.label}</td>
        <td class="html-adjust">{$form.custom_pre_id.html}
           <span class="description">{ts}Profile to be included above the billing information (but after the introductory message, amounts, and honoree section).{/ts}</span>
           </td>
     </tr>
     <tr class="crm-contribution-contributionpage-custom-form-block-custom_post_id">
-       <td class="label">{$form.custom_post_id.label}
-       </td>
-       <td class="html-adjust">{$form.custom_post_id.html}
-          <span class="description">{ts}Profile to be included at the bottom of the page.{/ts}</span>
-       </td>
+       <td class="label">{$form.custom_post_id.label}</td>
+       <td class="html-adjust">{$form.custom_post_id.html}</td>
     </tr>
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Premium.tpl
@@ -17,9 +17,7 @@
   <table class="form-layout-compressed">
     <tr class="crm-contribution-contributionpage-premium-form-block-premiums_active">
       <td class="label">{$form.premiums_active.label}</td>
-      <td class="html-adjust">{$form.premiums_active.html}<br/>
-        <span class="description">{ts}Is the Premiums section enabled for this Online Contributions page?{/ts}</span>
-      </td>
+      <td class="html-adjust">{$form.premiums_active.html}</td>
     </tr>
   </table>
 

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
@@ -16,6 +16,13 @@
 <p>{ts}NOTE: If you are using this contribution page for membership signup and renewals, the financial type configured in the membership type settings will be used when recording the membership payment. The financial type selected here will only be used if you are also collecting additional contributions (as configured on the Membership Settings page).{/ts}</p>
 {/htxt}
 
+{htxt id="id-for_organization-title"}
+  {ts}On behalf of Label{/ts}
+{/htxt}
+{htxt id="id-for_organization"}
+{ts}Text displayed next to the checkbox on the contribution form.{/ts}
+{/htxt}
+
 {htxt id="id-intro_msg-title"}
   {ts}Intro Content{/ts}
 {/htxt}
@@ -49,6 +56,20 @@
 {/htxt}
 {htxt id="id-honoree_section"}
 {ts}If you want to allow contributors to specify a person whom they are honoring with their gift, check this box. An optional Honoree section will be included in the form. Honoree information is automatically saved and linked with the contribution record.{/ts}
+{/htxt}
+
+{htxt id="id-honor_block_text-title"}
+  {ts}Honoree Introductory Message{/ts}
+{/htxt}
+{htxt id="id-honor_block_text"}
+{ts}Optional explanatory text for the Honoree section (displayed above the Honoree fields).{/ts}
+{/htxt}
+
+{htxt id="id-is_confirm_enabled-title"}
+  {ts}Use a Confirmation Page?{/ts}
+{/htxt}
+{htxt id="id-is_confirm_enabled"}
+{ts}If you disable this contributions will be processed immediately after submitting the contribution form.{/ts}
 {/htxt}
 
 {htxt id="id-is_organization-title"}

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -18,43 +18,40 @@
     {/if}
 </div>
 <div class="crm-block crm-form-block crm-contribution-contributionpage-settings-form-block">
-
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-  <table class="form-layout-compressed">
-  <tr class="crm-contribution-contributionpage-settings-form-block-title"><td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='title' id=$contributionPageID}{/if}</td><td>{$form.title.html}<br/>
-            <span class="description">{ts}This title will be displayed at the top of the page unless the frontend title field is filled out.<br />Please use only alphanumeric, spaces, hyphens and dashes for Title.{/ts}</span></td>
-  </tr>
-  <tr class="crm-contribution-contributionpage-settings-form-block-frontend-title"><td class="label">{$form.contribution_page_frontend_title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='frontend_title' id=$contributionPageID}{/if}</td><td>{$form.contribution_page_frontend_title.html}<br/>
-            <span class="description">{ts}This title will be displayed at the top of the page.<br />Please use only alphanumeric, spaces, hyphens and dashes for Title.{/ts}</span></td>
-  </tr>
-  <tr class="crm-contribution-contributionpage-settings-form-block-financial_type_id"><td class="label">{$form.financial_type_id.label}</td><td>{$form.financial_type_id.html}<br />
-            <span class="description">{ts}Select the corresponding financial type for contributions made using this page.{/ts}</span> {help id="id-financial_type"}</td>
-  </tr>
+    <table class="form-layout-compressed">
+        <tr class="crm-contribution-contributionpage-settings-form-block-title">
+            <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='title' id=$contributionPageID}{/if}</td>
+            <td>{$form.title.html}</td>
+        </tr>
+        <tr class="crm-contribution-contributionpage-settings-form-block-frontend-title">
+            <td class="label">{$form.contribution_page_frontend_title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_contribution_page' field='frontend_title' id=$contributionPageID}{/if}</td>
+            <td>{$form.contribution_page_frontend_title.html}</td>
+        </tr>
+        <tr class="crm-contribution-contributionpage-settings-form-block-financial_type_id">
+            <td class="label">{$form.financial_type_id.label} {help id="id-financial_type"}</td>
+            <td>{$form.financial_type_id.html}</td>
+        </tr>
 
   {* CRM-7362 --add campaign to contribution page *}
   {include file="CRM/Campaign/Form/addCampaignToComponent.tpl"
   campaignTrClass="crm-contribution-contributionpage-settings-form-block-campaign_id"}
 
-  <tr class="crm-contribution-contributionpage-settings-form-block-is_organization"><td>&nbsp;</td><td>{$form.is_organization.html} {$form.is_organization.label} {help id="id-is_organization"}</td></tr>
+  <tr class="crm-contribution-contributionpage-settings-form-block-is_organization">
+      <td>&nbsp;</td>
+      <td>{$form.is_organization.html} {$form.is_organization.label} {help id="id-is_organization"}</td>
+  </tr>
   <tr id="for_org_option" class="crm-contribution-form-block-is_organization">
         <td>&nbsp;</td>
         <td>
             <table class="form-layout-compressed">
-            <tr class="crm-contribution-for_organization_help">
-                <td class="description" colspan="2">
-                    {capture assign="profileURL"}{crmURL p='civicrm/admin/uf/group' q='reset=1'}{/capture}
-                    {ts 1=$profileURL}To change the organization data collected use the "On Behalf Of Organization" profile (<a href="%1">Administer > Customize Data and Screens > Profiles</a>).{/ts}
-                </td>
-            </tr>
             <tr class="crm-contribution-onbehalf_profile_id">
               <td class="label">{$form.onbehalf_profile_id.label}</td>
               <td>{$form.onbehalf_profile_id.html}</td>
             </tr>
             <tr id="for_org_text" class="crm-contribution-contributionpage-settings-form-block-for_organization">
-                <td class="label">{$form.for_organization.label}</td>
-                <td>{$form.for_organization.html}<br />
-                    <span class="description">{ts}Text displayed next to the checkbox on the contribution form.{/ts}</span>
-                </td>
+                <td class="label">{$form.for_organization.label} {help id="id-for_organization"}</td>
+                <td>{$form.for_organization.html}</td>
             </tr>
             <tr class="crm-contribution-contributionpage-settings-form-block-is_for_organization">
                 <td>&nbsp;</td>
@@ -88,47 +85,29 @@
 </table>
 <table class="form-layout-compressed" id="honor">
     <tr class="crm-contribution-contributionpage-settings-form-block-honor_block_title">
-        <td class="label">
-            {$form.honor_block_title.label}
-       </td>
-       <td>
-           {$form.honor_block_title.html}<br />
-           <span class="description">{ts}Title for the Honoree section (e.g. &quot;Honoree Information&quot;).{/ts}</span>
-       </td>
+        <td class="label">{$form.honor_block_title.label}</td>
+       <td>{$form.honor_block_title.html}</td>
    </tr>
    <tr class="crm-contribution-contributionpage-settings-form-block-honor_block_text">
        <td class="label">
            {crmAPI var='result' entity='OptionGroup' action='get' sequential=1 name='soft_credit_type'}
-           {$form.honor_block_text.label}
+           {$form.honor_block_text.label} {help id="id-honor_block_text"}
        </td>
-       <td>
-           {$form.honor_block_text.html}<br />
-           <span class="description">{ts}Optional explanatory text for the Honoree section (displayed above the Honoree fields).{/ts}</span>
-       </td>
+       <td>{$form.honor_block_text.html}</td>
   </tr>
   <tr class="crm-contribution-contributionpage-settings-form-block-honor_soft_credit_types">
-      <td class="label">
-          {$form.soft_credit_types.label}
-      </td>
-      <td>
-        {$form.soft_credit_types.html}
-      </td>
+      <td class="label">{$form.soft_credit_types.label}</td>
+      <td>{$form.soft_credit_types.html}</td>
   </tr>
   <tr class="crm-contribution-contributionpage-custom-form-block-custom_pre_id">
-      <td class="label">
-          {$form.honoree_profile.label}
-      </td>
-      <td class="html-adjust">
-          {$form.honoree_profile.html}
-          <span class="description">{ts}Profile to be included in the honoree section{/ts}</span>
-      </td>
+      <td class="label">{$form.honoree_profile.label}</td>
+      <td class="html-adjust">{$form.honoree_profile.html}</td>
    </tr>
 </table>
 <table class="form-layout-compressed">
         <tr class="crm-contribution-contributionpage-settings-form-block-is_confirm_enabled">
         <td>&nbsp;</td>
-        <td>{$form.is_confirm_enabled.html} {$form.is_confirm_enabled.label}<br />
-        <span class="description">{ts}If you disable this contributions will be processed immediately after submitting the contribution form.{/ts}</span></td>
+        <td>{$form.is_confirm_enabled.html} {$form.is_confirm_enabled.label} {help id="id-is_confirm_enabled"}</td>
       </tr>
         <tr class="crm-contribution-contributionpage-settings-form-block-is_share">
         <td>&nbsp;</td>

--- a/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Widget.tpl
@@ -27,13 +27,22 @@
 
     <div id="widgetFields">
         <table class="form-layout-compressed">
-            <tr class="crm-contribution-contributionpage-widget-form-block-title"><td class="label">{$form.title.label}<span class="crm-marker"> *</span></td><td>{$form.title.html}</td></tr>
-            <tr class="crm-contribution-form-block-url_logo"><td class="label">{$form.url_logo.label}</span></td><td>{$form.url_logo.html}</td></tr>
-            <tr class="crm-contribution-contributionpage-widget-form-block-button_title"><td class="label">{$form.button_title.label}</td><td>{$form.button_title.html}</td></tr>
-            <tr class="crm-contribution-contributionpage-widget-form-block-about"><td class="label">{$form.about.label}<span class="crm-marker"> *</span></td><td>{$form.about.html}
-<br /><span class="description">{ts}Enter content for the about message. You may include HTML formatting tags. You can also include images, as long as they are already uploaded to a server&mdash;reference them using complete URLs.{/ts}</span>
-</td></tr>
-
+            <tr class="crm-contribution-contributionpage-widget-form-block-title">
+                <td class="label">{$form.title.label}<span class="crm-marker"> *</span></td>
+                <td>{$form.title.html}</td>
+            </tr>
+            <tr class="crm-contribution-form-block-url_logo">
+                <td class="label">{$form.url_logo.label}</span></td>
+                <td>{$form.url_logo.html}</td>
+            </tr>
+            <tr class="crm-contribution-contributionpage-widget-form-block-button_title">
+                <td class="label">{$form.button_title.label}</td>
+                <td>{$form.button_title.html}</td>
+            </tr>
+            <tr class="crm-contribution-contributionpage-widget-form-block-about">
+                <td class="label">{$form.about.label}<span class="crm-marker"> *</span></td>
+                <td>{$form.about.html}</td>
+            </tr>
         </table>
 
         <div id="id-get_code">

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -47,9 +47,7 @@
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-title">
       <td class="label">{$form.title.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='title' id=$eventID}{/if}</td>
-      <td>{$form.title.html}<br />
-        <span class="description"> {ts}Please use only alphanumeric, spaces, hyphens and dashes for event names.{/ts}
-      </span></td>
+      <td>{$form.title.html}</td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-summary">
       <td class="label">{$form.summary.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='summary' id=$eventID}{/if}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.hlp
@@ -1,0 +1,22 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="id-pay-later-text-title"}
+  {ts}Pay Later Label{/ts}
+{/htxt}
+{htxt id="id-pay-later-text"}
+{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}
+{/htxt}
+
+{htxt id="id-is-discount-title"}
+  {ts}Discounts by Signup Date?{/ts}
+{/htxt}
+{htxt id="id-is-discount"}
+{ts}Check this box if you want to offer discounted fees based on registration date (e.g. 'early-registration discounts').{/ts}
+{/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -36,9 +36,7 @@
         <table id="currency" class="form-layout">
              <tr class='crm-event-manage-fee-form-block-currency'>
                 <td class="label">{$form.currency.label}</td>
-          <td>{$form.currency.html}<br />
-            <span class="description">{ts}Select the currency to be used for event registration.{/ts}</span>
-          </td>
+          <td>{$form.currency.html}</td>
              </tr>
         </table>
         {if $paymentProcessor}
@@ -67,13 +65,9 @@
 
         <table id="payLaterOptions" class="form-layout">
             <tr class="crm-event-manage-fee-form-block-pay_later_text">
-               <td class="label">{$form.pay_later_text.label}<span class="crm-marker"> *</span> </td>
+               <td class="label">{$form.pay_later_text.label}<span class="crm-marker"> *</span> {help id="id-pay-later-text"}</td>
                <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='pay_later_text' id=$id}{/if}{$form.pay_later_text.html|crmAddClass:big}
                </td>
-            </tr>
-            <tr>
-               <td>&nbsp;</td>
-               <td class="description">{ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}</td>
             </tr>
             <tr class="crm-event-manage-fee-form-block-pay_later_receipt">
                <td class="label">{$form.pay_later_receipt.label}<span class="crm-marker"> *</span> </td>
@@ -154,9 +148,8 @@
     <div id="isDiscount">
          <table class="form-layout">
              <tr class="crm-event-manage-fee-form-block-is_discount">
-                <td class="extra-long-fourty label">{$form.is_discount.html}</td>
-                <td>{$form.is_discount.label}<br /><span class="description">{ts}Check this box if you want to offer discounted fees based on registration date (e.g. 'early-registration discounts').{/ts}</span>
-                </td>
+                <td class="extra-long-fourty label">{$form.is_discount.html} {help id="id-is-discount"}</td>
+                <td>{$form.is_discount.label}</td>
              </tr>
          </table>
     </div>

--- a/templates/CRM/Friend/Form/Friend.tpl
+++ b/templates/CRM/Friend/Form/Friend.tpl
@@ -48,10 +48,7 @@
               {include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_tell_friend' field='intro' id=$friendId}
          {/if}
      </td>
-     <td>{$form.intro.html}<br />
-               <span class="description">{ts 1=$enduser}This message is displayed to the %1 at the top of the Tell a Friend form. You may include HTML tags to add formatting or links.{/ts}
-         </span>
-     </td>
+     <td>{$form.intro.html}</td>
         </tr>
         <tr class="crm-friend-manage-form-block-suggested_message">
      <td class="label">{$form.suggested_message.label}

--- a/templates/CRM/Member/Form/MembershipBlock.hlp
+++ b/templates/CRM/Member/Form/MembershipBlock.hlp
@@ -7,6 +7,14 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+
+{htxt id="id-is-required-title"}
+  {ts}Require Membership Signup{/ts}
+{/htxt}
+{htxt id="id-is-required"}
+{ts}If checked, user must signup for one of the displayed membership options before continuing.{/ts}
+{/htxt}
+
 {htxt id="id-separate-pay-title"}
   {ts}Separate Payment{/ts}
 {/htxt}

--- a/templates/CRM/Member/Form/MembershipBlock.tpl
+++ b/templates/CRM/Member/Form/MembershipBlock.tpl
@@ -16,35 +16,30 @@
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
     <table class="form-layout-compressed">
         <tr class="crm-member-membershipblock-form-block-member_is_active">
-            <td class="label"></td><td class="html-adjust">{$form.member_is_active.html}&nbsp;{$form.member_is_active.label}<br />
-            <span class="description">{ts}Include a Membership Signup section in this Online Contribution page?{/ts}</span></td>
+            <td class="label"></td><td class="html-adjust">{$form.member_is_active.html}&nbsp;{$form.member_is_active.label}</td>
         </tr>
     </table>
     <div id="memberFields">
       <table class="form-layout-compressed">
           <tr class="crm-member-membershipblock-form-block-new_title">
               <td class="label">{$form.new_title.label}
-              {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_membership_block' field='new_title' id=$membershipBlockId}{/if}</td><td>{$form.new_title.html}<br />
-              <span class="description">{ts}Membership section title - for new member signups.{/ts}</span></td>
+              {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_membership_block' field='new_title' id=$membershipBlockId}{/if}</td><td>{$form.new_title.html}</td>
           </tr>
           <tr class="crm-member-membershipblock-form-block-new_text">
               <td class="label">{$form.new_text.label}
               {if $action == 2}<br />{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_membership_block' field='new_text' id=$membershipBlockId}{/if}
               </td>
-              <td>{$form.new_text.html}<br />
-              <span class="description">{ts}Membership section introductory text - for new member signups.{/ts}<br /></span><br /></td>
+              <td>{$form.new_text.html}</td>
           </tr>
           <tr class="crm-member-membershipblock-form-block-renewal_title">
               <td class="label">{$form.renewal_title.label}
-              {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_membership_block' field='renewal_title' id=$membershipBlockId}{/if}</td><td>{$form.renewal_title.html}<br />
-              <span class="description">{ts}Membership section title - displayed to renewing members.{/ts}</span></td>
+              {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_membership_block' field='renewal_title' id=$membershipBlockId}{/if}</td><td>{$form.renewal_title.html}</td>
           </tr>
           <tr class="crm-member-membershipblock-form-block-renewal_text">
               <td class="label">{$form.renewal_text.label}
                 {if $action == 2}<br />{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_membership_block' field='renewal_text' id=$membershipBlockId}{/if}
               </td>
-              <td>{$form.renewal_text.html}<br />
-              <span class="description">{ts}Membership section introductory text - displayed to renewing members.{/ts}</span><br /></td>
+              <td>{$form.renewal_text.html}</td>
           </tr>
         <tr class="crm-member-membershipblock-form-block-member_price_set_id">
               <td class="label">{$form.member_price_set_id.label}</td>
@@ -100,16 +95,14 @@
               </td>
           </tr>
           <tr id="requiredSignup" class="crm-member-membershipblock-form-block-is_required">
-              <td class="label"></td><td class="html-adjust">{$form.is_required.html}&nbsp;{$form.is_required.label}<br />
-              <span class="description">{ts}If checked, user must signup for one of the displayed membership options before continuing.{/ts}</span></td>
+              <td class="label"></td><td class="html-adjust">{$form.is_required.html}&nbsp;{$form.is_required.label} {help id="id-is-required"}</td>
           </tr>
           <tr id="separatePayment" class="crm-member-membershipblock-form-block-is_separate_payment">
               <td class="label"></td><td class="html-adjust">{$form.is_separate_payment.html}&nbsp;{$form.is_separate_payment.label} {help id="id-separate-pay"}<br />
               <span class="description">{ts}Check this box if you are including both Membership Signup/Renewal AND a Contribution Amount section, AND you want the membership fee to be charged separately from any additional contribution amount.{/ts}</span></td>
           </tr>
           <tr id="displayFee" class="crm-member-membershipblock-form-block-display_min_fee">
-              <td class="label"></td><td class="html-adjust">{$form.display_min_fee.html}&nbsp;{$form.display_min_fee.label} {help id="id-display-fee"}<br />
-              <span class="description">{ts}Display the membership fee along with the membership name and description for each membership option?{/ts}</span></td>
+              <td class="label"></td><td class="html-adjust">{$form.display_min_fee.html}&nbsp;{$form.display_min_fee.label} {help id="id-display-fee"}</td>
     </tr>
 
       </table>


### PR DESCRIPTION
Overview
----------------------------------------
The Edit Contribution Page and Edit Event Registration forms are pretty busy and cluttered. Many of the descriptions on those pages are either redundant, basically just putting the field name in a sentence which doesn't add anything, or would be better as help text, so that it can be found if needed, but doesn't overwhelm users with small grey text.

To hopefully make these pages a little easier to use and a little easier on the eyes, I've made a start on this, covering the main tabs on these pages. I will continue in another PR to cover the remaining tabs, and perhaps some other forms, as long as this PR is supported.

Before
----------------------------------------
For example:
<img width="926" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/5405a0af-c263-4ba8-967e-edb6a0eb4767">

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/25517556/21261e84-bec7-4320-bc08-00ff6a29877b)

Technical Details
----------------------------------------
On Contribution Page > Amounts I thought the little wrench icon that you can click to edit an Option Group would make sense to allow editing of Price Sets, since this is pretty similar. I don't think there is an automatic way to do this, so I've done it manually. I think it's better than `Create or edit Price Sets here` with a link.
The help text here should also be the only new translation string required (it needed updating anyways, as select -none- no longer makes sense with a select2).

Comments
----------------------------------------
I tried to clean up the formatting of the tpl files a little as I went, on the leave it better than you found it theory, so this looks like more change than it actually is. Some of this is just making the line breaks and indents for tr and td tags a little more consistent.