### PR TITLE
Update related contribution trxn_id before sending email [must go into 5.64]

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -169,7 +169,7 @@ class CRM_Financial_BAO_Payment {
         }
       }
     }
-
+    self::updateRelatedContribution($params, $params['contribution_id']);
     if ($isPaymentCompletesContribution) {
       if ($contributionStatus === 'Pending refund') {
         // Ideally we could still call completetransaction as non-payment related actions should
@@ -213,7 +213,6 @@ class CRM_Financial_BAO_Payment {
       //  change status to refunded.
       self::updateContributionStatus($contribution['id'], 'Refunded');
     }
-    self::updateRelatedContribution($params, $params['contribution_id']);
     CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], CRM_Utils_Array::value('participant_id', $params), $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     return $trxn;
   }


### PR DESCRIPTION


Overview
----------------------------------------
Update related contribution trxn_id before sending email

Before
----------------------------------------
When a comtribution is completed by adding a payment an email goes out. However, this happens before the `trxn_id` is updated on the contribution, resulting in the `trxn_id` not including the relevant payment

After
----------------------------------------
The update happens before `completecontribution` is called, meaning the trxn_id is saved before the email goes out

Technical Details
----------------------------------------
This will allow https://github.com/civicrm/civicrm-core/pull/26659 to pass & merge

Comments
----------------------------------------
