### PR TITLE
dev/core#4336 Fix don't display payment fields on initial event registration form if payment on confirm is enabled

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -218,6 +218,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $this->_additionalParticipantIds = $this->get('additionalParticipantIds');
 
     $this->showPaymentOnConfirm = (in_array($this->_eventId, \Civi::settings()->get('event_show_payment_on_confirm')) || in_array('all', \Civi::settings()->get('event_show_payment_on_confirm')));
+    $this->assign('showPaymentOnConfirm', $this->showPaymentOnConfirm);
 
     if (!$this->_values) {
       // this is the first time we are hitting this, so check for permissions here

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -132,7 +132,7 @@
       </fieldset>
     {/if}
 
-    {if $priceSet}
+    {if $priceSet && !$showPaymentOnConfirm}
       {include file='CRM/Core/BillingBlockWrapper.tpl'}
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix for "On the first page, with pay later disabled, we get divs that shouldn't be there" with test processor (and maybe others)

Before
----------------------------------------
Fields showing when they shouldn't

After
----------------------------------------
Not showing.

Technical Details
----------------------------------------


Comments
----------------------------------------
@larssandergreen 
