### PR TITLE
dev/core#4287 Fix event_offline template phones & emails

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -76,40 +76,65 @@
       </tr>
      {/if}
 
-     {if !empty($location.phone.1.phone) || !empty($location.email.1.email)}
+     {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
       <tr>
        <td colspan="2" {$labelStyle}>
         {ts}Event Contacts:{/ts}
        </td>
       </tr>
-      {foreach from=$location.phone item=phone}
-       {if $phone.phone}
+
+       {if {event.loc_block_id.phone_id.phone|boolean}}
         <tr>
          <td {$labelStyle}>
-          {if $phone.phone_type}
-           {$phone.phone_type_display}
+          {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+            {event.loc_block_id.phone_id.phone_type_id:label}
           {else}
            {ts}Phone{/ts}
           {/if}
          </td>
          <td {$valueStyle}>
-          {$phone.phone} {if $phone.phone_ext}&nbsp;{ts}ext.{/ts} {$phone.phone_ext}{/if}
+          {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
          </td>
         </tr>
        {/if}
-      {/foreach}
-      {foreach from=$location.email item=eventEmail}
-       {if $eventEmail.email}
+         {if {event.loc_block_id.phone_2_id.phone|boolean}}
+           <tr>
+             <td {$labelStyle}>
+                 {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+                     {event.loc_block_id.phone_2_id.phone_type_id:label}
+                 {else}
+                     {ts}Phone{/ts}
+                 {/if}
+             </td>
+             <td {$valueStyle}>
+                 {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+             </td>
+           </tr>
+         {/if}
+
+
+       {if {event.loc_block_id.email_id.email|boolean}}
         <tr>
          <td {$labelStyle}>
           {ts}Email{/ts}
          </td>
          <td {$valueStyle}>
-          {$eventEmail.email}
+             {event.loc_block_id.email_id.email}
          </td>
         </tr>
        {/if}
-      {/foreach}
+
+       {if {event.loc_block_id.email_2_id.email|boolean}}
+         <tr>
+           <td {$labelStyle}>
+               {ts}Email{/ts}
+           </td>
+           <td {$valueStyle}>
+               {event.loc_block_id.email_2_id.email}
+           </td>
+         </tr>
+       {/if}
+
      {/if}
 
      {if !empty($event.is_public)}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -52,19 +52,24 @@
 {$location.address.1.display|strip_tags:false}
 {/if}{*End of isShowLocation condition*}
 
-{if !empty($location.phone.1.phone) || !empty($location.email.1.email)}
-
+{if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
 {ts}Event Contacts:{/ts}
-{foreach from=$location.phone item=phone}
-{if $phone.phone}
 
-{if $phone.phone_type}{$phone.phone_type_display}{else}{ts}Phone{/ts}{/if}: {$phone.phone}{/if} {if $phone.phone_ext} {ts}ext.{/ts} {$phone.phone_ext}{/if}
-{/foreach}
-{foreach from=$location.email item=eventEmail}
-{if $eventEmail.email}
-
-{ts}Email{/ts}: {$eventEmail.email}{/if}{/foreach}
+{if {event.loc_block_id.phone_id.phone|boolean}}
+{if {event.loc_block_id.phone_id.phone_type_id|boolean}}{event.loc_block_id.phone_id.phone_type_id:label}{else}{ts}Phone{/ts}{/if} {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}} {ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
 {/if}
+
+{if {event.loc_block_id.phone_2_id.phone|boolean}}
+{if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}{event.loc_block_id.phone_2_id.phone_type_id:label}{else}{ts}Phone{/ts}{/if} {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}} {ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+{/if}
+
+{if {event.loc_block_id.email_id.email|boolean}}
+{ts}Email {/ts}{event.loc_block_id.email_id.email}
+{/if}
+{if {event.loc_block_id.email_2_id.email|boolean}}
+{ts}Email {/ts}{event.loc_block_id.email_2_id.email}{/if}
+{/if}
+
 
 {if !empty($event.is_public)}
 {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
Fix event_offline template phones & emails

https://lab.civicrm.org/dev/core/-/issues/4287

Before
----------------------------------------
We have reports of the old smarty variables causing havoc

After
----------------------------------------
Using (tested) tokens - we can now preview them in Message Admin & see how they look...

![image](https://github.com/civicrm/civicrm-core/assets/336308/b27dc062-22b4-49a7-9030-726eccf6e362)

![image](https://github.com/civicrm/civicrm-core/assets/336308/ccaa2fce-7b32-4a13-b668-95963d0865e1)


Technical Details
----------------------------------------



Comments
----------------------------------------
