### PR TITLE
Simplify opt-out/unsubscribe help texts

### DIFF
--- a/templates/CRM/Mailing/Form/Optout.tpl
+++ b/templates/CRM/Mailing/Form/Optout.tpl
@@ -10,17 +10,10 @@
 
 <div class="crm-block crm-form-block crm-miscellaneous-form-block">
   <p>{ts}You are requesting to opt out this email address from all mailing lists:{/ts}</p>
-  <h3>{$email_masked}</h3>
-
-  <p>
-      {ts}If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
-      {ts}If this is your email address and you <strong>wish to opt out</strong> please click the <strong>Opt Out</strong> button to confirm.{/ts}
-  </p>
-
+  <p><strong>{$email_masked}</strong></p>
+  <p>{ts}If this is your email address and you <strong>wish to opt out</strong> please click the <strong>Opt Out</strong> button to confirm.{/ts}</p>
   <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-
   <br/>
 </div>
-

--- a/templates/CRM/Mailing/Form/Unsubscribe.tpl
+++ b/templates/CRM/Mailing/Form/Unsubscribe.tpl
@@ -23,9 +23,8 @@
     </table>
     <div class="crm-block crm-form-block crm-miscellaneous-form-block">
       <p>{ts}You are requesting to unsubscribe this email address:{/ts}</p>
-      <h3>{$email_masked}</h3>
+      <p><strong>{$email_masked}</strong></p>
       <p>
-        {ts}If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists.{/ts}
         {ts}If this is your email address and you <strong>wish to unsubscribe</strong> please click the <strong>Unsubscribe</strong> button to confirm.{/ts}
       </p>
       <div class="crm-submit-buttons">


### PR DESCRIPTION
Overview
----------------------------------------

On the mailing Opt-Out and Unsubscribe forms:

- Remove the sentence: "If this is not your email address, there is no need to do anything. You have <strong>not</strong> been added to any mailing lists." - because it's kind of a weird explanation, when you think of it.
- Converted the h3 email to a p-strong tag, because in most themes, h3 is rather huge. I think if there is less fluffy text, then we don't need to `<h3>` or `<blink>` actually important text.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/7289897c-a4af-4ed1-9ecb-7e1eeb82477e)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/4abfca8b-3645-4c8d-a543-911e5d472383)

Comments
----------------------------------------

It would look even better like this, without any bold and without a cancel, but it would break translations and I suppose it's more subjective:

![image](https://github.com/civicrm/civicrm-core/assets/254741/94680f1d-0094-49a7-9302-28f479db64d3)

Previous discussion on these forms: #21350 

cc @mattwire @larssandergreen 