### PR TITLE
APIv4 - Enable UNION and UNION ALL in API queries

### DIFF
--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -24,6 +24,8 @@ use Civi\Api4\Utils\CoreUtil;
  *
  * @method $this setHaving(array $clauses)
  * @method array getHaving()
+ * @method $this setUnion(array $unions)
+ * @method array getUnion()
  * @method $this setTranslationMode(string|null $mode)
  * @method string|null getTranslationMode()
  */
@@ -81,6 +83,17 @@ class DAOGetAction extends AbstractGetAction {
    * @var array
    */
   protected $having = [];
+
+  /**
+   * Additional api queries to combine using UNION or UNION ALL
+   *
+   * The SQL rules of unions apply: each query must SELECT the same number of fields
+   * with matching types (in order). Field names do not have to match; (returned fields
+   * will use the name from the original query).
+   *
+   * @var array
+   */
+  protected $union = [];
 
   /**
    * Should we automatically overload the result with translated data?
@@ -230,6 +243,17 @@ class DAOGetAction extends AbstractGetAction {
    */
   public function getJoin(): array {
     return $this->join;
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\DAOGetAction $apiRequest
+   * @param string $type
+   *   DISTINCT or ALL (default)
+   * @return $this
+   */
+  public function addUnion(DAOGetAction $apiRequest, string $type = 'ALL') {
+    $this->union[] = [$apiRequest->getEntityName(), $apiRequest->getActionName(), $apiRequest->getParams(), $type];
+    return $this;
   }
 
 }

--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -161,6 +161,14 @@
             <a href class="crm-hover-button" title="Clear" ng-click="clearParam('limit');clearParam('offset');" ng-show="!!params.limit || !!params.offset"><i class="crm-i fa-times" aria-hidden="true"></i></a>
           </div>
         </fieldset>
+        <fieldset ng-if="::availableParams.union" ng-mouseenter="help('union', availableParams.union)" ng-mouseleave="help()">
+          <legend>union</legend>
+          <api4-exp-union class="api4-input form-inline" ng-repeat="clause in params.union" union="clause" entities="entities" delete-row="clearParam('union', $index)" >
+          </api4-exp-union>
+          <div class="api4-input form-inline">
+            <input class="form-control" ng-model="controls.union" crm-ui-select="::{data: entities}" placeholder="Add union" />
+          </div>
+        </fieldset>
         <fieldset ng-if="::availableParams.chain" ng-mouseenter="help('chain', availableParams.chain)" ng-mouseleave="help()">
           <legend>chain</legend>
           <div class="api4-input form-inline" ng-repeat="clause in params.chain" api4-exp-chain="clause" entities="::entities" main-entity="::entity" >

--- a/ang/api4Explorer/Union.html
+++ b/ang/api4Explorer/Union.html
@@ -1,0 +1,7 @@
+<input class="form-control" ng-model="$ctrl.union[0]" crm-ui-select="{data: $ctrl.entities, allowClear: true, placeholder: 'None'}" />
+<input class="form-control api4-union-action" readonly value="get" >
+<input class="form-control api4-union-params" ng-model="$ctrl.union[2]" placeholder="{{:: ts('Params') }}" >
+<select class="form-control api4-union-type" ng-model="$ctrl.union[3]" placeholder="{{:: ts('Type') }}" >
+  <option value="DISTINCT">DISTINCT</option>
+  <option value="ALL">ALL</option>
+</select>

--- a/css/api4-explorer.css
+++ b/css/api4-explorer.css
@@ -133,10 +133,13 @@
 }
 
 #bootstrap-theme.api4-explorer-page .api4-operator,
+#bootstrap-theme.api4-explorer-page .api4-union-action,
+#bootstrap-theme.api4-explorer-page .api4-union-type,
 #bootstrap-theme.api4-explorer-page .api4-chain-index,
 #bootstrap-theme.api4-explorer-page .api4-chain-action {
   width: 90px;
 }
+#bootstrap-theme.api4-explorer-page .api4-union-params,
 #bootstrap-theme.api4-explorer-page .api4-chain-params {
   width: calc(100% - 390px);
 }

--- a/tests/phpunit/api/v4/Action/GetWithUnionTest.php
+++ b/tests/phpunit/api/v4/Action/GetWithUnionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Group;
+use Civi\Api4\Tag;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class GetWithUnionTest extends Api4TestBase implements TransactionalInterface {
+
+  public function testUnionGroupsWithTags() {
+    $this->saveTestRecords('Group', [
+      'records' => [
+        ['title' => '1G', 'description' => 'Group 1'],
+        ['title' => '2G', 'description' => 'Group 2'],
+        ['title' => '3G'],
+      ],
+    ]);
+    $this->saveTestRecords('Tag', [
+      'records' => [
+        ['name' => '3T', 'description' => 'Tag 3'],
+        ['name' => '2T', 'description' => 'Tag 2'],
+        ['name' => '1T', 'description' => 'Tag 1'],
+      ],
+    ]);
+    $result = Group::get(FALSE)
+      ->addSelect('title', 'description', '"group" AS thing')
+      ->addWhere('title', 'IN', ['1G', '2G', '3G'])
+      ->addUnion(Tag::get()
+        // The UNION will automatically alias Tag."name" to "title" because that's the column name in the 1st query
+        ->addSelect('name', 'description', '"tag" AS thing')
+        ->addWhere('name', 'IN', ['1T', '2T', '3T'])
+      )
+      ->addOrderBy('title')
+      ->setLimit(5)
+      ->execute();
+
+    $this->assertCount(5, $result);
+    $this->assertEquals(['title' => '1G', 'description' => 'Group 1', 'thing' => 'group'], $result[0]);
+    $this->assertEquals(['title' => '1T', 'description' => 'Tag 1', 'thing' => 'tag'], $result[1]);
+    $this->assertEquals(['title' => '2G', 'description' => 'Group 2', 'thing' => 'group'], $result[2]);
+    $this->assertEquals(['title' => '2T', 'description' => 'Tag 2', 'thing' => 'tag'], $result[3]);
+    $this->assertEquals(['title' => '3G', 'description' => NULL, 'thing' => 'group'], $result[4]);
+
+    // Try with a "HAVING" clause
+    $result = Group::get(FALSE)
+      ->addSelect('title', 'description', '"group" AS thing')
+      ->addWhere('title', 'IN', ['1G', '2G', '3G'])
+      ->addUnion(Tag::get()
+        ->addSelect('name', 'description', '"tag" AS thing')
+        ->addWhere('name', 'IN', ['1T', '2T', '3T'])
+      )
+      ->addOrderBy('title')
+      ->addHaving('title', 'LIKE', '1%')
+      ->execute();
+    $this->assertCount(2, $result);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
**NOTE:** This draft PR has been replaced by #26536 

![image](https://github.com/civicrm/civicrm-core/assets/2874912/77c42a50-1457-47ad-ac9f-03ae43192ab0)

Technical Details
-------
Supports UNION and UNION ALL with global limiting/sorting/having of the combined results. API syntax is similar to `chain`. Per SQL UNION rules, names do not need to match (columns in the UNIONed tables will be aliased to match the column names of the first table) but the number of columns and the data types do need to match.

Comments
--------
Added to the APIv4 explorer, but not the SearchKit UI (that might be difficult).