### PR TITLE
crmAutocomplete - Fix endless loop (again)

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -759,8 +759,11 @@
             ctrl.ngModel.$render = function() {
               // Trigger change so the Select2 renders the current value,
               // but only if the value has actually changed (to avoid recursion)
-              if (!angular.equals(ctrl.ngModel.$viewValue || '', element.val())) {
-                element.val(ctrl.ngModel.$viewValue || '').change();
+              // We need to coerce null|false in the model to '' and numbers to strings.
+              // We need 0 not to be equivalent to null|false|''
+              const newValue = (ctrl.ngModel.$viewValue === null || ctrl.ngModel.$viewValue === undefined || ctrl.ngModel.$viewValue === false) ? '' : ctrl.ngModel.$viewValue.toString();
+              if (newValue !== element.val().toString()) {
+                element.val(newValue).change();
               }
             };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a master-only regression in Afform.

Before
----------------------------------------
After selecting an "Existing" autocomplete in Afform, the browser enters an endless loop.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
This regressed in 65a6ae6b9228ad945b0f2dc9b80886468098555f because the comparison needs to equivocate numbers and numeric strings.