### PR TITLE
Don't show refund due when balance is owed on Additional Payments

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -152,10 +152,12 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $defaults['trxn_date'] = date('Y-m-d H:i:s');
     }
 
-    if ($this->isARefund() && $this->amountDue < 0) {
-      $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency(abs($this->amountDue));
+    if ($this->isARefund()) {
+      if ($this->amountDue < 0) {
+        $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency(abs($this->amountDue));
+      }
     }
-    elseif ($this->_owed && $this->amountDue > 0) {
+    elseif ($this->_owed) {
       $defaults['total_amount'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($this->_owed);
     }
 
@@ -244,9 +246,12 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
         $attributes['fee_amount']
       );
       $this->addRule('fee_amount', ts('Please enter a valid monetary value for Fee Amount.'), 'money');
+      $buttonName = $this->isARefund() ? ts('Record Refund') : ts('Record Payment');
+    }
+    else {
+      $buttonName = ts('Submit Payment');
     }
 
-    $buttonName = $this->isARefund() ? ts('Record Refund') : ts('Record Payment');
     $this->addButtons([
       [
         'type' => 'upload',

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -53,7 +53,7 @@
     <tr class="crm-payment-form-block-total_amount">
       <td class="label">{$form.total_amount.label}</td>
       <td>
-        <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>&nbsp; <span class="status">{if $paymentType EQ 'refund' || $paymentAmt < 0}{ts}Refund Due :&nbsp;{$absolutePaymentAmount|crmMoney} {/ts}{else}{ts}Balance Owed{/ts} :&nbsp;{$paymentAmt|crmMoney}{/if}</span>
+        <span id='totalAmount'>{$form.currency.html|crmAddClass:eight}&nbsp;{$form.total_amount.html|crmAddClass:eight}</span>&nbsp; <span class="status">{if $paymentAmt < 0}{ts}Refund Due :&nbsp;{$absolutePaymentAmount|crmMoney} {/ts}{else}{ts}Balance Owed{/ts} :&nbsp;{$paymentAmt|crmMoney}{/if}</span>
       </td>
       {if $email and $outBound_option != 2}
         <tr class="crm-payment-form-block-is_email_receipt">


### PR DESCRIPTION
Before
----------------------------------------
If a contributor owes an amount on a contribution, if you click Record Refund, the form incorrectly shows `Refund Due: $N` when $N is actually the balance owed. The amount field is also set by default to the balance owed when you are in fact recording a refund.

![image](https://github.com/civicrm/civicrm-core/assets/25517556/30b01b44-c31f-4125-ba78-a67c1e1026df)

The Submit Credit Card payment submit button says `Record Payment`.

After
----------------------------------------
If the contributor owes an amount on a contribution, if you click Record Refund, the form correctly shows `Balance Owed: $N`instead of `Refund Due: $N`. The amount field is only set by default if there is a refund due.

![image](https://github.com/civicrm/civicrm-core/assets/25517556/3d61664a-de67-4bcb-9eca-8e706033c087)

The Submit Credit Card payment submit button says `Submit Payment`.

Comments
----------------------------------------
`$this->_owed` and `$this->amountDue` are the same when `$this->_owed` is TRUE, so no need to check both.