### PR TITLE
Add deprecation notes to `processMembership` function deprecated in 2021

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1769,7 +1769,9 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
   }
 
   /**
-   * @deprecated
+   * @deprecated in CiviCRM 5.39, will be removed around CiviCRM 5.66.
+   *
+   * Deprecation issue in https://lab.civicrm.org/extensions/civimobileapi/-/issues/86
    *
    * @param int $contactID
    * @param int $membershipTypeID


### PR DESCRIPTION
I looked to remove this but the original PR spotted it was used by civimobile & I checked & it still is - albeit in code that is deprecated within civimobile. I created an issue on their repo & updated the notes on the function to point to it & also suggest that we remove it around 5.66 (which gives another 3-4 months for civimobile to respond now there is an active issue not just a notice)
