### PR TITLE
Stop truncating UFGroup on tearDown

### DIFF
--- a/tests/phpunit/CRM/Profile/Form/EditTest.php
+++ b/tests/phpunit/CRM/Profile/Form/EditTest.php
@@ -17,11 +17,6 @@ use Civi\Api4\UFJoin;
  */
 class CRM_Profile_Form_EditTest extends CiviUnitTestCase {
 
-  public function tearDown(): void {
-    $this->quickCleanup(['civicrm_uf_field', 'civicrm_uf_group']);
-    parent::tearDown();
-  }
-
   /**
    * Test the url on the profile edit form renders tokens
    *


### PR DESCRIPTION
Overview
----------------------------------------
Stop truncating UFGroup on tearDown

Before
----------------------------------------
UFGroup is already cleaned up but by truncating the table we get rid of the reserved values too

After
----------------------------------------
cleanup removed - rely on cleanup in parent

Technical Details
----------------------------------------
Picked up in the PR to find which tests leave UFGroup in an incorrect state

Comments
----------------------------------------
