### PR TITLE
Fix UFGroupTest to cleanup it's UFGroups

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/UFGroupTest.php
@@ -1,18 +1,21 @@
 <?php
 
+use Civi\Api4\UFGroup;
+
 /**
- * Class CRM_Core_BAO_UFGroupTest
+ * Class CRM_Core_BAO_UFGroupTest.
+ *
  * @group headless
  */
 class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
 
-  public function implementHookPre($op, $objectName, $id, &$params) {
-    if ($objectName == 'UFGroup') {
-      if ($op == 'create') {
+  public function implementHookPre($op, $objectName, $id, &$params): void {
+    if ($objectName === 'UFGroup') {
+      if ($op === 'create') {
         $params['is_active'] = 0;
       }
-      elseif ($op == 'delete') {
-        $systemLog = $this->callAPISuccess('SystemLog', 'create', [
+      elseif ($op === 'delete') {
+        $this->callAPISuccess('SystemLog', 'create', [
           'message' => "CRM_Core_BAO_UFGroupTest::implementHookPre $id",
           'level' => 'info',
         ]);
@@ -20,13 +23,13 @@ class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
     }
   }
 
-  public function implementHookPost($op, $objectName, $objectId, &$objectRef) {
-    if ($objectName == 'UFGroup') {
-      if ($op == 'create') {
+  public function implementHookPost($op, $objectName, $objectId, $objectRef): void {
+    if ($objectName === 'UFGroup') {
+      if ($op === 'create') {
         $objectRef->is_active = 0;
       }
-      elseif ($op == 'delete') {
-        $systemLog = $this->callAPISuccess('SystemLog', 'create', [
+      elseif ($op === 'delete') {
+        $this->callAPISuccess('SystemLog', 'create', [
           'message' => "CRM_Core_BAO_UFGroupTest::implementHookPost $objectId",
           'level' => 'info',
         ]);
@@ -34,36 +37,40 @@ class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
     }
   }
 
-  public function testPreHookIsCalledForCreate() {
+  /**
+   * Test that when creating a UFGroup the registered pre-hook is called.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPreHookIsCalledForCreate(): void {
     // Specify pre hook implementation.
-    $this->hookClass->setHook('civicrm_pre', array($this, 'implementHookPre'));
+    $this->hookClass->setHook('civicrm_pre', [$this, 'implementHookPre']);
 
-    // Create a ufgroup with BAO.
-    $params = [
+    $this->createUFGroup([
       'title' => 'testPreHookIsCalledForCreate',
       'is_active' => 1,
-    ];
-    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
-
-    // Assert that pre hook implemntation was called.
-    $this->assertEquals('testPreHookIsCalledForCreate', $ufGroup->title);
-    $this->assertEquals(0, $ufGroup->is_active, 'Is active should be 0');
+    ]);
+    // Assert that pre hook implementation was called.
+    $ufGroup = UFGroup::get()->addWhere('title', '=', 'testPreHookIsCalledForCreate')->execute()->first();
+    $this->assertEquals(0, $ufGroup['is_active'], 'Is active should be 0');
   }
 
-  public function testPreHookIsCalledForDelete() {
-    // Specify pre hook implementation.
-    $this->hookClass->setHook('civicrm_pre', array($this, 'implementHookPre'));
+  /**
+   * Test the hook is called during delete.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPreHookIsCalledForDelete(): void {
+    $this->hookClass->setHook('civicrm_pre', [$this, 'implementHookPre']);
 
-    // Create a ufgroup with BAO.
-    $params = [
+    $ufGroupID = $this->createUFGroup([
       'title' => 'testPreHookIsCalledForDelete',
       'is_active' => 1,
-    ];
-    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
-    $ufGroupID = $ufGroup->id;
-    $ufGroup = CRM_Core_BAO_UFGroup::deleteRecord(['id' => $ufGroupID]);
+    ])['id'];
 
-    // Assert that pre hook implemntation was called for delete op.
+    UFGroup::delete()->addWhere('id', '=', $ufGroupID)->execute();
+
+    // Assert that pre hook implementation was called for delete op.
     $systemLogCount = $this->callAPISuccess('SystemLog', 'getcount', [
       'message' => "CRM_Core_BAO_UFGroupTest::implementHookPre $ufGroupID",
       'level' => 'info',
@@ -72,38 +79,57 @@ class CRM_Core_BAO_UFGroupTest extends CiviUnitTestCase {
     $this->assertEquals(1, $systemLogCount, 'There should be one system log entry with message "CRM_Core_BAO_UFGroupTest::implementHookPre ' . $ufGroupID . '"');
   }
 
-  public function testPostHookIsCalledForCreate() {
-    $this->hookClass->setHook('civicrm_post', array($this, 'implementHookPost'));
-
-    $params = [
+  /**
+   * Test the hook is called when created a UF Group.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPostHookIsCalledForCreate(): void {
+    $this->hookClass->setHook('civicrm_post', [$this, 'implementHookPost']);
+    $ufGroup = $this->createUFGroup([
       'title' => 'testPostHookIsCalledForCreate',
       'is_active' => 1,
-    ];
-    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
+    ]);
 
-    // Assert that pre hook implemntation was called.
-    $this->assertEquals('testPostHookIsCalledForCreate', $ufGroup->title);
-    $this->assertEquals(0, $ufGroup->is_active, 'Is active should be 0');
+    // Assert that pre hook implementation was called.
+    $this->assertEquals('testPostHookIsCalledForCreate', $ufGroup['title']);
+    $this->assertEquals(0, $ufGroup['is_active'], 'Is active should be 0');
   }
 
-  public function testPostHookIsCalledForDelete() {
-    $this->hookClass->setHook('civicrm_post', array($this, 'implementHookPost'));
+  /**
+   * Test that the hook fires during UFGroup (profile) delete.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPostHookIsCalledForDelete(): void {
+    $this->hookClass->setHook('civicrm_post', [$this, 'implementHookPost']);
 
-    $params = [
+    $ufGroupID = UFGroup::create()->setValues([
       'title' => 'testPostHookIsCalledForDelete',
       'is_active' => 1,
-    ];
-    $ufGroup = CRM_Core_BAO_UFGroup::add($params);
-    $ufGroupID = $ufGroup->id;
-    $ufGroup = CRM_Core_BAO_UFGroup::deleteRecord(['id' => $ufGroupID]);
+    ])->execute()->first()['id'];
 
-    // Assert that pre hook implemntation was called for delete op.
+    UFGroup::delete()->addWhere('id', '=', $ufGroupID)->execute();
+
+    // Assert that pre hook implementation was called for delete op.
     $systemLogCount = $this->callAPISuccess('SystemLog', 'getcount', [
       'message' => "CRM_Core_BAO_UFGroupTest::implementHookPost $ufGroupID",
       'level' => 'info',
     ]);
 
     $this->assertEquals(1, $systemLogCount, 'There should be one system log entry with message "CRM_Core_BAO_UFGroupTest::implementHookPost ' . $ufGroupID . '"');
+  }
+
+  /**
+   * Create a UF Group.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function createUFGroup($values): ?array {
+    $ufGroup = UFGroup::create()->setValues($values)->execute()->first();
+    $this->ids['UFGroup'][] = $ufGroup['id'];
+    return $ufGroup;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix UFGroupTest to cleanup it's UFGroups

Before
----------------------------------------
The test is leaving an extra UFGroup

After
----------------------------------------
It is being removed during the `tearDown` (by virtue of it being declared)

Technical Details
----------------------------------------
I switched the functions to use the api - notably we want to remove direct calls to `add`

Comments
----------------------------------------
