### PR TITLE
dev/core#3815 Set options_per_line to zero when changing Custom Field html_type

### DIFF
--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -216,6 +216,9 @@
       if (htmlType === 'CheckBox' || htmlType === 'Radio') {
         $('#serialize', $form).prop('checked', htmlType === 'CheckBox');
       }
+      else {
+        $("#options_per_line", $form).val('');
+      }
 
       showSearchRange(dataType);
       customOptionHtmlType(dataType);


### PR DESCRIPTION
Overview
----------------------------------------
[See issue.](https://lab.civicrm.org/dev/core/-/issues/3815)

Ideally, this would be fixed at the template level, but there are a lot of different tpls that display custom fields and I don't think it makes sense to try to change each one of them. This fix just clears options_per_line in the custom fields form when changing the html_type away from Radio or CheckBox. Not ideal as you can still set options_per_line via API and you lose the options per line if you change the html_type from, for example, Radio to Select and back to Radio, but this is an improvement. 

Before
----------------------------------------
Options per line still has a value when it is hidden.

After
----------------------------------------
Options per line is cleared when it is hidden.