### PR TITLE
dev/core#4418 Fix Payment Processor accepted_credit_cards regression

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -429,7 +429,6 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
           $creditCards[$type] = $creditCardTypes[$type];
         }
       }
-      $creditCards = json_encode($creditCards);
     }
 
     $params = array_merge([


### PR DESCRIPTION
Overview
----------------------------------------
Edit: Turns out you have to pass the values to the API as an array, not as JSON.
See issue [#4418](https://lab.civicrm.org/dev/core/-/issues/4418)

Before
----------------------------------------
accepted_credit_cards not saved.

After
----------------------------------------
Works