### PR TITLE
Show Event Info at bottom of Registration Confirm & Fee Info above Payment

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -46,57 +46,6 @@
         </div>
     {/if}
 
-    {if $showPaymentOnConfirm}
-    <div class="crm-group event_info-group">
-      <div class="header-dark">
-          {ts}Payment details{/ts}
-      </div>
-    {if !empty($form.payment_processor_id.label)}
-      <fieldset class="crm-public-form-item crm-group payment_options-group" style="display:none;">
-        <legend>{ts}Payment Options{/ts}</legend>
-        <div class="crm-section payment_processor-section">
-          <div class="label">{$form.payment_processor_id.label}</div>
-          <div class="content">{$form.payment_processor_id.html}</div>
-          <div class="clear"></div>
-        </div>
-      </fieldset>
-    {/if}
-        {include file='CRM/Core/BillingBlockWrapper.tpl'}
-    {literal}<script>function calculateTotalFee() { return {/literal}{$totalAmount}{literal} }</script>{/literal}
-    </div>
-    {/if}
-
-    <div class="crm-group event_info-group">
-        <div class="header-dark">
-            {ts}Event Information{/ts}
-        </div>
-        <div class="display-block">
-            {include file="CRM/Event/Form/Registration/EventInfoBlock.tpl"}
-        </div>
-    </div>
-
-    {if $pcpBlock && $pcp_display_in_roll}
-    <div class="crm-group pcp_display-group">
-        <div class="header-dark">
-           {ts}Contribution Honor Roll{/ts}
-        </div>
-        <div class="display-block">
-          {ts}List my contribution{/ts}
-          {if $pcp_is_anonymous}
-              <strong>{ts}anonymously{/ts}.</strong>
-          {else}
-            {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
-            {if $pcp_personal_note}
-                {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
-            {else}
-             <strong>{ts}With no personal note{/ts}</strong>
-             {/if}
-          {/if}
-          <br />
-        </div>
-    </div>
-    {/if}
-
     {if $paidEvent && !$isRequireApproval && !$isOnWaitlist}
         <div class="crm-group event_fees-group">
             <div class="header-dark">
@@ -133,6 +82,48 @@
             {/if}
 
         </div>
+    {/if}
+
+    {if $showPaymentOnConfirm}
+    <div class="crm-group event_info-group">
+      <div class="header-dark">
+          {ts}Payment details{/ts}
+      </div>
+    {if !empty($form.payment_processor_id.label)}
+      <fieldset class="crm-public-form-item crm-group payment_options-group" style="display:none;">
+        <legend>{ts}Payment Options{/ts}</legend>
+        <div class="crm-section payment_processor-section">
+          <div class="label">{$form.payment_processor_id.label}</div>
+          <div class="content">{$form.payment_processor_id.html}</div>
+          <div class="clear"></div>
+        </div>
+      </fieldset>
+    {/if}
+        {include file='CRM/Core/BillingBlockWrapper.tpl'}
+    {literal}<script>function calculateTotalFee() { return {/literal}{$totalAmount}{literal} }</script>{/literal}
+    </div>
+    {/if}
+
+    {if $pcpBlock && $pcp_display_in_roll}
+    <div class="crm-group pcp_display-group">
+        <div class="header-dark">
+           {ts}Contribution Honor Roll{/ts}
+        </div>
+        <div class="display-block">
+          {ts}List my contribution{/ts}
+          {if $pcp_is_anonymous}
+              <strong>{ts}anonymously{/ts}.</strong>
+          {else}
+            {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
+            {if $pcp_personal_note}
+                {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
+            {else}
+             <strong>{ts}With no personal note{/ts}</strong>
+             {/if}
+          {/if}
+          <br />
+        </div>
+    </div>
     {/if}
 
     {if $event.participant_role neq 'Attendee' and $defaultRole}
@@ -182,6 +173,15 @@
         </div>
       {/crmRegion}
     {/if}
+
+    <div class="crm-group event_info-group">
+        <div class="header-dark">
+            {ts}Event Information{/ts}
+        </div>
+        <div class="display-block">
+            {include file="CRM/Event/Form/Registration/EventInfoBlock.tpl"}
+        </div>
+    </div>
 
     {if $contributeMode NEQ 'notify'} {* In 'notify mode, contributor is taken to processor payment forms next *}
     <div class="messages status section continue_message-section">


### PR DESCRIPTION
Overview
----------------------------------------
If I'm confirming my event registration, I think the most important information to me is what I'm paying and that I entered the details for the various participants correctly. The event info (event name, date and time, location, contact info) is not the most important info to me when I am confirming as I have presumably already seen this information before getting to the registration.

So, in the spirit of putting the most important information where it is most likely to be seen and most easily found, this moves the event info below the rest of the registration details on the registration confirmation page, putting the fees and participant details above it. If you are using the new [Payment on Confirm option](https://github.com/civicrm/civicrm-core/pull/24781), this puts the fees above the area to enter your payment details, so you can see what you're paying for and the total before you enter your card details (I think this is a pretty standard pattern, though maybe it would be better as a sidebar or something in the future).

Before
----------------------------------------
<img width="582" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/350389b4-b423-449c-939b-2e4277c4b16b">

After
----------------------------------------
<img width="582" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/22c1ad5b-a8c9-452a-afb0-6ecb464970f1">

With Payment on Confirm:
<img width="591" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/9fe5bd2e-c283-4818-b0a8-21fb6ecee61c">