### PR TITLE
Fix UFGroup cleanup in ReportTemplateTest

### DIFF
--- a/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
+++ b/tests/phpunit/CRMTraits/Custom/CustomDataTrait.php
@@ -40,7 +40,7 @@ trait CRMTraits_Custom_CustomDataTrait {
   public function createCustomGroup(array $params = []): int {
     $params = array_merge([
       'title' => 'Custom Group',
-      'extends' => $this->entity ?? 'Contact',
+      'extends' => $this->getEntity(),
       'weight' => 5,
       'style' => 'Inline',
       'max_multiple' => 0,
@@ -56,6 +56,18 @@ trait CRMTraits_Custom_CustomDataTrait {
       $this->fail('Could not create group ' . $e->getMessage());
     }
     return $this->ids['CustomGroup'][$identifier];
+  }
+
+  /**
+   * Get the entity being acted on.
+   *
+   * @return string
+   */
+  protected function getEntity(): string {
+    if (property_exists($this, 'entity')) {
+      return $this->entity;
+    }
+    return 'Contact';
   }
 
   /**

--- a/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
+++ b/tests/phpunit/CRMTraits/PCP/PCPTestTrait.php
@@ -11,6 +11,7 @@
 
 use Civi\Api4\Email;
 use Civi\Api4\PCPBlock;
+use Civi\Api4\UFGroup;
 
 /**
  * Trait CRMTraits_PCP_PCPTestTrait
@@ -24,17 +25,17 @@ trait CRMTraits_PCP_PCPTestTrait {
    *
    * Create the necessary initial objects for a pcpBlock, then return the
    * params needed to create the pcpBlock.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function pcpBlockParams() {
-    $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
-    $contribPageId = $contribPage->id;
-    $supporterProfile = CRM_Core_DAO::createTestObject('CRM_Core_DAO_UFGroup');
-    $supporterProfileId = $supporterProfile->id;
+  public function pcpBlockParams(): array {
+    $contributionPageID = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage')->id;
+    $this->ids['UFGroup']['pcp'] = UFGroup::create()->setValues(['name' => 'pcp', 'title' => 'PCP'])->execute()->first()['id'];
 
     return [
       'entity_table' => 'civicrm_contribution_page',
-      'entity_id' => $contribPageId,
-      'supporter_profile_id' => $supporterProfileId,
+      'entity_id' => $contributionPageID,
+      'supporter_profile_id' => $this->ids['UFGroup']['pcp'],
       'target_entity_id' => 1,
       'is_approval_needed' => 1,
       'is_tellfriend_enabled' => 1,
@@ -51,23 +52,21 @@ trait CRMTraits_PCP_PCPTestTrait {
    * Create the necessary initial objects for a pcp page, then return the
    * params needed to create the pcp page.
    *
-   * @throw CRM_Core_Exception
+   * @throws CRM_Core_Exception
    */
-  public function pcpParams() {
-    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
-    $contactId = $contact->id;
-    Email::create()->setValues(['email' => 'dobby@example.org', 'contact_id' => $contactId])->execute();
-    $contribPage = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage');
-    $contribPageId = $contribPage->id;
+  public function pcpParams(): array {
+    $contactID = $this->individualCreate();
+    Email::create()->setValues(['email' => 'dobby@example.org', 'contact_id' => $contactID])->execute();
+    $contributionPageID = CRM_Core_DAO::createTestObject('CRM_Contribute_DAO_ContributionPage')->id;
 
     return [
-      'contact_id' => $contactId,
+      'contact_id' => $contactID,
       'status_id' => '1',
       'title' => 'My PCP',
       'intro_text' => 'Hey you, contribute now!',
       'page_text' => 'You better give more.',
       'donate_link_text' => 'Donate Now',
-      'page_id' => $contribPageId,
+      'page_id' => $contributionPageID,
       'is_notify' => TRUE,
       'is_thermometer' => 1,
       'is_honor_roll' => 1,
@@ -82,6 +81,8 @@ trait CRMTraits_PCP_PCPTestTrait {
    * @param array $params
    *
    * @return int
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function createPCPBlock(array $params):int {
     $blockParams = $this->pcpBlockParams();

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Test\ACLPermissionTrait;
+
 /**
  *  Test APIv3 civicrm_report_instance_* functions
  *
@@ -18,13 +20,13 @@
  */
 class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
-  use Civi\Test\ACLPermissionTrait;
+  use ACLPermissionTrait;
   use CRMTraits_PCP_PCPTestTrait;
   use CRMTraits_Custom_CustomDataTrait;
 
   protected $contactIDs = [];
 
-  protected $aclGroupID = NULL;
+  protected $aclGroupID;
 
   /**
    * Our group reports use an alter so transaction cleanup won't work.
@@ -46,7 +48,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testReportTemplate() {
+  public function testReportTemplate(): void {
     /** @noinspection SpellCheckingInspection */
     $result = $this->callAPISuccess('ReportTemplate', 'create', [
       'label' => 'Example Form',
@@ -122,11 +124,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @dataProvider getReportTemplatesSupportingSelectWhere
    *
-   * @param $reportID
-   *
-   * @throws \CRM_Core_Exception
+   * @param string $reportID
    */
-  public function testReportTemplateSelectWhere($reportID): void {
+  public function testReportTemplateSelectWhere(string $reportID): void {
     $this->hookClass->setHook('civicrm_selectWhereClause', [$this, 'hookSelectWhere']);
     $result = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $reportID,
@@ -147,7 +147,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public function getReportTemplatesSupportingSelectWhere() {
+  public function getReportTemplatesSupportingSelectWhere(): array {
     $allTemplates = self::getReportTemplates();
     // Exclude all that do not work as of test being written. I have not dug into why not.
     $currentlyExcluded = [
@@ -386,7 +386,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getReportTemplates() {
+  public static function getReportTemplates(): array {
     $reportTemplates = [];
     $reportsToSkip = [
       'event/income' => "This report overrides buildQuery() so doesn't seem compatible with this test and you get a syntax error `WHERE civicrm_event.id IN( ) GROUP BY civicrm_event.id`",
@@ -440,9 +440,8 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     return $templates;
   }
 
-  public static function getConactMenbershipAndContributionReportTemplatesForACLGroupTests(): array {
-    $templates = array_merge([['contact/summary']], self::getMembershipAndContributionReportTemplatesForGroupTests());
-    return $templates;
+  public static function getContactMembershipAndContributionReportTemplatesForACLGroupTests(): array {
+    return array_merge([['contact/summary']], self::getMembershipAndContributionReportTemplatesForGroupTests());
   }
 
   /**
@@ -683,7 +682,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testReportsWithNonSmartGroupFilter($template) {
+  public function testReportsWithNonSmartGroupFilter(string $template): void {
     $groupID = $this->setUpPopulatedGroup();
     $rows = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,
@@ -697,7 +696,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   /**
    * Test the group filter works on various reports when ACLed user is in play
    *
-   * @dataProvider getConactMenbershipAndContributionReportTemplatesForACLGroupTests
+   * @dataProvider getContactMembershipAndContributionReportTemplatesForACLGroupTests
    *
    * @param string $template
    *   Report template unique identifier.
@@ -857,7 +856,8 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testContributionSummaryWithSingleContactsInTwoGroups(): void {
-    [$groupID1, $individualID] = $this->setUpPopulatedGroup(TRUE);
+    $groupID1 = $this->setUpPopulatedGroup();
+    $individualID = $this->ids['Contact']['primary'];
     // create second group and add the individual to it.
     $groupID2 = $this->groupCreate(['name' => 'test_group', 'title' => 'test_title']);
     $this->callAPISuccess('GroupContact', 'create', [
@@ -978,14 +978,11 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * This gives us a range of scenarios for testing contacts are included only once
    * whenever they are hard-added or in the criteria.
    *
-   * @param bool $returnAddedContact
-   *
    * @return int
-   * @throws \CRM_Core_Exception
    */
-  public function setUpPopulatedGroup($returnAddedContact = FALSE) {
+  public function setUpPopulatedGroup() {
     $individual1ID = $this->individualCreate();
-    $individualID = $this->individualCreate();
+    $individualID = $this->ids['Contact']['primary'] = $this->individualCreate();
     $individualIDRemoved = $this->individualCreate();
     $groupID = $this->groupCreate(['name' => uniqid(), 'title' => uniqid()]);
     $this->callAPISuccess('GroupContact', 'create', [
@@ -1006,11 +1003,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
 
     // Refresh the cache for test purposes. It would be better to alter to alter the GroupContact add function to add contacts to the cache.
     CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupID);
-
-    if ($returnAddedContact) {
-      return [$groupID, $individualID];
-    }
-
     return $groupID;
   }
 
@@ -1019,7 +1011,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function setUpIntersectingGroups() {
+  public function setUpIntersectingGroups(): array {
     $groupID = $this->setUpPopulatedGroup();
     $groupID2 = $this->setUpPopulatedSmartGroup();
     $addedToBothIndividualID = $this->individualCreate();
@@ -1144,12 +1136,8 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @param string $template
    *   Report template unique identifier.
-   *
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function testReportsCustomDataOrderBy($template) {
-    $this->entity = 'Contact';
+  public function testReportsCustomDataOrderBy(string $template): void {
     $this->createCustomGroupWithFieldOfType();
     $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,
@@ -1168,7 +1156,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testReportsWithNoTInSmartGroupFilter($template) {
+  public function testReportsWithNoTInSmartGroupFilter(string $template): void {
     $groupID = $this->setUpPopulatedGroup();
     $rows = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,
@@ -1833,7 +1821,7 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @param int|null $contactID
    * @param string $where
    */
-  public function aclGroupContactsOnly($type, &$tables, &$whereTables, &$contactID, &$where) {
+  public function aclGroupContactsOnly(string $type, array &$tables, array &$whereTables, &$contactID, &$where) {
     if (!empty($where)) {
       $where .= ' AND ';
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix UFGroup cleanup in ReportTemplateTest

Before
----------------------------------------
Not all `UFGroups` being removed

After
----------------------------------------
UFGroups being removed, other minor cleanup

Technical Details
----------------------------------------

Comments
----------------------------------------
