### PR TITLE
SearchKit - Add caret icon to dropdown menus, tweak defaults

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -62,9 +62,9 @@
           label: ts('Menu'),
           icon: 'fa-bars',
           defaults: {
-            text: ts('Actions'),
+            text: '',
             style: 'default',
-            size: 'btn-sm',
+            size: 'btn-xs',
             icon: 'fa-bars',
             links: []
           }

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/menu.html
@@ -26,6 +26,7 @@
         <i class="{{ col.icon ? 'crm-i ' + col.icon : '' }}"></i>
       </span>
       <span crm-ui-editable ng-model="col.text">{{ col.text }}</span>
+      <span class="caret disabled"></span>
     </button>
   </div>
   <crm-search-admin-token-select model="col" field="text" suffix=":label"></crm-search-admin-token-select>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -2,6 +2,7 @@
   <button type="button" class="dropdown-toggle {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: $ctrl.settings.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
     <i ng-if=":: $ctrl.settings.columns[colIndex].icon" class="crm-i {{:: $ctrl.settings.columns[colIndex].icon }}"></i>
     {{:: colData.text }}
+    <span class="caret"></span>
   </button>
   <ul class="dropdown-menu {{ $ctrl.settings.columns[colIndex].alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: colData.open">
     <li ng-repeat="link in colData.links" class="bg-{{:: link.style }}">

--- a/ext/search_kit/css/crmSearchDisplay.css
+++ b/ext/search_kit/css/crmSearchDisplay.css
@@ -20,6 +20,10 @@
   width: 60px;
 }
 
+#bootstrap-theme .crm-search-display button.dropdown-toggle {
+  white-space: nowrap;
+}
+
 /* Loading placeholders */
 #bootstrap-theme .crm-search-loading-placeholder {
   height: 2em;


### PR DESCRIPTION
Overview
----------------------------------------
Adds a caret icon to dropdown menus to clarify their function, and tweaks the defaults to the standard used by the AdminUI extension (xs size, no text). Adds css rule to prevent line breaks inside the button.

Before
----------------------------------------
Menu buttons look like this by default (especially terrible on narrow screens, they get bloated by a line-break):
![image](https://github.com/civicrm/civicrm-core/assets/2874912/5a38b92f-2fa9-4e7f-8653-60dc715187c0)


After
----------------------------------------
Menu buttons look like this. Line-break suppressed by a css rule:
![image](https://github.com/civicrm/civicrm-core/assets/2874912/b04f22c8-2739-41db-8d8f-59aad0d9012c)
