### PR TITLE
Don't show event URL on Manage Event Template

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -110,7 +110,7 @@
       <td>{$form.is_active.html} {$form.is_active.label}</td>
     </tr>
 
-    {if $eventID}
+    {if $eventID AND !$isTemplate}
       <tr class="crm-event-manage-eventinfo-form-block-info_link">
         <td>&nbsp;</td>
         <td class="description">


### PR DESCRIPTION
Overview
----------------------------------------

[From this SE question.
](https://civicrm.stackexchange.com/questions/45040/new-civievent-template-url-redirecting-to-events-template-page/)

Before
----------------------------------------
This doesn't make any sense for an Event Template and doesn't lead anywhere except to the listing of Event Templates:

<img width="757" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/5f89eb04-20a9-4a59-8a22-471edb79327f">

After
----------------------------------------
URL not shown on Event Templates.

Comments
----------------------------------------
[Related issue](https://lab.civicrm.org/dev/core/-/issues/4334) proposing to remove this entirely as it is redundant.