### PR TITLE
Use Permission=FALSE when retrieving price sets in examples

### DIFF
--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
@@ -134,7 +134,7 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
         $mockOrder->setDefaultFinancialTypeID($priceSet['financial_type_id']);
       }
     }
-    foreach (PriceField::get()->addWhere('price_set_id', '=', $mockOrder->getPriceSetID())->execute() as $index => $priceField) {
+    foreach (PriceField::get(FALSE)->addWhere('price_set_id', '=', $mockOrder->getPriceSetID())->execute() as $index => $priceField) {
       $priceFieldValue = PriceFieldValue::get()->addWhere('price_field_id', '=', $priceField['id'])->execute()->first();
       if (empty($example['is_show_line_items'])) {
         $priceFieldValue['amount'] = $contribution['total_amount'];
@@ -157,8 +157,7 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
    * @throws \CRM_Core_Exception
    */
   private function getNonQuickConfigPriceSet(): ?array {
-    // Permission check defaults to true - likely implicitly OK but may need to be false.
-    return PriceSet::get()
+    return PriceSet::get(FALSE)
       ->addWhere('is_quick_config', '=', FALSE)
       ->execute()
       ->first();

--- a/CRM/Event/WorkflowMessage/EventExamples.php
+++ b/CRM/Event/WorkflowMessage/EventExamples.php
@@ -72,7 +72,6 @@ class CRM_Event_WorkflowMessage_EventExamples extends WorkflowMessageExample {
    * @throws \CRM_Core_Exception
    */
   private function getPriceSets(): ?array {
-    // Permission check defaults to true - likely implicitly OK but may need to be false.
     $quickConfigPriceSet = $this->getPriceSet(TRUE);
     $nonQuickConfigPriceSet = $this->getPriceSet(FALSE);
 

--- a/CRM/Member/WorkflowMessage/Membership/Membership.php
+++ b/CRM/Member/WorkflowMessage/Membership/Membership.php
@@ -145,8 +145,7 @@ class CRM_Member_WorkflowMessage_Membership_Membership extends WorkflowMessageEx
    * @throws \CRM_Core_Exception
    */
   private function getPriceSet(): ?array {
-    // Permission check defaults to true - likely implicitly OK but may need to be false.
-    return (array) PriceSet::get()
+    return (array) PriceSet::get(FALSE)
       ->addWhere('extends', '=', CRM_Core_Component::getComponentID('CiviMember'))
       ->addOrderBy('is_quick_config', 'DESC')
       ->execute()->indexBy('id');


### PR DESCRIPTION
Doing a check causes the whole example to fail -
and this feels like fairly public info
