### PR TITLE
[REF][PHP8.1] Don't pass null to strtoupper in getDynamicCharacters

### DIFF
--- a/CRM/Utils/PagerAToZ.php
+++ b/CRM/Utils/PagerAToZ.php
@@ -97,7 +97,7 @@ class CRM_Utils_PagerAToZ {
 
     $dynamicAlphabets = [];
     while ($result->fetch()) {
-      $dynamicAlphabets[] = strtoupper($result->sort_name);
+      $dynamicAlphabets[] = strtoupper($result->sort_name ?? '');
     }
     return $dynamicAlphabets;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Don't pass null to `strtoupper` in `CRM_Utils_PagerAToZ::getDynamicCharacters`

Before
----------------------------------------
Mailings (and possibly other sortable entities) are allowed to be saved without a name. When visiting the "Find mailings" page, this error was triggered for each row without a name:

```
Deprecated function: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in CRM_Utils_PagerAToZ::getDynamicCharacters() (line 100 of [...]/web/sites/all/modules/civicrm/CRM/Utils/PagerAToZ.php).
```

After
----------------------------------------
We pass an empty string instead of `null` to keep PHP happy.