### PR TITLE
Pass field specs out to alter functions

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2572,14 +2572,14 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
               if (array_key_exists('alter_display', $specs)) {
                 $alterFunctions[$tableName . '_' . $field] = $specs['alter_display'];
                 $alterMap[$tableName . '_' . $field] = $field;
-                $alterSpecs[$tableName . '_' . $field] = NULL;
+                $alterSpecs[$tableName . '_' . $field] = $specs;
               }
               // Add any alters that can be intuited from the field specs.
               // So far only boolean but a lot more could be.
               if (empty($alterSpecs[$tableName . '_' . $field]) && isset($specs['type']) && $specs['type'] == CRM_Utils_Type::T_BOOLEAN) {
                 $alterFunctions[$tableName . '_' . $field] = 'alterBoolean';
                 $alterMap[$tableName . '_' . $field] = $field;
-                $alterSpecs[$tableName . '_' . $field] = NULL;
+                $alterSpecs[$tableName . '_' . $field] = $specs;
               }
             }
           }


### PR DESCRIPTION
This is code that was migrated into core from extended reports but when I updated extended reports to use the core version it turned out the
specs were being set to NULL not the expected field specs
