### PR TITLE
APIv4 - Fix CONTAINS operator to work with more types of serialized fields

### DIFF
--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -64,7 +64,7 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
   /**
    * Quick clean by emptying tables created for the test.
    *
-   * @param array $params
+   * @param array{tablesToTruncate: array} $params
    */
   public function cleanup(array $params): void {
     $params += [

--- a/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
@@ -104,7 +104,7 @@ class CustomContactRefTest extends CustomTestBase {
 
     $result = Contact::get(FALSE)
       ->addSelect('id')
-      ->addWhere('MyContactRef.FavPeople.first_name', 'CONTAINS', 'First')
+      ->addWhere('MyContactRef.FavPeople.first_name', 'CONTAINS', 'FirstFav')
       ->execute()
       ->single();
 
@@ -112,7 +112,7 @@ class CustomContactRefTest extends CustomTestBase {
 
     $result = Contact::get(FALSE)
       ->addSelect('id')
-      ->addWhere('MyContactRef.FavPeople.first_name', 'CONTAINS', 'Second')
+      ->addWhere('MyContactRef.FavPeople.first_name', 'CONTAINS', 'SecondFav')
       ->execute();
 
     $this->assertCount(2, $result);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in APIv4 where the CONTAINS operator would return false-positives for certain types of serialized fields.

Before
----------------------------------------
Given a group with parents [12, 35, 40] the CONTAINS match would return TRUE for `12` (correctly) but also return TRUE for `1` (incorrectly matching one of the digits instead of the complete number)

After
----------------------------------------
Fixed.