### PR TITLE
(dev/core#4303) Allow {htxt} guard to accommodate variable ID

### DIFF
--- a/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
+++ b/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
@@ -18,11 +18,15 @@ function smarty_prefilter_htxtFilter($tpl_source, &$smarty) {
   $_htxts = 0;
 
   $result = preg_replace_callback_array([
-    '/\{htxt id=([\'\"][^\'\"]+[\'\"])/' => function ($m) use (&$htxts) {
+    '/\{htxt id=(\"[-\w]+\")[ }]/' => function ($m) use (&$htxts) {
       $htxts++;
       return sprintf('{if $id == %s}%s', $m[1], $m[0]);
     },
-    '/\{htxt id=(\$\w+)}/' => function ($m) use (&$htxts) {
+    '/\{htxt id=(\'[-\w]+\')[ }]/' => function ($m) use (&$htxts) {
+      $htxts++;
+      return sprintf('{if $id == %s}%s', $m[1], $m[0]);
+    },
+    '/\{htxt id=(\$\w+)[ }]/' => function ($m) use (&$htxts) {
       $htxts++;
       return sprintf('{if $id == %s}%s', $m[1], $m[0]);
     },

--- a/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
+++ b/CRM/Core/Smarty/plugins/prefilter.htxtFilter.php
@@ -22,6 +22,10 @@ function smarty_prefilter_htxtFilter($tpl_source, &$smarty) {
       $htxts++;
       return sprintf('{if $id == %s}%s', $m[1], $m[0]);
     },
+    '/\{htxt id=(\$\w+)}/' => function ($m) use (&$htxts) {
+      $htxts++;
+      return sprintf('{if $id == %s}%s', $m[1], $m[0]);
+    },
     ';\{/htxt\};' => function($m) use (&$_htxts) {
       $_htxts++;
       return '{/htxt}{/if}';

--- a/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Class CRM_Core_Smarty_plugins_CrmScopeTest
+ * @group headless
+ */
+class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    require_once 'CRM/Core/Smarty.php';
+
+    // Templates should normally be file names, but for unit-testing it's handy to use "string:" notation
+    require_once 'CRM/Core/Smarty/resources/String.php';
+    civicrm_smarty_register_string_resource();
+  }
+
+  /**
+   * @return array
+   */
+  public function scopeCases() {
+    $cases = [];
+    $cases[] = ['yum yum apple!', '{htxt id="apple"}yum yum apple!{/htxt}', ['id' => 'apple']];
+    $cases[] = ['', '{htxt id="apple"}yum yum apple!{/htxt}', ['id' => 'not me']];
+    $cases[] = ['yum yum banana!', '{htxt id=$dynamic}yum yum {$dynamic}!{/htxt}', ['id' => 'banana', 'dynamic' => 'banana']];
+    $cases[] = ['', '{htxt id=$dynamic}yum yum {$dynamic}!{/htxt}', ['id' => 'apple', 'dynamic' => 'banana']];
+    // More advanced forms of dynamic-id's might be nice, but this is currently the ceiling on what's needed.
+    return $cases;
+  }
+
+  /**
+   * @dataProvider scopeCases
+   * @param string $expected
+   * @param string $input
+   * @param array $vars
+   */
+  public function testSupported(string $expected, string $input, array $vars) {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->pushScope($vars);
+    try {
+      $actual = $smarty->fetch('string:' . $input);
+      $this->assertEquals($expected, $actual, "Process input=[$input]");
+    }
+    finally {
+      $smarty->popScope();
+    }
+  }
+
+  public function testUnsupported() {
+    $smarty = CRM_Core_Smarty::singleton();
+    try {
+      $smarty->fetch('string:{htxt id=$dynamic.zx["$f{b}"]}power parser!{/htxt}');
+      $this->fail("Congratulations, the test failed! You are the road to a better parsing rule.");
+    }
+    catch (Throwable $t) {
+      ob_end_flush();
+      $this->assertTrue(str_contains($t->getMessage(), 'Invalid {htxt} tag'));
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/HtxtTest.php
@@ -8,6 +8,7 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
+    $this->useTransaction();
     require_once 'CRM/Core/Smarty.php';
 
     // Templates should normally be file names, but for unit-testing it's handy to use "string:" notation
@@ -18,18 +19,30 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
   /**
    * @return array
    */
-  public function scopeCases() {
+  public function supportedCases() {
     $cases = [];
-    $cases[] = ['yum yum apple!', '{htxt id="apple"}yum yum apple!{/htxt}', ['id' => 'apple']];
+    $cases[] = ['yum yum apple_pie!', '{htxt id="apple_pie"}yum yum apple_pie!{/htxt}', ['id' => 'apple_pie']];
+    $cases[] = ['yum yum Apple-Pie!', '{htxt id=\'Apple-Pie\'}yum yum Apple-Pie!{/htxt}', ['id' => 'Apple-Pie']];
+    $cases[] = ['yum yum apple!', '{htxt id="apple" other=stuff}yum yum apple!{/htxt}', ['id' => 'apple']];
     $cases[] = ['', '{htxt id="apple"}yum yum apple!{/htxt}', ['id' => 'not me']];
     $cases[] = ['yum yum banana!', '{htxt id=$dynamic}yum yum {$dynamic}!{/htxt}', ['id' => 'banana', 'dynamic' => 'banana']];
+    $cases[] = ['yum yum banana!', '{htxt id=$dynamic other=stuff}yum yum {$dynamic}!{/htxt}', ['id' => 'banana', 'dynamic' => 'banana']];
     $cases[] = ['', '{htxt id=$dynamic}yum yum {$dynamic}!{/htxt}', ['id' => 'apple', 'dynamic' => 'banana']];
     // More advanced forms of dynamic-id's might be nice, but this is currently the ceiling on what's needed.
     return $cases;
   }
 
+  public function unsupportedCases() {
+    $cases = [];
+    $cases[] = ['{htxt id=$dynamic.zx["$f{b}"]}not supported{/htxt}', []];
+    $cases[] = ['{htxt id=\'dragonfruit"}not supported{/htxt}', []];
+    $cases[] = ['{htxt id=\'apple\'"banana"]}not supported{/htxt}', []];
+    $cases[] = ['{htxt id=\'apple\'.banana]}not supported{/htxt}', []];
+    return $cases;
+  }
+
   /**
-   * @dataProvider scopeCases
+   * @dataProvider supportedCases
    * @param string $expected
    * @param string $input
    * @param array $vars
@@ -46,11 +59,16 @@ class CRM_Core_Smarty_plugins_HtxtTest extends CiviUnitTestCase {
     }
   }
 
-  public function testUnsupported() {
+  /**
+   * @dataProvider unsupportedCases
+   * @param string $input
+   * @param array $vars
+   */
+  public function testUnsupported(string $input, array $vars) {
     $smarty = CRM_Core_Smarty::singleton();
     try {
-      $smarty->fetch('string:{htxt id=$dynamic.zx["$f{b}"]}power parser!{/htxt}');
-      $this->fail("Congratulations, the test failed! You are the road to a better parsing rule.");
+      $smarty->fetch('string:' . $input);
+      $this->fail("That should have thrown an error. Are you working on a better parsing rule?");
     }
     catch (Throwable $t) {
       ob_end_flush();


### PR DESCRIPTION
Ovreview
------------

Fix recent regression (reported in https://lab.civicrm.org/dev/core/-/issues/4303) where `CustomField.hlp` generates an error while processing `{htxt}`.

Before
------

`{htxt}` guard works with static IDs (`{htxt id="abc"}`)

After
-----

`{htxt}` guard with with variable ID (`{htxt id=$abc}`)

Comments
--------

In my copy of universe, there's a similar construction in `nz.co.fuzion.entitysetting` (`entitysettingscommon.hlp`). However, in that case, it appears to loop through a list of settings and (conditionally) generates help blobs for each (*but ultimately only needs to display one*). I haven't actually `r-run` that extension, but I'd be hopeful that this addresses it as well.

