### PR TITLE
dev/core#4338 - Prevent people from sneakily adding fields to your extension's reserved custom groups by using the Move action

### DIFF
--- a/CRM/Custom/Form/MoveField.php
+++ b/CRM/Custom/Form/MoveField.php
@@ -91,7 +91,15 @@ class CRM_Custom_Form_MoveField extends CRM_Core_Form {
    */
   public function buildQuickForm() {
 
-    $customGroup = CRM_Core_PseudoConstant::get('CRM_Core_DAO_CustomField', 'custom_group_id');
+    $customGroup = [];
+    $groups = \Civi\Api4\CustomGroup::get()
+      ->addWhere('is_reserved', '=', FALSE)
+      ->addWhere('is_active', '=', TRUE)
+      ->addSelect('id', 'title')
+      ->execute();
+    foreach ($groups as $group) {
+      $customGroup[$group['id']] = $group['title'];
+    }
     unset($customGroup[$this->_srcGID]);
     if (empty($customGroup)) {
       CRM_Core_Error::statusBounce(ts('You need more than one custom group to move fields'));


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4338

Before
----------------------------------------
1. Make an extension that makes a reserved custom field group.
2. Someone adds a field to some other non-reserved custom field group.
3. Then they sneakily use the Move link from the links on the right to move it into your reserved group.
4. You make some code update that then crashes or mangles the data in that field because it's not expecting it to be there.

After
----------------------------------------
Reserved groups not listed as an option in the dropdown.

Technical Details
----------------------------------------
The UI currently goes out of its way to prevent you even seeing that reserved groups exist on the custom group admin screen, and bouncing if you try to hack an edit link to a field. It should also prevent moving a field into the group.

The call to Pseudoconstant::get is discouraged in its docblock so since I was changing it anyway I replaced with api.

Comments
----------------------------------------

