### PR TITLE
dev/core#4377 Disable broken Also Include for event scheduled reminders

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Form/ScheduleReminders.hlp
@@ -19,7 +19,7 @@
 
 {htxt id="limit_to"}
   <p>{ts}Select 'Limit to' if you want to only send reminders to contacts with the criteria selected above AND who ALSO match this criteria. If you select 'Choose Recipients' - only the chosen contacts will receive the reminder (AND only if they ALSO match the criteria above).{/ts}</p>
-  <p>{ts}Select 'Also include' if you want to also send reminders to contacts who match this criteria. If you select 'Choose Recipients' - the chosen contacts will also receive the reminder (in ADDITION TO the contacts who match the criteria above).{/ts}</p>
+  <p>{ts}Select 'Also include' if you want to also send reminders to contacts who match this criteria. If you select 'Choose Recipients' - the chosen contacts will also receive the reminder (in ADDITION TO the contacts who match the criteria above).{/ts} {ts}You can't also include contacts when the reminder is for an event.{/ts}</p>
 {/htxt}
 
 {htxt id="recipient"}

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -224,7 +224,7 @@
         $('#limit_to', $form).toggle(!($('#entity_0', $form).val() == '1'));
         if ($('#entity_0', $form).val() != '1' || !($('#entity_0').length)) {
           // Some Event entity is selected.
-          if (['2', '3', '5'].includes($('#entity_0', $form).val())) {
+          if (['2', '3', '5'].includes($('#entity_0', $form).val()) || {/literal}'{$context}'{literal} === 'event') {
             $('#limit_to option[value="2"]', $form).attr('disabled','disabled').removeAttr('selected');
           }
           else {


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #23101. Also Include did not actually work for event scheduled reminders, but it will still an available option through Manage Event.

Before
----------------------------------------
Also Include enabled from Manage Event.

After
----------------------------------------
Also Include disabled from Manage Event. Also added help text and added a missing ts.