### PR TITLE
SearchKit - Add task to refresh smart/parent group cache

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -135,6 +135,24 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       ];
     }
 
+    /*
+     * ENTITY-SPECIFIC TASKS BELOW
+     * FIXME: Move these somewhere?
+     */
+
+    if ($entity['name'] === 'Group') {
+      $tasks['Group']['refresh'] = [
+        'title' => E::ts('Refresh Group Cache'),
+        'icon' => 'fa-refresh',
+        'apiBatch' => [
+          'action' => 'refresh',
+          'runMsg' => E::ts('Refreshing %1 %2...'),
+          'successMsg' => E::ts('%1 %2 Refreshed.'),
+          'errorMsg' => E::ts('An error occurred while attempting to refresh %1 %2.'),
+        ],
+      ];
+    }
+
     if ($entity['name'] === 'Contact') {
       // Add contact tasks which support standalone mode
       $contactTasks = $this->checkPermissions ? \CRM_Contact_Task::permissionedTaskTitles(\CRM_Core_Permission::getPermission()) : NULL;

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -17,6 +17,7 @@
         ctrl = this,
         currentBatch = 0,
         totalBatches,
+        processedCount = 0,
         incrementer;
 
       this.progress = 0;
@@ -62,8 +63,10 @@
           function(result) {
             stopIncrementer();
             ctrl.progress = Math.floor(100 * ++currentBatch / totalBatches);
+            processedCount += result.count;
             if (ctrl.last >= ctrl.ids.length) {
               $timeout(function() {
+                result.batchCount = processedCount;
                 ctrl.success({result: result});
               }, 500);
             } else {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -14,8 +14,9 @@
       ctrl.start(ctrl.apiBatch.params);
     }
 
-    this.onSuccess = function() {
-      CRM.alert(ts(ctrl.apiBatch.successMsg, {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('%1 Complete', {1: ctrl.taskTitle}), 'success');
+    this.onSuccess = function(result) {
+      var entityTitle = this.getEntityTitle(result.batchCount);
+      CRM.alert(ts(ctrl.apiBatch.successMsg, {1: result.batchCount, 2: entityTitle}), ts('%1 Complete', {1: ctrl.taskTitle}), 'success');
       this.close();
     };
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
@@ -4,7 +4,7 @@
     <hr />
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts(model.apiBatch.runMsg, {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="{{:: model.apiBatch.action }}" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}"></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="{{:: model.apiBatch.action }}" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}"></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskBaseTrait.service.js
@@ -8,8 +8,11 @@
     // Trait properties get mixed into task controller using angular.extend()
     return {
 
-      getEntityTitle: function() {
-        return this.ids.length === 1 ? this.entityInfo.title : this.entityInfo.title_plural;
+      getEntityTitle: function(count) {
+        if (typeof count !== 'number') {
+          count = this.ids.length;
+        }
+        return count === 1 ? this.entityInfo.title : this.entityInfo.title_plural;
       },
 
       start: function(runParams) {


### PR DESCRIPTION
Overview
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/52e8d5f7-847f-4155-a81f-a2e15c6c887a)

Comments
------
This just adds the task (and fixes the success message to give the correct count). I'll do a followup after this is merged to add this to the AdminUI extension.