### PR TITLE
Use PriceSet permissions for related entities

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1245,7 +1245,7 @@ class CRM_Core_Permission {
     ];
 
     // Price sets are shared by several components, user needs access to at least one of them
-    $permissions['price_set'] = [
+    $permissions['price_set'] = $permissions['price_field'] = $permissions['price_field_value'] = $permissions['price_set_entity'] = [
       'default' => [
         ['access CiviEvent', 'access CiviContribute', 'access CiviMember'],
       ],


### PR DESCRIPTION

Overview
----------------------------------------
Use PriceSet permissions for related entities

Before
----------------------------------------
PriceSet entity has somewhat loose permissions but related entities default to stricter permissions

      'default' => [
        ['access CiviEvent', 'access CiviContribute', 'access CiviMember'],
      ],
      'get' => [
        ['access CiviCRM', 'view event info', 'make online contributions'],
      ],


After
----------------------------------------
The related entities of PriceField, PriceFieldValue and PriceSetEntity use the same permissions

Technical Details
----------------------------------------
This addresses a situation where price set permissions are looser than the associated fields, values & linkages to events & contribution pages

Comments
----------------------------------------
