### PR TITLE
SearchKit: Tweak order and text for select All, This Page, None

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html
@@ -7,9 +7,9 @@
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if="$ctrl.selectAllMenuOpen">
-    <li>
-      <a href ng-click="$ctrl.selectNone()">
-        {{:: ts('None') }}
+    <li ng-if="$ctrl.rowCount > $ctrl.results.length">
+      <a href ng-click="$ctrl.selectAllPages()">
+        {{:: ts('All') }}
       </a>
     </li>
     <li>
@@ -17,9 +17,9 @@
         {{ $ctrl.rowCount > $ctrl.results.length ? ts('This Page') : ts('All') }}
       </a>
     </li>
-    <li ng-if="$ctrl.rowCount > $ctrl.results.length">
-      <a href ng-click="$ctrl.selectAllPages()">
-        {{:: ts('All Pages') }}
+    <li>
+      <a href ng-click="$ctrl.selectNone()">
+        {{:: ts('None') }}
       </a>
     </li>
   </ul>


### PR DESCRIPTION
Overview
----------------------------------------
Just a little tweak for usability. We don't need to say "All Pages" when "All" is clearer (it doesn't matter that the entities are on pages and it is pretty clear from the presence of "This Page" that "All" doesn't mean only all of this page). Also makes sense to put All at the top and None at the bottom since All would be the most used.

Before
----------------------------------------
<img width="214" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/92117872-2d2a-4d99-aaa6-874ba656087d">

After
----------------------------------------
<img width="214" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/0739b2d1-8118-4acf-b89b-297b48ba618a">
