### PR TITLE
[PHP8] Fix warnings on activity and event management forms

### DIFF
--- a/templates/CRM/Core/Form/RecurringEntity.hlp
+++ b/templates/CRM/Core/Form/RecurringEntity.hlp
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{capture assign='entityType'}{$params.entityType|lower}{/capture}
+{capture assign='entityType'}{if array_key_exists('entityType', $params)}{$params.entityType|lower}{/if}{/capture}
 
 {htxt id="id-repeats-title"}
   {ts}Repeats{/ts}


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Go to New Activity. Screen fills with multiple lines of
```
Warning: Undefined array key "params" in include() (line 5 of .../templates_c/en_US/%%DF/DF0/DF0B0562%%RecurringEntity.hlp.php).
Warning: Trying to access array offset on value of type null in include() (line 5 of .../templates_c/en_US/%%DF/DF0/DF0B0562%%RecurringEntity.hlp.php).
Deprecated function: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in smarty_modifier_lower() (line 23 of .../packages/Smarty/plugins/modifier.lower.php).
```

After
----------------------------------------
No warnings. If you expand the repeat activity section the help bubbles still work.

Technical Details
----------------------------------------
The details are in the code comment, but briefly the file is parsed twice in the flow, the first time to get the help title, at which time the variable is not assigned anything.

Comments
----------------------------------------
This may overlap a little with https://github.com/civicrm/civicrm-core/pull/26265 but in the meantime this removes the warnings.
