### PR TITLE
Don't show SQL text in SK if user does not have view debug permission

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -21,5 +21,6 @@ return [
     'all CiviCRM permissions and ACLs',
     'administer CiviCRM',
     'administer afform',
+    'view debug output',
   ],
 ];

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -26,6 +26,9 @@
         ctrl.debug = {
           apiParams: JSON.stringify(ctrl.search.api_params, null, 2)
         };
+        ctrl.perm = {
+          viewDebugOutput: CRM.checkPerm('view debug output'),
+        };
         ctrl.results = null;
         ctrl.rowCount = null;
         ctrl.page = 1;

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/debug.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/debug.html
@@ -9,8 +9,10 @@
       <strong>API:</strong>
     </div>
     <pre>{{ $ctrl.debug.apiParams }}</pre>
-    <strong>SQL:</strong>
-    <pre ng-if="!$ctrl.debug.sql">{{:: ts('Run search to view SQL') }}</pre>
-    <pre ng-repeat="query in $ctrl.debug.sql">{{ query }}</pre>
+    <div ng-if="$ctrl.perm.viewDebugOutput">
+      <strong>SQL:</strong>
+      <pre ng-if="!$ctrl.debug.sql">{{:: ts('Run search to view SQL') }}</pre>
+      <pre ng-repeat="query in $ctrl.debug.sql">{{ query }}</pre>
+    </div>
   </div>
 </fieldset>


### PR DESCRIPTION
Before
----------------------------------------
If the user doesn't have `view debug output`, they will see this in SK, even after searching.
<img width="833" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/486875b7-e733-4139-b4b8-b6a863a21bc9">

After
----------------------------------------
If the user doesn't have `view debug output`, they won't see anything about SQL.

Comments
----------------------------------------
After doing this, I'm not sure it really makes sense to hide SQL from users who don't have `view debug output`, as it's really just their input in another form. Alternatively, we could change this so that the debug SQL is always available in API Explorer and SK.