### PR TITLE
Fix Advanced search reset button formatting

### DIFF
--- a/templates/CRM/Contact/Form/Search/Criteria/SearchSettings.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/SearchSettings.tpl
@@ -6,13 +6,11 @@
         {if !empty($form.deleted_contacts)}{$form.deleted_contacts.html} {$form.deleted_contacts.label}{/if}
       </td>
       <td class="adv-search-top-submit" colspan="2">
-        <div class="crm-submit-buttons">
           {include file="CRM/common/formButtons.tpl" location="top"}
-        </div>
         <div class="crm-submit-buttons reset-advanced-search">
-          <a href="{crmURL p='civicrm/contact/search/advanced' q='reset=1'}" id="resetAdvancedSearch" class="crm-hover-button css_right" title="{ts}Clear all search criteria{/ts}">
+          <a href="{crmURL p='civicrm/contact/search/advanced' q='reset=1'}" id="resetAdvancedSearch" class="crm-hover-button" title="{ts}Clear all search criteria{/ts}">
             <i class="crm-i fa-undo" aria-hidden="true"></i>
-            {ts}Reset Form{/ts}
+            &nbsp;{ts}Reset Form{/ts}
           </a>
         </div>
       </td>


### PR DESCRIPTION
Overview
----------------------------------------
Just a small change to fix busted formatting on top of the Advanced Search form.

Before
----------------------------------------
<img width="1017" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/ff5f9171-2068-42a5-80a2-330e9c0088a4">

After
----------------------------------------
Alignment isn't quite perfect, but it's the same as the bottom of the form, same html.
![image](https://github.com/civicrm/civicrm-core/assets/25517556/7596162d-3404-401c-b05e-055accaaf276)