### PR TITLE
Smarty - When temporarily setting variable, fix cleanup for previously-undefined values.

### DIFF
--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmScopeTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmScopeTest.php
@@ -13,6 +13,8 @@ class CRM_Core_Smarty_plugins_CrmScopeTest extends CiviUnitTestCase {
     // Templates should normally be file names, but for unit-testing it's handy to use "string:" notation
     require_once 'CRM/Core/Smarty/resources/String.php';
     civicrm_smarty_register_string_resource();
+
+    $this->useTransaction();
   }
 
   /**

--- a/tests/phpunit/CRM/Core/Smarty/plugins/CrmScopeTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/CrmScopeTest.php
@@ -24,9 +24,9 @@ class CRM_Core_Smarty_plugins_CrmScopeTest extends CiviUnitTestCase {
     $cases = [];
     $cases[] = ['', '{crmScope}{/crmScope}'];
     $cases[] = ['', '{crmScope x=1}{/crmScope}'];
-    $cases[] = ['x=', 'x={$x}'];
+    $cases[] = ['x=0', 'x={$x}'];
     $cases[] = ['x=1', '{crmScope x=1}x={$x}{/crmScope}'];
-    $cases[] = ['x=1', '{$x}{crmScope x=1}x={$x}{/crmScope}{$x}'];
+    $cases[] = ['x=0 x=1 x=0', 'x={$x} {crmScope x=1}x={$x}{/crmScope} x={$x}'];
     $cases[] = ['x=1 x=2 x=1', '{crmScope x=1}x={$x} {crmScope x=2}x={$x}{/crmScope} x={$x}{/crmScope}'];
     $cases[] = [
       'x=1 x=2 x=3 x=2 x=1',
@@ -37,7 +37,7 @@ class CRM_Core_Smarty_plugins_CrmScopeTest extends CiviUnitTestCase {
       'x=1,y=9 x=1,y=8 x=1,y=9',
       '{crmScope x=1 y=9}x={$x},y={$y} {crmScope y=8}x={$x},y={$y}{/crmScope} x={$x},y={$y}{/crmScope}',
     ];
-    $cases[] = ['x=', 'x={$x}'];
+    $cases[] = ['x=0', 'x={$x}'];
     return $cases;
   }
 
@@ -48,6 +48,7 @@ class CRM_Core_Smarty_plugins_CrmScopeTest extends CiviUnitTestCase {
    */
   public function testBlank($expected, $input) {
     $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('x', 0);
     $actual = $smarty->fetch('string:' . $input);
     $this->assertEquals($expected, $actual, "Process input=[$input]");
   }

--- a/tests/phpunit/CRM/Core/SmartyTest.php
+++ b/tests/phpunit/CRM/Core/SmartyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Class CRM_Core_SmartyTest
+ * @group headless
+ *
+ */
+class CRM_Core_SmartyTest extends CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+
+    require_once 'CRM/Core/Smarty/resources/String.php';
+    civicrm_smarty_register_string_resource();
+
+    $this->useTransaction();
+  }
+
+  /**
+   * Check that temporary Smarty variables work.
+   *
+   * This overlaps with CrmScopeTest (which actually tests more diverse scenarios). However, here we specifically check the PHP APIs
+   * (`fetchWith()`) and the correctness of different forms of emptiness.
+   *
+   * @see \CRM_Core_Smarty_plugins_CrmScopeTest
+   */
+  public function testFetchWith_CleanNonExistent() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $this->assertFalse(array_key_exists('my_variable', $smarty->get_template_vars()));
+
+    $rendered = $smarty->fetchWith('string:({$my_variable})', [
+      'my_variable' => 'temporary value',
+    ]);
+    $this->assertEquals('(temporary value)', $rendered);
+
+    $this->assertFalse(array_key_exists('my_variable', $smarty->get_template_vars()));
+  }
+
+  /**
+   * Check that temporary Smarty variables work.
+   *
+   * This overlaps with CrmScopeTest (which actually tests more diverse scenarios). However, here we specifically check the PHP APIs
+   * (`fetchWith()`) and the correctness of different forms of emptiness.
+   *
+   * @see \CRM_Core_Smarty_plugins_CrmScopeTest
+   */
+  public function testFetchWith_CleanNull() {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('my_variable', NULL);
+    $this->assertEquals(NULL, $smarty->get_template_vars()['my_variable']);
+
+    $tpl = 'string:({$my_variable})';
+    $this->assertEquals('()', $smarty->fetchWith($tpl, []));
+    $this->assertEquals('(temporary value)', $smarty->fetchWith($tpl, [
+      'my_variable' => 'temporary value',
+    ]));
+
+    // Assert global state
+    $this->assertEquals(NULL, $smarty->get_template_vars()['my_variable']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

You can temporarily assign Smarty values using various methods (`pushScope($vars)`/`popScope()` or `fetchWith(...$vars)` or `{crmScope ...}`). This expands the test-coverage for that mechanism.

Before
----------------------------------------

Fewer tests

After
----------------------------------------

Mo tests, mo problems.

Comments
----------------------------------------

Test expected to fail. Off-shoot from discussion with @demeritcowboy on #26432.

(Updated)
----------------------------------------

I've added a patch to fix the demonstrated failure.