### PR TITLE
[Test] Clean up payment processors when cleaning up other related entities

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1778,6 +1778,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       'civicrm_event',
       'civicrm_participant',
       'civicrm_participant_payment',
+      'civicrm_payment_processor',
       'civicrm_pledge',
       'civicrm_pcp_block',
       'civicrm_pcp',


### PR DESCRIPTION
From https://github.com/civicrm/civicrm-core/pull/26634 - I am assuming this is not the cause of the test failures but merging separately will resolve.....