### PR TITLE
Simplify messaging for event confirm page

### DIFF
--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -14,26 +14,24 @@
 {include file="CRM/common/TrackingFields.tpl"}
 
 <div class="crm-event-id-{$event.id} crm-block crm-event-confirm-form-block">
+    <div class="messages status section continue_message-section"><p>
     {if $isOnWaitlist}
-        <div class="help">
-            {ts}Please verify the information below. <span class="bold">Then click 'Register' to be added to the WAIT LIST for this event</span>. If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
-        </div>
+        {ts}Please verify your information.{/ts} <strong>{ts}If space becomes available you will receive an email with a link to complete your registration.{/ts}</strong>
+        {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags}Click <strong>%1</strong> to be added to the WAIT LIST for this event.{/ts}
     {elseif $isRequireApproval}
-        <div class="help">
-            {ts}Please verify the information below. Then click 'Register' to submit your registration. <span class="bold">Once approved, you will receive an email with a link to a web page where you can complete the registration process.</span>{/ts}
-        </div>
+        {ts}Please verify your information.{/ts} <strong>{ts}Once approved, you will receive an email with a link to complete the registration process.{/ts}</strong>
+        {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags}Click <strong>%1</strong> to submit your registration for approval.{/ts}
     {else}
-        <div class="help">
-        {ts}Please verify the information below. Click the <strong>Go Back</strong> button below if you need to make changes.{/ts}
-        {if $contributeMode EQ 'notify' and !$is_pay_later and ! $isAmountzero }
-          {ts 1=$paymentProcessor.name}Click the <strong>Register</strong> button to checkout to %1, where you will select your payment method and complete the registration.{/ts}
+        {ts}Please verify your information.{/ts}
+        {if $contributeMode EQ 'notify' and !$is_pay_later and !$isAmountzero}
+            {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags 2=$paymentProcessor.frontend_title}Click <strong>%1</strong> to checkout with %2.{/ts}
         {else}
-            {ts}Otherwise, click the <strong>Register</strong> button below to complete your registration.{/ts}
+            {ts 1=$form.buttons._qf_Confirm_next.html|strip_tags}Click <strong>%1</strong> to complete your registration.{/ts}
         {/if}
-        </div>
-        {if $is_pay_later and !$isAmountzero}
-            <div class="bold">{$pay_later_receipt}</div>
-        {/if}
+    {/if}
+    </p></div>
+    {if $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+    <div class="bold pay-later-receipt-instructions">{$pay_later_receipt}</div>
     {/if}
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">
@@ -182,14 +180,6 @@
             {include file="CRM/Event/Form/Registration/EventInfoBlock.tpl"}
         </div>
     </div>
-
-    {if $contributeMode NEQ 'notify'} {* In 'notify mode, contributor is taken to processor payment forms next *}
-    <div class="messages status section continue_message-section">
-        <p>
-        {ts}Your registration will not be submitted until you click the <strong>Register</strong> button. Please click the button one time only. If you need to change any details, click the Go Back button below to return to the previous screen.{/ts}
-        </p>
-    </div>
-    {/if}
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
Overview
----------------------------------------
_Replaces #26182 which stopped pulling in rebased changes for some reason._

The text on the confirm page hasn't changed for at least 10 years and there is a lot of it! This PR removes some and simplifies the rest to make it quicker / easier to read and hopefully clearer.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/731bf46f-e6a2-4a0e-9eaf-737d40c1e860)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2052161/49b1a221-c227-4f63-af01-e2e165538ac0)

Removes bottom block of text explaining how to use buttons.
Text at the top is shortened and simplified.


Technical Details
----------------------------------------


Comments
----------------------------------------

