### PR TITLE
crmCaseType: fix New Case Type link visiblity in obscure circumstances

### DIFF
--- a/ang/crmCaseType/list.html
+++ b/ang/crmCaseType/list.html
@@ -74,6 +74,6 @@ Required vars: caseTypes
   </table>
 
   <div class="crm-submit-buttons">
-    <a ng-href="#/caseType/new" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {{:: ts('New Case Type') }}</span></a>
+    <a href="#/caseType/new" class="button"><span><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {{:: ts('New Case Type') }}</span></a>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

In certain circumstances, the "New Case Type" button is not visible in the CiviCase admin (Administer > CiviCase > Case Types).

I could not reproduce the exact circumstances on a sandbox site, but I could reproduce the issue on different WordPress installs that we have (although they are all fairly standardized). I could not reproduce on our Drupal or Standalone sites.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/2d69d9a3-dfb0-4ba1-a903-0c0ff3b5d349)

After
----------------------------------------

Button is visible.

Technical Details
----------------------------------------

According to AngularJS docs, `ng-href` is only required when there are variables in the `href`, so this seems safe to remove.