### PR TITLE
dev/core#4282 Fix isShowMembershipBlock Regression

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -446,7 +446,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->set('values', $this->_values);
       $this->set('fields', $this->_fields);
     }
-    $this->assign('isShowMembershipQuickConfigBlock', $this->isShowMembershipQuickConfigBlock());
+    $this->assign('isShowMembershipBlock', $this->isShowMembershipBlock());
     $this->set('membershipBlock', $this->getMembershipBlock());
 
     // Handle PCP
@@ -1327,11 +1327,15 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   /**
    * Should the membership block be displayed.
    *
-   * This should be shown when the price set is quick config and is a membership price set.
+   * This should be shown when a membership is available to purchase.
+   *
+   * It could be a quick config price set or a standard price set that extends
+   * CiviMember.
+   *
    * @return bool
    */
-  protected function isShowMembershipQuickConfigBlock(): bool {
-    return CRM_Core_Component::isEnabled('CiviMember') && $this->getMembershipBlock() && $this->isQuickConfig();
+  protected function isShowMembershipBlock(): bool {
+    return CRM_Core_Component::isEnabled('CiviMember') && $this->getMembershipBlock();
   }
 
   /**

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -76,7 +76,7 @@
       <div class="help">{ts}You have a current Lifetime Membership which does not need to be renewed.{/ts}</div>
     {/if}
 
-    {if $isShowMembershipQuickConfigBlock && !$ccid}
+    {if $isShowMembershipBlock && !$ccid}
       <div class="crm-public-form-item crm-section">
         {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl" context="makeContribution"}
       </div>

--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -7,9 +7,9 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $isShowMembershipQuickConfigBlock}
+{if $context EQ "makeContribution"}
   <div id="membership" class="crm-group membership-group">
-    {if $context EQ "makeContribution"}
+
       <div id="priceset">
         <fieldset>
           {if $renewal_mode}
@@ -61,7 +61,7 @@
       <div class="display-block">
         {include file="CRM/Price/Page/LineItem.tpl" context="Membership"}
       </div>
-    {/if}
+
   </div>
 {literal}
   <script type="text/javascript">


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#4282 Fix isShowMembershipBlock Regression

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4282#note_57 in 5.60 users get the option to renew their membership automatically when the membership supports it, regardless of whether they are using a QuickConfig price set or not but in 5.61 this does not appear

After
----------------------------------------
The check box appears - as per 5.60

Technical Details
----------------------------------------
As determined by @konadave & also by myself this
`$isShowMembershipBlock` (equivalent) was always true when memberships were in play in 5.60, quick config or not,  - despite various code comments. I have renamed & assigned it regardless of QuickConfig. Since it is a condition of including the tpl & within it it already checks the context I made the context check the top level check & removed the isShowMembershipBlock check

There is a LOT going on here code-wise - and actually a lot of gitlabs too. I think it would be good to take what I've figured out & do further cleanup in master 

Comments
----------------------------------------
