### PR TITLE
Membership Type: allow changing the relationships even if there is data

### DIFF
--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -258,17 +258,12 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $result = civicrm_api3("Membership", "get", ["membership_type_id" => $this->_id, "options" => ["limit" => 1]]);
       $membershipRecords = ($result["count"] > 0);
-      if ($membershipRecords) {
-        $memberRel->freeze();
-      }
     }
 
     $this->assign('membershipRecordsExists', $membershipRecords);
-
-    $this->addFormRule(['CRM_Member_Form_MembershipType', 'formRule']);
-
     $this->assign('membershipTypeId', $this->_id);
     $this->assign('deferredFinancialType', Civi::settings()->get('deferred_revenue_enabled') ? array_keys(CRM_Financial_BAO_FinancialAccount::getDeferredFinancialType()) : NULL);
+    $this->addFormRule(['CRM_Member_Form_MembershipType', 'formRule']);
   }
 
   /**

--- a/templates/CRM/Member/Form/MembershipType.tpl
+++ b/templates/CRM/Member/Form/MembershipType.tpl
@@ -69,13 +69,11 @@
       <tr class="crm-membership-type-form-block-relationship_type_id">
         <td class="label">{$form.relationship_type_id.label}</td>
         <td>
-          {if !$membershipRecordsExists}
-            {$form.relationship_type_id.html}
-            <br />
-            {else}
-            {$form.relationship_type_id.html}<div class="status message">{ts}You cannot modify relationship type because there are membership records associated with this membership type.{/ts}</div>
-          {/if}
+          {$form.relationship_type_id.html}<br />
           <span class="description">{ts}Memberships can be automatically granted to related contacts by selecting a Relationship Type.{/ts} {help id="rel-type" file="CRM/Member/Page/MembershipType.hlp"}</span>
+          {if $membershipRecordsExists}
+            <div class="status message">{ts}There are membership records associated with this membership type. Changing this setting will not automatically update existing memberships (and those that would inherit a membership), which may cause inconsistent results.{/ts}</div>
+          {/if}
         </td>
       </tr>
       <tr id="maxRelated" class="crm-membership-type-form-block-max_related">


### PR DESCRIPTION
Overview
----------------------------------------

Once a Membership Type has memberships, it's not possible to edit the relationships that make it possible to inherit it.

This comes from a 2008 precaution, that perhaps it could lead to data integrity issues: https://issues.civicrm.org/jira/browse/CRM-3228

However, I change this all the time. The impact is really minor (especially compared to some other Membership Type settings), because it does not update existing data (which I think is fine). Either I'm on a dev site, or there is no impact on the existing memberships, or I want to add a new relationship, and the limitation is really annoying.

Considering that changing other settings, such as fixed/rolling, start/end dates, duration, can have similar impacts, I think it should be acceptable for an admin to venture if they want to.

To reproduce:

- Create a Membership Type
- Create a Membership for a Contact
- Then go to edit the Membership Type, to change the relationships

Before
----------------------------------------

Relationships cannot be edited:

![image](https://github.com/civicrm/civicrm-core/assets/254741/4e32ded6-3868-48c7-bf3c-ff5e299c41c4)

After
----------------------------------------

It is now possible to edit relationships, added a scary warning instead:

![image](https://github.com/civicrm/civicrm-core/assets/254741/6e9ccb5c-8c5d-465c-9a40-1a3227e52e4b)

