### PR TITLE
CiviGrant - Fix error when creating grant without permissions

### DIFF
--- a/ext/civigrant/CRM/Grant/BAO/Grant.php
+++ b/ext/civigrant/CRM/Grant/BAO/Grant.php
@@ -110,6 +110,7 @@ class CRM_Grant_BAO_Grant extends CRM_Grant_DAO_Grant {
       $title = CRM_Contact_BAO_Contact::displayName($grant->contact_id) . ' - ' . ts('Grant') . ': ' . $grantTypes[$grant->grant_type_id];
 
       civicrm_api4('RecentItem', 'create', [
+        'checkPermissions' => FALSE,
         'values' => [
           'entity_type' => 'Grant',
           'entity_id' => $grant->id,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression in CiviGrant

Before
----------------------------------------
When creating a grant with checkPermissions disabled (e.g. via API) the permissions were getting tripped by the RecentItem create action.

After
----------------------------------------
Works correctly with and without permissions.

Technical Details
----------------------------------------
Regressed due to switch from direct call to API call in https://github.com/civicrm/civicrm-core/commit/18cbf9fd74447caf0816f8f30107ad49ef99bd8f
