### PR TITLE
CRM_Utils_SQL_Select - Allow construction of UNION/INTERSECT with subqueries

### DIFF
--- a/tests/phpunit/CRM/Utils/SQL/SelectTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/SelectTest.php
@@ -308,6 +308,32 @@ class CRM_Utils_SQL_SelectTest extends CiviUnitTestCase {
     $this->assertLike('SELECT c, d, a, b, e FROM foo WHERE (c = "4") AND (a = 2) AND (whipit())', $query->toSQL());
   }
 
+  public function testUnion() {
+    $a = CRM_Utils_SQL_Select::from('a')->select('a_name')->where('a1 = !num')->param('num', 100);
+    $b = CRM_Utils_SQL_Select::from('b')->select('b_name')->where('b2 = @val')->param('val', "ab cd");
+    $u = CRM_Utils_SQL_Select::fromSet()->union([$a, $b])->limit(100)->orderBy('a_name');
+    $expectA = 'SELECT a_name FROM a WHERE (a1 = 100) ';
+    $expectB = 'SELECT b_name FROM b WHERE (b2 = "ab cd") ';
+    $expectUnion = "SELECT * FROM (($expectA) UNION ($expectB)) ORDER BY a_name LIMIT 100 OFFSET 0";
+    $this->assertLike($expectUnion, $u->toSQL());
+  }
+
+  public function testUnionIntersect() {
+    $a = CRM_Utils_SQL_Select::from('a')->select('a_name')->where('a1 = !num')->param('num', 100);
+    $b = CRM_Utils_SQL_Select::from('b')->select('b_name')->where('b2 = @val')->param('val', "bb bb");
+    $c = CRM_Utils_SQL_Select::from('c')->select('c_name')->where('c3 = @val')->param('val', "cc cc");
+    $u = CRM_Utils_SQL_Select::fromSet()
+      ->union([$a, $b])
+      ->setOp('INTERSECT', $c)
+      ->limit(100)
+      ->orderBy('a_name');
+    $expectA = 'SELECT a_name FROM a WHERE (a1 = 100) ';
+    $expectB = 'SELECT b_name FROM b WHERE (b2 = "bb bb") ';
+    $expectC = 'SELECT c_name FROM c WHERE (c3 = "cc cc") ';
+    $expectUnion = "SELECT * FROM (($expectA) UNION ($expectB) INTERSECT ($expectC)) ORDER BY a_name LIMIT 100 OFFSET 0";
+    $this->assertLike($expectUnion, $u->toSQL());
+  }
+
   public function testArrayGet() {
     $select = CRM_Utils_SQL_Select::from("foo")
       ->param('hello', 'world');


### PR DESCRIPTION
MySQL 5.7 supports "UNION" (which combines the result-sets from two queries). MySQL 8.0 and MariaDB 10.3 expand this more set-operations (eg "INTERSECT", "EXCEPT").

The patch allows CRM_Utils_SQL_Select to construct a range of queries with these operators.

Before
------

Not supported

After
-----

A few examples:

```php
CRM_Utils_SQL_Select::fromSet()
  ->union([$subQuery1, $subQuery2])
  ->limit(100);

CRM_Utils_SQL_Select::fromSet()
  ->union($subQuery1)
  ->union($subQuery2)
  ->union($subQuery3)
  ->where('foo = bar');

CRM_Utils_SQL_Select::fromSet()
  ->setOp('UNION ALL', [$subQuery1, $subQuery2])
  ->setOp('EXCEPT', [$subQuery3]);
```

Comments
--------

In these examples, we build one top-level `SELECT` query, and then use a sub-query to get the UNION/INTERSECT/EXCEPT data. This is not strictly necessary. (SQL allows set-ops without a top-level SELECT.) However, this pattern is powerful - because you can freely mix-in other subclauses (`WHERE`/`GROUP BY`/`HAVING`/etc).

I'm not 100% certain that these signatures are best. Looking at the MySQL BNF, these methods are still a bit reductive wrt precedence of the UNION / EXCEPT / INTERSECT operations. However, `CRM_Utils_SQL_Select` is already reductive about precedence of WHEREs...

Part of me wanted to model the UNION/setops as a separate object-type (independent of SELECT) -- and then improve subquery support, eg

```
$union = new CRM_Utils_SQL_SetOp('UNION', [$subQuery1, $subQuery2]);
$select = CRM_Utils_SQL_Select::from($union)->where('...');
```

However, in the CiviMail PR that uses UNION, there's an existing `Select` object where they iteratively mix-in more union clauses. It seems that the `Select::fromSet()->union()` might be a bit more amenable.

