### PR TITLE
Add deprecation notice to legacy exception class aliases

### DIFF
--- a/api/Exception.php
+++ b/api/Exception.php
@@ -10,5 +10,11 @@
 
 // These two classes were basically equivalent
 
+/**
+ * @deprecated in CiviCRM 5.52, will be removed around 5.92. Use CRM_Core_Exception
+ */
 class_alias('CRM_Core_Exception', 'API_Exception');
+/**
+ * @deprecated in CiviCRM 5.52, will be removed around 5.92. Use CRM_Core_Exception
+ */
 class_alias('CRM_Core_Exception', 'CiviCRM_API3_Exception');


### PR DESCRIPTION
Overview
----------------------------------------
Add deprecation notice to legacy exception class aliases

Before
----------------------------------------
There is no UI indication that these exceptions are deprecated.

After
----------------------------------------
The best we seem to be able to get is a very soft warning - but it's better than nothing & if IDE tools improve it will improve
https://youtrack.jetbrains.com/issue/WI-34715/Option-to-mark-a-class-alias-as-deprecated

![image](https://github.com/civicrm/civicrm-core/assets/336308/8d645e71-94bf-4129-a7dc-7a2fb8af4256)


Technical Details
----------------------------------------
I've set these to have a deprecation period of 40 months - it's longer than our standard period but these are likely to be widely used out there & I suspect that when we get to that point we will push it out further rather than remove them  - still at least we will be increasing visibility

Comments
----------------------------------------
