### PR TITLE
Add API4 Group.rebuildCache

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -141,6 +141,25 @@ AND (
   }
 
   /**
+   * Try to lock before running loadAll().
+   *
+   * @param array|null $groupIDs groupIDs of group that we are checking against
+   *                           if empty, all groups are checked
+   * @param int $limit
+   *   Limits the number of groups we evaluate.
+   *
+   * The lock handling is copied from Api3 Job.group_rebuild
+   */
+  public static function lockAndLoad($groupIDs = NULL, $limit = 0) {
+    $lock = \Civi::lockManager()->acquire('worker.core.GroupRebuild');
+    if (!$lock->isAcquired()) {
+      throw new \CRM_Core_Exception('Could not acquire lock, another GroupRebuild process is running');
+    }
+    self::loadAll($groupIDs, $limit);
+    $lock->release();
+  }
+
+  /**
    * Build the smart group cache for given groups.
    *
    * @param array $groupIDs

--- a/Civi/Api4/Action/Group/RebuildCache.php
+++ b/Civi/Api4/Action/Group/RebuildCache.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Group;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Rebuild the group contact cache.
+ *
+ * @method $this setLimit(int $limit) Set limit - number of groups to rebuild
+ * @method int getLimit() Get contact ID param
+ */
+class RebuildCache extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * Limit: number of groups to rebuild
+   *
+   * @var int
+   */
+  protected $limit;
+
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $lock = \Civi::lockManager()->acquire('worker.core.GroupRebuild');
+    if (!$lock->isAcquired()) {
+      throw new \CRM_Core_Exception('Could not acquire lock, another GroupRebuild process is running');
+    }
+
+    $limit = $params['limit'] ?? 0;
+
+    \CRM_Contact_BAO_GroupContactCache::loadAll(NULL, $this->limit);
+
+    $lock->release();
+  }
+
+}

--- a/Civi/Api4/Action/Group/RebuildCache.php
+++ b/Civi/Api4/Action/Group/RebuildCache.php
@@ -33,16 +33,7 @@ class RebuildCache extends \Civi\Api4\Generic\AbstractAction {
    * @param \Civi\Api4\Generic\Result $result
    */
   public function _run(Result $result) {
-    $lock = \Civi::lockManager()->acquire('worker.core.GroupRebuild');
-    if (!$lock->isAcquired()) {
-      throw new \CRM_Core_Exception('Could not acquire lock, another GroupRebuild process is running');
-    }
-
-    $limit = $params['limit'] ?? 0;
-
-    \CRM_Contact_BAO_GroupContactCache::loadAll(NULL, $this->limit);
-
-    $lock->release();
+    \CRM_Contact_BAO_GroupContactCache::lockAndLoad(NULL, $this->limit ?? 0);
   }
 
 }

--- a/Civi/Api4/Group.php
+++ b/Civi/Api4/Group.php
@@ -37,4 +37,13 @@ class Group extends Generic\DAOEntity {
     ] + $permissions;
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Contact\RebuildCache
+   */
+  public static function rebuildCache($checkPermissions = TRUE) {
+    return (new Action\Group\RebuildCache(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add API4 `Group.rebuildCache` function

Before
----------------------------------------
Api3 function `Job.group_rebuild`, no API4 version

After
----------------------------------------
API4 `Group.redbuildCache`  As discussed with @colemanw, this seems to sit better in the `Group` space than in `Job`.

Technical Details
----------------------------------------
This is based on the API3 version, including the locks.  ~~Seems a bit of out of place to manage the locks here rather than in the BAO if they are needed.  Other lock handling for cache rebuilds is in the BAO.    But also, in the 'Manage Groups' page, `CRM_Contact_BAO_GroupContactCache::loadAll()` is [called directly](https://github.com/civicrm/civicrm-core/blob/master/CRM/Group/Page/Group.php#L112-L113) rather than via api so no locks are used.~~

I've moved the lock handling out of the API function into the GroupContactCache BAO.

Comments
----------------------------------------
