### PR TITLE
🌶️ dev/core/-/issues/4416 CiviCRM 5.63.0 - Regression, Mailing click tracking now returns: Error 500 malformed header from script 'url.php': Bad header for all tracked URLs

### DIFF
--- a/extern/url.php
+++ b/extern/url.php
@@ -54,6 +54,6 @@ if (strlen($query_string) > 0) {
 $url = str_replace('&amp;', '&', $url);
 
 // CRM-17953 - The CMS is not bootstrapped so cannot use CRM_Utils_System::redirect
-header('X-Robots-Tag', 'noindex');
+header('X-Robots-Tag: noindex');
 header('Location: ' . $url);
 CRM_Utils_System::civiExit();


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM 5.63.0 - Regression, Mailing click tracking now returns: Error 500 malformed header from script 'url.php': Bad header for all tracked URLs.

eg, https://flippythongs.org.au/wp-content/plugins/civicrm/civicrm/extern/url.php?u=4238&qid=201344 returns error 500

Reported on Gitlab, https://lab.civicrm.org/dev/core/-/issues/4416

Before
----------------------------------------
Mailing click tracking no longer works.

After
----------------------------------------
Mailing click tracking no works again, rejoice!

Technical Details
----------------------------------------
CiviCRM 5.63.0 regression

Comments
----------------------------------------
This bug warrants a new CiviCRM release IMHO.

Agileware Ref: CIVICRM-2150