### PR TITLE
present friendlier error message if petition cannot be displayed.

### DIFF
--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -193,7 +193,10 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
       CRM_Core_Error::statusBounce(ts('Petition doesn\'t exist.'));
     }
     if ($this->petition['is_active'] == 0) {
-      CRM_Core_Error::statusBounce(ts('Petition is no longer active.'));
+      $this->assign('isActive', FALSE);
+    }
+    else {
+      $this->assign('isActive', TRUE);
     }
 
     //get userID from session

--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -21,34 +21,37 @@
   <div class='clear'></div>
 {/if}
 
-<div id="intro" class="crm-section">{$petition.instructions}</div>
-<div class="crm-block crm-petition-form-block">
-
-{if $duplicate == "confirmed"}
-  <p>
-  {ts}You have already signed this petition.{/ts}
-  </p>
-{/if}
-{if $duplicate == "unconfirmed"}
-  <p>{ts}You have already signed this petition but you still <b>need to verify your email address</b>.{/ts}<br/> {ts}Please check your email inbox for the confirmation email. If you don't find it, verify if it isn't in your spam folder.{/ts}</p>
-{/if}
-{if $duplicate}
-  <p>{ts}Thank you for your support.{/ts}</p>
-  {if $is_share}
-    {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" petition_id=$survey_id petitionTitle=$petitionTitle}
-  {/if}
+{if ! $isActive}
+  <p>{ts}This petition is no longer active.{/ts}</p>
 {else}
-  <div class="crm-section crm-petition-contact-profile">
-    {include file="CRM/UF/Form/Block.tpl" fields=$petitionContactProfile hideFieldset=true}
-  </div>
+  <div id="intro" class="crm-section">{$petition.instructions}</div>
+  <div class="crm-block crm-petition-form-block">
 
-  <div class="crm-section crm-petition-activity-profile">
-    {include file="CRM/UF/Form/Block.tpl" fields=$petitionActivityProfile hideFieldset=true}
-  </div>
+  {if $duplicate == "confirmed"}
+    <p>
+    {ts}You have already signed this petition.{/ts}
+    </p>
+  {/if}
+  {if $duplicate == "unconfirmed"}
+    <p>{ts}You have already signed this petition but you still <b>need to verify your email address</b>.{/ts}<br/> {ts}Please check your email inbox for the confirmation email. If you don't find it, verify if it isn't in your spam folder.{/ts}</p>
+  {/if}
+  {if $duplicate}
+    <p>{ts}Thank you for your support.{/ts}</p>
+    {if $is_share}
+      {include file="CRM/Campaign/Page/Petition/SocialNetwork.tpl" petition_id=$survey_id petitionTitle=$petitionTitle}
+    {/if}
+  {else}
+    <div class="crm-section crm-petition-contact-profile">
+      {include file="CRM/UF/Form/Block.tpl" fields=$petitionContactProfile hideFieldset=true}
+    </div>
 
-  <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl" location="bottom"}
-  </div>
+    <div class="crm-section crm-petition-activity-profile">
+      {include file="CRM/UF/Form/Block.tpl" fields=$petitionActivityProfile hideFieldset=true}
+    </div>
+
+    <div class="crm-submit-buttons">
+      {include file="CRM/common/formButtons.tpl" location="bottom"}
+    </div>
+  {/if}
 {/if}
-
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
This is a replacement PR for https://github.com/civicrm/civicrm-core/pull/25915

Provide a friendlier error message if a petition cannot be displayed for some reason.

Before
----------------------------------------

If a user clicks on a link to a petition that either doesn't exist, is disabled, or the link doesn't have a sid parameter - the user is redirected to the home page with an error message.

However, the home page may not be accessible to a non-logged in user, so instead of seeing the error, they simply get a forbidden message. Also, depending on how the theme is configured, they may get a page with a different theme than the petition page should display.

After
----------------------------------------

Instead of redirecting the user, display the petition page but without any of the petition elements. If the user has access to sign a petition, then they will stay on the page and get the friendly error message displayed.

Technical Details
----------------------------------------

The old code uses the `CRM_Core_Error::statusBounce()` call. That is replaced with a smarty assign to tell the template to display a message and not show the form fields.