### PR TITLE
Remove unneeded descriptions and clean up on search forms

### DIFF
--- a/CRM/Contribute/BAO/Query.php
+++ b/CRM/Contribute/BAO/Query.php
@@ -985,7 +985,7 @@ class CRM_Contribute_BAO_Query extends CRM_Core_BAO_Query {
       ]
     );
 
-    $form->addField('financial_trxn_card_type_id', ['entity' => 'FinancialTrxn', 'name' => 'card_type_id', 'action' => 'get']);
+    $form->addField('financial_trxn_card_type_id', ['entity' => 'FinancialTrxn', 'name' => 'card_type_id', 'action' => 'get', 'label' => ts('Card Type')]);
 
     $form->add('text', 'financial_trxn_pan_truncation', ts('Card Number'), [
       'size' => 5,

--- a/CRM/Group/Form/Search.php
+++ b/CRM/Group/Form/Search.php
@@ -35,11 +35,11 @@ class CRM_Group_Form_Search extends CRM_Core_Form {
   }
 
   public function buildQuickForm() {
-    $this->add('text', 'title', ts('Find'),
+    $this->add('text', 'title', ts('Group Name'),
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Group', 'title')
     );
 
-    $this->add('text', 'created_by', ts('Created By'),
+    $this->add('text', 'created_by', ts('Created By (Name)'),
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_Group', 'title')
     );
 

--- a/ext/civicrm_admin_ui/ang/afsearchManageContributionPages.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageContributionPages.aff.html
@@ -3,7 +3,7 @@
 </div>
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{label: 'Title', input_attrs: {}, help_post: 'Complete OR partial Contribution Page Title'}" />
+    <af-field name="title" defn="{label: 'Title', input_attrs: {}}" />
     <af-field name="financial_type_id" defn="{input_type: 'CheckBox', input_attrs: {}}" />
   </div>
   <div class="btn-group pull-right">

--- a/templates/CRM/Batch/Form/Search.tpl
+++ b/templates/CRM/Batch/Form/Search.tpl
@@ -11,12 +11,7 @@
   <h3>{ts}Data Entry Batches{/ts}</h3>
   <table class="form-layout-compressed">
     <tr>
-      <td>
-      {$form.title.html}<br />
-        <span class="description font-italic">
-        {ts}Complete OR partial batch name.{/ts}
-        </span>
-      </td>
+      <td>{$form.title.html}</td>
       <td>{include file="CRM/common/formButtons.tpl" location=''}</td>
     </tr>
   </table>

--- a/templates/CRM/Contribute/Form/SearchContribution.tpl
+++ b/templates/CRM/Contribute/Form/SearchContribution.tpl
@@ -11,12 +11,7 @@
 <h3>{ts}Find Contribution Pages{/ts}</h3>
 <table class="form-layout-compressed">
     <tr>
-        <td>{$form.title.html}
-            <div class="description font-italic">
-                {ts}Complete OR partial Contribution Page title.{/ts}
-            </div>
-        </td>
-
+        <td>{$form.title.html}</td>
         <td>
             <label>{ts}Financial Type{/ts}</label>
             <div class="listing-box">

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -17,9 +17,6 @@
         <td>
           <label>{$form.title.label}</label>
           {$form.title.html|crmAddClass:twenty}
-          <div class="description font-italic">
-                 {ts}Complete OR partial Event name.{/ts}
-          </div>
         </td>
         <td><label>{ts}Event Type{/ts}</label>
           {$form.event_type_id.html}

--- a/templates/CRM/Group/Form/Search.tpl
+++ b/templates/CRM/Group/Form/Search.tpl
@@ -18,36 +18,24 @@
           <tr>
             <td>
               {$form.title.label}<br />
-              {$form.title.html}<br />
-              <span class="description font-italic">
-                {ts}Complete OR partial group name.{/ts}
-              </span>
+              {$form.title.html}
             </td>
             {if !empty($form.created_by)}
               <td>
                 {$form.created_by.label}<br />
-                {$form.created_by.html}<br />
-                <span class="description font-italic">
-                  {ts}Complete OR partial creator name.{/ts}
-                </span>
+                {$form.created_by.html}
               </td>
             {/if}
             <td>
               {$form.visibility.label}<br />
-              {$form.visibility.html}<br />
-              <span class="description font-italic">
-               {ts}Filter search by visibility.{/ts}
-              </span>
+              {$form.visibility.html}
             </td>
           </tr>
           <tr>
             {if !empty($form.group_type_search)}
               <td id="group_type-block">
                 {$form.group_type_search.label}<br />
-                {$form.group_type_search.html}<br />
-                <span class="description font-italic">
-                  {ts}Filter search by group type(s).{/ts}
-                </span>
+                {$form.group_type_search.html}
               </td>
             {/if}
             {if !empty($form.group_status)}


### PR DESCRIPTION
Overview
----------------------------------------
Minor clean up removing descriptions on search forms that tell the user they can enter the complete or partial name to search (I think we can assume the user understands how searching works in 2023) and other redundant descriptions. Also updated a few labels for clarity and consistency.

Before
----------------------------------------
For example, this is the largest change:
<img width="800" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/346b53e7-1573-46b0-8088-99677640cc2b">

After
----------------------------------------
<img width="800" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/8d5c623d-87cd-49cd-8801-321578e596e7">
