### PR TITLE
(dev/core#4413) Don't remove core component permissions when disabled

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -290,7 +290,7 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
     if ($this->userPermissionClass->isModulePermissionSupported()) {
       // Can store permissions -- so do it!
       $this->userPermissionClass->upgradePermissions(
-        CRM_Core_Permission::basicPermissions()
+        CRM_Core_Permission::basicPermissions(TRUE)
       );
     }
     elseif (get_class($this->userPermissionClass) !== 'CRM_Core_Permission_UnitTests') {


### PR DESCRIPTION
Overview
----------------------------------------

Backport #26744 from 5.64-{alpha/beta} to 5.63-stable.

See: https://lab.civicrm.org/dev/core/-/issues/4413