### PR TITLE
Fix e-notices in contribution_offline_receipt text by removing always-empty field

### DIFF
--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -21,11 +21,7 @@
   <tr>
    <td>
     {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-    {if !empty($formValues.receipt_text)}
-     <p>{$formValues.receipt_text|htmlize}</p>
-    {else}
      <p>{ts}Below you will find a receipt for this contribution.{/ts}</p>
-    {/if}
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -1,8 +1,6 @@
 {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}{$greeting},{/if}
 
-{if !empty($formValues.receipt_text)}
-{$formValues.receipt_text}
-{else}{ts}Below you will find a receipt for this contribution.{/ts}{/if}
+{ts}Below you will find a receipt for this contribution.{/ts}
 
 ===========================================================
 {ts}Contribution Information{/ts}


### PR DESCRIPTION

Overview
----------------------------------------
Fix e-notices in contribution_offline_receipt text by removing always-empty field

Before
----------------------------------------
offline receipt template has a place for the receipt_text field from the form - but there is no receipt text field on the form - this is e-noticey

After
----------------------------------------
poof

Technical Details
----------------------------------------
On looking to fix this enotice through the form it turned out the contribution form does not have a field for this - so the formValues will never hold receipt_text.

Hence this PR removes it from the template.

Other forms do seem to have this & I will separately add userText or similar to the model

Comments
----------------------------------------
