### PR TITLE
(dev/core#4322) Smart groups in group tab for contact too slow

### DIFF
--- a/CRM/Contact/Page/View/ContactSmartGroup.php
+++ b/CRM/Contact/Page/View/ContactSmartGroup.php
@@ -38,7 +38,7 @@ class CRM_Contact_Page_View_ContactSmartGroup extends CRM_Core_Page {
       }
     }
 
-    $allGroup = CRM_Contact_BAO_GroupContactCache::contactGroup($this->_contactId);
+    $allGroup = CRM_Contact_BAO_GroupContactCache::contactGroup($this->_contactId, FALSE, FALSE);
     $this->assign('groupSmart', NULL);
     $this->assign('groupParent', NULL);
 


### PR DESCRIPTION
Overview
----------------------------------------
Smart groups in group tab for contact are too slow to load. 
It is super slow function since it ensure that all contact groups are loaded in the cache and loads all in rendering smart group tab useless as it never works and always loads new.


Before
----------------------------------------
params load ALL is true, takes ages.
It calls _loadAll_ method that is expensive and should be sparingly used if groupIDs is empty.

After
----------------------------------------
set loadAll to FALSE, quick to load.