### PR TITLE
fix fatal error on custom data import

### DIFF
--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -69,7 +69,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
       $this->setImportStatus($rowNumber, 'IMPORTED', '', $formatted['id']);
     }
     catch (CRM_Core_Exception $e) {
-      $this->setImportStatus($rowNumber, 'ERROR', '', $e->getMessage());
+      $this->setImportStatus($rowNumber, 'ERROR', $e->getMessage(), $formatted['id']);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
TypeError: Argument 4 passed to CRM_Import_Parser::setImportStatus() must be of the type int or null, string given, called in /var/www/html/drupal9/vendor/civicrm/civicrm-core/CRM/Custom/Import/Parser/Api.php on line 72 in CRM_Import_Parser->setImportStatus() (line 2146 of /var/www/html/drupal9/vendor/civicrm/civicrm-core/CRM/Import/Parser.php)