### PR TITLE
don't show membership block on confirmation page if no membership exists

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MembershipBlock.tpl
@@ -73,14 +73,14 @@
         });
       </script>
     {/literal}
-    {elseif $lineItem and $priceSetID AND !$is_quick_config}
-      {assign var="totalAmount" value=$amount}
-      <div class="header-dark">
-        {ts}Membership Fee{/ts}
-      </div>
-      <div class="display-block">
-        {include file="CRM/Price/Page/LineItem.tpl" context="Membership"}
-      </div>
+{elseif $membershipBlock and $lineItem and $priceSetID AND !$is_quick_config}
+  {assign var="totalAmount" value=$amount}
+  <div class="header-dark">
+    {ts}Membership Fee{/ts}
+  </div>
+  <div class="display-block">
+    {include file="CRM/Price/Page/LineItem.tpl" context="Membership"}
+  </div>
 {elseif $membershipBlock AND !$is_quick_config}
   <div id="membership" class="crm-group membership-group">
     {if $context EQ "makeContribution"}


### PR DESCRIPTION
Overview
----------------------------------------
A membership block is shown on contribution page confirmation screens even when the form doesn't involve a membership.

To replicate, create a contribution page with:
* No membership section.
* Uses a price set (i.e. not "quick config")
* Has a confirmation page.
* Make a contribution, look at the confirmation page.

Before
----------------------------------------
![Selection_1921](https://github.com/civicrm/civicrm-core/assets/1796012/42837c57-50d4-4bb8-8d0f-91645a7033db)

After
----------------------------------------
![Selection_1920](https://github.com/civicrm/civicrm-core/assets/1796012/ff86385a-16b0-4741-b8c8-1840b7c26a04)


Technical Details
----------------------------------------
There was an indentation problem with the template code, which I believe led to this bug.

We now respect the `$membershipBlock` variable.