### PR TITLE
Do not generate unshared variable in shared `processMessageTemplate`

### DIFF
--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -473,17 +473,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     //time being hack to strip '&nbsp;'
     //from particular letter line, CRM-6798
     $this->formatMessage($html_message);
-
-    $messageToken = CRM_Utils_Token::getTokens($html_message);
-
-    $returnProperties = [];
-    if (isset($messageToken['contact'])) {
-      foreach ($messageToken['contact'] as $key => $value) {
-        $returnProperties[$value] = 1;
-      }
-    }
-
-    return [$formValues, $html_message, $messageToken, $returnProperties];
+    return [$formValues, $html_message];
   }
 
   /**

--- a/CRM/Member/Form/Task/PDFLetter.php
+++ b/CRM/Member/Form/Task/PDFLetter.php
@@ -86,8 +86,8 @@ class CRM_Member_Form_Task_PDFLetter extends CRM_Member_Form_Task {
   public function postProcessMembers($membershipIDs, $contactIDs) {
     $form = $this;
     $formValues = $form->controller->exportValues($form->getName());
-    [$formValues, $html_message, $messageToken] = $this->processMessageTemplate($formValues);
-
+    [$formValues, $html_message] = $this->processMessageTemplate($formValues);
+    $messageToken = CRM_Utils_Token::getTokens($html_message);
     $html
       = $this->generateHTML(
       $membershipIDs,

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
@@ -56,7 +56,7 @@ class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
       'radio_ts' => 'ts_sel',
       'task' => CRM_Member_Task::PDF_LETTER,
     ]);
-    list($formValues, $html_message, $messageToken, $returnProperties) = $form->processMessageTemplate($formValues);
+    list($formValues) = $form->processMessageTemplate($formValues);
     list($html_message, $zip) = CRM_Utils_PDF_Document::unzipDoc($formValues['document_file_path'], $formValues['document_type']);
 
     foreach ($this->_contactIds as $item => $contactId) {


### PR DESCRIPTION
Overview
----------------------------------------
Do not generate unshared variable in shared `processMessagedTemplate`

Before
----------------------------------------
Only one of the places that calls `processMessageTemplate` uses either of the last 2 variables

![image](https://github.com/civicrm/civicrm-core/assets/336308/59f8e618-feb7-4c71-8f01-77758957066f)

The only universe call is in fact calling a legacy (now removed) class not this
![image](https://github.com/civicrm/civicrm-core/assets/336308/47b755b6-cfb5-4f22-b281-477020781fa8)


After
----------------------------------------
The last 2 values are not returned. The one that is quasi-needed is calculated in the Membership class

Technical Details
----------------------------------------

Comments
----------------------------------------
