### PR TITLE
ensure view only custom fields merge properly

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2038,10 +2038,10 @@ ORDER BY civicrm_custom_group.weight,
           $htmlType = (string) $fieldMetadata['html_type'];
           $isSerialized = CRM_Core_BAO_CustomField::isSerialized($fieldMetadata);
           $isView = (bool) $fieldMetadata['is_view'];
-          if ($isView) {
-            $viewOnlyCustomFields[$key] = $value;
-          }
           $submitted = self::processCustomFields($mainId, $key, $submitted, $value, $fieldID, $isView, $htmlType, $isSerialized);
+          if ($isView) {
+            $viewOnlyCustomFields[$key] = $submitted[$key];
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Ensure we can properly merge view only custom fields.

Before
----------------------------------------
When:

 * merging two contacts
 * with different view only custom fields 
 * in which one of the custom fields is a date field
 * and that custom field is selected to merge

We get a backtrace:

```
$Fatal Error Details = array:3 [
  "message" => "value: 2023-06-02 13:43:00 is not of the right field data type: Date"
  "code" => null
  "exception" => CRM_Core_Exception {#1590
    -errorData: array:1 [
      "error_code" => 0
    ]
    #cause: null
    -_trace: null
    #message: "value: 2023-06-02 13:43:00 is not of the right field data type: Date"
    #code: 0
    #file: "/var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomValueTable.php"
    #line: 657
    trace: {
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomValueTable.php:657 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Dedupe/Merger.php:2056 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Contact/Form/Merge.php:324 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Form.php:612 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/StateMachine.php:144 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Next.php:43 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-packages/HTML/QuickForm/Controller.php:203 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-packages/HTML/QuickForm/Page.php:103 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Controller.php:355 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Utils/Wrapper.php:98 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:292 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:69 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:36 { …}
      /var/www/powerbase/web/modules/contrib/civicrm/src/Civicrm.php:88 {
```

After
----------------------------------------

The merge completes successfully.

Technical Details
----------------------------------------

When merging, the values of the custom fields being merged pass through `self::processCustomField` which properly formats them. But if they are view only they don't get this benefit. That leads to a backtrace because date fields are not properly massaged into the right format.

Comments
----------------------------------------

This is admittedly quiet a corner case (but came up because [two people experienced it](https://github.com/progressivetech/net.ourpowerbase.sumfields/issues/98)]). 

An alternative might be to automatically exclude read-only fields from the merge screen? 

I also haven't noticed any side effects of this change - I specifically checked to ensure the display of the custom fields is still properly handled when viewing the comparison of the two contacts on the merge screen.
