### PR TITLE
Continue removing unneeded descriptions etc on Edit Event and Contribution Page

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -149,7 +149,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
       'entity' => 'PriceSet',
       'option_url' => 'civicrm/admin/price',
       'options' => $price,
-      'label' => 'Price Set',
+      'label' => ts('Price Set'),
       'onchange' => "showHideAmountBlock( this.value, 'price_set_id' );",
     ]);
 

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -255,7 +255,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
       $this->addSelect('financial_type_id', ['context' => 'search', 'options' => $financialTypes]);
     }
     // add pay later options
-    $this->addElement('checkbox', 'is_pay_later', ts('Enable Pay Later option?'), NULL,
+    $this->addElement('checkbox', 'is_pay_later', ts('Pay later option'), NULL,
       ['onclick' => "return showHideByValue('is_pay_later','','payLaterOptions','block','radio',false);"]
     );
     $this->addElement('textarea', 'pay_later_text', ts('Pay Later Label'),
@@ -274,9 +274,11 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     else {
       $this->assign('price', TRUE);
     }
-    $this->addField('price_set_id', [
-      'entity' => 'PriceField',
+    $this->addSelect('price_set_id', [
+      'entity' => 'PriceSet',
+      'option_url' => 'civicrm/admin/price',
       'options' => $price,
+      'label' => ts('Price Set'),
       'onchange' => "return showHideByValue('price_set_id', '', 'map-field', 'block', 'select', false);",
     ]);
 

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -170,10 +170,11 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
     else {
       $this->assign('price', TRUE);
     }
-    //$this->add('select', 'member_price_set_id', ts('Membership Price Set'), (['' => ts('- none -')] + $price));
 
-    $this->addField('member_price_set_id', [
-      'entity' => 'PriceField',
+    $this->addSelect('member_price_set_id', [
+      'entity' => 'PriceSet',
+      'option_url' => 'civicrm/admin/price',
+      'label' => ts('Membership Price Set'),
       'name' => 'price_set_id',
       'options' => $price,
     ]);

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -42,7 +42,7 @@
         <td>{$form.record_activity.html}</td>
     </tr>
     <tr id="relativeDateRepeat" class="crm-scheduleReminder-form-block-is_repeat"><td class="label" width="20%">{$form.is_repeat.label}</td>
-        <td>{$form.is_repeat.html}&nbsp;&nbsp;<span class="description">{ts}Enable repetition.{/ts}</span></td>
+        <td>{$form.is_repeat.html}</td>
     </tr>
     <tr id="repeatFields" class="crm-scheduleReminder-form-block-repeatFields"><td></td><td>
         <table class="form-layout-compressed">
@@ -81,7 +81,7 @@
     </tr>
     <tr id="recipientManual" class="crm-scheduleReminder-form-block-recipient_manual_id recipient">
         <td class="label">{$form.recipient_manual_id.label}</td>
-        <td>{$form.recipient_manual_id.html}{edit}<div class="description">{ts}You can manually send out the reminders to these recipients.{/ts}</div>{/edit}</td>
+        <td>{$form.recipient_manual_id.html}</td>
     </tr>
 
     <tr id="recipientGroup" class="crm-scheduleReminder-form-block-recipient_group_id recipient">
@@ -105,8 +105,8 @@
     </tr>
     {/if}
     <tr class="crm-scheduleReminder-form-block-active">
-      <td class="label"></td>
-      <td>{$form.is_active.html}&nbsp;{$form.is_active.label}</td>
+      <td class="label">{$form.is_active.label}</td>
+      <td>{$form.is_active.html}</td>
     </tr>
   </table>
   <fieldset id="email" class="crm-collapsible" style="display: block;">

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -35,7 +35,7 @@
           </tr>
         {/if}
         <tr class="crm-contribution-contributionpage-amount-form-block-is_pay_later"><td scope="row" class="label">{$form.is_pay_later.label}</td>
-          <td>{$form.is_pay_later.html}<br />
+          <td>{$form.is_pay_later.html}
           <span class="description">{ts}Check this box if you want to give users the option to submit payment offline (e.g. mail in a check, call in a credit card, etc.).{/ts}</span></td>
         </tr>
         <tr id="payLaterFields" class="crm-contribution-form-block-payLaterFields"><td>&nbsp;</td>

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -80,7 +80,8 @@
       <td>{$form.end_date.html}</td>
     </tr>
   <tr class="crm-contribution-contributionpage-settings-form-block-honor_block_is_active">
-      <td>&nbsp;</td><td>{$form.honor_block_is_active.html}{$form.honor_block_is_active.label} {help id="id-honoree_section"}</td>
+      <td class ="label">{$form.honor_block_is_active.label} {help id="id-honoree_section"}</td>
+      <td>{$form.honor_block_is_active.html}</td>
   </tr>
 </table>
 <table class="form-layout-compressed" id="honor">

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -89,7 +89,7 @@
     </tr>
     <tr id="id-waitlist-text" class="crm-event-manage-eventinfo-form-block-waitlist_text">
       {if !empty($form.waitlist_text)}
-        <td class="label">{$form.waitlist_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='waitlist_text' id=$eventID}{/if}<br />{help id="id-help-waitlist_text"}</td>
+        <td class="label">{$form.waitlist_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='waitlist_text' id=$eventID} {/if}{help id="id-help-waitlist_text"}</td>
         <td>{$form.waitlist_text.html}</td>
       {/if}
     </tr>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.hlp
@@ -7,6 +7,14 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{htxt id="id-payment_processor-title"}
+  {ts}Payment Processor{/ts}
+{/htxt}
+{htxt id="id-payment_processor-text"}
+ {ts}If this is a paid event and you want users to be able to register and pay online, select a payment processor to use.{/ts}
+{ts}NOTE: Alternatively, you can enable the <strong>Pay Later</strong> feature below without setting up a payment processor. All users will then be asked to submit payment offline (e.g. mail in a check, call in a credit card, etc.).{/ts} {docURL page="user/contributions/payment-processors"}
+{/htxt}
+
 {htxt id="id-pay-later-text-title"}
   {ts}Pay Later Label{/ts}
 {/htxt}
@@ -14,9 +22,23 @@
 {ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}
 {/htxt}
 
+{htxt id="id-is_billing_required-title"}
+  {ts}Billing address required{/ts}
+{/htxt}
+{htxt id="id-is_billing_required"}
+{ts}Check this box to require users who select the pay later option to provide billing name and address.{/ts}
+{/htxt}
+
 {htxt id="id-is-discount-title"}
   {ts}Discounts by Signup Date?{/ts}
 {/htxt}
 {htxt id="id-is-discount"}
+ {ts}This financial type will be assigned to payments made by participants when they register online. If using a price set below note that the contribution record will have this financial type, however line items will be processed using the actual financial type selected for the price set item.{/ts}
+{/htxt}
+
+{htxt id="id-financial_type_id-title"}
+  {ts}Financial Type{/ts}
+{/htxt}
+{htxt id="id-financial_type_id"}
 {ts}Check this box if you want to offer discounted fees based on registration date (e.g. 'early-registration discounts').{/ts}
 {/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -42,49 +42,42 @@
         {if $paymentProcessor}
          <table id="paymentProcessor" class="form-layout">
              <tr class="crm-event-manage-fee-form-block-payment_processor">
-                <td class="label">{$form.payment_processor.label}</td>
+                <td class="label">{$form.payment_processor.label} {help id="id-payment_processor-text"}</td>
               <td>{$form.payment_processor.html}</td>
-             </tr>
-           <tr>
-                <td class="">&nbsp;</td>
-                <td class="description">
-                 {ts}If this is a paid event and you want users to be able to register and pay online, select a payment processor to use.{/ts}
-                 {ts}NOTE: Alternatively, you can enable the <strong>Pay Later</strong> feature below without setting up a payment processor. All users will then be asked to submit payment offline (e.g. mail in a check, call in a credit card, etc.).{/ts} {docURL page="user/contributions/payment-processors"}<td>
              </tr>
          </table>
         {/if}
 
         <table id="payLater" class="form-layout">
             <tr class="crm-event-manage-fee-form-block-is_pay_later">
-               <td class="extra-long-fourty label">{$form.is_pay_later.html}</td>
-               <td>{$form.is_pay_later.label}<br />
+               <td class="label">{$form.is_pay_later.label}</td>
+               <td>{$form.is_pay_later.html}
                   <span class="description">{ts}Check this box if you want to give users the option to submit payment offline (e.g. mail in a check, call in a credit card, etc.).{/ts}</span>
               </td>
             </tr>
-        </table>
-
-        <table id="payLaterOptions" class="form-layout">
-            <tr class="crm-event-manage-fee-form-block-pay_later_text">
-               <td class="label">{$form.pay_later_text.label}<span class="crm-marker"> *</span> {help id="id-pay-later-text"}</td>
-               <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='pay_later_text' id=$id}{/if}{$form.pay_later_text.html|crmAddClass:big}
-               </td>
-            </tr>
-            <tr class="crm-event-manage-fee-form-block-pay_later_receipt">
-               <td class="label">{$form.pay_later_receipt.label}<span class="crm-marker"> *</span> </td>
-               <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='pay_later_receipt' id=$id}{/if}{$form.pay_later_receipt.html|crmAddClass:big}
-               </td>
-            </tr>
             <tr>
-                <td>&nbsp;</td>
-                <td class="description">{ts}Instructions added to Confirmation and Thank-you pages when the user selects the 'pay later' option (e.g. 'Mail your check to ... within 3 business days.').{/ts}
-                </td>
-            </tr>
-            <tr>
-               <td class="extra-long-fourty label">{$form.is_billing_required.html}</td>
-               <td>
-                 {$form.is_billing_required.label}<br />
-                 <span class="description">{ts}Check this box to require users who select the pay later option to provide billing name and address.{/ts}</span>
-               </td>
+              <td>&nbsp;</td>
+              <td>
+                <table id="payLaterOptions" class="form-layout">
+                    <tr class="crm-event-manage-fee-form-block-pay_later_text">
+                       <td class="label">{$form.pay_later_text.label}
+                         <span class="crm-marker"> *</span> {help id="id-pay-later-text"}</td>
+                       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='pay_later_text' id=$id}{/if}
+                         {$form.pay_later_text.html|crmAddClass:big}
+                       </td>
+                    </tr>
+                    <tr class="crm-event-manage-fee-form-block-pay_later_receipt">
+                       <td class="label">{$form.pay_later_receipt.label}<span class="crm-marker"> *</span> </td>
+                       <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='pay_later_receipt' id=$id}{/if}
+                         {$form.pay_later_receipt.html|crmAddClass:big}
+                       </td>
+                    </tr>
+                    <tr>
+                       <td class="label">{$form.is_billing_required.label} {help id="id-is_billing_required"}</td>
+                       <td>{$form.is_billing_required.html}</td>
+                    </tr>
+                </table>
+              </td>
             </tr>
         </table>
 
@@ -95,36 +88,17 @@
                <td>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='fee_label' id=$id}{/if}{$form.fee_label.html}
                </td>
             </tr>
-            <tr>
-               <td>&nbsp;</td>
-               <td class="description">{ts}This label is displayed with the list of event fees. When using a Price Set, this label is the title for the section containing the price fields.{/ts}
-               </td>
-            </tr>
             <tr class="crm-event-manage-fee-form-block-financial_type_id">
-               <td class="label">{$form.financial_type_id.label}<span class="crm-marker"> *</span></td>
+               <td class="label">{$form.financial_type_id.label}<span class="crm-marker"> *</span> {help id="id-financial_type_id"}</td>
                <td>{$form.financial_type_id.html}</td>
-            </tr>
-            <tr>
-               <td>&nbsp;</td>
-               <td class="description">{ts}This financial type will be assigned to payments made by participants when they register online. If using a price set below note that the contribution record will have this financial type, however line items will be processed using the actual financial type selected for the price set item.{/ts}
-               </td>
             </tr>
         </table>
 
       <table id="priceSet" class="form-layout">
             <tr class="crm-event-manage-fee-form-block-price_set_id">
                <td class="label">{$form.price_set_id.label}</td>
-         <td>{if $price eq false}
-            <div class="status message">{ts 1=$adminPriceSets}No Price Set has been configured / enabled for your site. Price sets allow you to meet the complex demands of your event registration structure.(e.g. "Pay $15 more for lunch."). Click <a href='%1'>here</a> if you want to configure price sets for your site.{/ts}</div>
-        {else}
-    {$form.price_set_id.html}
-    </td>
-              </tr>
-              <tr>
-                <td>&nbsp;</td>
-                <td class="description">{ts 1=$adminPriceSets}Select a pre-configured Price Set to offer multiple individually priced options for event registrants. Otherwise, select &quot;-none-&quot; and enter one or more fee levels in the table below. Create or edit Price Sets <a href='%1'>here</a>.{/ts}
-        {/if}
-         </td>
+               <td>{$form.price_set_id.html}
+                 <div class="description">{ts}Select a Price Set to offer multiple individually priced options for event registrants. Otherwise, leave this empty and enter fixed fee levels below.{/ts}</div></td>
             </tr>
       </table>
 
@@ -148,8 +122,8 @@
     <div id="isDiscount">
          <table class="form-layout">
              <tr class="crm-event-manage-fee-form-block-is_discount">
-                <td class="extra-long-fourty label">{$form.is_discount.html} {help id="id-is-discount"}</td>
-                <td>{$form.is_discount.label}</td>
+                <td class="label">{$form.is_discount.label}</td>
+                <td>{$form.is_discount.html} {help id="id-is-discount"}</td>
              </tr>
          </table>
     </div>
@@ -182,7 +156,6 @@
 
         {if $discountSection}
             <fieldset id="map-field"><legend>{ts}Discounted Fees{/ts}</legend>
-            <span class="description">{ts}Use the table below to enter descriptive labels and amounts for up to ten discounted event fees for each discount set. <strong>Don't forget to click 'Save' when you are finished.</strong>{/ts}</span>
       <table id="map-field-table">
             <tr class="columnheader">
          <td scope="column">{ts}Fee Label{/ts}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Registration.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.hlp
@@ -94,3 +94,24 @@
 {htxt id="id-selfcancelxfer_time"}
   {ts}Number of hours prior to event start date to allow self-service cancellation or transfer. Enter a negative number of hours to allow cancellation after the event starts. Enter 0 (or leave empty) to allow cancellation or transfer up until the event has started.{/ts}
 {/htxt}
+
+{htxt id="id-is_email_confirm-title"}
+  {ts}Send Confirmation Email?{/ts}
+{/htxt}
+{htxt id="id-is_email_confirm"}
+  {ts}Do you want a registration confirmation email sent automatically to the user? This email includes event date(s), location and contact information. For paid events, this email is also a receipt for their payment.{/ts}
+{/htxt}
+
+{htxt id="id-cc_confirm-title"}
+  {ts}CC Confirmation To{/ts}
+{/htxt}
+{htxt id="id-cc_confirm"}
+  {ts}You can notify event organizers of each online registration by specifying one or more email addresses to receive a carbon copy (cc). Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).{/ts}
+{/htxt}
+
+{htxt id="id-bcc_confirm-title"}
+  {ts}BCC Confirmation To{/ts}
+{/htxt}
+{htxt id="id-bcc_confirm"}
+  {ts}You may specify one or more email addresses to receive a blind carbon copy (bcc) of the confirmation email. Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).{/ts}
+{/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -8,19 +8,14 @@
  +--------------------------------------------------------------------+
 *}
 {if $addProfileBottomAdd OR $addProfileBottom}
