### PR TITLE
[REF][PHP8.2] Declare property in CRM_Contact_Form_Task_SMSCommonTest

### DIFF
--- a/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/SMSCommonTest.php
@@ -15,7 +15,15 @@
  */
 class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
 
-  protected $_smsRecipients = [];
+  /**
+   * @var array
+   */
+  protected $smsRecipients = [];
+
+  /**
+   * @var array
+   */
+  protected $contactIDs = [];
 
   /**
    * Set up for tests.
@@ -97,13 +105,13 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
     ]);
     // Track the contacts that should get an SMS and which
     // number they should receive it.
-    $this->_smsRecipients = [
+    $this->smsRecipients = [
       $contact1 => "1111111111",
       $contact2 => "2222222222",
       $contact3 => "3333333333",
     ];
 
-    $this->_contactIds = [
+    $this->contactIDs = [
       $contact1,
       $contact2,
       $contact3,
@@ -120,7 +128,7 @@ class CRM_Contact_Form_Task_SMSCommonTest extends CiviUnitTestCase {
    */
   public function testQuickFormMobileNumbersDisplay() {
     $form = $this->getFormObject('CRM_Core_Form');
-    $form->_contactIds = $this->_contactIds;
+    $form->_contactIds = $this->contactIDs;
     $form->_single = FALSE;
     CRM_Contact_Form_Task_SMSCommon::buildQuickForm($form);
     $contacts = json_decode($form->get_template_vars('toContact'));


### PR DESCRIPTION
Overview
----------------------------------------
Declare property in CRM_Contact_Form_Task_SMSCommonTest

Before
----------------------------------------
`_contactIds` was a dynamic property, causing deprecation warnings on PHP 8.2.

After
----------------------------------------
`contactIds` is declared.

Comments
----------------------------------------

- This test will probably still fail on 8.2 due to undefined properties in the class being tested (`CRM_Contact_Form_Task_SMSCommon`). I'll look at that separately.
- I've removed the leading `_` as they are not adding anything to the readability and the properties are properly declared `protected`