### PR TITLE
[REF] CRM_Core_StateMachine::addSequentialPages(): don't pass extra parameter

### DIFF
--- a/CRM/Activity/StateMachine/Search.php
+++ b/CRM/Activity/StateMachine/Search.php
@@ -41,7 +41,7 @@ class CRM_Activity_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages[$t] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Campaign/StateMachine/Search.php
+++ b/CRM/Campaign/StateMachine/Search.php
@@ -49,7 +49,7 @@ class CRM_Campaign_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages['CRM_Campaign_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Case/StateMachine/Search.php
+++ b/CRM/Case/StateMachine/Search.php
@@ -51,7 +51,7 @@ class CRM_Case_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages['CRM_Case_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Contact/StateMachine/Search.php
+++ b/CRM/Contact/StateMachine/Search.php
@@ -64,7 +64,7 @@ class CRM_Contact_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages['CRM_Contact_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Contribute/StateMachine/Contribution.php
+++ b/CRM/Contribute/StateMachine/Contribution.php
@@ -38,7 +38,7 @@ class CRM_Contribute_StateMachine_Contribution extends CRM_Core_StateMachine {
       'CRM_Contribute_Form_Contribution_ThankYou' => NULL,
     ];
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
 }

--- a/CRM/Contribute/StateMachine/ContributionPage.php
+++ b/CRM/Contribute/StateMachine/ContributionPage.php
@@ -50,7 +50,7 @@ class CRM_Contribute_StateMachine_ContributionPage extends CRM_Core_StateMachine
       unset($this->_pages['CRM_Member_Form_MembershipBlock']);
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
 }

--- a/CRM/Contribute/StateMachine/Search.php
+++ b/CRM/Contribute/StateMachine/Search.php
@@ -49,7 +49,7 @@ class CRM_Contribute_StateMachine_Search extends CRM_Core_StateMachine {
     if ($result) {
       $this->_pages['CRM_Contribute_Form_Task_Result'] = NULL;
     }
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Core/Controller/Simple.php
+++ b/CRM/Core/Controller/Simple.php
@@ -59,7 +59,7 @@ class CRM_Core_Controller_Simple extends CRM_Core_Controller {
       $mode = $savedAction;
     }
 
-    $this->_stateMachine->addSequentialPages($params, $mode);
+    $this->_stateMachine->addSequentialPages($params);
 
     $this->addPages($this->_stateMachine, $mode);
 

--- a/CRM/Event/StateMachine/Registration.php
+++ b/CRM/Event/StateMachine/Registration.php
@@ -70,7 +70,7 @@ class CRM_Event_StateMachine_Registration extends CRM_Core_StateMachine {
       unset($pages['CRM_Event_Form_Registration_Confirm']);
     }
 
-    $this->addSequentialPages($pages, $action);
+    $this->addSequentialPages($pages);
   }
 
 }

--- a/CRM/Event/StateMachine/Search.php
+++ b/CRM/Event/StateMachine/Search.php
@@ -49,7 +49,7 @@ class CRM_Event_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages['CRM_Event_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Export/StateMachine/Standalone.php
+++ b/CRM/Export/StateMachine/Standalone.php
@@ -33,7 +33,7 @@ class CRM_Export_StateMachine_Standalone extends CRM_Core_StateMachine {
       'CRM_' . $entity . '_Export_Form_Map' => NULL,
     ];
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Group/StateMachine.php
+++ b/CRM/Group/StateMachine.php
@@ -32,7 +32,7 @@ class CRM_Group_StateMachine extends CRM_Core_StateMachine {
       'CRM_Contact_Form_Task_Result' => NULL,
     ];
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/Import/StateMachine.php
+++ b/CRM/Import/StateMachine.php
@@ -36,7 +36,7 @@ class CRM_Import_StateMachine extends CRM_Core_StateMachine {
       $classType . '_Form_Preview' => NULL,
     ];
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
 }

--- a/CRM/Member/StateMachine/Search.php
+++ b/CRM/Member/StateMachine/Search.php
@@ -49,7 +49,7 @@ class CRM_Member_StateMachine_Search extends CRM_Core_StateMachine {
     if ($result) {
       $this->_pages['CRM_Member_Form_Task_Result'] = NULL;
     }
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/PCP/StateMachine/PCP.php
+++ b/CRM/PCP/StateMachine/PCP.php
@@ -41,7 +41,7 @@ class CRM_PCP_StateMachine_PCP extends CRM_Core_StateMachine {
       'CRM_PCP_Form_Campaign' => NULL,
     ];
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
 }

--- a/CRM/Pledge/StateMachine/Search.php
+++ b/CRM/Pledge/StateMachine/Search.php
@@ -51,7 +51,7 @@ class CRM_Pledge_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages['CRM_Pledge_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/CRM/SMS/StateMachine/Send.php
+++ b/CRM/SMS/StateMachine/Send.php
@@ -37,7 +37,7 @@ class CRM_SMS_StateMachine_Send extends CRM_Core_StateMachine {
       'CRM_SMS_Form_Schedule' => NULL,
     ];
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
 }

--- a/CRM/Upgrade/StateMachine.php
+++ b/CRM/Upgrade/StateMachine.php
@@ -34,7 +34,7 @@ class CRM_Upgrade_StateMachine extends CRM_Core_StateMachine {
 
     $this->_pages = &$pages;
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
 }

--- a/ext/civigrant/CRM/Grant/StateMachine/Search.php
+++ b/ext/civigrant/CRM/Grant/StateMachine/Search.php
@@ -51,7 +51,7 @@ class CRM_Grant_StateMachine_Search extends CRM_Core_StateMachine {
       $this->_pages['CRM_Grant_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**

--- a/ext/eventcart/CRM/Event/Cart/StateMachine/Checkout.php
+++ b/ext/eventcart/CRM/Event/Cart/StateMachine/Checkout.php
@@ -32,7 +32,7 @@ class CRM_Event_Cart_StateMachine_Checkout extends CRM_Core_StateMachine {
     }
     $pages["CRM_Event_Cart_Form_Checkout_Payment"] = NULL;
     $pages["CRM_Event_Cart_Form_Checkout_ThankYou"] = NULL;
-    $this->addSequentialPages($pages, $action);
+    $this->addSequentialPages($pages);
   }
 
 }

--- a/ext/legacycustomsearches/CRM/Legacycustomsearches/StateMachine/Search.php
+++ b/ext/legacycustomsearches/CRM/Legacycustomsearches/StateMachine/Search.php
@@ -50,7 +50,7 @@ class CRM_Legacycustomsearches_StateMachine_Search extends CRM_Core_StateMachine
       $this->_pages['CRM_Contact_Form_Task_Result'] = NULL;
     }
 
-    $this->addSequentialPages($this->_pages, $action);
+    $this->addSequentialPages($this->_pages);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_StateMachine::addSequentialPages()` method signature has 1 parameter (`&$pages`), but it's called with 2 parameters.

Before
----------------------------------------
Extra `$action` param is passed.

After
----------------------------------------
2nd parameter removed from all method calls.
