### PR TITLE
dev/core#4325 Fix extra brs in custom field note rich text

### DIFF
--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -69,8 +69,6 @@
                           {else}
                             {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
                               {', '|implode:$element.contact_ref_links}
-                            {elseif $element.field_data_type == 'Memo'}
-                              {$element.field_value|nl2br}
                             {else}
                               {$element.field_value}
                             {/if}
@@ -123,8 +121,6 @@
                   <div class="content">
                     {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
                       {', '|implode:$element.contact_ref_links}
-                    {elseif $element.field_data_type == 'Memo'}
-                      {if $element.field_value}{$element.field_value|nl2br}{else}<br/>{/if}
                     {else}
                       {if $element.field_value}{$element.field_value} {else}<br/>{/if}
                     {/if}


### PR DESCRIPTION
Before
----------------------------------------
<img width="397" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/e4cbb7a4-375d-4694-bcd5-c65cdd30e633">

Extra brs in the rich text and doubled brs in the plain text.

After
----------------------------------------
<img width="397" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/0e1c0fc0-a955-48c8-9c54-b8f7a128385c">

Paragraphs in the rich text and single brs in the plain text. We let Core/BAO/CustomField add the nl2br.

Comments
----------------------------------------
I can't figure out how to get into `multiRecordDisplay=single` mode, so haven't been able to test that. I tested this with a custom field on an Activity, display of custom fields on a Contact appears to be different and does not have this problem.