### PR TITLE
Switch to token for tax_exclusive_amount in offline receipt

### DIFF
--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -113,7 +113,7 @@
            {ts} Amount before Tax : {/ts}
          </td>
          <td {$valueStyle}>
-           {$formValues.total_amount-$totalTaxAmount|crmMoney:'{contribution.currency}'}
+           {contribution.tax_exclusive_amount}
          </td>
        </tr>
 

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -32,7 +32,7 @@
 
 
 {if $isShowTax && {contribution.tax_amount|boolean}}
-{ts}Amount before Tax{/ts} : {$formValues.total_amount-$totalTaxAmount|crmMoney:$currency}
+{ts}Amount before Tax{/ts} : {contribution.tax_exclusive_amount}
 {/if}
 {foreach from=$taxRateBreakdown item=taxDetail key=taxRate}
 {if $taxRate == 0}{ts}No{/ts} {$taxTerm}{else}{$taxTerm} {$taxDetail.percentage}%{/if} : {$taxDetail.amount|crmMoney:'{contribution.currency}'}


### PR DESCRIPTION


Overview
----------------------------------------
Switch to token for tax_exclusive_amount in offline receipt

This is less susceptible to notices, works in preview and follows our patter of using tokens where possible

Before
----------------------------------------
Notices when rendered outside form


After
----------------------------------------
Still renders :-)
![image](https://github.com/civicrm/civicrm-core/assets/336308/5e34e6e4-1d19-4360-af3d-95929a18607d)


Technical Details
----------------------------------------

Comments
----------------------------------------
