### PR TITLE
Remove redundant variable declared in the parent class

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -24,7 +24,6 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
   use CRM_Admin_Form_SettingTrait;
 
   protected $_settings = [];
-  public $_defaults = [];
 
   /**
    * @var bool


### PR DESCRIPTION
Overview
----------------------------------------
Removes a redundant variable because it's redundant.