### PR TITLE
Form Builder - Clarify "Security" options

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -44,8 +44,8 @@
       };
 
       this.securityModes = [
-        {id: 'RBAC', icon: 'fa-lock', text: ts('Enforce Permissions')},
-        {id: 'FBAC', icon: 'fa-unlock', text: ts('Open Access')},
+        {id: 'RBAC', icon: 'fa-user', text: ts('User-Based'), description: ts('Inherit permissions based on the current user or role')},
+        {id: 'FBAC', icon: 'fa-file-text', text: ts('Form-Based'), description: ts('Allow access to any fields listed on the form')},
       ];
 
       // Above mode for use with getterSetter


### PR DESCRIPTION
Follow-up to 54354d0430b2331bd8c80f1b5c868b2c668624f1, which was a small thing thrown into the bigger #24832

cc @colemanw 

Before
------

* Originally, "Security" options were labeled as "Role-Based" (RBAC) and "Form-Based" (FBAC)
    * This is confusing, because it packs a subtle distinction into two phrases which are a bit jargony.
* Currently, "Security" options are labeled as "Enforce Permissions" (RBAC) and "Open Access" (FBAC)
    * This is confusing, because "Open Access" wrongly suggests that the access is, well, open. (It's actually dependent on the overall configuration.)

After
-----

* Security is "User-Based" or "Form-Based"
* There is also a longer description.

<img width="364" alt="Screen Shot 2023-06-20 at 3 50 12 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/f7d37899-b226-45f6-ba31-029e0f8891f3">
