### PR TITLE
Remove obsolete comment

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -212,7 +212,7 @@
     </table>
   {/strip}
 {/if}
-{* Include JS for auto renew membership if priceset is Quick Config*}
+
 {if $membershipBlock}
 {literal}
   <script type="text/javascript">


### PR DESCRIPTION

Overview
----------------------------------------
Remove obsolete comment

Before
----------------------------------------
words

After
----------------------------------------
silence

Technical Details
----------------------------------------
This github tried to change the code to match the comment https://github.com/civicrm/civicrm-core/pull/25819

However, when we inadvertantly did that ... it messed with people's expected behaviour - so let's remove the comment instead


Comments
----------------------------------------
@agileware-fj @agileware-justin - you correctly identified a discrepancy that was going to hurt us - but I think now we have worked through it (although @composerjk says there might be a new regression on discount codes) we resolved that the comment was wrong...