### PR TITLE
Follow up to #26618 - set locale consistently when exporting model

### DIFF
--- a/Civi/WorkflowMessage/Traits/LocalizationTrait.php
+++ b/Civi/WorkflowMessage/Traits/LocalizationTrait.php
@@ -20,6 +20,18 @@ trait LocalizationTrait {
   protected $locale;
 
   /**
+   * The language that was requested to be rendered.
+   *
+   * This may not be the rendered locale - as the requested language
+   * might be available. This is primarily for extensions to use in
+   * custom workflow messages.
+   *
+   * @var string|null
+   * @scope tokenContext
+   */
+  protected $requestedLocale;
+
+  /**
    * @return string
    */
   public function getLocale(): ?string {
@@ -32,6 +44,31 @@ trait LocalizationTrait {
    */
   public function setLocale(?string $locale) {
     $this->locale = $locale;
+    return $this;
+  }
+
+  /**
+   * Get the requested locale.
+   *
+   * This may differ from the rendered locale (e.g. if a translation is not
+   * available). It is not used in core but extensions may leverage this
+   * information.
+   *
+   * @return string
+   */
+  public function getRequestedLocale(): ?string {
+    return $this->locale;
+  }
+
+  /**
+   * Set the requested locale.
+   *
+   * @param string|null $requestedLocale
+   *
+   * @return $this
+   */
+  public function setRequestedLocale(?string $requestedLocale): self {
+    $this->requestedLocale = $requestedLocale;
     return $this;
   }
 

--- a/Civi/WorkflowMessage/Traits/LocalizationTrait.php
+++ b/Civi/WorkflowMessage/Traits/LocalizationTrait.php
@@ -26,6 +26,13 @@ trait LocalizationTrait {
    * might be available. This is primarily for extensions to use in
    * custom workflow messages.
    *
+   * The use-case is a bit like this:
+   *
+   * 1. Your organization serves many similar locales (eg es_MX+es_CR+es_HN or en_GB+en_US+en_NZ).
+   * 2. You want to write one message (es_MX) for several locales (es_MX+es_CR+es_HN)
+   * 3. You want to include some conditional content that adapts the recipient's requested locale
+   *    (es_CR) -- _even though_ the template was stored as es_MX.
+   *
    * @var string|null
    * @scope tokenContext
    */

--- a/Civi/WorkflowMessage/Traits/TemplateTrait.php
+++ b/Civi/WorkflowMessage/Traits/TemplateTrait.php
@@ -11,6 +11,7 @@
 
 namespace Civi\WorkflowMessage\Traits;
 
+use Civi\Api4\Contact;
 use Civi\Api4\MessageTemplate;
 
 /**
@@ -56,10 +57,11 @@ trait TemplateTrait {
     $model = $this;
     $language = $model->getLocale();
     if (empty($language) && !empty($model->getContactID())) {
-      $language = \Civi\Api4\Contact::get(FALSE)->addWhere('id', '=', $this->getContactID())->addSelect('preferred_language')->execute()->first()['preferred_language'];
+      $language = Contact::get(FALSE)->addWhere('id', '=', $this->getContactID())->addSelect('preferred_language')->execute()->first()['preferred_language'];
     }
     [$mailContent, $translatedLanguage] = self::loadTemplate((string) $model->getWorkflowName(), $model->getIsTest(), $model->getTemplateId(), $model->getGroupName(), $model->getTemplate(), $language);
     $model->setLocale($translatedLanguage ?? $model->getLocale());
+    $model->setRequestedLocale($language);
     return $mailContent;
   }
 

--- a/Civi/WorkflowMessage/WorkflowMessage.php
+++ b/Civi/WorkflowMessage/WorkflowMessage.php
@@ -126,11 +126,16 @@ class WorkflowMessage {
   public static function exportAll(WorkflowMessageInterface $model): array {
     // The format is defined to match the traditional format of CRM_Core_BAO_MessageTemplate::sendTemplate().
     // At the top level, it is an "envelope", but it also has keys for other sections.
+    $swapLocale = !$model->getLocale() ? NULL : \CRM_Utils_AutoClean::swapLocale($model->getLocale());
+
     $values = $model->export('envelope');
     $values['tplParams'] = $model->export('tplParams');
     $values['tokenContext'] = $model->export('tokenContext');
     if (isset($values['tokenContext']['contactId'])) {
       $values['contactId'] = $values['tokenContext']['contactId'];
+    }
+    if ($swapLocale) {
+      $swapLocale->cleanup();
     }
     return $values;
   }

--- a/Civi/WorkflowMessage/WorkflowMessageInterface.php
+++ b/Civi/WorkflowMessage/WorkflowMessageInterface.php
@@ -79,6 +79,13 @@ interface WorkflowMessageInterface {
   public function assertValid($strict = FALSE);
 
   /**
+   * Get the locale in use, if set.
+   *
+   * @return string|null
+   */
+  public function getLocale(): ?string;
+
+  /**
    * Render a message template.
    *
    * TIP: Do not implement directly. Use FinalHelperTrait.


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #26618 - set locale consistently when exporting model

Before
----------------------------------------
The person writing code in a WorkflowMessage needs to remember to set the locale

After
----------------------------------------
The locale is set before exporting and unset straight after

Technical Details
----------------------------------------

Comments
----------------------------------------