### PR TITLE
dev/core#4333 Set default created_id for case and activity Attachments

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -149,6 +149,9 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
       $fileDAO->id = $dao->cfID;
       unlink($directoryName . DIRECTORY_SEPARATOR . $dao->uri);
     }
+    elseif (empty($fileParams['created_id'])) {
+      $fileDAO->created_id = CRM_Core_Session::getLoggedInContactID();
+    }
 
     if (!empty($fileParams)) {
       $fileDAO->copyValues($fileParams);

--- a/tests/phpunit/CRM/Core/BAO/FileTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FileTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use Civi\Api4\Activity;
+
+/**
+ * Class CRM_Core_BAO_FileTest
+ *
+ * @group headless
+ */
+class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
+  protected $sampleFile = NULL;
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->sampleFile = sys_get_temp_dir() . '/file.txt';
+    file_put_contents($this->sampleFile, 'This comes from a file');
+  }
+
+  /**
+   * Clean up after test.
+   */
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_activity', 'civicrm_file', 'civicrm_entity_file'], TRUE);
+    parent::tearDown();
+  }
+
+  /**
+   * Test creating a file.
+   */
+  public function testCreateFile(): void {
+    $file = $this->createFile();
+
+    $this->assertDBNotNull('CRM_Core_DAO_File', $file->id, 'created_id', 'id',
+      'Database check for created File.'
+    );
+
+    $fields = [
+      'id' => $file->id,
+      'mime_type' => 'image/jpg',
+      'uri' => 'fake_file.jpg',
+      'description' => 'Edited fake file',
+    ];
+    CRM_Core_BAO_File::create($fields);
+
+    $this->assertDBNotNull('CRM_Core_DAO_File', $fields['mime_type'], 'id', 'mime_type', 'Database check for edited File.');
+    $this->assertDBNotNull('CRM_Core_DAO_File', $fields['uri'], 'id', 'uri', 'Database check for edited File.');
+  }
+
+  /**
+   * Test creating a file using the filePostProcess method.
+   */
+  public function testCreateFileUsingPostProcess(): void {
+    $activity = $this->createActivity();
+
+    $path = $this->sampleFile;
+    $params = [
+      'path' => $path,
+      'file_type_id' => NULL,
+      'entity_table' => 'civicrm_activity',
+      'entity_id' => $activity['id'],
+      'entity_subtype' => NULL,
+      'overwrite' => TRUE,
+      'file_params' => [
+        'uri' => $path,
+        'type' => 'text/plain',
+        'location' => $path,
+        'upload_date' => '20230602075923',
+        'description' => '',
+        'tag' => [],
+        'attachment_taglist' => [],
+      ],
+      'upload_name' => 'uploadFile',
+      'mime_type' => 'text/plain',
+    ];
+    CRM_Core_BAO_File::filePostProcess(...array_values($params));
+
+    $this->assertDBNotNull('CRM_Core_DAO_File', 'file.txt', 'id', 'uri', 'Database check for created File.');
+  }
+
+  /**
+   * Test creating a file using the filePostProcess method as the logged in user.
+   */
+  public function testCreateFileUsingPostProcessAsTheLoggedInUser(): void {
+    $loggedInUser = $this->createLoggedInUser();
+    $activity = $this->createActivity();
+
+    $path = $this->sampleFile;
+    $params = [
+      'path' => $path,
+      'file_type_id' => NULL,
+      'entity_table' => 'civicrm_activity',
+      'entity_id' => $activity['id'],
+      'entity_subtype' => NULL,
+      'overwrite' => TRUE,
+      'file_params' => [
+        'uri' => $path,
+        'type' => 'text/plain',
+        'location' => $path,
+        'upload_date' => '20230602075923',
+        'description' => '',
+        'tag' => [],
+        'attachment_taglist' => [],
+      ],
+      'upload_name' => 'uploadFile',
+      'mime_type' => 'text/plain',
+    ];
+    CRM_Core_BAO_File::filePostProcess(...array_values($params));
+
+    $this->assertDBNotNull('CRM_Core_DAO_File', $loggedInUser, 'id', 'created_id', 'Database check for created File.');
+  }
+
+  /**
+   * Create a file
+   *
+   * @return array
+   */
+  protected function createFile() {
+    $contactId = $this->individualCreate();
+
+    $fields = [
+      'file_type_id' => NULL,
+      'mime_type' => 'image/png',
+      'uri' => 'fake_file.png',
+      'document' => NULL,
+      'description' => 'Fake file',
+      'upload_date' => '2023-05-10 15:00:00',
+      'created_id' => $contactId,
+    ];
+    $field = CRM_Core_BAO_File::create($fields);
+    return $field;
+  }
+
+  /**
+   * Create an activity
+   *
+   * @return array
+   */
+  protected function createActivity() {
+    $contactId = $this->individualCreate();
+    $activity = Activity::create()
+      ->addValue('source_contact_id', $contactId)
+      ->addValue('subject', 'Scheduling Meeting')
+      ->addValue('activity_type_id', 1)
+      ->execute()
+      ->single();
+
+    return $activity;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The Case attachments don't have the uploader information. The created_id is not supposed to be empty regardless of how you uploaded the attachments i.e. when creating new cases or creating/editing the related activities

Before
----------------------------------------
Files uploaded in steps two and four, don't have the uploader information i.e. the created_id value is empty.

https://github.com/civicrm/civicrm-core/assets/74309109/16a3072e-5173-4590-9ed3-08d9cba0c2b2




After
----------------------------------------
Files uploaded in steps two and four should have the uploader information.

https://github.com/civicrm/civicrm-core/assets/74309109/8cdc5f76-9bb6-4d4f-9bf2-c448cdf0858c



Technical Details
----------------------------------------
In the old [#11739](https://github.com/civicrm/civicrm-core/pull/11739) PR, it uses the current logged-in `$contact_id` for the created_id field when calling the method [create](https://github.com/civicrm/civicrm-core/blob/5.61.0/CRM/Core/BAO/File.php#L50):

```php
/**
 * BAO object for crm_log table
 */
class CRM_Core_BAO_File extends CRM_Core_DAO_File {
...
  public static function create($params) {
    $fileDAO = new CRM_Core_DAO_File();
    ...

    if (empty($params['id']) && empty($params['created_id'])) {
      $fileDAO->created_id = CRM_Core_Session::getLoggedInContactID();
    }
```

For case attachments, another method is called to create the File which is [filePostProcess](https://github.com/civicrm/civicrm-core/blob/5.61.0/CRM/Core/BAO/File.php#L100) :

```php
  public static function filePostProcess(...) {
    ...
    $fileDAO = new CRM_Core_DAO_File();
    $op = 'create';
    if (isset($dao->cfID) && $dao->cfID) {
      $op = 'edit';
      $fileDAO->id = $dao->cfID;
      unlink($directoryName . DIRECTORY_SEPARATOR . $dao->uri);
    }

    if (!empty($fileParams)) {
      $fileDAO->copyValues($fileParams);
    }
```

The proposed solution is to set the `$created_id` inside the [filePostProcess](https://github.com/civicrm/civicrm-core/blob/5.61.0/CRM/Core/BAO/File.php#L100) method :

```diff
    $fileDAO = new CRM_Core_DAO_File();
    $op = 'create';
    if (isset($dao->cfID) && $dao->cfID) {
      $op = 'edit';
      $fileDAO->id = $dao->cfID;
      unlink($directoryName . DIRECTORY_SEPARATOR . $dao->uri);
    }
+    else if (empty($fileParams['created_id'])) {
+      $fileDAO->created_id = CRM_Core_Session::getLoggedInContactID();
+    }
```

Issue: https://lab.civicrm.org/dev/core/-/issues/2512