### PR TITLE
Fixes core#4343 - SK ACL bypass not always respected when using an Afform filter

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1217,7 +1217,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $labelField = CoreUtil::getInfoItem($field['fk_entity'], 'label_field');
       if ($labelField) {
         $records = civicrm_api4($field['fk_entity'], 'get', [
-          'checkPermissions' => $this->checkPermissions,
+          'checkPermissions' => $this->checkPermissions && empty($this->display['acl_bypass']),
           'where' => [[$idField, 'IN', (array) $value]],
           'select' => [$labelField],
         ]);


### PR DESCRIPTION
Overview
----------------------------------------
Replication steps available at https://lab.civicrm.org/dev/core/-/issues/4343.

Before
----------------------------------------
Some SK queries return no results (with an "Authorization failed" in logs) even when ACL is supposed to be bypassed.

After
----------------------------------------
ACL bypass works correctly, record is returned.

Comments
----------------------------------------
API calls that happen within SearchKit that consider whether to check permissions based on the user's permissions also need to check if the ACL bypass is in place.