### PR TITLE
Enotice fix on frontend_title

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -301,6 +301,8 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       $fieldsToProvide = [
         'id',
         'name',
+        'title',
+        'frontend_title',
         'payment_processor_type_id',
         'user_name',
         'password',
@@ -331,6 +333,8 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
     $processors['values'][0] = [
       'object' => new CRM_Core_Payment_Manual(),
       'id' => 0,
+      'frontend_title' => ts('Pay later'),
+      'title' => ts('Pay later'),
       'payment_processor_type_id' => 0,
       // This shouldn't be required but there are still some processors hacked into core with nasty 'if's.
       'payment_processor_type' => 'Manual',


### PR DESCRIPTION
Overview
----------------------------------------
Enotice fix on frontend_title

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/b8ad6ee9-92ff-47b2-a384-f747760b995b)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/709ed4c7-c086-43e9-8dd9-38bbd0067710)


Technical Details
----------------------------------------
Note there is some caching here so applying the patch might not 'work' without cache clearing

Comments
----------------------------------------
I am not yet sure if 5.61 needs a port but should get to figuring that out once this is merged