### PR TITLE
SearchKit - Assign raw values to smarty in field rewrite

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -287,8 +287,21 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     $hasSmarty = strpos($column['rewrite'], '{') !== FALSE;
     $output = $this->replaceTokens($column['rewrite'], $data, 'view');
     if ($hasSmarty) {
+      $vars = [];
+      // Convert dots to nested arrays which are more Smarty-friendly
+      foreach ($data as $key => $value) {
+        $parent = &$vars;
+        $keys = array_map('CRM_Utils_String::munge', explode('.', $key));
+        while (count($keys) > 1) {
+          $level = array_shift($keys);
+          $parent[$level] = $parent[$level] ?? [];
+          $parent = &$parent[$level];
+        }
+        $level = array_shift($keys);
+        $parent[$level] = $value;
+      }
       $smarty = \CRM_Core_Smarty::singleton();
-      $output = $smarty->fetchWith("string:$output", []);
+      $output = $smarty->fetchWith("string:$output", $vars);
     }
     return $output;
   }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -283,13 +283,13 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
               'key' => 'first_name',
               'label' => 'Name',
               'type' => 'field',
-              'rewrite' => '{if "[nick_name]"}[nick_name]{else}[first_name]{/if} [last_name]',
+              'rewrite' => '{if $nick_name}{$nick_name}{else}[first_name]{/if} [last_name]',
             ],
             [
               'key' => 'Contact_Email_contact_id_01.email',
               'label' => 'Email',
               'type' => 'field',
-              'rewrite' => '{if "[Contact_Email_contact_id_01.email]"}[Contact_Email_contact_id_01.email] ([Contact_Email_contact_id_01.location_type_id:label]){/if}',
+              'rewrite' => '{if $Contact_Email_contact_id_01.email}{$Contact_Email_contact_id_01.email} ({$Contact_Email_contact_id_01.location_type_id_label}){/if}',
             ],
           ],
           'sort' => [


### PR DESCRIPTION
Overview
----------------------------------------
This helps support use-cases where the raw data (e.g. `YYYY-MM-DD` date format, or `true` and `false` booleans) are useful in smarty rewrites.

This was originally #22346 which stalled on discussion but I'm reopening it as it satisfies several use-cases.

Before
----------------------------------------
Only formatted values available.

After
----------------------------------------
Raw values available.