### PR TITLE
[NFC] Update test that's no longer doing what it was doing

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -145,7 +145,7 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
     CRM_Core_DAO::singleValueQuery('ANALYZE TABLE civicrm_acl');
     $this->assertEquals([
       'civicrm_worldregion' => 6,
-      'civicrm_acl' => 0,
+      'civicrm_acl' => 1,
       'civicrm_domain' => 2,
     ], CRM_Core_BAO_SchemaHandler::getRowCountForTables(['civicrm_domain', 'civicrm_acl', 'random_name', 'civicrm_worldregion']));
     $this->assertEquals(2, CRM_Core_BAO_SchemaHandler::getRowCountForTable('civicrm_domain'));

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -321,6 +321,9 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     // clear permissions stub to not check permissions
     $config->userPermissionClass->permissions = NULL;
 
+    // Normally a stock install has some acls in the table even if they aren't in use.
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_group', 0, NULL, NULL, 1)");
+
     //flush component settings
     CRM_Core_Component::getEnabledComponents(TRUE);
 
@@ -464,7 +467,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       CRM_Core_Transaction::forceRollbackIfEnabled();
       Manager::singleton(TRUE);
 
-      $tablesToTruncate = ['civicrm_contact', 'civicrm_uf_match', 'civicrm_email', 'civicrm_address'];
+      $tablesToTruncate = ['civicrm_contact', 'civicrm_uf_match', 'civicrm_email', 'civicrm_address', 'civicrm_acl'];
       $this->quickCleanup($tablesToTruncate);
       $this->createDomainContacts();
     }

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1457,8 +1457,12 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       ]));
   }
 
+  /**
+   * This is no longer guarding against the original issue, but is still a test
+   * of something. It's now mostly testing a different variation of
+   * relationship + the default in api3 being to not check permissions.
+   */
   public function testCreateWithLesserPermissions() {
-    $this->setUpACLByCheating();
     CRM_Core_Config::singleton()->userPermissionClass->permissions = [];
     $params = [
       'contact_id_a' => $this->_cId_a,
@@ -1468,16 +1472,6 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $id = $this->callAPISuccess('Relationship', 'create', $params)['id'];
     $relationship = $this->callAPISuccess('Relationship', 'getsingle', ['id' => $id]);
     $this->assertEquals($params, array_intersect_key($relationship, $params));
-    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_acl");
-  }
-
-  /**
-   * Normally a stock install has some acls in the table even if they aren't in
-   * use. I can't figure out how to set them up another way so I just lifted
-   * this from civicrm_generated.mysql
-   */
-  private function setUpACLByCheating() {
-    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl (name, deny, entity_table, entity_id, operation, object_table, object_id, acl_table, acl_id, is_active) VALUES ('Edit All Contacts', 0, 'civicrm_acl_role', 1, 'Edit', 'civicrm_group', 0, NULL, NULL, 1)");
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Let's see what I can break. Followup to #26615. 

Before
----------------------------------------
The test was originally pointing out a fail in real sites that wasn't in the test installs.

After
----------------------------------------
The related stock entries have since been removed from installs, with just the Everyone remaining. It has no effect on this particular test but having it for every test simulates a real install a little closer.

Technical Details
----------------------------------------


Comments
----------------------------------------
Not sure if there's a better place to put this.
