### PR TITLE
dev/core#4369 - fix upgrade for logging tables

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
@@ -29,6 +29,18 @@ class CRM_Upgrade_Incremental_php_FiveSixtyFour extends CRM_Upgrade_Incremental_
    */
   public function upgrade_5_64_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Update post_URL/cancel_URL in logging tables', 'updateLogging');
+  }
+
+  public static function updateLogging($ctx): bool {
+    if (\Civi::settings()->get('logging')) {
+      $dsn = defined('CIVICRM_LOGGING_DSN') ? CRM_Utils_SQL::autoSwitchDSN(CIVICRM_LOGGING_DSN) : CRM_Utils_SQL::autoSwitchDSN(CIVICRM_DSN);
+      $dsn = DB::parseDSN($dsn);
+      $table = '`' . $dsn['database'] . '`.`log_civicrm_uf_group`';
+      CRM_Core_DAO::executeQuery("ALTER TABLE $table CHANGE `post_URL` `post_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to URL on submit.',
+CHANGE `cancel_URL` `cancel_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to URL when Cancel button clicked.'");
+    }
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4369

Before
----------------------------------------
If logging is enabled:
`ALTER TABLE log_civicrm_uf_group ADD post_url varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'Redirect to URL on submit.' [nativecode=1060 ** Duplicate column name 'post_url']`
when upgrading to 5.64.

After
----------------------------------------
🆗 

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/26460 changed the case of the field, but when it reconciles it tries to add the new field to the log table instead of changing the old field, so it thinks it's a duplicate.

Comments
----------------------------------------

