### PR TITLE
Remove unneeded description text on Participant

### DIFF
--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -56,9 +56,7 @@
       {assign var=isShowBillingBlock value=true}
         <tr class="crm-event-eventfees-form-block-record_contribution">
             <td class="label">{$form.record_contribution.label}</td>
-            <td>{$form.record_contribution.html}<br />
-                <span class="description">{ts}Check this box to enter payment information. You will also be able to generate a customized receipt.{/ts}</span>
-            </td>
+            <td>{$form.record_contribution.html}</td>
         </tr>
         <tr id="payment_information" class="crm-event-eventfees-form-block-payment_information">
            <td class ='html-adjust' colspan=2>
@@ -66,7 +64,7 @@
              <table id="recordContribution" class="form-layout" style="width:auto;">
                 <tr class="crm-event-eventfees-form-block-financial_type_id">
                     <td class="label">{$form.financial_type_id.label}<span class="crm-marker"> *</span></td>
-                    <td>{$form.financial_type_id.html}<br /><span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
+                    <td>{$form.financial_type_id.html}</td>
                 </tr>
                 <tr class="crm-event-eventfees-form-block-total_amount"><td class="label">{$form.total_amount.label}</td><td>{$form.total_amount.html}</td></tr>
                 <tr>
@@ -96,7 +94,7 @@
       <table class="form-layout" style="width:auto;">
          <tr class="crm-event-eventfees-form-block-send_receipt">
             <td class="label">{if $paid}{ts}Send Confirmation and Receipt{/ts}{else}{ts}Send Confirmation{/ts}{/if}</td>
-            <td>{$form.send_receipt.html}<br>
+            <td>{$form.send_receipt.html}
               {if $email}
                 {if $paid}
                   <span class="description">{ts 1=$email}Automatically email a confirmation and receipt to %1?{/ts}</span></td>
@@ -111,10 +109,10 @@
         </tr>
         <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>
-          <td><span class="description">
-             {ts}Enter a message you want included at the beginning of the confirmation email. EXAMPLE: 'Thanks for registering for this event.'{/ts}
-             </span><br />
-             {$form.receipt_text.html|crmAddClass:huge}
+          <td>{$form.receipt_text.html|crmAddClass:huge}<br />
+             <span class="description">
+             {ts}Enter a message you want included at the beginning of the confirmation email.{/ts}
+             </span>
           </td>
         </tr>
       </table>
@@ -124,7 +122,7 @@
       <table class="form-layout" style="width:auto;">
        <tr class="crm-event-eventfees-form-block-send_receipt">
           <td class="label">{if $paid}{ts}Send Confirmation and Receipt{/ts}{else}{ts}Send Confirmation{/ts}{/if}</td>
-          <td>{$form.send_receipt.html}<br>
+          <td>{$form.send_receipt.html}
             {if $paid}
               <span class="description">{ts 1='<span id="email-address"></span>'}Automatically email a confirmation and receipt to %1?{/ts}</span>
             {else}
@@ -138,10 +136,11 @@
       </tr>
       <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>
-        <td><span class="description">
-          {ts}Enter a message you want included at the beginning of the confirmation email. EXAMPLE: 'Thanks for registering for this event.'{/ts}
-           </span><br />
-          {$form.receipt_text.html|crmAddClass:huge}</td>
+          <td>{$form.receipt_text.html|crmAddClass:huge}<br />
+             <span class="description">
+             {ts}Enter a message you want included at the beginning of the confirmation email.{/ts}
+             </span>
+          </td>
         </tr>
       </table>
     </fieldset>

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -101,8 +101,7 @@
             </td>
           </tr>
           <tr class="crm-participant-form-block-source">
-            <td class="label">{$form.source.label}</td><td>{$form.source.html|crmAddClass:huge}<br />
-            <span class="description">{ts}Source for this registration (if applicable).{/ts}</span></td>
+            <td class="label">{$form.source.label}</td><td>{$form.source.html|crmAddClass:huge}</td>
           </tr>
           {if $participantMode}
             <tr class="crm-participant-form-block-payment_processor_id">

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -119,11 +119,10 @@ CRM.$(function($) {
      {if $paymentInfo}
        <tr><td></td><td>
          <div class='crm-section'>
-         <div class='label'>{ts}Updated Fee(s){/ts}</div><div id="pricevalue" class='content updated-fee'></div>
+         <div class='label'>{ts}Updated Fee(s){/ts}</div><div id="pricevalue" class='content updated-fee'>&nbsp;</div>
          <div class='label'>{ts}Total Paid{/ts}</div>
          <div class='content'>
-           {$paymentInfo.paid|crmMoney}<br/>
-           <a class="crm-hover-button action-item crm-popup medium-popup" href='{crmURL p="civicrm/payment" q="view=transaction&action=browse&cid=`$contactId`&id=`$paymentInfo.id`&component=`$paymentInfo.component`&context=transaction"}'><i class="crm-i fa-list-alt" aria-hidden="true"></i> {ts}view payments{/ts}</a>
+           {$paymentInfo.paid|crmMoney} <a class="crm-hover-button action-item crm-popup medium-popup" href='{crmURL p="civicrm/payment" q="view=transaction&action=browse&cid=`$contactId`&id=`$paymentInfo.id`&component=`$paymentInfo.component`&context=transaction"}'><i class="crm-i fa-list-alt" aria-hidden="true"></i> {ts}view payments{/ts}</a>
          </div>
          <div class='label'><strong>{ts}Balance Owed{/ts}</strong></div><div class='content'><strong id='balance-fee'></strong></div>
           </div>
@@ -137,8 +136,7 @@ CRM.$(function($) {
       <table class="form-layout" style="width:auto;">
        <tr class="crm-event-eventfees-form-block-send_receipt">
           <td class="label">{ts}Send Confirmation{/ts}</td>
-          <td>{$form.send_receipt.html}<br>
-             <span class="description">{ts 1=$email}Automatically email a confirmation to %1?{/ts}</span>
+          <td>{$form.send_receipt.html} <span class="description">{ts 1=$email}Automatically email a confirmation to %1?{/ts}</span>
           </td>
        </tr>
        <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup of extraneous descriptions on Participant, including Price Set via change selections. Some minor formatting clean up.

Before
----------------------------------------
<img width="488" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/ea1d5fa1-3b73-4861-9215-fca56c1e4494">

<img width="775" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/6d5a68d0-6fe7-47c8-b54b-7a2563072461">

<img width="950" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/a4bc3e73-b073-456d-82a3-14cc2621125a">

On Change Selections
<img width="355" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/3ad0c0cf-2f1f-4aaf-8405-255961451fe3">

After
----------------------------------------
<img width="501" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/596d6044-0112-40ce-b928-07175766b0b2">

![image](https://github.com/civicrm/civicrm-core/assets/25517556/7d663ea7-6329-47e5-a937-2e423ac25148)

![image](https://github.com/civicrm/civicrm-core/assets/25517556/f6b65533-1b2a-45c9-bbab-dd86c7809dd2)

On Change Selections (still broken, but at least the formatting is better)
<img width="322" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/98dbee65-ae0b-42a0-b45a-0698098ed1ec">

