### PR TITLE
Remove unused variables from previously-shared function

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -672,7 +672,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if ($this->_membershipBlock) {
       $this->_currentMemberships = [];
 
-      $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
+      $membershipTypeIds = $membershipTypes = [];
       $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember);
 
       $autoRenewMembershipTypeOptions = [];
@@ -745,19 +745,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           elseif ($memType['is_active']) {
 
             if ($allowAutoRenewOpt) {
-              $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
               $isAvailableAutoRenew = $this->_membershipBlock['auto_renew'][$value] ?? 1;
               $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * $isAvailableAutoRenew;
-              $allowAutoRenewMembership = TRUE;
             }
             else {
-              $javascriptMethod = NULL;
               $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = 0;
             }
 
-            //add membership type.
-            $radio[$memType['id']] = NULL;
-            $radioOptAttrs[$memType['id']] = $javascriptMethod;
             if ($cid) {
               $membership = new CRM_Member_DAO_Membership();
               $membership->contact_id = $cid;
@@ -776,8 +770,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
               if ($membership->find(TRUE)) {
                 if (!$membership->end_date) {
-                  unset($radio[$memType['id']]);
-                  unset($radioOptAttrs[$memType['id']]);
                   $this->assign('islifetime', TRUE);
                   continue;
                 }

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -309,7 +309,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     if ($this->_membershipBlock) {
       $this->_currentMemberships = [];
 
-      $membershipTypeIds = $membershipTypes = $radio = $radioOptAttrs = [];
+      $membershipTypeIds = $membershipTypes = [];
       $membershipPriceset = (!empty($this->_priceSetId) && $this->_useForMember);
 
       $autoRenewMembershipTypeOptions = [];
@@ -372,19 +372,14 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
           elseif ($memType['is_active']) {
 
             if ($allowAutoRenewOpt) {
-              $javascriptMethod = ['onclick' => "return showHideAutoRenew( this.value );"];
               $isAvailableAutoRenew = $this->_membershipBlock['auto_renew'][$value] ?? 1;
               $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = (int) $memType['auto_renew'] * $isAvailableAutoRenew;
-              $allowAutoRenewMembership = TRUE;
             }
             else {
-              $javascriptMethod = NULL;
               $autoRenewMembershipTypeOptions["autoRenewMembershipType_{$value}"] = 0;
             }
 
             //add membership type.
-            $radio[$memType['id']] = NULL;
-            $radioOptAttrs[$memType['id']] = $javascriptMethod;
             if ($cid) {
               $membership = new CRM_Member_DAO_Membership();
               $membership->contact_id = $cid;
@@ -403,8 +398,6 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
 
               if ($membership->find(TRUE)) {
                 if (!$membership->end_date) {
-                  unset($radio[$memType['id']]);
-                  unset($radioOptAttrs[$memType['id']]);
                   $this->assign('islifetime', TRUE);
                   continue;
                 }


### PR DESCRIPTION
The `buildMembershipBlock` function was unshared by @mattwire a while ago due to the usual business of cramming all sorts of unshared stuff into a shared function. Per the code comments follow on cleanup was required to get rid of the cruft not relevant to all 3 forms.

In particular a lot of it is only relevant to the Main form - which has the input fields. This removes some variables from the other two


- `$radioOptAttrs` is set & unuset but never used - this makes sense as the point of it is to about adding options to a field on the Main contribution page - which no longer shares this function.
- `$radio` is set & unset but never used

- ` $allowAutoRenewMembership` is set but never used
- ` $javascriptMethod` is set but only used to add to  `$radioOptAttrs`
