### PR TITLE
dev/core#2184 - OAUTH - make google always return a refresh token

### DIFF
--- a/ext/oauth-client/CRM/OAuth/MailSetup.php
+++ b/ext/oauth-client/CRM/OAuth/MailSetup.php
@@ -23,6 +23,7 @@ class CRM_OAuth_MailSetup {
           'title' => sprintf('%s (ID #%s)', $provider['title'] ?? $provider['name'] ?? ts('OAuth2'), $client['id']),
           'callback' => ['CRM_OAuth_MailSetup', 'setup'],
           'oauth_client_id' => $client['id'],
+          'prompt' => $provider['options']['prompt'] ?? NULL,
         ];
       }
     }
@@ -46,7 +47,7 @@ class CRM_OAuth_MailSetup {
       ->addWhere('id', '=', $setupAction['oauth_client_id'])
       ->setStorage('OAuthSysToken')
       ->setTag('MailSettings:setup')
-      ->setPrompt('select_account')
+      ->setPrompt($setupAction['prompt'] ?? 'select_account')
       ->execute()
       ->single();
 

--- a/ext/oauth-client/providers/gmail.dist.json
+++ b/ext/oauth-client/providers/gmail.dist.json
@@ -10,7 +10,8 @@
     "scopes": [
       "https://mail.google.com/",
       "openid"
-    ]
+    ],
+    "prompt": "select_account consent"
   },
   "mailSettingsTemplate": {
     "name": "{{token.resource_owner.email}}",


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2184

Before
----------------------------------------
It doesn't except when setting up the very first time, but since everyone gets it wrong the first time, you end up with no refresh token by the time you get it working. It will work for an hour, but then since this is usually a cron job to fetch mail/bounces it will fail after that.

After
----------------------------------------
It does.

Technical Details
----------------------------------------
If you don't consent, google won't give the refresh token. "select_account" by itself won't ask for consent again if you just gave it, e.g. when you're recreating the civi mail account because you got it wrong the first time and are trying again.

But "select_account consent" can't be used for microsoft since it gives an error, so it needs to be per-provider.

More words in lab ticket if desired.

Comments
----------------------------------------
One bonus is that if for some reason you do want to turn off the consent, it doesn't need a code hack, you just make a local override of gmail.dist.json in `[civicrm.private]/oauth-providers`.