### PR TITLE
Clarify isPrimary, isPaidEvent variables

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -32,7 +32,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
 
   protected $_toDoNotEmail = NULL;
 
-  protected $_contributionId = NULL;
+  protected $contributionID;
 
   protected $fromEmailId = NULL;
 
@@ -58,14 +58,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $this->_eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_participantId, 'event_id');
     $this->_fromEmails = CRM_Event_BAO_Event::getFromEmailIds($this->_eventId);
 
-    $this->_contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $this->_participantId, 'contribution_id', 'participant_id');
-    if (!$this->_contributionId) {
-      if ($primaryParticipantId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Participant', $this->_participantId, 'registered_by_id')) {
-        $this->_contributionId = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $primaryParticipantId, 'contribution_id', 'participant_id');
-      }
-    }
-
-    if ($this->_contributionId) {
+    if ($this->getContributionID()) {
       $this->_isPaidEvent = TRUE;
     }
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, TRUE);
@@ -86,9 +79,9 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $this->assign('paymentInfo', $paymentInfo);
     $this->assign('feePaid', $this->_paidAmount);
 
-    $ids = CRM_Event_BAO_Participant::getParticipantIds($this->_contributionId);
+    $ids = CRM_Event_BAO_Participant::getParticipantIds($this->getContributionID());
     if (count($ids) > 1) {
-      $total = CRM_Price_BAO_LineItem::getLineTotal($this->_contributionId);
+      $total = CRM_Price_BAO_LineItem::getLineTotal($this->getContributionID());
       $this->assign('totalLineTotal', $total);
       $this->assign('lineItemTotal', $total);
     }
@@ -97,6 +90,29 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     if ($title) {
       $this->setTitle($title);
     }
