### PR TITLE
Add missing Mailing Events to API4: Delivered, Forward, Reply

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventDelivered.php
+++ b/CRM/Mailing/Event/BAO/MailingEventDelivered.php
@@ -17,15 +17,15 @@
 class CRM_Mailing_Event_BAO_MailingEventDelivered extends CRM_Mailing_Event_DAO_MailingEventDelivered {
 
   /**
-   * Create a new delivery event.
+   * Record a new delivery event.
    *
    * @param array $params
    *   Associative array of delivery event values.
    *
    * @return \CRM_Mailing_Event_BAO_MailingEventDelivered
    */
-  public static function &create(&$params) {
-    $q = &CRM_Mailing_Event_BAO_MailingEventQueue::verify($params['job_id'],
+  public static function recordDelivery(&$params) {
+    $q = CRM_Mailing_Event_BAO_MailingEventQueue::verify($params['job_id'],
       $params['event_queue_id'],
       $params['hash']
     );
@@ -52,6 +52,19 @@ class CRM_Mailing_Event_BAO_MailingEventDelivered extends CRM_Mailing_Event_DAO_
     }
 
     return $delivered;
+  }
+
+  /**
+   * Create function was renamed `recordDelivery` because it's not a standard CRUD create function
+   *
+   * @param array $params
+   * @deprecated
+   *
+   * @return \CRM_Mailing_Event_BAO_MailingEventDelivered
+   */
+  public static function create(&$params) {
+    CRM_Core_Error::deprecatedFunctionWarning('recordDelivery');
+    return self::recordDelivery($params);
   }
 
   /**

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -183,7 +183,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
       $successfulForward = TRUE;
       // Register the delivery event.
 
-      CRM_Mailing_Event_BAO_MailingEventDelivered::create($params);
+      CRM_Mailing_Event_BAO_MailingEventDelivered::recordDelivery($params);
     }
 
     $transaction->commit();

--- a/ext/civi_mail/Civi/Api4/MailingEventDelivered.php
+++ b/ext/civi_mail/Civi/Api4/MailingEventDelivered.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Tracks when a queued email is actually delivered to the MTA.
+ *
+ * @see \Civi\Api4\Mailing
+ * @since 5.64
+ * @package Civi\Api4
+ */
+class MailingEventDelivered extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnlyEntity;
+
+}

--- a/ext/civi_mail/Civi/Api4/MailingEventForward.php
+++ b/ext/civi_mail/Civi/Api4/MailingEventForward.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Tracks when a contact forwards a mailing to a (new) contact
+ *
+ * @see \Civi\Api4\Mailing
+ * @since 5.64
+ * @package Civi\Api4
+ */
+class MailingEventForward extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnlyEntity;
+
+}

--- a/ext/civi_mail/Civi/Api4/MailingEventReply.php
+++ b/ext/civi_mail/Civi/Api4/MailingEventReply.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * TTracks when a contact replies to a mailing.
+ *
+ * @see \Civi\Api4\Mailing
+ * @since 5.64
+ * @package Civi\Api4
+ */
+class MailingEventReply extends Generic\DAOEntity {
+  use Generic\Traits\ReadOnlyEntity;
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
What is says on the tin.

Comments
----------------------------------------
I had to do some wrangling to prevent the API from using the non-standard `create` method for `CRM_Mailing_Event_DAO_MailingEventDelivered`. This is the same as what @colemanw did previously to `CRM_Mailing_Event_DAO_MailingEventBounce`.