### PR TITLE
[REF][PHP8.2] Only clear cache values if property exists

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CacheTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CacheTest.php
@@ -76,7 +76,9 @@ class CRM_Core_BAO_CacheTest extends CiviUnitTestCase {
     // read is correct.
 
     CRM_Utils_Cache::$_singleton = NULL;
-    $this->a->values = [];
+    if (property_exists($this->a, 'values')) {
+      $this->a->values = [];
+    }
     $return_2 = $this->a->get('testSetGetItem');
     $this->assertEquals($originalValue, $return_2);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Only clear cache values if property exists.

Before
----------------------------------------
A number of cache related tests are failing on PHP 8.2:

<img width="1020" alt="Screenshot 2023-05-21 at 12 00 29" src="https://github.com/civicrm/civicrm-core/assets/1931323/65ee743f-bd1e-4b6f-805f-1ac1d5752ba4">

The test is writing `$this->a->values = [];`, which appears to be a way to reset the cache. Not all cache backends have a `values` property, so this code is needlessly creating dyamic properties.

After
----------------------------------------
`values` is only cleared if it actually exists in the first place.

