### PR TITLE
[REF][PHP8.2] Avoid dynamic properties in report summary

### DIFF
--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -36,6 +36,21 @@ class CRM_Logging_ReportSummary extends CRM_Report_Form {
   protected $currentLogTable;
 
   /**
+   * Set within `$this->buildTemporaryTables`
+   *
+   * @var CRM_Utils_SQL_TempTable
+   */
+  protected $temporaryTable;
+
+  /**
+   * The name of the temporary table.
+   * Set within `$this->buildTemporaryTables`
+   *
+   * @var string
+   */
+  protected $temporaryTableName;
+
+  /**
    * Class constructor.
    */
   public function __construct() {


### PR DESCRIPTION
Overview
----------------------------------------
Avoid dynamic properties in `CRM_Logging_ReportSummary`

Before
----------------------------------------
Dynamic properties caused deprecation warnings on PHP 8.2.

After
----------------------------------------
Properties declared.