### PR TITLE
[REF] Remove unnecessary CRM_Utils_Array::value and use short array syntax

### DIFF
--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -399,7 +399,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
 
       // add class to this row if overdue
       if (CRM_Utils_Date::overdue(CRM_Utils_Array::value('activity_date_time', $row))
-        && CRM_Utils_Array::value('status_id', $row) == 1
+        && ($row['status_id'] ?? NULL) == 1
       ) {
         $row['overdue'] = 1;
         $row['class'] = 'status-overdue';

--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -261,7 +261,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
     $dao->save();
 
     // CRM-11143 - Give warning message if update_greetings is Enabled (is_active) since it generally should not be run automatically via execute action or runjobs url.
-    if ($values['api_action'] == 'update_greeting' && CRM_Utils_Array::value('is_active', $values) == 1) {
+    if ($values['api_action'] == 'update_greeting' && ($values['is_active'] ?? NULL) == 1) {
       $docLink = CRM_Utils_System::docURL2("user/initial-set-up/scheduled-jobs/#job_update_greeting");
       $msg = ts('The update greeting job can be very resource intensive and is typically not necessary to run on a regular basis. If you do choose to enable the job, we recommend you do not run it with the force=1 option, which would rebuild greetings on all records. Leaving that option absent, or setting it to force=0, will only rebuild greetings for contacts that do not currently have a value stored. %1', [1 => $docLink]);
       CRM_Core_Session::setStatus($msg, ts('Warning: Update Greeting job enabled'), 'alert');

--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -81,7 +81,7 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
 
     $active = $this->add('advcheckbox', 'is_active', ts('Enabled'));
 
-    if (CRM_Utils_Array::value('name', $this->_defaults) == 'Home') {
+    if (($this->_defaults['name'] ?? NULL) == 'Home') {
       $active->freeze();
     }
     else {

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -542,11 +542,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $params['sms_body_text'] = $values['sms_text_message'] ?? NULL;
     $params['body_html'] = $values['html_message'] ?? NULL;
 
-    if (CRM_Utils_Array::value('recipient', $values) === 'manual') {
+    if (($values['recipient'] ?? NULL) === 'manual') {
       $params['recipient_manual'] = $values['recipient_manual_id'] ?? NULL;
       $params['group_id'] = $params['recipient'] = $params['recipient_listing'] = 'null';
     }
-    elseif (CRM_Utils_Array::value('recipient', $values) === 'group') {
+    elseif (($values['recipient'] ?? NULL) === 'group') {
       $params['group_id'] = $values['group_id'];
       $params['recipient_manual'] = $params['recipient'] = $params['recipient_listing'] = 'null';
     }

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -107,7 +107,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
    */
   public static function formRule($fields) {
     $errors = [];
-    if (CRM_Utils_Array::value('monetaryThousandSeparator', $fields) ==
+    if (($fields['monetaryThousandSeparator'] ?? NULL) ==
       CRM_Utils_Array::value('monetaryDecimalPoint', $fields)
     ) {
       $errors['monetaryThousandSeparator'] = ts('Thousands Separator and Decimal Delimiter can not be the same.');

--- a/CRM/Campaign/Form/Survey/Results.php
+++ b/CRM/Campaign/Form/Survey/Results.php
@@ -336,7 +336,7 @@ class CRM_Campaign_Form_Survey_Results extends CRM_Campaign_Form_Survey {
 
     $updateResultSet = FALSE;
     $resultSetOptGrpId = NULL;
-    if ((CRM_Utils_Array::value('option_type', $params) == 2) &&
+    if ((($params['option_type'] ?? NULL) == 2) &&
       !empty($params['option_group_id'])
     ) {
       $updateResultSet = TRUE;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -699,7 +699,8 @@ HERESQL;
       $casesList[$key]['manager'] = self::getCaseManagerContact($caseTypes[$case['case_type_id']], $case['case_id']);
 
       $casesList[$key]['date'] = $activityTypeLabels[$case['activity_type_id']] ?? NULL;
-      if ($actId = CRM_Utils_Array::value('activity_id', $case)) {
+      $actId = $case['activity_id'] ?? NULL;
+      if ($actId) {
         if (self::checkPermission($actId, 'view', $case['activity_type_id'], $userID)) {
           if ($type == 'recent') {
             $casesList[$key]['date'] = sprintf('<a class="action-item crm-hover-button" href="%s" title="%s">%s</a>',
@@ -1360,7 +1361,7 @@ HERESQL;
     $tplParams['activityTypeName'] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeId);
     $tplParams['activity'] = $activityInfo;
     foreach ($tplParams['activity']['fields'] as $k => $val) {
-      if (CRM_Utils_Array::value('label', $val) == ts('Subject')) {
+      if (($val['label'] ?? NULL) == ts('Subject')) {
         $activitySubject = $val['value'];
         break;
       }

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -336,7 +336,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
    */
   public static function formRule($fields, $files, $self) {
     // skip form rule if deleting
-    if (CRM_Utils_Array::value('_qf_Activity_next_', $fields) == 'Delete' || CRM_Utils_Array::value('_qf_Activity_next_', $fields) == 'Restore') {
+    if (($fields['_qf_Activity_next_'] ?? NULL) == 'Delete' || ($fields['_qf_Activity_next_'] ?? NULL) == 'Restore') {
       return TRUE;
     }
 

--- a/CRM/Case/Form/Activity/ChangeCaseStatus.php
+++ b/CRM/Case/Form/Activity/ChangeCaseStatus.php
@@ -129,7 +129,7 @@ class CRM_Case_Form_Activity_ChangeCaseStatus {
   public static function beginPostProcess(&$form, &$params) {
     $params['id'] = $params['case_id'] ?? NULL;
 
-    if (CRM_Utils_Array::value('updateLinkedCases', $params) === '1') {
+    if (($params['updateLinkedCases'] ?? NULL) === '1') {
       $caseID = CRM_Utils_Array::first($form->_caseId);
       $cases = CRM_Case_BAO_Case::getRelatedCases($caseID);
 

--- a/CRM/Case/Page/AJAX.php
+++ b/CRM/Case/Page/AJAX.php
@@ -93,7 +93,7 @@ class CRM_Case_Page_AJAX {
                                   <tr><td>" . ts('Case Start Date') . "</td><td>" . CRM_Utils_Date::customFormat($case['start_date']) . "</td></tr>
                                   <tr><td>" . ts('Case End Date') . "</td><td>" . (isset($case['end_date']) ? CRM_Utils_Date::customFormat($case['end_date']) : '') . "</td></tr></table>";
 
-    if (CRM_Utils_Array::value('snippet', $_GET) == 'json') {
+    if (($_GET['snippet'] ?? NULL) == 'json') {
       CRM_Core_Page_AJAX::returnJsonResponse($caseDetails);
     }
 

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -36,10 +36,7 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
   }
 
   public function getRedactionRules() {
-    foreach (array(
-      'redactionStringRules',
-      'redactionRegexRules',
-    ) as $key => $rule) {
+    foreach (['redactionStringRules', 'redactionRegexRules'] as $key => $rule) {
       $$rule = CRM_Case_PseudoConstant::redactionRule($key);
 
       if (!empty($$rule)) {
@@ -85,7 +82,7 @@ class CRM_Case_XMLProcessor_Report extends CRM_Case_XMLProcessor {
     // add Client to the strings to be redacted across the case session
     if (!array_key_exists($client, $this->_redactionStringRules)) {
       $this->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($this->_redactionStringRules,
-        array($client => 'name_' . rand(10000, 100000))
+        [$client => 'name_' . rand(10000, 100000)]
       );
       $clientSortName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $clientID, 'sort_name');
       if (!array_key_exists($clientSortName, $this->_redactionStringRules)) {
@@ -179,7 +176,7 @@ AND    a.id = ac.activity_id
 AND    ac.case_id = %1
 ";
 
-    $params = array(1 => array($caseID, 'Integer'));
+    $params = [1 => [$caseID, 'Integer']];
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     while ($dao->fetch()) {
       $activityTypeInfo = $map[$dao->activity_type_id];
@@ -233,7 +230,7 @@ LEFT JOIN civicrm_activity_contact at ON a.id = at.activity_id AND at.record_typ
 LEFT JOIN civicrm_activity_contact aa ON a.id = aa.activity_id AND aa.record_type_id = $assigneeID
 WHERE      a.id = %1
     ";
-      $params = array(1 => array($activityID, 'Integer'));
+      $params = [1 => [$activityID, 'Integer']];
       $dao = CRM_Core_DAO::executeQuery($query, $params);
 
       if ($dao->fetch()) {
@@ -272,11 +269,7 @@ WHERE      a.id = %1
     $activity['fields'] = [];
     if ($clientID) {
       $clientID = CRM_Utils_Type::escape($clientID, 'Integer');
-      if (!in_array($activityTypeInfo['name'], array(
-        'Email',
-        'Inbound Email',
-      ))
-      ) {
+      if (!in_array($activityTypeInfo['name'], ['Email', 'Inbound Email'])) {
         $activity['editURL'] = CRM_Utils_System::url('civicrm/case/activity',
           "reset=1&cid={$clientID}&caseid={$activityDAO->caseID}&action=update&atype={$activityDAO->activity_type_id}&id={$activityDAO->id}"
         );
@@ -290,7 +283,7 @@ WHERE      a.id = %1
       // suffixed with a randomly generated 4-digit number
       if (!array_key_exists($client, $this->_redactionStringRules)) {
         $this->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($this->_redactionStringRules,
-          array($client => 'name_' . rand(10000, 100000))
+          [$client => 'name_' . rand(10000, 100000)]
         );
 
         $clientSortName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $clientID, 'sort_name');
@@ -299,12 +292,12 @@ WHERE      a.id = %1
         }
       }
 
-      $activity['fields'][] = array(
+      $activity['fields'][] = [
         'name' => 'Client',
         'label' => ts('Client'),
         'value' => $this->redact($client),
         'type' => 'String',
-      );
+      ];
     }
 
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
@@ -317,7 +310,7 @@ WHERE      a.id = %1
       $processTarget = FALSE;
       $name = 'With Contact(s)';
       $label = ts('With Contact(s)');
-      if (in_array($activityTypeInfo['name'], array('Email', 'Inbound Email'))) {
+      if (in_array($activityTypeInfo['name'], ['Email', 'Inbound Email'])) {
         $processTarget = TRUE;
         $name = 'Recipient';
         $label = ts('Recipient');
@@ -338,7 +331,7 @@ WHERE      a.id = %1
           // suffixed with a randomly generated 4-digit number
           if (!array_key_exists($target, $this->_redactionStringRules)) {
             $this->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($this->_redactionStringRules,
-              array($target => 'name_' . rand(10000, 100000))
+              [$target => 'name_' . rand(10000, 100000)]
             );
             $targetSortName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $targetID, 'sort_name');
             if (!array_key_exists($targetSortName, $this->_redactionStringRules)) {
@@ -348,24 +341,24 @@ WHERE      a.id = %1
           $targetRedacted[] = $this->redact($target);
         }
 
-        $activity['fields'][] = array(
+        $activity['fields'][] = [
           'name' => $name,
           'label' => $label,
           'value' => implode('; ', $targetRedacted),
           'type' => 'String',
-        );
+        ];
       }
     }
 
     // Activity Type info is a special field
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Activity Type',
       'label' => ts('Activity Type'),
       'value' => $activityTypeInfo['label'],
       'type' => 'String',
-    );
+    ];
 
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Subject',
       'label' => ts('Subject'),
       // TODO: Why is this being escaped at this point in the flow? Should
@@ -375,21 +368,21 @@ WHERE      a.id = %1
       // for a few years?
       'value' => htmlspecialchars($this->redact($activityDAO->subject) ?? ''),
       'type' => 'Memo',
-    );
+    ];
 
     $creator = $this->getCreatedBy($activityDAO->id);
     // add Creator to the strings to be redacted across the case session
     if (!array_key_exists($creator, $this->_redactionStringRules)) {
       $this->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($this->_redactionStringRules,
-        array($creator => 'name_' . rand(10000, 100000))
+        [$creator => 'name_' . rand(10000, 100000)]
       );
     }
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Created By',
       'label' => ts('Created By'),
       'value' => $this->redact($creator),
       'type' => 'String',
-    );
+    ];
     $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
     $sourceID = CRM_Utils_Array::key('Activity Source', $activityContacts);
     $source_contact_id = CRM_Activity_BAO_Activity::getActivityContact($activityDAO->id, $sourceID);
@@ -402,7 +395,7 @@ WHERE      a.id = %1
     // suffixed with a randomly generated 4-digit number
     if (!array_key_exists($reporter, $this->_redactionStringRules)) {
       $this->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($this->_redactionStringRules,
-        array($reporter => 'name_' . rand(10000, 100000))
+        [$reporter => 'name_' . rand(10000, 100000)]
       );
 
       $reporterSortName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
@@ -414,89 +407,89 @@ WHERE      a.id = %1
       }
     }
 
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Reported By',
       'label' => ts('Reported By'),
       'value' => $this->redact($reporter),
       'type' => 'String',
-    );
+    ];
 
     if (!empty($activityDAO->assigneeID)) {
       //allow multiple assignee contacts.CRM-4503.
-      $assignee_contact_names = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames(array($activityDAO->id), TRUE);
+      $assignee_contact_names = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames([$activityDAO->id], TRUE);
 
       foreach ($assignee_contact_names as & $assignee) {
         // add Assignee to the strings to be redacted across the case session
         $this->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($this->_redactionStringRules,
-          array($assignee => 'name_' . rand(10000, 100000))
+          [$assignee => 'name_' . rand(10000, 100000)]
         );
         $assignee = $this->redact($assignee);
       }
       $assigneeContacts = implode(', ', $assignee_contact_names);
-      $activity['fields'][] = array(
+      $activity['fields'][] = [
         'name' => 'Assigned to',
         'label' => ts('Assigned to'),
         'value' => $assigneeContacts,
         'type' => 'String',
-      );
+      ];
     }
 
     if ($activityDAO->medium_id) {
-      $activity['fields'][] = array(
+      $activity['fields'][] = [
         'name' => 'Medium',
         'label' => ts('Medium'),
         'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'medium_id', $activityDAO->medium_id),
         'type' => 'String',
-      );
+      ];
     }
 
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Location',
       'label' => ts('Location'),
       'value' => $activityDAO->location,
       'type' => 'String',
-    );
+    ];
 
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Date and Time',
       'label' => ts('Date and Time'),
       'value' => $activityDAO->activity_date_time,
       'type' => 'Date',
-    );
+    ];
 
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Details',
       'label' => ts('Details'),
       'value' => $this->redact(CRM_Utils_String::purifyHTML(CRM_Utils_String::stripAlternatives($activityDAO->details))),
       'type' => 'Memo',
-    );
+    ];
 
     // Skip Duration field if empty (to avoid " minutes" output). Might want to do this for all fields at some point. dgg
     if ($activityDAO->duration) {
-      $activity['fields'][] = array(
+      $activity['fields'][] = [
         'name' => 'Duration',
         'label' => ts('Duration'),
         'value' => $activityDAO->duration . ' ' . ts('minutes'),
         'type' => 'Int',
-      );
+      ];
     }
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Status',
       'label' => ts('Status'),
       'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_DAO_Activity', 'activity_status_id',
         $activityDAO->status_id
       ),
       'type' => 'String',
-    );
+    ];
 
-    $activity['fields'][] = array(
+    $activity['fields'][] = [
       'name' => 'Priority',
       'label' => ts('Priority'),
       'value' => CRM_Core_PseudoConstant::getLabel('CRM_Activity_DAO_Activity', 'priority_id',
         $activityDAO->priority_id
       ),
       'type' => 'String',
-    );
+    ];
 
     //for now empty custom groups
     $activity['customGroups'] = $this->getCustomData($clientID,
@@ -517,7 +510,7 @@ WHERE      a.id = %1
   public function getCustomData($clientID, $activityDAO, &$activityTypeInfo) {
     list($typeValues, $options, $sql) = $this->getActivityTypeCustomSQL($activityTypeInfo['id'], '%Y-%m-%d');
 
-    $params = array(1 => array($activityDAO->id, 'Integer'));
+    $params = [1 => [$activityDAO->id, 'Integer']];
 
     $customGroups = [];
     foreach ($sql as $tableName => $sqlClause) {
@@ -526,7 +519,7 @@ WHERE      a.id = %1
         $customGroup = [];
         foreach ($typeValues[$tableName] as $columnName => $typeValue) {
 
-          if (CRM_Utils_Array::value('type', $typeValue) == 'Date') {
+          if (($typeValue['type'] ?? NULL) == 'Date') {
             $value = $dao->$columnName;
           }
           else {
@@ -539,19 +532,19 @@ WHERE      a.id = %1
             if (strstr($value, CRM_Core_DAO::VALUE_SEPARATOR)) {
               $value = trim($value, CRM_Core_DAO::VALUE_SEPARATOR);
             }
-            if (CRM_Utils_Array::value('type', $typeValue) == 'String' ||
-              CRM_Utils_Array::value('type', $typeValue) == 'Memo'
+            if (($typeValue['type'] ?? NULL) == 'String' ||
+              ($typeValue['type'] ?? NULL) == 'Memo'
             ) {
               $value = $this->redact($value);
             }
           }
           //$typeValue
-          $customGroup[] = array(
+          $customGroup[] = [
             'label' => $typeValue['label'],
             'value' => $value,
             'type' => $typeValue['type'],
             'fieldID' => $typeValue['fieldID'],
-          );
+          ];
         }
         $customGroups[$dao->groupTitle] = $customGroup;
       }
@@ -601,12 +594,12 @@ AND " . CRM_Core_Permission::customGroupClause(CRM_Core_Permission::VIEW, 'cg.')
         $query .= "AND cg.extends_entity_column_value IS NULL";
       }
       $query .= "ORDER BY cg.weight, cf.weight";
-      $params = array(
-        1 => array(
+      $params = [
+        1 => [
           $activityTypeID,
           'Integer',
-        ),
-      );
+        ],
+      ];
       $dao = CRM_Core_DAO::executeQuery($query, $params);
 
       $result = $options = $sql = $groupTitle = [];
@@ -615,18 +608,18 @@ AND " . CRM_Core_Permission::customGroupClause(CRM_Core_Permission::VIEW, 'cg.')
           $result[$dao->tableName] = [];
           $sql[$dao->tableName] = [];
         }
-        $result[$dao->tableName][$dao->columnName] = array(
+        $result[$dao->tableName][$dao->columnName] = [
           'label' => $dao->label,
           'type' => $dao->dataType,
           'fieldID' => $dao->fieldID,
-        );
+        ];
 
         $options[$dao->fieldID] = [];
-        $options[$dao->fieldID]['attributes'] = array(
+        $options[$dao->fieldID]['attributes'] = [
           'label' => $dao->label,
           'data_type' => $dao->dataType,
           'html_type' => $dao->htmlType,
-        );
+        ];
         // since we want to add ISO date format.
         if ($dateFormat && $dao->htmlType == 'Select Date') {
           $options[$dao->fieldID]['attributes']['format'] = $dateFormat;
@@ -638,7 +631,7 @@ SELECT label, value
  WHERE option_group_id = %1
 ";
 
-          $option = CRM_Core_DAO::executeQuery($query, array(1 => array($dao->optionGroupID, 'Positive')));
+          $option = CRM_Core_DAO::executeQuery($query, [1 => [$dao->optionGroupID, 'Positive']]);
           while ($option->fetch()) {
             $dataType = $dao->dataType;
             if ($dataType == 'Int' || $dataType == 'Float') {
@@ -666,7 +659,7 @@ WHERE  entity_id = %1
 ";
       }
 
-      $cache[$activityTypeID] = array($result, $options, $sql);
+      $cache[$activityTypeID] = [$result, $options, $sql];
     }
     return $cache[$activityTypeID];
   }
@@ -687,7 +680,7 @@ AND    l.modified_id  = c.id
 LIMIT  1
 ";
 
-    $params = array(1 => array($activityID, 'Integer'));
+    $params = [1 => [$activityID, 'Integer']];
     return CRM_Core_DAO::singleValueQuery($query, $params);
   }
 
@@ -757,7 +750,7 @@ LIMIT  1
     $case = $form->caseInfo($clientID, $caseID);
     $template->assign_by_ref('case', $case);
 
-    if (CRM_Utils_Array::value('include_activities', $params) == 1) {
+    if (($params['include_activities'] ?? NULL) == 1) {
       $template->assign('includeActivities', 'All');
     }
     else {
@@ -782,11 +775,11 @@ LIMIT  1
     }
 
     // next get activity set Information
-    $activitySet = array(
+    $activitySet = [
       'label' => $form->getActivitySetLabel($xml, $activitySetName),
       'includeActivities' => 'All',
       'redact' => 'false',
-    );
+    ];
     $template->assign_by_ref('activitySet', $activitySet);
 
     //now collect all the information about activities
@@ -828,7 +821,7 @@ LIMIT  1
       if ($isRedact) {
         if (!array_key_exists($value['name'], $report->_redactionStringRules)) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($value['name'] => 'name_' . rand(10000, 100000))
+            [$value['name'] => 'name_' . rand(10000, 100000)]
           );
         }
         $value['name'] = $report->redact($value['name'], TRUE, $report->_redactionStringRules);
@@ -836,7 +829,7 @@ LIMIT  1
           !array_key_exists($value['email'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($value['email'] => 'email_' . rand(10000, 100000))
+            [$value['email'] => 'email_' . rand(10000, 100000)]
           );
         }
 
@@ -846,7 +839,7 @@ LIMIT  1
           !array_key_exists($value['phone'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($value['phone'] => 'phone_' . rand(10000, 100000))
+            [$value['phone'] => 'phone_' . rand(10000, 100000)]
           );
         }
         $value['phone'] = $report->redact($value['phone'], TRUE, $report->_redactionStringRules);
@@ -859,7 +852,7 @@ LIMIT  1
         if (!array_key_exists(CRM_Utils_Array::value('sort_name', $client), $report->_redactionStringRules)) {
 
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array(CRM_Utils_Array::value('sort_name', $client) => 'name_' . rand(10000, 100000))
+            [($client['sort_name'] ?? NULL) => 'name_' . rand(10000, 100000)]
           );
         }
         if (!array_key_exists(CRM_Utils_Array::value('display_name', $client), $report->_redactionStringRules)) {
@@ -870,7 +863,7 @@ LIMIT  1
           !array_key_exists($client['email'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($client['email'] => 'email_' . rand(10000, 100000))
+            [$client['email'] => 'email_' . rand(10000, 100000)]
           );
         }
         $client['email'] = $report->redact(CRM_Utils_Array::value('email', $client), TRUE, $report->_redactionStringRules);
@@ -879,7 +872,7 @@ LIMIT  1
           !array_key_exists($client['phone'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($client['phone'] => 'phone_' . rand(10000, 100000))
+            [$client['phone'] => 'phone_' . rand(10000, 100000)]
           );
         }
         $client['phone'] = $report->redact(CRM_Utils_Array::value('phone', $client), TRUE, $report->_redactionStringRules);
@@ -894,7 +887,7 @@ LIMIT  1
       if ($isRedact) {
         if (!array_key_exists($r['name'], $report->_redactionStringRules)) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($r['name'] => 'name_' . rand(10000, 100000))
+            [$r['name'] => 'name_' . rand(10000, 100000)]
           );
         }
         if (!array_key_exists($r['display_name'], $report->_redactionStringRules)) {
@@ -906,7 +899,7 @@ LIMIT  1
           !array_key_exists($r['phone'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($r['phone'] => 'phone_' . rand(10000, 100000))
+            [$r['phone'] => 'phone_' . rand(10000, 100000)]
           );
         }
         $r['phone'] = $report->redact($r['phone'], TRUE, $report->_redactionStringRules);
@@ -915,7 +908,7 @@ LIMIT  1
           !array_key_exists($r['email'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($r['email'] => 'email_' . rand(10000, 100000))
+            [$r['email'] => 'email_' . rand(10000, 100000)]
           );
         }
         $r['email'] = $report->redact($r['email'], TRUE, $report->_redactionStringRules);
@@ -931,7 +924,7 @@ LIMIT  1
       if ($isRedact) {
         if (!array_key_exists($r['sort_name'], $report->_redactionStringRules)) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($r['sort_name'] => 'name_' . rand(10000, 100000))
+            [$r['sort_name'] => 'name_' . rand(10000, 100000)]
           );
         }
         if (!array_key_exists($r['display_name'], $report->_redactionStringRules)) {
@@ -943,7 +936,7 @@ LIMIT  1
           !array_key_exists($r['phone'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($r['phone'] => 'phone_' . rand(10000, 100000))
+            [$r['phone'] => 'phone_' . rand(10000, 100000)]
           );
         }
         $r['phone'] = $report->redact($r['phone'], TRUE, $report->_redactionStringRules);
@@ -952,7 +945,7 @@ LIMIT  1
           !array_key_exists($r['email'], $report->_redactionStringRules)
         ) {
           $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
-            array($r['email'] => 'email_' . rand(10000, 100000))
+            [$r['email'] => 'email_' . rand(10000, 100000)]
           );
         }
         $r['email'] = $report->redact($r['email'], TRUE, $report->_redactionStringRules);
@@ -961,17 +954,17 @@ LIMIT  1
 
     // Retrieve custom values for cases.
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($caseID, 'Case');
-    $extends = array('case');
+    $extends = ['case'];
     $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
     $caseCustomFields = [];
     foreach ($groupTree as $gid => $group_values) {
       foreach ($group_values['fields'] as $id => $field_values) {
         if (array_key_exists($id, $customValues)) {
           $caseCustomFields[$gid]['title'] = $group_values['title'];
-          $caseCustomFields[$gid]['values'][$id] = array(
+          $caseCustomFields[$gid]['values'][$id] = [
             'label' => $field_values['label'],
             'value' => $customValues[$id],
-          );
+          ];
         }
       }
     }

--- a/CRM/Contact/BAO/Individual.php
+++ b/CRM/Contact/BAO/Individual.php
@@ -44,7 +44,7 @@ class CRM_Contact_BAO_Individual extends CRM_Contact_DAO_Contact {
     // "null" value for example is passed by dedupe merge in order to empty.
     // Display name computation shouldn't consider such values.
     foreach (['first_name', 'middle_name', 'last_name', 'nick_name', 'formal_title', 'birth_date', 'deceased_date'] as $displayField) {
-      if (CRM_Utils_Array::value($displayField, $params) == "null") {
+      if (($params[$displayField] ?? NULL) == "null") {
         $params[$displayField] = '';
       }
     }

--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -328,7 +328,7 @@ ACOS(
    */
   public static function fixInputParams(&$input) {
     foreach ($input as $param) {
-      if (CRM_Utils_Array::value('0', $param) == 'prox_distance') {
+      if (($param['0'] ?? NULL) == 'prox_distance') {
         // add prox_ prefix to these
         $param_alter = ['street_address', 'city', 'postal_code', 'state_province', 'country'];
 

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1425,7 +1425,7 @@ LEFT JOIN  civicrm_country ON (civicrm_address.country_id = civicrm_country.id)
         $relTypeValues = [];
         CRM_Contact_BAO_RelationshipType::retrieve($relTypeParams, $relTypeValues);
 
-        if (CRM_Utils_Array::value('name_a_b', $relTypeValues) == CRM_Utils_Array::value('name_b_a', $relTypeValues)) {
+        if (($relTypeValues['name_a_b'] ?? NULL) == CRM_Utils_Array::value('name_b_a', $relTypeValues)) {
           $values[$cid]['relationshipTypeDirection'] = '_a_b';
         }
         else {

--- a/CRM/Contact/Form/Edit/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Edit/CommunicationPreferences.php
@@ -136,7 +136,7 @@ class CRM_Contact_Form_Edit_CommunicationPreferences {
     $greetings = self::getGreetingFields($self->_contactType);
     foreach ($greetings as $greeting => $details) {
       $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $details['field'], 'Customized');
-      if (CRM_Utils_Array::value($details['field'], $fields) == $customizedValue && empty($fields[$details['customField']])) {
+      if (($fields[$details['field']] ?? NULL) == $customizedValue && empty($fields[$details['customField']])) {
         $errors[$details['customField']] = ts('Custom  %1 is a required field if %1 is of type Customized.',
           [1 => $details['label']]
         );

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -196,7 +196,7 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
         return ['task' => 'Please select a valid action.'];
       }
 
-      if (CRM_Utils_Array::value('task', $fields) == CRM_Contact_Task::SAVE_SEARCH) {
+      if (($fields['task'] ?? NULL) == CRM_Contact_Task::SAVE_SEARCH) {
         // dont need to check for selection of contacts for saving search
         return TRUE;
       }

--- a/CRM/Contact/Form/Search/Builder.php
+++ b/CRM/Contact/Form/Search/Builder.php
@@ -473,7 +473,7 @@ class CRM_Contact_Form_Search_Builder extends CRM_Contact_Form_Search {
         elseif (in_array(substr($field, 0, 3), [
           'is_',
           'do_',
-        ]) || CRM_Utils_Array::value('data_type', $info) == 'Boolean'
+        ]) || ($info['data_type'] ?? NULL) == 'Boolean'
         ) {
           $options[$field] = 'yesno';
           if ($entity != 'contact') {

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -133,7 +133,7 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
     $isSelectedContacts = (self::$_searchFormValues['radio_ts'] ?? NULL) === 'ts_sel';
     $form->assign('isSelectedContacts', $isSelectedContacts);
     // all contacts or action = save a search
-    if ((CRM_Utils_Array::value('radio_ts', self::$_searchFormValues) == 'ts_all') ||
+    if (((self::$_searchFormValues['radio_ts'] ?? NULL) == 'ts_all') ||
       ($form->_task == CRM_Contact_Task::SAVE_SEARCH)
     ) {
       // since we don't store all contacts in prevnextcache, when user selects "all" use query to retrieve contacts

--- a/CRM/Contact/Form/Task/Delete.php
+++ b/CRM/Contact/Form/Task/Delete.php
@@ -49,8 +49,8 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
 
     // sort out whether it’s a delete-to-trash, delete-into-oblivion or restore (and let the template know)
     $values = $this->controller->exportValues();
-    $this->_skipUndelete = (CRM_Core_Permission::check('access deleted contacts') and (CRM_Utils_Request::retrieve('skip_undelete', 'Boolean', $this) or CRM_Utils_Array::value('task', $values) == CRM_Contact_Task::DELETE_PERMANENTLY));
-    $this->_restore = (CRM_Utils_Request::retrieve('restore', 'Boolean', $this) or CRM_Utils_Array::value('task', $values) == CRM_Contact_Task::RESTORE);
+    $this->_skipUndelete = (CRM_Core_Permission::check('access deleted contacts') and (CRM_Utils_Request::retrieve('skip_undelete', 'Boolean', $this) or ($values['task'] ?? NULL) == CRM_Contact_Task::DELETE_PERMANENTLY));
+    $this->_restore = (CRM_Utils_Request::retrieve('restore', 'Boolean', $this) or ($values['task'] ?? NULL) == CRM_Contact_Task::RESTORE);
 
     if ($this->_restore && !CRM_Core_Permission::check('access deleted contacts')) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this contact.'));

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -249,7 +249,7 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
         $valuesothers = CRM_Core_BAO_Location::getValues($paramsothers, $valuesothers);
         if (!empty($fv['location_type_id'])) {
           foreach ($valuesothers as $vals) {
-            if (CRM_Utils_Array::value('location_type_id', $vals) ==
+            if (($vals['location_type_id'] ?? NULL) ==
               CRM_Utils_Array::value('location_type_id', $fv)
             ) {
               foreach ($vals as $k => $v) {

--- a/CRM/Contact/Form/Task/LabelCommon.php
+++ b/CRM/Contact/Form/Task/LabelCommon.php
@@ -182,7 +182,7 @@ class CRM_Contact_Form_Task_LabelCommon {
         $valuesothers = CRM_Core_BAO_Location::getValues($paramsothers, $valuesothers);
         if ($locationTypeID) {
           foreach ($valuesothers as $vals) {
-            if (CRM_Utils_Array::value('location_type_id', $vals) ==
+            if (($vals['location_type_id'] ?? NULL) ==
               $locationTypeID
             ) {
               foreach ($vals as $k => $v) {

--- a/CRM/Contact/Page/Inline/ContactInfo.php
+++ b/CRM/Contact/Page/Inline/ContactInfo.php
@@ -35,7 +35,7 @@ class CRM_Contact_Page_Inline_ContactInfo extends CRM_Core_Page {
     CRM_Contact_BAO_Contact::getValues($params, $defaults);
 
     //get the current employer name
-    if (CRM_Utils_Array::value('contact_type', $defaults) == 'Individual') {
+    if (($defaults['contact_type'] ?? NULL) == 'Individual') {
       if (!empty($defaults['employer_id']) && !empty($defaults['organization_name'])) {
         $defaults['current_employer'] = $defaults['organization_name'];
         $defaults['current_employer_id'] = $defaults['employer_id'];

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3109,7 +3109,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $additionalParticipantId = [];
     $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['contribution_status_id'] ?? NULL);
 
-    if (CRM_Utils_Array::value('contribution_mode', $params) === 'participant') {
+    if (($params['contribution_mode'] ?? NULL) === 'participant') {
       $entityId = $params['participant_id'];
       $entityTable = 'civicrm_participant';
       $additionalParticipantId = CRM_Event_BAO_Participant::getAdditionalParticipantIds($entityId);

--- a/CRM/Contribute/Form/CancelSubscription.php
+++ b/CRM/Contribute/Form/CancelSubscription.php
@@ -257,7 +257,7 @@ class CRM_Contribute_Form_CancelSubscription extends CRM_Contribute_Form_Contrib
         $msgType = 'success';
       }
 
-      if (CRM_Utils_Array::value('is_notify', $params) == 1) {
+      if (($params['is_notify'] ?? NULL) == 1) {
         // send notification
         $sendTemplateParams
           = [

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -821,7 +821,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $membershipFieldId = $contributionFieldId = $errorKey = $otherFieldId = NULL;
         foreach ($self->_values['fee'] as $fieldKey => $fieldValue) {
           // if 'No thank you' membership is selected then set $membershipFieldId
-          if ($fieldValue['name'] == 'membership_amount' && CRM_Utils_Array::value('price_' . $fieldKey, $fields) == 0) {
+          if ($fieldValue['name'] == 'membership_amount' && ($fields['price_' . $fieldKey] ?? NULL) == 0) {
             $membershipFieldId = $fieldKey;
           }
           elseif ($membershipFieldId) {
@@ -832,7 +832,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
               $contributionFieldId = $fieldKey;
             }
 
-            if (!$errorKey || CRM_Utils_Array::value('price_' . $contributionFieldId, $fields) == '0') {
+            if (!$errorKey || ($fields['price_' . $contributionFieldId] ?? NULL) == '0') {
               $errorKey = $fieldKey;
             }
           }
@@ -958,7 +958,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     // validate PCP fields - if not anonymous, we need a nick name value
     if ($self->_pcpId && !empty($fields['pcp_display_in_roll']) &&
       empty($fields['pcp_is_anonymous']) &&
-      CRM_Utils_Array::value('pcp_roll_nickname', $fields) == ''
+      ($fields['pcp_roll_nickname'] ?? NULL) == ''
     ) {
       $errors['pcp_roll_nickname'] = ts('Please enter a name to include in the Honor Roll, or select \'contribute anonymously\'.');
     }
@@ -991,7 +991,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           if (!isset($fields['pledge_installments'])) {
             $errors['pledge_installments'] = ts('Pledge Installments is required field.');
           }
-          elseif (CRM_Utils_Array::value('pledge_installments', $fields) == 1) {
+          elseif (($fields['pledge_installments'] ?? NULL) == 1) {
             $errors['pledge_installments'] = ts('Pledges consist of multiple scheduled payments. Select one-time contribution if you want to make your gift in a single payment.');
           }
           elseif (empty($fields['pledge_installments'])) {
@@ -1061,7 +1061,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $params['amount_other'] = CRM_Utils_Rule::cleanMoney($params['amount_other']);
     }
 
-    if (CRM_Utils_Array::value('amount', $params) == 'amount_other_radio' || !empty($params['amount_other'])) {
+    if (($params['amount'] ?? NULL) == 'amount_other_radio' || !empty($params['amount_other'])) {
       $amount = $params['amount_other'];
     }
     elseif (!empty($params['pledge_amount'])) {
@@ -1143,7 +1143,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
                 $params['amount'] = $selectedPriceOptionID;
                 if ($priceField->name == 'contribution_amount' ||
                     ($priceField->name == 'membership_amount' &&
-                      CRM_Utils_Array::value('is_separate_payment', $this->_membershipBlock) == 0)
+                      ($this->_membershipBlock['is_separate_payment'] ?? NULL) == 0)
                 ) {
                   $this->_values['amount'] = $priceOptions[$selectedPriceOptionID]['amount'] ?? NULL;
                 }

--- a/CRM/Contribute/Form/ManagePremiums.php
+++ b/CRM/Contribute/Form/ManagePremiums.php
@@ -195,14 +195,14 @@ class CRM_Contribute_Form_ManagePremiums extends CRM_Contribute_Form {
   public static function formRule($params, $files) {
 
     // If choosing to upload an image, then an image must be provided
-    if (CRM_Utils_Array::value('imageOption', $params) == 'image'
+    if (($params['imageOption'] ?? NULL) == 'image'
       && empty($files['uploadFile']['name'])
     ) {
       $errors['uploadFile'] = ts('A file must be selected');
     }
 
     // If choosing to use image URLs, then both URLs must be present
-    if (CRM_Utils_Array::value('imageOption', $params) == 'thumbnail') {
+    if (($params['imageOption'] ?? NULL) == 'thumbnail') {
       if (!$params['imageUrl']) {
         $errors['imageUrl'] = ts('Image URL is Required');
       }

--- a/CRM/Contribute/Page/ContributionRecurPayments.php
+++ b/CRM/Contribute/Page/ContributionRecurPayments.php
@@ -120,10 +120,10 @@ class CRM_Contribute_Page_ContributionRecurPayments extends CRM_Core_Page {
   private function insertStatusLabels(&$contribution) {
     $contribution['contribution_status_label'] = $contribution['contribution_status'];
 
-    if ($contribution['is_pay_later'] && CRM_Utils_Array::value('contribution_status', $contribution) == 'Pending') {
+    if ($contribution['is_pay_later'] && ($contribution['contribution_status'] ?? NULL) == 'Pending') {
       $contribution['contribution_status_label'] .= ' (' . ts('Pay Later') . ')';
     }
-    elseif (CRM_Utils_Array::value('contribution_status', $contribution) == 'Pending') {
+    elseif (($contribution['contribution_status'] ?? NULL) == 'Pending') {
       $contribution['contribution_status_label'] .= ' (' . ts('Incomplete Transaction') . ')';
     }
   }
@@ -169,7 +169,7 @@ class CRM_Contribute_Page_ContributionRecurPayments extends CRM_Core_Page {
     );
 
     $isPayLater = FALSE;
-    if ($contribution['is_pay_later'] && CRM_Utils_Array::value('contribution_status', $contribution) == 'Pending') {
+    if ($contribution['is_pay_later'] && ($contribution['contribution_status'] ?? NULL) == 'Pending') {
       $isPayLater = TRUE;
 
       $links[CRM_Core_Action::ADD] = [

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -405,7 +405,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
       );
 
       $isPayLater = FALSE;
-      if ($result->is_pay_later && CRM_Utils_Array::value('contribution_status_name', $row) == 'Pending') {
+      if ($result->is_pay_later && ($row['contribution_status_name'] ?? NULL) == 'Pending') {
         $isPayLater = TRUE;
         $row['contribution_status'] .= ' (' . ts('Pay Later') . ')';
         $links[CRM_Core_Action::ADD] = [
@@ -415,7 +415,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
           'title' => ts('Pay with Credit Card'),
         ];
       }
-      elseif (CRM_Utils_Array::value('contribution_status_name', $row) == 'Pending') {
+      elseif (($row['contribution_status_name'] ?? NULL) == 'Pending') {
         $row['contribution_status'] .= ' (' . ts('Incomplete Transaction') . ')';
       }
 

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -916,7 +916,7 @@ SELECT is_primary,
     }
 
     // prevent an endless chain between two shared addresses (prevent chaining 3) CRM-21214
-    if (CRM_Utils_Array::value('id', $params) == $params['master_id']) {
+    if (($params['id'] ?? NULL) == $params['master_id']) {
       $params['master_id'] = NULL;
       CRM_Core_Session::setStatus(ts("You can't connect an address to itself"), '', 'warning');
     }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -191,7 +191,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       CRM_Core_BAO_SchemaHandler::changeUniqueToIndex($tableNameNeedingIndexUpdate, !empty($params['is_multiple']));
     }
 
-    if (CRM_Utils_Array::value('overrideFKConstraint', $params) == 1) {
+    if (($params['overrideFKConstraint'] ?? NULL) == 1) {
       $table = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup',
         $params['id'],
         'table_name'

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -243,7 +243,7 @@ class CRM_Core_BAO_CustomValueTable {
 
           $fieldExtends = $field['extends'] ?? NULL;
           if (
-            CRM_Utils_Array::value('entity_table', $field) === 'civicrm_contact'
+            ($field['entity_table'] ?? NULL) === 'civicrm_contact'
             || $fieldExtends === 'Contact'
             || $fieldExtends === 'Individual'
             || $fieldExtends === 'Organization'

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -888,7 +888,7 @@ ORDER BY weight";
    */
   public static function buildHomeMenu(&$menu) {
     foreach ($menu as &$item) {
-      if (CRM_Utils_Array::value('name', $item['attributes']) === 'Home') {
+      if (($item['attributes']['name'] ?? NULL) === 'Home') {
         unset($item['attributes']['label'], $item['attributes']['url']);
         $item['attributes']['icon'] = 'crm-logo-sm';
         $item['attributes']['attr']['accesskey'] = 'm';

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -516,7 +516,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
         $formattedField['options_per_line'] = $customFields[$field->field_name]['options_per_line'];
         $formattedField['html_type'] = $customFields[$field->field_name]['html_type'];
 
-        if (CRM_Utils_Array::value('html_type', $formattedField) == 'Select Date') {
+        if (($formattedField['html_type'] ?? NULL) == 'Select Date') {
           $formattedField['date_format'] = $customFields[$field->field_name]['date_format'];
           $formattedField['time_format'] = $customFields[$field->field_name]['time_format'];
           $formattedField['is_datetime_field'] = TRUE;
@@ -1286,7 +1286,7 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
         }
       }
 
-      if ((CRM_Utils_Array::value('visibility', $field) == 'Public Pages and Listings') &&
+      if ((($field['visibility'] ?? NULL) == 'Public Pages and Listings') &&
         CRM_Core_Permission::check('profile listings and forms')
       ) {
 
@@ -1919,7 +1919,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
         }
       }
     }
-    elseif (CRM_Utils_Array::value('name', $field) == 'membership_type') {
+    elseif (($field['name'] ?? NULL) == 'membership_type') {
       [$orgInfo, $types] = CRM_Member_BAO_MembershipType::getMembershipTypeInfo();
       $sel = &$form->addElement('hierselect', $name, $title);
       $select = ['' => ts('- select membership type -')];
@@ -1937,7 +1937,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       }
       $sel->setOptions([$orgInfo, $types]);
     }
-    elseif (CRM_Utils_Array::value('name', $field) == 'membership_status') {
+    elseif (($field['name'] ?? NULL) == 'membership_status') {
       $form->add('select', $name, $title,
         CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'label'), $required
       );
@@ -2198,7 +2198,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       if (substr($fieldName, 0, 3) === 'is_' or substr($fieldName, 0, 7) === 'do_not_') {
         $form->add('advcheckbox', $name, $title, $attributes, $required);
       }
-      elseif (CRM_Utils_Array::value('html_type', $field) === 'Select Date') {
+      elseif (($field['html_type'] ?? NULL) === 'Select Date') {
         $extra = isset($field['datepicker']) ? $field['datepicker']['extra'] : CRM_Utils_Date::getDatePickerExtra($field);
         $attributes = isset($field['datepicker']) ? $field['datepicker']['attributes'] : CRM_Utils_Date::getDatePickerAttributes($field);
         $form->add('datepicker', $name, $title, $attributes, $required, $extra);
@@ -3208,7 +3208,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                     $defaults['field'][$componentId][$name] = $customValue;
                     break;
                   }
-                  elseif (CRM_Utils_Array::value('data_type', $tree['fields'][$customFieldDetails[0]]) == 'Date') {
+                  elseif (($tree['fields'][$customFieldDetails[0]]['data_type'] ?? NULL) == 'Date') {
                     $skipValue = TRUE;
 
                     // CRM-6681, $default contains formatted date, time values.

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -840,7 +840,7 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   public static function makeAttribute($field) {
     if ($field) {
-      if (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_STRING) {
+      if (($field['type'] ?? NULL) == CRM_Utils_Type::T_STRING) {
         $maxLength = $field['maxlength'] ?? NULL;
         $size = $field['size'] ?? NULL;
         if ($maxLength || $size) {
@@ -854,7 +854,7 @@ class CRM_Core_DAO extends DB_DataObject {
           return $attributes;
         }
       }
-      elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_TEXT) {
+      elseif (($field['type'] ?? NULL) == CRM_Utils_Type::T_TEXT) {
         $rows = $field['rows'] ?? NULL;
         if (!isset($rows)) {
           $rows = 2;
@@ -869,7 +869,7 @@ class CRM_Core_DAO extends DB_DataObject {
         $attributes['cols'] = $cols;
         return $attributes;
       }
-      elseif (CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_INT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_FLOAT || CRM_Utils_Array::value('type', $field) == CRM_Utils_Type::T_MONEY) {
+      elseif (($field['type'] ?? NULL) == CRM_Utils_Type::T_INT || ($field['type'] ?? NULL) == CRM_Utils_Type::T_FLOAT || ($field['type'] ?? NULL) == CRM_Utils_Type::T_MONEY) {
         $attributes['size'] = 6;
         $attributes['maxlength'] = 14;
         return $attributes;
@@ -1643,7 +1643,7 @@ LIKE %1
     $result = $dao->query($queryStr, $i18nRewrite);
 
     // since it is unbuffered, ($dao->N==0) is true.  This blocks the standard fetch() mechanism.
-    if (CRM_Utils_Array::value('result_buffering', $options) === 0) {
+    if (($options['result_buffering'] ?? NULL) === 0) {
       $dao->N = TRUE;
     }
 
@@ -2742,8 +2742,8 @@ SELECT contact_id
         // We restrict to id + name + FK as we are extending this a bit, but cautiously.
         elseif (
           !empty($field['FKClassName'])
-          && CRM_Utils_Array::value('keyColumn', $pseudoConstant) === 'id'
-          && CRM_Utils_Array::value('labelColumn', $pseudoConstant) === 'name'
+          && ($pseudoConstant['keyColumn'] ?? NULL) === 'id'
+          && ($pseudoConstant['labelColumn'] ?? NULL) === 'name'
         ) {
           $pseudoFieldName = str_replace('_' . $pseudoConstant['keyColumn'], '', $field['name']);
           // This if is just an extra caution when adding change.
@@ -3068,7 +3068,7 @@ SELECT contact_id
     $skipContactCheckFor = ['Note'];
     foreach ($fields as $fieldName => $field) {
       // Clause for contact-related entities like Email, Relationship, etc.
-      if (strpos($field['name'], 'contact_id') === 0 && !in_array($field['entity'], $skipContactCheckFor) && CRM_Utils_Array::value('FKClassName', $field) == 'CRM_Contact_DAO_Contact') {
+      if (strpos($field['name'], 'contact_id') === 0 && !in_array($field['entity'], $skipContactCheckFor) && ($field['FKClassName'] ?? NULL) == 'CRM_Contact_DAO_Contact') {
         $contactClause = CRM_Utils_SQL::mergeSubquery('Contact');
         if (!empty($contactClause)) {
           $clauses[$field['name']] = $contactClause;

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -365,7 +365,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     CRM_Core_Error::backtrace('backTrace', TRUE);
 
     // If we are in an ajax callback, format output appropriately
-    if (CRM_Utils_Array::value('snippet', $_REQUEST) === CRM_Core_Smarty::PRINT_JSON) {
+    if (($_REQUEST['snippet'] ?? NULL) === CRM_Core_Smarty::PRINT_JSON) {
       $out = [
         'status' => 'fatal',
         'content' => '<div class="messages status no-popup">' . CRM_Core_Page::crmIcon('fa-info-circle') . ' ' . ts('Sorry but we are not able to provide this at the moment.') . '</div>',
@@ -927,7 +927,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       $title = ts('Error');
     }
     $session->setStatus($status, $title, 'alert', ['expires' => 0]);
-    if (CRM_Utils_Array::value('snippet', $_REQUEST) === CRM_Core_Smarty::PRINT_JSON) {
+    if (($_REQUEST['snippet'] ?? NULL) === CRM_Core_Smarty::PRINT_JSON) {
       CRM_Core_Page_AJAX::returnJsonResponse(['status' => 'error']);
     }
     CRM_Utils_System::redirect($redirect);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1687,7 +1687,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       foreach ($info['values'] as $uniqueName => $fieldSpec) {
         if (
           $uniqueName === $props['field'] ||
-          CRM_Utils_Array::value('name', $fieldSpec) === $props['field'] ||
+          ($fieldSpec['name'] ?? NULL) === $props['field'] ||
           in_array($props['field'], CRM_Utils_Array::value('api.aliases', $fieldSpec, []))
         ) {
           break;

--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -248,7 +248,7 @@ trait CRM_Core_Form_EntityFormTrait {
         $defaults[$fieldSpec['name']] = $value;
       }
       // Store a list of fields with money formatters
-      if (CRM_Utils_Array::value('formatter', $fieldSpec) == 'crmMoney') {
+      if (($fieldSpec['formatter'] ?? NULL) == 'crmMoney') {
         $moneyFields[] = $entityFieldName;
       }
     }

--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -327,7 +327,7 @@ class CRM_Core_Form_RecurringEntity {
       $params['entity_id'] = self::$_entityId;
     }
     //Process this function only when you get this variable
-    if (CRM_Utils_Array::value('allowRepeatConfigToSubmit', $params) == 1) {
+    if (($params['allowRepeatConfigToSubmit'] ?? NULL) == 1) {
       if (!empty($params['entity_table']) && !empty($params['entity_id']) && $type) {
         $params['used_for'] = $type;
         if (empty($params['parent_entity_id'])) {

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -55,7 +55,7 @@ class CRM_Core_Invoke {
       return NULL;
     }
     // CRM-15901: Turn off PHP errors display for all ajax calls
-    if (CRM_Utils_Array::value(1, $args) == 'ajax' || !empty($_REQUEST['snippet'])) {
+    if (($args[1] ?? NULL) == 'ajax' || !empty($_REQUEST['snippet'])) {
       ini_set('display_errors', 0);
     }
 

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -465,7 +465,7 @@ class CRM_Core_Page {
     $fields = civicrm_api3($entity, 'getfields', ['action' => 'get']);
     $dateFields = [];
     foreach ($fields['values'] as $fieldName => $fieldMetaData) {
-      if (isset($fieldMetaData['html']) && CRM_Utils_Array::value('type', $fieldMetaData['html']) == 'Select Date') {
+      if (isset($fieldMetaData['html']) && ($fieldMetaData['html']['type'] ?? NULL) == 'Select Date') {
         $dateFields[$fieldName] = CRM_Utils_Date::addDateMetadataToField($fieldMetaData, $fieldMetaData);
       }
     }

--- a/CRM/Core/Page/QUnit.php
+++ b/CRM/Core/Page/QUnit.php
@@ -66,7 +66,7 @@ class CRM_Core_Page_QUnit extends CRM_Core_Page {
     $arg = explode('/', CRM_Utils_System::currentPath());
 
     if ($arg[1] == 'dev'
-      && CRM_Utils_Array::value(2, $arg) == 'qunit'
+      && ($arg[2] ?? NULL) == 'qunit'
       && isset($arg[3])
       && isset($arg[4])
     ) {

--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -1529,7 +1529,7 @@ abstract class CRM_Core_Payment {
 
     if (isset($_GET['payment_date']) &&
       isset($_GET['merchant_return_link']) &&
-      CRM_Utils_Array::value('payment_status', $_GET) == 'Completed' &&
+      ($_GET['payment_status'] ?? NULL) == 'Completed' &&
       $paymentProcessor['payment_processor_type'] == "PayPal_Standard"
     ) {
       return TRUE;
@@ -1615,7 +1615,7 @@ abstract class CRM_Core_Payment {
       // This is called when processor_name is passed - passing processor_id instead is recommended.
       $sql .= " WHERE ppt.name = %2 AND pp.is_test = %1";
       $args[1] = [
-        (CRM_Utils_Array::value('mode', $params) == 'test') ? 1 : 0,
+        (($params['mode'] ?? NULL) == 'test') ? 1 : 0,
         'Integer',
       ];
       $args[2] = [$params['processor_name'], 'String'];

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -571,7 +571,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     // add CiviCRM BN code
     $args['BUTTONSOURCE'] = 'CiviCRM_SP';
 
-    if (CRM_Utils_Array::value('is_recur', $params) == 1) {
+    if (($params['is_recur'] ?? NULL) == 1) {
       $start_time = strtotime(date('m/d/Y'));
       $start_date = date('Y-m-d\T00:00:00\Z', $start_time);
 
@@ -601,7 +601,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     $params['recurr_profile_id'] = NULL;
 
-    if (CRM_Utils_Array::value('is_recur', $params) == 1) {
+    if (($params['is_recur'] ?? NULL) == 1) {
       $params['recurr_profile_id'] = $apiResult['profileid'];
     }
 

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -547,7 +547,7 @@ class CRM_Core_Permission {
 
     // check whether the following Ajax requests submitted the right key
     // FIXME: this should be integrated into ACLs proper
-    if (CRM_Utils_Array::value('page_type', $item) == 3) {
+    if (($item['page_type'] ?? NULL) == 3) {
       if (!CRM_Core_Key::validate($_REQUEST['key'], $item['path'])) {
         return FALSE;
       }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -285,7 +285,7 @@ class CRM_Core_PseudoConstant {
     }
 
     // Return "Yes" and "No" for boolean fields
-    elseif (CRM_Utils_Array::value('type', $fieldSpec) === CRM_Utils_Type::T_BOOLEAN) {
+    elseif (($fieldSpec['type'] ?? NULL) === CRM_Utils_Type::T_BOOLEAN) {
       $output = $context == 'validate' ? [0, 1] : CRM_Core_SelectValues::boolean();
       CRM_Utils_Hook::fieldOptions($entity, $fieldName, $output, $params);
       return $flip ? array_flip($output) : $output;

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -109,7 +109,7 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
         }
       }
       else {
-        if (CRM_Utils_Array::value('default_value', $fieldDefaults) == CRM_Utils_Array::value('value', $defaults)) {
+        if (($fieldDefaults['default_value'] ?? NULL) == CRM_Utils_Array::value('value', $defaults)) {
           $defaults['default_value'] = 1;
         }
       }

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2599,7 +2599,7 @@ ORDER BY civicrm_custom_group.weight,
         }
 
         // For other locations, don't merge/add if the values are the same
-        elseif (CRM_Utils_Array::value('main', $migrationInfo['rows'][$key]) == $migrationInfo['rows'][$key]['other']) {
+        elseif (($migrationInfo['rows'][$key]['main'] ?? NULL) == $migrationInfo['rows'][$key]['other']) {
           unset($migrationInfo[$key]);
         }
       }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1356,7 +1356,7 @@ WHERE civicrm_event.is_active = 1
           if (
             CRM_Utils_Array::value('data_type', $v, '') == 'File' ||
             CRM_Utils_Array::value('name', $v, '') == 'image_URL' ||
-            CRM_Utils_Array::value('field_type', $v) == 'Formatting'
+            ($v['field_type'] ?? NULL) == 'Formatting'
           ) {
             unset($fields[$k]);
           }

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -654,7 +654,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
 
         $discountPriceSets = !empty($this->_defaultValues['discount_price_set']) ? $this->_defaultValues['discount_price_set'] : [];
         $discountFieldIDs = !empty($this->_defaultValues['discount_option_id']) ? $this->_defaultValues['discount_option_id'] : [];
-        if (CRM_Utils_Array::value('is_discount', $params) == 1) {
+        if (($params['is_discount'] ?? NULL) == 1) {
           // if there are discounted set of label / values,
           // create custom options for them
           $labels = $params['discounted_label'] ?? NULL;

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -203,7 +203,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
     $deleteOldBlock = FALSE;
 
     // If 'Use existing location' is selected.
-    if (CRM_Utils_Array::value('location_option', $params) == 2) {
+    if (($params['location_option'] ?? NULL) == 2) {
 
       /*
        * If there is an existing LocBlock and the selected LocBlock is different,
@@ -231,7 +231,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
      * set the loc_block_id for this Event to null so that an update results in
      * creating a new LocBlock.
      */
-    if ($this->_oldLocBlockId && (CRM_Utils_Array::value('location_option', $params) == 1)) {
+    if ($this->_oldLocBlockId && (($params['location_option'] ?? NULL) == 1)) {
       $deleteOldBlock = TRUE;
       CRM_Core_DAO::setFieldValue('CRM_Event_DAO_Event', $this->_id,
         'loc_block_id', 'null'
@@ -266,7 +266,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
      * In order to do so, the IDs of the Address, Phone and Email "Blocks" have
      * to be retrieved and added in to the elements in the $params array.
      */
-    if (CRM_Utils_Array::value('location_option', $params) == 2) {
+    if (($params['location_option'] ?? NULL) == 2) {
       if (empty($this->locationBlock['loc_block_id']) && !empty($params['loc_event_id'])) {
         $isUpdateToExistingLocationBlock = TRUE;
         $existingLocBlock = LocBlock::get()

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -850,7 +850,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
           $ufAdd[1] = $params['custom_pre_id'];
           $wtAdd = 1;
         }
-        elseif (CRM_Utils_Array::value('additional_custom_pre_id', $params) == 'none') {
+        elseif (($params['additional_custom_pre_id'] ?? NULL) == 'none') {
         }
         else {
           $ufAdd[1] = $params['additional_custom_pre_id'];
@@ -862,7 +862,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
         if (empty($params['additional_custom_post_id'])) {
           $ufAdd[2] = $params['custom_post_id'];
         }
-        elseif (CRM_Utils_Array::value('additional_custom_post_id', $params) == 'none') {
+        elseif (($params['additional_custom_post_id'] ?? NULL) == 'none') {
         }
         else {
           $ufAdd[2] = $params['additional_custom_post_id'];

--- a/CRM/Event/Form/ManageEvent/TabHeader.php
+++ b/CRM/Event/Form/ManageEvent/TabHeader.php
@@ -223,7 +223,7 @@ WHERE      e.id = %1
 
     if (is_array($tabs)) {
       foreach ($tabs as $subPage => $pageVal) {
-        if (CRM_Utils_Array::value('current', $pageVal) === TRUE) {
+        if (($pageVal['current'] ?? NULL) === TRUE) {
           $current = $subPage;
           break;
         }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -868,11 +868,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $params = $this->controller->exportValues($this->_name);
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      if (CRM_Utils_Array::value('delete_participant', $params) == 2) {
+      if (($params['delete_participant'] ?? NULL) == 2) {
         $additionalId = (CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_id));
         $participantLinks = (CRM_Event_BAO_Participant::getAdditionalParticipantUrl($additionalId));
       }
-      if (CRM_Utils_Array::value('delete_participant', $params) == 1) {
+      if (($params['delete_participant'] ?? NULL) == 1) {
         $additionalIds = CRM_Event_BAO_Participant::getAdditionalParticipantIds($this->_id);
         foreach ($additionalIds as $value) {
           CRM_Event_BAO_Participant::deleteParticipant($value);
@@ -1476,7 +1476,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
       if (CRM_Financial_BAO_FinancialType::isACLFinancialTypeStatus()
         && empty($form->_values['fee'])
-        && CRM_Utils_Array::value('snippet', $_REQUEST) == CRM_Core_Smarty::PRINT_NOFORM
+        && ($_REQUEST['snippet'] ?? NULL) == CRM_Core_Smarty::PRINT_NOFORM
       ) {
         CRM_Core_Session::setStatus(ts('You do not have all the permissions needed for this page.'), 'Permission Denied', 'error');
         return FALSE;
@@ -1710,7 +1710,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
     $this->assign('event', $event);
     $this->assign('isShowLocation', $event['is_show_location']);
-    if (CRM_Utils_Array::value('is_show_location', $event) == 1) {
+    if (($event['is_show_location'] ?? NULL) == 1) {
       $locationParams = [
         'entity_id' => $eventID,
         'entity_table' => 'civicrm_event',
@@ -1787,7 +1787,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     $contribParams['is_test'] = 0;
-    if ($form->_action & CRM_Core_Action::PREVIEW || CRM_Utils_Array::value('mode', $params) == 'test') {
+    if ($form->_action & CRM_Core_Action::PREVIEW || ($params['mode'] ?? NULL) == 'test') {
       $contribParams['is_test'] = 1;
     }
 
@@ -1861,7 +1861,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'campaign_id' => $params['campaign_id'] ?? NULL,
     ];
 
-    if ($form->_action & CRM_Core_Action::PREVIEW || CRM_Utils_Array::value('mode', $params) == 'test') {
+    if ($form->_action & CRM_Core_Action::PREVIEW || ($params['mode'] ?? NULL) == 'test') {
       $participantParams['is_test'] = 1;
     }
     else {

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -325,7 +325,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $this->assign('event', $event);
 
     $this->assign('isShowLocation', $event['is_show_location']);
-    if (CRM_Utils_Array::value('is_show_location', $event) == 1) {
+    if (($event['is_show_location'] ?? NULL) == 1) {
       $locationParams = [
         'entity_id' => $params['event_id'],
         'entity_table' => 'civicrm_event',

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -442,7 +442,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
             else {
               // check with first_name and last_name for additional participants
               if (!empty($value['first_name']) && ($value['first_name'] == CRM_Utils_Array::value('first_name', $fields)) &&
-                (CRM_Utils_Array::value('last_name', $value) == CRM_Utils_Array::value('last_name', $fields))
+                (($value['last_name'] ?? NULL) == CRM_Utils_Array::value('last_name', $fields))
               ) {
                 $errors['first_name'] = ts('The first name and last name must be unique for each participant.');
                 break;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -93,14 +93,14 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     }
     elseif (!empty($fields['amount']) &&
       (isset($form->_values['discount'][$fields['amount']])
-        && CRM_Utils_Array::value('value', $form->_values['discount'][$fields['amount']]) == 0
+        && ($form->_values['discount'][$fields['amount']]['value'] ?? NULL) == 0
       )
     ) {
       $isZeroAmount = TRUE;
     }
     elseif (!empty($fields['amount']) &&
       (isset($form->_values['fee'][$fields['amount']])
-        && CRM_Utils_Array::value('value', $form->_values['fee'][$fields['amount']]) == 0
+        && ($form->_values['fee'][$fields['amount']]['value'] ?? NULL) == 0
       )
     ) {
       $isZeroAmount = TRUE;
@@ -617,8 +617,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
       foreach ($form->_feeBlock as $field) {
         // public AND admin visibility fields are included for back-office registration and back-office change selections
-        if (CRM_Utils_Array::value('visibility', $field) == 'public' ||
-          (CRM_Utils_Array::value('visibility', $field) == 'admin' && $adminFieldVisible == TRUE) ||
+        if (($field['visibility'] ?? NULL) == 'public' ||
+          (($field['visibility'] ?? NULL) == 'admin' && $adminFieldVisible == TRUE) ||
           $className == 'CRM_Event_Form_Participant' ||
           $className === 'CRM_Event_Form_Task_Register' ||
           $className == 'CRM_Event_Form_ParticipantFeeSelection'

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -124,7 +124,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
     $this->assign('isAmountzero', $this->_totalAmount <= 0);
 
     $this->assign('defaultRole', FALSE);
-    if (CRM_Utils_Array::value('defaultRole', $this->_params[0]) == 1) {
+    if (($this->_params[0]['defaultRole'] ?? NULL) == 1) {
       $this->assign('defaultRole', TRUE);
     }
     $defaults = [];

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -154,7 +154,7 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
       if (count($eventIds) == 1) {
         //convert form values to clause.
         $seatClause = [];
-        if (CRM_Utils_Array::value('participant_test', $this->_formValues) == '1' || CRM_Utils_Array::value('participant_test', $this->_formValues) == '0') {
+        if (($this->_formValues['participant_test'] ?? NULL) == '1' || ($this->_formValues['participant_test'] ?? NULL) == '0') {
           $seatClause[] = "( participant.is_test = {$this->_formValues['participant_test']} )";
         }
         if (!empty($this->_formValues['participant_status_id'])) {

--- a/CRM/Event/Form/Task/Delete.php
+++ b/CRM/Event/Form/Task/Delete.php
@@ -77,7 +77,7 @@ class CRM_Event_Form_Task_Delete extends CRM_Event_Form_Task {
     $params = $this->controller->exportValues($this->_name);
 
     $participantLinks = NULL;
-    if (CRM_Utils_Array::value('delete_participant', $params) == 2) {
+    if (($params['delete_participant'] ?? NULL) == 2) {
       $links = [];
       foreach ($this->_participantIds as $participantId) {
         $additionalId = (CRM_Event_BAO_Participant::getAdditionalParticipantIds($participantId));
@@ -86,7 +86,7 @@ class CRM_Event_Form_Task_Delete extends CRM_Event_Form_Task {
     }
     $deletedParticipants = $additionalCount = 0;
     foreach ($this->_participantIds as $participantId) {
-      if (CRM_Utils_Array::value('delete_participant', $params) == 1) {
+      if (($params['delete_participant'] ?? NULL) == 1) {
         $primaryParticipantId = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Participant", $participantId, 'registered_by_id', 'id');
         if (CRM_Event_BAO_Participant::isPrimaryParticipant($participantId)) {
           $additionalIds = (CRM_Event_BAO_Participant::getAdditionalParticipantIds($participantId));

--- a/CRM/Export/Form/Select.php
+++ b/CRM/Export/Form/Select.php
@@ -89,7 +89,7 @@ class CRM_Export_Form_Select extends CRM_Core_Form_Task {
 
     $count = 0;
     $this->_matchingContacts = FALSE;
-    if (CRM_Utils_Array::value('radio_ts', $values) == 'ts_sel') {
+    if (($values['radio_ts'] ?? NULL) == 'ts_sel') {
       foreach ($values as $key => $value) {
         if (strstr($key, 'mark_x')) {
           $count++;
@@ -232,7 +232,7 @@ FROM   {$this->_componentTable}
   public static function formRule($params, $files, $self) {
     $errors = [];
 
-    if (CRM_Utils_Array::value('mergeOption', $params) == self::EXPORT_MERGE_SAME_ADDRESS &&
+    if (($params['mergeOption'] ?? NULL) == self::EXPORT_MERGE_SAME_ADDRESS &&
       $self->_matchingContacts
     ) {
       $greetings = [
@@ -243,7 +243,7 @@ FROM   {$this->_componentTable}
       foreach ($greetings as $key => $value) {
         $otherOption = $params[$key] ?? NULL;
 
-        if ((CRM_Utils_Array::value($otherOption, $self->_greetingOptions[$key]) == ts('Other')) && empty($params[$value])) {
+        if ((($self->_greetingOptions[$key][$otherOption] ?? NULL) == ts('Other')) && empty($params[$value])) {
 
           $label = ucwords(str_replace('_', ' ', $key));
           $errors[$value] = ts('Please enter a value for %1 (when merging contacts), or select a pre-configured option from the list.', [1 => $label]);
@@ -262,8 +262,8 @@ FROM   {$this->_componentTable}
   public function postProcess() {
     $params = $this->controller->exportValues($this->_name);
     $exportOption = $params['exportOption'];
-    $mergeSameAddress = CRM_Utils_Array::value('mergeOption', $params) == self::EXPORT_MERGE_SAME_ADDRESS ? 1 : 0;
-    $mergeSameHousehold = CRM_Utils_Array::value('mergeOption', $params) == self::EXPORT_MERGE_HOUSEHOLD ? 1 : 0;
+    $mergeSameAddress = ($params['mergeOption'] ?? NULL) == self::EXPORT_MERGE_SAME_ADDRESS ? 1 : 0;
+    $mergeSameHousehold = ($params['mergeOption'] ?? NULL) == self::EXPORT_MERGE_HOUSEHOLD ? 1 : 0;
 
     $this->set('mergeSameAddress', $mergeSameAddress);
     $this->set('mergeSameHousehold', $mergeSameHousehold);
@@ -379,7 +379,7 @@ FROM   {$this->_componentTable}
       $options[$key] = ["$greetingCount" => ts('List of names')];
 
       foreach ($params as $id => $field) {
-        if (CRM_Utils_Array::value('filter', $field) == 4) {
+        if (($field['filter'] ?? NULL) == 4) {
           $options[$key][++$greetingCount] = $field['label'];
         }
       }

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -222,10 +222,10 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
         }
       }
     }
-    if (CRM_Utils_Array::value('account_relationship', $values) == 'select') {
+    if (($values['account_relationship'] ?? NULL) == 'select') {
       $errorMsg['account_relationship'] = 'Financial Account relationship is a required field.';
     }
-    if (CRM_Utils_Array::value('financial_account_id', $values) == 'select') {
+    if (($values['financial_account_id'] ?? NULL) == 'select') {
       $errorMsg['financial_account_id'] = 'Financial Account is a required field.';
     }
     if (!empty($values['account_relationship']) && !empty($values['financial_account_id'])) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1179,7 +1179,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
       $addressCnt = 1;
       foreach ($params['address'] as $cnt => $addressBlock) {
-        if (CRM_Utils_Array::value('location_type_id', $values) ==
+        if (($values['location_type_id'] ?? NULL) ==
           CRM_Utils_Array::value('location_type_id', $addressBlock)
         ) {
           $addressCnt = $cnt;

--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -219,7 +219,7 @@ WHERE lt.log_conn_id = %1
           continue;
         }
 
-        if (CRM_Utils_Array::value($diff, $original) === CRM_Utils_Array::value($diff, $changed)) {
+        if (($original[$diff] ?? NULL) === CRM_Utils_Array::value($diff, $changed)) {
           continue;
         }
 

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -372,9 +372,9 @@ WHERE  log_date <= %1 AND id = %2 ORDER BY log_date DESC LIMIT 1";
 
     foreach ($this->_logTables as $entity => $detail) {
       if ((in_array($this->getLogType($entity), $logTypes) &&
-          CRM_Utils_Array::value('log_type_op', $this->_params) == 'in') ||
+          ($this->_params['log_type_op'] ?? NULL) == 'in') ||
         (!in_array($this->getLogType($entity), $logTypes) &&
-          CRM_Utils_Array::value('log_type_op', $this->_params) == 'notin')
+          ($this->_params['log_type_op'] ?? NULL) == 'notin')
       ) {
         $this->currentLogTable = $entity;
         $sql = $this->buildQuery(FALSE);

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -284,7 +284,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
 
       $addressCnt = 1;
       foreach ($params['address'] as $cnt => $addressBlock) {
-        if (CRM_Utils_Array::value('location_type_id', $values) ==
+        if (($values['location_type_id'] ?? NULL) ==
           CRM_Utils_Array::value('location_type_id', $addressBlock)
         ) {
           $addressCnt = $cnt;

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -127,14 +127,14 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       $this->set('sortByCharacter', NULL);
     }
 
-    if (CRM_Utils_Array::value(3, $newArgs) == 'unscheduled') {
+    if (($newArgs[3] ?? NULL) == 'unscheduled') {
       $this->_unscheduled = TRUE;
     }
     $this->set('unscheduled', $this->_unscheduled);
 
     $this->set('archived', $this->isArchived($newArgs));
 
-    if (CRM_Utils_Array::value(3, $newArgs) == 'scheduled') {
+    if (($newArgs[3] ?? NULL) == 'scheduled') {
       $this->_scheduled = TRUE;
     }
     $this->set('scheduled', $this->_scheduled);
@@ -243,7 +243,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
     if ($this->get('sms')) {
       $urlParams .= '&sms=1';
     }
-    if (CRM_Utils_Array::value(3, $newArgs) == 'unscheduled') {
+    if (($newArgs[3] ?? NULL) == 'unscheduled') {
       $urlString .= '/unscheduled';
       $urlParams .= '&scheduled=false';
       $this->assign('unscheduled', TRUE);
@@ -253,7 +253,7 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       $urlString .= '/archived';
       $this->assign('archived', TRUE);
     }
-    elseif (CRM_Utils_Array::value(3, $newArgs) == 'scheduled') {
+    elseif (($newArgs[3] ?? NULL) == 'scheduled') {
       $urlString .= '/scheduled';
       $urlParams .= '&scheduled=true';
     }

--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -163,7 +163,7 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     }
     CRM_Utils_System::setTitle($mailing['subject']);
 
-    if (CRM_Utils_Array::value('snippet', $_GET) === 'json') {
+    if (($_GET['snippet'] ?? NULL) === 'json') {
       CRM_Core_Page_AJAX::returnJsonResponse($content);
     }
     if ($print) {

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -316,13 +316,13 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
     }
 
     $fixed_period_rollover = FALSE;
-    if (CRM_Utils_Array::value('period_type', $membershipTypeDetails) == 'rolling') {
+    if (($membershipTypeDetails['period_type'] ?? NULL) == 'rolling') {
       if (!$startDate) {
         $startDate = $joinDate;
       }
       $actualStartDate = $startDate;
     }
-    elseif (CRM_Utils_Array::value('period_type', $membershipTypeDetails) == 'fixed') {
+    elseif (($membershipTypeDetails['period_type'] ?? NULL) == 'fixed') {
       // calculate start date
       // if !$startDate then use $joinDate
       $toDay = explode('-', (empty($startDate) ? $joinDate : $startDate));

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -759,7 +759,7 @@ DESC limit 1");
         }
 
         $membershipDetails = CRM_Member_BAO_MembershipType::getMembershipType($memType);
-        if ($startDate && CRM_Utils_Array::value('period_type', $membershipDetails) === 'rolling') {
+        if ($startDate && ($membershipDetails['period_type'] ?? NULL) === 'rolling') {
           if ($startDate < $joinDate) {
             $errors['start_date'] = ts('Start date must be the same or later than Member since.');
           }

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -333,7 +333,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
     // send email notification to supporter, if initial setup / add mode.
     if (!$this->_pageId) {
       CRM_PCP_BAO_PCP::sendStatusUpdate($pcp->id, $statusId, TRUE, $this->_component);
-      if ($approvalMessage && CRM_Utils_Array::value('status_id', $params) == 1) {
+      if ($approvalMessage && ($params['status_id'] ?? NULL) == 1) {
         $notifyStatus .= ts(' You will receive a second email as soon as the review process is complete.');
       }
     }

--- a/CRM/Pledge/Form/Payment.php
+++ b/CRM/Pledge/Form/Payment.php
@@ -137,7 +137,7 @@ class CRM_Pledge_Form_Payment extends CRM_Core_Form {
     $pledgeId = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_PledgePayment', $params['id'], 'pledge_id');
 
     CRM_Pledge_BAO_PledgePayment::add($params);
-    $adjustTotalAmount = (CRM_Utils_Array::value('option_type', $formValues) == 2);
+    $adjustTotalAmount = (($formValues['option_type'] ?? NULL) == 2);
 
     $pledgeScheduledAmount = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_PledgePayment',
       $params['id'],

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -874,7 +874,7 @@ WHERE li.contribution_id = %1";
     foreach ($previousLineItems as $id => $previousLineItem) {
       if (in_array($previousLineItem['price_field_value_id'], $submittedPriceFieldValueIDs)) {
         $submittedLineItem = $submittedLineItems[$previousLineItem['price_field_value_id']];
-        if (CRM_Utils_Array::value('html_type', $lineItemsToAdd[$previousLineItem['price_field_value_id']]) == 'Text') {
+        if (($lineItemsToAdd[$previousLineItem['price_field_value_id']]['html_type'] ?? NULL) == 'Text') {
           // If a 'Text' price field was updated by changing qty value, then we are not adding new line-item but updating the existing one,
           //  because unlike other kind of price-field, it's related price-field-value-id isn't changed and thats why we need to make an
           //  exception here by adding financial item for updated line-item and will reverse any previous financial item entries.

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -745,7 +745,7 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
       elseif ($totalAmount > 0 &&
       // if total amount is equal to all selected amount in hand
         $totalPaymentAmountEnteredOnForm >= $totalAmount &&
-        (CRM_Utils_Array::value('contribution_status_id', $fields) == CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Partially paid'))
+        (($fields['contribution_status_id'] ?? NULL) == CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Partially paid'))
       ) {
         $error['total_amount'] = ts('You have specified the status Partially Paid but have entered an amount that equals or exceeds the amount due. Please adjust the status of the payment or the amount');
       }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1573,7 +1573,7 @@ WHERE     ct.id = cp.financial_type_id AND
         CRM_Price_BAO_LineItem::format($id, $params, $field, $lineItem);
         $optionValueId = key($field['options']);
 
-        if (CRM_Utils_Array::value('name', $field['options'][$optionValueId]) === 'contribution_amount') {
+        if (($field['options'][$optionValueId]['name'] ?? NULL) === 'contribution_amount') {
           $taxRates = CRM_Core_PseudoConstant::getTaxRates();
           if (array_key_exists($params['financial_type_id'], $taxRates)) {
             $field['options'][key($field['options'])]['tax_rate'] = $taxRates[$params['financial_type_id']];
@@ -1653,8 +1653,8 @@ WHERE     ct.id = cp.financial_type_id AND
     $adminFieldVisible = CRM_Core_Permission::check('administer CiviCRM');
     $checklifetime = FALSE;
     foreach ($feeBlock as $id => $field) {
-      if (CRM_Utils_Array::value('visibility', $field) == 'public' ||
-        (CRM_Utils_Array::value('visibility', $field) == 'admin' && $adminFieldVisible == TRUE) ||
+      if (($field['visibility'] ?? NULL) == 'public' ||
+        (($field['visibility'] ?? NULL) == 'admin' && $adminFieldVisible == TRUE) ||
         !$validFieldsOnly
       ) {
         $options = $field['options'] ?? NULL;

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -430,7 +430,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     if ((is_numeric(CRM_Utils_Array::value('count', $fields)) &&
         empty($fields['count'])
       ) &&
-      (CRM_Utils_Array::value('html_type', $fields) == 'Text')
+      (($fields['html_type'] ?? NULL) == 'Text')
     ) {
       $errors['count'] = ts('Participant Count must be greater than zero.');
     }

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -548,7 +548,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
       if ($this->_isContactActivityProfile) {
         $contactFields = $activityFields = [];
         foreach ($this->_fields as $fieldName => $field) {
-          if (CRM_Utils_Array::value('field_type', $field) == 'Activity') {
+          if (($field['field_type'] ?? NULL) == 'Activity') {
             $activityFields[$fieldName] = $field;
           }
           else {
@@ -604,7 +604,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
           if ($htmlType == 'File') {
             $entityId = $this->_id;
-            if (CRM_Utils_Array::value('field_type', $field) == 'Activity' &&
+            if (($field['field_type'] ?? NULL) == 'Activity' &&
               $this->_activityId
             ) {
               $entityId = $this->_activityId;
@@ -651,7 +651,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
           if ($htmlType == 'File') {
             $entityId = $this->_id;
-            if (CRM_Utils_Array::value('field_type', $field) == 'Activity' && $this->_activityId) {
+            if (($field['field_type'] ?? NULL) == 'Activity' && $this->_activityId) {
               $entityId = $this->_activityId;
             }
             $url = CRM_Core_BAO_CustomField::getFileURL($entityId, $customFieldID);
@@ -1252,7 +1252,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     if (($this->_mode & self::MODE_EDIT) && $this->_activityId && $this->_isContactActivityProfile) {
       $profileFields = $activityParams = [];
       foreach ($this->_fields as $fieldName => $field) {
-        if (CRM_Utils_Array::value('field_type', $field) == 'Activity') {
+        if (($field['field_type'] ?? NULL) == 'Activity') {
           if (isset($params[$fieldName])) {
             $activityParams[$fieldName] = $params[$fieldName];
           }

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -256,7 +256,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
       //reformat fields array
       foreach ($fields as $name => $field) {
         // also eliminate all formatting fields
-        if (CRM_Utils_Array::value('field_type', $field) == 'Formatting') {
+        if (($field['field_type'] ?? NULL) == 'Formatting') {
           unset($fields[$name]);
         }
 
@@ -270,7 +270,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
         $contactFields = $activityFields = [];
 
         foreach ($fields as $fieldName => $field) {
-          if (CRM_Utils_Array::value('field_type', $field) == 'Activity') {
+          if (($field['field_type'] ?? NULL) == 'Activity') {
             $activityFields[$fieldName] = $field;
           }
           else {

--- a/CRM/Profile/Page/Listings.php
+++ b/CRM/Profile/Page/Listings.php
@@ -171,8 +171,8 @@ class CRM_Profile_Page_Listings extends CRM_Core_Page {
           $value = '%' . $value . '%';
         }
       }
-      elseif (CRM_Utils_Array::value('html_type', $field) == 'Multi-Select State/Province'
-        || CRM_Utils_Array::value('html_type', $field) == 'Multi-Select Country'
+      elseif (($field['html_type'] ?? NULL) == 'Multi-Select State/Province'
+        || ($field['html_type'] ?? NULL) == 'Multi-Select Country'
       ) {
         $value = CRM_Utils_Request::retrieve($name, 'String', $this, FALSE, NULL, 'REQUEST');
         if (!is_array($value)) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1047,17 +1047,17 @@ class CRM_Report_Form extends CRM_Core_Form {
           }
           //assign default value as "in" for multiselect
           //operator, To freeze the select element
-          if (CRM_Utils_Array::value('operatorType', $field) ==
+          if (($field['operatorType'] ?? NULL) ==
             CRM_Report_Form::OP_MULTISELECT
           ) {
             $this->_defaults["{$fieldName}_op"] = 'in';
           }
-          if (CRM_Utils_Array::value('operatorType', $field) ==
+          if (($field['operatorType'] ?? NULL) ==
             CRM_Report_Form::OP_ENTITYREF
           ) {
             $this->_defaults["{$fieldName}_op"] = 'in';
           }
-          elseif (CRM_Utils_Array::value('operatorType', $field) ==
+          elseif (($field['operatorType'] ?? NULL) ==
             CRM_Report_Form::OP_MULTISELECT_SEPARATOR
           ) {
             $this->_defaults["{$fieldName}_op"] = 'mhas';
@@ -2123,7 +2123,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         }
         if ($value !== NULL && is_array($value) && count($value) > 0) {
           $sqlOP = $this->getSQLOperator($op);
-          if (CRM_Utils_Array::value('type', $field) ==
+          if (($field['type'] ?? NULL) ==
             CRM_Utils_Type::T_STRING
           ) {
             //cycle through selections and escape values
@@ -4194,7 +4194,7 @@ ORDER BY cg.weight, cf.weight";
         // handle for ContactReference
         if (array_key_exists('fields', $prop)) {
           foreach ($prop['fields'] as $fieldName => $field) {
-            if (CRM_Utils_Array::value('dataType', $field) ==
+            if (($field['dataType'] ?? NULL) ==
               'ContactReference'
             ) {
               $columnName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', CRM_Core_BAO_CustomField::getKeyID($fieldName), 'column_name');
@@ -4741,7 +4741,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   public function fiscalYearOffset($fieldName) {
     $config = CRM_Core_Config::singleton();
     $fy = $config->fiscalYearStart;
-    if (CRM_Utils_Array::value('yid_op', $this->_params) == 'calendar' ||
+    if (($this->_params['yid_op'] ?? NULL) == 'calendar' ||
       ($fy['d'] == 1 && $fy['M'] == 1)
     ) {
       return "YEAR( $fieldName )";
@@ -6065,7 +6065,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    */
   protected function generateFilterClause($field, $fieldName) {
     if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-      if (CRM_Utils_Array::value('operatorType', $field) ==
+      if (($field['operatorType'] ?? NULL) ==
         CRM_Report_Form::OP_MONTH
       ) {
         $op = $this->_params["{$fieldName}_op"] ?? NULL;

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -577,7 +577,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
           }
 
           if ($field['name'] == 'current_user') {
-            if (CRM_Utils_Array::value("{$fieldName}_value", $this->_params) ==
+            if (($this->_params["{$fieldName}_value"] ?? NULL) ==
               1
             ) {
               // get current user
@@ -657,7 +657,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
    * @throws Exception
    */
   public function add2group($groupID) {
-    if (CRM_Utils_Array::value("contact_target_op", $this->_params) == 'nll') {
+    if (($this->_params["contact_target_op"] ?? NULL) == 'nll') {
       CRM_Core_Error::statusBounce(ts('Current filter criteria didn\'t have any target contact to add to group'));
     }
 
@@ -729,12 +729,12 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
     //Assign those recordtype to array which have filter operator as 'Is not empty' or 'Is empty'
     $nullFilters = [];
     foreach (['target', 'source', 'assignee'] as $type) {
-      if (CRM_Utils_Array::value("contact_{$type}_op", $this->_params) ==
+      if (($this->_params["contact_{$type}_op"] ?? NULL) ==
         'nnll' || !empty($this->_params["contact_{$type}_value"])
       ) {
         $nullFilters[] = " civicrm_contact_contact_{$type}_id IS NOT NULL ";
       }
-      elseif (CRM_Utils_Array::value("contact_{$type}_op", $this->_params) ==
+      elseif (($this->_params["contact_{$type}_op"] ?? NULL) ==
         'nll'
       ) {
         $nullFilters[] = " civicrm_contact_contact_{$type}_id IS NULL ";

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -562,10 +562,10 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
 
     $isStatusFilter = FALSE;
     $relStatus = NULL;
-    if (CRM_Utils_Array::value('is_active_value', $this->_params) == '1') {
+    if (($this->_params['is_active_value'] ?? NULL) == '1') {
       $relStatus = ts('Is equal to Active');
     }
-    elseif (CRM_Utils_Array::value('is_active_value', $this->_params) == '0') {
+    elseif (($this->_params['is_active_value'] ?? NULL) == '0') {
       $relStatus = ts('Is equal to Inactive');
     }
     if (!empty($statistics['filters'])) {
@@ -573,7 +573,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         // For displaying relationship type filter.
         if ($value['title'] == 'Relationship') {
           $relTypes = CRM_Core_PseudoConstant::relationshipType();
-          $op = CRM_Utils_Array::value('relationship_type_id_op', $this->_params) == 'in' ? ts('Is one of') . ' ' : ts('Is not one of') . ' ';
+          $op = ($this->_params['relationship_type_id_op'] ?? NULL) == 'in' ? ts('Is one of') . ' ' : ts('Is not one of') . ' ';
           $relationshipTypes = [];
           foreach ($this->_params['relationship_type_id_value'] as $relationship) {
             $relationshipTypes[] = $relTypes[$relationship]['label_' . $this->relationType];

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -549,7 +549,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
       $this->noDisplayContributionOrSoftColumn = TRUE;
     }
 
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'contributions_only') {
+    if (($this->_params['contribution_or_soft_value'] ?? NULL) == 'contributions_only') {
       $this->isContributionBaseMode = TRUE;
     }
     if ($this->isContributionBaseMode &&
@@ -586,7 +586,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
     $sql = "{$select} {$this->_from} {$this->_where} $this->_groupBy";
     $this->createTemporaryTable('civireport_contribution_detail_temp2', $sql);
 
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
+    if (($this->_params['contribution_or_soft_value'] ?? NULL) ==
       'soft_credits_only'
     ) {
       // revise pager : prev, next based on soft-credits only
@@ -610,7 +610,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
         "(SELECT * FROM {$this->temporaryTables['civireport_contribution_detail_temp1']['name']})"
       );
     }
-    elseif (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) ==
+    elseif (($this->_params['contribution_or_soft_value'] ?? NULL) ==
       'soft_credits_only'
     ) {
       $this->createTemporaryTable('civireport_contribution_detail_temp3',
@@ -692,7 +692,7 @@ UNION ALL
         }
       }
 
-      if (CRM_Utils_Array::value('civicrm_contribution_contribution_or_soft', $rows[$rowNum]) ==
+      if (($rows[$rowNum]['civicrm_contribution_contribution_or_soft'] ?? NULL) ==
         'Contribution'
       ) {
         unset($rows[$rowNum]['civicrm_contribution_soft_soft_credit_type_id']);
@@ -935,10 +935,10 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
         // ts exception to avoid having ts("%1 %2: %3")
         $title = '%1 contributions / soft-credits: %2';
 
-        if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'contributions_only') {
+        if (($this->_params['contribution_or_soft_value'] ?? NULL) == 'contributions_only') {
           $title = '%1 contributions: %2';
         }
-        elseif (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'soft_credits_only') {
+        elseif (($this->_params['contribution_or_soft_value'] ?? NULL) == 'soft_credits_only') {
           $title = '%1 soft-credits: %2';
         }
         foreach ($totals as $key => $total) {
@@ -1033,12 +1033,12 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
    * Add join to the soft credit table.
    */
   protected function joinContributionToSoftCredit() {
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'contributions_only'
+    if (($this->_params['contribution_or_soft_value'] ?? NULL) == 'contributions_only'
       && !$this->isTableSelected('civicrm_contribution_soft')) {
       return;
     }
     $joinType = ' LEFT ';
-    if (CRM_Utils_Array::value('contribution_or_soft_value', $this->_params) == 'soft_credits_only') {
+    if (($this->_params['contribution_or_soft_value'] ?? NULL) == 'soft_credits_only') {
       $joinType = ' INNER ';
     }
     $this->_from .= "

--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -342,7 +342,7 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
               continue;
             }
             elseif ($fieldName == 'receive_date') {
-              if ((CRM_Utils_Array::value('this_year_op', $this->_params) ==
+              if ((($this->_params['this_year_op'] ?? NULL) ==
                   'fiscal' && !empty($this->_params['this_year_value'])) ||
                 (CRM_Utils_Array::value('other_year_op', $this->_params ==
                     'fiscal') && !empty($this->_params['other_year_value']))
@@ -598,12 +598,12 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
     $addWhere = '';
 
     if (!empty($this->_referenceYear['other_year'])) {
-      (CRM_Utils_Array::value('other_year_op', $this->_params) ==
+      (($this->_params['other_year_op'] ?? NULL) ==
         'calendar') ? $other_receive_date = 'YEAR (contri.receive_date)' : $other_receive_date = self::fiscalYearOffset('contri.receive_date');
       $addWhere .= " AND {$this->_aliases['civicrm_contact']}.id NOT IN ( SELECT DISTINCT cont.id FROM civicrm_contact cont, civicrm_contribution contri WHERE  cont.id = contri.contact_id AND {$other_receive_date} = {$this->_referenceYear['other_year']} AND contri.is_test = 0 AND contri.is_template = 0 ) ";
     }
     if (!empty($this->_referenceYear['this_year'])) {
-      (CRM_Utils_Array::value('this_year_op', $this->_params) ==
+      (($this->_params['this_year_op'] ?? NULL) ==
         'calendar') ? $receive_date = 'YEAR (contri.receive_date)' : $receive_date = self::fiscalYearOffset('contri.receive_date');
       $addWhere .= " AND {$this->_aliases['civicrm_contact']}.id IN ( SELECT DISTINCT cont.id FROM civicrm_contact cont, civicrm_contribution contri WHERE cont.id = contri.contact_id AND {$receive_date} = {$this->_referenceYear['this_year']} AND contri.is_test = 0 AND contri.is_template = 0 ) ";
     }

--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -329,12 +329,12 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
                     ON  {$this->_aliases['civicrm_mailing_event_delivered']}.event_queue_id = civicrm_mailing_event_queue.id
         LEFT JOIN civicrm_mailing_event_bounce {$this->_aliases['civicrm_mailing_event_bounce']}
           ON {$this->_aliases['civicrm_mailing_event_bounce']}.event_queue_id = civicrm_mailing_event_queue.id";
-      if (CRM_Utils_Array::value('delivery_status_value', $this->_params) ==
+      if (($this->_params['delivery_status_value'] ?? NULL) ==
         'bounced'
       ) {
         $this->_columns['civicrm_mailing_event_delivered']['filters']['delivery_status']['clause'] = "{$this->_aliases['civicrm_mailing_event_bounce']}.id IS NOT NULL";
       }
-      elseif (CRM_Utils_Array::value('delivery_status_value', $this->_params) ==
+      elseif (($this->_params['delivery_status_value'] ?? NULL) ==
         'successful'
       ) {
         $this->_columns['civicrm_mailing_event_delivered']['filters']['delivery_status']['clause'] = "{$this->_aliases['civicrm_mailing_event_delivered']}.id IS NOT NULL AND {$this->_aliases['civicrm_mailing_event_bounce']}.id IS NULL";
@@ -347,7 +347,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     if (array_key_exists('reply_id', $this->_params['fields']) ||
       is_numeric(CRM_Utils_Array::value('is_replied_value', $this->_params))
     ) {
-      if (CRM_Utils_Array::value('is_replied_value', $this->_params) == 1) {
+      if (($this->_params['is_replied_value'] ?? NULL) == 1) {
         $joinType = 'INNER';
         $this->_columns['civicrm_mailing_event_reply']['filters']['is_replied']['clause'] = '(1)';
       }
@@ -365,7 +365,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     if (array_key_exists('unsubscribe_id', $this->_params['fields']) ||
       is_numeric(CRM_Utils_Array::value('is_unsubscribed_value', $this->_params))
     ) {
-      if (CRM_Utils_Array::value('is_unsubscribed_value', $this->_params) == 1
+      if (($this->_params['is_unsubscribed_value'] ?? NULL) == 1
       ) {
         $joinType = 'INNER';
         $this->_columns['civicrm_mailing_event_unsubscribe']['filters']['is_unsubscribed']['clause'] = '(1)';
@@ -385,7 +385,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     if (array_key_exists('optout_id', $this->_params['fields']) ||
       is_numeric(CRM_Utils_Array::value('is_optout_value', $this->_params))
     ) {
-      if (CRM_Utils_Array::value('is_optout_value', $this->_params) == 1) {
+      if (($this->_params['is_optout_value'] ?? NULL) == 1) {
         $joinType = 'INNER';
         $this->_columns['civicrm_mailing_event_unsubscribe']['filters']['is_optout']['clause'] = '(1)';
       }
@@ -404,7 +404,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     if (array_key_exists('forward_id', $this->_params['fields']) ||
       is_numeric(CRM_Utils_Array::value('is_forwarded_value', $this->_params))
     ) {
-      if (CRM_Utils_Array::value('is_forwarded_value', $this->_params) == 1) {
+      if (($this->_params['is_forwarded_value'] ?? NULL) == 1) {
         $joinType = 'INNER';
         $this->_columns['civicrm_mailing_event_forward']['filters']['is_forwarded']['clause'] = '(1)';
       }

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -286,7 +286,7 @@ class CRM_Report_Utils_Get {
       if ($urlFields = CRM_Utils_Array::value("fld", $_GET)) {
         $urlFields = explode(',', $urlFields);
       }
-      if (CRM_Utils_Array::value("ufld", $_GET) == 1) {
+      if (($_GET["ufld"] ?? NULL) == 1) {
         // unset all display columns
         $defaults['fields'] = [];
       }

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -254,12 +254,12 @@ WHERE  inst.report_id = %1";
           $value = str_replace('"', '""', html_entity_decode(strip_tags($value), ENT_QUOTES | ENT_HTML401));
 
           if (CRM_Utils_Array::value('type', $form->_columnHeaders[$v]) & 4) {
-            if (CRM_Utils_Array::value('group_by', $form->_columnHeaders[$v]) == 'MONTH' ||
-              CRM_Utils_Array::value('group_by', $form->_columnHeaders[$v]) == 'QUARTER'
+            if (($form->_columnHeaders[$v]['group_by'] ?? NULL) == 'MONTH' ||
+              ($form->_columnHeaders[$v]['group_by'] ?? NULL) == 'QUARTER'
             ) {
               $value = CRM_Utils_Date::customFormat($value, $config->dateformatPartial);
             }
-            elseif (CRM_Utils_Array::value('group_by', $form->_columnHeaders[$v]) == 'YEAR') {
+            elseif (($form->_columnHeaders[$v]['group_by'] ?? NULL) == 'YEAR') {
               $value = CRM_Utils_Date::customFormat($value, $config->dateformatYear);
             }
             elseif ($form->_columnHeaders[$v]['type'] == 12) {
@@ -272,7 +272,7 @@ WHERE  inst.report_id = %1";
           }
           // Note the reference to a specific field does not belong in this generic class & does not work on all reports.
           // @todo - fix this properly rather than just supressing the en-otice. Repeat transaction report is a good example.
-          elseif (CRM_Utils_Array::value('type', $form->_columnHeaders[$v]) == 1024 && !empty($row['civicrm_contribution_currency'])) {
+          elseif (($form->_columnHeaders[$v]['type'] ?? NULL) == 1024 && !empty($row['civicrm_contribution_currency'])) {
             $value = CRM_Utils_Money::format($value, $row['civicrm_contribution_currency']);
           }
           $displayRows[$v] = '"' . $value . '"';

--- a/CRM/SMS/Form/Schedule.php
+++ b/CRM/SMS/Form/Schedule.php
@@ -114,7 +114,7 @@ class CRM_SMS_Form_Schedule extends CRM_Core_Form {
       CRM_Utils_System::redirect($url);
     }
 
-    if ((isset($params['send_option']) && $params['send_option'] == 'send_immediate') || CRM_Utils_Array::value('_qf_Schedule_back', $params) == ts('Previous')) {
+    if ((isset($params['send_option']) && $params['send_option'] == 'send_immediate') || ($params['_qf_Schedule_back'] ?? NULL) == ts('Previous')) {
       return TRUE;
     }
 

--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -792,7 +792,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
     //adding group field, email field should be present in the group
     //fixed for  issue CRM-2861 & CRM-4153
     if (CRM_Core_BAO_UFGroup::isProfileDoubleOptin()) {
-      if (CRM_Utils_Array::value(1, $fields['field_name']) == 'group') {
+      if (($fields['field_name'][1] ?? NULL) == 'group') {
         $dao = new CRM_Core_BAO_UFField();
         $dao->uf_group_id = $fields['group_id'];
         $dao->find();
@@ -961,7 +961,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
           }
         }
         elseif (
-          CRM_Utils_Array::value(1, $fields['field_name']) == 'contact_sub_type' &&
+          ($fields['field_name'][1] ?? NULL) == 'contact_sub_type' &&
           !in_array($profileType, CRM_Contact_BAO_ContactType::basicTypes(TRUE), TRUE) &&
           !in_array($profileType, CRM_Contact_BAO_ContactType::subTypes(), TRUE)
         ) {

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -90,13 +90,13 @@ class CRM_Utils_Date {
     ) {
       // we have time too..
       if (!empty($date['h'])) {
-        if (CRM_Utils_Array::value('A', $date) == 'PM' or CRM_Utils_Array::value('a', $date) == 'pm') {
+        if (($date['A'] ?? NULL) == 'PM' or ($date['a'] ?? NULL) == 'pm') {
           if ($date['h'] != 12) {
             $date['h'] = $date['h'] + 12;
           }
         }
-        if ((CRM_Utils_Array::value('A', $date) == 'AM' or CRM_Utils_Array::value('a', $date) == 'am') &&
-          CRM_Utils_Array::value('h', $date) == 12
+        if ((($date['A'] ?? NULL) == 'AM' or ($date['a'] ?? NULL) == 'am') &&
+          ($date['h'] ?? NULL) == 12
         ) {
           $date['h'] = '00';
         }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1405,7 +1405,7 @@ class CRM_Utils_System {
       return NULL;
     }
 
-    if (CRM_Utils_Array::value('resource', $params) == 'wiki') {
+    if (($params['resource'] ?? NULL) == 'wiki') {
       $docBaseURL = self::getWikiBaseURL();
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Auto-replace a bunch of conditionals using CRM_Utils_Array with equivalent expressions using the null-coalescing operator.

Comments
----------------------------------------
I can't believe there are still so many of these.
