### PR TITLE
Remove Search Builder link from search results

### DIFF
--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -13,15 +13,11 @@
 {elseif $context EQ 'amtg'}{crmURL p='civicrm/contact/search/advanced' q="context=amtg&amtgID=`$group.id`&reset=1&force=1"}
 {else}{crmURL p='civicrm/contact/search/advanced' q="reset=1"}
 {/if}{/capture}
-{capture assign=searchBuilderURL}{crmURL p='civicrm/contact/search/builder' q="reset=1"}{/capture}
 
  <div id="search-status">
   <div class="float-right right">
     {if $action eq 256}
-        <a href="{$advSearchURL}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Advanced Search{/ts}</a><br />
-        {if $context eq 'search'} {* Only show Search Builder link for basic search. *}
-            <a href="{$searchBuilderURL}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Search Builder{/ts}</a><br />
-        {/if}
+        <a href="{$advSearchURL}">{ts}Advanced Search{/ts}</a><br />
         {if $context eq 'smog'}
             {help id="id-smog-criteria" group_title=$group.title}
         {elseif $context eq 'amtg'}
@@ -29,10 +25,8 @@
         {else}
             {help id="id-basic-criteria"}
         {/if}
-    {elseif $action eq 512}
-        <a href="{$searchBuilderURL}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Search Builder{/ts}</a><br />
     {elseif $action eq 8192}
-        <a href="{$advSearchURL}"><i class="crm-i fa-chevron-right" aria-hidden="true"></i> {ts}Advanced Search{/ts}</a><br />
+        <a href="{$advSearchURL}">{ts}Advanced Search{/ts}</a><br />
     {/if}
   </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
Since Search Builder is on the way out, I don't think we need the links to Search Builder from Find Contacts or Advanced Search results. We could replace these with link to SearchKit, but I don't think that's particularly helpful to anyone since it's right there in the menu already.

Also removed the somewhat strange > icon in front of Advanced Search as we are not clicking on it to 'advance to the next thing' as the UI Reference indicates for `fa-chevron-right`. I think it's there to tell you that the link takes you somewhere, but that's sort of the nature of links.

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/25517556/168c9f7f-e13f-4153-8841-9472b32e5ab5)
![image](https://github.com/civicrm/civicrm-core/assets/25517556/4de8ec0f-9c64-497c-8dec-901e821b9d53)

After
----------------------------------------
Bye-bye.
<img width="1034" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/7e1f272e-2645-4b3e-a426-5f8eaf60add5">
<img width="1026" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/91ac746c-84a3-45b4-8df2-7d1c5476f627">

