### PR TITLE
dev/core#3989 When merging, don't overwrite source even when original source is empty

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1565,6 +1565,8 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
 
       // Display a checkbox to migrate, only if the values are different
       if ($value != $main[$field]) {
+        // Don't check source if main is empty, because the source of the other contact is not the source of the merged contact
+        $isChecked = ($field === 'source') ? FALSE : (!isset($main[$field]) || $main[$field] === '');
         $elements[] = [
           0 => 'advcheckbox',
           1 => "move_$field",
@@ -1572,7 +1574,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           3 => NULL,
           4 => NULL,
           5 => $value,
-          'is_checked' => (!isset($main[$field]) || $main[$field] === ''),
+          'is_checked' => $isChecked,
         ];
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
The source of a contact should be set when the contact is added to the database or manually at a later point. In general, it doesn't make sense to merge two contacts and overwrite the empty source in the original with the new source. In our case, we have contacts who may have been in our database for a decade, but then they get merged with a newly created contact and, unless the user is paying careful attention, the ten year old contact can end up with a source of 'Some event two week ago'.

If this is supported, I will also do the same for batch merging. [Discussion on Gitlab.](https://lab.civicrm.org/dev/core/-/issues/3989) I'm happy to make this a setting as well, but it seems like a reasonable default to me that can be changed by the user while merging if needed.

Before
----------------------------------------
If merging a duplicate contact with a non-empty source into an original contact with an original source, the checkbox to add the source to the merged contact is checked by default.

After
----------------------------------------
The checkbox for source is never checked by default. The user must click the checkbox if they wish to overwrite the empty source with the duplicate contact source.