### PR TITLE
-not-yet-mergeable - A.net to fix - Add deprecation notice to calling `repeatTransaction` via `completeOrder`

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3816,6 +3816,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public static function completeOrder($input, $recurringContributionID, $contributionID, $isPostPaymentCreate = FALSE) {
     if (!$contributionID) {
+      CRM_Core_Error::deprecatedWarning('call the v3 Contribution.repeattransaction api');
       return self::repeatTransaction($input, $recurringContributionID);
     }
     $transaction = new CRM_Core_Transaction();


### PR DESCRIPTION
Overview
----------------------------------------
Add deprecation notice to calling `repeatTransaction` via `completeOrder`
Builds on https://github.com/civicrm/civicrm-core/pull/26557

Before
----------------------------------------
Not sure which code is still going through this path

After
----------------------------------------
We will soon know

Technical Details
----------------------------------------

Comments
----------------------------------------
