### PR TITLE
[REF][PHP8.2] Declare getSiteDefaultCountry property

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -91,6 +91,11 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected $statesByCountry = [];
 
   /**
+   * @var int|null
+   */
+  protected $siteDefaultCountry = NULL;
+
+  /**
    * @return int|null
    */
   public function getUserJobID(): ?int {
@@ -1954,7 +1959,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @return int
    */
   protected function getSiteDefaultCountry(): int {
-    if (!isset($this->siteDefaultCountry)) {
+    if ($this->siteDefaultCountry === NULL) {
       $this->siteDefaultCountry = (int) Civi::settings()->get('defaultContactCountry');
     }
     return $this->siteDefaultCountry;


### PR DESCRIPTION
Overview
----------------------------------------
Declare property for `getSiteDefaultCountry` method.

Before
----------------------------------------
Code threw a deprecation notice on PHP 8.2, due to use of dynamic properties.

After
----------------------------------------
PHP 8.2 compatiable.