### PR TITLE
distmaker - Add some options to speed up frequent rebuilds

### DIFF
--- a/distmaker/distmaker.conf.dist
+++ b/distmaker/distmaker.conf.dist
@@ -22,3 +22,12 @@ DM_REF_DRUPAL8=${DM_REF_CORE}
 DM_REF_JOOMLA=${DM_REF_CORE}
 DM_REF_WORDPRESS=${DM_REF_CORE}
 DM_REF_PACKAGES=${DM_REF_CORE}
+
+## Keep the existing git checkouts
+# DM_KEEP_GIT=1
+
+## Keep the existing dependencies
+# DM_KEEP_DEPS=1
+
+## Don't build Joomla's alt. Useful if you're frequently rebuilding Joomla for dev-test process.
+# DM_SKIP_ALT=1

--- a/distmaker/distmaker.conf.dist
+++ b/distmaker/distmaker.conf.dist
@@ -31,3 +31,6 @@ DM_REF_PACKAGES=${DM_REF_CORE}
 
 ## Don't build Joomla's alt. Useful if you're frequently rebuilding Joomla for dev-test process.
 # DM_SKIP_ALT=1
+
+## Don't download external extensions
+# DM_SKIP_EXT=1

--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -238,10 +238,12 @@ if [ -d "$DM_SOURCEDIR/drupal-8" ]; then
   dm_git_checkout "$DM_SOURCEDIR/drupal-8" "$DM_REF_DRUPAL8"
 fi
 
