### PR TITLE
SearchKit: Don't show the pager unless it is needed

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Assigned_Financial_Accounts.mgd.php
@@ -70,6 +70,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Contact_Types.mgd.php
@@ -56,6 +56,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
@@ -64,6 +64,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'sort' => [],
           'columns' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
@@ -76,6 +76,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'sort' => [],
           'columns' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Accounts.mgd.php
@@ -62,6 +62,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Financial_Types.mgd.php
@@ -78,6 +78,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Location_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Location_Types.mgd.php
@@ -60,6 +60,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Manage_Group.mgd.php
@@ -92,7 +92,11 @@ return [
             ],
           ],
           'limit' => 50,
-          'pager' => [],
+          'pager' => [
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+            'hide_single' => TRUE,
+          ],
           'placeholder' => 5,
           'columns' => [
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Payment_Processors.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Payment_Processors.mgd.php
@@ -85,6 +85,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
@@ -61,6 +61,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Profiles.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Profiles.mgd.php
@@ -74,6 +74,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
@@ -58,6 +58,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
@@ -57,6 +57,7 @@ return [
           'pager' => [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
+            'hide_single' => TRUE,
           ],
           'placeholder' => 5,
           'sort' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
@@ -68,7 +68,11 @@ return [
             ],
           ],
           'limit' => 50,
-          'pager' => [],
+          'pager' => [
+            'show_count' => TRUE,
+            'expose_limit' => TRUE,
+            'hide_single' => TRUE,
+          ],
           'placeholder' => 5,
           'columns' => [
             [

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
@@ -19,14 +19,20 @@
     <input id="crm-search-admin-display-limit" type="number" min="1" step="1" class="form-control" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
     <div class="checkbox-inline form-control">
       <label>
+        <input type="checkbox" ng-model="$ctrl.display.settings.pager.expose_limit" >
+        <span>{{:: ts('Adjustable Page Size') }}</span>
+      </label>
+    </div>
+    <div class="checkbox-inline form-control">
+      <label>
         <input type="checkbox" ng-model="$ctrl.display.settings.pager.show_count" >
         <span>{{:: ts('Show Count in Pager') }}</span>
       </label>
     </div>
     <div class="checkbox-inline form-control">
       <label>
-        <input type="checkbox" ng-model="$ctrl.display.settings.pager.expose_limit" >
-        <span>{{:: ts('Adjustable Page Size') }}</span>
+        <input type="checkbox" ng-model="$ctrl.display.settings.pager.hide_single">
+        <span>{{:: ts('Hide Pager if One Page') }}</span>
       </label>
     </div>
   </div>

--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -3,7 +3,7 @@
     <div class="form-inline" ng-if="$ctrl.settings.pager.show_count" ng-include="'~/crmSearchDisplay/ResultCount.html'">
     </div>
   </div>
-  <div class="text-center crm-flex-2">
+  <div ng-if="!$ctrl.settings.pager.hide_single || ($ctrl.rowCount > $ctrl.limit)" class="text-center crm-flex-2">
     <ul uib-pagination
         class="pagination"
         boundary-links="true"


### PR DESCRIPTION
Overview
----------------------------------------
We don't need to show the pager in Search Displays if the number of rows is less than the page size.

Before
----------------------------------------
E.g. Manage Contribution Pages, pager just taking up space.
<img width="1036" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/28b08ab3-1a10-44c5-b103-34baf705509c">

After
----------------------------------------
No more pager.
<img width="1032" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/25213510-6a4a-4172-b02f-403ae5a344eb">

If you adjust the page size, the pager is shown as appropriate.