### PR TITLE
Fix participantListingURL on Manage Event

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -115,7 +115,13 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
       }
 
       $participantListingID = $eventInfo['participant_listing_id'] ?? NULL;
-      //CRM_Core_DAO::getFieldValue( 'CRM_Event_DAO_Event', $this->_id, 'participant_listing_id' );
+      if ($participantListingID) {
+        $participantListingURL = CRM_Utils_System::url('civicrm/event/participant',
+          "reset=1&id={$this->_id}",
+          FALSE, NULL, TRUE, TRUE
+        );
+      }
+      $this->assign('participantListingURL', $participantListingURL ?? NULL);
       $this->assign('participantListingID', $participantListingID);
       $this->assign('isOnlineRegistration', CRM_Utils_Array::value('is_online_registration', $eventInfo));
 


### PR DESCRIPTION
Overview
----------------------------------------
There was a PHP warning for this, but it turns out that there was supposed to be a Public Participant Listing link in the Find Participants menu, when enabled, but there was no code to assign participantListingURL.

Before
----------------------------------------
PHP warning on Manage Event (this is the last one remaining that I can see).

After
----------------------------------------
No more warning.
When enabled, there is a Public Participant Listing link at the bottom of the Find Participants menu.