### PR TITLE
Fix payment validation for Payment on Confirm

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -398,6 +398,15 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $errors['payment_processor_id'] = ts('Please select a Payment Method');
     }
 
+    if ($form->showPaymentOnConfirm) {
+      CRM_Core_Payment_Form::validatePaymentInstrument(
+        $fields['payment_processor_id'],
+        $fields,
+        $errors,
+        (!$form->_isBillingAddressRequiredForPayLater ? NULL : 'billing')
+      );
+    }
+
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -922,12 +922,15 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       ) {
         return empty($errors) ? TRUE : $errors;
       }
-      CRM_Core_Payment_Form::validatePaymentInstrument(
-        $fields['payment_processor_id'],
-        $fields,
-        $errors,
-        (!$form->_isBillingAddressRequiredForPayLater ? NULL : 'billing')
-      );
+
+      if (!$form->showPaymentOnConfirm) {
+        CRM_Core_Payment_Form::validatePaymentInstrument(
+          $fields['payment_processor_id'],
+          $fields,
+          $errors,
+          (!$form->_isBillingAddressRequiredForPayLater ? NULL : 'billing')
+        );
+      }
     }
 
     return empty($errors) ? TRUE : $errors;


### PR DESCRIPTION
Before
----------------------------------------
If using the new Show Payment on Confirm option, there is a PHP Notice shown on dmaster on the second page:
![image](https://github.com/civicrm/civicrm-core/assets/25517556/01243bc5-9c6f-473a-992f-eed323032750)

`validatePaymentInstrument()` was also not being called on submitting the payment/confirmation page.

After
----------------------------------------
No more PHP Notice.
Validation is done on payment/confirmation page if needed.