### PR TITLE
[REF][PHP8.2] Remove unused entity dynamic property

### DIFF
--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -407,7 +407,6 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
    * Test convert custom saved search
    */
   public function testSmartGroupCustomDateRangeSearch() {
-    $this->entity = 'Contact';
     $this->createCustomGroupWithFieldOfType([], 'date');
     $dateCustomFieldName = $this->getCustomFieldName('date');
     $this->callAPISuccess('SavedSearch', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused entity dynamic property.

Before
----------------------------------------
`CRM_Upgrade_Incremental_BaseTest` was setting `$this->entity = 'Contact';`. `entity` was not declared and so was a dynamic property, deprecated in PHP 8.2.

At one point, `entity` needed to be explicitely set for `createCustomGroup` (in this case called via `createCustomGroupWithFieldOfType`), but these days 'Contact' is a default value.

After
----------------------------------------
Another dynamic property deprecation gone.
