### PR TITLE
dev/core#4383 - Crash for lesser-permissioned users

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -265,10 +265,12 @@ ORDER BY a.object_id
    AND   a.object_id IN (%1)
 ORDER BY a.object_id
 ";
-      $denyDao = CRM_Core_DAO::executeQuery($denyQuery, [1 => [implode(',', $ids), 'CommaSeparatedIntegers']]);
-      while ($denyDao->fetch()) {
-        $key = array_search($denyDao->object_id, $ids);
-        unset($ids[$key]);
+      if (!empty($ids)) {
+        $denyDao = CRM_Core_DAO::executeQuery($denyQuery, [1 => [implode(',', $ids), 'CommaSeparatedIntegers']]);
+        while ($denyDao->fetch()) {
+          $key = array_search($denyDao->object_id, $ids);
+          unset($ids[$key]);
+        }
       }
 
       if (!empty($ids)) {

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1457,4 +1457,28 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       ]));
   }
 
+  public function testCreateWithLesserPermissions() {
+    $this->setUpACLByCheating();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
+    $params = [
+      'contact_id_a' => $this->_cId_a,
+      'contact_id_b' => $this->_cId_b,
+      'relationship_type_id' => $this->relationshipTypeID,
+    ];
+    $id = $this->callAPISuccess('Relationship', 'create', $params)['id'];
+    $relationship = $this->callAPISuccess('Relationship', 'getsingle', ['id' => $id]);
+    $this->assertEquals($params, array_intersect_key($relationship, $params));
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_acl");
+  }
+
+  /**
+   * Normally a stock install has some acls in the table even if they aren't in
+   * use. I can't figure out how to set them up another way so I just lifted
+   * this from civicrm_generated.mysql
+   */
+  private function setUpACLByCheating() {
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_saved_search', 0, NULL, NULL, 1)");
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Core ACL',0,'civicrm_acl_role',0,'All','access CiviMail subscribe/unsubscribe pages',NULL,NULL,NULL,1)");
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4383

Before
----------------------------------------
You can see this with something as simple as `cv ev "civicrm_api3('Relationship', 'create', ['contact_id_a' => 8, 'contact_id_b' => 9, 'relationship_type_id' => 'Sibling of']);"`
where 8 and 9 are suitable individual contacts.

=> `One of parameters (value: ) is not of the type CommaSeparatedIntegers`

After
----------------------------------------


Technical Details
----------------------------------------
It actually happens during the CRM_Utils_Recent::add(), but it's because https://github.com/civicrm/civicrm-core/pull/26041/files#diff-7fd1affe37f9de9a37acf9decf9cecb5433999cf097eccda8b1f2af2286c32e3R268 assumes the loop above will populate ids.

Comments
----------------------------------------
This maybe should have triggered a test run fail earlier but the stock tests don't have anything in the acl tables like a real install. A real install always has something even if not in use.
