### PR TITLE
SearchKit - Fix saving created/modified fields

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -28,7 +28,7 @@
           savedSearch: function($route, crmApi4) {
             var params = $route.current.params;
             return crmApi4('SavedSearch', 'get', {
-              select: ['*', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
+              select: ['id', 'name', 'label', 'description', 'api_entity', 'api_params', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
               where: [['id', '=', params.id]],
               join: [
                 ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes saving created/modified info when updating a savedSearch in SearchKit.

Before
----------------------------------------
1. Edit a search
2. The name of the last-modified user ought to be set to *you*, but instead it is unchanged.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Don't select created/modified id or date fields when loading SavedSearch so they don't get sent back as values. The BAO will then be free to auto-fill them.

Comments
----------------------------------------
I think there are some larger issues here where we need to teach APIv4 not to mess with fields set to `<readonly>` in the schema. But this PR is the most minimal change and can be safely merged regardless of what other stuff we end up doing.