### PR TITLE
dev/core#4355 - Fix crash for radio custom fields

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -19,19 +19,17 @@
     <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
       {assign var="count" value="1"}
-      {* sort by fails for option per line. Added a variable to iterate through the element array*}
-      {assign var="index" value="1"}
       {foreach name=outer key=key item=item from=$formElement}
-        {if $index < 10}
-          {assign var="index" value=`$index+1`}
-        {else}
-          {$formElement.$key.html}
+        {if is_array($item) && array_key_exists('html', $item)}
+          {$item.html}
           {if $count == $element.options_per_line}
             <br />
             {assign var="count" value="1"}
           {else}
             {assign var="count" value=`$count+1`}
           {/if}
+        {else}
+          {* Skip because this isn't one of the numeric keyed elements that are the options to display, it's non-numeric keys like the field label and metadata. *}
         {/if}
       {/foreach}
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4355

Before
----------------------------------------
1. Create a radio field for activities.
2. Go to Contacts - New Activity.
3. Red alert box "network error" and the custom fields don't display. TypeError: Cannot access offset of type string on string in include() (line 31 of .../templates_c/en_US/%%1D/1DB/1DB03A28%%CustomField.tpl.php).

Using php 8. Doesn't happen in php 7.

After
----------------------------------------
* No crash.
* Reason for the mystery index looping solved.

Technical Details
----------------------------------------
Sooo, the $formElement variable it loops over contains both non-numeric keys, for things like the label and metadata, and numeric keys, for the option choices. The way the loop dealt with that, since it was first introduced in the 2000's, was to note that the array starts with 9 non-numeric keys, so let's skip them by counting to 9.

In https://github.com/civicrm/civicrm-core/pull/26265 it added a 10th (the change in CRM/Core/Form/Renderer).

It looks something like:

```
Array (12)
name => "custom_23_-1"
value => null
type => "group"
frozen => false
required => false
error => null
label => "<label>rad</label>"
separator => null
html => "<input data-crm-custom="Activity_file..."
textLabel => "rad"
1 => Array (10)
  name => "custom_23_-1"
  value => 1
  type => "radio"
  frozen => false
  required => false
  error => null
  id => "CIVICRM_QFID_1_custom_23_1"
  label => ""
  html => "<input data-crm-custom="Activity_file..."
  textLabel => ""
2 => Array (10)
  name => "custom_23_-1"
  value => 2
  type => "radio"
  frozen => false
  required => false
  error => null
  id => "CIVICRM_QFID_2_custom_23_1"
  label => ""
  html => "<input data-crm-custom="Activity_file..."
  textLabel => ""
```

Comments
----------------------------------------
Master-only regression.
FYI @larssandergreen 
