### PR TITLE
dev/core#4348 - Fix leaky variable in SearchKit traits

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/crmSearchDisplayEntity.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/crmSearchDisplayEntity.component.js
@@ -13,8 +13,8 @@
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayTable.html',
     controller: function($scope, $element, searchDisplayBaseTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        // Mix in traits to this controller
-        ctrl = angular.extend(this, searchDisplayBaseTrait);
+        // Mix in a copy of searchDisplayBaseTrait
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait));
 
       this.$onInit = function() {
         // Adding this stuff for the sake of preview, but pollutes the display settings

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -12,8 +12,8 @@
     templateUrl: '~/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html',
     controller: function($scope, $element, searchMeta, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        // Mix in traits to this controller
-        ctrl = angular.extend(this, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait);
+        // Mix in copies of traits to this controller
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplaySortableTrait));
 
       function buildSettings() {
         ctrl.apiEntity = ctrl.search.api_entity;

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -11,7 +11,7 @@
     controller: function($scope, $element, $q, crmApi4, crmStatus, searchMeta, searchDisplayBaseTrait, searchDisplaySortableTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in traits to this controller
-        ctrl = angular.extend(this, searchDisplayBaseTrait, searchDisplaySortableTrait),
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplaySortableTrait)),
         afformLoad;
 
       this.searchDisplayPath = CRM.url('civicrm/search');

--- a/ext/search_kit/ang/crmSearchAdmin/searchSegmentListing/crmSearchAdminSegmentListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegmentListing/crmSearchAdminSegmentListing.component.js
@@ -11,7 +11,7 @@
     controller: function($scope, $element, crmApi4, searchMeta, searchDisplayBaseTrait, searchDisplaySortableTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in traits to this controller
-        ctrl = angular.extend(this, searchDisplayBaseTrait, searchDisplaySortableTrait);
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplaySortableTrait));
 
       this.apiEntity = 'SearchSegment';
       this.search = {

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.component.js
@@ -17,8 +17,8 @@
     templateUrl: '~/crmSearchDisplayGrid/crmSearchDisplayGrid.html',
     controller: function($scope, $element, searchDisplayBaseTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        // Mix in properties of searchDisplayBaseTrait
-        ctrl = angular.extend(this, searchDisplayBaseTrait);
+        // Mix in a copy of searchDisplayBaseTrait
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait));
 
       this.$onInit = function() {
         this.initializeDisplay($scope, $element);

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -17,8 +17,8 @@
     templateUrl: '~/crmSearchDisplayList/crmSearchDisplayList.html',
     controller: function($scope, $element, searchDisplayBaseTrait) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        // Mix in properties of searchDisplayBaseTrait
-        ctrl = angular.extend(this, searchDisplayBaseTrait);
+        // Mix in a copy of searchDisplayBaseTrait
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait));
 
       this.$onInit = function() {
         this.initializeDisplay($scope, $element);

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -16,8 +16,8 @@
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayTable.html',
     controller: function($scope, $element, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait, crmApi4) {
       var ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        // Mix in traits to this controller
-        ctrl = angular.extend(this, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait);
+        // Mix in copies of traits to this controller
+        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplaySortableTrait));
 
       this.$onInit = function() {
         var tallyParams;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes "Grand tally" rows at the bottom of searchKit displays to not interfere with each other when multiple displays are on a page.

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4348

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Variables were leaking into each other due to the reuse of traits. This fixes it by copying each trait before using it.