### PR TITLE
[REF][PHP8.2] Remove unused dynamic property showMembershipSummary

### DIFF
--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -32,7 +32,6 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
     //what they have access to
     //@todo implement acls on dashboard querys (preferably via api to enhance that at the same time)
     if (!CRM_Core_Permission::check('view all contacts') && !CRM_Core_Permission::check('edit all contacts')) {
-      $this->showMembershipSummary = FALSE;
       $this->assign('membershipSummary', FALSE);
       return;
     }


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Member_Page_DashBoard` set `$this->showMembershipSummary = FALSE;`, but there were issues with this:

 - There was no default value set to `TRUE`, which would make the property awkward to use,
 - The property was not declared (causing deprecation warnings on PHP 8.2. due to use of a dynamic property)
 - The property was not read within core.

Before
----------------------------------------
Use of dynamic property caused deprecation warning on PHP 8.2.

After
----------------------------------------
The property is removed.

Comments
----------------------------------------
Looking back through the GIT history, we can see even at the time the property was added it was not used by core: https://github.com/civicrm/civicrm-core/commit/46c910131eb3a99b7da3b337f3ddaa298b90ee59

I don't have [universe](https://docs.civicrm.org/dev/en/latest/tools/universe/) setup, someone who does may want to double-check this property is not being used before merging, but given the lack of default value, I think it's unlikely. 
