### PR TITLE
NFC: standardise ufId to ufID to avoid confusion

### DIFF
--- a/CRM/Campaign/BAO/Survey.php
+++ b/CRM/Campaign/BAO/Survey.php
@@ -837,8 +837,8 @@ INNER JOIN  civicrm_contact contact_a ON ( activityTarget.contact_id = contact_a
       return NULL;
     }
 
-    static $ufIds = [];
-    if (!array_key_exists($surveyId, $ufIds)) {
+    static $ufIDs = [];
+    if (!array_key_exists($surveyId, $ufIDs)) {
       //get the profile id.
       $ufJoinParams = [
         'entity_id' => $surveyId,
@@ -849,14 +849,14 @@ INNER JOIN  civicrm_contact contact_a ON ( activityTarget.contact_id = contact_a
       list($first, $second) = CRM_Core_BAO_UFJoin::getUFGroupIds($ufJoinParams);
 
       if ($first) {
-        $ufIds[$surveyId] = [$first];
+        $ufIDs[$surveyId] = [$first];
       }
       if ($second) {
-        $ufIds[$surveyId][] = array_shift($second);
+        $ufIDs[$surveyId][] = array_shift($second);
       }
     }
 
-    return $ufIds[$surveyId] ?? NULL;
+    return $ufIDs[$surveyId] ?? NULL;
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -961,12 +961,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           if (count($organizations)) {
             // Related org url - pass checksum if needed
             $args = [
-              'ufId' => $form->_values['onbehalf_profile_id'],
+              'ufID' => $form->_values['onbehalf_profile_id'],
               'cid' => '',
             ];
             if (!empty($_GET['cs'])) {
               $args = [
-                'ufId' => $form->_values['onbehalf_profile_id'],
+                'ufID' => $form->_values['onbehalf_profile_id'],
                 'uid' => $this->_contactID,
                 'cs' => $_GET['cs'],
                 'cid' => '',

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -376,8 +376,8 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
 
         //On subsequent honor_block_is_active uncheck, disable(don't delete)
         //that particular honoree profile entry in UFjoin table, CRM-13981
-        $ufId = CRM_Core_BAO_UFJoin::findJoinEntryId($ufJoinParam);
-        if ($ufId) {
+        $ufID = CRM_Core_BAO_UFJoin::findJoinEntryId($ufJoinParam);
+        if ($ufID) {
           $ufJoinParam['uf_group_id'] = CRM_Core_BAO_UFJoin::findUFGroupId($ufJoinParam);
           $ufJoinParam['is_active'] = 0;
           CRM_Core_BAO_UFJoin::create($ufJoinParam);

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2520,7 +2520,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    * Check whether a profile is valid combination of
    * required profile fields
    *
-   * @param array $ufId
+   * @param array $ufID
    *   Integer id of the profile.
    * @param array $required
    *   Array of fields those are required in the profile.
@@ -2528,17 +2528,17 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
    * @return array
    *   associative array of profiles
    */
-  public static function checkValidProfile($ufId, $required = NULL) {
+  public static function checkValidProfile($ufID, $required = NULL) {
     $validProfile = FALSE;
-    if (!$ufId) {
+    if (!$ufID) {
       return $validProfile;
     }
 
-    if (!CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $ufId, 'is_active')) {
+    if (!CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFGroup', $ufID, 'is_active')) {
       return $validProfile;
     }
 
-    $profileFields = self::getFields($ufId, FALSE, CRM_Core_Action::VIEW, NULL,
+    $profileFields = self::getFields($ufID, FALSE, CRM_Core_Action::VIEW, NULL,
       NULL, FALSE, NULL, FALSE, NULL,
       CRM_Core_Permission::CREATE, NULL
     );

--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -551,13 +551,13 @@ AND    domain_id    = %4
     $query = "SELECT MAX(uf_id)+1 AS next_uf_id FROM civicrm_uf_match";
     $dao = CRM_Core_DAO::executeQuery($query);
     if ($dao->fetch()) {
-      $ufId = $dao->next_uf_id;
+      $ufID = $dao->next_uf_id;
     }
 
-    if (!isset($ufId)) {
-      $ufId = 1;
+    if (!isset($ufID)) {
+      $ufID = 1;
     }
-    return $ufId;
+    return $ufID;
   }
 
   /**

--- a/CRM/Core/Page/AJAX/Location.php
+++ b/CRM/Core/Page/AJAX/Location.php
@@ -32,7 +32,7 @@ class CRM_Core_Page_AJAX_Location {
    */
   public static function getPermissionedLocation() {
     $cid = CRM_Utils_Request::retrieve('cid', 'Integer', CRM_Core_DAO::$_nullObject, TRUE);
-    $ufId = CRM_Utils_Request::retrieve('ufId', 'Integer', CRM_Core_DAO::$_nullObject, TRUE);
+    $ufID = CRM_Utils_Request::retrieve('ufID', 'Integer', CRM_Core_DAO::$_nullObject, TRUE);
 
     // Verify user id
     $user = CRM_Utils_Request::retrieve('uid', 'Integer', CRM_Core_DAO::$_nullObject, FALSE, CRM_Core_Session::singleton()
@@ -54,7 +54,7 @@ class CRM_Core_Page_AJAX_Location {
 
     $addressSequence = array_flip(CRM_Utils_Address::sequence(\Civi::settings()->get('address_format')));
 
-    $profileFields = CRM_Core_BAO_UFGroup::getFields($ufId, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE,
+    $profileFields = CRM_Core_BAO_UFGroup::getFields($ufID, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE,
       NULL, FALSE, NULL, CRM_Core_Permission::CREATE, NULL
     );
     $website = CRM_Core_BAO_Website::getValues($entityBlock, $values);

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -31,7 +31,7 @@ class Standalone implements AuthxInterface {
     $this->loginStateless($userId);
 
     $session = \CRM_Core_Session::singleton();
-    $session->set('ufId', $userId);
+    $session->set('ufID', $userId);
 
     // Identify the contact
     $contactID = civicrm_api3('UFMatch', 'get', [
@@ -64,7 +64,7 @@ class Standalone implements AuthxInterface {
   public function getCurrentUserId() {
     global $loggedInUserId;
     if (empty($loggedInUserId) && session_status() === PHP_SESSION_ACTIVE) {
-      $loggedInUserId = \CRM_Core_Session::singleton()->get('ufId');
+      $loggedInUserId = \CRM_Core_Session::singleton()->get('ufID');
     }
     return $loggedInUserId;
   }

--- a/js/view/crm.profile-selector.js
+++ b/js/view/crm.profile-selector.js
@@ -110,9 +110,9 @@
       var profileSelectorView = this;
       var designerDialog = new CRM.Designer.DesignerDialog({
         findCreateUfGroupModel: function(options) {
-          var ufId = profileSelectorView.getUfGroupId();
+          var ufID = profileSelectorView.getUfGroupId();
           // Retrieve UF group and fields from the api
-          CRM.api('UFGroup', 'getsingle', {id: ufId, "api.UFField.get": 1}, {
+          CRM.api('UFGroup', 'getsingle', {id: ufID, "api.UFField.get": 1}, {
             success: function(formData) {
               // Note: With chaining, API returns some extraneous keys that aren't part of UFGroupModel
               var ufGroupModel = new CRM.UF.UFGroupModel(_.pick(formData, _.keys(CRM.UF.UFGroupModel.prototype.schema)));
@@ -132,9 +132,9 @@
       var profileSelectorView = this;
       var designerDialog = new CRM.Designer.DesignerDialog({
         findCreateUfGroupModel: function(options) {
-          var ufId = profileSelectorView.getUfGroupId();
+          var ufID = profileSelectorView.getUfGroupId();
           // Retrieve UF group and fields from the api
-          CRM.api('UFGroup', 'getsingle', {id: ufId, "api.UFField.get": 1}, {
+          CRM.api('UFGroup', 'getsingle', {id: ufID, "api.UFField.get": 1}, {
             success: function(formData) {
               // Note: With chaining, API returns some extraneous keys that aren't part of UFGroupModel
               var ufGroupModel = new CRM.UF.UFGroupModel(_.pick(formData, _.keys(CRM.UF.UFGroupModel.prototype.schema)));


### PR DESCRIPTION
Overview
----------------------------------------

The codebase is full of a mix of `ufID` and `ufId` with the former being more common.


Before
----------------------------------------

Mix of capitalisation, causing confusion.


After
----------------------------------------

It's `ufID`. Get over it. At least it's clear.


Comments
----------------------------------------

Now don't get me started that ufID is used to actually refer to multiple different things :scream_cat: 

This might look like a silly thing, but, for ex, in Standalone I'd gone with ufId after seeing it somewhere, when the correct one is ufID.

I believe this to be entirely NFC
