### PR TITLE
dev/core#4392 - Distribute `sql/civicrm_data/` with tarball

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -77,7 +77,7 @@ function dm_install_core() {
   local repo="$1"
   local to="$2"
 
-  for dir in ang css i js PEAR templates bin CRM api extern Reports install mixin settings Civi partials release-notes xml setup ; do
+  for dir in ang css i js PEAR templates bin CRM api extern Reports install mixin settings Civi partials release-notes xml setup sql/civicrm_data ; do
     [ -d "$repo/$dir" ] && dm_install_dir "$repo/$dir" "$to/$dir"
   done
 


### PR DESCRIPTION
Overview
----------------------------------------

Add the folder `sql/civicrm_data/` to the tarballs.

This is a follow-up to #26245 and #26270 (5.63-alpha), wherein `sql/civicrm_data/` became mandatory for installation.

cc @demeritcowboy 

Before
----------------------------------------

* Installing 5.63-rc from git is OK -- because the folder exists
* Installing 5.63-rc from tarball fails -- because the folder missing

After
----------------------------------------

* Both work

Comments
----------------------------------------

I did a local run of `distmaker` to make the D7 tarball. The files showed up in the list. I also used `civihydra` to install D7+tarball -- that seemed to work fine.