### PR TITLE
Center SearchKit pagination

### DIFF
--- a/ext/search_kit/css/crmSearchDisplay.css
+++ b/ext/search_kit/css/crmSearchDisplay.css
@@ -52,3 +52,7 @@
     left: 100%;
   }
 }
+
+#bootstrap-theme .crm-search-display ul.pagination > li {
+  margin: 0;
+}


### PR DESCRIPTION
Before
----------------------------------------
Funky styles mean centered element is not really centered.

![image](https://github.com/civicrm/civicrm-core/assets/25517556/6c5224ff-f61a-499f-bf13-c7ebcd49f428)
![image](https://github.com/civicrm/civicrm-core/assets/25517556/81da6db9-47e8-4d1c-a1cb-6450958462b6)

After
----------------------------------------
No more inherited margins, now centered.

![image](https://github.com/civicrm/civicrm-core/assets/25517556/b6afe36f-0869-462f-a107-f86761a9d0ff)
![image](https://github.com/civicrm/civicrm-core/assets/25517556/0fa3508e-9f10-4e32-b38f-f4679c28fc0f)
