### PR TITLE
APIv4 - Add more metadata to CustomValue entities; use AutoService

### DIFF
--- a/Civi/Api4/CustomValue.php
+++ b/Civi/Api4/CustomValue.php
@@ -142,9 +142,10 @@ class CustomValue {
   public static function getInfo() {
     return [
       'class' => __CLASS__,
-      'type' => ['CustomValue'],
+      'type' => ['CustomValue', 'DAOEntity'],
       'searchable' => 'secondary',
       'primary_key' => ['id'],
+      'dao' => 'CRM_Core_BAO_CustomValue',
       'see' => [
         'https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields/#multiple-record-fieldsets',
         '\Civi\Api4\CustomGroup',

--- a/Civi/Api4/Provider/CustomEntityProvider.php
+++ b/Civi/Api4/Provider/CustomEntityProvider.php
@@ -14,8 +14,23 @@ namespace Civi\Api4\Provider;
 use Civi\Api4\CustomValue;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CustomEntityProvider {
+/**
+ * @service
+ * @internal
+ */
+class CustomEntityProvider extends AutoService implements EventSubscriberInterface {
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api4.entityTypes' => ['addCustomEntities', 100],
+    ];
+  }
 
   /**
    * Get custom-field pseudo-entities

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -440,7 +440,6 @@ class Container {
 
     $dispatcher->addListener('civi.api4.validate', $aliasMethodEvent('civi.api4.validate', 'getEntityName'), 100);
     $dispatcher->addListener('civi.api4.authorizeRecord', $aliasMethodEvent('civi.api4.authorizeRecord', 'getEntityName'), 100);
-    $dispatcher->addListener('civi.api4.entityTypes', ['\Civi\Api4\Provider\CustomEntityProvider', 'addCustomEntities'], 100);
 
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -83,7 +83,7 @@ class CustomValueTest extends CustomTestBase {
     $entity = Entity::get(FALSE)
       ->addWhere('name', '=', "Custom_$group")
       ->execute()->single();
-    $this->assertEquals(['CustomValue'], $entity['type']);
+    $this->assertEquals(['CustomValue', 'DAOEntity'], $entity['type']);
     $this->assertEquals(['id'], $entity['primary_key']);
     $this->assertEquals($customGroup['table_name'], $entity['table_name']);
     $this->assertEquals('Civi\Api4\CustomValue', $entity['class']);


### PR DESCRIPTION
Overview
--------
Metadata improvements for multi-record custom field pseudo-entities.

Technical Details
----------------------------------------
There are several places in SearchKit code that check an entity 'type' to see if it contains 'DAOEntity'; they all seem designed to test if the query will go through `Api4SelectQuery` (so does it support joins, etc?) and custom entities were getting overlooked.

While I was at it I switch to our new standard 'AutoService' style of event listener