### PR TITLE
CRM_Mailing_Form_Optout, CRM_Mailing_Form_Unsubscribe: change properties to protected from private

### DIFF
--- a/CRM/Mailing/Form/Optout.php
+++ b/CRM/Mailing/Form/Optout.php
@@ -27,22 +27,22 @@ class CRM_Mailing_Form_Optout extends CRM_Core_Form {
   /**
    * @var int
    */
-  private $_job_id;
+  protected $_job_id;
 
   /**
    * @var int
    */
-  private $_queue_id;
+  protected $_queue_id;
 
   /**
    * @var string
    */
-  private $_hash;
+  protected $_hash;
 
   /**
    * @var string
    */
-  private $_email;
+  protected $_email;
 
   public function preProcess() {
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);

--- a/CRM/Mailing/Form/Unsubscribe.php
+++ b/CRM/Mailing/Form/Unsubscribe.php
@@ -27,22 +27,22 @@ class CRM_Mailing_Form_Unsubscribe extends CRM_Core_Form {
   /**
    * @var int
    */
-  private $_job_id;
+  protected $_job_id;
 
   /**
    * @var int
    */
-  private $_queue_id;
+  protected $_queue_id;
 
   /**
    * @var string
    */
-  private $_hash;
+  protected $_hash;
 
   /**
    * @var string
    */
-  private $_email;
+  protected $_email;
 
   public function preProcess() {
     $this->_job_id = $job_id = CRM_Utils_Request::retrieve('jid', 'Integer', $this);


### PR DESCRIPTION
Overview
----------------------------------------
I'd like to hook into the Opt-out and Unsubscribe process but `job_id`, `queue_id` and `hash` are declared private so they are not accessible.

Before
----------------------------------------
`CRM_Core_Form::getVar('_job_id')` returns `null`

After
----------------------------------------
`CRM_Core_Form::getVar('_job_id')` returns correct Job ID.

Technical Details
----------------------------------------
They were declared with private visibility in #21350. Before that they were undefined properties so changing visibility to protected shouldn't break any encapsulation as originally there were public. I think private here is just too strict.
