### PR TITLE
Fix lifetime membership with end date error message

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -780,7 +780,7 @@ DESC limit 1");
             }
 
             if (empty($params['status_id']) || in_array($params['status_id'], $status_ids) == FALSE) {
-              $errors['status_id'] = ts('Please enter a status that does NOT represent a current membership status.');
+              $errors['status_id'] = ts('A current lifetime membership cannot have an end date. You can either remove the end date or change the status to a non-current status like Cancelled, Expired, or Deceased.');
             }
 
             if (!empty($params['is_override']) && !CRM_Member_StatusOverrideTypes::isPermanent($params['is_override'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This was a strange warning that wanted you to change the membership status if you tried to save a current lifetime membership with an end date (e.g. if changing from a non-lifetime membership to a lifetime one and not knowing that you need to manually clear the end date). 

The warning did not tell you that removing the end date would allow you to submit the form, now it does.