### PR TITLE
SearchKit - Add sticky table header style

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -19,7 +19,8 @@
       this.tableClasses = [
         {name: 'table', label: ts('Row Borders')},
         {name: 'table-bordered', label: ts('Column Borders')},
-        {name: 'table-striped', label: ts('Even/Odd Stripes')}
+        {name: 'table-striped', label: ts('Even/Odd Stripes')},
+        {name: 'crm-sticky-header', label: ts('Sticky Header')}
       ];
 
       // Check if array contains item

--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -12,3 +12,8 @@
 #bootstrap-theme .crm-search-display.crm-search-display-table tfoot > tr > td {
   font-weight: bold;
 }
+
+table.crm-sticky-header > thead > tr {
+  position: sticky !important;
+  top: var(--crm-menubar-bottom, 0px);
+}

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -101,11 +101,13 @@
       if (typeof speed === 'number') {
         $('#civicrm-menu').slideDown(speed, function() {
           $(this).css('display', '');
+          handleResize();
         });
       }
       $('body')
         .removeClass('crm-menubar-hidden')
         .addClass('crm-menubar-visible');
+      handleResize();
     },
     hide: function(speed, showMessage) {
       if (typeof speed === 'number') {
@@ -116,6 +118,7 @@
       $('body')
         .addClass('crm-menubar-hidden')
         .removeClass('crm-menubar-visible');
+      document.documentElement.style.setProperty('--crm-menubar-bottom', '0px');
       if (showMessage === true && $('#crm-notification-container').length && initialized) {
         var alert = CRM.alert('<a href="#" id="crm-restore-menu" >' + _.escape(ts('Restore CiviCRM Menu')) + '</a>', ts('Menu hidden'), 'none', {expires: 10000});
         $('#crm-restore-menu')
@@ -503,6 +506,7 @@
     } else {
       $('body').removeClass('crm-menubar-wrapped');
     }
+    document.documentElement.style.setProperty('--crm-menubar-bottom', ($('#civicrm-menu').height() + $('#civicrm-menu').position().top) + 'px');
   }
 
   // Figure out if we've hit the mobile breakpoint, based on the rule in crm-menubar.css


### PR DESCRIPTION
Overview
----------------------------------------
Allows SearchKit table displays to have "sticky" headers which don't scroll past the top of the screen.

<img width="783" alt="Screenshot 2023-05-24 at 10 50 35 AM" src="https://github.com/civicrm/civicrm-core/assets/2874912/c2955e48-ae9c-4944-823c-78e751cf4d26">


Technical Details
----------------------------------------
The tricky part was figuring out the exact location to "stick" to. The position of the bottom of the menubar is different depending on the CMS, the menubar settings, the screen width, the number of items in the menu, etc. CSS variables to the rescue!

Comments
----------------------------------------
Inspired by @aydun's comment https://chat.civicrm.org/civicrm/pl/w3f97iskebr5uy7desymcjc54e
