### PR TITLE
[NFC] Change PHPDoc return type (findById)

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1303,7 +1303,7 @@ LIKE %1
    * @param int $id
    *   Id of the DAO object being searched for.
    *
-   * @return CRM_Core_DAO
+   * @return static
    *   Object of the type of the class that called this function.
    *
    * @throws Exception


### PR DESCRIPTION
Overview
----------------------------------------
Very minor refactoring in `CRM/Core/DAO.php`. By typing the return type as `static`, developer tools can better understand what methods and properties exist on the returned class.

This matches what we already do for other methods, e.g. `writeRecord`