### PR TITLE
Don't show events without end date forever on Manage Events

### DIFF
--- a/CRM/Event/Page/ManageEvent.php
+++ b/CRM/Event/Page/ManageEvent.php
@@ -536,12 +536,14 @@ ORDER BY start_date desc
       }
       else {
         $curDate = date('YmdHis');
-        $clauses[] = "(end_date >= {$curDate} OR end_date IS NULL)";
+        $dayBefore = date_sub(date_create(), date_interval_create_from_date_string("1 day"))->format('YmdHis');
+        $clauses[] = "(end_date >= {$curDate} OR (end_date IS NULL AND start_date >= {$dayBefore}))";
       }
     }
     else {
       $curDate = date('YmdHis');
-      $clauses[] = "(end_date >= {$curDate} OR end_date IS NULL)";
+      $dayBefore = date_sub(date_create(), date_interval_create_from_date_string("1 day"))->format('YmdHis');
+      $clauses[] = "(end_date >= {$curDate} OR (end_date IS NULL AND start_date >= {$dayBefore}))";
     }
 
     if ($sortBy &&


### PR DESCRIPTION
Overview
----------------------------------------
Since end date is not required for events, I find users often leave it blank for events that are just one day. Consequently, those events hang around on Manage Events with the default `Show Current and Upcoming Events` forever. I can't really see the utility of having open ended events shown here as it seems like it is the nature of events to end (without getting too philosophical here). If anyone is in fact using open-ended events, they can still find them by using `Search All or by Date Range`.

Before
----------------------------------------
Events without end date show forever.

After
----------------------------------------
Events without end date are no longer shown 1 day after their start date.

Comments
----------------------------------------
The Events Dashboard is doing something completely different, only searching for events that started in the last 7 days and ignoring end date. I could bring this logic over there if people feel it would be helpful, but that one is written in pure SQL.