### PR TITLE
dev/core#4386 Fix contact tags added using civirules for contact form

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1008,6 +1008,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     if (array_key_exists('TagsAndGroups', $this->_editOptions)) {
       //add contact to tags
       if (isset($params['tag'])) {
+        if ($this->_action & CRM_Core_Action::ADD) {
+          $existingTags = CRM_Core_BAO_EntityTag::getTag($params['contact_id'], 'civicrm_contact');
+          $params['tag'] = implode(',', $existingTags);
+        }
         $params['tag'] = array_flip(explode(',', $params['tag']));
         CRM_Core_BAO_EntityTag::create($params['tag'], 'civicrm_contact', $params['contact_id']);
       }


### PR DESCRIPTION
Overview
----------------------------------------

This PR fixes the issue with Contact Tags when used with the CiviRules extension. There is an issue where adding tags to a contact does not work as expected when adding a new contact using the contact form. The problem arises when a rule is triggered for the "Add Tag to Contact" action, which causes it to remove any tags added by CiviRules before saving the contact form.

Issue - https://lab.civicrm.org/dev/core/-/issues/4386

Before
----------------------------------------
![issue_civirules](https://github.com/civicrm/civicrm-core/assets/2689257/3fe8d201-21c2-461a-83f9-602934520f0e)

After
----------------------------------------
![issue_civirules_after](https://github.com/civicrm/civicrm-core/assets/2689257/8f91a9ca-f2e8-4c79-9494-54914c96a278)

Technical Details
----------------------------------------

- While adding a new contact, we check if there are any existing tags added via CiviRules, and then we update the process to handle that case.
