### PR TITLE
CiviEventDispatcher::dispatch() - add deprecation warning for deprecated event class

### DIFF
--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -253,6 +253,9 @@ class CiviEventDispatcher implements CiviEventDispatcherInterface {
 
       }
     }
+    if (is_a($event, '\\Symfony\\Component\\EventDispatcher\\Event')) {
+      \CRM_Core_Error::deprecatedWarning('\\Symfony\\Component\\EventDispatcher\\Event is deprecated. Consider using \\Civi\\Core\\Event\\GenericHookEvent. For more information see ' . \CRM_Utils_System::docURL2('dev/hooks/usage/symfony/#events', TRUE));
+    }
     $this->bindPatterns($eventName);
     if ($event === NULL) {
       $event = GenericHookEvent::create([]);


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/26276 and https://github.com/civicrm/civicrm-core/pull/26212

Before
----------------------------------------
No warning - extension will fail hard in drupal 10 or when civi ups the minimum symfony version.

After
----------------------------------------
Warning

Technical Details
----------------------------------------
See above linked PRs.

I've linked to the dev docs where we could add some more discussion so have tried to keep the message here straightforward and not require too much thinking for those who don't need it. See also https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1078 since the dev docs reference the outdated class.

Comments
----------------------------------------
I tested what happens if run when the class doesn't exist. It doesn't seem to mind.

@totten @dontub