### PR TITLE
Fix actions on Relationship search using Searchkit

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -118,6 +118,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   protected function formatResult(iterable $result): array {
     $rows = [];
     $keyName = CoreUtil::getIdFieldName($this->savedSearch['api_entity']);
+    if ($this->savedSearch['api_entity'] === 'RelationshipCache') {
+      $keyName = 'relationship_id';
+    }
     foreach ($result as $index => $record) {
       $data = $columns = [];
       foreach ($this->getSelectClause() as $key => $item) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -34,7 +34,8 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
    */
   public function _run(\Civi\Api4\Generic\Result $result) {
     // Adding checkPermissions filters out actions the user is not allowed to perform
-    $entity = Entity::get($this->checkPermissions)->addWhere('name', '=', $this->entity)
+    $entityName = ($this->entity === 'RelationshipCache') ? 'Relationship' : $this->entity;
+    $entity = Entity::get($this->checkPermissions)->addWhere('name', '=', $entityName)
       ->addSelect('name', 'title_plural')
       ->setChain([
         'actions' => ['$name', 'getActions', ['where' => [['name', 'IN', ['update', 'delete']]]], 'name'],

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasks.component.js
@@ -42,8 +42,17 @@
         return $scope.$eval('' + ctrl.ids.length + action.number);
       };
 
+      this.updateActionData = function() {
+        if (this.entity === 'RelationshipCache') {
+          this.entity = 'Relationship';
+          this.entityInfo.title = ts('Relationship');
+          this.entityInfo.title_plural = ts('Relationships');
+        }
+      };
+
       this.getActionTitle = function(action) {
         if (ctrl.isActionAllowed(action)) {
+          ctrl.updateActionData();
           return ctrl.ids.length ?
             ts('Perform action on %1 %2', {1: ctrl.ids.length, 2: ctrl.entityInfo[ctrl.ids.length === 1 ? 'title' : 'title_plural']}) :
             ts('Perform action on all %1', {1: ctrl.entityInfo.title_plural});
@@ -55,6 +64,9 @@
         if (!ctrl.isActionAllowed(action)) {
           return;
         }
+        // Update data specific to entity actions.
+        ctrl.updateActionData();
+
         var data = {
           ids: ctrl.ids,
           entity: ctrl.entity,


### PR DESCRIPTION
Overview
----------------------------------------
Fix actions on Relationship search using Searchkit

Before
----------------------------------------
To replicate:

- Create `New search` from searchkit UI.
- Search for Related Contacts.
- Hit Search.
- Click on `Action` button to check the list of available actions for this entity.
- Action dropdown does not lists actions for update, enable/disable, delete relationships

![image](https://github.com/civicrm/civicrm-core/assets/5929648/235af44b-9253-4abb-af16-b57b98f6a31c)

The problems seems to be in identifying the entity. When the Action button is selected, the search is made to retrieve actions for `RelationshipCache` entity instead of `Relationship`.

After
----------------------------------------
Action dropdown has required actions available for Relationship entity.

![image](https://github.com/civicrm/civicrm-core/assets/5929648/de5a4784-5ac5-4536-9475-d64c0d76ddff)

![image](https://github.com/civicrm/civicrm-core/assets/5929648/0e1d2334-d37c-48cd-b5e2-71891c1784aa)

![image](https://github.com/civicrm/civicrm-core/assets/5929648/5ff6c267-21bd-4c08-9b23-20f63eb8af3e)


Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/4376