### PR TITLE
[REF][PHP8.2] Use standard variables - CRM_Activity_Form_ActivityView

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -64,16 +64,16 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     $this->assign('activityTypeDescription', $activityTypeDescription);
 
     if (!empty($defaults['mailingId'])) {
-      $this->_mailing_id = $defaults['source_record_id'] ?? NULL;
-      $mailingReport = CRM_Mailing_BAO_Mailing::report($this->_mailing_id, TRUE);
+      $mailing_id = $defaults['source_record_id'] ?? NULL;
+      $mailingReport = CRM_Mailing_BAO_Mailing::report($mailing_id, TRUE);
       CRM_Mailing_BAO_Mailing::getMailingContent($mailingReport, $this);
       $this->assign('mailingReport', $mailingReport);
 
       $full_open_report = CRM_Mailing_Event_BAO_MailingEventOpened::getRows(
-        $this->_mailing_id, NULL, FALSE, NULL, NULL, NULL, $cid);
+        $mailing_id, NULL, FALSE, NULL, NULL, NULL, $cid);
       $this->assign('openreport', $full_open_report);
 
-      $click_thru_report = CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::getRows($this->_mailing_id, NULL, FALSE, NULL, NULL, NULL, NULL, $cid);
+      $click_thru_report = CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::getRows($mailing_id, NULL, FALSE, NULL, NULL, NULL, NULL, $cid);
       $this->assign('clickreport', $click_thru_report);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Use standard variables - `CRM_Activity_Form_ActivityView` test

Before
----------------------------------------
`CRM_Activity_Form_ActivityView` used dyamic propertiy `_mailing_id`, causing tests to fail on PHP 8.2.

After
----------------------------------------
Standard variables are used instead.

Comments
----------------------------------------
This is not test code, so there is a small chance that extensions are using the `_mailing_id` properties. I consider the risk low, especially as the leading underscore should have indicated the property was intented to be treated as private.
