### PR TITLE
CiviGrant - Support APIv4 autocompletes

### DIFF
--- a/ext/civigrant/Civi/Api4/Service/Autocomplete/GrantAutocompleteProvider.php
+++ b/ext/civigrant/Civi/Api4/Service/Autocomplete/GrantAutocompleteProvider.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class GrantAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
+
+  /**
+   * Provide default SavedSearch for Grant autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_autocompleteDefault(GenericHookEvent $e) {
+    if (!is_array($e->savedSearch) || $e->savedSearch['api_entity'] !== 'Grant') {
+      return;
+    }
+    $e->savedSearch['api_params'] = [
+      'version' => 4,
+      'select' => [
+        'id',
+        'contact_id.display_name',
+        'grant_type_id:label',
+        'financial_type_id:label',
+        'status_id:label',
+      ],
+      'orderBy' => [],
+      'where' => [],
+      'groupBy' => [],
+      'join' => [],
+      'having' => [],
+    ];
+  }
+
+  /**
+   * Provide default SearchDisplay for Grant autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Grant') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['contact_id.sort_name', 'ASC'],
+        ['application_received_date', 'DESC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'contact_id.display_name',
+          'rewrite' => '[contact_id.display_name] - [grant_type_id:label]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'financial_type_id:label',
+          'rewrite' => '#[id] [status_id:label]',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'financial_type_id:label',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -34,6 +34,7 @@
     <mixin>afform-entity-php@1.0.0</mixin>
     <mixin>smarty-v2@1.0.1</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Grant</namespace>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes CiviGrant autocompletes.

Before
----------------------------------------
Create an Afform. Add a "Grant" entity and an "Existing Grant" field.
View the form and the autocomplete returns an error.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Same as a few other entities (Contribution, etc) which do not have a "LabelField" so need a specialized callback to generate a search display.