### PR TITLE
Resize mailing preview modal

### DIFF
--- a/ang/crmMailing/services.js
+++ b/ang/crmMailing/services.js
@@ -453,6 +453,8 @@
           .then(function (content) {
             var options = CRM.utils.adjustDialogDefaults({
               autoOpen: false,
+              height: '90%',
+              width: '800px',
               title: ts('Subject: %1', {
                 1: content.subject
               })


### PR DESCRIPTION
Before
----------------------------------------
Short and wide, not ideal for mailings, height: auto doesn't seem to work.
![image](https://github.com/civicrm/civicrm-core/assets/25517556/e267e382-3ea2-422f-8a28-b6e0ca5bb548)

After
----------------------------------------
Tall with width of 800px, which should be enough for any mailing.
![image](https://github.com/civicrm/civicrm-core/assets/25517556/5de25aa5-778b-4bab-9bdd-98fd59b1b051)

Technical Details
----------------------------------------
Not sure why height: auto doesn't work here, but I don't see the harm in making the height 90% as I think most mailings are going to fill that. Also tried maxWidth: 800 instead to avoid a fixed width in pixels, but that did not work and also is less than ideal as it would prevent users from resizing wider themselves. If there's a better way though, I'd love to hear it.

Comments
----------------------------------------
I think this is currently only used on A/B tests.