### PR TITLE
Add deployID to civicrm.settings.php

### DIFF
--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -95,6 +95,9 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     if (isset($config['prefix'])) {
       $this->_prefix = $config['prefix'];
     }
+    if (defined('CIVICRM_DEPLOY_ID')) {
+      $this->_prefix = CIVICRM_DEPLOY_ID . '_' . $this->_prefix;
+    }
 
     $this->_cache = self::connect($config);
   }

--- a/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
+++ b/setup/plugins/installFiles/GenerateCredKey.civi-setup.php
@@ -25,6 +25,10 @@ if (!defined('CIVI_SETUP')) {
     $e->getModel()->credKeys = [$e->getModel()->credKeys];
   }
 
+  if (empty($e->getModel()->deployID)) {
+    $e->getModel()->deployID = $toAlphanum(random_bytes(10));
+  }
+
     \Civi\Setup::log()->info(sprintf('[%s] Done %s', basename(__FILE__), 'installFiles'));
 
   }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
@@ -100,8 +100,9 @@ if (!defined('CIVI_SETUP')) {
     $params['siteKey'] = addslashes($m->siteKey);
     $params['credKeys'] = addslashes(implode(' ', $m->credKeys));
     $params['signKeys'] = addslashes(implode(' ', $m->signKeys));
+    $params['deployID'] = addslashes($m->deployID);
 
-    $extraSettings = array();
+    $extraSettings = [];
 
     foreach ($m->paths as $key => $aspects) {
       foreach ($aspects as $aspect => $value) {

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -32,6 +32,8 @@ namespace Civi\Setup;
  *   Ex: ['::abcd1234ABCD9876'].
  * @property string[] $signKeys
  *   Ex: ['jwt-hs256::abcd1234ABCD9876'].
+ * @property string $deployID
+ *   Ex: '1234ABCD9876'.
  * @property string|NULL $lang
  *   The language of the default dataset.
  *   Ex: 'fr_FR'.

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -335,6 +335,12 @@ if (!defined('CIVICRM_CRED_KEYS') ) {
   // Some old installers may not set a decent value, and this extra complexity is a failsafe.
   // Feel free to simplify post-install.
 }
+if (!defined('CIVICRM_DEPLOY_ID') ) {
+  define( '_CIVICRM_DEPLOY_ID', '%%deployID%%');
+  define( 'CIVICRM_DEPLOY_ID', _CIVICRM_DEPLOY_ID === '%%' . 'deployID' . '%%' ? '' : _CIVICRM_DEPLOY_ID );
+  // Some old installers may not set a decent value, and this extra complexity is a failsafe.
+  // Feel free to simplify post-install.
+}
 
 /**
  * The signing key is used to generate and verify shareable tokens.


### PR DESCRIPTION
Overview
----------------------------------------
Add deployID to civicrm.settings.php

Before
----------------------------------------
When installing in a dev environment with `Redis` the `Redis` cache may not be flushed - leading the install to crash

After
----------------------------------------
The use of `Redis` in the prefix means a new cache is used when a new install is created

Technical Details
----------------------------------------

Comments
----------------------------------------
