### PR TITLE
Reduce PHP warnings on Contribution

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -850,9 +850,11 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
           $trxnId->freeze();
         }
         $financialType->freeze();
-        $this->assign('freezeFinancialType', TRUE);
+        $freezeFinancialType = TRUE;
+
       }
     }
+    $this->assign('freezeFinancialType', $freezeFinancialType ?? FALSE);
 
     if ($this->_action & CRM_Core_Action::VIEW) {
       $this->freeze();

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -22,7 +22,7 @@
       {elseif $contactId}
         {ts 1=$displayName}Use this form to submit a new contribution on behalf of %1.{/ts}
       {else}
-        {ts 1=$displayName}Use this form to submit a new contribution.{/ts}
+        {ts}Use this form to submit a new contribution.{/ts}
       {/if}
       {if $contributionMode == 'live'}
         {ts}<strong>A LIVE transaction will be submitted</strong> using the selected payment processor.{/ts}

--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -39,7 +39,7 @@
         {/foreach}
       </div>
     </fieldset>
-    {if $paymentAgreementTitle}
+    {if !$isBackOffice && $paymentAgreementTitle}
       <div id="payment_notice">
         <fieldset class="crm-public-form-item crm-group payment_notice-group">
           <legend>{$paymentAgreementTitle}</legend>


### PR DESCRIPTION
Overview
----------------------------------------
Small changes to reduce PHP errors on Contribution.

Can't see any reason we would ever show a payment agreement on the backend.