### PR TITLE
Fix Invoice test to user EventTestTrait, require less in order API

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -594,6 +594,30 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Get the default values for line items using this price field value id.
+   *
+   * @param int $id
+   *
+   * @return array
+   */
+  public function getPriceFieldValueDefaults(int $id): array {
+    $valueDefaults = array_intersect_key($this->getPriceFieldValueSpec($id), array_fill_keys([
+      'financial_type_id',
+      'non_deductible_amount',
+      'membership_type_id',
+      'membership_num_terms',
+      'amount',
+      'description',
+      'price_field_id',
+      'label',
+    ], TRUE));
+    $valueDefaults['qty'] = 1;
+    $valueDefaults['unit_price'] = $valueDefaults['amount'];
+    unset($valueDefaults['amount']);
+    return $valueDefaults;
+  }
+
+  /**
    * Get the metadata for the fields in the price set.
    *
    * @internal use in tested core code only.
@@ -996,6 +1020,14 @@ class CRM_Financial_BAO_Order {
       $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
     }
     else {
+      if (!empty($lineItem['price_field_value_id'])) {
+        // Let's make sure it is an integer not '2' for sanity.
+        $lineItem['price_field_value_id'] = (int) $lineItem['price_field_value_id'];
+        $lineItem = array_merge($this->getPriceFieldValueDefaults($lineItem['price_field_value_id']), $lineItem);
+      }
+      if (!isset($lineItem['line_total'])) {
+        $lineItem['line_total'] = $lineItem['qty'] * $lineItem['unit_price'];
+      }
       $lineItem['tax_rate'] = $this->getTaxRate($lineItem['financial_type_id']);
       $lineItem['tax_amount'] = ($lineItem['tax_rate'] / 100) * $lineItem['line_total'];
     }

--- a/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/InvoiceTest.php
@@ -109,53 +109,55 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
 
     $this->enableTaxAndInvoicing();
 
-    $event = $this->legacyEventCreatePaid([]);
+    $event = $this->eventCreatePaid([]);
 
-    $individualOneId = $this->individualCreate();
-    $individualTwoId = $this->individualCreate();
-    $contactIds = [$individualOneId, $individualTwoId];
+    $individualOneID = $this->individualCreate();
+    $individualTwoID = $this->individualCreate();
 
-    $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $event['id']);
+    $priceSetId = $this->ids['PriceSet']['PaidEvent'];
     $priceField = $this->callAPISuccess('PriceField', 'get', ['price_set_id' => $priceSetId]);
     $priceFieldValues = $this->callAPISuccess('PriceFieldValue', 'get', [
       'sequential' => 1,
       'price_field_id' => $priceField['id'],
     ]);
 
-    $lineItemParams = [];
-    foreach ($priceFieldValues['values'] as $key => $priceFieldValue) {
-      $lineItemParams[] = [
+    $lineItemParams = [
+      [
         'line_item' => [
-          $priceFieldValue['id'] => [
+          $this->ids['PriceField']['PaidEvent'] => [
             'price_field_id' => $priceField['id'],
-            'label' => $priceFieldValue['label'],
-            'financial_type_id' => $priceFieldValue['financial_type_id'],
-            'price_field_value_id' => $priceFieldValue['id'],
+            'price_field_value_id' => $this->ids['PriceFieldValue']['PaidEvent_standard'],
             'qty' => 1,
-            'field_title' => $priceFieldValue['label'],
-            'unit_price' => $priceFieldValue['amount'],
-            'line_total' => $priceFieldValue['amount'],
             'entity_table' => 'civicrm_participant',
           ],
         ],
         // participant params
         'params' => [
-          'contact_id' => $contactIds[$key],
+          'contact_id' => $individualOneID,
           'event_id' => $event['id'],
           'status_id' => 1,
-          'price_set_id' => $priceSetId,
-          'participant_fee_amount' => $priceFieldValue['amount'],
-          'participant_fee_level' => $priceFieldValue['label'],
         ],
-      ];
-    }
+      ],
+      [
+        'line_item' => [
+          $this->ids['PriceField']['PaidEvent'] => [
+            'price_field_id' => $priceField['id'],
+            'price_field_value_id' => $this->ids['PriceFieldValue']['PaidEvent_student'],
+            'qty' => 1,
+            'entity_table' => 'civicrm_participant',
+          ],
+        ],
+        // participant params
+        'params' => [
+          'contact_id' => $individualTwoID,
+          'event_id' => $event['id'],
+          'status_id' => 1,
+        ],
+      ],
+    ];
 
     $orderParams = [
-      'contact_id' => $individualOneId,
-      'total_amount' => array_reduce($priceFieldValues['values'], function($total, $priceFieldValue) {
-        $total += $priceFieldValue['amount'];
-        return $total;
-      }),
+      'contact_id' => $individualOneID,
       'financial_type_id' => $priceFieldValues['values'][0]['financial_type_id'],
       'currency' => 'USD',
       'line_items' => $lineItemParams,
@@ -168,7 +170,7 @@ class CRM_Contribute_Form_Task_InvoiceTest extends CiviUnitTestCase {
       'forPage' => 1,
     ];
 
-    $invoiceHTML = CRM_Contribute_Form_Task_Invoice::printPDF([$order['id']], $pdfParams, [$individualOneId]);
+    $invoiceHTML = CRM_Contribute_Form_Task_Invoice::printPDF([$order['id']], $pdfParams, [$individualOneID]);
 
     $lineItems = $this->callAPISuccess('LineItem', 'get', ['contribution_id' => $order['id']]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix Invoice test to user EventTestTrait, require less in order API

In order to update the Invoice Test I have altered the order api so that it requires less information

Before
----------------------------------------
When passing line items to the order api it is necessary to pass in the price_field_value_id AND the relevant amount

After
----------------------------------------
A look up is done to load the amount rather than requiring it to be passed in

Technical Details
----------------------------------------
While I don't want to block this PR I want to start spit balling what the Order api needs.
https://lab.civicrm.org/dev/core/-/issues/4367

Comments
----------------------------------------
