### PR TITLE
crmMoney filter - allow coercing locale

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -477,7 +477,7 @@ class TokenProcessor {
       switch ($filter[0] ?? NULL) {
         case NULL:
         case 'crmMoney':
-          return \Civi::format()->money($value->getAmount(), $value->getCurrency());
+          return \Civi::format()->money($value->getAmount(), $value->getCurrency(), $filter[1] ?? NULL);
 
         case 'boolean':
           // We resolve boolean to 0 or 1 or smarty chokes on FALSE.

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -476,6 +476,11 @@ class TokenProcessorTest extends \CiviUnitTestCase {
         'empty_string' => '',
         'and_such' => '<strong>testing &amp; such</strong>',
       ],
+      'my_currencies' => [
+        'amount' => \Brick\Money\Money::of(123, 'USD', new \Brick\Money\Context\DefaultContext()),
+        'currency' => 'EUR',
+        'locale' => 'fr_FR',
+      ],
     ];
 
     $testCases = [];
@@ -523,6 +528,15 @@ class TokenProcessorTest extends \CiviUnitTestCase {
       ],
       $exampleTokens,
     ];
+    $testCases['crmMoney testing'] = [
+      'text/plain',
+      [
+        'Amount: {my_currencies.amount}' => 'Amount: $123.00',
+        'Amount as money: {my_currencies.amount|crmMoney}' => 'Amount as money: $123.00',
+        'Amount as money in France: {my_currencies.amount|crmMoney:"fr_FR"}' => 'Amount as money in France: 123,00 $US',
+      ],
+      $exampleTokens,
+    ];
     return $testCases;
   }
 
@@ -546,7 +560,8 @@ class TokenProcessorTest extends \CiviUnitTestCase {
         $p->addMessage('example', $inputMessage, $messageFormat);
         $p->addRow()
           ->format('text/plain')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_text']))
-          ->format('text/html')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_rich_text']));
+          ->format('text/html')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_rich_text']))
+          ->format('text/plain')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_currencies']));
         foreach ($p->evaluate()->getRows() as $row) {
           $this->assertEquals($expectOutput, $row->render('example'));
           $actualExampleCount++;


### PR DESCRIPTION
Overview
----------------------------------------
This adds a `crmMoney` filter to tokens, comparable to `crmDate`, for coercing money into a particular format.

Before
----------------------------------------
You couldn't force money to render a particular way in a message template.

After
----------------------------------------
Now you can.

Comments
----------------------------------------
This needs documentation, which I'll do when this is merge-ready.

Slightly out of scope, but there's a not in `Civi/Token/TokenProcessor` that says `// TODO: Move this to StandardFilters`.  This doesn't *quite* work, but with a bit of tweaking, that `if` block can be removed from `TokenProcessor`.