### PR TITLE
WIP fix for reminders for Autorenew memberships

### DIFF
--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -93,10 +93,12 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     // FIXME: Numbers should be constants.
     if (in_array(2, $selectedStatuses)) {
       //auto-renew memberships
-      $query->where("e.contribution_recur_id IS NOT NULL");
+      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id')
+      $query->where("contribution_recur.contribution_status_id = 2");
     }
     elseif (in_array(1, $selectedStatuses)) {
-      $query->where("e.contribution_recur_id IS NULL");
+      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id')
+      $query->where("contribution_recur.contribution_status_id <> 2");
     }
 
     if (!empty($selectedValues)) {

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -93,11 +93,11 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     // FIXME: Numbers should be constants.
     if (in_array(2, $selectedStatuses)) {
       //auto-renew memberships
-      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id')
+      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id');
       $query->where("contribution_recur.contribution_status_id = 2");
     }
     elseif (in_array(1, $selectedStatuses)) {
-      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id')
+      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id');
       $query->where("contribution_recur.contribution_status_id <> 2");
     }
 

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -98,8 +98,8 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
       $query->where("contribution_recur.contribution_status_id = #pending", ['pending' => $contribution_status_id_pending]);
     }
     elseif (in_array(1, $selectedStatuses)) {
-      $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id');
-      $query->where("contribution_recur.contribution_status_id <> #pending", ['pending' => $contribution_status_id_pending]);
+      $query->join('contribution_recur', 'left join civicrm_contribution_recur on e.contribution.id = contribution_recur.id');
+      $query->where("contribution_recur.contribution_status_id <> #pending or contribution_recur.contribution_status_id is NULL", ['pending' => $contribution_status_id_pending]);
     }
 
     if (!empty($selectedValues)) {

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -91,14 +91,15 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\Mapping {
     }
 
     // FIXME: Numbers should be constants.
+    $contribution_status_id_pending = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
     if (in_array(2, $selectedStatuses)) {
       //auto-renew memberships
       $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id');
-      $query->where("contribution_recur.contribution_status_id = 2");
+      $query->where("contribution_recur.contribution_status_id = #pending", ['pending' => $contribution_status_id_pending]);
     }
     elseif (in_array(1, $selectedStatuses)) {
       $query->join('contribution_recur', 'inner join civicrm_contribution_recur on e.contribution.id = contribution_recur.id');
-      $query->where("contribution_recur.contribution_status_id <> 2");
+      $query->where("contribution_recur.contribution_status_id <> #pending", ['pending' => $contribution_status_id_pending]);
     }
 
     if (!empty($selectedValues)) {


### PR DESCRIPTION
Overview
----------------------------------------
Is it as simple as joining on this field? 

Before
----------------------------------------
CiviCRM assumes that if a membership has a contribution_recur_id then that means that the Membership will be renewed. However this auto renewal could be cancelled or otherwise stopped.

This impacts both reminders that should go to people who are auto renewing and people that should get a reminder ro renew.

Contacts with a cancelled (or otherwise) recurring contribution would get a reminder saying your membership is going to renew.

Contacts with a cancelled (or otherwise) recurring contribution would not get a reminder saying you need to renew your membership.

After
----------------------------------------

Do we just need to join another table here?


Technical Details
----------------------------------------

I'm guessing there is a lot to be fixed here.


Comments
----------------------------------------

Is there any testing of this!
