### PR TITLE
Don't add Contact to Domain Group on edit

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -298,7 +298,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
 
     $params['contact_id'] = $contact->id;
 
-    if (Civi::settings()->get('is_enabled')) {
+    if (!$isEdit && Civi::settings()->get('is_enabled')) {
       // Enabling multisite causes the contact to be added to the domain group.
       $domainGroupID = CRM_Core_BAO_Domain::getGroupId();
       if (!empty($domainGroupID)) {


### PR DESCRIPTION
Overview
----------------------------------------
I'm not really familiar with multisite, so would appreciate someone who is taking a look at this. It seems logical to me that we would only add the Contact to the Domain Group when we are creating, not editing, otherwise we get what seems like unintended behaviour.

Before
----------------------------------------
Contact added to Domain Group when editing or when using API Contact create with a contact id.

After
----------------------------------------
Contact only added to Domain Group on create.
