### PR TITLE
Update Api.php to correct external_identifier to type STRING

### DIFF
--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -83,7 +83,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
       $this->importableFieldsMetadata = array_merge([
         'do_not_import' => ['title' => ts('- do not import -')],
         'contact_id' => ['title' => ts('Contact ID'), 'name' => 'contact_id', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE, 'headerPattern' => '/contact?|id$/i'],
-        'external_identifier' => ['title' => ts('External Identifier'), 'name' => 'external_identifier', 'type' => CRM_Utils_Type::T_INT, 'options' => FALSE, 'headerPattern' => '/external\s?id/i'],
+        'external_identifier' => ['title' => ts('External Identifier'), 'name' => 'external_identifier', 'type' => CRM_Utils_Type::T_STRING, 'options' => FALSE, 'headerPattern' => '/external\s?id/i'],
       ], $importableFields);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Update Api.php to correct external_identifier to type STRING

Before
----------------------------------------
Multiple Value Custom Field Import with ext IDs which were strings failed with error "Invalid value for field(s) : External Identifier"

After
----------------------------------------
Multiple Value Custom Field Import with ext IDs which were strings process as expected

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
