### PR TITLE
dev/core#4330 - Fix APIv4 orderBy to resolve ambiguous column names

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -1346,10 +1346,11 @@ class Api4SelectQuery {
    */
   protected function renderExpr($expr) {
     $exprVal = explode(':', $expr->getExpr())[0];
-    // If this expression is already in use in the select clause, use the existing alias
-    // This allows calculated fields to be reused in SELECT, GROUP BY and ORDER BY
+    // If this expression is already aliased in the select clause, use the existing alias.
+    // This allows calculated fields to be reused in SELECT, GROUP BY and ORDER BY.
     foreach ($this->selectAliases as $alias => $selectVal) {
-      if ($exprVal === explode(':', $selectVal)[0]) {
+      $selectVal = explode(':', $selectVal)[0];
+      if ($alias !== $selectVal && $exprVal === $selectVal) {
         return "`$alias`";
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes APIv4 regression documented in https://lab.civicrm.org/dev/core/-/issues/4330

Technical Details
----------------------------------------
This regressed from ff2a73c, the fix is to only use names from the select clause if they are actual aliases.