### PR TITLE
Install SK as part of headless test baseline

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -125,6 +125,7 @@ class Test {
       ->callback(function ($ctx) {
         \Civi\Test::data()->populate();
       }, 'populate');
+    $builder->install(['org.civicrm.search_kit']);
     return $builder;
   }
 

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -46,8 +46,7 @@ class Api4TestBase extends TestCase implements HeadlessInterface {
   }
 
   public function setUpHeadless(): CiviEnvBuilder {
-    // TODO: search_kit should probably be part of the 'headless()' baseline.
-    return Test::headless()->install(['org.civicrm.search_kit'])->apply();
+    return Test::headless()->apply();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
SK is required in order to turn managed entities into saved searches. Managed entities can be in core extensions. So we need SK in order to build for tests once we add managed entities to core extensions. See discussion on #26674.