### PR TITLE
dev/core#4381 remove the hardcoded page orientation in civireport

### DIFF
--- a/CRM/Report/OutputHandler/Pdf.php
+++ b/CRM/Report/OutputHandler/Pdf.php
@@ -65,8 +65,7 @@ class CRM_Report_OutputHandler_Pdf extends OutputHandlerBase implements OutputHa
     return CRM_Utils_PDF_Utils::html2pdf(
       $this->getForm()->compileContent(),
       $this->getFileName(),
-      TRUE,
-      ['orientation' => 'landscape']
+      TRUE
     );
   }
 
@@ -90,8 +89,7 @@ class CRM_Report_OutputHandler_Pdf extends OutputHandlerBase implements OutputHa
     CRM_Utils_PDF_Utils::html2pdf(
       $this->getForm()->compileContent(),
       $this->getFileName(),
-      FALSE,
-      ['orientation' => 'landscape']
+      FALSE
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
I was unable to set the orientation for pdf output of reports with these steps:
1. Configure a PDF output format in settings: civicrm/admin/pdfFormats
2. Use the "print PDF letter"-action on a report

Before
----------------------------------------
The pdf would always be in landscape

After
----------------------------------------
After removing the hardcoded page orientation PDF's will be be output according to the settings.
