### PR TITLE
[PHP8] Codegen - Don't generate invalid secondary emails

### DIFF
--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -1051,8 +1051,8 @@ class CRM_Core_CodeGen_GenerateData {
    * @return string
    */
   private function _individualEmail($contact, $domain = NULL) {
-    $first = $contact->first_name;
-    $last = $contact->last_name;
+    $first = $contact->first_name ?? ($this->probability(.5) ? $this->randomItem('male_name') : $this->randomItem('female_name'));
+    $last = $contact->last_name ?? $this->randomItem('last_name');
     $f = $first[0];
     $l = $last[0];
     $m = $contact->middle_name ? $contact->middle_name[0] . '.' : '';


### PR DESCRIPTION
Overview
----------------------------------------
When running regen you can sometimes get invalid secondary emails in the sample data.

Before
----------------------------------------
When running regen in php 8 you sometimes see `Warning: Trying to access array offset on value of type null in ...\CRM\Core\CodeGen\GenerateData.php on line 1056`. But here the warning is actually trying to tell us something. You only see it sometimes because of the randomness of the data.

If you look in the db you'll see there's now a contact with a work email like `@acme.org` or sometimes `.@acme.org`.

After
----------------------------------------
Valid emails.

Technical Details
----------------------------------------
The code assumes the contact has a first/last name. Not all contacts do.
There's an argument here that since this is usually coming up when creating a work email for an employee of an org, and so they likely have names in real life (until all workers are replaced by robots), the contact should have a first/last name, but I've chosen not to mess with that and just make sure the email is valid.

There aren't any in the current civicrm_generated.mysql, but you can see an example [here](https://raw.githubusercontent.com/civicrm/civicrm-core/321ab58dd5d135e853afe3a92a4a375ef415b1d5/sql/civicrm_generated.mysql) at id 150 in civicrm_email. And also id 153 is a similar one because randomly it sometimes adds numbers, so in this case was blank and then added numbers.

Comments
----------------------------------------
The easiest way to reproduce this without running the full regen is take an install you don't care about (IT WILL INSERT/UPDATE THE REAL DATABASE), or use somebody else's install who you don't like, and `cd sql && php GenerateData.php`. You might have to do it a second time to see the warning. (Note you'll get an error about the group table, but it's not related and is because you're not running the full regen.)
