### PR TITLE
[REF][PHP8.2] Avoid unnecessary property in WebsiteTest

### DIFF
--- a/tests/phpunit/api/v3/WebsiteTest.php
+++ b/tests/phpunit/api/v3/WebsiteTest.php
@@ -27,9 +27,9 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
     $this->useTransaction();
 
     $this->_entity = 'website';
-    $this->_contactID = $this->organizationCreate();
+    $contactID = $this->organizationCreate();
     $this->params = [
-      'contact_id' => $this->_contactID,
+      'contact_id' => $contactID,
       'url' => 'website.com',
       'website_type_id' => 1,
     ];


### PR DESCRIPTION
Before
----------------------------------------
`contactID` was used as a dynamic property. Dynamic properties are deprecated in PHP 8.2.

After
----------------------------------------
A standard variable works just as well, without triggering a deprecation notice.
