### PR TITLE
dev/core#4254 - Add autoOpen feature to SearchKit 'addNew' button

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
@@ -201,6 +201,7 @@ return [
             'path' => 'civicrm/admin/custom/group/field/add?reset=1&action=add&gid=[custom_group_id]',
             'text' => E::ts('Add Custom Field'),
             'icon' => 'fa-plus',
+            'autoOpen' => TRUE,
           ],
           'placeholder' => 5,
         ],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_ProfileFields.mgd.php
@@ -174,6 +174,7 @@ return [
             'path' => 'civicrm/admin/uf/group/field/add?reset=1&action=add&gid=[uf_group_id]',
             'text' => E::ts('Add Field'),
             'icon' => 'fa-plus',
+            'autoOpen' => TRUE,
           ],
           'cssRules' => [
             [

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -168,6 +168,14 @@
                 ctrl.rowCount = result.count;
               });
             }
+            // If there are no results on initial load, open the "addNew" link if configured as "autoOpen"
+            if (!ctrl.results.length && requestId === 1 && ctrl.settings.addButton && ctrl.settings.addButton.autoOpen) {
+              CRM.loadForm(ctrl.getButtonUrl())
+                .on('crmFormSuccess', function() {
+                  ctrl.rowCount = null;
+                  ctrl.getResultsPronto();
+                });
+            }
           }
           _.each(ctrl.onPostRun, function(callback) {
             callback.call(ctrl, ctrl.results, 'success', editedRow);


### PR DESCRIPTION
Overview
----------------------------------------
This partially solves [dev/core#4254](https://lab.civicrm.org/dev/core/-/issues/4254) by adding a feature to SearchKit that auto-clicks the "Add new" button if there are no results.

Before
----------------------------------------
No way to re-create the core behavior for custom fields and profile fields in the AdminUI extension.

After
----------------------------------------
This opens the way to re-create it, and we can do so as a follow-up.

Comments
----------------------------------------
To test this new feature:

1. Enable AdminUI extension with this patch (clear caches after applying if testing locally).
2. Create a group of custom fields but do not add any fields to it. Note the redirect after you save the custom group takes you to the old custom field list with the "Add new field" form already popped-up. That's the behavior we want to recreate.
3. If you navigate back to the AdminUI list of custom groups, you'll see your new group. Click on the button that says **Fields (0)**
4. It takes you to the new SK listing and pops up the "Add new field" form automatically!

To complete this feature for the AdminUI extension, we'll need to use a hook to change the redirect on that "Add custom group" form.

**Note:** I haven't exposed this "AutoOpen" option to the SearchKit UI - that whole "Configure Display" screen is getting terribly cluttered and needs some reorganization. For now I think this is obscure enough to stay hidden.