### PR TITLE
Converts the CryptoExceptions into session messages.

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -256,7 +256,13 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
         $this->_defaults = $mailingBackend;
 
         if (!empty($this->_defaults['smtpPassword'])) {
-          $this->_defaults['smtpPassword'] = \Civi::service('crypto.token')->decrypt($this->_defaults['smtpPassword']);
+          try {
+            $this->_defaults['smtpPassword'] = \Civi::service('crypto.token')->decrypt($this->_defaults['smtpPassword']);
+          }
+          catch (Exception $e) {
+            Civi::log()->error($e->getMessage());
+            CRM_Core_Session::setStatus(ts('Unable to retrieve the encrypted password. Please check your configured encryption keys. The error message is: %1', [1 => $e->getMessage()]), ts("Encryption key error"), "error");
+          }
         }
       }
       else {


### PR DESCRIPTION
Overview
----------------------------------------
Converts the CryptoExceptions into session messages. Please see https://lab.civicrm.org/dev/core/-/issues/4308 for more information

Before
----------------------------------------
If you change the CIVICRM_CRED_KEYS variable (or clone the site), access to `/civicrm/admin/setting/smtp?reset=1` is producing a WSOD due to the key change

After
----------------------------------------
Gain access to `/civicrm/admin/setting/smtp?reset=1` but also warn the user that his/her key is invalid and needs to re-enter it.
