### PR TITLE
Show manually added Smart Groups on Contact edit

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -956,7 +956,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     }
     elseif (!empty($params['contact_id']) && ($this->_action & CRM_Core_Action::UPDATE)) {
       // figure out which all groups are intended to be removed
-      $contactGroupList = CRM_Contact_BAO_GroupContact::getContactGroup($params['contact_id'], 'Added');
+      $contactGroupList = CRM_Contact_BAO_GroupContact::getContactGroup($params['contact_id'], 'Added', NULL, FALSE, TRUE, FALSE, TRUE, NULL, TRUE);
       if (is_array($contactGroupList)) {
         foreach ($contactGroupList as $key) {
           if ((!array_key_exists($key['group_id'], $params['group']) || $params['group'][$key['group_id']] != 1) && empty($key['is_hidden'])) {

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -168,7 +168,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
         $fName = $fieldName;
       }
 
-      $contactGroup = CRM_Contact_BAO_GroupContact::getContactGroup($id, 'Added', NULL, FALSE, TRUE);
+      $contactGroup = CRM_Contact_BAO_GroupContact::getContactGroup($id, 'Added', NULL, FALSE, TRUE, FALSE, TRUE, NULL, TRUE);
       if ($contactGroup) {
         if ($groupElementType == 'select') {
           $defaults[$fName] = implode(',', CRM_Utils_Array::collect('group_id', $contactGroup));


### PR DESCRIPTION
Before
----------------------------------------
Smart Groups to which a Contact has been manually added are not shown on Contact edit (the edit form, not the Contact Groups tab).

After
----------------------------------------
Manually added Smart Groups are shown - and Contacts can be removed from them.