### PR TITLE
Add unit test cover + nl2br for location in event emails

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -209,8 +209,8 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
         'city' => $event['loc_block_id.address_id.city'],
         'state_province' => $event['loc_block_id.address_id.state_province_id:label'],
         'postal_code' => $event['loc_block_id.address_id.postal_code'],
-
       ]);
+      $tokens['location']['text/html'] = nl2br(trim($tokens['location']['text/plain']));
       $tokens['info_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
       $tokens['registration_url']['text/html'] = \CRM_Utils_System::url('civicrm/event/register', 'reset=1&id=' . $eventID, TRUE, NULL, FALSE, TRUE);
       $tokens['start_date']['text/html'] = !empty($event['start_date']) ? new DateTime($event['start_date']) : '';

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -668,9 +668,8 @@ event.summary :If you have any CiviCRM related issues or want to track where Civ
 event.loc_block_id.email_id.email :event@example.com
 event.loc_block_id.phone_id.phone :456 789
 event.description :event description
-event.location :15 Walton St
+event.location :15 Walton St<br />
 Emerald City, Maine 90210
-
 event.info_url :' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&reset=1&id=1
 event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1
 event.pay_later_receipt :Please transfer funds to our bank account.
@@ -889,7 +888,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $mut->checkMailLog($toCheck);
     $tokens = array_keys($this->getEventTokens());
     $html = $this->getTokenString($tokens);
-    $tokenProcessor->addMessage('html', $html, 'text/plain');
+    $tokenProcessor->addMessage('html', $html, 'text/html');
     $tokenProcessor->addRow(['eventId' => $this->ids['Event'][0]]);
     $tokenProcessor->evaluate();
     $this->assertEquals($expectedEventString, $tokenProcessor->getRow(0)->render('html'));
@@ -919,7 +918,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     ]);
     $html = $this->getTokenString(array_keys($this->getEventTokens()));
 
-    $tokenProcessor->addMessage('html', $html, 'text/plain');
+    $tokenProcessor->addMessage('html', $html, 'text/html');
     $tokenProcessor->addRow(['eventId' => $this->ids['Event'][0]]);
     $tokenProcessor->evaluate();
     $this->assertEquals($expected, $tokenProcessor->getRow(0)->render('html'));

--- a/tests/templates/message_templates/event_offline_receipt_html.tpl
+++ b/tests/templates/message_templates/event_offline_receipt_html.tpl
@@ -1,0 +1,3 @@
+event.location:{event.location}
+$location.address.1.display:{$location.address.1.display|nl2br}
+      


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test cover + nl2br for location in event emails

Before
----------------------------------------
In looking to swap the notice-y  `{$location.address.1.display}` for the token `event.location` I realised that the line breaks were not being converted to page breaks

After
----------------------------------------
The html version of the token now converts line breaks to page breaks & is tested.

Technical Details
----------------------------------------
This highlights that in fact what is being rendered is

```
<div class="location vcard"><span class="adr"><span class="street-address">8 Baker Street</span><br />
<span class="extended-address">Upstairs</span><br />
<span class="locality">London</span>,<br />
</span></div>
```

I want to confirm this is desirable & if so tokens should support it. I found this library https://github.com/jeroendesloovere/vcard 

There is a question as to how it would 'look' - we really should support address display at the api-v4 level - 

1) what is the name for the pseudofield for address display?  'title'? 'display'? (I thought of title initially because it is what we would want to show for an address 'title' in autocomplete?)
2) if we want to offer a vcard output is that a separate field? 



Comments
----------------------------------------