### PR TITLE
dev/core#3570: Don't show current mailing in include/exclude previous mailings

### DIFF
--- a/ang/crmMailing/Recipients.js
+++ b/ang/crmMailing/Recipients.js
@@ -222,7 +222,7 @@
                 break;
 
               case 'civicrm_mailing':
-                filterParams = { is_hidden: 0, is_active: 1 };
+                filterParams = { is_hidden: 0, is_active: 1, id: {"!=": scope.$parent.mailing.id} };
                 break;
               }
               var params = {


### PR DESCRIPTION
Before
----------------------------------------
You can include or exclude the current mailing recipients from your mailing, which makes no sense.

After
----------------------------------------
Current mailing does not appear in the options to include or exclude.