### PR TITLE
Include `entityTrait` in `ContactTestTrait`

### DIFF
--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -15,6 +15,8 @@ namespace Civi\Test;
  */
 trait ContactTestTrait {
 
+  use EntityTrait;
+
   /**
    * API version to use for any api calls.
    *

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
@@ -29,12 +29,6 @@ use PHPUnit\Framework\TestCase;
  */
 class FullTextTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
-  /**
-   * Entity ids created as part of test
-   * @var array
-   */
-  protected $ids;
-
   use Test\ContactTestTrait;
   use Test\Api3TestTrait;
 
@@ -51,6 +45,8 @@ class FullTextTest extends TestCase implements HeadlessInterface, HookInterface,
 
   /**
    * Test ACL contacts are filtered properly.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testFilterACLContacts(): void {
     $userId = $this->createLoggedInUser();

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -42,7 +42,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   protected $_recurId;
   protected $_membershipId;
   protected $input;
-  protected $ids;
   protected $objects;
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Include `entityTrait` in `ContactTestTrait`

Before
----------------------------------------
 `ContactTestTrait` calls a function on the `EntityTrait` but does not `use` it  - relying on the test calss to `use` it

After
----------------------------------------
`use` statement added

Technical Details
----------------------------------------
The function in question is `createTestEntity` - which is just a wrapper for the apiv4 create action that also registers the ids & entities created in ways that are compatible with 2 styles of `tearDown`

Causing this test fail
https://test.civicrm.org/job/CiviCRM-Ext-Matrix/BKPROF=max,BUILDTYPE=normal,CIVIVER=master,EXTKEY=uk.co.vedaconsulting.mosaico,label=bknix-tmp/4265/testReport/junit/(root)/CRM_Mosaico_AbDemuxTest/testDistribution_with_data_set__0/

Comments
----------------------------------------
