### PR TITLE
fix parameters in Payment.get

### DIFF
--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -42,9 +42,8 @@ function civicrm_api3_payment_get($params) {
     if (empty($eft)) {
       return civicrm_api3_create_success([], $params, 'Payment', 'get');
     }
-    foreach ($eft as $entityFinancialTrxn) {
-      $params['financial_trxn_id']['IN'][] = $entityFinancialTrxn['financial_trxn_id'];
-    }
+    $ftIds = array_column($eft, 'financial_trxn_id');
+    $params['financial_trxn_id'] = ['IN' => $ftIds];
   }
 
   $financialTrxn = civicrm_api3('FinancialTrxn', 'get', array_merge($params, ['sequential' => FALSE]))['values'];


### PR DESCRIPTION
Overview
----------------------------------------
There's a bug in how financial transaction IDs are searched in APIv3 `Payment.get`.

Technical Details
----------------------------------------
The old code produced a malformed parameter such that `Payment.get` with a contribution ID specified never returned a value.  Since this hasn't been caught be tests, I don't think this is very serious - I came across it while testing something that turned out to be unrelated.

Comments
----------------------------------------
Since tests are passing and no one has reported an issue here, any test failures this provokes should be indications of a deeper bug elsewhere.
