### PR TITLE
SearchKit - Expose expires_date field to UI

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -38,11 +38,13 @@
             'modified_id.display_name',
             'created_date',
             'modified_date',
+            'expires_date',
             'has_base',
             'base_module:label',
             'local_modified_date',
             'DATE(created_date) AS date_created',
             'DATE(modified_date) AS date_modified',
+            'DATE(expires_date) AS expires',
             'GROUP_CONCAT(display.name ORDER BY display.id) AS display_name',
             'GROUP_CONCAT(display.label ORDER BY display.id) AS display_label',
             'GROUP_CONCAT(display.type:icon ORDER BY display.id) AS display_icon',
@@ -271,6 +273,13 @@
             })
           );
         }
+        ctrl.display.settings.columns.push(
+          searchMeta.fieldToColumn('expires_date', {
+            label: ts('Expires'),
+            title: '[expires_date]',
+            rewrite: '[expires]'
+          })
+        );
         ctrl.display.settings.columns.push({
           type: 'include',
           alignment: 'text-right',

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -2,6 +2,17 @@
   <textarea class="form-control" placeholder="{{:: ts('Description (shown above default display)') }}" ng-model="$ctrl.savedSearch.description"></textarea>
 </li>
 <li>
+  <div class="form-inline" title="{{:: ts('Search Expiry Date') }}">
+    <div class="form-group">
+      <label class="sr-only" for="expires_date">{{:: ts('Search Expiry Date') }}</label>
+      <div class="input-group">
+        <div class="input-group-addon"><i class="crm-i fa-calendar-times-o"></i></div>
+        <input id="expires_date" class="form-control" crm-ui-datepicker="{time: true}" ng-model="$ctrl.savedSearch.expires_date" placeholder="Expires">
+      </div>
+    </div>
+  </div>
+</li>
+<li>
   <crm-search-admin-tags tag-ids="$ctrl.savedSearch.tag_id" class="btn-group btn-group-sm"></crm-search-admin-tags>
 </li>
 <li role="presentation" ng-class="{active: controls.tab === 'compose'}">

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -28,6 +28,16 @@
   width: 275px;
 }
 
+/* Style expires_date date/time width */
+#bootstrap-theme.crm-search #expires_date + input,
+#bootstrap-theme.crm-search #expires_date + input + input {
+  width: calc(100% - 30px);
+}
+/* Hide time field if date & time are both empty */
+#bootstrap-theme.crm-search #expires_date + input:placeholder-shown + input:placeholder-shown {
+  display: none;
+}
+
 #bootstrap-theme.crm-search div.form-control.disabled,
 #bootstrap-theme.crm-search div.form-control.disabled * {
   cursor: not-allowed;


### PR DESCRIPTION
Overview
----------------------------------------
Show the expiration date of saved searches, and allow it to be set in the UI.

### On the listing page

![image](https://github.com/civicrm/civicrm-core/assets/2874912/a710914b-0ee1-4139-b1b4-b1aa5c36b0fa)

### When editing a search

![image](https://github.com/civicrm/civicrm-core/assets/2874912/bd42e2ba-2c1a-4d72-8fb2-6905e50af26a)
