### PR TITLE
Add select2s for Contribution, etc

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -706,7 +706,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
       ts('Payment Processor'),
       array_diff_key($this->_processors, [0 => 1]),
       $isRequired,
-      $js
+      $js + ['class' => 'crm-select2']
     );
     // The concept of _online is not really explained & the code is old
     // @todo figure out & document.

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -128,10 +128,9 @@ class CRM_Contribute_Form_AdditionalInfo {
 
     $form->add('select', 'contribution_page_id',
       ts('Contribution Page'),
-      [
-        '' => ts('- select -'),
-      ] +
-      CRM_Contribute_PseudoConstant::contributionPage()
+      ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::contributionPage(),
+      FALSE,
+      ['class' => 'crm-select2']
     );
 
     $form->add('textarea', 'note', ts('Notes'), ["rows" => 4, "cols" => 60]);

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -191,7 +191,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
 
     CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer'));
-    $this->add('select', 'payment_processor_id', ts('Payment Processor'), $this->_processors, NULL);
+    $this->add('select', 'payment_processor_id', ts('Payment Processor'), $this->_processors, NULL, ['class' => 'crm-select2']);
 
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialTrxn');
 
@@ -209,7 +209,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $eventID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'event_id', 'id');
     }
 
-    $this->add('select', 'from_email_address', ts('Receipt From'), CRM_Financial_BAO_Payment::getValidFromEmailsForPayment($eventID ?? NULL));
+    $this->add('select', 'from_email_address', ts('Receipt From'), CRM_Financial_BAO_Payment::getValidFromEmailsForPayment($eventID ?? NULL), FALSE, ['class' => 'crm-select2 huge']);
 
     $this->add('textarea', 'receipt_text', ts('Confirmation Message'));
 
@@ -236,7 +236,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
         ts('Payment Method'),
         ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::paymentInstrument(),
         TRUE,
-        ['onChange' => "return showHideByValue('payment_instrument_id','4','checkNumber','table-row','select',false);"]
+        ['onChange' => "return showHideByValue('payment_instrument_id','4','checkNumber','table-row','select',false);", 'class' => 'crm-select2']
       );
 
       $this->add('text', 'check_number', ts('Check Number'), $attributes['financial_trxn_check_number']);

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -651,7 +651,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       ts('Financial Type'),
       ['' => ts('- select -')] + $financialTypes,
       TRUE,
-      ['onChange' => "CRM.buildCustomData( 'Contribution', this.value );"]
+      ['onChange' => "CRM.buildCustomData( 'Contribution', this.value );", 'class' => 'crm-select2']
     );
 
     $paymentInstrument = FALSE;
@@ -662,7 +662,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $paymentInstrument = $this->add('select', 'payment_instrument_id',
         ts('Payment Method'),
         ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'create'),
-        $required, ['onChange' => "return showHideByValue('payment_instrument_id','{$checkPaymentID}','checkNumber','table-row','select',false);"]
+        $required,
+        ['onChange' => "return showHideByValue('payment_instrument_id','{$checkPaymentID}','checkNumber','table-row','select',false);", 'class' => 'crm-select2']
       );
     }
 
@@ -671,7 +672,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     //add receipt for offline contribution
     $this->addElement('checkbox', 'is_email_receipt', ts('Send Receipt?'));
 
-    $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails);
+    $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails, FALSE, ['class' => 'crm-select2 huge']);
 
     $componentDetails = [];
     if ($this->_id) {
@@ -691,7 +692,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $statusElement = $this->add('select', 'contribution_status_id',
       ts('Contribution Status'),
       $status,
-      FALSE
+      FALSE,
+      ['class' => 'crm-select2']
     );
 
     $currencyFreeze = FALSE;
@@ -756,10 +758,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         // instead of selecting manually
         $financialTypeIds = CRM_Price_BAO_PriceSet::getAssoc(FALSE, 'CiviContribute', 'financial_type_id');
         $element = $this->add('select', 'price_set_id', ts('Choose price set'),
-          [
-            '' => ts('Choose price set'),
-          ] + $priceSets,
-          NULL, ['onchange' => "buildAmount( this.value, " . json_encode($financialTypeIds) . ");"]
+          ['' => ts('Choose price set')] + $priceSets,
+          NULL,
+          ['onchange' => "buildAmount( this.value, " . json_encode($financialTypeIds) . ");", 'class' => 'crm-select2']
         );
         if ($this->_online && !($this->_action & CRM_Core_Action::UPDATE)) {
           $element->freeze();

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -681,7 +681,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     //}
 
     $form->add('text', 'installments', ts('installments'),
-      $attributes['installments']
+      $attributes['installments'] + ['class' => 'two']
     );
     $form->addRule('installments', ts('Number of installments must be a whole number.'), 'integer');
 
@@ -714,11 +714,11 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
         }
       }
-      $frequencyUnit = &$form->addElement('select', 'frequency_unit', NULL, $units, ['aria-label' => ts('Frequency Unit')]);
+      $frequencyUnit = &$form->add('select', 'frequency_unit', NULL, $units, FALSE, ['aria-label' => ts('Frequency Unit'), 'class' => 'crm-select2 eight']);
     }
 
     if (!empty($form->_values['is_recur_interval']) || $className == 'CRM_Contribute_Form_Contribution') {
-      $form->add('text', 'frequency_interval', $unit, $attributes['frequency_interval'] + ['aria-label' => ts('Every')]);
+      $form->add('text', 'frequency_interval', $unit, $attributes['frequency_interval'] + ['aria-label' => ts('Every'), 'class' => 'two']);
       $form->addRule('frequency_interval', ts('Frequency must be a whole number (EXAMPLE: Every 3 months).'), 'integer');
     }
     else {

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -175,7 +175,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         );
         $this->add('datepicker', 'pledge_calendar_date', ts('Specific Calendar Date'), [], FALSE, ['time' => FALSE]);
         $month = CRM_Utils_Date::getCalendarDayOfMonth();
