### PR TITLE
Installer - Clarify the function and purpose of sample data

### DIFF
--- a/install/template.html
+++ b/install/template.html
@@ -132,7 +132,7 @@ if ($text_direction == 'rtl') {
 
 <p>
     <label for="loadGenerated"><span>Load sample data:</span><input id="loadGenerated" type="checkbox" name="loadGenerated" value=1 <?php if ( $loadGenerated == 1 ) { echo "checked='checked'"; } ?> /></label> <br />
-    <span class="testResults">Check this box to pre-populate CiviCRM with sample English contact records, online contribution pages, profile forms, etc. These examples can help you learn about CiviCRM features.</span><br />
+    <span class="testResults">Fill the database with randomly-generated individuals, organizations, households, contributions, activities, etc. (English only). Sample data is mainly used for demo and testing sites, not for real installs.</span><br />
 </p>
 
 <p style="margin-left: 2em"><button type="submit"><?php echo ts('Re-check requirements', ['escape' => 'js']); ?></button></p>

--- a/setup/plugins/blocks/sample-data.tpl.php
+++ b/setup/plugins/blocks/sample-data.tpl.php
@@ -4,7 +4,7 @@ endif; ?>
 
 <p>
   <label for="loadGenerated"><span>Load sample data:</span><input id="loadGenerated" type="checkbox" name="civisetup[loadGenerated]" value=1 <?php echo $model->loadGenerated ? "checked='checked'" : ""; ?> /></label> <br />
-  <span class="advancedTip"><?php echo ts("Check this box to pre-populate CiviCRM with sample English contact records, online contribution pages, profile forms, etc. These examples can help you learn about CiviCRM features."); ?></span><br />
+  <span class="advancedTip"><?php echo ts("Fill the database with randomly-generated individuals, organizations, households, contributions, activities, etc. (English only). Sample data is mainly used for demo and testing sites, not for real installs."); ?></span><br />
 </p>
 
 <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
13 years ago, I installed CiviCRM for the first time. There was a little checkbox for "Load Sample Data" that said "These examples can help you learn about CiviCRM features." That sounded good, I wanted to learn about CiviCRM features, so I clicked the box... and then it filled my nice new database with garbage. All it really helped me learn was how to spend the next few hours finding and deleting a bunch of unwanted contacts, contributions, activities, etc. from my new database.

That annoyed me, and I wished the help text had actually told me what it was going to do and what it was for. So 13 years later I'm finally doing something about it!

Before
----------------------------------------
Help text says:
> _"Check this box to pre-populate CiviCRM with sample English contact records, online contribution pages, profile forms, etc. These examples can help you learn about CiviCRM features."_

I disagree with that statement.

After
----------------------------------------
Help text says:

> _"Fill the database with randomly-generated individuals, organizations, households, contributions, activities, etc. (English only). Sample data is mainly used for demo and testing sites, not for real installs."_
