### PR TITLE
Show Email bounce history on Contact summary

### DIFF
--- a/ext/civi_mail/ang/afsearchEmailBounceHistory.aff.html
+++ b/ext/civi_mail/ang/afsearchEmailBounceHistory.aff.html
@@ -1,0 +1,4 @@
+<div af-fieldset="">
+  <crm-search-display-table search-name="Email_Bounce_History" display-name="Email_Bounce_History_Table" filters="{'MailingEventBounce_MailingEventQueue_event_queue_id_01.id': routeParams['MailingEventBounce_MailingEventQueue_event_queue_id_01.email_id']}">
+  </crm-search-display-table>
+</div>

--- a/ext/civi_mail/ang/afsearchEmailBounceHistory.aff.json
+++ b/ext/civi_mail/ang/afsearchEmailBounceHistory.aff.json
@@ -1,0 +1,7 @@
+{
+    "type": "search",
+    "title": "Email Bounce History",
+    "icon": "fa-list-alt",
+    "server_route": "civicrm/contact/view/bounces",
+    "permission": "access CiviCRM"
+}

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -29,6 +29,7 @@
   </classloader>
   <mixins>
     <mixin>scan-classes@1.0.0</mixin>
+    <mixin>mgd-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Mailing</namespace>

--- a/ext/civi_mail/managed/SavedSearch_Email_Bounce_History.mgd.php
+++ b/ext/civi_mail/managed/SavedSearch_Email_Bounce_History.mgd.php
@@ -1,0 +1,147 @@
+<?php
+use CRM_Mailing_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Email_Bounce_History',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Email_Bounce_History',
+        'label' => E::ts('Email Bounce History'),
+        'form_values' => NULL,
+        'mapping_id' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'MailingEventBounce',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'time_stamp',
+            'bounce_type_id:label',
+            'bounce_reason',
+            'MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01_MailingJob_Mailing_mailing_id_01.name',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [
+            [
+              'MailingEventQueue AS MailingEventBounce_MailingEventQueue_event_queue_id_01',
+              'INNER',
+              [
+                'event_queue_id',
+                '=',
+                'MailingEventBounce_MailingEventQueue_event_queue_id_01.id',
+              ],
+            ],
+            [
+              'MailingJob AS MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01',
+              'INNER',
+              [
+                'MailingEventBounce_MailingEventQueue_event_queue_id_01.job_id',
+                '=',
+                'MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01.id',
+              ],
+            ],
+            [
+              'Mailing AS MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01_MailingJob_Mailing_mailing_id_01',
+              'INNER',
+              [
+                'MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01.mailing_id',
+                '=',
+                'MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01_MailingJob_Mailing_mailing_id_01.id',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+        'expires_date' => NULL,
+        'description' => NULL,
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Email_Bounce_History_SearchDisplay_Email_Bounce_History_Table',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Email_Bounce_History_Table',
+        'label' => E::ts('Email_Bounce_History'),
+        'saved_search_id.name' => 'Email_Bounce_History',
+        'type' => 'table',
+        'settings' => [
+          'description' => '',
+          'sort' => [
+            [
+              'time_stamp',
+              'DESC',
+            ],
+          ],
+          'limit' => 10,
+          'pager' => [
+            'hide_single' => TRUE,
+          ],
+          'placeholder' => 3,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'time_stamp',
+              'dataType' => 'Timestamp',
+              'label' => E::ts('Date'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'bounce_type_id:label',
+              'dataType' => 'Integer',
+              'label' => E::ts('Type'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'bounce_reason',
+              'dataType' => 'String',
+              'label' => E::ts('Reason'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01_MailingJob_Mailing_mailing_id_01.name',
+              'dataType' => 'String',
+              'label' => E::ts('Mailing'),
+              'sortable' => FALSE,
+              'link' => [
+                'path' => '',
+                'entity' => 'Mailing',
+                'action' => 'view',
+                'join' => 'MailingEventBounce_MailingEventQueue_event_queue_id_01_MailingEventQueue_MailingJob_job_id_01_MailingJob_Mailing_mailing_id_01',
+                'target' => 'crm-popup',
+              ],
+              'title' => NULL,
+            ],
+          ],
+          'actions' => FALSE,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'noResultsText' => '',
+        ],
+        'acl_bypass' => FALSE,
+      ],
+      'match' => [
+        'name',
+        'saved_search_id',
+      ],
+    ],
+  ],
+];

