### PR TITLE
extensions/uplang#6 Fix menu description translations on the Administration Console

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -541,8 +541,11 @@ class CRM_Core_I18n {
         $this->localizeTitles($value);
         $array[$key] = $value;
       }
-      elseif ((string ) $key == 'title') {
-        $array[$key] = ts($value, ['context' => 'menu']);
+      else {
+        $key = (string) $key;
+        if ($key == 'title' || $key == 'desc') {
+          $array[$key] = ts($value, ['context' => 'menu']);
+        }
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

The descriptions displayed on the Administration Console (Administer > Console) were not being localized.

Before
----------------------------------------

English only descriptions:

![image](https://github.com/civicrm/civicrm-core/assets/254741/f798a81d-d8a7-4a42-894f-6f2f4239b9e6)

After
----------------------------------------

Translation works, assuming:

- The descriptions are now extracted by the string extraction tools (https://lab.civicrm.org/dev/translation/-/commit/a4608b6a7b38ed599a715546769b7422d37c97f3)
- The strings have been translated on Transifex (strings were updated yesterday, but it will take a while for translators to do their magic)
- The CiviCRM site has updated their local translations (either manually, or using an extension such as [uplang](https://civicrm.org/extensions/update-language-files))


Comments
----------------------------------------

The fix is a bit meh, style-wise. Any better ways of doing this?