### PR TITLE
Fix show_public regression

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -527,16 +527,16 @@ WHERE civicrm_custom_group.is_active = 1
         );
     }
 
-    if ($showPublicOnly && $is_public_version) {
-      $strWhere .= "AND civicrm_custom_group.is_public = 1";
+    if ($showPublicOnly) {
+      $strWhere .= 'AND civicrm_custom_group.is_public = 1';
     }
 
-    $orderBy = "
+    $orderBy = '
 ORDER BY civicrm_custom_group.weight,
          civicrm_custom_group.title,
          civicrm_custom_field.weight,
          civicrm_custom_field.label
-";
+';
 
     // final query string
     $queryString = "$strSelect $strFrom $strWhere $orderBy";


### PR DESCRIPTION



Overview
----------------------------------------
Fix show_public regression

Before
----------------------------------------
This shows up as an e-notice but
would probably result in the is_public filter being broken as the if clause is never entered

After
----------------------------------------
The variable is no longer set since https://github.com/civicrm/civicrm-core/commit/16c5faa5db26149e5f1b7d3f45e3d5f2c24bf422#diff-d20bbdac5d9d1d3ec28be6f1972f8cb747ead74dea90c9076daa2de2a627873cL110
& with this PR it is no longer referenced either


Technical Details
----------------------------------------

Comments
----------------------------------------

@colemanw one you missed