### PR TITLE
Fix ommitted port when constructing redirect URL

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -116,7 +116,9 @@
           if (url.indexOf('civicrm/') === 0) {
             url = CRM.url(url);
           } else if (url.indexOf('/') === 0) {
-            url = $location.protocol() + '://' + $location.host() + url;
+            let port = $location.port();
+            port = port ? `:${port}` : '';
+            url = `${$location.protocol()}://${$location.host()}${port}${url}`;
           }
           $window.location.href = url;
         }


### PR DESCRIPTION
Form Builder can be configured to send a redirect after a submission form has submitted. Before this change it rebuilt URLs with all the parts except the port, causing failures on sites that use a non standard port. After this change, a port is used if there is one.

I've tested this for the case that a port is part of the URL, but it's unclear to me from the [angularjs docs](https://docs.angularjs.org/api/ng/service/$location#port) what happens if there isn't one in the URL - perhaps it returns 80 / 443. If so, I still think we're better with this patch (both cases will function) than without.

If anyone feels strongly I can add a commit to remove the port when the proto is http/s and the port is 80/443 resp.

From angular docs (and probably the cause of the bug): location.host (native JS) includes the `:port` if it is there, whereas `$location.host()` never includes the port.






