### PR TITLE
dev/core#4260 Improve Event Registration buttons for free registrations, additional participants and review

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -336,25 +336,37 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     //CRM-4320
     if ($allowToProceed) {
-      $buttons = array_merge($buttons, [
-        [
-          'type' => 'upload',
-          'name' => ts('Continue'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ],
-      ]);
       if ($includeSkipButton) {
-        $buttons = array_merge($buttons, [
+        $buttons[] =
           [
             'type' => 'next',
             'name' => ts('Skip Participant'),
             'subName' => 'skip',
             'icon' => 'fa-fast-forward',
-          ],
-        ]);
+          ];
       }
+      $buttonParams = [
+        'type' => 'upload',
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+      ];
+      if ($this->isLastParticipant(TRUE)) {
+        if ($this->_values['event']['is_confirm_enabled'] || $this->_values['event']['is_monetary']) {
+          $buttonParams['name'] = ts('Review');
+          $buttonParams['icon'] = 'fa-chevron-right';
+        }
+        else {
+          $buttonParams['name'] = ts('Register');
+          $buttonParams['icon'] = 'fa-check';
+        }
+      }
+      else {
+        $buttonParams['name'] = ts('Continue');
+        $buttonParams['icon'] = 'fa-chevron-right';
+      }
+      $buttons[] = $buttonParams;
     }
+
     $this->addButtons($buttons);
     $this->addFormRule(['CRM_Event_Form_Registration_AdditionalParticipant', 'formRule'], $this);
     $this->unsavedChangesWarn = TRUE;

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -275,7 +275,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     //consider total amount.
     $this->assign('isAmountzero', $this->_totalAmount <= 0);
 
-    $contribButton = ts('Continue');
+    $contribButton = ts('Register');
     $this->addButtons([
       [
         'type' => 'back',

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -513,11 +513,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
         'isDefault' => TRUE,
       ];
-      if (
-        !$this->_values['event']['is_multiple_registrations']
-        && !$this->_values['event']['is_monetary']
-        && !$this->_values['event']['is_confirm_enabled']
-      ) {
+      if (!$this->_values['event']['is_monetary'] && !$this->_values['event']['is_confirm_enabled']) {
         $buttonParams['name'] = ts('Register');
       }
       else {

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -16,19 +16,19 @@
 <div class="crm-event-id-{$event.id} crm-block crm-event-confirm-form-block">
     {if $isOnWaitlist}
         <div class="help">
-            {ts}Please verify the information below. <span class="bold">Then click 'Continue' to be added to the WAIT LIST for this event</span>. If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
+            {ts}Please verify the information below. <span class="bold">Then click 'Register' to be added to the WAIT LIST for this event</span>. If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
         </div>
     {elseif $isRequireApproval}
         <div class="help">
-            {ts}Please verify the information below. Then click 'Continue' to submit your registration. <span class="bold">Once approved, you will receive an email with a link to a web page where you can complete the registration process.</span>{/ts}
+            {ts}Please verify the information below. Then click 'Register' to submit your registration. <span class="bold">Once approved, you will receive an email with a link to a web page where you can complete the registration process.</span>{/ts}
         </div>
     {else}
         <div class="help">
         {ts}Please verify the information below. Click the <strong>Go Back</strong> button below if you need to make changes.{/ts}
         {if $contributeMode EQ 'notify' and !$is_pay_later and ! $isAmountzero }
-          {ts 1=$paymentProcessor.name}Click the <strong>Continue</strong> button to checkout to %1, where you will select your payment method and complete the registration.{/ts}
+          {ts 1=$paymentProcessor.name}Click the <strong>Register</strong> button to checkout to %1, where you will select your payment method and complete the registration.{/ts}
         {else}
-            {ts}Otherwise, click the <strong>Continue</strong> button below to complete your registration.{/ts}
+            {ts}Otherwise, click the <strong>Register</strong> button below to complete your registration.{/ts}
         {/if}
         </div>
         {if $is_pay_later and !$isAmountzero}
@@ -166,7 +166,7 @@
     {if $contributeMode NEQ 'notify'} {* In 'notify mode, contributor is taken to processor payment forms next *}
     <div class="messages status section continue_message-section">
         <p>
-        {ts}Your registration will not be submitted until you click the <strong>Continue</strong> button. Please click the button one time only. If you need to change any details, click the Go Back button below to return to the previous screen.{/ts}
+        {ts}Your registration will not be submitted until you click the <strong>Register</strong> button. Please click the button one time only. If you need to change any details, click the Go Back button below to return to the previous screen.{/ts}
         </p>
     </div>
     {/if}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -170,6 +170,7 @@
   {literal}
 
   CRM.$(function($) {
+    toggleAdditionalParticipants();
     $('#additional_participants').change(function() {
       toggleAdditionalParticipants();
       allowParticipant();
@@ -177,14 +178,18 @@
 
     function toggleAdditionalParticipants() {
       var submit_button = $("#crm-submit-buttons > button").html();
-      var review_translated = '{/literal}{ts escape="js"}Review{/ts}{literal}';
+      {/literal}{if $event.is_monetary || $event.is_confirm_enabled}{literal}
+        var next_translated = '{/literal}{ts escape="js"}Review{/ts}{literal}';
+      {/literal}{else}{literal}
+        var next_translated = '{/literal}{ts escape="js"}Register{/ts}{literal}';
+      {/literal}{/if}{literal}
       var continue_translated = '{/literal}{ts escape="js"}Continue{/ts}{literal}';
       if ($('#additional_participants').val()) {
         $("#additionalParticipantsDescription").show();
-        $("#crm-submit-buttons > button").html(submit_button.replace(review_translated, continue_translated));
+        $("#crm-submit-buttons > button").html(submit_button.replace(next_translated, continue_translated));
       } else {
         $("#additionalParticipantsDescription").hide();
-        $("#crm-submit-buttons > button").html(submit_button.replace(continue_translated, review_translated));
+        $("#crm-submit-buttons > button").html(submit_button.replace(continue_translated, next_translated));
       }
     }
   });


### PR DESCRIPTION
Before
----------------------------------------
For free event registrations with the confirmation screen off, the button text was 'Review' — but the user would not be reviewing anything on the next page because they would be registered.
Button text was inconsistent if going back or if you hit a validation error.
Skip Participant button for additional participants was to the right of Continue. Continue icon was check mark.
<img width="336" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/7d88e9a1-e45b-46e1-8c84-ae6de4ffd5c7">

On the Review page, the button was 'Continue'.
On the last Additional Participant, the button was always 'Continue'.

After
----------------------------------------
For free event registrations with the confirmation screen off, the button text now says 'Register', so the user knows they are registering by clicking.
Button text is updated on page load, making it consistent.
Skip Participant button for additional participants is between Go Back and Continue, leaving the most common option on the far right instead of hiding it between the other two buttons. Continue icon is >.
<img width="336" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/630881b4-9078-4360-8f6a-9ca6e80ac6ab">

On the Review page, the button is 'Register' because that's what the user is doing.
<img width="336" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/997fa572-a93c-4876-8738-dce4eac0bc53">

On the last Additional Participant, the button is 'Register' or 'Review' as appropriate.


Comments
----------------------------------------
Icon on the first page when switching from Register to Continue when selecting Additional Participants does not change, which is slightly inconsistent.