### PR TITLE
(dev/core#4391) Prohibit uninstallation of core components

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -455,6 +455,12 @@ class CRM_Extension_Manager {
     // TODO: to mitigate the risk of crashing during installation, scan
     // keys/statuses/types before doing anything
 
+    // Component data still lives inside of core-core. Uninstalling is nonsensical.
+    $notUninstallable = array_intersect($keys, $this->mapper->getKeysByTag('component'));
+    if (count($notUninstallable)) {
+      throw new CRM_Extension_Exception("Cannot uninstall extensions which are tagged as components: " . implode(', ', $notUninstallable));
+    }
+
     $this->addProcess($keys, 'uninstall');
 
     foreach ($keys as $key) {

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -15,6 +15,9 @@
   <releaseDate>2023-04-08</releaseDate>
   <version>5.63.beta1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>component</tag>
+  </tags>
   <compatibility>
     <ver>5.63</ver>
   </compatibility>


### PR DESCRIPTION
Overview
----------------------------------------

In 5.63, each core `Component` (eg CiviMail) has a corresponding `Extension` (eg `civi_mail`). However, extensions support more lifecycle actions - esp. the `uninstall` action - which don't make sense for components.

See: https://lab.civicrm.org/dev/core/-/issues/4391

Before
----------------------------------------

You are allowed to submit a request to `uninstall` a component-extension. But it doesn't entirely work; and then the subsequent re-installation fails.

After
----------------------------------------

You are not allowed to `uninstall` a component-extension.

Technical details
-------------------------------------

Compare traditional lifecycles of `Component`s and `Extension`s:

| Status | Component | Extension
| -- | -- | -- |
| __Enabled__ | Code and data both active. | Code and data both active. |
| __Disabled__ | Code inactive. Data still retained. |  Code inactive. Data still retained.
| __Uninstalled__ | (*Not applicable*) | Code inactive. Data removed. |

The problem is that "Uninstalled" doesn't make sense for a "Component" (where data-structures are always, regardless of whether it's been enabled).