### PR TITLE
dev/core#4418 Add in Upgrade script to fix double json encoding

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
@@ -65,10 +65,10 @@ CHANGE `cancel_URL` `cancel_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to 
    * Fix any double json encoding in Payment Processor accepted_credit_cards field
    */
   public static function fixDoubleEscapingPaymentProcessorCreditCards() {
-    $paymentProcessors = PaymentProcessor::get(FALSE)->execute();
+    $paymentProcessors = PaymentProcessor::get(FALSE)->addWhere('is_test', 'IS NOT NULL')->addWhere('domain_id', 'IS NOT NULL')->execute();
     foreach ($paymentProcessors as $paymentProcessor) {
-      if (is_numeric(array_keys($paymentProcessor['accepted_credit_cards'])[0])) {
-        PaymentProcessor::update(FALSE)->addValue('accepted_credit_cards', json_decode($paymentProcessor['accepted_credit_cards'], TRUE))->addWhere('id', '=', $paymentProcessor['id'])->execute();
+      if (is_array($paymentProcessor['accepted_credit_cards']) && is_numeric(array_keys($paymentProcessor['accepted_credit_cards'])[0])) {
+        PaymentProcessor::update(FALSE)->addValue('accepted_credit_cards', json_decode($paymentProcessor['accepted_credit_cards'][0], TRUE))->addWhere('id', '=', $paymentProcessor['id'])->execute();
       }
     }
     return TRUE;

--- a/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
@@ -9,8 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Api4\PaymentProcessor;
-
 /**
  * Upgrade logic for the 5.64.x series.
  *
@@ -65,10 +63,16 @@ CHANGE `cancel_URL` `cancel_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to 
    * Fix any double json encoding in Payment Processor accepted_credit_cards field
    */
   public static function fixDoubleEscapingPaymentProcessorCreditCards() {
-    $paymentProcessors = PaymentProcessor::get(FALSE)->addWhere('is_test', 'IS NOT NULL')->addWhere('domain_id', 'IS NOT NULL')->execute();
-    foreach ($paymentProcessors as $paymentProcessor) {
-      if (is_array($paymentProcessor['accepted_credit_cards']) && is_numeric(array_keys($paymentProcessor['accepted_credit_cards'])[0])) {
-        PaymentProcessor::update(FALSE)->addValue('accepted_credit_cards', json_decode($paymentProcessor['accepted_credit_cards'][0], TRUE))->addWhere('id', '=', $paymentProcessor['id'])->execute();
+    $paymentProcessors = CRM_Core_DAO::executeQuery("SELECT id, accepted_credit_cards FROM civicrm_payment_processor");
+    while ($paymentProcessors->fetch()) {
+      if (!empty($paymentProcessors->accepted_credit_cards)) {
+        $accepted_credit_cards = json_decode($paymentProcessors->accepted_credit_cards, TRUE);
+        if (is_numeric(array_keys($accepted_credit_cards)[0])) {
+          CRM_Core_DAO::executeQuery("UPDATE civicrm_payment_processor SET accepted_credit_cards = %1 WHERE id = %2", [
+            1 => [$accepted_credit_cards[0], 'String'],
+            2 => [$paymentProcessors->id, 'Positive'],
+          ]);
+        }
       }
     }
     return TRUE;

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/FiveSixtyFourTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/FiveSixtyFourTest.php
@@ -22,10 +22,14 @@ class CRM_Upgrade_Incremental_php_FiveSixtyFourTest extends CiviUnitTestCase {
     ];
     PaymentProcessor::update()->addValue('accepted_credit_cards', $creditCards)->addWhere('id', '=', $this->ids['PaymentProcessor']['anet'])->execute();
     PaymentProcessor::update()->addValue('accepted_credit_cards', json_encode($creditCards))->addWhere('id', '=', $this->ids['PaymentProcessor']['authorize_net'])->execute();
+    $dummyPaymentProcessor = $this->processorCreate();
+    PaymentProcessor::update()->addValue('accepted_credit_cards', NULL)->addWhere('id', '=', $dummyPaymentProcessor)->execute();
     CRM_Upgrade_Incremental_php_FiveSixtyFour::fixDoubleEscapingPaymentProcessorCreditCards();
-    $paymentProcessors = PaymentProcessor::get()->execute();
+    $paymentProcessors = PaymentProcessor::get()->addWhere('id', 'IN', [$this->ids['PaymentProcessor']['anet'], $this->ids['PaymentProcessor']['authorize_net'], $dummyPaymentProcessor])->execute();
     foreach ($paymentProcessors as $paymentProcessor) {
-      $this->assertEquals($creditCards, $paymentProcessor['accepted_credit_cards']);
+      if (!empty($paymentProcessor['accepted_credit_cards'])) {
+        $this->assertEquals($creditCards, $paymentProcessor['accepted_credit_cards']);
+      }
     }
   }
 

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/FiveSixtyFourTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/FiveSixtyFourTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Civi\Api4\PaymentProcessor;
+
+/**
+ * Class CRM_Upgrade_Incremental_php_FiveSixtyFour
+ * @group headless
+ */
+class CRM_Upgrade_Incremental_php_FiveSixtyFourTest extends CiviUnitTestCase {
+
+  use CRM_Core_Payment_AuthorizeNetTrait;
+
+  /**
+   * Test that fixing the double json encode works as expected
+   */
+  public function testFixDobuleJsonEncode() {
+    $this->createAuthorizeNetProcessor();
+    $this->paymentProcessorAuthorizeNetCreate();
+    $creditCards = [
+      'visa' => 'visa',
+      'mastercard' => 'mastercard',
+    ];
+    PaymentProcessor::update()->addValue('accepted_credit_cards', $creditCards)->addWhere('id', '=', $this->ids['PaymentProcessor']['anet'])->execute();
+    PaymentProcessor::update()->addValue('accepted_credit_cards', json_encode($creditCards))->addWhere('id', '=', $this->ids['PaymentProcessor']['authorize_net'])->execute();
+    CRM_Upgrade_Incremental_php_FiveSixtyFour::fixDoubleEscapingPaymentProcessorCreditCards();
+    $paymentProcessors = PaymentProcessor::get()->execute();
+    foreach ($paymentProcessors as $paymentProcessor) {
+      $this->assertEquals($creditCards, $paymentProcessor['accepted_credit_cards']);
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds in an upgrade script to fix potential double json encoding of the accepted credit cards

Before
----------------------------------------
Bad data possibly in the database

After
----------------------------------------
All good data

ping @larssandergreen @eileenmcnaughton @colemanw 