### PR TITLE
Cleanup Email Invoice form to remove longest ever field label

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -138,7 +138,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     $this->preventAjaxSubmit();
     $this->assign('isAdmin', CRM_Core_Permission::check('administer CiviCRM'));
 
-    $this->add('select', 'from_email_address', ts('From'), $this->_fromEmails, TRUE);
+    $this->add('select', 'from_email_address', ts('From'), $this->_fromEmails, TRUE, ['class' => 'crm-select2 huge']);
     if ($this->_selectedOutput != 'email') {
       $this->addElement('radio', 'output', NULL, ts('Email Invoice'), 'email_invoice');
       $this->addElement('radio', 'output', NULL, ts('PDF Invoice'), 'pdf_invoice');
@@ -149,13 +149,12 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $this->addRule('from_email_address', ts('From Email Address is required'), 'required');
     }
 
-    $attributes = ['class' => 'huge'];
     $this->addEntityRef('cc_id', ts('CC'), [
       'entity' => 'Email',
       'multiple' => TRUE,
     ]);
-    $this->add('text', 'subject', ts('Subject'), $attributes + ['placeholder' => ts('Optional')]);
-    $this->add('wysiwyg', 'email_comment', ts('If you would like to add personal message to email please add it here. (If sending to more then one receipient the same message will be sent to each contact.)'), [
+    $this->add('text', 'subject', ts('Replace Subject'), ['class' => 'huge', 'placeholder' => ts('Optional')]);
+    $this->add('wysiwyg', 'email_comment', ts('Additional Message'), [
       'rows' => 2,
       'cols' => 40,
     ]);

--- a/templates/CRM/Contribute/Form/Task/Invoice.hlp
+++ b/templates/CRM/Contribute/Form/Task/Invoice.hlp
@@ -32,3 +32,7 @@
 <p>{ts}You can send your email as a simple text-only message, as an HTML formatted message, or both. Text-only messages are sufficient for most email communication, and some recipients may prefer not to receive HTML formatted messages.{/ts}</p>
 <p>{ts}HTML messages have more visual impact, allow you to include images, and may be more readable if you are including links to website pages. However, different email programs may interpret HTML formats differently, so use this option cautiously unless you have a template format that has been tested with different web and desktop email programs.{/ts}</p>
 {/htxt}
+
+{htxt id="id-email_comment"}
+{ts}You can add a message that will appear at the top of the invoice email. This message will be the same for all recipients.{/ts}
+{/htxt}

--- a/templates/CRM/Contribute/Form/Task/Invoice.tpl
+++ b/templates/CRM/Contribute/Form/Task/Invoice.tpl
@@ -16,7 +16,7 @@
     {ts}You may choose to email invoice to contributors OR download a PDF file containing one invoice per page to your local computer by clicking <strong>Process Invoice(s)</strong> . Your browser may display the file for you automatically, or you may need to open it for printing using any PDF reader (such as Adobe&reg; Reader).{/ts}
   </div>
 {/if}
-
+<div class="crm-block crm-form-block">
 <table class="form-layout-compressed">
   {if $selectedOutput ne 'email'}
     <tr>
@@ -41,7 +41,7 @@
     </td>
   </tr>
   <tr class="crm-email-element">
-    <td class="label">{$form.email_comment.label}</td>
+    <td class="label">{$form.email_comment.label} {help id="id-email_comment"}</td>
     <td>{$form.email_comment.html}</td>
   </tr>
   {if $selectedOutput ne 'email'}
@@ -55,6 +55,7 @@
     <td>{$form.pdf_format_id.html}</td>
   </tr>
 </table>
+</div>
 
 <div class="spacer"></div>
 <div class="crm-submit-buttons">


### PR DESCRIPTION
Overview
----------------------------------------
Also changed from_email to select2 while I was in there and clarified the subject label, plus a little light cleanup.

Before
----------------------------------------
<img width="764" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/413c3932-921b-4c23-86ab-53f53bdaa73c">

After
----------------------------------------
<img width="773" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/b8904e2e-6c9f-40d1-994b-b3c5d9f95c70">
