### PR TITLE
(dev/core#4358) Verbiage changes on Find Groups screen

### DIFF
--- a/CRM/Group/Form/Search.php
+++ b/CRM/Group/Form/Search.php
@@ -45,7 +45,7 @@ class CRM_Group_Form_Search extends CRM_Core_Form {
 
     $optionTypes = [
       '1' => ts('Smart Group'),
-      '2' => ts('Normal Group'),
+      '2' => ts('Regular Group'),
     ];
     $this->add('select', 'saved_search', ts('Group Type'),
       ['' => ts('- any -')] + $optionTypes


### PR DESCRIPTION
Overview
----------------------------------------
Change _Normal Group_ option to _Regular Group_. Well because there's nothing abnormal about the smart groups :)

Before
----------------------------------------
Strange name for regular group.

After
----------------------------------------
Fix nomenclature.