### PR TITLE
[REF][PHP8.2] Remove seemingly unused write to dynamic property

### DIFF
--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -162,7 +162,6 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
   public function testDeleteWithMembershipError(): void {
     $membershipStatusID = $this->membershipStatusCreate();
     $this->_contactID = $this->individualCreate();
-    $this->_entity = 'membership';
     $params = [
       'contact_id' => $this->_contactID,
       'membership_type_id' => $this->_membershipTypeID,


### PR DESCRIPTION
Overview
----------------------------------------
Remove seemingly unused write to dynamic property.

Before
----------------------------------------
`_entity` was being written (`$this->_entity = 'membership';`), but nothing seems to be using it (including drilling down to `callAPISuccess` and `callAPIFailure`.

`_entity` was a dynamic property, so removing this line improves our PHP 8.2 support.

After
----------------------------------------
Another dynamic property gone.