### PR TITLE
Serialize Participant fee_level when using Change Selections

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1034,7 +1034,7 @@ WHERE li.contribution_id = %1";
         $line[$getUpdatedLineItemsDAO->price_field_value_id] = $getUpdatedLineItemsDAO->label . ' - ' . (float) $getUpdatedLineItemsDAO->qty;
       }
 
-      $partUpdateFeeAmt['fee_level'] = implode(', ', $line);
+      $partUpdateFeeAmt['fee_level'] = $line;
       $partUpdateFeeAmt['fee_amount'] = $inputParams['amount'];
       CRM_Event_BAO_Participant::add($partUpdateFeeAmt);
 


### PR DESCRIPTION
Before
----------------------------------------
When using Participant Change Selections, the fee_level is saved as a comma-separated list with spaces, which is then bookended as a single value.

After
----------------------------------------
The fee_level is properly serialized.
