### PR TITLE
(dev/core#4340) Fix behavior of summary action hook

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3021,7 +3021,6 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
       ];
     }
 
-    CRM_Utils_Hook::summaryActions($menu, $contactId);
     //1. check for component is active.
     //2. check for user permissions.
     //3. check for acls.
@@ -3104,6 +3103,7 @@ LEFT JOIN civicrm_email    ON ( civicrm_contact.id = civicrm_email.contact_id )
     ksort($contextMenu['moreActions']);
     ksort($contextMenu['otherActions']);
 
+    CRM_Utils_Hook::summaryActions($contextMenu, $contactId);
     return $contextMenu;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix behavior of summary action hook to make it indeed useful. The hook needs to called for manipulation at the very last. The hook is being called early and then all the sorting etc takes place, rendering it useless.

Before
----------------------------------------
 Hook is called and then all the changes /sorting of the action items takes place.

After
----------------------------------------
Delay calling the hook after forming action items.