### PR TITLE
Fix broken event message template preview

### DIFF
--- a/CRM/Event/WorkflowMessage/EventOnlineReceipt.php
+++ b/CRM/Event/WorkflowMessage/EventOnlineReceipt.php
@@ -21,6 +21,7 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
  */
 class CRM_Event_WorkflowMessage_EventOnlineReceipt extends GenericWorkflowMessage {
   use CRM_Event_WorkflowMessage_ParticipantTrait;
+  use CRM_Contribute_WorkflowMessage_ContributionTrait;
   public const WORKFLOW = 'event_online_receipt';
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
Fix broken event message template preview

Before
----------------------------------------
event online registraition template preview fails with a js error

![image](https://github.com/civicrm/civicrm-core/assets/336308/6fd8567d-c8b6-4ef1-a9f8-cd58401da582)


After
----------------------------------------
event online registraition template previews

![image](https://github.com/civicrm/civicrm-core/assets/336308/7a5e1022-5181-4dbb-a90a-a6bcfbbb4f3f)

Technical Details
----------------------------------------
This is outside most live use cases but it currently fails on an api error due to a mismatch between example data & expectations.

Breakage in https://github.com/civicrm/civicrm-core/commit/54caa518c1e472d4a73848668c9e17016212476c#diff-32748b0ded3d7cf196ce73c579967f4ef44cb41a4444b4416dd4a0c2c52123d0R64 in 5.63 rc

Comments
----------------------------------------
