### PR TITLE
Fix missing </table> tag on repeat event change confirm tpl.

### DIFF
--- a/templates/CRM/Core/Page/RecurringEntityPreview.tpl
+++ b/templates/CRM/Core/Page/RecurringEntityPreview.tpl
@@ -29,6 +29,7 @@
         {/foreach}
       {/foreach}
     </tbody>
+  </table>
 {/if}
 
 <h3>


### PR DESCRIPTION
Overview
----------------------------------------

When changing the repeat end for events, a missing end-table HTML tag causes the heading that introduces a 2nd table to appear above the first table; thus muddling the communication.


Before
----------------------------------------


>    ⚠️ There are participants registered for repeating events being removed from the set. Those with participants will be converted to standalone events, and those without registration will be deleted.
>
>   A repeating set will be created with the following dates.  
>  ➊ (table listing existing events to be removed)  
>  ➋ (table listing events to be created)  

After
----------------------------------------
>    ⚠️ There are participants registered for repeating events being removed from the set. Those with participants will be converted to standalone events, and those without registration will be deleted.
>  ➊ (table listing existing events to be removed)  
>
>   A repeating set will be created with the following dates.  
>  ➋ (table listing events to be created)  

Technical Details
----------------------------------------

I suspect this is the [least of concerns in this code](https://civicrm.stackexchange.com/q/45111/35), but at least this is something that is definitely wrong and can be fixed in a cinch.