### PR TITLE
Standalone - Track logged-in user object

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -338,6 +338,18 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     return TRUE;
   }
 
+  public function loadUser($username) {
+    $security = \Civi\Standalone\Security::singleton();
+    $user = $security->loadUserByName($username);
+    if ($user) {
+      $security->loginAuthenticatedUserRecord($user, TRUE);
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
   /**
    * @inheritdoc
    */

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -28,19 +28,8 @@ class Standalone implements AuthxInterface {
    * @inheritDoc
    */
   public function loginSession($userId) {
-    $this->loginStateless($userId);
-
-    $session = \CRM_Core_Session::singleton();
-    $session->set('ufID', $userId);
-
-    // Identify the contact
-    $contactID = civicrm_api3('UFMatch', 'get', [
-      'sequential' => 1,
-      'return' => ['contact_id'],
-      'uf_id' => $userId,
-    ])['values'][0]['contact_id'] ?? NULL;
-    // Confusingly, Civi stores it's *Contact* ID as *userId* on the session.
-    $session->set('userId', $contactID);
+    $user = Security::singleton()->loadUserByID($userId);
+    Security::singleton()->loginAuthenticatedUserRecord($user, TRUE);
   }
 
   /**
@@ -54,10 +43,8 @@ class Standalone implements AuthxInterface {
    * @inheritDoc
    */
   public function loginStateless($userId) {
-    global $loggedInUserId;
-    $loggedInUserId = $userId;
-    global $loggedInUser;
-    $loggedInUser = \Civi\Standalone\Security::singleton()->loadUserByID($userId);
+    $user = Security::singleton()->loadUserByID($userId);
+    Security::singleton()->loginAuthenticatedUserRecord($user, FALSE);
   }
 
   /**

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -56,6 +56,8 @@ class Standalone implements AuthxInterface {
   public function loginStateless($userId) {
     global $loggedInUserId;
     $loggedInUserId = $userId;
+    global $loggedInUser;
+    $loggedInUser = \Civi\Standalone\Security::singleton()->loadUserByID($userId);
   }
 
   /**

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -227,7 +227,7 @@ class Security {
   public function loginAuthenticatedUserRecord(array $user, bool $withSession) {
     global $loggedInUserId, $loggedInUser;
     $loggedInUserId = $user['id'];
-    $loggedInUser = \Civi\Standalone\Security::singleton()->loadUserByID($user['id']);
+    $loggedInUser = $user;
 
     if ($withSession) {
       $session = \CRM_Core_Session::singleton();

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -239,8 +239,8 @@ class Security {
         'return' => ['contact_id'],
         'uf_id' => $user['id'],
       ])['values'][0]['contact_id'] ?? NULL;
-      // Confusingly, Civi stores it's *Contact* ID as *userId* on the session.
-      $session->set('userId', $contactID);
+      // Confusingly, Civi stores it's *Contact* ID as *userID* on the session.
+      $session->set('userID', $contactID);
     }
   }
 


### PR DESCRIPTION
Overview
--------

This is a partial solution for running `E2E_Extern_CliRunnerTest::testPermissionLookup()` on Standalone.

~~For a full solution to the test, this needs a corresponding update (https://github.com/civicrm/cv/pull/163).~~ (Provided by `cv` v0.3.43 in a guarded way.)

Technical Details
-----------------

The test calls:

```
cv ev --user='admin' 'echo json_encode(CRM_Core_Config::singleton()->userPermissionClass->check("administer CiviCRM", 0));'
```

Internally, this command relies on `CRM_Core_BAO_UFMatch::synchronize()` by way of:

https://github.com/civicrm/cv/blob/59efd9ffefde8dc500643e048d37db90e0de11b7/src/Util/BootTrait.php#L213-L235

Calls to `UFMatch::synchronize($user)` are expected to pass in the user-record. However, this requires access to the current user-record.

Before
------

Standalone logins track the active user-ID (`$GLOBALS['loggedInUserId']`) -- but not the active user-record.

After
------

Standalone logins track the active user-ID (`$GLOBALS['loggedInUserId']`) and active user-record (`$GLOBALS['loggedInUser']`). This parallels the use of `$user` (Drupal) and `$current_user` (WordPress).

The `$loggedInUser` can be supplied to `UFMatch::synchronize()`.

Comments
-----------

The patch looks a little more complicated because there are two commits. The first (smaller) commit shows the main essence of the change. The second (larger) commit is an optimization.

We could theoretically do a future simplification by dropping `$loggedInUserId` and using `$loggedInUser['id']` instead.