-## Get fresh dependencies
-[ -d "$DM_SOURCEDIR/vendor" ] && rm -rf $DM_SOURCEDIR/vendor
-[ -d "$DM_SOURCEDIR/bower_components" ] && rm -rf $DM_SOURCEDIR/bower_components
-dm_generate_vendor "$DM_SOURCEDIR"
+if [ -z "$DM_KEEP_DEPS" ]; then
+  ## Get fresh dependencies
+  [ -d "$DM_SOURCEDIR/vendor" ] && rm -rf $DM_SOURCEDIR/vendor
+  [ -d "$DM_SOURCEDIR/bower_components" ] && rm -rf $DM_SOURCEDIR/bower_components
+  dm_generate_vendor "$DM_SOURCEDIR"
+fi
 
 # Before anything - regenerate DAOs
 

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -276,6 +276,9 @@ function dm_git_checkout() {
 ## Download a Civi extension
 ## usage: dm_install_cvext <full-ext-key> <target-path>
 function dm_install_cvext() {
+  if [ -n "$DM_SKIP_EXT" ]; then
+    return
+  fi
   # cv dl -b '@https://civicrm.org/extdir/ver=4.7.25|cms=Drupal/com.iatspayments.civicrm.xml' --destination=$PWD/iatspayments
   cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION|cms=Drupal/$1.xml" --to="$2"
 }

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -258,6 +258,10 @@ function civicrmVersion( ) {
 ## Perform a hard checkout on a given report
 ## usage: dm_git_checkout <repo_path> <tree-ish>
 function dm_git_checkout() {
+  if [ -n "$DM_KEEP_GIT" ]; then
+    echo "Skip git checkout ($1 => $2)"
+    return
+  fi
   pushd "$1"
     git checkout .
     git checkout "$2"

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -10,6 +10,11 @@ function dm_reset_dirs() {
   mkdir -p "$@"
 }
 
+function dm_rsync() {
+  # ${DM_RSYNC:-rsync} -avC "$@"
+  ${DM_RSYNC:-rsync} -aC "$@"
+}
+
 ## Assert that a folder contains no symlinks
 ##
 ## ex: dev/core#1393, dev/core#1990
@@ -31,7 +36,7 @@ function dm_install_dir() {
   if [ ! -d "$to" ]; then
     mkdir -p "$to"
   fi
-  ${DM_RSYNC:-rsync} -avC --exclude=.git --exclude=.svn "$from/./"  "$to/./"
+  dm_rsync --exclude=.git --exclude=.svn "$from/./"  "$to/./"
 }
 
 ## Copy listed files
@@ -68,7 +73,7 @@ function dm_install_bower() {
   done
 
   [ ! -d "$to" ] && mkdir "$to"
-  ${DM_RSYNC:-rsync} -avC $excludes_rsync "$repo/./" "$to/./"
+  dm_rsync $excludes_rsync "$repo/./" "$to/./"
 }
 
 ## Copy all core files
@@ -112,7 +117,7 @@ function dm_install_coreext() {
 
   for relext in "$@" ; do
     [ ! -d "$to/ext/$relext" ] && mkdir -p "$to/ext/$relext"
-    ${DM_RSYNC:-rsync} -avC $excludes_rsync --include=core "$repo/ext/$relext/./" "$to/ext/$relext/./"
+    dm_rsync $excludes_rsync --include=core "$repo/ext/$relext/./" "$to/ext/$relext/./"
   done
 }
 
@@ -140,7 +145,7 @@ function dm_install_packages() {
   ##   packages/Files packages/PHP packages/Text
 
   [ ! -d "$to" ] && mkdir "$to"
-  ${DM_RSYNC:-rsync} -avC $excludes_rsync --include=core "$repo/./" "$to/./"
+  dm_rsync $excludes_rsync --include=core "$repo/./" "$to/./"
 }
 
 ## Copy Drupal-integration module
@@ -202,7 +207,7 @@ function dm_install_vendor() {
   done
 
   [ ! -d "$to" ] && mkdir "$to"
-  ${DM_RSYNC:-rsync} -avC $excludes_rsync "$repo/./" "$to/./"
+  dm_rsync $excludes_rsync "$repo/./" "$to/./"
   ## We don't this use CLI script in production, and the symlink breaks D7/BD URL installs
   dm_remove_files "$to" "bin/pscss" "bin/cssmin"
 }
@@ -215,7 +220,7 @@ function dm_install_wordpress() {
   if [ ! -d "$to" ]; then
     mkdir -p "$to"
   fi
-  ${DM_RSYNC:-rsync} -avC \
+  dm_rsync \
     --exclude=.git \
     --exclude=.svn \
     --exclude=civicrm.config.php.wordpress \

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 P=`dirname $0`
 CFFILE=$P/../distmaker.conf

--- a/distmaker/dists/joomla_php5.sh
+++ b/distmaker/dists/joomla_php5.sh
@@ -37,10 +37,12 @@ cp "$SRC/joomla/admin/admin.civicrm.php" "$DM_TMPDIR/com_civicrm/admin/civicrm.p
 cd $DM_TMPDIR;
 
 # generate alt version of package
-cp -R -p civicrm com_civicrm/admin/civicrm
-${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
-${DM_ZIP:-zip} -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
-rm -rf com_civicrm/admin/civicrm
+if [ -z "$DM_SKIP_ALT" ]; then
+  cp -R -p civicrm com_civicrm/admin/civicrm
+  ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION alt
+  ${DM_ZIP:-zip} -q -r -9 $DM_TARGETDIR/civicrm-$DM_VERSION-joomla-alt.zip com_civicrm
+  rm -rf com_civicrm/admin/civicrm
+fi
 
 # generate zip version of civicrm.xml
 ${DM_PHP:-php} $DM_SOURCEDIR/distmaker/utils/joomlaxml.php $DM_SOURCEDIR com_civicrm $DM_VERSION zip


### PR DESCRIPTION
Overview
----------------------------------------

Add a few new options to `distmaker` to make it run a bit faster. These options sacrifice "cleanness" and "correctness" in favor of "performance", but they are strictly opt-in.

This is primarily useful when working on the Joomla installer - to do a full/proper test-run of the Joomla installer, you need an updated zip file. This makes it slightly faster to get such a file.

(Contributing step for https://lab.civicrm.org/dev/core/-/issues/1615.)

Technical Details
----------------------------------------

* `DM_KEEP_DEPS`: Keep `vendor` folder as-is. Don't re-run `composer`.
* `DM_KEEP_GIT`: Preserve the local data. Do not checkout specified branches. This should OK to use as long as you don't need multiple versions of Drupal.
* `DM_SKIP_EXT`: Do not download extra extensions
* `DM_SKIP_ALT`: Do not build the "Joomla ALT" zip file.