### PR TITLE
[Test] Switch some unpaid event test setup to use createUnPaidEvent

### DIFF
--- a/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/UserDashBoardTest.php
@@ -268,12 +268,11 @@ class CRM_Contact_Page_View_UserDashBoardTest extends CiviUnitTestCase {
       'register for events',
       'access Contact Dashboard',
     ];
-    $event1id = $this->eventCreate()['id'];
-    $event2id = $this->eventCreate(['title' => 'Social Distancing Meetup Group'])['id'];
+
     $params['contact_id'] = $this->contactID;
-    $params['event_id'] = $event1id;
+    $params['event_id'] = $this->eventCreateUnpaid()['id'];;
     $this->participantCreate($params);
-    $params['event_id'] = $event2id;
+    $params['event_id'] = $this->eventCreateUnpaid(['title' => 'Social Distancing Meetup Group'], 'event_2')['id'];
     $this->participantCreate($params);
     $this->runUserDashboard();
     $expectedStrings = [

--- a/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
+++ b/tests/phpunit/CRM/Event/BAO/EventPermissionsTest.php
@@ -45,7 +45,7 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
   }
 
   public function createOwnEvent() {
-    $event = $this->eventCreate([
+    $event = $this->eventCreateUnpaid([
       'created_id' => $this->contactID,
     ]);
     $this->ownEventID = $event['id'];
@@ -53,7 +53,7 @@ class CRM_Event_BAO_EventPermissionsTest extends CiviUnitTestCase {
 
   public function createOtherEvent() {
     $this->otherContactID = $this->contactID + 1;
-    $event = $this->eventCreate([
+    $event = $this->eventCreateUnpaid([
       'created_id' => $this->otherContactID,
     ]);
     $this->otherEventID = $event['id'];

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -306,6 +306,8 @@ class api_v3_JobTest extends CiviUnitTestCase {
 
   /**
    * Event templates should not send reminders to additional contacts.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testTemplateRemindAdditionalContacts(): void {
     $contactId = $this->individualCreate();
@@ -314,7 +316,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
       'group_id' => $groupId,
     ]);
-    $event = $this->eventCreate(['is_template' => 1, 'template_title' => "I'm a template", 'title' => NULL]);
+    $event = $this->eventCreateUnpaid(['is_template' => 1, 'template_title' => "I'm a template", 'title' => NULL]);
     $eventId = $event['id'];
 
     $this->callAPISuccess('action_schedule', 'create', [
@@ -346,7 +348,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
       'group_id' => $groupId,
     ]);
-    $event = $this->eventCreate(['title' => 'delete this event']);
+    $event = $this->eventCreateUnpaid(['title' => 'delete this event']);
     $eventId = $event['id'];
 
     $this->callAPISuccess('action_schedule', 'create', [


### PR DESCRIPTION
This resolves some of the ambiguity / mismatched data

Spin off from https://github.com/civicrm/civicrm-core/pull/26348
