### PR TITLE
Fix for domains that have the string .css in them

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -129,7 +129,7 @@ class CRM_Core_Resources_Common {
       if (is_array($item)) {
         $bundle->addSetting($item);
       }
-      elseif (strpos($item, '.css')) {
+      elseif (preg_match('/(\.css$)|(\.css[?&])/', $item)) {
         Civi::resources()->isFullyFormedUrl($item) ? $bundle->addStyleUrl($item, -100) : $bundle->addStyleFile('civicrm', $item, -100);
       }
       elseif (Civi::resources()->isFullyFormedUrl($item)) {


### PR DESCRIPTION
Overview
----------------------------------------

Fixes JavaScript loading on domains with `.css` in them. Ex: `crm.cssxxxxxxxxx.org` (not the actual domain)

Before
----------------------------------------

Javascript was being loaded as `text/css` instead of `text/javascript`:

```
<link href="https://crm.cssxxxxxxxxx.org/wp-content/plugins/civicrm/civicrm/packages/jquery/plugins/jquery.timeentry.min.js" rel\="stylesheet" type\="text/css"/\>
```

After
----------------------------------------

Fixed

Technical Details
----------------------------------------

The code was matching `.css` regardless of where it is located in the string, including the domain name. Tested of WordPress with a standard/default configuration.

Comments
---------------------------------

Bug found by syxys.