### PR TITLE
[REF] Don't add Contacts to Groups they are already Added to on Edit

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -962,6 +962,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           if ((!array_key_exists($key['group_id'], $params['group']) || $params['group'][$key['group_id']] != 1) && empty($key['is_hidden'])) {
             $params['group'][$key['group_id']] = -1;
           }
+          // don't try to add to groups that the contact is already Added to
+          elseif (array_key_exists($key['group_id'], $params['group']) && $params['group'][$key['group_id']] == 1) {
+            unset($params['group'][$key['group_id']]);
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
If you edit a Contact (`contact/add?action=update`), on saving, the form calls `CRM_Contact_BAO_Contact::create` with `params['groups']` including all the groups the contact was in before editing and wasn't removed from, which calls `CRM_Contact_BAO_GroupContact::addContactsToGroup` _for each group_, which provides the pre and post hooks and calls `CRM_Contact_BAO_GroupContact::bulkAddContactsToGroup` which finally checks the table and says, oh wait, that Contact is already in that Group, there's nothing to do here. Rinse and repeat for each Group.

Before
----------------------------------------
Attempt to add Contact to all Groups submitted in the edit form.

After
----------------------------------------
Only attempt to add Contact to Groups that it was not already added to. On my local, this saves a few tenths of a second with a handful of groups.

This will also stop erroneous GroupContact hook triggers, but that's a more general problem that also needs to be solved  in GroupContact.

Technical Details
----------------------------------------
We don't technically need to check `$params['group'][$key['group_id']] == 1` here, but it seems safer and more readable to do so.
