### PR TITLE
FlexMailer\Listener\OpenTracker: remove deprecated isLegacy check

### DIFF
--- a/ext/flexmailer/src/Listener/OpenTracker.php
+++ b/ext/flexmailer/src/Listener/OpenTracker.php
@@ -29,7 +29,7 @@ class OpenTracker extends BaseListener {
       $mailParams = $task->getMailParams();
 
       if (!empty($mailParams) && !empty($mailParams['html'])) {
-        $openUrl = \CRM_Utils_System::externUrl('extern/open', 'q='. $task->getEventQueueId());
+        $openUrl = \CRM_Utils_System::externUrl('extern/open', 'q=' . $task->getEventQueueId());
         $mailParams['html'] .= "\n" . '<img src="' . htmlentities($openUrl) . "\" width='1' height='1' alt='' border='0'>";
 
         $task->setMailParams($mailParams);

--- a/ext/flexmailer/src/Listener/OpenTracker.php
+++ b/ext/flexmailer/src/Listener/OpenTracker.php
@@ -24,20 +24,12 @@ class OpenTracker extends BaseListener {
       return;
     }
 
-    $config = \CRM_Core_Config::singleton();
-
-    // TODO: After v5.21 goes EOL, remove the $isLegacy check.
-    $isLegacy = version_compare(\CRM_Utils_System::version(), '5.23.alpha', '<');
-
     foreach ($e->getTasks() as $task) {
       /** @var \Civi\FlexMailer\FlexMailerTask $task */
       $mailParams = $task->getMailParams();
 
       if (!empty($mailParams) && !empty($mailParams['html'])) {
-        $openUrl = $isLegacy
-          ? $config->userFrameworkResourceURL . "extern/open.php?q=" . $task->getEventQueueId()
-          : \CRM_Utils_System::externUrl('extern/open', "q=" . $task->getEventQueueId());
-
+        $openUrl = \CRM_Utils_System::externUrl('extern/open', 'q='. $task->getEventQueueId());
         $mailParams['html'] .= "\n" . '<img src="' . htmlentities($openUrl) . "\" width='1' height='1' alt='' border='0'>";
 
         $task->setMailParams($mailParams);


### PR DESCRIPTION
Overview
----------------------------------------
Fix `Todo: After v5.21 goes EOL, remove the $isLegacy check.`

Before
----------------------------------------
Checking if Civi version is greater than `5.23.alpha`.

After
----------------------------------------
Check removed.