### PR TITLE
dev/drupal#186 - UFMatch crash on drupal 9 - minimal RC fix to do like before 5.59 passing on contact_id

### DIFF
--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -179,15 +179,6 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
       if (!empty($_POST) && !$isLogin) {
         $dedupeParameters = $_POST;
         $dedupeParameters['email'] = $uniqId;
-        // dev/core#1858 Ensure that if we have a contactID parameter which is
-        // set in the Create user Record contact task form. That this contactID
-        // value is passed through as the contact_id to the get duplicate
-        // contacts function. This is necessary because for Drupal 8 this
-        // function gets invoked. Before the civicrm_uf_match record is added
-        // where as in D7 it isn't called until the user tries to actually login.
-        if (!empty($dedupeParameters['contactID'])) {
-          $dedupeParameters['contact_id'] = $dedupeParameters['contactID'];
-        }
 
         $ids = CRM_Contact_BAO_Contact::getDuplicateContacts($dedupeParameters, 'Individual', 'Unsupervised', [], FALSE);
 
@@ -239,6 +230,16 @@ AND    domain_id = %2
           'user' => $user,
           'uniqId' => $uniqId,
         ]);
+        // dev/core#1858 Ensure that if we have a contactID parameter
+        // set in the Create user Record contact task form that this contactID
+        // value is passed through as the contact_id to the contact create.
+        // This is necessary because for Drupal 8 synchronizeUFMatch gets
+        // invoked before the civicrm_uf_match record is added whereas in D7
+        // it isn't called until later.
+        // Note this is taken from our dedupeParameters from earlier.
+        if (empty($contactParameters['contact_id']) && !empty($dedupeParameters['contactID'])) {
+          $contactParameters['contact_id'] = $dedupeParameters['contactID'];
+        }
 
         if ($ctype === 'Organization') {
           $contactParameters['organization_name'] = $uniqId;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/drupal/-/issues/186

Alternative to https://github.com/civicrm/civicrm-core/pull/26426

Before
----------------------------------------
1. Set up unsupervised dedupe rules to use e.g. first+last+email, weight 10 each, threshold 30.
2. In drupal 9, use the Create User Record action on a contact from the contact summary.
3. Crash.

After
----------------------------------------


Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/25549/files in 5.59 it separated out the $params from the $params, but the existing code comment about contact_id may have led it astray because it's actually talking about the call to update the contact lower down. So the contact_id got left out and this causes it to create a duplicate contact with just the email address, and then later when when it tries to create the correct ufmatch it fails because it already exists against this duplicate contact.

So this PR just puts contact_id back in again as a minimal fix for the RC.

A more comprehensive fix could be looked at in master/future.

Comments
----------------------------------------

