### PR TITLE
dev/core#4309 Fix schedule reminder getting overwritten

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -47,15 +47,6 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
   }
 
   /**
-   * Build all the data structures needed to build the form.
-   */
-  public function preProcess() {
-    parent::preProcess();
-
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
-  }
-
-  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -47,6 +47,15 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
   }
 
   /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess() {
+    parent::preProcess();
+
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
+  }
+
+  /**
    * Build the form object.
    *
    * @throws \CRM_Core_Exception
@@ -97,6 +106,10 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       if ($isEvent) {
         $this->add('hidden', 'mappingID', $mappingID);
       }
+    }
+
+    if ($this->_id) {
+      $this->add('hidden', 'id', $this->_id);
     }
 
     $this->add(


### PR DESCRIPTION
Overview
----------------------------------------
Fixes Schedule Reminder form to use an id form field instead of getting the id value from the session.

Before
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4309 outlines the issue - opening the Edit link for multiple Scheduled Reminders in new tabs/windows and saving any but the most recently opened causes the most recently opened reminder gets overwritten.

After
----------------------------------------
Now uses a hidden id field to store the ID rather than the session.

Comments
----------------------------------------
Based on fixes for contributions and participants in  #14244 