### PR TITLE
Create export mappings without admin perms

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1516,6 +1516,12 @@ class CRM_Core_Permission {
         'access CiviCRM',
       ],
     ];
+    $permissions['mapping'] = [
+      'default' => [
+        'access CiviCRM',
+      ],
+    ];
+    $permissions['mapping_field'] = $permissions['mapping'];
 
     $permissions['saved_search'] = [
       'default' => ['administer CiviCRM data'],

--- a/ang/exportui.ang.php
+++ b/ang/exportui.ang.php
@@ -13,7 +13,6 @@ return [
     'ang/exportui',
   ],
   'basePages' => [],
-  'permissions' => ['administer CiviCRM'],
   'requires' => [
     'crmUi',
     'crmUtil',

--- a/ang/exportui/export.html
+++ b/ang/exportui/export.html
@@ -19,7 +19,7 @@
     <tr>
       <td colspan="6">
         <input class="crm-action-menu fa-plus crm-export-add-field" crm-ui-select="{data: getFields, placeholder: ts('Add field')}" ng-model="new.col" />
-        <span ng-if="data.columns.length && perms.admin">
+        <span ng-if="data.columns.length">
           <button type="button" ng-click="saveMappingDialog()" crm-icon="fa-save">
             {{:: ts('Save Fields') }}
           </button>

--- a/ang/exportui/exportui.js
+++ b/ang/exportui/exportui.js
@@ -24,9 +24,6 @@
         contact_type: '',
         columns: []
       };
-      $scope.perms = {
-        admin: CRM.checkPerm('administer CiviCRM')
-      };
       // For the "add new field" dropdown
       $scope.new = {col: ''};
       var contactTypes = _.transform($scope.contact_types, function (result, type) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2435
Import mappings, and AFAICT export mappings before `ang/exportui`, don't require admin permissions to create. However, the Mapping API required admin permissions, but that's a default that I imagine no one ever changed.

With the advent of `ang/exportui`, one could no longer save an export mapping without admin permissions.  This corrects that.

Note that Coleman created https://github.com/civicrm/civicrm-core/pull/19733 to make the UI match the permission, intentionally sidestepping the permission question. I can't see any reason not to change the permission though.


Before
----------------------------------------
Non-admin users don't have a "Save Fields" button in the Export UI.

After
----------------------------------------
"Save Fields" appears.

Comments
----------------------------------------
My only "real" change is in `CRM/Core/Permissions.php`.  The other files are reverting Colemans' alternate fix.
