### PR TITLE
Don't show pay_later processor on additional live Payment

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -697,7 +697,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
     if (!$this->_mode) {
       return;
     }
-    $js = ($isBuildRecurBlock ? ['onChange' => "buildRecurBlock( this.value ); return false;"] : NULL);
+    $js = ($isBuildRecurBlock ? ['onChange' => "buildRecurBlock( this.value ); return false;"] : []);
     if ($isBuildAutoRenewBlock) {
       $js = ['onChange' => "buildAutoRenew( null, this.value, '{$this->_mode}');"];
     }

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -191,7 +191,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     }
 
     CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, CRM_Utils_Request::retrieve('payment_instrument_id', 'Integer'));
-    $this->add('select', 'payment_processor_id', ts('Payment Processor'), $this->_processors, NULL, ['class' => 'crm-select2']);
+    $this->addPaymentProcessorSelect(FALSE);
 
     $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialTrxn');
 


### PR DESCRIPTION
Overview
----------------------------------------

Reviewers commit of https://github.com/civicrm/civicrm-core/pull/26509 which went stale when https://github.com/civicrm/civicrm-core/pull/26502 was merged. In testing I hit an error 

Note this is when Submit Credit Card payment is selected - record payment is unaffected

![image](https://github.com/civicrm/civicrm-core/assets/336308/706b8dd5-d49b-4871-80e0-80e7ff96a616)


Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/c6b53f6c-3d9a-4eb4-be52-b3293d42a33c)


pay_later shown on Additional Payment live mode.

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/04adcc6f-133c-430a-9ed2-7d9c7f33f13d)

Technical details 
-------------------------------------------
On review I hit a type error when there is no js which I fixed by defaulting to `[]` not `NULL`

![image](https://github.com/civicrm/civicrm-core/assets/336308/0b5a28a2-0fd3-4283-9566-aabcbb5731cb)
