### PR TITLE
CiviMail - Sundry cleanups

### DIFF
--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -130,8 +130,8 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     $this->_sortByCharacter
       = CRM_Utils_Request::retrieve('sortByCharacter', 'String', $this);
 
-    // CRM-11920 all should set sortByCharacter to null, not empty string
-    if (strtolower($this->_sortByCharacter) == 'all' || !empty($_POST)) {
+    // CRM-11920 "all" should set sortByCharacter to null, not empty string
+    if (strtolower($this->_sortByCharacter ?: '') == 'all' || !empty($_POST)) {
       $this->_sortByCharacter = NULL;
       $this->set('sortByCharacter', NULL);
     }

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -116,16 +116,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
   public function run() {
     $this->preProcess();
 
-    $newArgs = func_get_args();
-    // since we want only first function argument
-    $newArgs = $newArgs[0];
-    $this->_isArchived = $this->isArchived($newArgs);
-    if (isset($_GET['runJobs']) || CRM_Utils_Array::value('2', $newArgs) == 'queue') {
-      $mailerJobSize = Civi::settings()->get('mailerJobSize');
-      CRM_Mailing_BAO_MailingJob::runJobs_pre($mailerJobSize);
-      CRM_Mailing_BAO_MailingJob::runJobs();
-      CRM_Mailing_BAO_MailingJob::runJobs_post();
-    }
+    $newArgs = func_get_args()[0];
 
     $this->_sortByCharacter
       = CRM_Utils_Request::retrieve('sortByCharacter', 'String', $this);

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -160,13 +160,6 @@
     <weight>685</weight>
   </item>
   <item>
-    <path>civicrm/mailing/queue</path>
-    <title>Sending Mail</title>
-    <page_callback>CRM_Mailing_Page_Browse</page_callback>
-    <access_arguments>access CiviMail</access_arguments>
-    <weight>690</weight>
-  </item>
-  <item>
     <path>civicrm/mailing/report/event</path>
     <title>Mailing Event</title>
     <page_callback>CRM_Mailing_Page_Event</page_callback>

--- a/ext/flexmailer/src/Listener/Abdicator.php
+++ b/ext/flexmailer/src/Listener/Abdicator.php
@@ -30,15 +30,8 @@ class Abdicator {
    * @return bool
    */
   public static function isFlexmailPreferred($mailing) {
-    if ($mailing->sms_provider_id) {
-      return FALSE;
-    }
-
-    // Use FlexMailer for new-style email blasts (with custom `template_type`).
-    if ($mailing->template_type && $mailing->template_type !== 'traditional') {
-      return TRUE;
-    }
-    return TRUE;
+    // Yes for CiviMail - no for CiviSMS
+    return empty($mailing->sms_provider_id);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Small collection of random cleanups relating to CiviMail:

* Remove an old/hidden mechanism for manually firing jobs. (You can do this in supported ways through API Explorer or CLI.)
* Fix a PHP 8 warning
* Simplify some conditionals in Flexmailer