### PR TITLE
Mailing Report: when scheduled, displays stats so that we can see recipient count and scheduled date

### DIFF
--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -9,60 +9,56 @@
 *}
 <fieldset>
 <legend>{ts}Delivery Summary{/ts}</legend>
-{if $report.jobs.0.start_date}
-  {strip}
-  <table class="crm-info-panel">
-    <tr><td class="label"><a href="{$report.event_totals.links.queue}">{ts}Intended Recipients{/ts}</a></td>
-        <td>{$report.event_totals.queue}</td>
-        <td>{$report.event_totals.actionlinks.queue}</td></tr>
-    <tr><td class="label"><a href="{$report.event_totals.links.delivered}">{ts}Successful Deliveries{/ts}</a></td>
-        <td>{$report.event_totals.delivered} ({$report.event_totals.delivered_rate|string_format:"%0.2f"}%)</td>
-        <td>{$report.event_totals.actionlinks.delivered}</td></tr>
-  {if $report.mailing.open_tracking}
-    <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
-        <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
-        <td>{$report.event_totals.actionlinks.opened_unique}</td></tr>
-    <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
-        <td>{$report.event_totals.total_opened}</td>
-        <td>{$report.event_totals.actionlinks.opened}</td></tr>
-  {/if}
-  {if $report.mailing.url_tracking}
-    <tr><td class="label"><a href="{$report.event_totals.links.clicks}">{ts}Click-throughs{/ts}</a></td>
-        <td>{$report.event_totals.url} ({$report.event_totals.clickthrough_rate|string_format:"%0.2f"}%)</td>
-        <td>{$report.event_totals.actionlinks.clicks}</td></tr>
-  {/if}
-  <tr><td class="label"><a href="{$report.event_totals.links.forward}">{ts}Forwards{/ts}</a></td>
-      <td>{$report.event_totals.forward}</td>
-      <td>{$report.event_totals.actionlinks.forward}</td></tr>
-  <tr><td class="label"><a href="{$report.event_totals.links.reply}">{ts}Replies{/ts}</a></td>
-      <td>{$report.event_totals.reply}</td>
-      <td>{$report.event_totals.actionlinks.reply}</td></tr>
-  <tr><td class="label"><a href="{$report.event_totals.links.bounce}">{ts}Bounces{/ts}</a></td>
-      <td>{$report.event_totals.bounce} ({$report.event_totals.bounce_rate|string_format:"%0.2f"}%)</td>
-      <td>{$report.event_totals.actionlinks.bounce}</td></tr>
-  <tr><td class="label"><a href="{$report.event_totals.links.unsubscribe}">{ts}Unsubscribe Requests{/ts}</a></td>
-      <td>{$report.event_totals.unsubscribe} ({$report.event_totals.unsubscribe_rate|string_format:"%0.2f"}%)</td>
-      <td>{$report.event_totals.actionlinks.unsubscribe}</td></tr>
-  <tr><td class="label"><a href="{$report.event_totals.links.optout}">{ts}Opt-out Requests{/ts}</a></td>
-      <td>{$report.event_totals.optout} ({$report.event_totals.optout_rate|string_format:"%0.2f"}%)</td>
-      <td>{$report.event_totals.actionlinks.optout}</td></tr>
-  <tr><td class="label">{ts}Scheduled Date{/ts}</td>
-      <td colspan=2>{$report.jobs.0.scheduled_date}</td></tr>
-  <tr><td class="label">{ts}Status{/ts}</td>
-      <td colspan=2>{$report.jobs.0.status}</td></tr>
-  <tr><td class="label">{ts}Start Date{/ts}</td>
-      <td colspan=2>{$report.jobs.0.start_date}</td></tr>
-  <tr><td class="label">{ts}End Date{/ts}</td>
-      <td colspan=2>{$report.jobs.0.end_date}</td></tr>
-  </table>
-  {/strip}
-{else}
-    <div class="messages status no-popup">
-        {ts}<strong>Delivery has not yet begun for this mailing.</strong> If the scheduled delivery date and time is past, ask the system administrator or technical support contact for your site to verify that the automated mailer task ('cron job') is running - and how frequently.{/ts} {docURL page="user/advanced-configuration/email-system-configuration"}
-    </div>
+{if !$report.jobs.0.start_date}
+  <div class="messages status no-popup">
+    {ts}<strong>Delivery has not yet begun for this mailing.</strong> If the scheduled delivery date and time is past, ask the system administrator or technical support contact for your site to verify that the automated mailer task ('cron job') is running - and how frequently.{/ts} {docURL page="user/advanced-configuration/email-system-configuration"}
+  </div>
 {/if}
