### PR TITLE
Add workflow message template for sign_petition, confirm petition

### DIFF
--- a/CRM/Campaign/WorkflowMessage/PetitionConfirmationNeeded.php
+++ b/CRM/Campaign/WorkflowMessage/PetitionConfirmationNeeded.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Invoice generated when invoicing is enabled.
+ *
+ * @method $this setSurveyID(int $surveyID)
+ * @method int getSurveyID()
+ * @method $this setSurvey(array $survey)
+ * @method array getSurvey()
+ * @method $this setActivityID(int $activityID)
+ * @method int getActivityID()
+ *
+ * @support template-only
+ *
+ * @see CRM_Campaign_BAO_Petition::sendEmail
+ */
+class CRM_Campaign_WorkflowMessage_PetitionConfirmationNeeded extends GenericWorkflowMessage {
+
+  public const WORKFLOW = 'petition_confirmation_needed';
+
+  /**
+   * Survey ID.
+   *
+   * @var int
+   *
+   * @scope tokenContext as surveyId
+   */
+  public $surveyID;
+
+  /**
+   * Survey ID.
+   *
+   * @var int
+   *
+   * @scope tokenContext as activityId
+   */
+  public $activityID;
+
+  /**
+   * Survey.
+   *
+   * @var array
+   *
+   * @scope tokenContext as survey
+   */
+  public $survey;
+
+}

--- a/CRM/Campaign/WorkflowMessage/PetitionSign.php
+++ b/CRM/Campaign/WorkflowMessage/PetitionSign.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Invoice generated when invoicing is enabled.
+ *
+ * @method $this setSurveyID(int $surveyID)
+ * @method int getSurveyID()
+ * @method $this setSurvey(array $survey)
+ * @method array getSurvey()
+ *
+ * @support template-only
+ *
+ * @see CRM_Campaign_BAO_Petition::sendEmail
+ */
+class CRM_Campaign_WorkflowMessage_PetitionSign extends GenericWorkflowMessage {
+
+  public const WORKFLOW = 'petition_sign';
+
+  /**
+   * Survey ID.
+   *
+   * @var int
+   *
+   * @scope tokenContext as surveyId
+   */
+  public $surveyID;
+
+  /**
+   * Survey.
+   *
+   * @var array
+   *
+   * @scope tokenContext as survey
+   */
+  public $survey;
+
+}

--- a/CRM/Campaign/WorkflowMessage/Survey/Survey.php
+++ b/CRM/Campaign/WorkflowMessage/Survey/Survey.php
@@ -1,0 +1,59 @@
+<?php
+
+use Civi\Api4\WorkflowMessage;
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+use Civi\WorkflowMessage\WorkflowMessageExample;
+
+/**
+ * Basic contribution example for contribution templates.
+ *
+ * @noinspection PhpUnused
+ */
+class CRM_Campaign_WorkflowMessage_Survey_Survey extends WorkflowMessageExample {
+
+  /**
+   * Get the examples this class is able to deliver.
+   */
+  public function getExamples(): iterable {
+    $workflows = ['petition_sign', 'petition_confirmation_needed'];
+    foreach ($workflows as $workflow) {
+      yield [
+        'name' => 'workflow/' . $workflow . '/basic_eur',
+        'title' => ts('Save the whales'),
+        'tags' => ['preview'],
+        'workflow' => $workflow,
+      ];
+    }
+  }
+
+  /**
+   * Build an example to use when rendering the workflow.
+   *
+   * @param array $example
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function build(array &$example): void {
+    $workFlow = WorkflowMessage::get(TRUE)->addWhere('name', '=', $example['workflow'])->execute()->first();
+    $this->setWorkflowName($workFlow['name']);
+    $messageTemplate = new $workFlow['class']();
+    $this->addExampleData($messageTemplate);
+    $example['data'] = $this->toArray($messageTemplate);
+  }
+
+  /**
+   * Add relevant example data.
+   *
+   * @param \Civi\WorkflowMessage\GenericWorkflowMessage $messageTemplate
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function addExampleData(GenericWorkflowMessage $messageTemplate): void {
+    $messageTemplate->setContact(\Civi\Test::example('entity/Contact/Barb'));
+    $messageTemplate->setSurvey([
+      'id' => 60,
+      'title' => ts('Save the whales'),
+    ]);
+  }
+
+}


### PR DESCRIPTION
This should make tokens available
(once added per https://github.com/civicrm/civicrm-core/pull/26650 but no actual runtime change as yet

Overview
----------------------------------------
Add workflow message template for sign_petition

Before
----------------------------------------
No workflow model or example

After
----------------------------------------
The classes exist

Technical Details
----------------------------------------

Comments
----------------------------------------
