### PR TITLE
NFC: Add debug level log message when afform submissions catch exceptions

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -331,6 +331,7 @@ class Submit extends AbstractProcessor {
       catch (\CRM_Core_Exception $e) {
         // What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
         // intentionally left blank. Other times it's a real error the user should know about.
+        \Civi::log()->debug("Silently ignoring exception in Afform processGenericEntity call: " . $e->getMessage());
       }
     }
   }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -331,7 +331,7 @@ class Submit extends AbstractProcessor {
       catch (\CRM_Core_Exception $e) {
         // What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
         // intentionally left blank. Other times it's a real error the user should know about.
-        \Civi::log()->debug("Silently ignoring exception in Afform processGenericEntity call: " . $e->getMessage());
+        \Civi::log('afform')->debug("Silently ignoring exception in Afform processGenericEntity call: " . $e->getMessage());
       }
     }
   }


### PR DESCRIPTION
The code comments suggest we don't really know what to do here, previously we did nothing, which was not helpful to a developer trying to figure out why their code did nothing.

Now we emit the exception's message to the log file.

