### PR TITLE
Remove unused line item variable from signature

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -246,8 +246,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $feeBlock = $this->_values['fee'];
-    $lineItems = $this->_values['line_items'];
-    CRM_Price_BAO_LineItem::changeFeeSelections($params, $this->_participantId, 'participant', $this->getContributionID(), $feeBlock, $lineItems);
+    CRM_Price_BAO_LineItem::changeFeeSelections($params, $this->_participantId, 'participant', $this->getContributionID(), $feeBlock);
     $this->contributionAmt = CRM_Core_DAO::getFieldValue('CRM_Contribute_BAO_Contribution', $this->getContributionID(), 'total_amount');
     // email sending
     if (!empty($params['send_receipt'])) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1395,8 +1395,6 @@ DESC limit 1");
         return;
       }
 
-      // fetch lineitems by updated membership ID
-      $lineItems = CRM_Price_BAO_LineItem::getLineItems($this->getMembershipID(), 'membership');
       // retrieve the related contribution ID
       $contributionID = CRM_Core_DAO::getFieldValue(
         'CRM_Member_DAO_MembershipPayment',
@@ -1423,8 +1421,7 @@ DESC limit 1");
         $this->getMembershipID(),
         'membership',
         $contributionID,
-        $priceSetDetails['fields'],
-        $lineItems
+        $priceSetDetails['fields']
       );
       CRM_Core_Session::setStatus(ts('Associated contribution is updated on membership type change.'), ts('Success'), 'success');
     }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -618,7 +618,6 @@ WHERE li.contribution_id = %1";
    * @param int $entity
    * @param int $contributionId
    * @param $feeBlock
-   * @param array $lineItems
    *
    * @throws \CRM_Core_Exception
    */
@@ -627,10 +626,9 @@ WHERE li.contribution_id = %1";
     $entityID,
     $entity,
     $contributionId,
-    $feeBlock,
-    $lineItems
+    $feeBlock
   ) {
-    $entityTable = "civicrm_" . $entity;
+    $entityTable = 'civicrm_' . $entity;
     $newLineItems = [];
     CRM_Price_BAO_PriceSet::processAmount($feeBlock,
       $params, $newLineItems

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -288,19 +288,17 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $this->registerParticipantAndPay();
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;
-    $lineItem = $this->getParticipantLineItems();
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->balanceCheck($this->_cheapFee);
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->expensiveFeeValueID;
-    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->ids['Participant']['order']);
 
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
 
     $this->balanceCheck($this->_expensiveFee);
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->balanceCheck($this->_veryExpensive);
   }
 
@@ -315,7 +313,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $this->assertEquals($this->callAPISuccessGetValue('Contribution', ['id' => $this->ids['Contribution']['order'], 'return' => 'contribution_status_id']), $partiallyPaidContributionStatus);
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->assertEquals($this->callAPISuccessGetValue('Contribution', ['id' => $this->ids['Contribution']['order'], 'return' => 'contribution_status_id']), $partiallyPaidContributionStatus);
   }
 
@@ -328,13 +326,13 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $this->registerParticipantAndPay();
     $actualPaidAmount = 100;
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->expensiveFeeValueID;
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->balanceCheck($this->_expensiveFee);
     $contributionBalance = ($this->_expensiveFee - $actualPaidAmount);
     $this->assertEquals($contributionBalance, CRM_Contribute_BAO_Contribution::getContributionBalance($this->ids['Contribution']['order']));
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->balanceCheck($this->_cheapFee);
     $contributionBalance = ($this->_cheapFee - $actualPaidAmount);
     $this->assertEquals($contributionBalance, CRM_Contribute_BAO_Contribution::getContributionBalance($this->ids['Contribution']['order']));
@@ -425,10 +423,10 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     // CASE 2: Choose text price qty 3 (x$10 = $30 amount)
     $priceSetParams['price_' . $this->priceSetFieldID] = 3;
     $lineItem = $this->getParticipantLineItems();
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $participant['id'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $participant['id'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
 
     // CASE 3: Choose text price qty 2 (x$10 = $20 amount)
-    CRM_Price_BAO_LineItem::changeFeeSelections(['price_' . $this->priceSetFieldID => 2], $participant['id'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections(['price_' . $this->priceSetFieldID => 2], $participant['id'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
 
     $financialItems = $this->callAPISuccess('FinancialItem', 'Get', [
       'entity_table' => 'civicrm_line_item',
@@ -485,7 +483,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->ids['Participant']['order']);
     $this->assertEquals($this->_expensiveFee, $lineItem[1]['line_total']);
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
 
     $this->validateContribution($this->_cheapFee, 'Pending refund');
 
@@ -493,7 +491,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $lineItem = $this->getParticipantLineItems();
     $this->assertEquals('0.00', $lineItem[1]['line_total']);
     $this->assertEquals($this->_cheapFee, $lineItem[2]['line_total']);
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->validateContribution($this->_cheapFee, 'Completed');
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
@@ -502,7 +500,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $this->assertEquals('0.00', $lineItem[2]['line_total']);
     // @todo this doesn't seem to work right even tho it should
     //$this->assertDBCompareValue('CRM_Contribute_BAO_Contribution', $this->ids['Contribution']['order'], 'total_amount', 'id', $this->_expensiveFee, "Total Amount equals " . $this->_expensiveFee);
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->ids['Participant']['order']);
     $this->assertEquals('0.00', $lineItem[1]['line_total']);
     $this->assertEquals('0.00', $lineItem[2]['line_total']);
@@ -519,14 +517,14 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
     $this->registerParticipantAndPay();
     $actualPaidAmount = 100;
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->expensiveFeeValueID;
-    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID);
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->balanceCheck($this->_expensiveFee);
     $contributionBalance = ($this->_expensiveFee - $actualPaidAmount);
     $this->assertEquals($contributionBalance, CRM_Contribute_BAO_Contribution::getContributionBalance($this->ids['Contribution']['order']));
 
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->noFeeID;
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $this->getParticipantLineItems());
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $this->balanceCheck($this->_noFee);
     $contributionBalance = ($this->_noFee - $actualPaidAmount);
     $this->assertEquals($contributionBalance, CRM_Contribute_BAO_Contribution::getContributionBalance($this->ids['Contribution']['order']));
@@ -569,8 +567,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
   public function testPartialPaymentEntries(): void {
     $this->registerParticipantAndPay($this->_expensiveFee);
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->veryExpensiveFeeValueID;
-    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID);
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item'])['values'];
     $this->assertCount(3, $actualResults);
     $expectedResults = [
@@ -610,8 +607,7 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
   public function testRefundPaymentEntries(): void {
     $this->registerParticipantAndPay($this->_expensiveFee);
     $priceSetParams['price_' . $this->priceSetFieldID] = $this->cheapFeeValueID;
-    $lineItem = CRM_Price_BAO_LineItem::getLineItems($this->participantID);
-    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock, $lineItem);
+    CRM_Price_BAO_LineItem::changeFeeSelections($priceSetParams, $this->ids['Participant']['order'], 'participant', $this->ids['Contribution']['order'], $this->_feeBlock);
     $actualResults = $this->callAPISuccess('EntityFinancialTrxn', 'get', ['sequential' => 1, 'entity_table' => 'civicrm_financial_item', 'return' => ['amount', 'entity_id']])['values'];
     $expectedResults = [
       [


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused line item variable from signature

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/eafd1500-a9e6-4acd-ab65-e749a901523c)


After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------
I am not going to remove the variable from the test with a currently open pr