+<table class="crm-info-panel">
+  <tr><td class="label"><a href="{$report.event_totals.links.queue}">{ts}Intended Recipients{/ts}</a></td>
+      <td>{$report.event_totals.queue}</td>
+      <td>{$report.event_totals.actionlinks.queue}</td></tr>
+  <tr><td class="label"><a href="{$report.event_totals.links.delivered}">{ts}Successful Deliveries{/ts}</a></td>
+      <td>{$report.event_totals.delivered} ({$report.event_totals.delivered_rate|string_format:"%0.2f"}%)</td>
+      <td>{$report.event_totals.actionlinks.delivered}</td></tr>
+{if $report.mailing.open_tracking}
+  <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
+      <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
+      <td>{$report.event_totals.actionlinks.opened_unique}</td></tr>
+  <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
+      <td>{$report.event_totals.total_opened}</td>
+      <td>{$report.event_totals.actionlinks.opened}</td></tr>
+{/if}
+{if $report.mailing.url_tracking}
+  <tr><td class="label"><a href="{$report.event_totals.links.clicks}">{ts}Click-throughs{/ts}</a></td>
+      <td>{$report.event_totals.url} ({$report.event_totals.clickthrough_rate|string_format:"%0.2f"}%)</td>
+      <td>{$report.event_totals.actionlinks.clicks}</td></tr>
+{/if}
+<tr><td class="label"><a href="{$report.event_totals.links.forward}">{ts}Forwards{/ts}</a></td>
+    <td>{$report.event_totals.forward}</td>
+    <td>{$report.event_totals.actionlinks.forward}</td></tr>
+<tr><td class="label"><a href="{$report.event_totals.links.reply}">{ts}Replies{/ts}</a></td>
+    <td>{$report.event_totals.reply}</td>
+    <td>{$report.event_totals.actionlinks.reply}</td></tr>
+<tr><td class="label"><a href="{$report.event_totals.links.bounce}">{ts}Bounces{/ts}</a></td>
+    <td>{$report.event_totals.bounce} ({$report.event_totals.bounce_rate|string_format:"%0.2f"}%)</td>
+    <td>{$report.event_totals.actionlinks.bounce}</td></tr>
+<tr><td class="label"><a href="{$report.event_totals.links.unsubscribe}">{ts}Unsubscribe Requests{/ts}</a></td>
+    <td>{$report.event_totals.unsubscribe} ({$report.event_totals.unsubscribe_rate|string_format:"%0.2f"}%)</td>
+    <td>{$report.event_totals.actionlinks.unsubscribe}</td></tr>
+<tr><td class="label"><a href="{$report.event_totals.links.optout}">{ts}Opt-out Requests{/ts}</a></td>
+    <td>{$report.event_totals.optout} ({$report.event_totals.optout_rate|string_format:"%0.2f"}%)</td>
+    <td>{$report.event_totals.actionlinks.optout}</td></tr>
+<tr><td class="label">{ts}Scheduled Date{/ts}</td>
+    <td colspan=2>{$report.jobs.0.scheduled_date}</td></tr>
+<tr><td class="label">{ts}Status{/ts}</td>
+    <td colspan=2>{$report.jobs.0.status}</td></tr>
+<tr><td class="label">{ts}Start Date{/ts}</td>
+    <td colspan=2>{$report.jobs.0.start_date}</td></tr>
+<tr><td class="label">{ts}End Date{/ts}</td>
+    <td colspan=2>{$report.jobs.0.end_date}</td></tr>
+</table>
 </fieldset>
-
 <fieldset>
 <legend>{ts}Recipients{/ts}</legend>
 {if $report.group.include|@count}
@@ -149,7 +145,7 @@
 {/if}
 
 <fieldset>
-<legend>{ts}Content / Components{/ts}</legend>
+<legend>{ts}Content{/ts}</legend>
 {strip}
 <table class="crm-info-panel">
 {if $report.mailing.body_text}


### PR DESCRIPTION
Overview
----------------------------------------

When a Mailing is Scheduled, CiviCRM kindly informs us that the delivery has not yet begun, and that we maybe have a technical issue if the mailing scheduled date is in the past. However, we cannot see the Scheduled Date from that screen.

So you have to look at the URL, find the "id", and then go back to "mailings" and hover the report links to confirm the Scheduled Date.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/e3dd4129-b3b3-4c8e-a529-d25281cf32b1)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/57e14143-2b00-4ac6-9a0b-3589032eb73b)

Technical Details
--------------------------------------

I only moved the warning up, restructured the "if/else" (despite the large number of lines changed).

Comments
----------------------------------------

I have also had feedback from admins that they couldn't see the number of intended recipients until the mailing starts, so it feels fine to show most of the data while it's Scheduled.