### PR TITLE
fix Mailsettings.testconnection picking wrong settings to test

### DIFF
--- a/Civi/Api4/Action/MailSettings/TestConnection.php
+++ b/Civi/Api4/Action/MailSettings/TestConnection.php
@@ -12,6 +12,7 @@
 namespace Civi\Api4\Action\MailSettings;
 
 use Civi\Api4\Generic\BasicBatchAction;
+use Civi\Api4\MailSettings;
 
 class TestConnection extends BasicBatchAction {
 
@@ -24,8 +25,13 @@ class TestConnection extends BasicBatchAction {
    * @return array
    */
   protected function doTask($item) {
+    $mailingName = MailSettings::get(FALSE)
+      ->addSelect('name')
+      ->addWhere('id', '=', $item['id'])
+      ->execute()
+      ->first()['name'];
     try {
-      $mailStore = \CRM_Mailing_MailStore::getStore($item['name']);
+      $mailStore = \CRM_Mailing_MailStore::getStore($mailingName);
     }
     catch (\Throwable $t) {
       \Civi::log()->warning('MailSettings: Failed to establish test connection', [


### PR DESCRIPTION
Overview
----------------------------------------
If you create a new Mail Account (**Administer » CiviMail » Mail Accounts**) and press **Save & Test**, the wrong mail account will be tested unless you're testing the default account.

The simplest replication: 
* Set up the default mail account with nothing but the required fields and the server name. Set up a second mail account the same way, but don't set it as default.  Use a different server name on account 2. Press **Save & Test**.  After a few moments, you'll see an error come back referencing the server from account 1.

Before
----------------------------------------
Incorrect return values on testing mail connections.

After
----------------------------------------
Correct account is tested.

Technical Details
----------------------------------------
The problem is in API4 `MailSettings.testconnection`.  It tries to pass `$item['name']` to `\CRM_Mailing_MailStore::getStore();` but the name isn't available in `$item`.

Comments
----------------------------------------
It seems like the constructor is trying to get the name by passing `['id, 'name']` as the `$doer`, but that takes a callback function, not an array of return values.
