### PR TITLE
Replace isset with token for pay_later_receipt

### DIFF
--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -48,7 +48,7 @@
       <p>{ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</p>
      {/if}
     {elseif !empty($is_pay_later) && empty($isAmountzero) && empty($isAdditionalParticipant)}
-     <p>{if isset($pay_later_receipt)}{$pay_later_receipt}{/if}</p> {* FIXME: this might be text rather than HTML *}
+     <p>{if {event.pay_later_receipt|boolean}}{event.pay_later_receipt|boolean}{/if}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 
    </td>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -34,7 +34,7 @@
 
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
-{if isset($pay_later_receipt)}{$pay_later_receipt}{/if}
+{if {event.pay_later_receipt|boolean}}{event.pay_later_receipt|boolean}{/if}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
 {/if}


### PR DESCRIPTION

Overview
----------------------------------------
Replace isset with token for pay_later_receipt

Before
----------------------------------------
Use of `isset` in templates causes hard-errors with smarty-secure mode enabled

After
----------------------------------------
Replaced with a token, this is also previewable

Technical Details
----------------------------------------
As tested in https://github.com/civicrm/civicrm-core/pull/26294/files#diff-a5d237ba4e392d0e8ad764a535315f0b1101cc5ca61c39b4e572de42f5c6b4bcR676 this token works & removes one of the breaky issets

Comments
----------------------------------------
