### PR TITLE
[REF][PHP8.2] Sort out dynamic properties in api_v3_ReportTemplateTest

### DIFF
--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -27,6 +27,11 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
   protected $aclGroupID = NULL;
 
   /**
+   * @var int
+   */
+  protected $activityID;
+
+  /**
    * Our group reports use an alter so transaction cleanup won't work.
    *
    * @throws \Exception
@@ -1149,7 +1154,6 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testReportsCustomDataOrderBy($template) {
-    $this->entity = 'Contact';
     $this->createCustomGroupWithFieldOfType();
     $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => $template,


### PR DESCRIPTION
Overview
----------------------------------------
Sort out dynamic properties in `api_v3_ReportTemplateTest`

Before
----------------------------------------
Dynamic properties in `api_v3_ReportTemplateTest` cause deprecation warnings in PHP 8.2

After
----------------------------------------
Dynamic properties no longer.

The `$this->entity = 'Contact';` line was no longer needed as `createCustomGroup` (which used to use it) now defaults to `'Contact'`.

Comments
----------------------------------------
Tons of report tests are failing on PHP 8.2. due to missing tables. I think it's happening because a `tearDown` isn't running correctly, but I don't expect this to actually address that issue.
