### PR TITLE
SearchKit - Tidy up admin buttons and table header sort icons

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -1,12 +1,18 @@
-<div class="btn-group btn-group-xs">
-  <a class="btn btn-primary" ng-href="#/edit/{{:: row.data.id }}" ng-if=":: row.permissionToEdit">
-    <i class="crm-i fa-pencil"></i>
-    {{:: ts('Edit') }}
+<div class="btn-group btn-group-xs crm-search-admin-search-listing-buttons">
+  <a class="btn btn-primary" ng-href="#/edit/{{:: row.data.id }}" ng-if=":: row.permissionToEdit" title="{{:: ts('Edit search and displays') }}">
+    <i class="crm-i fa-pencil fa-fw"></i>
   </a>
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="row.menuOpen = true">
     <i class="crm-i fa-bars"></i>
+    <span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right" ng-if=":: row.menuOpen">
+    <li ng-if=":: row.permissionToEdit" title="{{:: ts('Edit search and displays') }}">
+      <a ng-href="#/edit/{{:: row.data.id }}">
+        <i class="crm-i fa-pencil fa-fw"></i>
+        {{:: ts('Edit') }}
+      </a>
+    </li>
     <li title="{{:: ts('View search results table') }}">
       <a ng-href="{{:: $ctrl.searchDisplayPath + '#/display/' + row.data.name }}" target="_blank">
         <i class="crm-i fa-table"></i>
@@ -28,13 +34,13 @@
     <li ng-if="!row.data['base_module:label']" title="{{:: ts('Delete search along with any displays and forms') }}">
       <a href ng-click="$ctrl.deleteOrRevert(row)">
         <i class="crm-i fa-trash"></i>
-        {{:: ts('Delete...') }}
+        {{:: ts('Delete') }}
       </a>
     </li>
     <li ng-if="row.data['base_module:label'] && row.data['local_modified_date']" title="{{:: ts('Revert search to its packaged state') }}">
       <a href ng-click="$ctrl.deleteOrRevert(row)">
         <i class="crm-i fa-undo"></i>
-        {{:: ts('Revert...') }}
+        {{:: ts('Revert') }}
       </a>
     </li>
   </ul>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -1,5 +1,5 @@
-<div class="btn-group">
-  <button type="button" class="dropdown-toggle {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: $ctrl.settings.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
+<div class="btn-group" role="group">
+  <button type="button" class="dropdown-toggle btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: $ctrl.settings.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
     <i ng-if=":: $ctrl.settings.columns[colIndex].icon" class="crm-i {{:: $ctrl.settings.columns[colIndex].icon }}"></i>
     {{:: colData.text }}
     <span class="caret"></span>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -12,8 +12,8 @@
         <th ng-class="{'crm-search-result-select': $ctrl.settings.actions}" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.hasExtraFirstColumn()">
         </th>
         <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" class="{{:: $ctrl.isSortable(col) ? 'crm-sortable-col' : ''}}" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
-          <i ng-if=":: $ctrl.isSortable(col)" class="crm-i {{ $ctrl.getSort(col) }}"></i>
-          <span>{{:: col.label }}</span>
+          <i ng-if=":: $ctrl.isSortable(col)" class="crm-i crm-search-table-column-sort-icon {{ $ctrl.getSort(col) }}"></i>
+          <span class="crm-search-display-table-column-label">{{:: col.label }}</span>
         </th>
       </tr>
     </thead>

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -11,6 +11,10 @@
   top: 0;
 }
 
+#bootstrap-theme .crm-search-admin-search-listing-buttons {
+  min-width: 65px;
+}
+
 #bootstrap-theme.crm-search .nav-stacked {
   margin-left: 0;
   margin-right: 20px;

--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -1,5 +1,20 @@
 /* SearchKit table display styling */
 
+#bootstrap-theme .crm-search-display-table > table.table > thead > tr > th {
+  position: relative;
+}
+
+#bootstrap-theme .crm-search-display-table > table.table > thead > tr > th i.crm-search-table-column-sort-icon {
+  position: absolute;
+  left: 2px;
+  bottom: 10px;
+}
+
+#bootstrap-theme .crm-search-display-table > table.table > thead > tr > th i.crm-search-table-column-sort-icon + .crm-search-display-table-column-label {
+  margin-left: 4px;
+  display: inline-block;
+}
+
 #bootstrap-theme .crm-search-display-table > table.table > thead > tr > th.crm-search-result-select {
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Gives SearchKit table headers and the buttons on the right side of the admin screen a bit of polish.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/18fbc8a1-f956-4bde-8867-45eb62889958)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/2874912/f8f19658-a4e6-454b-8190-ca0ca6c7f962)
