### PR TITLE
Add import listing for admins

### DIFF
--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -164,4 +164,51 @@ return [
       ],
     ],
   ],
+  [
+    'name' => 'SavedSearch_Imports',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Imports',
+        'label' => 'Imports',
+        'form_values' => NULL,
+        'mapping_id' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'UserJob',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'created_id.display_name',
+            'created_date',
+            'job_type:label',
+            'start_date',
+            'end_date',
+            'status_id:label',
+          ],
+          'orderBy' => [],
+          'where' => [
+            [
+              'is_template',
+              '=',
+              FALSE,
+            ],
+            [
+              'is_current',
+              '=',
+              TRUE,
+            ],
+          ],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+        'expires_date' => NULL,
+        'description' => NULL,
+      ],
+    ],
+  ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
@colemanw is is possible to have a search display only show for some users? This search is intended to allow the admin users with permissions to see OTHER people's imports a list of all imports - but for users without that permission this is going to only show their own imports - which the 'My Imports' search already does... I can make it for some users in the menu I guess...

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
