### PR TITLE
dev/core#2549

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -266,7 +266,8 @@ class CRM_Dedupe_Merger {
   public static function locTables() {
     static $locTables;
     if (!$locTables) {
-      $locTables = ['civicrm_email', 'civicrm_address', 'civicrm_phone'];
+      // should be in sync with getLocationBlockInfo
+      $locTables = ['civicrm_email', 'civicrm_address', 'civicrm_phone', 'civicrm_im', 'civicrm_website'];
 
       // Allow hook_civicrm_merge() to adjust $locTables
       CRM_Utils_Hook::merge('locTables', $locTables);


### PR DESCRIPTION
Overview
----------------------------------------
c.f. https://lab.civicrm.org/dev/core/-/issues/2549

Before
----------------------------------------
Merging contact always merge websites even if the checkbox to copy is not checked

Comments
----------------------------------------
There is a special treatment for table with location that are found in CRM/Dedupe/Merger.php::getLocationBlockInfo

Even if the websites does not have a location, they are going through the same process.

Added `civicrm_im` as well which as the same issue.

Ideally `locTables` and `getLocationBlockInfo` should be linked somehow to avoid adding info to one without doing it for the other.
