### PR TITLE
Fix apiv4 bug on custom fields with spaces in name

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -93,7 +93,7 @@ abstract class Api4Query {
       $result = [];
       foreach ($this->selectAliases as $alias => $expr) {
         $returnName = $alias;
-        $alias = str_replace('.', '_', $alias);
+        $alias = str_replace(['.', ' '], '_', $alias);
         $result[$returnName] = property_exists($query, $alias) ? $query->$alias : NULL;
       }
       $results[] = $result;

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -159,7 +159,7 @@ class Api4SelectQuery extends Api4Query {
         ], ['custom_group' => 'custom_group']);
         $customSelect = [];
         foreach ($customGroups as $groupName) {
-          $customSelect[] = "$groupName.*";
+          $customSelect[] = str_replace([' '], '_', $groupName) . '.*';
         }
         array_splice($select, $customStar, 1, $customSelect);
       }

--- a/tests/phpunit/api/v4/Custom/ContactCustomJoinTest.php
+++ b/tests/phpunit/api/v4/Custom/ContactCustomJoinTest.php
@@ -32,22 +32,56 @@ class ContactCustomJoinTest extends CustomTestBase {
   /**
    * Add test to ensure that in the very unusual and not really supported situation where there is a space in the
    * custom group machine name. This is not supported but has been seen in the wild and as such we have this test to lock in the fix for dev/mail#103
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testContactCustomJoin() {
+  public function testContactCustomJoin(): void {
     $customGroup = CustomGroup::create()->setValues([
       'name' => 'D - Identification_20',
       'table_name' => 'civicrm_value_demographics',
       'title' => 'D - Identification',
       'extends' => 'Individual',
     ])->execute();
+    CustomGroup::create()->setValues([
+      'name' => 'other',
+      'title' => 'other',
+      'extends' => 'Individual',
+    ])->execute();
     \CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_group SET name = 'D - Identification_20' WHERE id = %1", [1 => [$customGroup[0]['id'], 'Integer']]);
     $customField = CustomField::create()->setValues([
       'label' => 'Test field',
+      'name' => 'test field',
       'custom_group_id' => $customGroup[0]['id'],
       'html_type' => 'Text',
       'data_type' => 'String',
     ])->execute();
-    Contact::get()->addSelect('*')->addSelect('custom.*')->execute();
+    \CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_field SET name = 'D - Identification_20' WHERE id = %1", [1 => [$customField[0]['id'], 'Integer']]);
+    CustomField::create()->setValues([
+      'label' => 'other',
+      'name' => 'other',
+      'custom_group_id:name' => 'other',
+      'html_type' => 'Text',
+      'data_type' => 'String',
+    ])->execute();
+    $contactID = Contact::create()->setValues([
+      'contact_type' => 'Individual',
+      'first_name' => 'Ben',
+      'other.other' => 'other',
+      'D - Identification_20.D - Identification_20' => 10,
+    ])->execute()->first()['id'];
+    $this->assertEquals(10, Contact::get()->addSelect('*')
+      ->addSelect('D - Identification_20.D - Identification_20')
+      ->addWhere('id', '=', $contactID)
+      ->execute()->first()['D - Identification_20.D - Identification_20']);
+
+    // Test that calling a get with custom.* does not fatal.
+    // Ideally we would also check it returns our field - but so far I haven't
+    // figured out how to make it do that - so this maintains the prior level of cover.
+    Contact::get()
+      ->addSelect('*')
+      ->addSelect('custom.*')
+      ->addWhere('id', '=', $contactID)
+      ->execute()->first();
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fix apiv4 bug on custom fields with spaces in name

It turns out it is possible to have spaces in names of custom fields & that those fields can't be retrieved using CustomGroup.CustomFieldName syntax without this patch.

Before
----------------------------------------
Create a custom field with a name like 'Field Name' and try to retrieve using apiv4 
```
Contact::get()->addSelect('CustomGroup.Field Name')->execute();
```
The key is present in the return array but not populated

After
----------------------------------------
The value can be retrieved

Technical Details
----------------------------------------
We are str_replacing more aggressively in one place than another...

Comments
----------------------------------------
Re-created https://github.com/civicrm/civicrm-core/pull/26323 cos it wouldn't let me update