### PR TITLE
Add calculated optout & unsub mailing stats to API 4

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/MailingGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/MailingGetSpecProvider.php
@@ -99,6 +99,14 @@ class MailingGetSpecProvider extends \Civi\Core\Service\AutoService implements G
       ->setSqlRenderer([__CLASS__, 'countMailingEvents']);
     $spec->addFieldSpec($field);
 
+    $field = new FieldSpec('stats_optouts_and_unsubscribes', 'Mailing', 'Integer');
+    $field->setLabel(ts('Stats: Opt Outs & Unsubscribes'))
+      ->setDescription(ts('Total contacts who opted out or unsubscribed from a mailing'))
+      ->setColumnName('id')
+      ->setReadonly(TRUE)
+      ->setSqlRenderer([__CLASS__, 'countMailingEvents']);
+    $spec->addFieldSpec($field);
+
     $field = new FieldSpec('stats_forwards', 'Mailing', 'Integer');
     $field->setLabel(ts('Stats: Forwards'))
       ->setDescription(ts('Total mailing forwards'))
@@ -170,6 +178,11 @@ class MailingGetSpecProvider extends \Civi\Core\Service\AutoService implements G
         $tableName = \CRM_Mailing_Event_BAO_MailingEventUnsubscribe::getTableName();
         $unsubscribeType = 1;
         $count = "DISTINCT $tableName.event_queue_id,$tableName.org_unsubscribe";
+        break;
+
+      case 'stats_optouts_and_unsubscribes':
+        $tableName = \CRM_Mailing_Event_BAO_MailingEventUnsubscribe::getTableName();
+        $count = "DISTINCT $tableName.event_queue_id";
         break;
 
       case 'stats_forwards':

--- a/tests/phpunit/api/v4/Entity/MailingEvent.php
+++ b/tests/phpunit/api/v4/Entity/MailingEvent.php
@@ -103,15 +103,15 @@ class MailingEventTest extends Api4TestBase implements TransactionalInterface {
         'records' => [
           ['event_queue_id' => $queueIDs[0], 'org_unsubscribe' => 0],
           ['event_queue_id' => $queueIDs[0], 'org_unsubscribe' => 0],
-          ['event_queue_id' => $queueIDs[0], 'org_unsubscribe' => 1],
-          ['event_queue_id' => $queueIDs[0], 'org_unsubscribe' => 1],
+          ['event_queue_id' => $queueIDs[1], 'org_unsubscribe' => 1],
           ['event_queue_id' => $queueIDs[1], 'org_unsubscribe' => 1],
         ],
       ]);
 
     $mailings = \Civi\Api4\Mailing::get(FALSE)
-      ->addSelect('stats_intended_recipients', 'stats_successful', 'stats_opens_total', 'stats_opens_unique', 'stats_clicks_total',
-        'stats_clicks_unique', 'stats_bounces', 'stats_unsubscribes', 'stats_optouts', 'stats_forwards', 'stats_replies')
+      ->addSelect('stats_intended_recipients', 'stats_successful', 'stats_opens_total', 'stats_opens_unique',
+        'stats_clicks_total', 'stats_clicks_unique', 'stats_bounces', 'stats_unsubscribes', 'stats_optouts',
+        'stats_optouts_and_unsubscribes', 'stats_forwards', 'stats_replies')
       ->addWhere('id', 'IN', [$mid1, $mid2])
       ->addOrderBy('id', 'ASC')
       ->execute();
@@ -136,8 +136,10 @@ class MailingEventTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(0, $mailings[1]['stats_replies']);
     $this->assertEquals(1, $mailings[0]['stats_unsubscribes']);
     $this->assertEquals(0, $mailings[1]['stats_unsubscribes']);
-    $this->assertEquals(2, $mailings[0]['stats_optouts']);
+    $this->assertEquals(1, $mailings[0]['stats_optouts']);
     $this->assertEquals(0, $mailings[1]['stats_optouts']);
+    $this->assertEquals(2, $mailings[0]['stats_optouts_and_unsubscribes']);
+    $this->assertEquals(0, $mailings[1]['stats_optouts_and_unsubscribes']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
 A simple follow up to #26689 with one forgotten stat: combined opt outs and unsubscribes, since often contacts will do both, but for reporting purposes, what we often want is the number of contacts who either opted out or unsubscribed.
 
 Includes test update.