### PR TITLE
[Tests] Fix a few more places to use eventTrait & remove `legacyEventCreate`

### DIFF
--- a/tests/phpunit/CRM/Upgrade/SnapshotTest.php
+++ b/tests/phpunit/CRM/Upgrade/SnapshotTest.php
@@ -72,16 +72,19 @@ class CRM_Upgrade_SnapshotTest extends CiviUnitTestCase {
   }
 
   /**
-   * This example creates multiple snapshots (attributed to different versions, v5.45 and v5.50),
-   * and it ensures that they can be cleaned-up by future upgrades (eg v5.52 and v5.58).
+   * This example creates multiple snapshots (attributed to different versions,
+   * v5.45 and v5.50), and it ensures that they can be cleaned-up by future
+   * upgrades (eg v5.52 and v5.58).
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testBasicLifecycle(): void {
     for ($i = 0; $i < 15; $i++) {
       $this->individualCreate([], $i);
       $this->organizationCreate([], $i);
     }
-    $this->eventCreate([]);
-    $this->eventCreate([]);
+    $this->eventCreateUnpaid([]);
+    $this->eventCreateUnpaid([]);
 
     $this->runAll(CRM_Upgrade_Snapshot::createTasks('civicrm', '5.45', 'names', CRM_Utils_SQL_Select::from('civicrm_contact')
       ->select('id, display_name, sort_name')

--- a/tests/phpunit/Civi/Token/ImpliedContextSubscriberTest.php
+++ b/tests/phpunit/Civi/Token/ImpliedContextSubscriberTest.php
@@ -3,7 +3,7 @@ namespace Civi\Token;
 
 class ImpliedContextSubscriberTest extends \CiviUnitTestCase {
 
-  public function testParticipant_ImplicitEvent() {
+  public function testParticipantImplicitEvent(): void {
     $participantId = $this->participantCreate();
 
     $messages = \CRM_Core_TokenSmarty::render(
@@ -13,9 +13,9 @@ class ImpliedContextSubscriberTest extends \CiviUnitTestCase {
     $this->assertEquals('Go to Annual CiviCRM meet!', $messages['text']);
   }
 
-  public function testParticipant_ExplicitEvent() {
+  public function testParticipantExplicitEvent(): void {
     $participantId = $this->participantCreate();
-    $otherEventId = $this->eventCreate(['title' => 'Alternate Event'])['id'];
+    $otherEventId = $this->eventCreateUnpaid(['title' => 'Alternate Event'])['id'];
 
     $messages = \CRM_Core_TokenSmarty::render(
       ['text' => 'You may also like {event.title}!'],

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1042,35 +1042,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * Create a paid event.
-   *
-   * @param array $params
-   *
-   * @param array $options
-   *
-   * @param string $key
-   *   Index for storing event ID in ids array.
-   *
-   * @return array
-   */
-  protected function legacyEventCreatePaid(array $params = [], array $options = [['name' => 'hundred', 'amount' => 100]], string $key = 'PaidEvent'): array {
-    // @todo - uncomment these - but need to fix an e-notice first.
-    // $this->dummyProcessorCreate();
-    // $params['payment_processor'] = [$this->ids['PaymentProcessor']['dummy_live']];
-    $params = array_merge([
-      'is_monetary' => TRUE,
-      'financial_type_id:name' => 'Event Fee',
-    ], $params);
-
-    $event = $this->eventCreate($params);
-
-    $this->ids['Event'][$key] = (int) $event['id'];
-    $this->ids['PriceSet'][$key] = $this->eventPriceSetCreate(55, 0, 'Radio', $options);
-    CRM_Price_BAO_PriceSet::addTo('civicrm_event', $event['id'], $this->ids['PriceSet'][$key]);
-    return $event;
-  }
-
-  /**
    * Delete event.
    *
    * @param int $id


### PR DESCRIPTION
Overview
----------------------------------------
Fix a few more places to use eventTrait & remove `legacyEventCreate`

Before
----------------------------------------
We are still using the legacy function and creating events with mis-matched data in others

After
----------------------------------------
The legacy function is gone, less of the mis-matched data method

Technical Details
----------------------------------------
Also fixes one place where financials were invalid

Comments
----------------------------------------
