### PR TITLE
Remove 'Payment Amount (most recent)' column from membership report

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -178,10 +178,7 @@ class CRM_Report_Form_Member_Detail extends CRM_Report_Form {
           'receipt_date' => NULL,
           'fee_amount' => NULL,
           'net_amount' => NULL,
-          'total_amount' => [
-            'title' => ts('Payment Amount (most recent)'),
-            'statistics' => ['sum' => ts('Amount')],
-          ],
+          'total_amount' => NULL,
         ],
         'filters' => [
           'receive_date' => ['operatorType' => CRM_Report_Form::OP_DATE],


### PR DESCRIPTION
Overview
----------------------------------------
As per [https://github.com/civicrm/civicrm-core/pull/26111#issuecomment-1525844282](https://github.com/civicrm/civicrm-core/pull/26111#issuecomment-1525844282)

Before
----------------------------------------
The `Payment Amount (most recent)` column doesn't make sense.

After
----------------------------------------
The `Payment Amount (most recent)` column is removed.

Technical Details
----------------------------------------

Comments
----------------------------------------

