### PR TITLE
add `contactId` to params array in EmailTrait

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -919,6 +919,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     // create the params array
     $mailParams = [
       'groupName' => 'Activity Email Sender',
+      'contactId' => $toID,
       'from' => $from,
       'toName' => $toDisplayName,
       'toEmail' => $toEmail,


### PR DESCRIPTION
Overview
----------------------------------------
Add `contactId` to params array in EmailTrait calling wrapper function send email.
Related to [add contact_id to email params in emailLetter function](https://github.com/civicrm/civicrm-core/pull/22538).

Before
----------------------------------------
Params array of `alterMailParams` hook does not contain `contactId` when context is `singleEmail`.

After
----------------------------------------
Params array of `alterMailParams` hook contains `contactId` when context is `singleEmail`.

Comments
----------------------------------------
These comments are not referring to this PR, but to the `alterMailParams` hook  that I encountered while during my testing.  

When I send a single email `alterMailParams` hook is called 2 times: one for context `messageTemplate` and one for `singleEmail`. I have no way of knowing whether it is called only for rendering the template or for sending the email: respectively functions `CRM_Core_BAO_MessageTemplate:renderTemplate` and `CRM_Core_BAO_MessageTemplate:sendTemplate`.   

In this hook I add attachments for context `messageTemplate`, these attachments are ignored because function `sendMessage` is called ignoring the attachements in rendered template (see row 796 of `CRM_Contact_Form_Task_EmailTrait` class).

Finally, I do not understand why `CRM_Contribute_Form_Task_PDFLetter` does not use `CRM_Contact_Form_Task_EmailTrait` trait.

Let me know if you think there are things that can be improved in this PR. If not, I can open issues.


