### PR TITLE
Api4: add calculated field `contact_count` to Group

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/GroupGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/GroupGetSpecProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class GroupGetSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    // Number of contacts
+    if (!$spec->getValue('contact_count')) {
+      $field = new FieldSpec('contact_count', 'Group', 'Integer');
+      $field->setLabel(ts('Contact Count'))
+        ->setDescription(ts('Number of contacts in group'))
+        ->setColumnName('id')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'countContacts']);
+      $spec->addFieldSpec($field);
+    }
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'Group' && $action === 'get';
+  }
+
+  /**
+   * Generate SQL for counting contacts
+   * in static and smart groups
+   *
+   * @return string
+   */
+  public static function countContacts(array $field): string {
+    return "COALESCE(
+      NULLIF((SELECT COUNT(contact_id) FROM `civicrm_group_contact_cache` WHERE `group_id` = {$field['sql_name']}), 0),
+      (SELECT COUNT(contact_id) FROM `civicrm_group_contact` WHERE `group_id` = {$field['sql_name']} AND `status` = 'Added')
+    )";
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/GroupContactTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupContactTest.php
@@ -20,20 +20,34 @@
 namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Group;
 
 /**
  * @group headless
  */
 class GroupContactTest extends Api4TestBase {
 
-  public function testCreate() {
+  public function testCount() {
     $contact = $this->createTestRecord('Contact');
     $group = $this->createTestRecord('Group');
+
+    $count = Group::get(FALSE)
+      ->addWhere('id', '=', $group['id'])
+      ->addSelect('contact_count')
+      ->execute()->single();
+    $this->assertEquals(0, $count['contact_count']);
+
     $result = $this->createTestRecord('GroupContact', [
       'group_id' => $group['id'],
       'contact_id' => $contact['id'],
     ]);
     $this->assertEquals('Added', $result['status']);
+
+    $count = Group::get(FALSE)
+      ->addWhere('id', '=', $group['id'])
+      ->addSelect('contact_count')
+      ->execute()->single();
+    $this->assertEquals(1, $count['contact_count']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a calculated field 'contact_count` to the `Group.get()` API.  This provides the current count of 'added' group members and smart group members.  Note this does not rebuild the group cache so smart group counts may be out of date or zero.

Before
----------------------------------------
Cannot get count of smart group contacts.

After
----------------------------------------
Count of smart group contacts available as `contact_count` field

Technical Details
----------------------------------------
Contacts manually added to a smart group are included in the `civicrm_group_contact_cache` table.  So if the count from that table is non-zero, the group is smart and the count is the total number of contacts.  If the count is zero, either the group is not smart, or the cache table has not been rebuilt.  Either way, report the number of contacts in `civicrm_group_contact`

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
