### PR TITLE
Fix group count for delete confirmation

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -124,12 +124,15 @@ class CRM_Group_Form_Edit extends CRM_Core_Form {
     if ($this->_action == CRM_Core_Action::DELETE) {
       if (isset($this->_id)) {
         $this->assign('title', $this->_title);
-        try {
-          $this->assign('count', CRM_Contact_BAO_Group::memberCount($this->_id));
+        if (!($this->_groupValues['saved_search_id'])) {
+          try {
+            $count = CRM_Contact_BAO_Group::memberCount($this->_id);
+          }
+          catch (CRM_Core_Exception $e) {
+            // If the group is borked the query might fail but delete should be possible.
+          }
         }
-        catch (CRM_Core_Exception $e) {
-          // If the group is borked the query might fail but delete should be possible.
-        }
+        $this->assign('count', $count ?? NULL);
         $this->setTitle(ts('Confirm Group Delete'));
       }
       if ($this->_groupValues['is_reserved'] == 1 && !CRM_Core_Permission::check('administer reserved groups')) {

--- a/templates/CRM/Group/Form/Delete.tpl
+++ b/templates/CRM/Group/Form/Delete.tpl
@@ -14,7 +14,7 @@
     <div class="messages status no-popup">
         <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
     {ts 1=$title}Are you sure you want to delete the group %1?{/ts}<br /><br />
-    {if $count}
+    {if $count !== NULL}
         {ts count=$count plural='This group currently has %count members in it.'}This group currently has one member in it.{/ts}
     {/if}
     {ts}Deleting this group will NOT delete the member contact records. However, all contact subscription information and history for this group will be deleted.{/ts} {ts}If this group is used in CiviCRM profiles, those fields will be reset.{/ts} {ts}This action cannot be undone.{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
When you delete a group, you get a confirmation that shows the count of the members of the group, but it doesn't seem to work correctly for smart groups, sometimes reporting one member, sometimes nothing at all. It can also be slow because it may rebuild the smart group, which is not desirable (you might be deleting it because it is very slow) or particularly helpful if you are deleting a smart group.

![image](https://github.com/civicrm/civicrm-core/assets/25517556/79e37714-177c-4c7c-a354-c70b49293c73)

Before
----------------------------------------
Smart groups sometimes incorrectly report one member, sometimes don't report members.
Regular groups don't report number of members if count is 0.

After
----------------------------------------
Smart groups don't calculate or show number of members.
Regular groups report number of members even if it is 0.