### PR TITLE
Don't show pay_later processor on additional live Payment

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -191,7 +191,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
 
     CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer'));
-    $this->add('select', 'payment_processor_id', ts('Payment Processor'), $this->_processors, NULL);
+    $this->addPaymentProcessorSelect(FALSE);
 
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialTrxn');
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow up on #11141, just applying the same fix to AdditionalPayment.

Before
----------------------------------------
pay_later shown on Additional Payment live mode.

After
----------------------------------------
Not shown.