### PR TITLE
dev/joomla#51 Fix Joomla permissions warning

### DIFF
--- a/CRM/Core/Permission/Joomla.php
+++ b/CRM/Core/Permission/Joomla.php
@@ -53,23 +53,13 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
     // not execute hooks if joomla is not loaded
     if (defined('_JEXEC')) {
       $user = JFactory::getUser($userId);
-      $api_key    = CRM_Utils_Request::retrieve('api_key', 'String', $store, FALSE, NULL, 'REQUEST');
+      $api_key = CRM_Utils_Request::retrieve('api_key', 'String');
 
       // If we are coming from REST we don't have a user but we do have the api_key for a user.
       if ($user->id === 0 && !is_null($api_key)) {
-        // This is a codeblock copied from /Civicrm/Utils/REST
-        $uid = NULL;
-        if (!$uid) {
-          $store = NULL;
-
-          $contact_id = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $api_key, 'id', 'api_key');
-
-          if ($contact_id) {
-            $uid = CRM_Core_BAO_UFMatch::getUFId($contact_id);
-          }
-          $user = JFactory::getUser($uid);
-
-        }
+        $contact_id = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $api_key, 'id', 'api_key');
+        $uid = ($contact_id) ? CRM_Core_BAO_UFMatch::getUFId($contact_id) : NULL;
+        $user = JFactory::getUser($uid);
       }
 
       return $user->authorise($translated[0], $translated[1]);


### PR DESCRIPTION
Before
----------------------------------------
PHP warning because `$store` is undefined. 

After
----------------------------------------
No more `$store`, no more warning. `FALSE, NULL, 'REQUEST'` are the defaults for `retrieve` so aren't needed either.
Also did a little simplification of the next few lines.

Comments
----------------------------------------
Tried to give this a test run, but I didn't realize buildkit can't do Joomla, so this is untested. I'd appreciate if someone with Joomla set up is able to test. I just did this as a quick fix for an issue on SE.