### PR TITLE
Fix enotices in Register task formRule by separating functions

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -833,7 +833,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
     // For single additions - show validation error if the contact has already been registered
     // for this event.
-    if ($self->_single && ($self->_action & CRM_Core_Action::ADD)) {
+    if (($self->_action & CRM_Core_Action::ADD)) {
       if ($self->_context == 'standalone') {
         $contactId = $values['contact_id'] ?? NULL;
       }
@@ -855,11 +855,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $dupeCheck->whereAdd("status_id != {$cancelledStatusID} ");
         $dupeCheck->find(TRUE);
         if (!empty($dupeCheck->id)) {
-          $errorMsg['event_id'] = ts("This contact has already been assigned to this event.");
+          $errorMsg['event_id'] = ts('This contact has already been assigned to this event.');
         }
       }
     }
-    return CRM_Utils_Array::crmIsEmptyArray($errorMsg) ? TRUE : $errorMsg;
+    return empty($errorMsg) ? TRUE : $errorMsg;
   }
 
   /**

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -142,4 +142,97 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
   }
 
+
+  /**
+   * Add local and global form rules.
+   *
+   * @return void
+   */
+  public function addRules(): void {
+    $this->addFormRule(['CRM_Event_Form_Task_Register', 'formRule']);
+  }
+
+  /**
+   * Global validation rules for the form.
+   *
+   * @param array $values
+   *   Posted values of the form.
+   * @param $files
+   * @param self $self
+   *
+   * @return array|true
+   *   list of errors to be posted back to the form
+   */
+  public static function formRule($values, $files, $self) {
+    // If $values['_qf_Participant_next'] is Delete or
+    // $values['event_id'] is empty, then return
+    // instead of proceeding further.
+
+    if ((($values['_qf_Participant_next'] ?? NULL) === 'Delete') ||
+      empty($values['event_id'])
+    ) {
+      return TRUE;
+    }
+
+    $errorMsg = [];
+
+    if (!empty($values['payment_processor_id'])) {
+      // make sure that payment instrument values (e.g. credit card number and cvv) are valid
+      CRM_Core_Payment_Form::validatePaymentInstrument($values['payment_processor_id'], $values, $errorMsg, NULL);
+    }
+
+    if (!empty($values['record_contribution'])) {
+      if (empty($values['financial_type_id'])) {
+        $errorMsg['financial_type_id'] = ts('Please enter the associated Financial Type');
+      }
+      if (empty($values['payment_instrument_id'])) {
+        $errorMsg['payment_instrument_id'] = ts('Payment Method is a required field.');
+      }
+      if (!empty($values['priceSetId'])) {
+        CRM_Price_BAO_PriceField::priceSetValidation($values['priceSetId'], $values, $errorMsg);
+      }
+    }
+
+    // do the amount validations.
+    //skip for update mode since amount is freeze, CRM-6052
+    if ((!$self->_id && empty($values['total_amount']) &&
+        empty($self->_values['line_items'])
+      ) ||
+      ($self->_id && !$self->_paymentId && isset($self->_values['line_items']) && is_array($self->_values['line_items']))
+    ) {
+      if ($priceSetId = CRM_Utils_Array::value('priceSetId', $values)) {
+        CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $values, $errorMsg, TRUE);
+      }
+    }
+    // For single additions - show validation error if the contact has already been registered
+    // for this event.
+    if ($self->_single && ($self->_action & CRM_Core_Action::ADD)) {
+      if ($self->_context == 'standalone') {
+        $contactId = $values['contact_id'] ?? NULL;
+      }
+      else {
+        $contactId = $self->_contactId;
+      }
+
+      $eventId = $values['event_id'] ?? NULL;
+
+      $event = new CRM_Event_DAO_Event();
+      $event->id = $eventId;
+      $event->find(TRUE);
+
+      if (!$event->allow_same_participant_emails && !empty($contactId) && !empty($eventId)) {
+        $cancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Cancelled');
+        $dupeCheck = new CRM_Event_BAO_Participant();
+        $dupeCheck->contact_id = $contactId;
+        $dupeCheck->event_id = $eventId;
+        $dupeCheck->whereAdd("status_id != {$cancelledStatusID} ");
+        $dupeCheck->find(TRUE);
+        if (!empty($dupeCheck->id)) {
+          $errorMsg['event_id'] = ts("This contact has already been assigned to this event.");
+        }
+      }
+    }
+    return CRM_Utils_Array::crmIsEmptyArray($errorMsg) ? TRUE : $errorMsg;
+  }
+
 }

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -142,7 +142,6 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     CRM_Core_Session::setStatus($statusMsg, ts('Saved'), 'success');
   }
 
