### PR TITLE
Use already translated string (followup to 26446)

### DIFF
--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -22,7 +22,7 @@
 {/if}
 
 {if ! $isActive}
-  <p>{ts}This petition is no longer active.{/ts}</p>
+  <p>{ts}Petition is no longer active.{/ts}</p>
 {else}
   <div id="intro" class="crm-section">{$petition.instructions}</div>
   <div class="crm-block crm-petition-form-block">


### PR DESCRIPTION
Overview
----------------------------------------
I just merged https://github.com/civicrm/civicrm-core/pull/26446 but just noticed the string is now different than before but doesn't really add anything, so better to use the previous string as-is which is already translated.