### PR TITLE
Remove unneeded description text on Memberships

### DIFF
--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -177,7 +177,7 @@
           <tr id="send-receipt" class="crm-membership-form-block-send_receipt">
             <td class="label">{$form.send_receipt.label}</td>
             <td>
-              {$form.send_receipt.html}<br />
+              {$form.send_receipt.html}
               <span class="description">
                 {ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1? OR if the payment is from a different contact, this email will only go to them.{/ts}
                 <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>
@@ -188,7 +188,7 @@
           <tr id="email-receipt" style="display:none;">
             <td class="label">{$form.send_receipt.label}</td>
             <td>
-              {$form.send_receipt.html}<br />
+              {$form.send_receipt.html}
               <span class="description">
                 {ts}Automatically email a membership confirmation and receipt to {/ts}<span id="email-address"></span>? {ts}OR if the payment is from a different contact, this email will only go to them.{/ts}
                 <span class="auto-renew-text">{ts}For auto-renewing memberships the emails are sent when each payment is received{/ts}</span>

--- a/templates/CRM/Member/Form/MembershipBlock.hlp
+++ b/templates/CRM/Member/Form/MembershipBlock.hlp
@@ -7,6 +7,13 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
+{htxt id="id-member_price_set_id-title"}
+  {ts}Membership Price Set{/ts}
+{/htxt}
+{htxt id="id-member_price_set_id"}
+{ts}Price sets allow you to configure more complex membership signup and renewal options, including allowing constituents to sign up for multiple memberships at the same time.{/ts}
+{/htxt}
+
 
 {htxt id="id-is-required-title"}
   {ts}Require Membership Signup{/ts}

--- a/templates/CRM/Member/Form/MembershipBlock.tpl
+++ b/templates/CRM/Member/Form/MembershipBlock.tpl
@@ -42,27 +42,18 @@
               <td>{$form.renewal_text.html}</td>
           </tr>
         <tr class="crm-member-membershipblock-form-block-member_price_set_id">
-              <td class="label">{$form.member_price_set_id.label}</td>
-              <td>
-              {if $price eq false}
-                {capture assign=adminPriceSetsURL}{crmURL p="civicrm/admin/price" q="reset=1"}{/capture}
-            <div class="status message">{ts 1=$adminPriceSetsURL}No Membership Price Sets have been configured / enabled for your site. Price sets allow you to configure more complex membership signup and renewal options, including allowing constituents to sign up for multiple memberships at the same time. Click <a href='%1'>here</a> if you want to configure price sets for your site.{/ts}</div>
-          {else}
-              {$form.member_price_set_id.html}
-          {/if}
-          </td>
+            <td class="label">{$form.member_price_set_id.label} {help id="id-member_price_set_id"}</td>
+            <td>{$form.member_price_set_id.html}<br />
+            {if $isQuick}
+                <div id="quickConfigConvertMessage" class="description">{ts}Click <a id='memQuickconfig' href='#'>here</a> if you want to configure the Membership Types below as part of a Price Set, with the added flexibility and complexity that entails.{/ts}</div>
+            {/if}
+            </td>
         </tr>
-    {if $isQuick}
-    <tr id="quickConfigConvertMessage">
-      <td></td>
-      <td><div class="status message">{ts}Click <a id='memQuickconfig' href='#'>here</a> if you want to configure the Membership Types below as part of a Price Set, with the added flexibility and complexity that entails.{/ts}</div></td>
-    </tr>
-    {/if}
-          <tr id="membership_type-label" class="crm-member-membershipblock-form-block-membership_type_label">
+        <tr id="membership_type-label" class="crm-member-membershipblock-form-block-membership_type_label">
             <td class="label">{$form.membership_type_label.label}</td>
             <td>{$form.membership_type_label.html}</td>
-          </tr>
-          <tr id="membership_type-block" class="crm-member-membershipblock-form-block-membership_type">
+        </tr>
+        <tr id="membership_type-block" class="crm-member-membershipblock-form-block-membership_type">
               <td class="label">{$form.membership_type.label}</td>
               <td>
                 {assign var="count" value="1"}
@@ -98,8 +89,7 @@
               <td class="label"></td><td class="html-adjust">{$form.is_required.html}&nbsp;{$form.is_required.label} {help id="id-is-required"}</td>
           </tr>
           <tr id="separatePayment" class="crm-member-membershipblock-form-block-is_separate_payment">
-              <td class="label"></td><td class="html-adjust">{$form.is_separate_payment.html}&nbsp;{$form.is_separate_payment.label} {help id="id-separate-pay"}<br />
-              <span class="description">{ts}Check this box if you are including both Membership Signup/Renewal AND a Contribution Amount section, AND you want the membership fee to be charged separately from any additional contribution amount.{/ts}</span></td>
+              <td class="label"></td><td class="html-adjust">{$form.is_separate_payment.html}&nbsp;{$form.is_separate_payment.label} {help id="id-separate-pay"}</td>
           </tr>
           <tr id="displayFee" class="crm-member-membershipblock-form-block-display_min_fee">
               <td class="label"></td><td class="html-adjust">{$form.display_min_fee.html}&nbsp;{$form.display_min_fee.label} {help id="id-display-fee"}</td>

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -23,8 +23,7 @@
 
         <tr class="crm-{$formClass}-form-block-total_amount">
           <td class="label">{$form.total_amount.label}</td>
-          <td>{$form.total_amount.html}<br />
-            <span class="description">{ts}Membership payment amount. A contribution record will be created for this amount.{/ts}</span><div class="totaltaxAmount"></div></td>
+          <td>{$form.total_amount.html}</td>
         </tr>
         <tr class="crm-{$formClass}-form-block-receive_date">
           <td class="label">{$form.receive_date.label}</td>
@@ -32,9 +31,7 @@
         </tr>
         <tr class="crm-{$formClass}-form-block-financial_type_id">
           <td class="label">{$form.financial_type_id.label}</td>
-          <td>{$form.financial_type_id.html}<br/>
-            <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span>
-          </td>
+          <td>{$form.financial_type_id.html}</td>
         </tr>
         <tr class="crm-{$formClass}-form-block-payment_instrument_id">
           <td class="label">{$form.payment_instrument_id.label}<span class='marker'>*</span></td>
@@ -70,8 +67,7 @@
   {/if}
   <tr class="crm-member-{$formClass}-form-block-financial_type_id">
     <td class="label">{$form.financial_type_id.label}</td>
-    <td>{$form.financial_type_id.html}<br/>
-      <span class="description">{ts}Select the appropriate financial type for this payment.{/ts}</span></td>
+    <td>{$form.financial_type_id.html}</td>
   </tr>
   <tr class="crm-{$formClass}-form-block-total_amount">
     <td class="label">{$form.total_amount.label}</td>

--- a/templates/CRM/Member/Form/MembershipRenewal.tpl
+++ b/templates/CRM/Member/Form/MembershipRenewal.tpl
@@ -68,8 +68,7 @@
       </tr>
       <tr class="crm-member-membershiprenew-form-block-membership_status">
         <td class="label">{ts}Membership Status{/ts}</td>
-        <td class="html-adjust">&nbsp;{$membershipStatus}<br/>
-          <span class="description">{ts}Status of this membership.{/ts}</span></td>
+        <td class="html-adjust">&nbsp;{$membershipStatus}</td>
       </tr>
       <tr class="crm-member-membershiprenew-form-block-end_date">
         <td class="label">{ts}Membership Expiration Date{/ts}</td>
@@ -77,29 +76,21 @@
       </tr>
       <tr class="crm-member-membershiprenew-form-block-renewal_date">
         <td class="label">{$form.renewal_date.label}</td>
-        <td>{$form.renewal_date.html}</td>
-      </tr>
-      <tr id="defaultNumTerms" class="crm-member-membershiprenew-form-block-default-num_terms">
-        <td colspan="2" class="description">
-          {ts}Renewal extends Membership Expiration Date by one membership period{/ts}
-          &nbsp; <a id="changeTermsLink" href='#'
-                    onclick='changeNumTerms(); return false;'>{ts}change{/ts}</a>
+        <td>{$form.renewal_date.html}
+          <div id="defaultNumTerms" class="crm-member-membershiprenew-form-block-default-num_terms description">
+            {ts}Renewal extends Membership Expiration Date by one membership period{/ts}
+            &nbsp;<a id="changeTermsLink" href='#' onclick='changeNumTerms(); return false;'>{ts}change{/ts}</a>
+          </div>
         </td>
       </tr>
       <tr id="changeNumTerms" class="crm-member-membershiprenew-form-block-change-num_terms">
         <td class="label">{$form.num_terms.label}</td>
-        <td>{$form.num_terms.html|crmAddClass:two} {ts}membership periods{/ts}<br/>
-          <span
-            class="description">{ts}Extend the Membership Expiration Date by this many membership periods. Make sure the appropriate corresponding fee is entered below.{/ts}</span>
-        </td>
+        <td>{$form.num_terms.html|crmAddClass:two} {ts}membership periods{/ts}</td>
       </tr>
       {if $accessContribution and ! $membershipMode}
         <tr class="crm-member-membershiprenew-form-block-record_contribution">
           <td class="label">{$form.record_contribution.label}</td>
-          <td class="html-adjust">{$form.record_contribution.html}<br/>
-            <span
-              class="description">{ts}Check this box to enter payment information. You will also be able to generate a customized receipt.{/ts}</span>
-          </td>
+          <td class="html-adjust">{$form.record_contribution.html}</td>
         </tr>
         <tr id="recordContribution" class="crm-member-membershiprenew-form-block-membership_renewal">
           <td colspan="2">
@@ -112,7 +103,7 @@
       <table class="form-layout">
         <tr class="crm-{$formClass}-form-block-send_receipt">
           <td class="label">{$form.send_receipt.label}</td>
-          <td>{$form.send_receipt.html}<br/>
+          <td>{$form.send_receipt.html}
             <span class="description">{ts 1=$emailExists}Automatically email a membership confirmation and receipt to %1?{/ts}</span>
           </td>
         </tr>
@@ -122,9 +113,11 @@
         </tr>
         <tr id="notice" class="crm-member-membershiprenew-form-block-receipt_text">
           <td class="label">{$form.receipt_text.label}</td>
-          <td><span
-              class="description">{ts}Enter a message you want included at the beginning of the emailed receipt. EXAMPLE: 'Thanks for supporting our organization with your membership.'{/ts}</span><br/>
-            {$form.receipt_text.html|crmAddClass:huge}</td>
+          <td>{$form.receipt_text.html|crmAddClass:huge}<br />
+             <span class="description">
+             {ts}Enter a message you want included at the beginning of the emailed receipt.{/ts}
+             </span>
+          </td>
         </tr>
       </table>
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Removing more unneeded description text, this time for Membership and the Membership tab on Manage Contribution Pages.

Before
----------------------------------------
Membership tab on Manage Contribution Page
<img width="991" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/8b2cf7f6-8257-41e9-b32a-7739b03ed465">

Membership renewal (includes changes to the Payment block also shared with all memberships)
<img width="977" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/b88acefe-13a4-4718-900c-ee4f07ee6842">


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/25517556/a8fd8062-a4c0-43e7-834f-5042ebc48a19)

<img width="768" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/296f1ec9-028e-4e24-bd7a-b7343a78d26f">
