### PR TITLE
dev/core#4317 Fix import issue when civicrm_custom_group.name ends in `_`

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -104,6 +104,10 @@ class CRM_Contribute_Import_Form_MapField extends CRM_Import_Form_MapField {
       }
       // Swap out dots for double underscores so as not to break the quick form js.
       // We swap this back on postProcess.
+      // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore,
+      // which is indistinguishable to convert back - ie ___ could be _. or ._.
+      // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
+      $name = str_replace('_.', '~~', $name);
       $name = str_replace('.', '__', $name);
       if (($field['entity'] ?? '') === 'Contact' && $this->isFilterContactFields() && empty($field['match_rule'])) {
         // Filter out metadata that is intended for create & update - this is not available in the quick-form

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -740,6 +740,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
       }
       // Swap out dots for double underscores so as not to break the quick form js.
       // We swap this back on postProcess.
+      // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore.
+      // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
+      $name = str_replace('_.', '~~', $name);
       $name = str_replace('.', '__', $name);
       $return[$name] = $field['html']['label'] ?? $field['title'];
     }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1696,6 +1696,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $fieldMap = $this->getOddlyMappedMetadataFields();
     $fieldMapName = empty($fieldMap[$fieldName]) ? $fieldName : $fieldMap[$fieldName];
     $fieldMapName = str_replace('__', '.', $fieldMapName);
+    // See https://lab.civicrm.org/dev/core/-/issues/4317#note_91322 - a further hack for quickform not
+    // handling dots in field names. One day we will get rid of the Quick form screen...
+    $fieldMapName = str_replace('~~', '_.', $fieldMapName);
     // This whole business of only loading metadata for one type when we actually need it for all is ... dubious.
     if (empty($this->getImportableFieldsMetadata()[$fieldMapName])) {
       if ($loadOptions || !$limitToContactType) {


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4317 Fix import issue when civicrm_custom_group.name ends in `_`

Before
----------------------------------------
Importing to a custom field fails in the value in `civicrm_custom_group.name` ends in `_`

After
----------------------------------------
it works

Technical Details
----------------------------------------
The issue is that in order to get around the apiv4 style names causing js errors with the hierarchical select widget we are swapping them out for `__` - however, it turns out the group names can have a trailing `_` so we wind up with `___` which could be `_.` or `._` - this leans into the hack but fixes the bug. Once we can get rid of the Quickform form & just use the angularJS one we can remove this

Comments
----------------------------------------
