### PR TITLE
Make implicit TRUE permissions check explicit in API 4 Explorer for PHP

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -734,6 +734,8 @@
             break;
 
           case 'php':
+            // Always shows implicit true permissions check for PHP
+            params.checkPermissions = (params.checkPermissions === false) ? false : true;
             // Write php code
             code.php = '$' + results + " = civicrm_api4('" + entity + "', '" + action + "', [";
             _.each(params, function(param, key) {
@@ -876,9 +878,8 @@
         newLine = "\n" + _.repeat(' ', indent),
         code = '\\' + info.class + '::' + action + '(',
         args = _.cloneDeep(info.class_args || []);
-      if (params.checkPermissions === false) {
-        args.push(false);
-      }
+      // Always shows implicit true permissions check for PHP
+      args.push((params.checkPermissions === false) ? false : true);
       code += _.map(args, phpFormat).join(', ') + ')';
       _.each(params, function(param, key) {
         var val = '';


### PR DESCRIPTION
Overview
----------------------------------------
It feels like we end up with quite a few bugs because of the implicit TRUE permissions checks in API 4. I think it might make life a little easier if we make the implicit TRUE explicit in the API 4 Explorer, so if we're copying and pasting we're more likely to stop and think if we should be checking permissions or not.

This only changes the PHP.

The downside is possibly a few more lines of code in core when using traditional style PHP, but that seems well worth it if we avoid a few bugs.