### PR TITLE
dev/core#4305 - Fix pluses being turned into spaces in hook_alterAngular

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -14,7 +14,7 @@
       </a>
     </li>
     <li title="{{:: ts('Create a new search based on this one') }}">
-      <a href="#/create/{{:: row.data.api_entity + '?params=' + $ctrl.encode(row.data.api_params) }}">
+      <a ng-href="#/create/{{:: row.data.api_entity + '?params=' + $ctrl.encode(row.data.api_params) }}">
         <i class="crm-i fa-copy"></i>
         {{:: ts('Clone...') }}
       </a>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4305

Before
----------------------------------------
1. Implement hook_alterAngular on a file that contains an href tag where its value is an angular expression using `+`.
2. Even if your hook doesn't change anything, just calling addChangeset breaks the href attribute.

After
----------------------------------------
It still does, but it's now an ng-href which doesn't have the problem, which the angular docs suggest using for other reasons too.

Technical Details
----------------------------------------
See lab ticket. I don't think this is workaroundable in a consistent way in Civi\Angular\Coder so that you could still use regular href.

Comments
----------------------------------------
Has test, sort of.
