### PR TITLE
dev/core#4112 Move legacycustomsearch-only function to the extension-class `ContactIDSql`

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -224,32 +224,6 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
   }
 
   /**
-   * Contact IDS Sql (whatever that means!).
-   *
-   * @param int $id
-   *
-   * @return string
-   */
-  public static function contactIDsSQL($id) {
-    $params = self::getSearchParams($id);
-    if ($params && !empty($params['customSearchID'])) {
-      return CRM_Contact_BAO_SearchCustom::contactIDSQL(NULL, $id);
-    }
-    else {
-      $tables = $whereTables = ['civicrm_contact' => 1];
-      $where = CRM_Contact_BAO_SavedSearch::whereClause($id, $tables, $whereTables);
-      if (!$where) {
-        $where = '( 1 )';
-      }
-      $from = CRM_Contact_BAO_Query::fromClause($whereTables);
-      return "
-SELECT contact_a.id
-$from
-WHERE  $where";
-    }
-  }
-
-  /**
    * Deprecated function, gets a value from Group entity
    *
    * @deprecated

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -247,7 +247,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
           if (in_array($values, $smartGroup)) {
             $ssId = CRM_Utils_Array::key($values, $smartGroup);
 
-            $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
+            $smartSql = CRM_Contact_BAO_SearchCustom::contactIDSQL(NULL, $ssId);
 
             $smartSql = $smartSql . " AND contact_a.id NOT IN (
                               SELECT contact_id FROM civicrm_group_contact
@@ -295,7 +295,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
 
           $ssId = CRM_Utils_Array::key($values, $smartGroup);
 
-          $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
+          $smartSql = CRM_Contact_BAO_SearchCustom::contactIDSQL(NULL, $ssId);
 
           $smartSql .= " AND contact_a.id IN (
                                    SELECT id AS contact_id

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/RandomSegment.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/RandomSegment.php
@@ -194,7 +194,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
         if (in_array($values, $smartGroup)) {
           $ssId = CRM_Utils_Array::key($values, $smartGroup);
 
-          $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
+          $smartSql = CRM_Contact_BAO_SearchCustom::contactIDSQL(NULL, $ssId);
 
           $smartSql = $smartSql . " AND contact_a.id NOT IN (
                           SELECT contact_id FROM civicrm_group_contact
@@ -245,7 +245,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
 
         $ssId = CRM_Utils_Array::key($values, $smartGroup);
 
-        $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
+        $smartSql = CRM_Contact_BAO_SearchCustom::contactIDSQL(NULL, $ssId);
 
         $smartSql .= " AND contact_a.id NOT IN (
                                SELECT contact_id FROM civicrm_group_contact


### PR DESCRIPTION

Overview
----------------------------------------
Move legacycustomsearch-only function to the extension-class `ContactIDSql`

Before
----------------------------------------

`contactIDsSQL` is on core class `BAO_SavedSearch` but just calls the custom search class iw a round about way

![image](https://github.com/civicrm/civicrm-core/assets/336308/7af6968f-13cb-40f4-9576-6a3539460666)


After
----------------------------------------
 `ContactIDSql` removed - calls short-circuited


Technical Details
----------------------------------------

Comments
----------------------------------------
