### PR TITLE
Put link first in SearchDisplay Links options

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -2,10 +2,10 @@
   <thead>
     <tr>
       <th class="crm-search-admin-icon-col"></th>
+      <th>{{:: ts('Link') }}</th>
       <th class="crm-search-admin-icon-col">{{:: ts('Icon') }}</th>
       <th>{{:: ts('Open') }}</th>
       <th>{{:: ts('Text') }}</th>
-      <th>{{:: ts('Link') }}</th>
       <th>{{:: ts('Show if') }}</th>
       <th>{{:: ts('Style') }}</th>
       <th class="crm-search-admin-icon-col"></th>
@@ -15,6 +15,9 @@
     <tr ng-repeat="item in $ctrl.group" class="crm-draggable">
       <td class="crm-search-admin-icon-col">
         <i class="crm-i fa-arrows crm-search-move-icon"></i>
+      </td>
+      <td class="form-inline">
+        <crm-search-admin-link-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" link="item" links="$ctrl.links" on-change="$ctrl.onChangeLink(item, newLink)"></crm-search-admin-link-select>
       </td>
       <td class="crm-search-admin-icon-col">
         <span class="crm-editable-enabled" ng-click="pickIcon($index)">
@@ -31,9 +34,6 @@
       <td class="form-inline">
         <input type="text" class="form-control" ng-model="item.text">
         <crm-search-admin-token-select model="item" field="text" suffix=":label"></crm-search-admin-token-select>
-      </td>
-      <td class="form-inline">
-        <crm-search-admin-link-select api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" link="item" links="$ctrl.links" on-change="$ctrl.onChangeLink(item, newLink)"></crm-search-admin-link-select>
       </td>
       <td class="form-inline">
         <input ng-model="item.condition[0]" crm-ui-select="{placeholder: item.action ? ts('Allowed') : ts('Always'), data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition(item)">


### PR DESCRIPTION
Overview
----------------------------------------
Just a little UI tweak to avoid frustration.

Before
----------------------------------------
When you add a Links, Menu or Buttons element to a SearchDisplay, the Link (e.g. View Entity, Edit Entity, Other) is in the middle of the options. When you change the Link, the other fields are changed. If you start editing a row from left to right, you might change the Icon, the Open option, the Text and then change the Link, resetting all the changes you just made.

<img width="805" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/a5694376-4bf1-41f4-ba34-1806fadbf577">

After
----------------------------------------
Link is the first option so you'll change it first, then change other options if desired.

<img width="821" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/02f27f6d-84cd-4e94-9d26-21c988645f2b">