### PR TITLE
Fix PHP warning on Export Contacts

### DIFF
--- a/templates/CRM/Export/Form/Select.tpl
+++ b/templates/CRM/Export/Form/Select.tpl
@@ -68,11 +68,6 @@
       </table>
       <div class="clear">&nbsp;</div>
     </div>
-
-    <div class="content crm-content-mergeSameHousehold">
-        &nbsp;{$form.merge_same_household.html}
-    </div>
-    <br/>
     <div class="label crm-label-postalMailingExport">{$form.postal_mailing_export.label}</div>
     <div class="content crm-content-postalMailingExport">
         &nbsp;{$form.postal_mailing_export.html}


### PR DESCRIPTION
Overview
----------------------------------------
merge_same_household is never set and it isn't clear what it might be for. Possibly it was copy-paste from Print Labels or possibly it was meant to be implemented in some way similar to the greetings merging options for Same Address here, but there's no sign of that having been done at all (the show-hide JS here only deals with Same Address). Either way, it does nothing and causes PHP warnings ([see SE here](https://civicrm.stackexchange.com/questions/45057/undefined-array-key-merge-same-household)), so it should go.

Before
----------------------------------------
PHP warnings

After
----------------------------------------
Gone