### PR TITLE
dev/core#4048 Fatal error when changing membership type on membership with no contributions

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1510,9 +1510,13 @@ DESC limit 1");
     //CRM-15187
     // display message when membership type is changed
     if (($this->_action & CRM_Core_Action::UPDATE) && $this->getMembershipID() && !in_array($this->_memType, $this->_memTypeSelected)) {
-      $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->getMembershipID(), 'membership');
-      $maxID = max(array_keys($lineItem));
-      $lineItem = $lineItem[$maxID];
+      $lineItems = CRM_Price_BAO_LineItem::getLineItems($this->getMembershipID(), 'membership');
+      if (empty($lineItems)) {
+        return;
+      }
+
+      $maxID = max(array_keys($lineItems));
+      $lineItem = $lineItems[$maxID];
       $membershipTypeDetails = $this->allMembershipTypeDetails[$this->getMembership()['membership_type_id']];
       if ($membershipTypeDetails['financial_type_id'] != $lineItem['financial_type_id']) {
         CRM_Core_Session::setStatus(


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4048 Fixes [fatal error when changing membership type on membership with no contributions](https://lab.civicrm.org/dev/core/-/issues/4048)

Before
----------------------------------------
When updating a membership, a fatal error would occur if:

1. The membership type was being updated,
2. The membership being updated had no associated contribution (or more specifically, no line-items).

After
----------------------------------------
No fatal occurs.

Comments
----------------------------------------
This is pretty easy to reproduce. We have a client where this occurs fairly frequently so this would be nice to sort out (in the client's case there are lots of memberships without a contribution as we migrated them from a previous CRM which didn't consistently record payments).

Prior to PHP 8 a warning rather than a fatal error occurs, which I think is why this hasn't been reported by anyone else.