-  <td scope="row" class="label"
-      width="20%">{if $addProfileBottomAdd }{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].label}
+  <td scope="row" class="label" width="20%">
+    {if $addProfileBottomAdd }{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].label}
     {else}{$form.custom_post_id_multiple[$profileBottomNum].label}{/if}</td>
-  <td>{if $addProfileBottomAdd }{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].html}{else}{$form.custom_post_id_multiple[$profileBottomNum].html}{/if}
+  <td>
+    {if $addProfileBottomAdd}{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].html}
+    {else}{$form.custom_post_id_multiple[$profileBottomNum].html}{/if}
     <span class='profile_bottom_link_remove'><a href="#" class="crm-hover-button crm-button-rem-profile" data-addtlPartc="{$addProfileBottomAdd}"><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}remove profile{/ts}</a></span>
     <span class='profile_bottom_link'>&nbsp;<a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile (bottom of page){/ts}</a></span>
-    {if $addProfileBottomAdd }
-      <div
-        class="description">{ts}Change this if you want to use a different profile for additional participants.{/ts}</div>
-    {else}
-      <div
-        class="description">{ts}Include additional fields on this registration form by selecting and configuring a CiviCRM Profile to be included at the bottom of the page.{/ts}</div>
-    {/if}
     <br/><span class="profile-links"></span>
   </td>
 {else}
