### PR TITLE
Fix e-notices on New Participant form, strict smarty

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -676,14 +676,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     CRM_Campaign_BAO_Campaign::addCampaign($this, $campaignId);
     $this->add('datepicker', 'register_date', ts('Registration Date'), [], TRUE, ['time' => TRUE]);
 
-    if ($this->_id) {
-      $this->assign('entityID', $this->_id);
-    }
+    $this->assign('entityID', $this->_id);
 
     $this->addSelect('role_id', ['multiple' => TRUE, 'class' => 'huge'], TRUE);
 
     // CRM-4395
-    $checkCancelledJs = ['onchange' => "return sendNotification( );"];
+    $checkCancelledJs = ['onchange' => 'return sendNotification( );'];
     $confirmJS = NULL;
     if ($this->_onlinePendingContributionId) {
       $cancelledparticipantStatusId = array_search('Cancelled', CRM_Event_PseudoConstant::participantStatus());

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -151,7 +151,7 @@
     {/if}
 
     {*include custom data js file*}
-    {include file="CRM/common/customData.tpl"}
+    {include file="CRM/common/customData.tpl" groupID=''}
 
     <script type="text/javascript">
       {literal}


### PR DESCRIPTION
Overview
----------------------------------------
Fix e-notices on New Participant form, strict smarty

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/2c04980d-37f1-40d5-8712-b3f0ded5f624)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/84318dc9-50b7-4048-8b84-f6d204903bd7)


Technical Details
----------------------------------------
The `entityID` is assigned fairly frequently when this template is used by `groupID` is rarely assigned - so this addresses when including the file - and could probably be done in other places that include it

![image](https://github.com/civicrm/civicrm-core/assets/336308/1f40619c-8187-4158-bb05-662d1cd06dcc)


Comments
----------------------------------------
