### PR TITLE
APIv4 - Fix passing '0' as a function argument

### DIFF
--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -224,7 +224,7 @@ abstract class SqlExpression {
   protected function captureExpressions(string &$arg, array $mustBe, int $max) {
     $captured = [];
     $arg = ltrim($arg);
-    while ($arg) {
+    while (strlen($arg)) {
       $item = $this->captureExpression($arg);
       $arg = ltrim(substr($arg, strlen($item)));
       $expr = self::convert($item, FALSE, $mustBe);

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -167,7 +167,7 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
 
     $result = Activity::get(FALSE)
       ->addWhere('id', 'IN', $aids)
-      ->addSelect('IF(is_deleted, "Trash", "No Trash") AS trashed')
+      ->addSelect('IF(is_deleted, 1, 0) AS trashed')
       ->addSelect('NULLIF(subject, location) AS nullif_subject_is_location')
       ->addSelect('NULLIF(duration, 456) AS nullif_duration_is_456')
       ->addSelect('COALESCE(duration, location) AS coalesce_duration_location')
@@ -179,9 +179,9 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ->execute()->indexBy('id');
 
     $this->assertCount(3, $result);
-    $this->assertEquals('No Trash', $result[$aids[0]]['trashed']);
-    $this->assertEquals('Trash', $result[$aids[1]]['trashed']);
-    $this->assertEquals('No Trash', $result[$aids[2]]['trashed']);
+    $this->assertEquals(0, $result[$aids[0]]['trashed']);
+    $this->assertEquals(1, $result[$aids[1]]['trashed']);
+    $this->assertEquals(0, $result[$aids[2]]['trashed']);
 
     $this->assertEquals(NULL, $result[$aids[0]]['nullif_subject_is_location']);
     $this->assertEquals('xyz', $result[$aids[1]]['nullif_subject_is_location']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an edge-case bug in APIv4

Before
----------------------------------------
"CRM_Core_Exception : Too few arguments to param 3 for SQL function IF"

After
----------------------------------------
Function works with '0' as an argument.
