### PR TITLE
Fix recent regression - Use consistent value for checkPermissions in merger

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1541,12 +1541,12 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
         continue;
       }
       $rows["move_$field"] = [
-        'main' => self::getFieldValueAndLabel($field, $main)['label'],
-        'other' => self::getFieldValueAndLabel($field, $other)['label'],
+        'main' => self::getFieldValueAndLabel($field, $main, $checkPermissions)['label'],
+        'other' => self::getFieldValueAndLabel($field, $other, $checkPermissions)['label'],
         'title' => $fields[$field]['label'],
       ];
 
-      $value = self::getFieldValueAndLabel($field, $other)['value'];
+      $value = self::getFieldValueAndLabel($field, $other, $checkPermissions)['value'];
       //CRM-14334
       if ($value === NULL || $value === '') {
         $value = 'null';
@@ -2767,14 +2767,15 @@ ORDER BY civicrm_custom_group.weight,
   /**
    * Get the field value & label for the given field.
    *
-   * @param $field
-   * @param $contact
+   * @param string $field
+   * @param array $contact
+   * @param bool $checkPermissions
    *
    * @return array
    * @throws \Exception
    */
-  private static function getFieldValueAndLabel($field, $contact): array {
-    $fields = self::getMergeFieldsMetadata();
+  private static function getFieldValueAndLabel(string $field, array $contact, bool $checkPermissions): array {
+    $fields = self::getMergeFieldsMetadata($checkPermissions);
     $value = $label = $contact[$field] ?? NULL;
     $fieldSpec = $fields[$field];
     if (!empty($fieldSpec['serialize']) && is_array($value)) {


### PR DESCRIPTION

Overview
----------------------------------------
Fix recent regression - Use consistent value for checkPermissions in merger

Before
----------------------------------------
When merge is called via an api with `checkPermissions` = FALSE and a non-permissioned used it fails with an authorization error

After
----------------------------------------
it passes

Technical Details
----------------------------------------
We recently added a permission check when retrieving metadata here https://github.com/civicrm/civicrm-core/commit/0e88731ff38f4bcf5a4d53c7e2ced01f70533ff1#diff-fe60c89ebe94bbd40114d135459371cc53708db1f2952ade6c0ce9b3468c4dabR2306

However, when that function is called from getFieldValueAndLabel that is not being passed and is defaulting to TRUE. This is causing issues in a cron context where checkPermissions is being used (well actually in a unit test in our custom code simulating that possiblility)

Comments
----------------------------------------
