### PR TITLE
description is wrong for permission to view notes that are marked for author only

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -43,13 +43,13 @@ class CRM_Core_BAO_Note extends CRM_Core_DAO_Note implements \Civi\Core\HookInte
   }
 
   /**
-   * Given a note id, decide if the note should be displayed based on privacy setting
+   * Given a note id, decide if the note should be hidden based on privacy setting
    *
    * @param object $note
    *   Either the id of the note to retrieve, or the CRM_Core_DAO_Note object itself.
    *
    * @return bool
-   *   TRUE if the note should be displayed, otherwise FALSE
+   *   TRUE if the note should be hidden, otherwise FALSE
    *
    */
   public static function getNotePrivacyHidden($note) {

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -782,7 +782,7 @@ class CRM_Core_Permission {
 
       'view all notes' => [
         $prefix . ts('view all notes'),
-        ts("View notes (for visible contacts) even if they're marked admin only"),
+        ts("View notes (for visible contacts) even if they're marked author only"),
       ],
       'add contact notes' => [
         $prefix . ts('add contact notes'),


### PR DESCRIPTION
The description is wrong. The permission is about viewing notes that are marked for author only, not for admin.
Also the comments are wrong on the function getNotePrivacyHidden, as came up in the chat.

see the discussion on https://chat.civicrm.org/civicrm/pl/ye4bu5w87b81mennu3at5ifcrr
and the issue I filed here: https://lab.civicrm.org/dev/core/-/issues/4329
