### PR TITLE
Explorer: Remove trailing spaces on export

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1025,7 +1025,7 @@
         }
         $.each(val, function(k, v) {
           var ts = localizable && localizable.includes(k) && _.isString(v) ? 'E::ts(' : '';
-          ret += (ret ? ', ' : '') + newLine + indent + "'" + k + "' => " + ts + phpFormat(v, indentChild, indentChildren, localizable) + (ts ? ')' : '');
+          ret += (ret ? ',' : '') + newLine + indent + "'" + k + "' => " + ts + phpFormat(v, indentChild, indentChildren, localizable) + (ts ? ')' : '');
         });
         return '[' + ret + trailingComma + newLine + baseLine + ']';
       }
@@ -1034,7 +1034,7 @@
           return '[]';
         }
         $.each(val, function(k, v) {
-          ret += (ret ? ', ' : '') + newLine + indent + phpFormat(v, indentChild, indentChildren, localizable);
+          ret += (ret ? ',' : '') + newLine + indent + phpFormat(v, indentChild, indentChildren, localizable);
         });
         return '[' + ret + trailingComma + newLine + baseLine + ']';
       }


### PR DESCRIPTION
Overview
----------------------------------------
Remove trailing spaces on output from the 'export' command

Before
----------------------------------------
Some lines have trailing spaces

After
----------------------------------------
Gone.

One less thing to change when exporting entities into a `.mgd.php` file.

Technical Details
----------------------------------------
There are also leading spaces ... not sure how to fix that!

