### PR TITLE
Standalone - Generate proper HTTP response code for permission-errors

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -544,4 +544,10 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     return Security::singleton()->getCMSPermissionsUrlParams();
   }
 
+  public function permissionDenied() {
+    http_response_code(403);
+    echo "403 Forbidden: You do not have permission to access this resource.\n";
+    // TODO: Prettier error page
+  }
+
 }


### PR DESCRIPTION
`E2E_Core_ErrorTest` checks for HTTP response codes on permission-errors

* Before: Sends HTTP 200. Test fails.
* After: Sends HTTP 403. Test passes.
