### PR TITLE
[TEST] Use paid or unpaid event create functions

### DIFF
--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -760,7 +760,7 @@ WHERE eft.entity_id = %1 AND ft.to_financial_account_id <> %2";
     $allowUpdate = CRM_Contribute_BAO_Contribution::allowUpdateRevenueRecognitionDate($order['id']);
     $this->assertTrue($allowUpdate);
 
-    $event = $this->eventCreate();
+    $event = $this->eventCreatePaid();
     $params = [
       'contact_id' => $contactID,
       'receive_date' => '2010-01-20',

--- a/tests/phpunit/CRM/Core/CopyTest.php
+++ b/tests/phpunit/CRM/Core/CopyTest.php
@@ -73,7 +73,7 @@ class CRM_Core_CopyTest extends CiviUnitTestCase {
     $cleanup = $this->useMultilingual(['en_US' => ['fr_CA', 'nl_NL']]);
     CRM_Core_I18n::singleton()->setLocale('en_US');
 
-    $event = $this->eventCreate();
+    $event = $this->eventCreatePaid();
     $eventId = $event['id'];
     $eventData = civicrm_api3('Event', 'getsingle', ['id' => $eventId]);
 

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -370,7 +370,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
    *
    */
   public function _setUpParticipantObjects(string $participantStatus = 'Attended'): void {
-    $event = $this->eventCreate(['is_email_confirm' => 1, 'email_confirm_text' => '']);
+    $event = $this->eventCreatePaid(['is_email_confirm' => 1, 'email_confirm_text' => '']);
     $this->setupContribution();
 
     $this->_eventId = $event['id'];

--- a/tests/phpunit/CRM/Event/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Event/BAO/QueryTest.php
@@ -15,7 +15,7 @@ class CRM_Event_BAO_QueryTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testParticipantNote() {
-    $event = $this->eventCreate();
+    $event = $this->eventCreateUnpaid();
     $this->individualCreate([
       'api.participant.create' => [
         'event_id' => $event['id'],
@@ -50,7 +50,7 @@ class CRM_Event_BAO_QueryTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testEventType() {
-    $event = $this->eventCreate();
+    $event = $this->eventCreateUnpaid();
     $contactId = $this->individualCreate([
       'api.participant.create' => [
         'event_id' => $event['id'],

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3871,10 +3871,10 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Test sending a mail via the API.
    */
-  public function testSendMailEvent() {
+  public function testSendMailEvent(): void {
     $mut = new CiviMailUtils($this, TRUE);
     $contribution = $this->callAPISuccess('contribution', 'create', $this->_params);
-    $event = $this->eventCreate([
+    $event = $this->eventCreatePaid([
       'is_email_confirm' => 1,
       'confirm_from_email' => 'test@civicrm.org',
     ]);
@@ -3974,7 +3974,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function createPendingParticipantContribution() {
-    $this->_ids['event']['test'] = $this->eventCreate(['is_email_confirm' => 1, 'confirm_from_email' => 'test@civicrm.org', 'confirm_email_text' => ''])['id'];
+    $this->_ids['event']['test'] = $this->eventCreatePaid(['is_email_confirm' => 1, 'confirm_from_email' => 'test@civicrm.org', 'confirm_email_text' => ''])['id'];
     $participantID = $this->participantCreate(['event_id' => $this->_ids['event']['test'], 'status_id' => 6, 'contact_id' => $this->individualID]);
     $this->_ids['participant'] = $participantID;
     $params = array_merge($this->_params, ['contact_id' => $this->individualID, 'contribution_status_id' => 2, 'financial_type_id' => 'Event Fee']);
@@ -4284,7 +4284,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @return array|int
    * @throws \CRM_Core_Exception
    */
-  protected function setUpRecurringContribution($generalParams = [], $recurParams = []) {
+  protected function setUpRecurringContribution(array $generalParams = [], $recurParams = []) {
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'create', array_merge([
       'contact_id' => $this->individualID,
       'installments' => '12',
@@ -4303,8 +4303,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
         'contribution_status_id' => 'Pending',
       ], $generalParams);
     $contributionParams['api.Payment.create'] = ['total_amount' => $contributionParams['total_amount']];
-    $originalContribution = $this->callAPISuccess('Order', 'create', $contributionParams);
-    return $originalContribution;
+    return $this->callAPISuccess('Order', 'create', $contributionParams);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
[TEST] Use paid or unpaid event create functions

Before
----------------------------------------
Tests use `eventCreate` which is ambiguous / mixed on financial data

After
----------------------------------------
tests use `eventCreatePaid()` or `eventCreateUnpaid` appropriately

Technical Details
----------------------------------------

Comments
----------------------------------------
