### PR TITLE
SearchKit - Allow custom fields in join conditions

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -507,7 +507,7 @@
     };
 
     function getFieldsForJoin(joinEntity) {
-      return {results: ctrl.getAllFields(':name', ['Field', 'Extra'], null, joinEntity)};
+      return {results: ctrl.getAllFields(':name', ['Field', 'Custom', 'Extra'], null, joinEntity)};
     }
 
     // @return {function}

--- a/tests/phpunit/api/v4/Custom/ContactCustomJoinTest.php
+++ b/tests/phpunit/api/v4/Custom/ContactCustomJoinTest.php
@@ -22,6 +22,7 @@ namespace api\v4\Custom;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomField;
+use Civi\Api4\Participant;
 
 /**
  * @group headless
@@ -47,6 +48,42 @@ class ContactCustomJoinTest extends CustomTestBase {
       'data_type' => 'String',
     ])->execute();
     Contact::get()->addSelect('*')->addSelect('custom.*')->execute();
+  }
+
+  /**
+   * Ensures we can join two entities with a custom field in the ON clause
+   */
+  public function testJoinWithCustomFieldInOnClause(): void {
+    CustomGroup::create(FALSE)
+      ->addValue('extends', 'Participant')
+      ->addValue('title', 'p_set')
+      ->addChain('field', CustomField::create()
+        ->addValue('custom_group_id', '$id')
+        ->addValue('label', 'p_field')
+        ->addValue('html_type', 'Text')
+      )
+      ->execute();
+    $cid = $this->saveTestRecords('Contact', ['records' => 3])->column('id');
+    $this->saveTestRecords('Participant', [
+      'records' => [
+        ['contact_id' => $cid[0], 'p_set.p_field' => 'Value A'],
+        ['contact_id' => $cid[1], 'p_set.p_field' => 'Value B'],
+        ['contact_id' => $cid[2], 'p_set.p_field' => 'Value A'],
+      ],
+    ]);
+    $results = Participant::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('p_set.p_field', '=', 'Value A')
+      ->execute();
+    $this->assertCount(2, $results);
+    $results = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addJoin('Participant AS participant', 'INNER',
+        ['id', '=', 'participant.contact_id'],
+        ['participant.p_set.p_field', '=', '"Value A"'],
+      )
+      ->execute();
+    $this->assertCount(2, $results);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows you to use custom fields in the clause when joining in SearchKit

![image](https://github.com/civicrm/civicrm-core/assets/2874912/2bc6e1d8-cac4-4111-9f4d-44b54cd74102)

Technical Details
-----------------
This was really hard.