### PR TITLE
Install extensions before components

### DIFF
--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/SampleTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/SampleTest.php
@@ -237,7 +237,7 @@ class SampleTest extends TestCase implements HeadlessInterface, HookInterface, T
         'Household - CA - 2',
       ]),
     ];
-    $searches = SavedSearch::get()->addSelect('*')->execute();
+    $searches = SavedSearch::get()->addSelect('*')->addWhere('has_base', '=', FALSE)->execute();
     foreach ($searches as $index => $search) {
       $formValues = CRM_Contact_BAO_SavedSearch::getFormValues($search['id']);
       $obj = new CRM_Contact_Form_Search_Custom_Sample($formValues);

--- a/setup/plugins/installDatabase/InstallComponents.civi-setup.php
+++ b/setup/plugins/installDatabase/InstallComponents.civi-setup.php
@@ -29,4 +29,4 @@ Civi\Setup::dispatcher()
     }
 
     \Civi::settings()->set('enable_components', $e->getModel()->components);
-  }, \Civi\Setup::PRIORITY_LATE + 300);
+  }, \Civi\Setup::PRIORITY_LATE + 200);

--- a/setup/plugins/installDatabase/InstallExtensions.civi-setup.php
+++ b/setup/plugins/installDatabase/InstallExtensions.civi-setup.php
@@ -20,4 +20,4 @@ if (!defined('CIVI_SETUP')) {
     \civicrm_api3('Extension', 'enable', array(
       'keys' => $e->getModel()->extensions,
     ));
-  }, \Civi\Setup::PRIORITY_LATE + 200);
+  }, \Civi\Setup::PRIORITY_LATE + 300);

--- a/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
@@ -44,7 +44,7 @@ class CRM_Mailing_Form_Task_AdhocMailingTest extends CiviUnitTestCase {
     catch (CRM_Core_Exception_PrematureExitException $e) {
       // Nothing to see here.
     }
-    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', ['where' => [['has_base', '=', FALSE]]]);
     $this->assertEquals($formValues, $savedSearch['form_values']);
   }
 

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -175,7 +175,7 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     $delete_params = ['id' => $create_result['id']];
     $this->callAPIAndDocument(
         $this->_entity, 'delete', $delete_params, __FUNCTION__, __FILE__);
-    $get_result = $this->callAPISuccess($this->_entity, 'get', []);
+    $get_result = $this->callAPISuccess($this->_entity, 'get', ['where' => [['has_base', '=', TRUE]]]);
 
     $this->assertEquals(0, $get_result['count']);
   }

--- a/tests/phpunit/api/v4/Action/CurrentFilterTest.php
+++ b/tests/phpunit/api/v4/Action/CurrentFilterTest.php
@@ -150,9 +150,9 @@ class CurrentFilterTest extends Api4TestBase implements TransactionalInterface {
       'name' => 'expired',
     ])->execute()->first();
 
-    $getCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', TRUE)->execute()->indexBy('id');
-    $notCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', FALSE)->execute()->indexBy('id');
-    $getAll = (array) SavedSearch::get()->addSelect('is_current')->execute()->indexBy('id');
+    $getCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', TRUE)->addWhere('has_base', '=', FALSE)->execute()->indexBy('id');
+    $notCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', FALSE)->addWhere('has_base', '=', FALSE)->execute()->indexBy('id');
+    $getAll = (array) SavedSearch::get()->addSelect('is_current')->addWhere('has_base', '=', FALSE)->execute()->indexBy('id');
 
     $this->assertTrue($getAll[$current['id']]['is_current']);
     $this->assertTrue($getAll[$indefinite['id']]['is_current']);


### PR DESCRIPTION
Overview
----------------------------------------
If we don't enable SK before enabling core extensions, which can have managed entities in them, the managed entities can't be saved as SearchDisplays. If this proves to not work, the other option would be to enable SK specifically, then the core extensions, then the rest of the extensions.

This includes a handful of small fixes where tests assumed that the only SavedSearches would be those created in the test, but now there are managed SavedSearches from extensions as well. ~~I expect more test failures, so this is just to see where I stand on a fresh build.~~

This is pulled out from #26674, see discussion there.