### PR TITLE
Stop assigning variables removed from core templates in 2019

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2120,7 +2120,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
     $notSent = [];
     $this->assign('module', 'Event Registration');
     $this->assignEventDetailsToTpl($params['event_id'], CRM_Utils_Array::value('role_id', $params), CRM_Utils_Array::value('receipt_text', $params), $this->_isPaidEvent);
-    $this->assign('isAmountzero', 1);
 
     if ($this->_isPaidEvent) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
@@ -2147,10 +2146,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
 
       $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($params);
       $this->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
-
-      // The concept of contributeMode is deprecated.
-      $this->assign('contributeMode', 'direct');
-      $this->assign('isAmountzero', 0);
       $this->assign('is_pay_later', 0);
       $this->assign('isPrimary', 1);
     }

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -307,7 +307,6 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       $event['confirm_email_text'] = $params['receipt_text'];
     }
 
-    $this->assign('isAmountzero', 1);
     $this->assign('event', $event);
 
     $this->assign('isShowLocation', $event['is_show_location']);

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -443,7 +443,6 @@ class CRM_Financial_BAO_Payment {
       'isShowLocation',
       'location',
       'isRefund',
-      'isAmountzero',
       'refundAmount',
       'totalPaid',
       'paymentsComplete',

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -684,8 +684,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         $this->_params,
         $this->_bltID
       ));
-      $this->assign('contributeMode', 'direct');
-      $this->assign('isAmountzero', 0);
+
       $this->assign('is_pay_later', 0);
       $this->assign('isPrimary', 1);
       if ($this->_mode === 'test') {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1766,6 +1766,11 @@ class CRM_Utils_Token {
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
           'receipt_text_renewal' => 'receipt_text',
+          '$isAmountZero' => 'no longer available / relevant',
+        ],
+        'event_offline_receipt' => [
+          '$contributeMode' => 'no longer available / relevant',
+          '$isAmountZero' => 'no longer available / relevant',
         ],
         'pledge_acknowledgement' => [
           '$domain' => 'no longer available / relevant',


### PR DESCRIPTION

Overview
----------------------------------------
Stop assigning variables removed from core templates in 2019

Before
----------------------------------------
We stopped using these variables in shipped templates 4 years ago & there have been some update prompts for these 2 templates over the last 4 years - but we are still assigning the variables

After
----------------------------------------
We stop assigning them - but add a bit of system check noise if they are still present

Technical Details
----------------------------------------
They were there to control whether billingName showed up - the likely impact on sites which had not touched their templates in the last 4 years is that the Billing Name could disappear off the back office event & membership receipts - which probably wouldn't be noticed even if it happened - but I added to the deprecated tokens to get it noticed.


Comments
----------------------------------------
@seamuslee001 this is follow up on an old change of yours - https://github.com/civicrm/civicrm-core/commit/c6c66ed70bdb125304c395a9655505801145ec3b
