### PR TITLE
SearchKit - Clear selection when changing search params

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -29,6 +29,7 @@
         ctrl.results = null;
         ctrl.rowCount = null;
         ctrl.page = 1;
+        ctrl.selectNone();
       }
 
       this.$onInit = function() {


### PR DESCRIPTION
Overview
----------------------------------------
Ensures all checkboxes are unchecked when changing search params in SearchKit.
Fixes [dev/core#4274](https://lab.civicrm.org/dev/core/-/issues/4274)

Before
----------------------------------------
If you search for Contacts in SearchKit, select all or some of the Contacts, then edit your search to make it more specific and click search again, the previously selected Contacts, who may not be within the results of the current search, remain selected. 

After
----------------------------------------
Selection is cleared when editing the search.
