### PR TITLE
Improve select for Add Navigation Menu Item > Parent

### DIFF
--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -77,7 +77,7 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
 
     //make separator location configurable
     $separator = CRM_Core_SelectValues::navigationMenuSeparator();
-    $this->add('select', 'has_separator', ts('Separator'), $separator);
+    $this->add('select', 'has_separator', ts('Separator'), $separator, FALSE, ['class' => 'crm-select2']);
 
     $active = $this->add('advcheckbox', 'is_active', ts('Enabled'));
 
@@ -95,7 +95,7 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
       $homeMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Home', 'id', 'name');
       unset($parentMenu[$homeMenuId]);
 
-      $this->add('select', 'parent_id', ts('Parent'), ['' => ts('Top level')] + $parentMenu, FALSE, ['class' => 'crm-select2']);
+      $this->add('select', 'parent_id', ts('Parent'), ['' => ts('Top level')] + $parentMenu, FALSE, ['class' => 'crm-select2 huge']);
     }
   }
 

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -173,7 +173,8 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
       $domainID = CRM_Core_Config::domainID();
       $query = "
 SELECT id, label, parent_id, weight, is_active, name
-FROM civicrm_navigation WHERE domain_id = $domainID";
+FROM civicrm_navigation WHERE domain_id = $domainID
+ORDER BY weight";
       $result = CRM_Core_DAO::executeQuery($query);
 
       $pidGroups = [];

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -134,7 +134,7 @@ class CRM_Report_Form_Instance {
     // navigation field
     $parentMenu = CRM_Core_BAO_Navigation::getNavigationList();
 
-    $form->add('select', 'parent_id', ts('Parent Menu'), ['' => ts('- select -')] + $parentMenu);
+    $form->add('select', 'parent_id', ts('Parent Menu'), ['' => ts('- select -')] + $parentMenu, FALSE, ['class' => 'crm-select2 huge']);
 
     // For now we only providing drilldown for one primary detail report only. In future this could be multiple reports
     foreach ($form->_drilldownReport as $reportUrl => $drillLabel) {


### PR DESCRIPTION
Before
----------------------------------------
1. Hard to use select for Parent because items break onto two lines due to narrow width.
<img width="471" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/8e5c8c4b-464c-4381-984f-2d62e34fcb25">

2. Ordering of menu items in select does not respect weight if changed, i.e. if you have re-ordered the menu items, you still get the original order based on id here. 

3. Same select in Reports is not select2.

After
----------------------------------------
1. Wider, more usable. Also made Separator a select2.
<img width="457" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/739b1039-0761-439b-9c2b-0f34321cbe73">

2. Ordering of menu items respects weight, i.e. it is the same as the actual menu.

3. Select2 in Reports.

Comments
----------------------------------------
CiviHR has a copy of `CRM/Core/BAO/Navigation.php`, so this is a courtesy page for @olayiwola-compucorp (I hope you're the right person).