### PR TITLE
ACL - Ensure all priorities are unique

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -29,7 +29,8 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
 
     if ($this->_action & CRM_Core_Action::ADD) {
       $defaults['object_type'] = 1;
-      $defaults['priority'] = 0;
+      $defaults['deny'] = 0;
+      $defaults['priority'] = 1 + CRM_Utils_Weight::getMax(CRM_ACL_DAO_ACL::class, NULL, 'priority');
     }
 
     $showHide = new CRM_Core_ShowHideBlocks();
@@ -164,8 +165,8 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     $this->addRadio('deny', ts('Mode'), [
       0 => ts('Allow'),
       1 => ts('Deny'),
-    ]);
-    $this->add('number', 'priority', ts('Priority'));
+    ], [], NULL, TRUE);
+    $this->add('number', 'priority', ts('Priority'), ['min' => 1], TRUE);
 
     $this->addFormRule(['CRM_ACL_Form_ACL', 'formRule']);
   }
@@ -288,6 +289,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
         $params['id'] = $this->_id;
       }
 
+      $params['priority'] = \CRM_Utils_Weight::updateOtherWeights(CRM_ACL_DAO_ACL::class, $this->_values['priority'] ?? NULL, $params['priority'], NULL, 'priority');
       CRM_ACL_BAO_ACL::writeRecord($params);
     }
   }

--- a/CRM/Upgrade/Incremental/sql/5.64.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.64.alpha1.mysql.tpl
@@ -1,5 +1,7 @@
 {* file to handle db changes in 5.64.alpha1 during upgrade *}
 
+UPDATE `civicrm_acl` SET `priority` = `id`;
+
 -- fix mis-casing of field name. Note the php function doesn't permit the name change hence it is here
 -- but field is not localised.
 ALTER TABLE civicrm_uf_group

--- a/Civi/Api4/ACL.php
+++ b/Civi/Api4/ACL.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Generic\Traits\SortableEntity;
+
 /**
  * ACL (Access Control List).
  *
@@ -24,8 +26,10 @@ namespace Civi\Api4;
  * @searchable none
  * @see https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control
  * @since 5.19
+ * @orderBy priority
  * @package Civi\Api4
  */
 class ACL extends Generic\DAOEntity {
+  use SortableEntity;
 
 }

--- a/templates/CRM/ACL/Form/ACL.tpl
+++ b/templates/CRM/ACL/Form/ACL.tpl
@@ -51,7 +51,7 @@
      </tr>
      <tr class="crm-acl-form-block-priority">
        <td class="label">{$form.priority.label}</td>
-       <td>{$form.priority.label}<br />
+       <td>{$form.priority.html}<br />
          <span class="description">{ts}Higher priority ACL rules will override lower priority rules{/ts}</span>
        </td>
      </tr>

--- a/templates/CRM/ACL/Page/ACL.tpl
+++ b/templates/CRM/ACL/Page/ACL.tpl
@@ -24,14 +24,14 @@
           <table id="options" class="display">
             <thead>
             <tr class="columnheader">
-              <th id="sortable">{ts}Role{/ts}</th>
+              <th>{ts}Role{/ts}</th>
               <th>{ts}Operation{/ts}</th>
               <th>{ts}Type of Data{/ts}</th>
               <th>{ts}Which Data{/ts}</th>
               <th>{ts}Description{/ts}</th>
               <th>{ts}Enabled?{/ts}</th>
               <th>{ts}Mode{/ts}</th>
-              <th>{ts}Priority{/ts}</th>
+              <th id="sortable">{ts}Priority{/ts}</th>
               <th></th>
             </tr>
             </thead>


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #26041 this ensures each ACL rule has a unique value for `priority`.

Before
----------------------------------------
If two priorities are the same, what to do?

After
----------------------------------------
Dilemma eliminated.
