### PR TITLE
(NFC) CiviEventDispatcher - Update type declaration. Add test demonstion

### DIFF
--- a/Civi/Core/CiviEventDispatcherInterface.php
+++ b/Civi/Core/CiviEventDispatcherInterface.php
@@ -26,10 +26,12 @@ interface CiviEventDispatcherInterface {
    *
    * @param string $eventName The name of the event to dispatch. The name of
    *   the event is the name of the method that is invoked on listeners.
-   * @param Event|null $event The event to pass to the event handlers/listeners
-   *   If not supplied, an empty Event instance is created
-   *
-   * @return Event
+   * @param object|null $event The event to pass to the event handlers/listeners
+   *   The dispatcher accepts any kind of event-object.
+   *   Events defined by CiviCRM-core are usually based on `GenericHookEvent`.
+   *   If $event is a null, then an empty `GenericHookEvent` is created.
+   * @return object
+   *   The final event object.
    */
   public function dispatch($eventName, $event = NULL);
 

--- a/Civi/Core/CiviEventDispatcherInterface.php
+++ b/Civi/Core/CiviEventDispatcherInterface.php
@@ -27,9 +27,22 @@ interface CiviEventDispatcherInterface {
    * @param string $eventName The name of the event to dispatch. The name of
    *   the event is the name of the method that is invoked on listeners.
    * @param object|null $event The event to pass to the event handlers/listeners
-   *   The dispatcher accepts any kind of event-object.
-   *   Events defined by CiviCRM-core are usually based on `GenericHookEvent`.
-   *   If $event is a null, then an empty `GenericHookEvent` is created.
+   *   The dispatcher technically accepts any kind of event-object.
+   *
+   *   CiviCRM typically uses GenericHookEvent. Specifically:
+   *   - For `hook_civicrm_*`, GenericHookEvent is strongly required.
+   *   - For `civi.*`, GenericHookEvent is typical but not strongly required.
+   *
+   *   Symfony also defines classes for event-objects (`Event`, `GenericEvent`).
+   *   Historically, these types -were- mandatory, but they have had poor
+   *   interoperability (across versions/environments). `GenericHookEvent` has
+   *   provided easier interoperability.
+   *
+   *   Looking forward, the current dispatcher does not specifically require any
+   *   single type, and there may be use-cases where libraries or extensions
+   *   define other types. The suitability of this is left as an exercise to the reader.
+   *
+   *   If $event is a null, then an empty placeholder (`GenericHookEvent`) is used.
    * @return object
    *   The final event object.
    */

--- a/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
+++ b/tests/phpunit/Civi/Core/CiviEventDispatcherTest.php
@@ -51,4 +51,20 @@ class CiviEventDispatcherTest extends \CiviUnitTestCase {
     }
   }
 
+  /**
+   * This checks whether Civi's dispatcher can be used as a backend for
+   * routing other event-objects (as in PSR-14).
+   */
+  public function testBasicEventObject(): void {
+    $d = new CiviEventDispatcher(\Civi::container());
+    $count = 0;
+    $d->addListener('testBasicEventObject', function($e) use (&$count) {
+      $this->assertTrue(is_object($e));
+      $count += $e->number;
+    });
+    $d->dispatch('testBasicEventObject', (object) ['number' => 100]);
+    $d->dispatch('testBasicEventObject', (object) ['number' => 200]);
+    $this->assertEquals(300, $count, '100 + 200 = 300.');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

This is a revision of @dontub's #26212. (cc @demeritcowboy)

Before
----------------------------------------

`dispatcher($eventName, $event)` hints that the `$event` is type `Event`.  This does not resolve to a valid class. (`\Civi\Core\Event` does not exist.)

After
----------------------------------------

`dispatcher($eventName, $event)` hints that the `$event` is type `object`.

Technical Details
----------------------------------------

* It already works, as you can see in the unit-test. This is because we've inherited behavior from Symfony 4.4+ (which supports PSR-14). 
* PSR-14 recommends modeling events as [any kind of object](https://www.php-fig.org/psr/psr-14/#events).
* There's currently no need for Civi to specifically have a PSR-14 adapter or integration. But this doesn't hurt us either.
* https://en.wikipedia.org/wiki/Robustness_principle
