### PR TITLE
APIv4 - Add bridge entity metadata to GroupNesting entity

### DIFF
--- a/Civi/Api4/GroupNesting.php
+++ b/Civi/Api4/GroupNesting.php
@@ -14,10 +14,27 @@ namespace Civi\Api4;
  * GroupNesting entity.
  *
  * @see \Civi\Api4\Group
- * @searchable none
+ * @searchable bridge
  * @since 5.19
  * @package Civi\Api4
  */
 class GroupNesting extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
+  use Generic\Traits\ReadOnlyEntity;
+
+  /**
+   * @return array
+   */
+  public static function getInfo() {
+    $info = parent::getInfo();
+    $info['bridge'] = [
+      'child_group_id' => [
+        'label' => ts('Children'),
+        'description' => ts('Sub-groups nested under this group'),
+        'to' => 'parent_group_id',
+      ],
+    ];
+    return $info;
+  }
 
 }

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -178,10 +178,6 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
     $this->assertNotEmpty($info['primary_key']);
     $this->assertRegExp(';^\d\.\d+$;', $info['since']);
     $this->assertContains($info['searchable'], ['primary', 'secondary', 'bridge', 'none']);
-    // Bridge must be between exactly 2 entities
-    if (in_array('EntityBridge', $info['type'], TRUE)) {
-      $this->assertCount(2, $info['bridge']);
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Allows SearchKit to join between Group and nested Group (parent-child relationship):

![image](https://github.com/civicrm/civicrm-core/assets/2874912/dfda765c-95d9-4176-b437-65ad787af721)


Comments
----------------------------------------
As I mentioned in #26352 there are 3 places where group nesting data is stored. This exposes the 3rd one to SearchKit. It sounds redundant, and it is in fact redundant. Also redundant. But useful too, and building out a "Manage Groups" page in SearchKit is hard so we need all the tools we can get.