### PR TITLE
Fix ACLs to use the correct name of the civicrm_group table

### DIFF
--- a/CRM/ACL/API.php
+++ b/CRM/ACL/API.php
@@ -148,7 +148,7 @@ class CRM_ACL_API {
   public static function group(
     $type,
     $contactID = NULL,
-    $tableName = 'civicrm_saved_search',
+    $tableName = 'civicrm_group',
     $allGroups = NULL,
     $includedGroups = []
   ) {
@@ -181,7 +181,7 @@ class CRM_ACL_API {
     $type,
     $groupID,
     $contactID = NULL,
-    $tableName = 'civicrm_saved_search',
+    $tableName = 'civicrm_group',
     $allGroups = NULL,
     $includedGroups = NULL
   ) {

--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -234,7 +234,7 @@ SELECT   a.operation, a.object_id
   FROM   civicrm_acl_cache c, civicrm_acl a
  WHERE   c.acl_id       =  a.id
    AND   a.is_active    =  1
-   AND   a.object_table = 'civicrm_saved_search'
+   AND   a.object_table = 'civicrm_group'
    AND   a.id        IN ( $aclKeys )
    AND   a.deny         = 0
 ORDER BY a.object_id
@@ -259,7 +259,7 @@ ORDER BY a.object_id
   FROM   civicrm_acl_cache c, civicrm_acl a
  WHERE   c.acl_id       =  a.id
    AND   a.is_active    =  1
-   AND   a.object_table = 'civicrm_saved_search'
+   AND   a.object_table = 'civicrm_group'
    AND   a.id        IN ( $aclKeys )
    AND   a.deny         = 1
    AND   a.object_id IN (%1)
@@ -333,7 +333,7 @@ SELECT g.*
   public static function group(
     $type,
     $contactID = NULL,
-    $tableName = 'civicrm_saved_search',
+    $tableName = 'civicrm_group',
     $allGroups = NULL,
     $includedGroups = []
   ) {

--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -37,7 +37,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
 
     if (isset($defaults['object_table'])) {
       switch ($defaults['object_table']) {
-        case 'civicrm_saved_search':
+        case 'civicrm_group':
           $defaults['group_id'] = $defaults['object_id'];
           $defaults['object_type'] = 1;
           $showHide->addShow("id-group-acl");
@@ -265,7 +265,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
       // Figure out which type of object we're permissioning on and set object_table and object_id.
       switch ($params['object_type']) {
         case 1:
-          $params['object_table'] = 'civicrm_saved_search';
+          $params['object_table'] = 'civicrm_group';
           $params['object_id'] = $params['group_id'];
           break;
 

--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -142,7 +142,7 @@ class CRM_ACL_Page_ACL extends CRM_Core_Page_Basic {
       }
 
       switch ($acl[$dao->id]['object_table']) {
-        case 'civicrm_saved_search':
+        case 'civicrm_group':
           $acl[$dao->id]['object'] = $group[$acl[$dao->id]['object_id']] ?? NULL;
           $acl[$dao->id]['object_name'] = ts('Group');
           break;

--- a/CRM/Bridge/OG/Drupal.php
+++ b/CRM/Bridge/OG/Drupal.php
@@ -175,7 +175,7 @@ SELECT v.id
   public static function updateCiviACL(&$params, $op) {
     $dao = new CRM_ACL_DAO_ACL();
 
-    $dao->object_table = 'civicrm_saved_search';
+    $dao->object_table = 'civicrm_group';
     $dao->object_id = $params['civicrm_group_id'];
 
     if ($op == 'delete') {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -285,7 +285,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $permissions = NULL;
     if (CRM_Core_Permission::check('edit all contacts') ||
       CRM_ACL_API::groupPermission(CRM_ACL_API::EDIT, $id, NULL,
-        'civicrm_saved_search', $allGroups
+        'civicrm_group', $allGroups
       )
     ) {
       $permissions[] = CRM_Core_Permission::EDIT;
@@ -293,7 +293,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
     if (CRM_Core_Permission::check('view all contacts') ||
       CRM_ACL_API::groupPermission(CRM_ACL_API::VIEW, $id, NULL,
-        'civicrm_saved_search', $allGroups
+        'civicrm_group', $allGroups
       )
     ) {
       $permissions[] = CRM_Core_Permission::VIEW;
@@ -316,8 +316,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $clauses = [];
     if (!CRM_Core_Permission::check([['edit all contacts', 'view all contacts']])) {
       $allGroups = CRM_Core_PseudoConstant::allGroup(NULL, FALSE);
-      // FIXME: TableName 'civicrm_saved_search' seems wrong but is consistent with self::checkPermission
-      $allowedGroups = \CRM_ACL_API::group(CRM_ACL_API::VIEW, NULL, 'civicrm_saved_search', $allGroups);
+      $allowedGroups = \CRM_ACL_API::group(CRM_ACL_API::VIEW, NULL, 'civicrm_group', $allGroups);
       $groupsIn = $allowedGroups ? implode(',', $allowedGroups) : '0';
       $clauses['id'][] = "IN ($groupsIn)";
     }

--- a/CRM/Core/Permission/Base.php
+++ b/CRM/Core/Permission/Base.php
@@ -169,7 +169,7 @@ class CRM_Core_Permission_Base {
         Civi::$statics[__CLASS__]['viewPermissionedGroups_' . $domainId . '_' . $userId][$groupKey] = $groups;
       }
 
-      $ids = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_saved_search', $groups);
+      $ids = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_group', $groups);
       if (!empty($ids)) {
         foreach (array_values($ids) as $id) {
           $title = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $id, 'title');
@@ -178,7 +178,7 @@ class CRM_Core_Permission_Base {
         }
       }
 
-      $ids = CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_saved_search', $groups);
+      $ids = CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_group', $groups);
       if (!empty($ids)) {
         foreach (array_values($ids) as $id) {
           $title = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $id, 'title');

--- a/CRM/Upgrade/Incremental/sql/5.64.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.64.alpha1.mysql.tpl
@@ -4,7 +4,10 @@ UPDATE `civicrm_acl` SET `priority` = `id`;
 
 -- Remove obsolete "Basic ACLs"
 DELETE FROM civicrm_acl
-WHERE object_table NOT IN ('civicrm_saved_search', 'civicrm_uf_group', 'civicrm_custom_group', 'civicrm_event');
+WHERE object_table NOT IN ('civicrm_group', 'civicrm_saved_search', 'civicrm_uf_group', 'civicrm_custom_group', 'civicrm_event');
+
+-- Fix wrong table name
+UPDATE `civicrm_acl` SET `object_table` = 'civicrm_group' WHERE `object_table` = 'civicrm_saved_search';
 
 -- fix mis-casing of field name. Note the php function doesn't permit the name change hence it is here
 -- but field is not localised.

--- a/Civi/Test/ACLPermissionTrait.php
+++ b/Civi/Test/ACLPermissionTrait.php
@@ -125,7 +125,7 @@ trait ACLPermissionTrait {
    * @throws CRM_Core_Exception
    */
   public function setupCoreACLPermittedAcl($permissionedEntities = [], $groupAllowedAccess = 'Everyone', $operation = 'View', $entity = 'Group') {
-    $tableMap = ['Group' => 'civicrm_saved_search', 'CustomGroup' => 'civicrm_custom_group', 'Profile' => 'civicrm_uf_match', 'Event' => 'civicrm_event'];
+    $tableMap = ['Group' => 'civicrm_group', 'CustomGroup' => 'civicrm_custom_group', 'Profile' => 'civicrm_uf_group', 'Event' => 'civicrm_event'];
     $entityTable = $tableMap[$entity];
 
     $permittedRoleID = ($groupAllowedAccess === 'Everyone') ? 0 : $groupAllowedAccess;

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -666,6 +666,9 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
    * @param array $currentGroups
    */
   public function hook_civicrm_aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
+    if ($tableName !== 'civicrm_group') {
+      return;
+    }
     //don't use api - you will get a loop
     $sql = " SELECT * FROM civicrm_group WHERE name LIKE '%pick%'";
     $groups = [];
@@ -734,7 +737,7 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
       `name`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `is_active`
       )
       VALUES (
-      'core-580', 'civicrm_acl_role', 55, 'Edit', 'civicrm_saved_search', 0, 1
+      'core-580', 'civicrm_acl_role', 55, 'Edit', 'civicrm_group', 0, 1
       );
       ");
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -225,6 +225,9 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
    * @param array $currentGroups
    */
   public function hook_civicrm_aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
+    if ($tableName !== 'civicrm_group') {
+      return;
+    }
     //don't use api - you will get a loop
     $sql = " SELECT * FROM civicrm_group";
     $groups = [];

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2182,7 +2182,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       `name`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `is_active`
       )
       VALUES (
-      'view picked', 'civicrm_group', $this->_permissionedGroup , 'Edit', 'civicrm_saved_search', {$this->_permissionedGroup}, 1
+      'view picked', 'civicrm_group', $this->_permissionedGroup , 'Edit', 'civicrm_group', {$this->_permissionedGroup}, 1
       );
       ");
 
@@ -2191,7 +2191,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       `name`, `entity_table`, `entity_id`, `operation`, `object_table`, `object_id`, `is_active`
       )
       VALUES (
-      'view picked', 'civicrm_group',  $this->_permissionedGroup, 'Edit', 'civicrm_saved_search', {$this->_permissionedDisabledGroup}, 1
+      'view picked', 'civicrm_group',  $this->_permissionedGroup, 'Edit', 'civicrm_group', {$this->_permissionedDisabledGroup}, 1
       );
       ");
     }

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -362,8 +362,10 @@ class api_v3_GroupTest extends CiviUnitTestCase {
    * @param array $ids
    */
   public function aclGroupAllGroups($type, $contactID, $tableName, $allGroups, &$ids) {
-    $group = $this->callAPISuccess('Group', 'get', ['name' => 'Test Group 1']);
-    $ids = array_keys($group['values']);
+    if ($tableName === 'civicrm_group') {
+      $group = $this->callAPISuccess('Group', 'get', ['name' => 'Test Group 1']);
+      $ids = array_keys($group['values']);
+    }
   }
 
 }

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1477,8 +1477,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
    * this from civicrm_generated.mysql
    */
   private function setUpACLByCheating() {
-    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_saved_search', 0, NULL, NULL, 1)");
-    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Core ACL',0,'civicrm_acl_role',0,'All','access CiviMail subscribe/unsubscribe pages',NULL,NULL,NULL,1)");
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_group', 0, NULL, NULL, 1)");
   }
 
 }

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -1811,7 +1811,9 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * @param array $ids
    */
   public function aclGroupOnly($type, $contactID, $tableName, $allGroups, &$ids) {
-    $ids = [$this->aclGroupID];
+    if ($tableName === 'civicrm_group') {
+      $ids = [$this->aclGroupID];
+    }
   }
 
   /**

--- a/xml/templates/civicrm_acl.tpl
+++ b/xml/templates/civicrm_acl.tpl
@@ -14,7 +14,7 @@
 -- Create ACL to edit and view contacts in all groups
 INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active, priority)
 VALUES
-('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_saved_search', 0, NULL, NULL, 1, 1);
+('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_group', 0, NULL, NULL, 1, 1);
 
 -- Create default Groups for User Permissioning
 INSERT INTO civicrm_group (`id`, `name`, `title`, `description`, `source`, `saved_search_id`, `is_active`, `visibility`, `group_type`)


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a weird quirk in the ACL code.

Technical Details
----------------------------------------
For unknown historical reasons, group-based ACLs incorrectly used `'civicrm_saved_search'` as the value for `'object_table'` when referencing a Group (the correct name of that table is `'civicrm_group'`).

This updates all ACL records, tests, and strings.

**Hook Update:** Unfortunately that incorrect value was being passed to `hook_civicrm_aclGroup`. This PR deals with that by calling the hook twice with both values. If your hook listener responds to the old `'civicrm_saved_search'` value, it will emit a deprecation notice.