### PR TITLE
[REF][PHP8.2] Declare property in CRM_Report_Form_Contact_Log

### DIFF
--- a/CRM/Report/Form/Contact/Log.php
+++ b/CRM/Report/Form/Contact/Log.php
@@ -18,6 +18,8 @@ class CRM_Report_Form_Contact_Log extends CRM_Report_Form {
 
   protected $_summary = NULL;
 
+  protected $activityTypes = [];
+
   /**
    * Class constructor.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Declare property in `CRM_Report_Form_Contact_Log`.

Before
----------------------------------------
`activityTypes` was not declared, leading to deprecation notices on PHP 8.2.

After
----------------------------------------
Property is declared.

