### PR TITLE
FormBuilder: don't make 'Primary' required

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/AddressCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/AddressCreationSpecProvider.php
@@ -25,6 +25,7 @@ class AddressCreationSpecProvider extends \Civi\Core\Service\AutoService impleme
    */
   public function modifySpec(RequestSpec $spec) {
     $spec->getFieldByName('location_type_id')->setRequired(TRUE);
+    $spec->getFieldByName('is_primary')->setRequired(FALSE);
   }
 
   /**

--- a/Civi/Api4/Service/Spec/Provider/IMCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/IMCreationSpecProvider.php
@@ -18,26 +18,20 @@ use Civi\Api4\Service\Spec\RequestSpec;
  * @service
  * @internal
  */
-class EmailCreationSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+class IMCreationSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
 
   /**
    * @inheritDoc
    */
   public function modifySpec(RequestSpec $spec) {
-    $spec->getFieldByName('email')->setRequired(TRUE);
-    $spec->getFieldByName('on_hold')->setRequired(FALSE);
-    $spec->getFieldByName('is_bulkmail')->setRequired(FALSE);
     $spec->getFieldByName('is_primary')->setRequired(FALSE);
-
-    $defaultLocationType = \CRM_Core_BAO_LocationType::getDefault()->id ?? NULL;
-    $spec->getFieldByName('location_type_id')->setDefaultValue($defaultLocationType);
   }
 
   /**
    * @inheritDoc
    */
   public function applies($entity, $action) {
-    return $entity === 'Email' && $action === 'create';
+    return $entity === 'IM' && $action === 'create';
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/PhoneCreationSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/PhoneCreationSpecProvider.php
@@ -25,6 +25,7 @@ class PhoneCreationSpecProvider extends \Civi\Core\Service\AutoService implement
    */
   public function modifySpec(RequestSpec $spec) {
     $spec->getFieldByName('phone')->setRequired(TRUE);
+    $spec->getFieldByName('is_primary')->setRequired(FALSE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In the FormBuilder blocks for Address, Email, IM and Phone, don't make 'Primary' required, otherwise repeated blocks fail.

Before
----------------------------------------
These FormBuilder blocks bring make 'Is Primary' radios to be required.  When using the 'Multiple' option to add multiple Emails (or other), form validation fails saying Primary is required despite being selected on one entity.

After
----------------------------------------
'Primary' is not required.

Technical Details
----------------------------------------


Comments
----------------------------------------

