### PR TITLE
Remove unreachable code in event registration templates for tax total

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -254,9 +254,6 @@
            {if $priceset || $priceset == 0}
             <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
             <td>&nbsp;{$value|crmMoney:$currency}</td>
-           {else}
-            <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
-            <td>&nbsp;{$value|crmMoney:$currency}</td>
            {/if}
           </tr>
         {/foreach}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -129,8 +129,6 @@
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}
 {$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
-{else}
-{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -277,9 +277,6 @@
           {if $priceset || $priceset == 0}
            <td>&nbsp;{$taxTerm} {$priceset|string_format:"%.2f"}%</td>
            <td>&nbsp;{$value|crmMoney:$currency}</td>
-          {else}
-           <td>&nbsp;{ts}No{/ts} {$taxTerm}</td>
-           <td>&nbsp;{$value|crmMoney:$currency}</td>
           {/if}
          </tr>
         {/foreach}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -148,8 +148,6 @@ You were registered by: {$payer.name}
 {foreach from=$dataArray item=value key=priceset}
 {if $priceset || $priceset == 0}
 {$taxTerm} {$priceset|string_format:"%.2f"}%: {$value|crmMoney:$currency}
-{else}
-{ts}No{/ts} {$taxTerm}: {$value|crmMoney:$currency}
 {/if}
 {/foreach}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
`{if $priceset || $priceset == 0}` is true if the array key is truthy or falsy except if it is an empty string in PHP 8, so we can't reach the else unless the array key is an empty string, which it is not (I really hope!). Bigger picture, adding `No Tax $0` to the template is not useful as we already cover the 0% tax rate case in the if.

Follow up on #26343
