### PR TITLE
#4360 #4384 fixing multiple regressions with path civicrm/contact/search

### DIFF
--- a/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
+++ b/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
@@ -17,6 +17,9 @@ class CRM_CivicrmAdminUi_Upgrader extends CRM_Extension_Upgrader_Base {
       ->execute();
   }
 
+  /**
+   * @todo "install" and "uninstall" may not be needed if enable and disable are present. See https://github.com/civicrm/civicrm-core/pull/26669
+   */
   public function install(): void {
     $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
   }

--- a/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
+++ b/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
@@ -1,0 +1,41 @@
+<?php
+// phpcs:disable
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+// phpcs:enable
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_CivicrmAdminUi_Upgrader extends CRM_Extension_Upgrader_Base {
+
+  protected function replaceFindContactMenuPath($path) {
+    // point Find Contacts menu to the FB/SK version or back to the original path
+    // this is temporary until everything is in FB/SK and we can use the original path
+    $results = \Civi\Api4\Navigation::update(FALSE)
+      ->addValue('url', $path)
+      ->addWhere('name', '=', 'Find Contacts')
+      ->execute();
+  }
+
+  public function install(): void {
+    $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
+  }
+
+  public function uninstall(): void {
+    $this->replaceFindContactMenuPath('civicrm/contact/search');
+  }
+
+  public function enable(): void {
+    $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
+  }
+
+  public function disable(): void {
+    $this->replaceFindContactMenuPath('civicrm/contact/search');
+  }
+
+  public function upgrade_1000(): bool {
+    $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
+    return TRUE;
+  }
+
+}

--- a/ext/civicrm_admin_ui/ang/afsearchContactSearch.aff.json
+++ b/ext/civicrm_admin_ui/ang/afsearchContactSearch.aff.json
@@ -2,7 +2,7 @@
     "type": "search",
     "title": "Find Contacts",
     "icon": "fa-list-alt",
-    "server_route": "civicrm/contact/search",
+    "server_route": "civicrm/adminui/contact/search",
     "permission": "access CiviCRM",
     "navigation": null,
     "requires": [],

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.civix.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.civix.php
@@ -133,8 +133,8 @@ function _civicrm_admin_ui_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -32,9 +32,10 @@
   <civix>
     <namespace>CRM/CivicrmAdminUi</namespace>
     <angularModule>crmCivicrmAdminUi</angularModule>
-    <format>23.02.0</format>
+    <format>23.02.1</format>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>
   </mixins>
+  <upgrader>CRM_CivicrmAdminUi_Upgrader</upgrader>
 </extension>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Search.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Search.mgd.php
@@ -3,32 +3,6 @@
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
 return [
-  // using a temporary alternate path to avoid breaking legacy path
-  [
-    'name' => 'Navigation_Find_Contacts',
-    'entity' => 'Navigation',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'domain_id' => 'current_domain',
-        'label' => E::ts('Find Contacts'),
-        'name' => 'Find Contacts',
-        'url' => 'civicrm/adminui/contact/search',
-        'icon' => NULL,
-        'permission' => NULL,
-        'permission_operator' => '',
-        'parent_id.name' => 'Search',
-        'is_active' => TRUE,
-        'has_separator' => NULL,
-        'weight' => 1,
-      ],
-      'match' => [
-        'name',
-      ],
-    ],
-  ],
   [
     'name' => 'SavedSearch_Find_Contacts',
     'entity' => 'SavedSearch',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Search.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Search.mgd.php
@@ -3,6 +3,32 @@
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
 return [
+  // using a temporary alternate path to avoid breaking legacy path
+  [
+    'name' => 'Navigation_Find_Contacts',
+    'entity' => 'Navigation',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'domain_id' => 'current_domain',
+        'label' => E::ts('Find Contacts'),
+        'name' => 'Find Contacts',
+        'url' => 'civicrm/adminui/contact/search',
+        'icon' => NULL,
+        'permission' => NULL,
+        'permission_operator' => '',
+        'parent_id.name' => 'Search',
+        'is_active' => TRUE,
+        'has_separator' => NULL,
+        'weight' => 1,
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
   [
     'name' => 'SavedSearch_Find_Contacts',
     'entity' => 'SavedSearch',


### PR DESCRIPTION
Overview
----------------------------------------
Issue dev/core#4360 dev/core#4384

Before
----------------------------------------
- issues when accessing search contact/search with qfKey
- crash when doing advanced search

After
----------------------------------------
Use the legacy search in most context except when using the menu

Technical Details
----------------------------------------
Using alternate path `civicrm/adminui/contact/search` for SearchKit/Formbuilder version
