### PR TITLE
Fix receive_date error saving on Edit Participant with Record Contribution

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1209,7 +1209,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $contributionParams['non_deductible_amount'] = 'null';
         $contributionParams['receipt_date'] = !empty($params['send_receipt']) ? CRM_Utils_Array::value('receive_date', $params) : 'null';
         $contributionParams['contact_id'] = $this->_contactID;
-        $contributionParams['receive_date'] = $params['receive_date'] ?? date('Y-m-d');
+        $contributionParams['receive_date'] = !(empty($params['receive_date'])) ? $params['receive_date'] : $now;
 
         $recordContribution = [
           'financial_type_id',


### PR DESCRIPTION
Overview
----------------------------------------
@JoeMurray describes how to reproduce this issue [here](https://github.com/civicrm/civicrm-core/pull/24657#issuecomment-1570614380):

1. Backoffice register a contact in fall fundraiser, making sure to unselect Record Payment.
2. Edit the registration, enable Record Payment, Save.
3. On dmaster, it saves.
4. On test instance, it hangs (I got the same locally on master)

The issue was that receive_date was an empty string, so the check this PR replaces wasn't changing it to a default date. In some cases, that causes a DB error. On dmaster, it creates the contribution and transaction with an empty date. Not sure why the behaviour is different, but that doesn't really matter, because it is broken either way.

Before
----------------------------------------
Can't save Participant or Contribution created with empty receive_date if no receive_date entered on the form.

After
----------------------------------------
Participant saved as normal, Contribution created with current date and time or as entered on form.