### PR TITLE
[REF][PHP8.2] Declare properties on OrganizationSummary report

### DIFF
--- a/CRM/Report/Form/Contribute/OrganizationSummary.php
+++ b/CRM/Report/Form/Contribute/OrganizationSummary.php
@@ -33,6 +33,16 @@ class CRM_Report_Form_Contribute_OrganizationSummary extends CRM_Report_Form {
   protected $otherContact;
 
   /**
+   * @var int
+   */
+  protected $relationshipId;
+
+  /**
+   * @var array
+   */
+  protected $relationTypes = [];
+
+  /**
    * Class constructor.
    */
   public function __construct() {


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties within `CRM_Report_Form_Contribute_OrganizationSummary` class.

Before
----------------------------------------
Undeclared properties cause deprecation warnings on PHP 8.2.

After
----------------------------------------
Properties declared.