### PR TITLE
Add additional message to invoice template if present

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -14,6 +14,11 @@
       </table>
     {/if}
     <table style="font-family: Arial, Verdana, sans-serif;" width="100%" height="100" border="0" cellpadding="5" cellspacing="0">
+      {if $email_comment}
+        <tr>
+          <td><font size="1" colspan="3">{$email_comment}</font></td>
+        </tr>
+      {/if}
       <tr>
         <td width="30%"><b><font size="4" align="center">{ts}INVOICE{/ts}</font></b></td>
         <td width="50%" valign="bottom"><b><font size="1" align="center">{ts}Invoice Date:{/ts}</font></b></td>


### PR DESCRIPTION
Overview
----------------------------------------
Seems like this was lost many years ago, so it can't be too popular of a feature, but might as well implement it so it actually works.

Before
----------------------------------------
Additional Message content not included in emailed invoice sent from Email Invoice form.

After
----------------------------------------
Additional Message included above invoice.

Technical Details
----------------------------------------
Looks like we're missing the text version here, but that's not implemented at all for invoices, so no need.