### PR TITLE
APIv4 Explorer - Don't translate empty strings

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1024,7 +1024,7 @@
           return '[]';
         }
         $.each(val, function(k, v) {
-          var ts = localizable && localizable.includes(k) && _.isString(v) ? 'E::ts(' : '';
+          var ts = localizable && localizable.includes(k) && _.isString(v)  && v.length ? 'E::ts(' : '';
           ret += (ret ? ', ' : '') + newLine + indent + "'" + k + "' => " + ts + phpFormat(v, indentChild, indentChildren, localizable) + (ts ? ')' : '');
         });
         return '[' + ret + trailingComma + newLine + baseLine + ']';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in #26058 where the API Explorer would translate empty strings.
