### PR TITLE
Fix for membership discounts not showing in 5.62

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -369,7 +369,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       // build price set form.
       $this->set('priceSetId', $this->_priceSetId);
       if (empty($this->_ccid)) {
-        CRM_Price_BAO_PriceSet::buildPriceSet($this, $this->getMainEntityType());
+        CRM_Price_BAO_PriceSet::buildPriceSet($this, $this->getFormContext());
       }
       if ($this->_values['is_monetary'] &&
         $this->_values['is_recur'] && empty($this->_values['pledge_id'])

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1305,7 +1305,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   protected function isMembershipPriceSet(): bool {
     if ($this->_useForMember === NULL) {
-      if ($this->getMainEntityType() === 'membership' &&
+      if ($this->getFormContext() === 'membership' &&
         !$this->isQuickConfig()) {
         $this->_useForMember = 1;
       }
@@ -1317,11 +1317,15 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     return (bool) $this->_useForMember;
   }
 
-  public function getMainEntityType() {
-    if (CRM_Core_Component::isEnabled('CiviMember') && (int) CRM_Core_Component::getComponentID('CiviMember') === (int) $this->order->getPriceSetMetadata()['extends']) {
-      return 'membership';
-    }
-    return 'contribution';
+  /**
+   * Get the form context.
+   *
+   * This is important for passing to the buildAmount hook as CiviDiscount checks it.
+   *
+   * @return string
+   */
+  public function getFormContext(): string {
+    return $this->order->isMembershipPriceSet() ? 'membership' : 'contribution';
   }
 
   /**

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -651,11 +651,21 @@ class CRM_Financial_BAO_Order {
   public function getPriceSetMetadata(): array {
     if (empty($this->priceSetMetadata)) {
       $priceSetMetadata = CRM_Price_BAO_PriceSet::getCachedPriceSetDetail($this->getPriceSetID());
+      // @todo - make sure this is an array - commented out for now as this PR is against the rc.
+      // $priceSetMetadata['extends'] = explode(CRM_Core_DAO::VALUE_SEPARATOR, $priceSetMetadata['extends']);
       $this->setPriceFieldMetadata($priceSetMetadata['fields']);
       unset($priceSetMetadata['fields']);
       $this->priceSetMetadata = $priceSetMetadata;
     }
     return $this->priceSetMetadata;
+  }
+
+  public function isMembershipPriceSet() {
+    if (!CRM_Core_Component::isEnabled('CiviMember')) {
+      return FALSE;
+    }
+    $extends = explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->getPriceSetMetadata()['extends']);
+    return in_array(CRM_Core_Component::getComponentID('CiviMember'), $extends, FALSE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix for membership discounts not showing in 5.62

Before
----------------------------------------
A membership configured per the screen shot automatically is applied for a renewing member in 5.61 but not 5.62

![image](https://github.com/civicrm/civicrm-core/assets/336308/5c8a6c1d-df5a-4554-a983-e174c41c92eb)

After
----------------------------------------
Functionality is returned


Technical Details
----------------------------------------
The issue is due to https://github.com/civicrm/civicrm-core/pull/24765

In 5.61 membership price sets had a value of 3 in the extends column and in 5.62 (after the upgrade is run as @kewljuice cleverly spotted) the value is no longer 3 but 3 wrapped in custom separators & hence the match is not made, the form is not identifed to the hook as a 'membership' form and civi-discount does not leap into action.

I put the change in a function ONLY called by this code patch because it is the rc but it should move to a more generic spot in the BAO_Order class in master. Also note I renamed the context  function on the form as it is doing the same thing [as one differently named on similar forms](https://lab.civicrm.org/dev/core/-/issues/4352#note_91575). The function is [newly added in 5.61](https://github.com/civicrm/civicrm-core/commit/c3f9fce37e336ebc70f13a54a190260c3ba3d4da#diff-a387458ba3c5d92e0dcc4c0ba4a2ad97cf36844f4c9b32fcd9862df33672f1a2R1320)



Comments
----------------------------------------
