### PR TITLE
Add deprecation warning and fix deprecated constructor call (followup to #26398)

### DIFF
--- a/Civi/Api4/Action/MailSettings/TestConnection.php
+++ b/Civi/Api4/Action/MailSettings/TestConnection.php
@@ -16,7 +16,7 @@ use Civi\Api4\Generic\BasicBatchAction;
 class TestConnection extends BasicBatchAction {
 
   public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName, ['id', 'name']);
+    parent::__construct($entityName, $actionName);
   }
 
   /**

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -54,6 +54,9 @@ class BasicBatchAction extends AbstractBatchAction {
       \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $doer as 4th param; it should be the 3rd as the $select param has been removed');
     }
     else {
+      if ($doer && !is_callable($doer)) {
+        \CRM_Core_Error::deprecatedWarning(__CLASS__ . ' constructor received $doer as a non-callable; the 3rd param as the $select param has been removed');
+      }
       $this->doer = $doer;
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/26398

Before
----------------------------------------
The added deprecation warning shows that a deprecated constructor is being used.

After
----------------------------------------
Core good (at least whatever's tested).
The added deprecation warning will also notify extension authors.

Technical Details
----------------------------------------
See other PR discussion.

Comments
----------------------------------------
Has test, sort of.
