### PR TITLE
Remove unneeded text on Contribution

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -127,7 +127,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     }
 
     $form->add('select', 'contribution_page_id',
-      ts('Online Contribution Page'),
+      ts('Contribution Page'),
       [
         '' => ts('- select -'),
       ] +

--- a/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
@@ -13,15 +13,10 @@
     <table class="form-layout-compressed">
         <tr  class="crm-contribution-form-block-contribution_page"><td class="label">{$form.contribution_page_id.label}</td><td{$valueStyle}>{$form.contribution_page_id.html|crmAddClass:twenty}</td></tr>
         <tr class="crm-contribution-form-block-note"><td class="label" style="vertical-align:top;">{$form.note.label}</td><td>{$form.note.html}</td></tr>
-        <tr class="crm-contribution-form-block-non_deductible_amount"><td class="label">{$form.non_deductible_amount.label}</td><td{$valueStyle}>{$form.non_deductible_amount.html}<br />
-            <span class="description">{ts}Non-deductible portion of this contribution.{/ts}</span></td></tr>
-        <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html}<br />
-            <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
-        <tr class="crm-contribution-form-block-invoice_id"><td class="label">{$form.invoice_id.label}</td><td{$valueStyle}>{$form.invoice_id.html}<br />
-            <span class="description">{ts}Unique internal reference ID for this contribution.{/ts}</span></td></tr>
-        <tr class="crm-contribution-form-block-creditnote_id"><td class="label">{$form.creditnote_id.label}</td><td{$valueStyle}>{$form.creditnote_id.html}<br />
-            <span class="description">{ts}Unique internal Credit Note ID for this contribution.{/ts}</span></td></tr>
-        <tr class="crm-contribution-form-block-thankyou_date"><td class="label">{$form.thankyou_date.label}</td><td>{$form.thankyou_date.html}<br />
-            <span class="description">{ts}Date that a thank-you message was sent to the contributor.{/ts}</span></td></tr>
+        <tr class="crm-contribution-form-block-non_deductible_amount"><td class="label">{$form.non_deductible_amount.label}</td><td{$valueStyle}>{$form.non_deductible_amount.html}</td></tr>
+        <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html}</td></tr>
+        <tr class="crm-contribution-form-block-invoice_id"><td class="label">{$form.invoice_id.label}</td><td{$valueStyle}>{$form.invoice_id.html}</td></tr>
+        <tr class="crm-contribution-form-block-creditnote_id"><td class="label">{$form.creditnote_id.label}</td><td{$valueStyle}>{$form.creditnote_id.html}</td></tr>
+        <tr class="crm-contribution-form-block-thankyou_date"><td class="label">{$form.thankyou_date.label}</td><td>{$form.thankyou_date.html}</td></tr>
     </table>
 </div>

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -60,7 +60,7 @@
           <td class="label">
             {$form.is_email_receipt.label}
           </td>
-          <td>{$form.is_email_receipt.html}&nbsp;
+          <td>{$form.is_email_receipt.html}
               <span class="description">{ts 1=$email}Automatically email a receipt to %1?{/ts}</span>
           </td>
         </tr>
@@ -95,8 +95,10 @@
             <td class="label">{$form.trxn_id.label}</td>
             <td>{$form.trxn_id.html} {help id="id-trans_id"}</td>
           </tr>
-          <tr class="crm-payment-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html}<br />
-            <span class="description">{ts}Processing fee for this transaction (if applicable).{/ts}</span></td></tr>
+          <tr class="crm-payment-form-block-fee_amount">
+            <td class="label">{$form.fee_amount.label}</td>
+            <td{$valueStyle}>{$form.fee_amount.html}</td>
+          </tr>
         </table>
       </div>
       {/if}

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -93,7 +93,6 @@
 
                 {if !empty($ppID)}{ts}<a class='action-item crm-hover-button' onclick='adjustPayment();'>adjust payment amount</a>{/ts}{help id="adjust-payment-amount"}{/if}
                 <div id="totalAmountBlock">
