### PR TITLE
Order mailings for selects in search and reports by id DESC

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2787,7 +2787,7 @@ AND    e.id NOT IN ( SELECT email_id FROM civicrm_mailing_recipients mr WHERE ma
 SELECT civicrm_mailing.id, civicrm_mailing.name, civicrm_mailing_job.end_date
 FROM   civicrm_mailing
 INNER JOIN civicrm_mailing_job ON civicrm_mailing.id = civicrm_mailing_job.mailing_id {$where}
-ORDER BY civicrm_mailing.name";
+ORDER BY civicrm_mailing.id DESC";
       $mailing = CRM_Core_DAO::executeQuery($query);
 
       while ($mailing->fetch()) {


### PR DESCRIPTION
Overview
----------------------------------------
Mailing name selects (in Advanced Search, various reports) are ordered by name. Assuming you have more than a few mailings, this is not very useful. If I'm searching for mailings and I start typing the name of the mailing, I want to see the most recent mailings at the top of the list, not have them sorted by name. This also allows the user to select the most recent mailings directly from the top of the list.

Before
----------------------------------------
Mailing selects sorted by name.

After
----------------------------------------
Mailing selects are sorted by mailing id descending, so most recent mailings are at the top of the list.

Technical Details
----------------------------------------
This function is only used in CRM/Mailings/BAO/Query (it has another use in here, but the order doesn't matter for that) and the five Mailing reports. No other uses in universe except one similar use in a report in SendGrid extension.

