### PR TITLE
Remove meaningless header in batch update participants

### DIFF
--- a/CRM/Event/Form/Task/Batch.php
+++ b/CRM/Event/Form/Task/Batch.php
@@ -89,7 +89,6 @@ class CRM_Event_Form_Task_Batch extends CRM_Event_Form_Task {
 
     $this->_fields = CRM_Core_BAO_UFGroup::getFields($ufGroupId, FALSE, CRM_Core_Action::VIEW);
     if (array_key_exists('participant_status', $this->_fields)) {
-      $this->assign('statusProfile', 1);
       $this->assignToTemplate();
     }
 

--- a/templates/CRM/Event/Form/Task/Batch.tpl
+++ b/templates/CRM/Event/Form/Task/Batch.tpl
@@ -24,9 +24,6 @@
         </div>
       {/if}
     {else}
-      {if $statusProfile EQ 1} {* Update Participant Status in batch task *}
-        <div class="status">{$status}</div>
-      {/if}
       {ts}Update field values for each participant as needed. To set a field to the same value for ALL rows, enter that value for the first participation and then click the
         <strong>Copy icon</strong>
         (next to the column title).{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Came up during PR review

Before
----------------------------------------
1. Find Participants.
2. Choose Update Multiple from the actions dropdown.
3. Choose a profile
4. See this weird thing:

<img width="413" alt="Untitled3" src="https://github.com/civicrm/civicrm-core/assets/2967821/87ae2c67-7ae9-46ee-a3ff-c5df0a6109a1">


After
----------------------------------------
Gone. Even if it was a word like "Attended", what is that telling us?

Technical Details
----------------------------------------
In the code `$status` is [assigned the value TRUE](https://github.com/civicrm/civicrm-core/blob/3522b22ba429f692ec09f70dbbc4e1650c690c9d/CRM/Event/Form/Task/Batch.php#L371), so it doesn't make sense to display that value.
Also this is the only place `$statusProfile` is used in universe, so it can go too.

Comments
----------------------------------------