+  }
+
+  /**
+   * Get the contribution ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getContributionID(): ?int {
+    if ($this->contributionID === NULL) {
+      $this->contributionID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment', $this->_participantId, 'contribution_id', 'participant_id') ?: FALSE;
+
+      if (!$this->contributionID) {
+        $primaryParticipantID = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_Participant', $this->_participantId, 'registered_by_id');
+        if ($primaryParticipantID) {
+          $this->contributionID = CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $primaryParticipantID, 'contribution_id', 'participant_id') ?: FALSE;
+        }
+      }
+    }
+    return $this->contributionID ?: NULL;
   }
 
   /**
@@ -231,8 +247,8 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
 
     $feeBlock = $this->_values['fee'];
     $lineItems = $this->_values['line_items'];
-    CRM_Price_BAO_LineItem::changeFeeSelections($params, $this->_participantId, 'participant', $this->_contributionId, $feeBlock, $lineItems);
-    $this->contributionAmt = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $this->_contributionId, 'total_amount');
+    CRM_Price_BAO_LineItem::changeFeeSelections($params, $this->_participantId, 'participant', $this->getContributionID(), $feeBlock, $lineItems);
+    $this->contributionAmt = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $this->getContributionID(), 'total_amount');
     // email sending
     if (!empty($params['send_receipt'])) {
       $fetchParticipantVals = ['id' => $this->_participantId];
@@ -332,11 +348,13 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       }
 
       $this->assign('totalAmount', $this->contributionAmt);
-
-      $this->assign('isPrimary', 1);
       $this->assign('checkNumber', CRM_Utils_Array::value('check_number', $params));
     }
-
+    // @todo isPrimary no longer used from 5.63 in core templates, remove
+    // once users have been 'pushed' to update their templates (via
+    // upgrade message - which we don't always do whenever we change
+    // a minor variable.
+    $this->assign('isPrimary', $this->_isPaidEvent);
     $this->assign('register_date', $params['register_date']);
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email
@@ -356,6 +374,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       'modelProps' => [
         'participantID' => $this->_participantId,
         'eventID' => $params['event_id'],
+        'contributionID' => $this->getContributionID(),
       ],
     ];
 

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -27,15 +27,11 @@
     {/if}
 
     {if !empty($isOnWaitlist)}
-     <p>{ts}You have been added to the WAIT LIST for this event.{/ts}</p>
-     {if !empty($isPrimary)}
-       <p>{ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}</p>
-     {/if}
+      <p>{ts}You have been added to the WAIT LIST for this event.{/ts}</p>
+      <p>{ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}</p>
     {elseif !empty($isRequireApproval)}
-     <p>{ts}Your registration has been submitted.{/ts}</p>
-     {if !empty($isPrimary)}
+      <p>{ts}Your registration has been submitted.{/ts}</p>
       <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
-     {/if}
     {elseif $is_pay_later}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
@@ -141,7 +137,7 @@
      {/if}
 
 
-     {if !empty($event.is_monetary)}
+     {if {event.is_monetary|boolean}}
 
       <tr>
        <th {$headerStyle}>
@@ -152,7 +148,6 @@
       {if !empty($lineItem)}
        {foreach from=$lineItem item=value key=priceset}
         {if $value neq 'skip'}
-         {if !empty($isPrimary)}
           {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
            <tr>
             <td colspan="2" {$labelStyle}>
@@ -160,7 +155,7 @@
             </td>
            </tr>
           {/if}
-         {/if}
+
          <tr>
           <td colspan="2" {$valueStyle}>
            <table>
@@ -262,7 +257,7 @@
         </td>
        </tr>
       {/if}
-      {if !empty($isPrimary)}
+      {if {event.is_monetary|boolean}}
        {if {contribution.balance_amount|boolean}}
          <tr>
            <td {$labelStyle}>{ts}Total Paid{/ts}</td>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -8,10 +8,8 @@
 
 {ts}You have been added to the WAIT LIST for this event.{/ts}
 
-{if !empty($isPrimary)}
 {ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
 
-{/if}
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 
 {elseif !empty($isRequireApproval)}
@@ -19,10 +17,8 @@
 
 {ts}Your registration has been submitted.{/ts}
 
-{if !empty($isPrimary)}
 {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}
 
-{/if}
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 
 {elseif $is_pay_later}
@@ -93,7 +89,7 @@
 {if !empty($lineItem)}{foreach from=$lineItem item=value key=priceset}
 
 {if $value neq 'skip'}
-{if !empty($isPrimary)}
+{if {event.is_monetary|boolean}}
 {if $lineItem|@count GT 1} {* Header for multi participant registration cases. *}
 {ts 1=$priceset+1}Participant %1{/ts}
 {/if}
@@ -143,7 +139,7 @@
 {if $totalTaxAmount}
 {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
 {/if}
-{if !empty($isPrimary)}
+{if {event.is_monetary|boolean}}
 
 {if {contribution.balance_amount|boolean}}{ts}Total Paid{/ts}: {if {contribution.paid_amount|boolean}}{contribution.paid_amount}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 {ts}Balance{/ts}: {contribution.balance_amount}


### PR DESCRIPTION
Overview
----------------------------------------
Clarify isPrimary, isPaidEvent variables

Before
----------------------------------------
The event_offline receipt has big conditionals around the mystery `$isPrimary` variable - the meaning of which is unclear 


On digging through the code I concluded this was largely copy & paste from the online template & in the offline template it actually means 'event is monetary' - it is assigned to the template when event.is_monetary is true. It is also assigned when in credit card mode - but that is only the case when event.is_monetary is true.

Preview is very limited
![image](https://github.com/civicrm/civicrm-core/assets/336308/4327b30a-75bf-4768-8050-1a8ee36f5f68)


After
----------------------------------------
isPrimary assignment is clearly based on event.is_monetary at the form level & within the template is replaces with the token `{event.is_monetary|boolean}`

This makes MORE (but still not all) of the template preview-able

![image](https://github.com/civicrm/civicrm-core/assets/336308/967c84c9-ae43-4809-bd25-94fce0569dc9)


Technical Details
----------------------------------------

Comments
----------------------------------------