### PR TITLE
APIv4 - Deprecate unused event

### DIFF
--- a/Civi/Api4/Event/PostSelectQueryEvent.php
+++ b/Civi/Api4/Event/PostSelectQueryEvent.php
@@ -12,63 +12,14 @@
 
 namespace Civi\Api4\Event;
 
-use Civi\Api4\Query\Api4SelectQuery;
 use Civi\Core\Event\GenericHookEvent;
 
+/**
+ * Unused event.
+ * Kept around because of https://lab.civicrm.org/dev/joomla/-/issues/28
+ * @see Events::POST_SELECT_QUERY
+ * @deprecated
+ */
 class PostSelectQueryEvent extends GenericHookEvent {
-
-  /**
-   * @var array
-   */
-  protected $results;
-
-  /**
-   * @var \Civi\Api4\Query\Api4SelectQuery
-   */
-  protected $query;
-
-  /**
-   * PostSelectQueryEvent constructor.
-   * @param array $results
-   * @param \Civi\Api4\Query\Api4SelectQuery $query
-   */
-  public function __construct(array $results, Api4SelectQuery $query) {
-    $this->results = $results;
-    $this->query = $query;
-  }
-
-  /**
-   * @return array
-   */
-  public function getResults() {
-    return $this->results;
-  }
-
-  /**
-   * @param array $results
-   * @return $this
-   */
-  public function setResults($results) {
-    $this->results = $results;
-
-    return $this;
-  }
-
-  /**
-   * @return \Civi\Api4\Query\Api4SelectQuery
-   */
-  public function getQuery() {
-    return $this->query;
-  }
-
-  /**
-   * @param \Civi\Api4\Query\Api4SelectQuery $query
-   * @return $this
-   */
-  public function setQuery($query) {
-    $this->query = $query;
-
-    return $this;
-  }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Marks an unused APIv4 event class as deprecated.

Technical Details
----------------------------------------
Not deleting it entirely because of https://lab.civicrm.org/dev/joomla/-/issues/28
