### PR TITLE
Move recurring handling to recur function in PaypalIPN 

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -25,6 +25,13 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
    */
   protected $_inputParameters = [];
 
+  /***
+   * Loaded contribution object.
+   *
+   * @var \CRM_Contribute_BAO_Contribution
+   */
+  private $contribution;
+
   /**
    * Constructor function.
    *
@@ -60,20 +67,28 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
 
   /**
    * @param array $input
-   * @param CRM_Contribute_BAO_ContributionRecur $recur
-   * @param CRM_Contribute_BAO_Contribution $contribution
-   * @param bool $first
    *
    * @return void
    *
    * @throws \CRM_Core_Exception
    */
-  public function recur($input, $recur, $contribution, $first) {
-
+  public function recur($input) {
+    $contribution = $this->getContribution();
+    $contributionRecur = new CRM_Contribute_BAO_ContributionRecur();
+    $contributionRecur->id = $this->getContributionRecurID();
+    if (!$contributionRecur->find(TRUE)) {
+      throw new CRM_Core_Exception('Could not find contribution contributionRecur record');
+    }
+    // check if first contribution is completed, else complete first contribution
+    $first = TRUE;
+    $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+    if ($contribution->contribution_status_id == $completedStatusId) {
+      $first = FALSE;
+    }
     // make sure the invoice ids match
     // make sure the invoice is valid and matches what we have in the contribution record
-    if ($recur->invoice_id != $input['invoice']) {
-      Civi::log()->debug('PayPalIPN: Invoice values dont match between database and IPN request (RecurID: ' . $recur->id . ').');
+    if ($contributionRecur->invoice_id != $input['invoice']) {
+      Civi::log()->debug('PayPalIPN: Invoice values dont match between database and IPN request (RecurID: ' . $contributionRecur->id . ').');
       throw new CRM_Core_Exception("Failure: Invoice values dont match between database and IPN request");
     }
 
@@ -83,43 +98,55 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
     $contributionStatuses = array_flip(CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate'));
     switch ($this->getTrxnType()) {
       case 'subscr_signup':
-        $recur->create_date = $now;
+        $contributionRecur->create_date = $now;
         // sometimes subscr_signup response come after the subscr_payment and set to pending mode.
 
         $statusID = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionRecur',
-          $recur->id, 'contribution_status_id'
+          $contributionRecur->id, 'contribution_status_id'
         );
         if ($statusID != $contributionStatuses['In Progress']) {
-          $recur->contribution_status_id = $contributionStatuses['Pending'];
+          $contributionRecur->contribution_status_id = $contributionStatuses['Pending'];
         }
-        $recur->processor_id = $this->retrieve('subscr_id', 'String');
-        $recur->trxn_id = $recur->processor_id;
-        $recur->save();
+        $contributionRecur->processor_id = $this->retrieve('subscr_id', 'String');
+        $contributionRecur->trxn_id = $contributionRecur->processor_id;
+        $contributionRecur->save();
+        //send recurring Notification email for user
+        CRM_Contribute_BAO_ContributionPage::recurringNotify(
+          $this->getContributionID(),
+          CRM_Core_Payment::RECURRING_PAYMENT_START,
+          $contributionRecur
+        );
         return;
 
       case 'subscr_eot':
-        if ($recur->contribution_status_id != $contributionStatuses['Cancelled']) {
-          $recur->contribution_status_id = $contributionStatuses['Completed'];
+        if ($contributionRecur->contribution_status_id != $contributionStatuses['Cancelled']) {
+          $contributionRecur->contribution_status_id = $contributionStatuses['Completed'];
         }
-        $recur->end_date = $now;
-        $recur->save();
+        $contributionRecur->end_date = $now;
+        $contributionRecur->save();
+        //send recurring Notification email for user
+        CRM_Contribute_BAO_ContributionPage::recurringNotify(
+          $this->getContributionID(),
+          CRM_Core_Payment::RECURRING_PAYMENT_END,
+          $contributionRecur
+        );
         return;
 
       case 'subscr_cancel':
-        $recur->contribution_status_id = $contributionStatuses['Cancelled'];
-        $recur->cancel_date = $now;
-        $recur->save();
+        $contributionRecur->contribution_status_id = $contributionStatuses['Cancelled'];
+        $contributionRecur->cancel_date = $now;
+        $contributionRecur->save();
         return;
 
       case 'subscr_failed':
-        $recur->contribution_status_id = $contributionStatuses['Failed'];
-        $recur->modified_date = $now;
-        $recur->save();
+        $contributionRecur->contribution_status_id = $contributionStatuses['Failed'];
+        $contributionRecur->modified_date = $now;
+        $contributionRecur->save();
         break;
 
       case 'subscr_modify':
-        Civi::log()->debug('PayPalIPN: We do not handle modifications to subscriptions right now  (RecurID: ' . $recur->id . ').');
-        echo "Failure: We do not handle modifications to subscriptions right now<p>";
+        Civi::log()->debug('PayPalIPN: We do not handle modifications to subscriptions right now  (RecurID: ' . $contributionRecur->id . ').');
+        echo 'Failure: We do not handle modifications to subscriptions right now<p>';
         return;
 
     }
@@ -152,25 +179,24 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       // Also consider accepting 'Failed' like other processors.
       $input['contribution_status_id'] = $contributionStatuses['Completed'];
       $input['original_contribution_id'] = $contribution->id;
-      $input['contribution_recur_id'] = $recur->id;
+      $input['contribution_recur_id'] = $contributionRecur->id;
 
       civicrm_api3('Contribution', 'repeattransaction', $input);
       return;
     }
 
-    $this->single($input, $contribution, TRUE);
+    $this->single($input, TRUE);
   }
 
   /**
    * @param array $input
-   * @param \CRM_Contribute_BAO_Contribution $contribution
    * @param bool $recur
    *
    * @return void
    * @throws \CRM_Core_Exception
    */
-  public function single($input, $contribution, $recur = FALSE) {
-
+  public function single($input, $recur = FALSE) {
+    $contribution = $this->getContribution();
     // make sure the invoice is valid and matches what we have in the contribution record
     if ($contribution->invoice_id != $input['invoice']) {
       Civi::log()->debug('PayPalIPN: Invoice values dont match between database and IPN request. (ID: ' . $contribution->id . ').');
@@ -218,31 +244,11 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
       $paymentProcessorID = $this->getPayPalPaymentProcessorID($input, $this->getContributionRecurID());
 
       Civi::log()->debug('PayPalIPN: Received (ContactID: ' . $this->getContactID() . '; trxn_id: ' . $input['trxn_id'] . ').');
-      $contribution = $this->getContribution();
 
       $input['payment_processor_id'] = $paymentProcessorID;
 
       if ($this->getContributionRecurID()) {
-        $contributionRecur = new CRM_Contribute_BAO_ContributionRecur();
-        $contributionRecur->id = $this->getContributionRecurID();
-        if (!$contributionRecur->find(TRUE)) {
-          throw new CRM_Core_Exception('Could not find contribution recur record');
-        }
-        // check if first contribution is completed, else complete first contribution
-        $first = TRUE;
-        $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-        if ($contribution->contribution_status_id == $completedStatusId) {
-          $first = FALSE;
-        }
-        $this->recur($input, $contributionRecur, $contribution, $first);
-        if ($this->getFirstOrLastInSeriesStatus()) {
-          //send recurring Notification email for user
-          CRM_Contribute_BAO_ContributionPage::recurringNotify(
-            $contributionID,
-            $this->getFirstOrLastInSeriesStatus(),
-            $contributionRecur
-          );
-        }
+        $this->recur($input);
         return;
       }
 
@@ -271,7 +277,7 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
         Civi::log()->debug('Returning since contribution status is not handled');
         return;
       }
-      $this->single($input, $contribution);
+      $this->single($input);
     }
     catch (CRM_Core_Exception $e) {
       Civi::log()->debug($e->getMessage() . ' input {input}', ['input' => $input]);
@@ -380,26 +386,6 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
   }
 
   /**
-   * Get status code for first or last recurring in the series.
-   *
-   * If this is the first or last then return the status code, else
-   * null.
-   *
-   * @return string|null
-   * @throws \CRM_Core_Exception
-   */
-  protected function getFirstOrLastInSeriesStatus(): ?string {
-    $subscriptionPaymentStatus = NULL;
-    if ($this->getTrxnType() === 'subscr_signup') {
-      return CRM_Core_Payment::RECURRING_PAYMENT_START;
-    }
-    if ($this->getTrxnType() === 'subscr_eot') {
-      return CRM_Core_Payment::RECURRING_PAYMENT_END;
-    }
-    return NULL;
-  }
-
-  /**
    * Get the recurring contribution ID.
    *
    * @return int|null
@@ -440,15 +426,17 @@ class CRM_Core_Payment_PayPalIPN extends CRM_Core_Payment_BaseIPN {
    * @throws \CRM_Core_Exception
    */
   protected function getContribution(): CRM_Contribute_BAO_Contribution {
-    $contribution = new CRM_Contribute_BAO_Contribution();
-    $contribution->id = $this->getContributionID();
-    if (!$contribution->find(TRUE)) {
-      throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: "]);
+    if (!$this->contribution) {
+      $this->contribution = new CRM_Contribute_BAO_Contribution();
+      $this->contribution->id = $this->getContributionID();
+      if (!$this->contribution->find(TRUE)) {
+        throw new CRM_Core_Exception('Failure: Could not find contribution record for ' . (int) $contribution->id, NULL, ['context' => "Could not find contribution record: {$contribution->id} in IPN request: "]);
+      }
+      if ((int) $this->contribution->contact_id !== $this->getContactID()) {
+        CRM_Core_Error::debug_log_message("Contact ID in IPN not found but contact_id found in contribution.");
+      }
     }
-    if ((int) $contribution->contact_id !== $this->getContactID()) {
-      CRM_Core_Error::debug_log_message("Contact ID in IPN not found but contact_id found in contribution.");
-    }
-    return $contribution;
+    return $this->contribution;
   }
 
 }

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -25,16 +25,6 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   protected $_customFieldID;
 
   /**
-   * Should financials be checked after the test but before tear down.
-   *
-   * Ideally all tests (or at least all that call any financial api calls ) should do this but there
-   * are some test data issues and some real bugs currently blockinng.
-   *
-   * @var bool
-   */
-  protected $isValidateFinancialsOnPostAssert = TRUE;
-
-  /**
    * Set up function.
    */
   public function setUp(): void {
@@ -63,7 +53,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    * Test IPN response updates contribution and invoice is attached in mail reciept
    *
    * The scenario is that a pending contribution exists and the IPN call will update it to completed.
-   * And also if Tax and Invoicing is enabled, this unit test ensure that invoice pdf is attached with email recipet
+   * And also if Tax and Invoicing is enabled, this unit test ensure that invoice pdf is attached with email receipt
    *
    * @throws \CRM_Core_Exception
    */
@@ -90,8 +80,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $_REQUEST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $this->getPaypalTransaction();
 
     $mut = new CiviMailUtils($this, TRUE);
-    $paymentProcesors = $this->callAPISuccessGetSingle('PaymentProcessor', ['id' => $this->_paymentProcessorID]);
-    $payment = Civi\Payment\System::singleton()->getByProcessor($paymentProcesors);
+    $payment = Civi\Payment\System::singleton()->getByProcessor($this->callAPISuccessGetSingle('PaymentProcessor', ['id' => $this->_paymentProcessorID]));
     $payment->handlePaymentNotification();
 
     // Check if invoice pdf is attached with contribution mail reciept
@@ -145,7 +134,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(2, $contributions['count']);
     $contribution2 = $contributions['values'][1];
-    $this->assertEquals('secondone', $contribution2['trxn_id']);
+    $this->assertEquals('second_one', $contribution2['trxn_id']);
     $paramsThatShouldMatch = [
       'total_amount',
       'net_amount',
@@ -177,7 +166,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertEquals(1, $contribution['contribution_status_id']);
     $this->assertEquals('8XA571746W2698126', $contribution['trxn_id']);
     // source gets set by processor
-    $this->assertTrue(substr($contribution['contribution_source'], 0, 20) === "Online Contribution:");
+    $this->assertSame(substr($contribution['contribution_source'], 0, 20), 'Online Contribution:');
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurSubsequentTransaction());
@@ -189,7 +178,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'sequential' => 1,
     ]);
     $this->assertEquals(2, $contribution['count']);
-    $this->assertEquals('secondone', $contribution['values'][1]['trxn_id']);
+    $this->assertEquals('second_one', $contribution['values'][1]['trxn_id']);
     $this->callAPISuccessGetCount('line_item', [
       'entity_id' => $this->ids['membership'],
       'entity_table' => 'civicrm_membership',
@@ -227,7 +216,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   /**
    * Get IPN style details for an incoming paypal standard transaction.
    */
-  public function getPaypalTransaction() {
+  public function getPaypalTransaction(): array {
     return [
       'contactID' => $this->_contactID,
       'contributionID' => $this->_contributionID,
@@ -240,7 +229,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'payment_status' => 'Completed',
       'receiver_email' => 'sunil._1183377782_biz_api1.webaccess.co.in',
       'txn_type' => 'web_accept',
-      'last_name' => 'Roberty',
+      'last_name' => 'Robert',
       'payment_fee' => '0.63',
       'first_name' => 'Robert',
       'txn_id' => '8XA571746W2698126',
@@ -254,17 +243,21 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    *
    * @return array
    */
-  public function getPaypalRecurSubsequentTransaction() {
-    return array_merge($this->getPaypalRecurTransaction(), ['txn_id' => 'secondone']);
+  public function getPaypalRecurSubsequentTransaction(): array {
+    return array_merge($this->getPaypalRecurTransaction(), ['txn_id' => 'second_one']);
   }
 
   /**
-   * Test IPN response updates contribution and invoice is attached in mail reciept
-   * Test also AlterIPNData intercepts at the right point and allows for custom processing
-   * The scenario is that a pending contribution exists and the IPN call will update it to completed.
-   * And also if Tax and Invoicing is enabled, this unit test ensure that invoice pdf is attached with email recipet
+   * Test IPN response updates contribution and invoice is attached in mail
+   * reciept Test also AlterIPNData intercepts at the right point and allows
+   * for custom processing The scenario is that a pending contribution exists
+   * and the IPN call will update it to completed. And also if Tax and
+   * Invoicing is enabled, this unit test ensure that invoice pdf is attached
+   * with email receipt
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testhookAlterIPNDataOnIPNPaymentSuccess() {
+  public function testHookAlterIPNDataOnIPNPaymentSuccess(): void {
 
     $pendingStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
     $completedStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
@@ -286,20 +279,23 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     global $_REQUEST;
     $_REQUEST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $this->getPaypalTransaction();
 
-    $mut = new CiviMailUtils($this, TRUE);
     CRM_Core_Payment::handlePaymentMethod('PaymentNotification', ['processor_id' => $this->_paymentProcessorID]);
 
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $this->_contributionID, 'sequential' => 1]);
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
     $this->assertEquals($_REQUEST['txn_id'], $contribution['trxn_id']);
     $this->assertEquals($completedStatusID, $contribution['contribution_status_id']);
-    $this->assertEquals('test12345', $contribution['custom_' . $this->_customFieldID]);
+    $this->assertEquals('test12345', $contribution['custom_' . $this->ids['CustomField']['Contribution']]);
   }
 
   /**
-   * Allow IPNs to validate when the supplied contact_id has been deleted from the database but there is a valid contact id in the contribution recur object or contribution object
+   * Allow IPNs to validate when the supplied contact_id has been deleted from
+   * the database but there is a valid contact id in the contribution recur
+   * object or contribution object
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testPayPalIPNSuccessDeletedContact() {
+  public function testPayPalIPNSuccessDeletedContact(): void {
     $contactTobeDeleted = $this->individualCreate();
     $pendingStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
     $completedStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
@@ -322,7 +318,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     global $_REQUEST;
     $_REQUEST = ['q' => CRM_Utils_System::url('civicrm/payment/ipn/' . $this->_paymentProcessorID)] + $payPalIPNParams;
     // Now process the IPN noting that the contact id that was supplied with the IPN has been deleted but there is still a valid one on the contribution id
-    $payment = CRM_Core_Payment::handlePaymentMethod('PaymentNotification', ['processor_id' => $this->_paymentProcessorID]);
+    CRM_Core_Payment::handlePaymentMethod('PaymentNotification', ['processor_id' => $this->_paymentProcessorID]);
 
     $contribution = $this->callAPISuccess('contribution', 'get', ['id' => $this->_contributionID, 'sequential' => 1]);
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
@@ -333,18 +329,18 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
   /**
    * Store Custom data passed in from the PayPalIPN in a custom field
    */
-  public function hookCiviCRMAlterIPNData($data) {
+  public function hookCiviCRMAlterIPNData($data): void {
     if (!empty($data['custom'])) {
       $customData = json_decode($data['custom'], TRUE);
-      $customField = $this->callAPISuccess('custom_field', 'get', ['label' => 'TestCustomFieldIPNHook']);
-      $this->callAPISuccess('contribution', 'create', ['id' => $this->_contributionID, 'custom_' . $customField['id'] => $customData['cgid']]);
+      $customField = $this->callAPISuccess('CustomField', 'get', ['label' => 'TestCustomFieldIPNHook']);
+      $this->callAPISuccess('Contribution', 'create', ['id' => $this->_contributionID, 'custom_' . $customField['id'] => $customData['cgid']]);
     }
   }
 
   /**
    * @return array
    */
-  protected function createCustomField() {
+  protected function createCustomField(): array {
     $customGroup = $this->customGroupCreate(['extends' => 'Contribution']);
     $fields = [
       'label' => 'TestCustomFieldIPNHook',
@@ -352,8 +348,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'html_type' => 'Text',
       'custom_group_id' => $customGroup['id'],
     ];
-    $field = CRM_Core_BAO_CustomField::create($fields);
-    $this->_customFieldID = $field->id;
+    $this->ids['CustomField']['Contribution'] = $this->callAPISuccess('CustomField', 'create', $fields)['id'];
     return $customGroup;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[Move recurring handling to recur function in PaypalIPN](https://github.com/civicrm/civicrm-core/commit/25bcecf487b1bb46a3ad36fd75494c73bb25f0b4)

Before
----------------------------------------
The code looks like

```
    if ($this->getContributionRecurID()) {
       - load the recurring contribution
       -- figure out if it is the first contribution
       - call recur with these values
       - send a nofitifcation if applicable
       - return, end processing
    }

   function(recur)  {
   --- do recurring stuff
   }
   
```

After
----------------------------------------

```
    if ($this->getContributionRecurID()) {
         - call recur
          - return, end processing
    }

   function(recur)  {
          - load the recurring contribution
       -- figure out if it is the first contribution
   --- do recurring stuff
       - send a nofitifcation if applicable
   
```

Technical Details
----------------------------------------
This builds on earlier cleanup which makes this separation an easy next step

Comments
----------------------------------------
