### PR TITLE
Standardise casing on ids in WorkflowMessages

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -966,8 +966,8 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'isTest' => (bool) ($form->_action & CRM_Core_Action::PREVIEW),
         'modelProps' => [
-          'contributionId' => $this->getCurrentRowContributionID(),
-          'contactId' => $form->_receiptContactId,
+          'contributionID' => $this->getCurrentRowContributionID(),
+          'contactID' => $form->_receiptContactId,
           'membershipID' => $this->getCurrentRowMembershipID(),
         ],
       ]

--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -21,7 +21,7 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    * @var int
    * @scope tokenContext as contributionId, tplParams as contributionID
    */
-  public $contributionId;
+  public $contributionID;
 
   /**
    * Is the site configured such that tax should be displayed.
@@ -67,9 +67,9 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    * @return \CRM_Financial_BAO_Order|null
    */
   private function getOrder(): ?CRM_Financial_BAO_Order {
-    if (!$this->order && $this->contributionId) {
+    if (!$this->order && $this->contributionID) {
       $this->order = new CRM_Financial_BAO_Order();
-      $this->order->setTemplateContributionID($this->contributionId);
+      $this->order->setTemplateContributionID($this->contributionID);
     }
     return $this->order;
   }
@@ -170,7 +170,7 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
   public function setContribution(array $contribution): self {
     $this->contribution = $contribution;
     if (!empty($contribution['id'])) {
-      $this->contributionId = $contribution['id'];
+      $this->contributionID = $contribution['id'];
     }
     return $this;
   }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2255,7 +2255,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         'modelProps' => [
           'participantID' => $this->_id,
           'eventID' => $params['event_id'],
-          'contributionId' => $this->getContributionID(),
+          'contributionID' => $this->getContributionID(),
         ],
       ];
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -981,8 +981,8 @@ DESC limit 1");
         'isTest' => (bool) ($this->_action & CRM_Core_Action::PREVIEW),
         'modelProps' => [
           'receiptText' => $this->getSubmittedValue('receipt_text'),
-          'contributionId' => $formValues['contribution_id'],
-          'contactId' => $this->_receiptContactId,
+          'contributionID' => $formValues['contribution_id'],
+          'contactID' => $this->_receiptContactId,
           'membershipID' => $this->getMembershipID(),
         ],
       ]

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -703,8 +703,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'modelProps' => [
           'receiptText' => $this->getSubmittedValue('receipt_text'),
-          'contactId' => $this->_receiptContactId,
-          'contributionId' => $this->getContributionID(),
+          'contactID' => $this->_receiptContactId,
+          'contributionID' => $this->getContributionID(),
           'membershipID' => $this->_membershipId,
         ],
       ]

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -21,8 +21,8 @@ use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
 /**
  * Generic base-class for describing the inputs for a workflow email template.
  *
- * @method $this setContactId(int|null $contactId)
- * @method int|null getContactId()
+ * @method $this setContactID(int|null $contactID)
+ * @method int|null getContactID()
  * @method $this setContact(array|null $contact)
  * @method array|null getContact()
  *
@@ -64,10 +64,10 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
    * The contact receiving this message.
    *
    * @var int|null
-   * @scope tokenContext, tplParams as contactID
+   * @scope tokenContext as contactId, tplParams as contactID
    * @fkEntity Contact
    */
-  protected $contactId;
+  protected $contactID;
 
   /**
    * @var array|null
@@ -82,7 +82,7 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
    * @see ReflectiveWorkflowTrait::validate()
    */
   protected function validateExtra_contact(array &$errors) {
-    if (empty($this->contactId) && empty($this->contact['id'])) {
+    if (empty($this->contactID) && empty($this->contact['id'])) {
       $errors[] = [
         'severity' => 'error',
         'fields' => ['contactId', 'contact'],
@@ -90,7 +90,7 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
         'message' => ts('Message template requires one of these fields (%1)', ['contactId, contact']),
       ];
     }
-    if (!empty($this->contactId) && !empty($this->contact)) {
+    if (!empty($this->contactID) && !empty($this->contact)) {
       $errors[] = [
         'severity' => 'warning',
         'fields' => ['contactId', 'contact'],

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -308,7 +308,7 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
 
     $msg = WorkflowMessage::create('case_activity', [
       'modelProps' => [
-        'contactId' => $contact_id,
+        'contactID' => $contact_id,
         'contact' => ['role' => 'Sand grain counter'],
         'isCaseActivity' => 1,
         'clientId' => $client_id,

--- a/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
+++ b/tests/phpunit/Civi/WorkflowMessage/ExampleWorkflowMessageTest.php
@@ -109,7 +109,7 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     /** @var \Civi\WorkflowMessage\WorkflowMessageInterface $ex */
     $ex = static::createExample();
     $ex->import('modelProps', [
-      'contactId' => $this->individualCreate(),
+      'contactID' => $this->individualCreate(),
       'myPublicString' => 'ok',
       'implicitStringArray' => ['single'],
       'myProtectedInt' => 2,
@@ -268,7 +268,7 @@ class ExampleWorkflowMessageTest extends \CiviUnitTestCase {
     $rand = rand(0, 1000);
     $cid = $this->individualCreate(['first_name' => 'Foo', 'last_name' => 'Bar' . $rand, 'prefix_id' => NULL, 'suffix_id' => NULL]);
     /** @var \Civi\WorkflowMessage\GenericWorkflowMessage $ex */
-    $ex = $this->createExample()->setContactId($cid);
+    $ex = $this->createExample()->setContactID($cid);
     \Civi::dispatcher()->addListener('hook_civicrm_alterMailParams', function($e) use (&$hookCount) {
       $hookCount++;
       $this->assertEquals('my_example_wf', $e->params['workflow'], 'ExampleWorkflow::WORKFLOW should propagate to params[workflow]');


### PR DESCRIPTION
bOverview
----------------------------------------
Standardise casing on ids in WorkflowMessages

Before
----------------------------------------
As @seamuslee001 noted the id fields on the Workflow messages have a mix of casing - ie `contributionId` but `eventID`, `participantID`, membershipID`

After
----------------------------------------
They all use consistent casing - ie `contributionID`

Technical Details
----------------------------------------

This resolves the inconsistencies in id fields in the workFlowMessages

My general feeling is this hasn't really been adopted outside of core as yet as it has been so immature so I'm fixing the core uses - these are all heavily tested


Comments
----------------------------------------
I added to the apiv4 changelog - not strictly an apiv4 thing but that is the supported way to call them - worth a release notes callout
https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/api/v4/changes.md