### PR TITLE
[REF][PHP8.2] Declare campaigns property

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -553,6 +553,14 @@ class CRM_Report_Form extends CRM_Core_Form {
   protected $_charts = [];
 
   /**
+   * Array of campaign data,
+   * populated by calling `$this::addCampaignFields()`
+   *
+   * @var array
+   */
+  protected $campaigns = [];
+
+  /**
    * @var \Civi\Report\OutputHandlerInterface
    */
   private $outputHandler;

--- a/CRM/Report/Form/Event/ParticipantListing.php
+++ b/CRM/Report/Form/Event/ParticipantListing.php
@@ -22,7 +22,6 @@ class CRM_Report_Form_Event_ParticipantListing extends CRM_Report_Form {
   protected $_groupFilter = TRUE;
   protected $_tagFilter = TRUE;
   protected $_balance = FALSE;
-  protected $campaigns;
 
   protected $_customGroupExtends = array(
     'Participant',


### PR DESCRIPTION
Overview
----------------------------------------
Declare `campaigns` property in `CRM_Report_Form`.

Before
----------------------------------------
17 different report classes call `addCampaignFields`, which was dyamically setting `$this->campaigns` and therefore triggering a deprcation notice on PHP 8.2.

After
----------------------------------------
The campaigns property is properly declared. This should reduce the number of tests failing on PHP 8.2.

Comments
----------------------------------------
There is still lots more to do on reports - this is just 1 step towards full PHP 8.2 compatiability. 