-
   /**
    * Add local and global form rules.
    *
@@ -164,23 +163,7 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
    *   list of errors to be posted back to the form
    */
   public static function formRule($values, $files, $self) {
-    // If $values['_qf_Participant_next'] is Delete or
-    // $values['event_id'] is empty, then return
-    // instead of proceeding further.
-
-    if ((($values['_qf_Participant_next'] ?? NULL) === 'Delete') ||
-      empty($values['event_id'])
-    ) {
-      return TRUE;
-    }
-
     $errorMsg = [];
-
-    if (!empty($values['payment_processor_id'])) {
-      // make sure that payment instrument values (e.g. credit card number and cvv) are valid
-      CRM_Core_Payment_Form::validatePaymentInstrument($values['payment_processor_id'], $values, $errorMsg, NULL);
-    }
-
     if (!empty($values['record_contribution'])) {
       if (empty($values['financial_type_id'])) {
         $errorMsg['financial_type_id'] = ts('Please enter the associated Financial Type');
@@ -195,44 +178,15 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
 
     // do the amount validations.
     //skip for update mode since amount is freeze, CRM-6052
-    if ((!$self->_id && empty($values['total_amount']) &&
+    if (empty($values['total_amount']) &&
         empty($self->_values['line_items'])
-      ) ||
-      ($self->_id && !$self->_paymentId && isset($self->_values['line_items']) && is_array($self->_values['line_items']))
-    ) {
+      ) {
       if ($priceSetId = CRM_Utils_Array::value('priceSetId', $values)) {
         CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $values, $errorMsg, TRUE);
       }
     }
-    // For single additions - show validation error if the contact has already been registered
-    // for this event.
-    if ($self->_single && ($self->_action & CRM_Core_Action::ADD)) {
-      if ($self->_context == 'standalone') {
-        $contactId = $values['contact_id'] ?? NULL;
-      }
-      else {
-        $contactId = $self->_contactId;
-      }
 
-      $eventId = $values['event_id'] ?? NULL;
-
-      $event = new CRM_Event_DAO_Event();
-      $event->id = $eventId;
-      $event->find(TRUE);
-
-      if (!$event->allow_same_participant_emails && !empty($contactId) && !empty($eventId)) {
-        $cancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Cancelled');
-        $dupeCheck = new CRM_Event_BAO_Participant();
-        $dupeCheck->contact_id = $contactId;
-        $dupeCheck->event_id = $eventId;
-        $dupeCheck->whereAdd("status_id != {$cancelledStatusID} ");
-        $dupeCheck->find(TRUE);
-        if (!empty($dupeCheck->id)) {
-          $errorMsg['event_id'] = ts("This contact has already been assigned to this event.");
-        }
-      }
-    }
-    return CRM_Utils_Array::crmIsEmptyArray($errorMsg) ? TRUE : $errorMsg;
+    return empty($errorMsg) ? TRUE : $errorMsg;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotices in Register task formRule by separating functions

Before
----------------------------------------
1) notice regression in the formRule on the register task (in master)
![image](https://github.com/civicrm/civicrm-core/assets/336308/b8802218-2516-4e09-91a6-7f64593834bc)

2) the register form object is partially separated from it's parent - with a view to eliminating the relationship - but the `formRule` function is shared

After
----------------------------------------
The register form has it's own formRule function with no notice

Technical Details
----------------------------------------
`self->_single` is always TRUE for the parent `Participant` form and always FALSE for the `Register` form
`self->_id` is never true on the register form

I have some doubts about the price set validation choices it is making but haven't dug in to see if they are needed / appropriate

Comments
----------------------------------------
