### PR TITLE
Standalone - Auto-enable user subsystem. Tweak default user.

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -50,58 +50,12 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
 
     $users = \Civi\Api4\User::get(FALSE)->selectRowCount()->execute()->countMatched();
     if ($users == 0) {
-
       CRM_Core_DAO::executeQuery('DELETE FROM civicrm_uf_match');
-
-      // Create an admin contact.
-      $contactID = \Civi\Api4\Contact::create(FALSE)
-        ->setValues([
-          'contact_type' => 'Individual',
-          'first_name' => 'Standalone',
-          'last_name' => 'Admin',
-        ])
-        ->execute()->first()['id'];
-      $dummyEmail = 'admin@localhost.localdomain';
-
-      // Create user
-      $password = substr(base64_encode(random_bytes(8)), 0, 12);
-      $params = [
-        'cms_name'   => 'admin',
-        'cms_pass'   => $password,
-        'notify'     => FALSE,
-        $dummyEmail => $dummyEmail,
-        'contactID'  => $contactID,
-      ];
-      $userID = \CRM_Core_BAO_CMSUser::create($params, $dummyEmail);
-
-      // Create Role
-      $roleID = \Civi\Api4\Role::create(FALSE)->setValues(['name' => 'Administrator'])->execute()->first()['id'];
-
-      // Assign role to user
-      \Civi\Api4\UserRole::create(FALSE)->setValues(['role_id' => $roleID, 'user_id' => $userID])->execute();
-
-      // Create permissions for role
-      // @todo I expect there's a better way than this; this doesn't even bring in all the permissions.
-      $records = [['permission' => 'authenticate with password']];
-      foreach (array_keys(\CRM_Core_Permission::getCorePermissions()) as $permission) {
-        $records[] = ['permission' => $permission];
-      }
-      \Civi\Api4\RolePermission::save(FALSE)
-        ->setDefaults(['role_id' => $roleID])
-        ->setRecords($records)
-        ->execute();
-
-      $message = "Created New admin User $userID and contact $contactID with password $password and ALL permissions.";
-      \Civi::log()->notice($message);
-      if (php_sapi_name() === 'cli') {
-        print $message . "\n";
-      }
-      else {
-        $authx = new \Civi\Authx\Standalone();
-        $authx->loginSession($userID);
-        CRM_Core_Session::setStatus($message . " You are logged in!", 'Standalone installed', 'alert');
-      }
     }
