### PR TITLE
APIv4 - Clarify specProvider code

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php
@@ -40,7 +40,8 @@ class ContactGetSpecProvider extends \Civi\Core\Service\AutoService implements G
       ->setOptionsCallback([__CLASS__, 'getGroupList']);
     $spec->addFieldSpec($field);
 
-    // Fields specific to Individuals
+    // The following fields are specific to Individuals, so omit them if
+    // `contact_type` value was passed to `getFields` and is not "Individual"
     if (!$spec->getValue('contact_type') || $spec->getValue('contact_type') === 'Individual') {
       // Age field
       $field = new FieldSpec('age_years', 'Contact', 'Integer');

--- a/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php
@@ -27,40 +27,34 @@ class ContributionGetSpecProvider extends \Civi\Core\Service\AutoService impleme
    * @throws \CRM_Core_Exception
    */
   public function modifySpec(RequestSpec $spec): void {
-    // Amount paid field
-    if (!$spec->getValue('paid_amount')) {
-      $field = new FieldSpec('paid_amount', 'Contribution', 'Float');
-      $field->setLabel(ts('Amount Paid'))
-        ->setTitle(ts('Amount Paid'))
-        ->setDescription(ts('Amount paid'))
-        ->setType('Extra')
-        ->setDataType('Money')
-        ->setReadonly(TRUE)
-        ->setSqlRenderer([__CLASS__, 'calculateAmountPaid']);
-      $spec->addFieldSpec($field);
-    }
-    if (!$spec->getValue('balance_amount')) {
-      $field = new FieldSpec('balance_amount', 'Contribution', 'Float');
-      $field->setLabel(ts('Balance'))
-        ->setTitle(ts('Balance'))
-        ->setDescription(ts('Balance'))
-        ->setType('Extra')
-        ->setDataType('Money')
-        ->setReadonly(TRUE)
-        ->setSqlRenderer([__CLASS__, 'calculateBalance']);
-      $spec->addFieldSpec($field);
-    }
-    if (!$spec->getValue('tax_exclusive_amount')) {
-      $field = new FieldSpec('tax_exclusive_amount', 'Contribution', 'Float');
-      $field->setLabel(ts('Tax Exclusive Amount'))
-        ->setTitle(ts('Tax Exclusive Amount'))
-        ->setDescription(ts('Tax Exclusive Amount'))
-        ->setType('Extra')
-        ->setDataType('Money')
-        ->setReadonly(TRUE)
-        ->setSqlRenderer([__CLASS__, 'calculateTaxExclusiveAmount']);
-      $spec->addFieldSpec($field);
-    }
+    // Add calculated fields
+    $field = new FieldSpec('paid_amount', 'Contribution', 'Float');
+    $field->setLabel(ts('Amount Paid'))
+      ->setTitle(ts('Amount Paid'))
+      ->setDescription(ts('Amount paid'))
+      ->setType('Extra')
+      ->setDataType('Money')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'calculateAmountPaid']);
+    $spec->addFieldSpec($field);
+    $field = new FieldSpec('balance_amount', 'Contribution', 'Float');
+    $field->setLabel(ts('Balance'))
+      ->setTitle(ts('Balance'))
+      ->setDescription(ts('Balance'))
+      ->setType('Extra')
+      ->setDataType('Money')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'calculateBalance']);
+    $spec->addFieldSpec($field);
+    $field = new FieldSpec('tax_exclusive_amount', 'Contribution', 'Float');
+    $field->setLabel(ts('Tax Exclusive Amount'))
+      ->setTitle(ts('Tax Exclusive Amount'))
+      ->setDescription(ts('Tax Exclusive Amount'))
+      ->setType('Extra')
+      ->setDataType('Money')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'calculateTaxExclusiveAmount']);
+    $spec->addFieldSpec($field);
   }
 
   /**

--- a/Civi/Api4/Service/Spec/Provider/GroupGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/GroupGetSpecProvider.php
@@ -27,16 +27,14 @@ class GroupGetSpecProvider extends \Civi\Core\Service\AutoService implements Gen
    * @throws \CRM_Core_Exception
    */
   public function modifySpec(RequestSpec $spec): void {
-    // Number of contacts
-    if (!$spec->getValue('contact_count')) {
-      $field = new FieldSpec('contact_count', 'Group', 'Integer');
-      $field->setLabel(ts('Contact Count'))
-        ->setDescription(ts('Number of contacts in group'))
-        ->setColumnName('id')
-        ->setReadonly(TRUE)
-        ->setSqlRenderer([__CLASS__, 'countContacts']);
-      $spec->addFieldSpec($field);
-    }
+    // Calculated field counts contacts in group
+    $field = new FieldSpec('contact_count', 'Group', 'Integer');
+    $field->setLabel(ts('Contact Count'))
+      ->setDescription(ts('Number of contacts in group'))
+      ->setColumnName('id')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'countContacts']);
+    $spec->addFieldSpec($field);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Some not-well-documented code led to confusion that's been copy-pasted a couple times now. This removes the unnecessarily-pasted code and adds clarifying comments to the code which originally caused the confusion.

Before
----------------------------------------
Unnecessary conditionals which could potentially lead to subtle bugs.

After
----------------------------------------
That's better.

FYI @eileenmcnaughton @aydun 