-        $this->add('select', 'pledge_calendar_month', ts('Specific day of Month'), $month);
+        $this->add('select', 'pledge_calendar_month', ts('Specific day of Month'), $month, FALSE, ['class' => 'crm-select2 eight']);
         $pledgeDefaults = [
           'contribution_date' => ts('Day of Contribution'),
           'calendar_date' => ts('Specific Calendar Date'),

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -260,7 +260,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       '' => ts('- Unsupervised rule -'),
     ];
     $dedupeRules += CRM_Dedupe_BAO_DedupeRuleGroup::getByType('Individual');
-    $this->add('select', 'dedupe_rule_group_id', ts('Duplicate matching rule'), $dedupeRules);
+    $this->add('select', 'dedupe_rule_group_id', ts('Duplicate matching rule'), $dedupeRules, FALSE, ['class' => 'crm-select2 huge']);
 
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     if (in_array('Awaiting approval', $participantStatuses) and in_array('Pending from approval', $participantStatuses) and in_array('Rejected', $participantStatuses)) {

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -391,7 +391,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
       $form->assign('profile', $profile);
     }
 
-    $form->add('select', 'supporter_profile_id', ts('Supporter Profile'), ['' => ts('- select -')] + $profile, TRUE);
+    $form->add('select', 'supporter_profile_id', ts('Supporter Profile'), ['' => ts('- select -')] + $profile, TRUE, ['class' => 'crm-select2']);
 
     //CRM-15821 - To add new option for PCP "Owner" notification
     $ownerNotifications = CRM_Core_OptionGroup::values('pcp_owner_notify');

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -273,7 +273,8 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $frequencyUnit = $this->add('select', 'frequency_unit',
       ts('Frequency'),
       ['' => ts('- select -')] + $freqUnitsDisplay,
-      TRUE
+      TRUE,
+      ['class' => 'crm-select2 eight']
     );
 
     $frequencyDay = $this->add('number', 'frequency_day', ts('Payments are due on the'), $attributes['frequency_day'], TRUE);
@@ -317,7 +318,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
         ['onclick' => "showHideByValue( 'is_acknowledge', '', 'acknowledgeDate', 'table-row', 'radio', true); showHideByValue( 'is_acknowledge', '', 'fromEmail', 'table-row', 'radio', false );"]
       );
 
-      $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails);
+      $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails, FALSE, ['class' => 'crm-select2 huge']);
     }
 
     $this->add('datepicker', 'acknowledge_date', ts('Acknowledgment Date'), [], FALSE, ['time' => FALSE]);
@@ -325,7 +326,8 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $this->add('select', 'financial_type_id',
       ts('Financial Type'),
       ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::financialType(),
-      TRUE
+      TRUE,
+      ['class' => 'crm-select2']
     );
 
     // CRM-7362 --add campaigns.
@@ -341,7 +343,9 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $pledgePages[$value['entity_id']] = $pages[$value['entity_id']];
     }
     $this->add('select', 'contribution_page_id', ts('Self-service Payments Page'),
-      ['' => ts('- select -')] + $pledgePages
+      ['' => ts('- select -')] + $pledgePages,
+      FALSE,
+      ['class' => 'crm-select2']
     );
 
     $mailingInfo = Civi::settings()->get('mailing_backend');

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -103,13 +103,12 @@
             <tr id='recurringPaymentBlock'>
               <td></td>
               <td>
-                <strong>{$form.is_recur.html} {ts}every{/ts}
-                  &nbsp;{$form.frequency_interval.html}
-                  &nbsp;{$form.frequency_unit.html}&nbsp;
-                  {ts}for{/ts}
-                  &nbsp;{$form.installments.html}
-                  &nbsp;{$form.installments.label}
-                </strong>
+                {$form.is_recur.html} {ts}every{/ts}
+                &nbsp;{$form.frequency_interval.html}
+                &nbsp;{$form.frequency_unit.html}&nbsp;
+                {ts}for{/ts}
+                &nbsp;{$form.installments.html}
+                &nbsp;{$form.installments.label}
                 <br />
                 <span class="description">
             {ts}You can leave the number of installments blank if you want to make an open-ended commitment. In either case, you can choose to cancel at any time.{/ts}


### PR DESCRIPTION
Overview
----------------------------------------

Changed old-school selects to select2s on Contribution, Manage Contribution Page, one on Manage Event Registration, Payments, PCPs, Pledges.

Also made the recurring interval selection a little more reasonably sized and not bold on the backend.

Before
----------------------------------------
For example, this hodge-podge
<img width="619" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/ab5ff96c-e96d-445b-a191-44be28848861">

![image](https://github.com/civicrm/civicrm-core/assets/25517556/030cd154-18f5-48db-bfad-2df13f058319)

After
----------------------------------------
Consistent, more usable
<img width="631" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/6575ba58-4f1d-412a-93ca-dd7fd6c85b6b">

![image](https://github.com/civicrm/civicrm-core/assets/25517556/18741d63-bc85-432c-ae62-ed79b5e00c86)