### PR TITLE
Get help text title from field label if htxt title is not provided

### DIFF
--- a/CRM/Core/Form/Renderer.php
+++ b/CRM/Core/Form/Renderer.php
@@ -85,6 +85,7 @@ class CRM_Core_Form_Renderer extends HTML_QuickForm_Renderer_ArraySmarty {
     self::updateAttributes($element, $required, $error);
 
     $el = parent::_elementToArray($element, $required, $error);
+    $el['textLabel'] = $element->_label ?? NULL;
 
     // add label html
     if (!empty($el['label'])) {

--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -39,22 +39,21 @@ function smarty_function_help($params, &$smarty) {
   }
 
   $params['file'] = str_replace(['.tpl', '.hlp'], '', $params['file']);
+  $fieldID = str_replace('-', '_', preg_replace('/^id-/', '', $params['id']));
 
   if (empty($params['title'])) {
     $vars = $smarty->get_template_vars();
     $smarty->assign('id', $params['id'] . '-title');
 
-    $name = trim($smarty->fetch($params['file'] . '.hlp'));
-    $extraoutput = '';
+    $name = trim($smarty->fetch($params['file'] . '.hlp')) ?: $vars['form'][$fieldID]['textLabel'] ?? '';
     $additionalTPLFile = $params['file'] . '.extra.hlp';
     if ($smarty->template_exists($additionalTPLFile)) {
-      $extraoutput .= trim($smarty->fetch($additionalTPLFile));
-      // Allow override param to replace default text e.g. {hlp id='foo' override=1}
-      if ($smarty->get_template_vars('override_help_text')) {
-        $name = '';
+      $extraoutput = trim($smarty->fetch($additionalTPLFile));
+      if ($extraoutput) {
+        // Allow override param to replace default text e.g. {hlp id='foo' override=1}
+        $name = ($smarty->get_template_vars('override_help_text') || empty($name)) ? $extraoutput : $name . ' ' . $extraoutput;
       }
     }
-    $name .= $extraoutput;
 
     // Ensure we didn't change any existing vars CRM-11900
     foreach ($vars as $key => $value) {
@@ -64,7 +63,7 @@ function smarty_function_help($params, &$smarty) {
     }
   }
   else {
-    $name = trim(strip_tags($params['title']));
+    $name = trim(strip_tags($params['title'])) ?: $vars['form'][$fieldID]['textLabel'] ?? '';
   }
 
   $class = "helpicon";


### PR DESCRIPTION
Overview
----------------------------------------
This PR is for discussion, not sure the approach makes sense.
The aim is to avoid having to put the help text title for each help text in the .hlp files when the title is usually the field label. This would prevent the field label and help text title from getting out of sync if the field label changes and it makes it faster to add help texts. Question is if this is worthwhile or better just to keep copy-pasting the field names into the titles manually.

After
----------------------------------------
If the help text title is provided, no change.
If the help text title is not provided, the field label is used, providing the htxt id is `id-field_name` or `id-field-name` (both are used).

Bonus
----------------------------------------
Before if an extra.hlp file existed with a non-override title, it was appended without a space like `TitleExtra`. Now it is appended with a space like `Title Extra`, which is how the help text itself works.