### PR TITLE
Admin UI - be like regular civi and don't show reserved custom groups

### DIFF
--- a/CRM/Custom/Form/DeleteField.php
+++ b/CRM/Custom/Form/DeleteField.php
@@ -47,6 +47,12 @@ class CRM_Custom_Form_DeleteField extends CRM_Core_Form {
     $params = ['id' => $this->_id];
     CRM_Core_BAO_CustomField::retrieve($params, $defaults);
 
+    if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $defaults['custom_group_id'], 'is_reserved')) {
+      // I think this does not have ts() because the only time you would see
+      // this is if you manually made a url you weren't supposed to.
+      CRM_Core_Error::statusBounce("You cannot delete fields in a reserved custom field-set.");
+    }
+
     $this->_title = $defaults['label'] ?? NULL;
     $this->assign('title', $this->_title);
     $this->setTitle(ts('Delete %1', [1 => $this->_title]));

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -99,6 +99,8 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     }
 
     if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_gid, 'is_reserved')) {
+      // I think this does not have ts() because the only time you would see
+      // this is if you manually made a url you weren't supposed to.
       CRM_Core_Error::statusBounce("You cannot add or edit fields in a reserved custom field-set.");
     }
 

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Fields.mgd.php
@@ -29,7 +29,7 @@ return [
             'option_group_id:label',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [['custom_group_id.is_reserved', '=', FALSE]],
           'groupBy' => [],
           'join' => [],
           'having' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Groups.mgd.php
@@ -30,7 +30,7 @@ return [
             'GROUP_CONCAT(DISTINCT CustomGroup_CustomField_custom_group_id_01.label) AS GROUP_CONCAT_CustomGroup_CustomField_custom_group_id_01_label',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [['is_reserved', '=', FALSE]],
           'groupBy' => [
             'id',
           ],
@@ -149,7 +149,7 @@ return [
                   'text' => E::ts('Settings'),
                   'style' => 'default',
                   'path' => '',
-                  'condition' => ['is_reserved', '=', FALSE],
+                  'condition' => [],
                 ],
               ],
               'type' => 'buttons',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4365

Followup to https://lab.civicrm.org/dev/core/-/issues/4338
and https://github.com/civicrm/civicrm-core/pull/26518

Reserved custom groups are always created by extensions, and often depend on them being unchangeable by users.

Before
----------------------------------------
1. It shows you the reserved groups in the listing - regular core doesn't do this.
2. It lets you delete fields in those groups - not good.
3. It lets you delete the group after you've deleted those fields - not good.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
The addition to DeleteField.php is just copied from Field.php and prevents hacking a url in both core and adminui.