+
+    // `standaloneusers` is installed as part of the overall install process for `Standalone`.
+    // A subsequent step will configure some default users (*depending on local options*).
+    // See also: `StandaloneUsers.civi-setup.php`
   }
 
   /**

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -17,10 +17,11 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
    */
   public function onInstall() {
     $config = \CRM_Core_Config::singleton();
-    if (!($config->userPermissionClass instanceof \CRM_Core_Permission_Standalone)) {
+    // We generally only want to run on standalone. In theory, we might also run headless tests.
+    if (!in_array(get_class($config->userPermissionClass), ['CRM_Core_Permission_Standalone', 'CRM_Core_Permission_Headless'])) {
       throw new \CRM_Core_Exception("standaloneusers can only be installed on standalone");
     }
-    if (!($config->userSystem instanceof \CRM_Utils_System_Standalone)) {
+    if (!in_array(get_class($config->userSystem), ['CRM_Utils_System_Standalone', 'CRM_Utils_System_Headless'])) {
       throw new \CRM_Core_Exception("standaloneusers can only be installed on standalone");
     }
     parent::onInstall();

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -10,6 +10,23 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 
   /**
+   * Ensure that we're installing on suitable environment.
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public function onInstall() {
+    $config = \CRM_Core_Config::singleton();
+    if (!($config->userPermissionClass instanceof \CRM_Core_Permission_Standalone)) {
+      throw new \CRM_Core_Exception("standaloneusers can only be installed on standalone");
+    }
+    if (!($config->userSystem instanceof \CRM_Utils_System_Standalone)) {
+      throw new \CRM_Core_Exception("standaloneusers can only be installed on standalone");
+    }
+    parent::onInstall();
+  }
+
+  /**
    * Example: Run an external SQL script when the module is installed.
    *
    * public function install() {
@@ -42,11 +59,6 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
       $dummyEmail = 'admin@localhost.localdomain';
 
       // Create user
-      $config = \CRM_Core_Config::singleton();
-      $originalUFPermission = $config->userPermissionClass;
-      $originalUF = $config->userSystem;
-      $config->userPermissionClass = new \CRM_Core_Permission_Standalone();
-      $config->userSystem = new \CRM_Utils_System_Standalone();
       $password = substr(base64_encode(random_bytes(8)), 0, 12);
       $params = [
         'cms_name'   => 'admin',
@@ -56,8 +68,6 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
         'contactID'  => $contactID,
       ];
       $userID = \CRM_Core_BAO_CMSUser::create($params, $dummyEmail);
-      $config->userPermissionClass = $originalUFPermission;
-      $config->userSystem = $originalUF;
 
       // Create Role
       $roleID = \Civi\Api4\Role::create(FALSE)->setValues(['name' => 'Administrator'])->execute()->first()['id'];

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -43,6 +43,11 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
    */
   public function postInstall() {
 
+    Civi::settings()->set('authx_login_cred', array_unique(array_merge(
+      Civi::settings()->get('authx_login_cred'),
+      ['pass']
+    )));
+
     $users = \Civi\Api4\User::get(FALSE)->selectRowCount()->execute()->countMatched();
     if ($users == 0) {
 

--- a/ext/standaloneusers/README.md
+++ b/ext/standaloneusers/README.md
@@ -15,26 +15,37 @@ The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
 ## Getting started
 
-First, get standalone set up - e.g. you can see the admin interface up and running.
-
-Next configure AuthX from **Administer » System Settings » Authentication**. You'll need to add **User Password** to the **Acceptable credentials (HTTP Session Login) select. And hit Save.
-
-Now you can install this extension from the command line. (Clone this repo into web/upload/ext/ then enable it with `cv en standaloneusers`).
-
-On install, an account is created, user `admin`, and the password is printed on the console (if you install through the UI, the password is output in the Civi logs). The admin user is granted all permissions. Example:
+Normal installation methods (such as `cv core:install` or `civibuild`) should enable `standaloneusers` by default.
+The installer should display the default user account, such as:
 
 ```
-% cv en standaloneusers
-Enabling extension "standaloneusers"
-Created New admin User 1 and contact 203 with password iLkPsffZYYA= and ALL permissions.
+  "adminUser": "super",
+  "adminPass": "O5fAlyXgdEU",
+  "adminEmail": "admin@localhost.localdomain"
 ```
 
-Now if you try to load your site it should fail: you've got no access rights.
+If not, you may also find the default credentials in the local log.
+
+```
+[notice] Created new user "admin" (user ID #1, contact ID #203) with default password "admin" and ALL permissions.
+```
+
+If you try to load your site it should fail: you've got no access rights.
 
 At this stage, because you're moving from a system that had no concept of users to one that does, you'll need to clear your browser cookies for the site, otherwise login will get confused (You may see a "session already active" authx error.)
 
 Done that? Then head to `/civicrm/login`, enter your credentials and hopefully you're now back in the admin interface!
 
+## Advanced
+
+To customize the default credentials, pass any of these arguments to the installer:
+
+```bash
+cv core:install ... \
+  -m 'extras.adminUser=zeta' \
+  -m 'extras.adminPass=SECRET' \
+  -m 'extras.adminEmail=zeta@example.com'
+```
 
 ## Conventions
 

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -56,7 +56,7 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements HeadlessInterf
   }
 
   public function testCreateUser():void {
-    list($contactID, $userID, $security) = $this->createFixtureContactAndUser();
+    [$contactID, $userID, $security] = $this->createFixtureContactAndUser();
 
     $user = \Civi\Api4\User::get(FALSE)
       ->addSelect('*', 'uf_match.*')
@@ -73,7 +73,7 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements HeadlessInterf
   }
 
   public function testPerms() {
-    list($contactID, $userID, $security) = $this->createFixtureContactAndUser();
+    [$contactID, $userID, $security] = $this->createFixtureContactAndUser();
     // Create role,
     $roleID = \Civi\Api4\Role::create(FALSE)
       ->setValues(['name' => 'staff'])->execute()->first()['id'];

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -2,9 +2,7 @@
 namespace Civi\Standalone;
 
 use CRM_Standaloneusers_ExtensionUtil as E;
-use Civi\Test\CiviEnvBuilder;
-use Civi\Test\HeadlessInterface;
-use Civi\Core\HookInterface;
+use Civi\Test\EndToEndInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -19,35 +17,33 @@ use Civi\Test\TransactionalInterface;
  *       a. Do all that using setupHeadless() and Civi\Test.
  *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
  *
- * @group headless
+ * Fun fact: Running E2E tests with TransactionalInterface is usually prohibitive because of the
+ * split DB. However, with Standalone, there's a single DB, so it may work some of the time.
+ * (It only becomes prohibitive if you actually use HTTP.)
+ *
+ * @group e2e
  */
-class SecurityTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface, TransactionalInterface {
 
   protected $originalUF;
   protected $originalUFPermission;
   protected $contactID;
   protected $userID;
 
-  /**
-   * Setup used when HeadlessInterface is implemented.
-   *
-   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
-   *
-   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
-   *
-   * @return \Civi\Test\CiviEnvBuilder
-   *
-   * @throws \CRM_Extension_Exception_ParseException
-   */
-  public function setUpHeadless(): CiviEnvBuilder {
-    return \Civi\Test::headless()
-      ->install(['authx', 'org.civicrm.search_kit', 'org.civicrm.afform', 'standaloneusers'])
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+    \Civi\Test::e2e()
+      // ->install(['authx', 'org.civicrm.search_kit', 'org.civicrm.afform', 'standaloneusers'])
+      // We only run on "Standalone", so all the above is given.
       // ->installMe(__DIR__) This causes failure, so we do                 ↑
       ->apply(FALSE);
   }
 
   public function setUp():void {
     parent::setUp();
+    if (CIVICRM_UF !== 'Standalone') {
+      $this->markTestSkipped('Test only applies on Standalone');
+    }
   }
 
   public function tearDown():void {

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -73,7 +73,7 @@ if (!defined('CIVI_SETUP')) {
     \Civi\Api4\UserRole::create(FALSE)->setValues(['role_id' => $roleID, 'user_id' => $userID])->execute();
 
     // TODO - If admin specified an explicit password, then we don't really need to log it.
-    $message = "Created new user \"admin\" (user ID #$userID, contact ID #$contactID) with default password \"" . ($e->getModel()->extras['adminPass']) . "\" and ALL permissions.";
+    $message = "Created new user \"{$e->getModel()->extras['adminUser']}\" (user ID #$userID, contact ID #$contactID) with password \"" . ($e->getModel()->extras['adminPass']) . "\" and ALL permissions.";
     \Civi::log()->notice($message);
 
   }, \Civi\Setup::PRIORITY_LATE);

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -2,7 +2,7 @@
 /**
  * @file
  *
- * By default, enable the "standaloneusers" extension on "Standalone" UF. Setup credentials.
+ * On "Standalone" UF, default policy is to enable `standaloneusers` and create user+role.
  */
 
 if (!defined('CIVI_SETUP')) {
@@ -17,23 +17,63 @@ if (!defined('CIVI_SETUP')) {
 
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
 
+    // Assign defaults. (These may be overridden by the agent performing installation.)
     $e->getModel()->extensions[] = 'standaloneusers';
-    if (empty($e->getModel()->extras['adminPass'])) {
-      $toAlphanum = function ($bits) {
-        return preg_replace(';[^a-zA-Z0-9];', '', base64_encode($bits));
-      };
-      $e->getModel()->extras['adminPass'] = $toAlphanum(random_bytes(8));
-    }
+
+    $toAlphanum = function ($bits) {
+      return preg_replace(';[^a-zA-Z0-9];', '', base64_encode($bits));
+    };
+    $defaults = [
+      'adminUser' => 'admin',
+      'adminPass' => $toAlphanum(random_bytes(8)),
+      'adminEmail' => 'admin@localhost.localdomain',
+    ];
+    $e->getModel()->extras = array_merge($defaults, $e->getModel()->extras);
   });
 
 \Civi\Setup::dispatcher()
   ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
-    if (!in_array('standaloneusers', $e->getModel()->extensions)) {
+    if ($e->getModel()->cms !== 'Standalone' || !in_array('standaloneusers', $e->getModel()->extensions)) {
       return;
     }
 
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installDatabase'));
 
-    $security = \Civi\Standalone\Security::singleton();
-    // $security->se
+    // Create role with permissions
+    $roleID = \Civi\Api4\Role::create(FALSE)->setValues(['name' => 'Administrator'])->execute()->first()['id'];
+    // @todo I expect there's a better way than this; this doesn't even bring in all the permissions.
+    $records = [['permission' => 'authenticate with password']];
+    foreach (array_keys(\CRM_Core_Permission::getCorePermissions()) as $permission) {
+      $records[] = ['permission' => $permission];
+    }
+    \Civi\Api4\RolePermission::save(FALSE)
+      ->setDefaults(['role_id' => $roleID])
+      ->setRecords($records)
+      ->execute();
+
+    // Create contact+user for admin.
+    $contactID = \Civi\Api4\Contact::create(FALSE)
+      ->setValues([
+        'contact_type' => 'Individual',
+        'first_name' => 'Standalone',
+        'last_name' => 'Admin',
+      ])
+      ->execute()->first()['id'];
+    $adminEmail = $e->getModel()->extras['adminEmail'];
+    $params = [
+      'cms_name'   => $e->getModel()->extras['adminUser'],
+      'cms_pass'   => $e->getModel()->extras['adminPass'],
+      'notify'     => FALSE,
+      $adminEmail => $adminEmail,
+      'contactID'  => $contactID,
+    ];
+    $userID = \CRM_Core_BAO_CMSUser::create($params, $adminEmail);
+
+    // Assign role to user
+    \Civi\Api4\UserRole::create(FALSE)->setValues(['role_id' => $roleID, 'user_id' => $userID])->execute();
+
+    // TODO - If admin specified an explicit password, then we don't really need to log it.
+    $message = "Created new user \"admin\" (user ID #$userID, contact ID #$contactID) with default password \"" . ($e->getModel()->extras['adminPass']) . "\" and ALL permissions.";
+    \Civi::log()->notice($message);
+
   }, \Civi\Setup::PRIORITY_LATE);

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @file
+ *
+ * By default, enable the "standaloneusers" extension on "Standalone" UF. Setup credentials.
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.init', function (\Civi\Setup\Event\InitEvent $e) {
+    if ($e->getModel()->cms !== 'Standalone') {
+      return;
+    }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
+
+    $e->getModel()->extensions[] = 'standaloneusers';
+    if (empty($e->getModel()->extras['adminPass'])) {
+      $toAlphanum = function ($bits) {
+        return preg_replace(';[^a-zA-Z0-9];', '', base64_encode($bits));
+      };
+      $e->getModel()->extras['adminPass'] = $toAlphanum(random_bytes(8));
+    }
+  });
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
+    if (!in_array('standaloneusers', $e->getModel()->extensions)) {
+      return;
+    }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installDatabase'));
+
+    $security = \Civi\Standalone\Security::singleton();
+    // $security->se
+  }, \Civi\Setup::PRIORITY_LATE);


### PR DESCRIPTION
Overview
----------------------------------------

This update should slightly simplify the flow for setting up a new site on `Standalone`.

For me, this makes it easier to use `civibuild create` and `civibuild reinstall` with `standalone-clean`.

ping @artfulrobot 

Before
----------------------------------------

* Need to manually setup `authx`, `standaloneusers`, and password support
* Creates a default user - but the email address / password / username cannot be configured.
* When using `civibuild`, there are contradictory messages about the administrative username/password/email.

After
----------------------------------------

* On new "Standalone" installations, auto-enable `authx`, `standaloneusers`, and password support
* Optionally, allow the installer to customize the default user, e.g.
    ```
    cv core:install ... \
      -m 'extras.adminUser=zeta' \
      -m 'extras.adminPass=SECRET' \
      -m 'extras.adminEmail=zeta@example.com'
    ```
* When using `civibuild`, there are consistent (accurate) messages about the administrative username/password/email.