### PR TITLE
[REF] Refactor text fields in price sets

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -291,26 +291,15 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
     //use value field.
     $valueFieldName = 'amount';
-    $separator = '|';
-    $taxTerm = Civi::settings()->get('tax_term');
-    $displayOpt = Civi::settings()->get('tax_display_settings');
-    $invoicing = Civi::settings()->get('invoicing');
     switch ($field->html_type) {
       case 'Text':
         $optionKey = key($customOption);
-        $count = CRM_Utils_Array::value('count', $customOption[$optionKey], '');
-        $max_value = CRM_Utils_Array::value('max_value', $customOption[$optionKey], '');
-        $taxAmount = $customOption[$optionKey]['tax_amount'] ?? NULL;
-        if (isset($taxAmount) && $displayOpt && $invoicing) {
-          $qf->assign('displayOpt', $displayOpt);
-          $qf->assign('taxTerm', $taxTerm);
-          $qf->assign('invoicing', $invoicing);
-        }
-        $priceVal = implode($separator, [
-          $customOption[$optionKey][$valueFieldName] + $taxAmount,
-          $count,
-          $max_value,
-        ]);
+        // Text elements have a label before and then a second label after with amount, etc
+        // The second label is added here, we start by clearing out the existing text which is the first label.
+        $customOption[$optionKey]['label'] = NULL;
+        $priceOptionText = self::buildPriceOptionText($customOption[$optionKey], $field->is_display_amounts, $valueFieldName);
+        // This second label is then added to the form as a second form element which just carries the label and is not otherwise used.
+        $elementLabelAfter = &$qf->add('static', $elementName . '_label_after', $priceOptionText['label']);
 
         $extra = [];
         if (!empty($qf->_membershipBlock) && $isQuickConfig && $field->name == 'other_amount' && empty($qf->_contributionAmount)) {
@@ -332,7 +321,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $element = &$qf->add('text', $elementName, $label,
           array_merge($extra,
             [
-              'price' => json_encode([$optionKey, $priceVal]),
+              'price' => json_encode([$optionKey, $priceOptionText['priceVal']]),
               'size' => '4',
             ]
           ),
@@ -346,7 +335,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         if (in_array($optionKey, $freezeOptions)) {
           self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
           // CRM-14696 - Improve display for sold out price set options
-          $element->setLabel($label . '&nbsp;<span class="sold-out-option">' . ts('Sold out') . '</span>');
+          $elementLabelAfter->setLabel('<span class="sold-out-option">' . $elementLabelAfter->getLabel() . '&nbsp;(' . ts('Sold out') . ')</span>');
         }
 
         //CRM-10117
@@ -777,7 +766,7 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
    * @return array
    *   Price field option label, price value
    */
-  public static function buildPriceOptionText($opt, $isDisplayAmounts, $valueFieldName) {
+  protected static function buildPriceOptionText($opt, $isDisplayAmounts, $valueFieldName) {
     $preHelpText = $postHelpText = '';
     $optionLabel = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . $opt['label'] . '</span>' : '';
     if (!empty($opt['help_pre'])) {

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -27,13 +27,13 @@
 
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
-        {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard' }
-            {if $element.help_pre}<span class="content description">{$element.help_pre}</span><br />{/if}
+        {if $element.visibility EQ 'public' || ($element.visibility EQ 'admin' && $adminFld EQ true) || $context eq 'standalone' || $context eq 'advanced' || $context eq 'search' || $context eq 'participant' || $context eq 'dashboard'}
             <div class="crm-section {$element.name}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_"|cat:$field_id}
               <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name}-content">
+              {if $element.help_pre}<div class="description">{$element.help_pre}</div>{/if}
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
@@ -62,36 +62,13 @@
 
                 <div class="label">{$form.$element_name.label}</div>
                 <div class="content {$element.name}-content">
+                  {if $element.help_pre}<div class="description">{$element.help_pre}</div>{/if}
                   {$form.$element_name.html}
-                  {if $element.html_type eq 'Text'}
-                    {if $element.is_display_amounts}
-                    <span class="price-field-amount{if $form.$element_name.frozen EQ 1} sold-out-option{/if}">
-                    {foreach item=option from=$element.options}
-                      {if ($option.tax_amount || $option.tax_amount == "0") && $displayOpt && $invoicing}
-                        {assign var="amount" value=`$option.amount+$option.tax_amount`}
-                        {if $displayOpt == 'Do_not_show'}
-                          {$amount|crmMoney:$currency}
-                        {elseif $displayOpt == 'Inclusive'}
-                          {$amount|crmMoney:$currency}
-                          <span class='crm-price-amount-tax'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney:$currency}(includes %1 of %2){/ts}</span>
-                        {else}
-                          {$option.amount|crmMoney:$currency}
-                          <span class='crm-price-amount-tax'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
-                        {/if}
-                      {else}
-                        {$option.amount|crmMoney:$currency} {$fieldHandle} {$form.$fieldHandle.frozen}
-                      {/if}
-                      {if $form.$element_name.frozen EQ 1} ({ts}Sold out{/ts}){/if}
-                    {/foreach}
-                    </span>
-                    {else}
-                      {* Not showing amount, but still need to conditionally show Sold out marker *}
-                      {if $form.$element_name.frozen EQ 1}
-                        <span class="sold-out-option">({ts}Sold out{/ts})<span>
-                      {/if}
+                    {if $element.html_type eq 'Text'}
+                      {assign var="element_name_label_after" value="`$element_name`_label_after"}
+                      {$form.$element_name_label_after.label}
                     {/if}
-                  {/if}
-                  {if $element.help_post}<br /><span class="description">{$element.help_post}</span>{/if}
+                  {if $element.help_post}<div class="description">{$element.help_post}</div>{/if}
                 </div>
 
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Following up on #26375, this refactors the display of text fields in price sets.

Before
----------------------------------------
Text fields are partly put together in the BAO and partly in the tpl. As all the other kinds of price fields are put together exclusively in the BAO, this is confusing and hard to maintain. It also causes sold out options to be labelled (Sold Out) twice.

After
----------------------------------------
No change except sold out options are only labelled once.

Technical Details
----------------------------------------
Text price fields are kind of weird in that they are both fields and options at the same time, so there is a little bit of a work around in here for the labels. Not ideal, but I think it's a reasonable way around that weirdness.

Comments
----------------------------------------
Also makes the new `buildPriceOptionText()` from the previous PR protected.

After this one, the next step will actually improve functionality.