### PR TITLE
Update Recurring end_date when setting status to completed

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -973,6 +973,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     if (!empty($existing['installments']) && self::isComplete($recurringContributionID, $existing['installments'])) {
       $params['contribution_status_id'] = 'Completed';
       $params['next_sched_contribution_date'] = 'null';
+      $params['end_date'] = 'now';
     }
     else {
       // Only update next sched date if it's empty or up to 48 hours away because payment processors may be managing

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -782,6 +782,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     ], $params);
 
     $result = $this->callAPISuccess('PaymentProcessor', 'create', $params);
+    $this->ids['PaymentProcessor']['authorize_net'] = (int) $result['id'];
     return (int) $result['id'];
   }
 
@@ -2335,8 +2336,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'processor_id' => $this->ids['Contact']['individual_0'],
       'api.Order.create' => $contributionParams,
     ], $recurParams))['values'][0];
-    $this->_contributionRecurID = $contributionRecur['id'];
-    $this->_contributionID = $contributionRecur['api.Order.create']['id'];
+    $this->ids['ContributionRecur']['default'] = $this->_contributionRecurID = $contributionRecur['id'];
+    $this->ids['Contribution']['default'] = $this->_contributionID = $contributionRecur['api.Order.create']['id'];
     $this->ids['Contribution'][0] = $this->_contributionID;
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Update Recurring end_date when setting status to completed

This moves the logic from Authorize.net to the ContributionRecur function that is called when a contribution is added to a recurring such that when it determines it is completed it also sets the end_date

Before
----------------------------------------
The contributionRecur object takes charge of updating status of recurrings to Completed but does not set the end_date when it does that

After
----------------------------------------
End_date set when completed status is set, removed from Authorize.net

Technical Details
----------------------------------------
There was already a test in the code comment but I didn't read that until I had added a new one

Comments
----------------------------------------
