### PR TITLE
Reduce PHP warnings with paymentBlock

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -9,6 +9,7 @@
 *}
 {literal}
 <script type="text/javascript">
+{/literal}{if !$isBackOffice}{literal}
   /**
    * Show or hide payment options.
    *
@@ -68,17 +69,18 @@
     showHidePayment(isHide);
   }
   skipPaymentMethod();
+{/literal}{/if}{literal}
 
   CRM.$(function($) {
     function buildPaymentBlock(type) {
       var $form = $('#billing-payment-block').closest('form');
       {/literal}
-      {if $contributionPageID}
+      {if !$isBackOffice && $contributionPageID}
         {capture assign='contributionPageID'}id={$contributionPageID}&{/capture}
       {else}
-        {capture assign='pageID'}{/capture}
+        {capture assign='contributionPageID'}{/capture}
       {/if}
-      {if $custom_pre_id}
+      {if !$isBackOffice && $custom_pre_id}
         {capture assign='preProfileID'}pre_profile_id={$custom_pre_id}&{/capture}
       {else}
         {capture assign='preProfileID'}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
This reduces the PHP warnings on the backend when using paymentBlock.tpl.
First, by not adding any of the unnecessary JS to show/hide the payment block when on the backend.
Second, by not checking $contributionPageID and $custom_pre_id when on the backend.

Still more to do here in the future, but this is a step forwards.