### PR TITLE
APIv4 - Add Group.cache_expired calculated field and Group::refresh action

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -336,11 +336,12 @@ WHERE  id IN ( $groupIDs )
   /**
    * Load the smart group cache for a saved search.
    *
-   * @param object $group
+   * @param CRM_Core_DAO $group
    *   The smart group that needs to be loaded.
    * @param bool $force
    *   deprecated parameter = Should we force a search through.
    *
+   * return bool
    * @throws \CRM_Core_Exception
    */
   public static function load($group, $force = FALSE) {
@@ -361,6 +362,7 @@ WHERE  id IN ( $groupIDs )
       self::releaseGroupLocks([$groupID]);
       $groupContactsTempTable->drop();
     }
+    return in_array($groupID, $lockedGroups);
   }
 
   /**
@@ -482,14 +484,15 @@ ORDER BY   gc.contact_id, g.children
   }
 
   /**
-   * Invalidates the smart group cache for a particular group
-   * @param int $groupID - Group to invalidate
+   * Invalidates the smart group cache for one or more groups
+   * @param int|int[] $groupID - Group to invalidate
    */
   public static function invalidateGroupContactCache($groupID): void {
+    $groupIDs = implode(',', (array) $groupID);
     CRM_Core_DAO::executeQuery('UPDATE civicrm_group
       SET cache_date = NULL
-      WHERE id = %1 AND (saved_search_id IS NOT NULL OR children IS NOT NULL)', [
-        1 => [$groupID, 'Positive'],
+      WHERE id IN (%1) AND (saved_search_id IS NOT NULL OR children IS NOT NULL)', [
+        1 => [$groupIDs, 'CommaSeparatedIntegers'],
       ]);
   }
 

--- a/Civi/Api4/Action/Group/Refresh.php
+++ b/Civi/Api4/Action/Group/Refresh.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Group;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * @inheritDoc
+ */
+class Refresh extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected function processBatch(Result $result, array $items) {
+    if ($items) {
+      \CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache(array_column($items, 'id'));
+    }
+    foreach ($items as $item) {
+      $group = new \CRM_Contact_DAO_Group();
+      $group->id = $item['id'];
+      if (\CRM_Contact_BAO_GroupContactCache::load($group)) {
+        $result[] = $item;
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/Group.php
+++ b/Civi/Api4/Group.php
@@ -23,6 +23,16 @@ class Group extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
 
   /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\Group\Refresh
+   * @throws \CRM_Core_Exception
+   */
+  public static function refresh(bool $checkPermissions = TRUE): Action\Group\Refresh {
+    return (new Action\Group\Refresh(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * Provides more-open permissions that will be further restricted by checkAccess
    *
    * @see \CRM_Contact_BAO_Group::_checkAccess()
@@ -34,6 +44,7 @@ class Group extends Generic\DAOEntity {
     return [
       // Create permission depends on the group type (see CRM_Contact_BAO_Group::_checkAccess).
       'create' => ['access CiviCRM', ['edit groups', 'access CiviMail', 'create mailings']],
+      'refresh' => ['access CiviCRM'],
     ] + $permissions;
   }
 

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -188,7 +188,7 @@ class CoreUtil {
     // For get actions, just run a get and ACLs will be applied to the query.
     // It's a cheap trick and not as efficient as not running the query at all,
     // but BAO::checkAccess doesn't consistently check permissions for the "get" action.
-    if (is_a($apiRequest, '\Civi\Api4\Generic\DAOGetAction')) {
+    if (is_a($apiRequest, '\Civi\Api4\Generic\AbstractGetAction')) {
       return (bool) $apiRequest->addSelect('id')->addWhere('id', '=', $record['id'])->execute()->count();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds to APIv4 a way to check if a smart group needs refreshing, and a method to refresh it.

This is an alternative to #26311

Technical Details
----------------------------------------
Calculated field `cache_expired` added to the APIv4 group entity.
`refresh` action added which can be combined with that field to only target groups that need refreshing.
