### PR TITLE
Use dot to delimit log filename for domain ID

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -689,7 +689,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       else {
         $hash = '';
       }
-      $fileName = $config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '_' . $prefixString . $hash . 'log';
+      $fileName = $config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '.' . $prefixString . $hash . 'log';
 
       // Roll log file monthly or if greater than our threshold.
       // Size-based rotation introduced in response to filesize limits on

--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -107,7 +107,7 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
     $log->log('Little lamb');
     $config = CRM_Core_Config::singleton();
     $fileContents = file_get_contents($log->_filename);
-    $this->assertEquals($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '_' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log', $log->_filename);
+    $this->assertEquals($config->configAndLogDir . 'CiviCRM.' . CIVICRM_DOMAIN_ID . '.' . 'my-test.' . CRM_Core_Error::generateLogFileHash($config) . '.log', $log->_filename);
     // The 5 here is a bit arbitrary - on my local the date part is 15 chars (Mar 29 05:29:16) - but we are just checking that
     // there are chars for the date at the start.
     $this->assertTrue(strpos($fileContents, '[info] Mary had a little lamb') > 10);


### PR DESCRIPTION
Overview
----------------------------------------
Since domain ID was incorporated in log filename (#24893), if `CIVICRM_LOG_HASH=false` and no prefix is used (general Civi log file) the generated log file name looks inconsistent compared to all other cases (log hash is true and/or a prefix is used).

Before
----------------------------------------
`CiviCRM.1_log`

After
----------------------------------------
`CiviCRM.1.log`

Technical Details
----------------------------------------
Log filename is a `.` delimited string so domain ID part could follow this convention also.
Though it's possible to apply some logic to add an extra dot (so name would look like `CiviCRM.1_.log`) I think the suggested way is more natural. 

Comments
----------------------------------------
The log file is still just a text file so this is not about any functionality.
