### PR TITLE
fix 'Enable Double Opt-in for Profiles which use the "Add to Group" setting'

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1971,15 +1971,16 @@ ORDER BY civicrm_email.is_primary DESC";
 
     // to add profile in default group
     // @todo merge this with code above which also calls addContactsToGroup
-    if (is_array($addToGroupID)) {
-      $contactIds = [$contactID];
-      foreach ($addToGroupID as $groupId) {
-        CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIds, $groupId);
+    if ($addToGroupID) {
+      $isDoubleOptIn = CRM_Core_BAO_UFGroup::isProfileAddToGroupDoubleOptin() ? 'Pending' : 'Added';
+      if ($isDoubleOptIn) {
+        CRM_Mailing_Event_BAO_MailingEventSubscribe::commonSubscribe((array) $addToGroupID, reset($data['email']), $contactID, 'profile_add_to_group_double_optin');
       }
-    }
-    elseif ($addToGroupID) {
-      $contactIds = [$contactID];
-      CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIds, $addToGroupID);
+      else {
+        foreach ((array) $addToGroupID as $groupId) {
+          CRM_Contact_BAO_GroupContact::addContactsToGroup((array) $contactID, $groupId);
+        }
+      }
     }
 
     if ($editHook) {


### PR DESCRIPTION
Overview
----------------------------------------
The 'Enable Double Opt-in for Profiles which use the "Add to Group" setting' doesn't do anything.

To replicate, you must enable this setting (in CiviMail Component Settings) and configure a profile to automatically add users to a group in "Advanced Settings" for the profile.

Before
----------------------------------------
Contacts are added to the group without double opt-in.

After
----------------------------------------
Double opt-in setting is respected.

Comments
----------------------------------------
This code is messy, I did some cleanup so as to not make it messier.

Eileen is gonna make me put this against the rc even though this has surely been broken a while, so I planned ahead.