-                  {if $hasPriceSets}<span class="description">{ts}Alternatively, you can use a price set.{/ts}</span>{/if}
                   <div id="totalTaxAmount" class="label"></div>
                 </div>
               {/if}
@@ -206,14 +205,15 @@
         {if empty($is_template) and $email and $outBound_option != 2}
           <tr class="crm-contribution-form-block-is_email_receipt">
             <td class="label">{$form.is_email_receipt.label}</td>
-            <td>{$form.is_email_receipt.html}&nbsp;
+            <td>{$form.is_email_receipt.html}
               <span class="description">{ts 1=$email}Automatically email a receipt for this payment to %1?{/ts}</span>
             </td>
           </tr>
         {elseif empty($is_template) and $context eq 'standalone' and $outBound_option != 2 }
           <tr id="email-receipt" style="display:none;" class="crm-contribution-form-block-is_email_receipt">
             <td class="label">{$form.is_email_receipt.label}</td>
-            <td>{$form.is_email_receipt.html} <span class="description">{ts}Automatically email a receipt for this payment to {/ts}<span id="email-address"></span>?</span>
+            <td>{$form.is_email_receipt.html}
+              <span class="description">{ts}Automatically email a receipt for this payment to {/ts}<span id="email-address"></span>?</span>
             </td>
           </tr>
         {/if}
@@ -226,9 +226,7 @@
         {if empty($is_template)}
         <tr id="receiptDate" class="crm-contribution-form-block-receipt_date">
           <td class="label">{$form.receipt_date.label}</td>
-          <td>{$form.receipt_date.html}<br />
-            <span class="description">{ts}Date that a receipt was sent to the contributor.{/ts}</span>
-          </td>
+          <td>{$form.receipt_date.html}</td>
         </tr>
         {/if}
         {if !empty($form.payment_processor_id)}
@@ -304,16 +302,11 @@
                     </tr>
                     <tr id="nickID" class="crm-contribution-form-block-pcp_roll_nickname">
                       <td class="label">{$form.pcp_roll_nickname.label}</td>
-                      <td>{$form.pcp_roll_nickname.html|crmAddClass:big}<br/>
-                        <div class="description">{ts}Name or nickname contributor wants to be displayed in the Honor Roll. Enter "Anonymous" for anonymous contributions.{/ts}</div>
-                      </td>
+                      <td>{$form.pcp_roll_nickname.html|crmAddClass:big}</td>
                     </tr>
                     <tr id="personalNoteID" class="crm-contribution-form-block-pcp_personal_note">
                       <td class="label" style="vertical-align: top">{$form.pcp_personal_note.label}</td>
-                      <td>
-                        {$form.pcp_personal_note.html}
-                        <div class="description">{ts}Personal message submitted by contributor for display in the Honor Roll.{/ts}</div>
-                      </td>
+                      <td>{$form.pcp_personal_note.html}</td>
                     </tr>
                   </table>
                 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Cleaning up unneeded description text on New Contribution and Record Payment. Also changed "Online Contribution Page" to "Contribution Page" for consistency and made minor formatting improvements.

Before
----------------------------------------
<img width="643" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/f1165db8-6c59-4531-a2dd-8629e15bb1a7">

<img width="1004" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/c3c4a595-a803-42f0-8ec5-69c100e1b421">

<img width="614" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/eca70b3d-4f46-4b6a-9db3-a3c98ba13603">

<img width="564" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/3bab3fbe-7c46-4c05-96ef-a1b0491527d1">

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/25517556/3458afdf-3d27-464d-a9e0-08ebe8dc6046)

![image](https://github.com/civicrm/civicrm-core/assets/25517556/1fd20a32-d29f-42f3-a1d3-ee5abda1ddf8)

![image](https://github.com/civicrm/civicrm-core/assets/25517556/58ac2df3-1f11-42fd-b6a0-2a4fe1381e02)

![image](https://github.com/civicrm/civicrm-core/assets/25517556/948be712-86ab-4f35-a7eb-d96df0cb02b7)
