### PR TITLE
dev/core#4319 SearchKit - Fix in-place editable in list/grid displays

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3375,6 +3375,7 @@ span.crm-select-item-color {
 }
 
 /* in place edit  */
+.crm-container .crm-editable-disabled,
 .crm-container .crm-editable-enabled {
   padding-left: 2px;
   border: 2px dashed transparent;
@@ -3396,6 +3397,7 @@ span.crm-select-item-color {
 .crm-container span.crm-editable-textarea-enabled {
   width: 96%;
 }
+.crm-container span.crm-editable-disabled,
 .crm-container span.crm-editable-enabled {
   display: inline-block !important;
   padding-right: 2px;

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,5 +1,5 @@
 <crm-search-display-editable row="row" col="colData" do-save="$ctrl.runSearch([apiCall], {}, row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
-<span ng-if="::!colData.links" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
+<span ng-if="::!colData.links" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing, 'crm-editable-disabled': colData.edit && $ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
   <i ng-repeat="icon in colData.icons" ng-if="icon.side === 'left'" class="crm-i {{:: icon['class'] }}"></i>
   {{:: $ctrl.formatFieldValue(colData) }}
   <i ng-repeat="icon in colData.icons" ng-if="icon.side === 'right'" class="crm-i {{:: icon['class'] }}"></i>

--- a/ext/search_kit/ang/crmSearchDisplayGrid.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayGrid.ang.php
@@ -12,7 +12,7 @@ return [
     'css/crmSearchDisplayGrid.css',
   ],
   'basePages' => ['civicrm/search', 'civicrm/admin/search'],
-  'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap'],
+  'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap', 'crmSearchTasks'],
   'bundles' => ['bootstrap3'],
   'exports' => [
     'crm-search-display-grid' => 'E',

--- a/ext/search_kit/ang/crmSearchDisplayList.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayList.ang.php
@@ -9,7 +9,7 @@ return [
     'ang/crmSearchDisplayList',
   ],
   'basePages' => ['civicrm/search', 'civicrm/admin/search'],
-  'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap'],
+  'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap', 'crmSearchTasks'],
   'bundles' => ['bootstrap3'],
   'exports' => [
     'crm-search-display-list' => 'E',

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -5,6 +5,7 @@
 }
 
 .crm-search-display.crm-search-display-table td > crm-search-display-editable,
+.crm-search-display.crm-search-display-table td > .crm-editable-disabled,
 .crm-search-display.crm-search-display-table td > .crm-editable-enabled {
   display: block !important;
 }
@@ -13,12 +14,13 @@
   position: relative;
 }
 
-.crm-search-display crm-search-display-editable + span {
+.crm-search-display crm-search-display-editable + span.crm-editable-disabled {
   display: none !important;
 }
 
 .crm-search-display .crm-search-display-editable-buttons {
   position: absolute;
-  bottom: -22px;
+  bottom: -24px;
   left: 0;
+  min-width: 50px;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the bug described in [dev/core#4319](https://lab.civicrm.org/dev/core/-/issues/4319) where list and grid SearchKit displays had broken in-place edit functionality.

Technical Details
----------------------------------------
2 parts to this fix:
1. Include missing `crmSearchTasks` dependency to allow in-place edit.
2. Fix css to prevent the entire list from shifting around during editing. Added a `crm-editable-disabled` css class to mirror the `crm-editable-enabled` padding and border.