### PR TITLE
Don't show filtered from NaN on Groups when 0 groups found

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -815,8 +815,8 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
 
     $groupsDT = [];
     $groupsDT['data'] = $groupList;
-    $groupsDT['recordsTotal'] = !empty($params['total']) ? $params['total'] : NULL;
-    $groupsDT['recordsFiltered'] = !empty($params['total']) ? $params['total'] : NULL;
+    $groupsDT['recordsTotal'] = !empty($params['total']) ? $params['total'] : 0;
+    $groupsDT['recordsFiltered'] = !empty($params['total']) ? $params['total'] : 0;
 
     return $groupsDT;
   }


### PR DESCRIPTION
Overview
----------------------------------------
I know this will be replaced with SK, but it's a simple fix to remove a NaN when using Manage Groups and filtering so 0 groups are found. We don't show the "filtered from" text normally, I think it only shows up when you have zero groups.

Before
----------------------------------------
<img width="405" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/f5208513-71cd-4eb5-a82f-57b3ad3608e8">

After
----------------------------------------
<img width="409" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/2ec8778e-cb8b-4342-b9af-62d95844b58b">
