### PR TITLE
[NFC] Fix capitalization of class names

### DIFF
--- a/tests/phpunit/CRM/Contact/Page/View/NoteTest.php
+++ b/tests/phpunit/CRM/Contact/Page/View/NoteTest.php
@@ -33,7 +33,7 @@ class CRM_Contact_Page_View_NoteTest extends CiviUnitTestCase {
     }
     $page = new CRM_Contact_Page_View_Note();
     $page->_contactId = $contactId;
-    $page->_permission = CRM_Core_PERMISSION::EDIT;
+    $page->_permission = CRM_Core_Permission::EDIT;
     $page->browse();
     $this->assertEquals(count($page->values), 5);
     foreach ($page->values as $note) {

--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -125,7 +125,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
-    $this->cache = new CRM_Utils_Cache_Arraycache([]);
+    $this->cache = new CRM_Utils_Cache_ArrayCache([]);
     self::initWebResponses();
   }
 

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -180,7 +180,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertTrue(substr($contribution['contribution_source'], 0, 20) === "Online Contribution:");
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
-    $paypalIPN = new CRM_Core_Payment_PaypalIPN($this->getPaypalRecurSubsequentTransaction());
+    $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurSubsequentTransaction());
     $paypalIPN->main();
     $renewedMembershipEndDate = $this->membershipRenewalDate($durationUnit, $membershipEndDate);
     $this->assertEquals($renewedMembershipEndDate, $this->callAPISuccessGetValue('membership', ['return' => 'end_date']));

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -112,7 +112,7 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
     $this->assertEquals('Online Contribution:', substr($contribution['contribution_source'], 0, 20));
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
-    $paypalIPN = new CRM_Core_Payment_PaypalProIPN($this->getPaypalProRecurSubsequentTransaction());
+    $paypalIPN = new CRM_Core_Payment_PayPalProIPN($this->getPaypalProRecurSubsequentTransaction());
     $paypalIPN->main();
 
     $renewedMembershipEndDate = $this->membershipRenewalDate($durationUnit, $membershipEndDate);

--- a/tests/phpunit/CRM/Core/Resources/StringsTest.php
+++ b/tests/phpunit/CRM/Core/Resources/StringsTest.php
@@ -22,7 +22,7 @@ class CRM_Core_Resources_StringsTest extends CiviUnitTestCase {
   public function testGet() {
     $basedir = $this->createExamples();
     $strings = new CRM_Core_Resources_Strings(
-      new CRM_Utils_Cache_Arraycache(NULL)
+      new CRM_Utils_Cache_ArrayCache(NULL)
     );
     $this->assertEquals(
       ['Hello from Javascript'],

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -41,7 +41,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     parent::setUp();
 
     $this->mapper = $this->createMapper();
-    $cache = new CRM_Utils_Cache_Arraycache([]);
+    $cache = new CRM_Utils_Cache_ArrayCache([]);
     $this->res = new CRM_Core_Resources($this->mapper, new CRM_Core_Resources_Strings($cache), NULL);
     $this->res->setCacheCode('resTest');
     CRM_Core_Resources::singleton($this->res);

--- a/tests/phpunit/CRM/Extension/Container/BasicTest.php
+++ b/tests/phpunit/CRM/Extension/Container/BasicTest.php
@@ -74,7 +74,7 @@ class CRM_Extension_Container_BasicTest extends CiviUnitTestCase {
   }
 
   public function testCaching() {
-    $cache = new CRM_Utils_Cache_Arraycache([]);
+    $cache = new CRM_Utils_Cache_ArrayCache([]);
     $this->assertTrue(!is_array($cache->get('basic-scan')));
     [$basedir, $c] = $this->_createContainer($cache, 'basic-scan');
     $this->assertEquals('http://example/basedir/foo', $c->getResUrl('test.foo'));

--- a/tests/phpunit/CRM/Extension/Container/CollectionTest.php
+++ b/tests/phpunit/CRM/Extension/Container/CollectionTest.php
@@ -66,7 +66,7 @@ class CRM_Extension_Container_CollectionTest extends CiviUnitTestCase {
   }
 
   public function testCaching() {
-    $cache = new CRM_Utils_Cache_Arraycache([]);
+    $cache = new CRM_Utils_Cache_ArrayCache([]);
     $this->assertTrue(!is_array($cache->get('ext-collection')));
     $c = $this->_createContainer($cache, 'ext-collection');
     $this->assertEquals('http://foo', $c->getResUrl('test.foo'));

--- a/tests/phpunit/CRM/Import/DataSource/CsvTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/CsvTest.php
@@ -36,7 +36,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    */
   public function testToCsv(array $fileData): void {
     $form = $this->submitDatasourceForm($fileData['filename']);
-    $csvObject = new CRM_Import_DataSource_Csv($form->getUserJobID());
+    $csvObject = new CRM_Import_DataSource_CSV($form->getUserJobID());
     $rows = $csvObject->getRows(0, 0, [], FALSE);
     foreach (['first_name', 'last_name', 'email'] as $field) {
       $json = json_encode($rows[0][$field]);
@@ -137,7 +137,7 @@ class CRM_Import_DataSource_CsvTest extends CiviUnitTestCase {
    */
   public function testBlankLineAtEnd(): void {
     $form = $this->submitDatasourceForm('blankLineAtEnd.csv');
-    $csvObject = new CRM_Import_DataSource_Csv($form->getUserJobID());
+    $csvObject = new CRM_Import_DataSource_CSV($form->getUserJobID());
 
     $json = json_encode($csvObject->getRow()['email']);
     $this->assertEquals('"yogi@yellowstone.park"', $json);

--- a/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
+++ b/tests/phpunit/CRM/Utils/API/MatchOptionTest.php
@@ -39,7 +39,7 @@ class CRM_Utils_API_MatchOptionTest extends CiviUnitTestCase {
       $this->assertEquals('ignore1@example.com', $value['email']);
       $this->assertEquals(1, count($value['api.Address.get']['values']));
     }
-    CRM_core_DAO::executeQuery('DELETE FROM civicrm_address WHERE contact_id=%1', [
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_address WHERE contact_id=%1', [
       1 => [$this->noise['individual'], 'Positive'],
     ]);
     $this->callAPISuccess('Contact', 'delete', [

--- a/tests/phpunit/Civi/Core/SettingsManagerTest.php
+++ b/tests/phpunit/Civi/Core/SettingsManagerTest.php
@@ -131,7 +131,7 @@ class SettingsManagerTest extends \CiviUnitTestCase {
    * @return SettingsManager
    */
   protected function createManager() {
-    $cache = new \CRM_Utils_Cache_Arraycache([]);
+    $cache = new \CRM_Utils_Cache_ArrayCache([]);
     $cache->set('defaults_domain', $this->domainDefaults);
     $cache->set('defaults_contact', $this->contactDefaults);
     foreach ($this->mandates as $entity => $keyValues) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix capitalization of class names.

This updates the dozen instances across CiviCRM core where classes were being used with different capitalisation than is used where the class is defined.

Technical Details
----------------------------------------
Whilst classes are case-insensitive in PHP I still think this makes sense:

- Consistency is good,
- Can avoid confusing if doing a search with case-sensitivity turned on,
- Avoid warnings in certain static analysis tools