### PR TITLE
SearchKit - Fix check for smarty syntax in rewrite output

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -283,9 +283,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   private function rewrite(array $column, array $data): string {
-    $output = $this->replaceTokens($column['rewrite'], $data, 'view');
     // Cheap strpos to skip Smarty processing if not needed
-    if (strpos($output, '{') !== FALSE) {
+    $hasSmarty = strpos($column['rewrite'], '{') !== FALSE;
+    $output = $this->replaceTokens($column['rewrite'], $data, 'view');
+    if ($hasSmarty) {
       $smarty = \CRM_Core_Smarty::singleton();
       $output = $smarty->fetchWith("string:$output", []);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4405](https://lab.civicrm.org/dev/core/-/issues/4405)

Before
----------------------------------------
Smarty errors if column value contains a `{` character (even if you aren't trying to use smarty in the rewrite value).

After
----------------------------------------
Would still cause errors if you tried smarty tokens with output containing `{` characters, but not if you don't.