### PR TITLE
Fix PHP errors on profiles and custom fields when using options per line

### DIFF
--- a/templates/CRM/Contact/Form/Task/Batch.tpl
+++ b/templates/CRM/Contact/Form/Task/Batch.tpl
@@ -38,11 +38,9 @@
             <table class="form-layout-compressed">
             <tr>
             {* sort by fails for option per line. Added a variable to iterate through the element array*}
-              {assign var="index" value="1"}
               {foreach name=optionOuter key=optionKey item=optionItem from=$form.field.$cid.$n}
-                {if $index < 10}
-                  {assign var="index" value=`$index+1`}
-                {else}
+                {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
+                {if is_array($optionItem) && array_key_exists('html', $optionItem)}
                   <td class="labels font-light">{$form.field.$cid.$n.$optionKey.html}</td>
                   {if $count == $field.options_per_line}
                   </tr>

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -43,11 +43,9 @@
                 <table class="form-layout-compressed">
                  <tr>
                    {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                   {assign var="index" value="1"}
                    {foreach name=outer key=key item=item from=$form.$element_name}
-                        {if $index < 10}
-                            {assign var="index" value=`$index+1`}
-                        {else}
+                     {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
+                     {if is_array($item) && array_key_exists('html', $item)}
                           <td class="labels font-light">{$form.$element_name.$key.html}</td>
                               {if $count == $element.options_per_line}
                                 {assign var="count" value="1"}

--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -65,11 +65,9 @@
                       <table class="form-layout-compressed">
                       <tr>
                         {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                        {assign var="index" value="1"}
                         {foreach name=optionOuter key=optionKey item=optionItem from=$form.field.$pid.$n}
-                          {if $index < 10}
-                            {assign var="index" value=`$index+1`}
-                          {else}
+                          {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
+                          {if is_array($optionItem) && array_key_exists('html', $optionItem)}
                             <td class="labels font-light">{$form.field.$pid.$n.$optionKey.html}</td>
                             {if $count == $field.options_per_line}
                             </tr>

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -103,11 +103,9 @@
                 <table class="form-layout-compressed">
                 <tr>
                 {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {assign var="index" value="1"}
                   {foreach name=outer key=key item=item from=$form.$n}
-                    {if $index < 10}
-                      {assign var="index" value=`$index+1`}
-                    {else}
+                    {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
+                    {if is_array($item) && array_key_exists('html', $item)}
                       <td class="labels font-light">{$form.$n.$key.html}</td>
                       {if $count == $field.options_per_line}
                       </tr>

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -57,11 +57,9 @@
             <table class="form-layout-compressed">
               <tr>
                 {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                {assign var="index" value="1"}
                 {foreach name=outer key=key item=item from=$formElement}
-                {if $index < 10}
-                {assign var="index" value=`$index+1`}
-                {else}
+                  {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
+                  {if is_array($item) && array_key_exists('html', $item)}
                 <td class="labels font-light">{$formElement.$key.html}</td>
                 {if $count == $field.options_per_line}
               </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Five more fixes for this strange counting to ten pattern previously covered in #26757 and #26517, fixing regressions due to #26265. These should be all of them, based on searching.

This should be included in 5.64 and backported to 5.63, since that's where the regression came into play.

Before
----------------------------------------
Five places where PHP 8 errors cause a crash, all when you have a custom field with options per line set:
1) Previewing the custom field from custom fields
2) Previewing a profile with a custom field
3) Using a profile in Create mode, etc
4) Batch update on contacts with profile with custom field
5) Batch update on participants with profile with custom field

After
----------------------------------------
All good.