### PR TITLE
Remove unneeded and strange profile field save success alert

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -551,9 +551,6 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
 
       $this->setMessageIfCountryNotAboveState($fieldName, CRM_Utils_Array::value('location_type_id', $apiFormattedParams), $apiFormattedParams['weight'], $apiFormattedParams['uf_group_id']);
 
-      CRM_Core_Session::setStatus(ts('Your CiviCRM Profile Field \'%1\' has been saved to \'%2\'.',
-        [1 => $name, 2 => $this->_title]
-      ), ts('Profile Field Saved'), 'success');
     }
     $buttonName = $this->controller->getButtonName();
 


### PR DESCRIPTION
Before
----------------------------------------
Strange success message when saving a profile field.
<img width="372" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/bef05720-12e7-4bca-adb3-c6b5bf66d785">

After
----------------------------------------
No more success message.

Comments
----------------------------------------
I don't think we need to alert the user that we successfully saved a profile field. Profiles are more of an admin area and we don't need to alert the user to every successful save here.
