### PR TITLE
Clean up Scheduled Jobs admin page

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -52,17 +52,17 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
           'qs' => 'jid=%%id%%&reset=1',
           'title' => ts('See log entries for this Scheduled Job'),
         ],
+        CRM_Core_Action::VIEW => [
+          'name' => ts('Execute'),
+          'url' => 'civicrm/admin/job/edit',
+          'qs' => 'action=view&id=%%id%%&reset=1',
+          'title' => ts('Execute Scheduled Job Now'),
+        ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/admin/job/edit',
           'qs' => 'action=update&id=%%id%%&reset=1',
           'title' => ts('Edit Scheduled Job'),
-        ],
-        CRM_Core_Action::VIEW => [
-          'name' => ts('Execute Now'),
-          'url' => 'civicrm/admin/job/edit',
-          'qs' => 'action=view&id=%%id%%&reset=1',
-          'title' => ts('Execute Scheduled Job Now'),
         ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Disable'),

--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -42,11 +42,11 @@
         {foreach from=$rows item=row}
         <tr id="job-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"} {$row.class}{if NOT $row.is_active} disabled{/if}">
             <td class="crm-job-name"><strong><span data-field="name">{$row.name}</span></strong> ({$row.run_frequency})<br/>
-                {$row.description}<br />
+                {if array_key_exists('description', $row)}{$row.description}{/if}<br />
                 {ts}API Entity:{/ts} {$row.api_entity}<br/>
                 {ts}API Action:{/ts} <strong>{$row.api_action}</strong><br/>
             </td>
-            <td class="crm-job-name">{if $row.parameters eq null}<em>{ts}no parameters{/ts}</em>{else}<pre>{$row.parameters}</pre>{/if}</td>
+            <td class="crm-job-name">{if $row.parameters eq null}<em>{ts}no parameters{/ts}</em>{else}{$row.parameters|nl2br}{/if}</td>
             <td class="crm-job-name">{if $row.last_run eq null}never{else}{$row.last_run|crmDate:$config->dateformatDatetime}{/if}</td>
             <td id="row_{$row.id}_status" class="crm-job-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>


### PR DESCRIPTION
Before
----------------------------------------
Table overflowing because of use of `<pre>` tags.
Execute Now hidden under menu, when I think this is much more commonly used than Edit.
One PHP8 warning.
<img width="1383" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/abe02795-8b07-41fb-b37b-5650ffba4647">

<img width="1047" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/68109af1-b5c0-4d51-af7a-cec4217b975f">

After
----------------------------------------
Table no longer overflows, params shown with nl2br.
Execute easily accessible, name shortened (this translation string already exists).
No warning.
![image](https://github.com/civicrm/civicrm-core/assets/25517556/8e4b098e-c361-44c7-9bbd-7c88a5c10b2b)
Maybe not ideal display of params, but better than having the table overflow a lot. If you need to seriously examine the params, you can still click through to edit. Only a few scheduled jobs have params by default.
<img width="637" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/35544112-9a6e-4be6-af58-cbe5f6c0459f">
