### PR TITLE
Fix PHP8 tax_rate warning on Participant

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2193,7 +2193,10 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         $eventAmount = [];
         $totalTaxAmount = 0;
 
-        //add dataArray in the receipts in ADD and UPDATE condition
+        // add dataArray in the receipts in ADD and UPDATE condition
+        // dataArray contains the total tax amount for each tax rate, in the form [tax rate => total tax amount]
+        // include 0% tax rate if it exists because if $dataArray controls if tax is shown for each line item
+        // in the message templates and we want to show 0% tax if set, even if there is no total tax
         $dataArray = [];
         if ($this->_action & CRM_Core_Action::ADD) {
           $line = $lineItem ?? [];
@@ -2203,13 +2206,13 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         }
         if (Civi::settings()->get('invoicing')) {
           foreach ($line as $key => $value) {
-            if (isset($value['tax_amount'])) {
+            if (isset($value['tax_amount']) && isset($value['tax_rate'])) {
               $totalTaxAmount += $value['tax_amount'];
               if (isset($dataArray[(string) $value['tax_rate']])) {
-                $dataArray[(string) $value['tax_rate']] = $dataArray[(string) $value['tax_rate']] + CRM_Utils_Array::value('tax_amount', $value);
+                $dataArray[(string) $value['tax_rate']] += $value['tax_amount'];
               }
               else {
-                $dataArray[(string) $value['tax_rate']] = $value['tax_amount'] ?? NULL;
+                $dataArray[(string) $value['tax_rate']] = $value['tax_amount'];
               }
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
`tax_amount` could be zero while `tax_rate` was not set, resulting in warnings after form submission. This happens if you enable tax and invoicing, but don't actually set tax accounts and financial type. I guess this would happen if you wanted invoicing but not tax.

We can't add to `$dataArray` if `$value['tax_rate']` is not set, so we can skip all that code. We do want to add to `$dataArray` if the tax rate is 0, but we do not want to add anything if the tax rate is not set.

I also simplified the code a little and added a comment explaining what the strange `$dataArray` actually does in the template, because it is not intuitive at all.