### PR TITLE
Switch to generic user_text for form-entered text

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -983,7 +983,7 @@ DESC limit 1");
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'isTest' => (bool) ($this->_action & CRM_Core_Action::PREVIEW),
         'modelProps' => [
-          'receiptText' => $this->getSubmittedValue('receipt_text'),
+          'userText' => $this->getSubmittedValue('receipt_text'),
           'contributionID' => $formValues['contribution_id'],
           'contactID' => $this->_receiptContactId,
           'membershipID' => $this->getMembershipID(),

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -702,7 +702,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         'PDFFilename' => ts('receipt') . '.pdf',
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'modelProps' => [
-          'receiptText' => $this->getSubmittedValue('receipt_text'),
+          'userText' => $this->getSubmittedValue('receipt_text'),
           'contactID' => $this->_receiptContactId,
           'contributionID' => $this->getContributionID(),
           'membershipID' => $this->_membershipId,

--- a/CRM/Member/WorkflowMessage/Membership/Membership.php
+++ b/CRM/Member/WorkflowMessage/Membership/Membership.php
@@ -135,6 +135,7 @@ class CRM_Member_WorkflowMessage_Membership_Membership extends WorkflowMessageEx
     $contribution['tax_amount'] = $mockOrder->getTotalTaxAmount() ? round($mockOrder->getTotalTaxAmount(), 2) : 0;
     $messageTemplate->setContribution($contribution);
     $messageTemplate->setOrder($mockOrder);
+    $messageTemplate->setUserText(ts('Send payment by check'));
     $messageTemplate->setContribution($contribution);
   }
 

--- a/CRM/Member/WorkflowMessage/MembershipOfflineReceipt.php
+++ b/CRM/Member/WorkflowMessage/MembershipOfflineReceipt.php
@@ -25,13 +25,4 @@ class CRM_Member_WorkflowMessage_MembershipOfflineReceipt extends GenericWorkflo
   use CRM_Contribute_WorkflowMessage_ContributionTrait;
   public const WORKFLOW = 'membership_offline_receipt';
 
-  /**
-   * Additional text to include in the receipt.
-   *
-   * @var string
-   *
-   * @scope tplParams as receipt_text
-   */
-  protected $receiptText;
-
 }

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -25,6 +25,8 @@ use Civi\WorkflowMessage\Traits\ReflectiveWorkflowTrait;
  * @method int|null getContactID()
  * @method $this setContact(array|null $contact)
  * @method array|null getContact()
+ * @method string getUserText()
+ * @method setUserText(string $userText)
  *
  * @support template-only
  * GenericWorkflowMessage should aim for "full" support, but it's prudent to keep
@@ -68,6 +70,13 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
    * @fkEntity Contact
    */
   protected $contactID;
+
+  /**
+   * @var string
+   *
+   * @scope tplParams as user_text
+   */
+  protected $userText;
 
   /**
    * @var array|null

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -23,8 +23,8 @@
     <tr>
       <td>
         {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-        {if $receipt_text}
-          <p>{$receipt_text|htmlize}</p>
+        {if $user_text}
+          <p>{$user_text|htmlize}</p>
         {else}
           <p>{ts}Thank you for this contribution.{/ts}</p>
         {/if}


### PR DESCRIPTION


Overview
----------------------------------------
Switch to generic user_text for form-entered text

This changes from membership receipt specific 'receipt_text' to 'user_text' supported on the generic workflow class - to give us one way to do it across forms & templates

Before
----------------------------------------
The variable for user-entered text on receipts is specific to the membership receipt class & the name is receipt which might not always make sense

After
----------------------------------------
The generic workflow assigns `userText` so this will
a) never give off a notice if it is in the templates and
b) can be assigned to any template

Technical Details
----------------------------------------

Comments
----------------------------------------
@larssandergreen - this is what I mean