@@ -38,9 +33,7 @@
   <table class="form-layout">
     <tr class="crm-event-manage-registration-form-block-is_online_registration">
       <td class="label">{$form.is_online_registration.label}</td>
-      <td>{$form.is_online_registration.html}
-        <span class="description">{ts}Online registration enabled?{/ts}</span>
-      </td>
+      <td>{$form.is_online_registration.html}</td>
     </tr>
   </table>
 </div>
@@ -115,31 +108,22 @@
       <tr class="crm-event-manage-registration-form-block-intro_text">
         <td scope="row" class="label"
             width="20%">{$form.intro_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='intro_text' id=$eventID}{/if}</td>
-        <td>{$form.intro_text.html}
-          <div
-            class="description">{ts}Introductory message / instructions for online event registration page (may include HTML formatting tags).{/ts}</div>
-        </td>
+        <td>{$form.intro_text.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-footer_text">
         <td scope="row" class="label"
             width="20%">{$form.footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='footer_text' id=$eventID}{/if}</td>
-        <td>{$form.footer_text.html}
-          <div class="description">{ts}Optional footer text for registration screen.{/ts}</div>
-        </td>
+        <td>{$form.footer_text.html}</td>
       </tr>
     </table>
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-custom_pre_id">
-        <td scope="row" class="label" width="20%">{$form.custom_pre_id.label}</td>
-        <td>{$form.custom_pre_id.html}
-          <div
-            class="description">{ts}Include additional fields on this registration form by selecting and configuring a CiviCRM Profile to be included at the top of the page (immediately after the introductory message).{/ts}{help id="event-profile"}</div>
-        </td>
+        <td scope="row" class="label" width="20%">{$form.custom_pre_id.label} {help id="event-profile"}</td>
+        <td>{$form.custom_pre_id.html}</td>
       </tr>
       <tr id="profile_post" class="crm-event-manage-registration-form-block-custom_post_id">
         <td scope="row" class="label" width="20%">{$form.custom_post_id.label}</td>
         <td>{$form.custom_post_id.html}
-          <div class="description">{ts}Include additional fields on this registration form by selecting and configuring a CiviCRM Profile to be included at the bottom of the page.{/ts}</div>
           <span class='profile_bottom_link_main {if $profilePostMultiple}hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile (bottom of page){/ts}</a></span>
           <br/>
         </td>
@@ -174,17 +158,12 @@
       <tr id="additional_profile_pre" class="crm-event-manage-registration-form-block-additional_custom_pre_id">
         <td scope="row" class="label" width="20%">{$form.additional_custom_pre_id.label}</td>
         <td>{$form.additional_custom_pre_id.html}
-              <div
-                class="description">{ts}Change this if you want to use a different profile for additional participants.{/ts}</div>
-          <br/><span class="profile-links"></span>
+          <span class="profile-links"></span>
         </td>
       </tr>
       <tr id="additional_profile_post" class="crm-event-manage-registration-form-block-additional_custom_post_id">
         <td scope="row" class="label" width="20%">{$form.additional_custom_post_id.label}</td>
         <td>{$form.additional_custom_post_id.html}
-          <div
-            class="description">{ts}Change this if you want to use a different profile for additional participants.{/ts}
-          </div>
           <span class='profile_bottom_add_link_main{if $profilePostMultipleAdd} hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile (bottom of page){/ts}</a></span>
           <br/><span class="profile-links"></span>
         </td>
@@ -237,24 +216,17 @@
         <td scope="row" class="label" width="20%">{$form.confirm_title.label} <span
             class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_title' id=$eventID}{/if}
         </td>
-        <td>{$form.confirm_title.html}<br/>
-                <span
-                  class="description">{ts}Page title for screen where user reviews and confirms their registration information.{/ts}</span>
-        </td>
+        <td>{$form.confirm_title.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-confirm_text">
         <td scope="row" class="label"
             width="20%">{$form.confirm_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_text' id=$eventID}{/if}</td>
-        <td>{$form.confirm_text.html}
-          <div class="description">{ts}Optional instructions / message for Confirmation screen.{/ts}</div>
-        </td>
+        <td>{$form.confirm_text.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-confirm_footer_text">
         <td scope="row" class="label"
             width="20%">{$form.confirm_footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_footer_text' id=$eventID}{/if}</td>
-        <td>{$form.confirm_footer_text.html}
-          <div class="description">{ts}Optional page footer text for Confirmation screen.{/ts}</div>
-        </td>
+        <td>{$form.confirm_footer_text.html}</td>
       </tr>
     </table>
   </div>
@@ -268,25 +240,16 @@
       <td scope="row" class="label" width="20%">{$form.thankyou_title.label} <span
           class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_title' id=$eventID}{/if}
       </td>
-      <td>{$form.thankyou_title.html}
-        <div class="description">{ts}Page title for registration Thank-you screen.{/ts}</div>
-      </td>
+      <td>{$form.thankyou_title.html}</td>
     </tr>
     <tr class="crm-event-manage-registration-form-block-confirm_thankyou_text">
-      <td scope="row" class="label"
-          width="20%">{$form.thankyou_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_text' id=$eventID}{/if}</td>
-      <td>{$form.thankyou_text.html}
-        <div
-          class="description">{ts}Optional message for Thank-you screen (may include HTML formatting).{/ts}</div>
-      </td>
+      <td scope="row" class="label" width="20%">{$form.thankyou_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_text' id=$eventID}{/if}</td>
+      <td>{$form.thankyou_text.html}</td>
     </tr>
     <tr class="crm-event-manage-registration-form-block-confirm_thankyou_footer_text">
       <td scope="row" class="label"
           width="20%">{$form.thankyou_footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_footer_text' id=$eventID}{/if}</td>
-      <td>{$form.thankyou_footer_text.html}
-        <div
-          class="description">{ts}Optional footer text for Thank-you screen (often used to include links to other pages/activities on your site).{/ts}</div>
-      </td>
+      <td>{$form.thankyou_footer_text.html}</td>
     </tr>
   </table>
 </fieldset>
@@ -297,11 +260,8 @@
   <div>
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_email_confirm">
-        <td scope="row" class="label" width="20%">{$form.is_email_confirm.label}</td>
-        <td>{$form.is_email_confirm.html}<br/>
-          <span
-            class="description">{ts}Do you want a registration confirmation email sent automatically to the user? This email includes event date(s), location and contact information. For paid events, this email is also a receipt for their payment.{/ts}</span>
-        </td>
+        <td scope="row" class="label" width="20%">{$form.is_email_confirm.label} {help id="id-is_email_confirm"}</td>
+        <td>{$form.is_email_confirm.html}</td>
       </tr>
     </table>
     <div id="confirmEmail">
@@ -318,30 +278,19 @@
           <td scope="row" class="label" width="20%">{$form.confirm_from_name.label} <span
               class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_from_name' id=$eventID}{/if}
           </td>
-          <td>{$form.confirm_from_name.html}<br/>
-            <span class="description">{ts}FROM name for email.{/ts}</span>
-          </td>
+          <td>{$form.confirm_from_name.html}</td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-confirm_from_email">
           <td scope="row" class="label" width="20%">{$form.confirm_from_email.label} <span class="crm-marker">*</span></td>
-          <td>{$form.confirm_from_email.html}<br/>
-            <span
-              class="description">{ts}FROM email address (this must be a valid email account with your SMTP email service provider).{/ts}</span>
-          </td>
+          <td>{$form.confirm_from_email.html}</td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-cc_confirm">
-          <td scope="row" class="label" width="20%">{$form.cc_confirm.label}</td>
-          <td>{$form.cc_confirm.html}<br/>
-            <span
-              class="description">{ts}You can notify event organizers of each online registration by specifying one or more email addresses to receive a carbon copy (cc). Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).{/ts}</span>
-          </td>
+          <td scope="row" class="label" width="20%">{$form.cc_confirm.label} {help id="id-cc_confirm"}</td>
+          <td>{$form.cc_confirm.html}</td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-bcc_confirm">
-          <td scope="row" class="label" width="20%">{$form.bcc_confirm.label}</td>
-          <td>{$form.bcc_confirm.html}<br/>
-            <span
-              class="description">{ts}You may specify one or more email addresses to receive a blind carbon copy (bcc) of the confirmation email. Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).{/ts}</span>
-          </td>
+          <td scope="row" class="label" width="20%">{$form.bcc_confirm.label} {help id="id-bcc_confirm"}</td>
+          <td>{$form.bcc_confirm.html}</td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
Continuing where #26257 left off, this completes my clean up of the Edit Event and Contribution Page forms. Primarily, this removes redundant descriptions or moves the description into a help text instead of displaying it on the form. Some formatting clean up and one minor label wording change for consistency between Events and Contribution Pages. Indent Pay Later fields on Events to match Contribution Pages and make the form clearer. Wrench icon to edit price sets for Events and Memberships, as in previous PR for Contribution Amounts. Some incidental clean up of tpl formatting.

Before
----------------------------------------
Example, this is the most changed form in this PR:
<img width="665" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/2631bdc2-8194-4d0d-9f23-79a99b8aace6">

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/25517556/e4068e20-ff4d-465a-9154-e1c494b50f5e)