### PR TITLE
dev/core#4396 AdminUI Find contact using sort_name

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchContactSearch.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchContactSearch.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-container">
     <div class="af-container af-layout-inline">
-      <af-field name="display_name,email_primary.email" defn="{label: 'Name or Email', input_type: 'Text'}" />
+      <af-field name="display_name,sort_name,email_primary.email" defn="{label: 'Name or Email', input_type: 'Text'}" />
       <af-field name="contact_type" defn="{input_attrs: {multiple: true, placeholder: '-any contact type-'}}" />
       <af-field name="contact_sub_type" defn="{input_attrs: {multiple: true, placeholder: '-any contact subtype-'}}" />
       <af-field name="groups" defn="{input_attrs: {multiple: true, placeholder: '-any group-'}}" />


### PR DESCRIPTION
Overview
----------------------------------------
With CiviCRM Administration UI extension enabled, the Name or Email field doesn't recognize the sort name format.

See dev/core#4396

Before
----------------------------------------
The new AdminUI Find contact doesn't allow to search with the sort_name syntax "Last name, First name"

After
----------------------------------------
It works:

![ksnip_20230629-161439](https://github.com/civicrm/civicrm-core/assets/372004/11028a84-c5a5-4e85-8cc1-2513ecd0ffd5)