--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -45,7 +45,8 @@
         {else}
           {$item.email}
         {/if}
-        {if $item.on_hold == 2}&nbsp;({ts}On Hold - Opt Out{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{elseif $item.on_hold}&nbsp;({ts}On Hold{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{/if}{if $item.is_bulkmail}&nbsp;({ts}Bulk{/ts}){/if}
+        {crmAPI var='civi_mail' entity='Extension' action='get' full_name="civi_mail" is_active=1}
+        {if $item.on_hold == 2}&nbsp;({ts}On Hold - Opt Out{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{elseif $item.on_hold}&nbsp;{if $civi_mail.count}<a href="{crmURL p="civicrm/contact/view/bounces" q="email_id=`$item.id`"}" class="crm-popup" title="{ts 1=$item.email}Email Bounce History{/ts}">{/if}({ts}On Hold{/ts})&nbsp;{ts}{$item.hold_date|truncate:10:''|crmDate}{/ts}{if $civi_mail.count}&nbsp;<i class="crm-i fa-list-alt" aria-hidden="true"></i></a>{/if}{/if}{if $item.is_bulkmail}&nbsp;({ts}Bulk{/ts}){/if}
         {if !empty($item.signature_text) OR !empty($item.signature_html)}
         <span class="signature-link description">
           <a href="#" title="{ts}Signature{/ts}" onClick="showHideSignature( '{$blockId}' ); return false;">{ts}(signature){/ts}</a>


### PR DESCRIPTION
Overview
----------------------------------------
Ever wondered why an email is on hold? Wish you could quickly check the history of bounces to see if something may have gone wrong? Now, thanks to the magic of SearchKit, you can.

Emails on hold have a link (and a little icon):
![image](https://github.com/civicrm/civicrm-core/assets/25517556/4f9fdc86-4133-47e6-9bdd-a789bad66a7c)

You get a popup that shows you all bounces for that email and you can also check the mailing reports for each:
![image](https://github.com/civicrm/civicrm-core/assets/25517556/dd04221b-a955-4647-8965-34a47719b788)

This is my first PR using an afform and I did run into a few issues, so I don't think this is quite ready yet, but it all works at the moment and I'm hoping for some feedback to resolve these issues and questions:

1. The SavedSearch is managed in the CiviMail core extension, per discussion with @colemanw, but thinking this through further, I'm not sure that's right. It results in having some silliness in the tpl file to only show this link if civi_mail is enabled (I don't think trying to do this via buildform hook is going to be feasible).
Maybe it would make more sense to manage this in core instead, though I don't think we have a way to do that currently. It seems to me that on hold is not part of CiviMail but actually in core (i.e. you don't expect that emails are going to be taken off hold if you disable civi_mail).
2. Permissions: We can assume that anyone viewing a contact should be able to view their email. But this form is also available to pass in any email id in the url, so do we need to handle permissions or ACLs at all here or is that taken care of?
3. Popup window is taller than it needs to be. Not the end of the world, but if there is a way to match the height to the content, that would be nice (not just here, but I can think of a few other similar places as well).
4. Is the form title in the json file somehow translated automatically? AfformScanner won't accept E::ts.
5. UI is not great as it overlaps somewhat with the Add or edit email hover link, depending on your theme and screen width, but I'm not sure what would be better as I don't think we want to break this onto a second line. Added the icon to show that there is more information there and made the whole on hold text clickable to at least make it usable even if the hover link covers part of it.

Excited to get going with some more little SK popups that let you drill down from the Contact to see specific data like this!