### PR TITLE
Note Form: use EntityFormTrait and setEntityId for postProcess hooks

### DIFF
--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -25,6 +25,8 @@
  */
 class CRM_Note_Form_Note extends CRM_Core_Form {
 
+  use CRM_Core_Form_EntityFormTrait;
+
   /**
    * The table name, used when editing/creating a note
    *
@@ -38,13 +40,6 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
    * @var int
    */
   protected $_entityId;
-
-  /**
-   * The note id, used when editing the note
-   *
-   * @var int
-   */
-  protected $_id;
 
   /**
    * The parent note id, used when adding a comment to a note
@@ -192,6 +187,9 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
 
     $ids = [];
     $note = CRM_Core_BAO_Note::add($params, $ids);
+
+    // Required for postProcess hooks
+    $this->setEntityId($note->id);
 
     CRM_Core_Session::setStatus(ts('Your Note has been saved.'), ts('Saved'), 'success');
   }


### PR DESCRIPTION
Overview
----------------------------------------

Minor tweak to make it easier for extension developers to use the postProcess hook when notes are edited.

Before
----------------------------------------

In the postProcess hook, it was not possible to get the node ID that was created.

After
----------------------------------------

ID is available

Comments
----------------------------------------

Similar to https://github.com/civicrm/civicrm-core/pull/17639