### PR TITLE
dev/core#4327 Possible fix for GroupTest occasional failures

### DIFF
--- a/tests/phpunit/api/v4/Entity/GroupTest.php
+++ b/tests/phpunit/api/v4/Entity/GroupTest.php
@@ -225,6 +225,7 @@ class GroupTest extends Api4TestBase {
       ->addSelect('id', 'child_group.id', 'child_group.title')
       ->addJoin('Group AS child_group', 'INNER', 'GroupNesting', ['id', '=', 'child_group.parent_group_id'])
       ->addOrderBy('id')
+      ->addOrderBy('child_group.id')
       ->execute();
 
     $this->assertCount(3, $joined);


### PR DESCRIPTION
Makes sure the order of api results is deterministic.

Looking at the API call for $joined, I think it could return two equally valid sets of results with orderby id, either [parent1 child1, parent2 child1, parent2 child2] or [parent1 child1, parent2 child2, parent2 child1], so this changes it to orderby child_group.id as well as the parent id.