### PR TITLE
Edit Manage Job: remove double-title, top buttons, help only on the main job page

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -27,11 +27,32 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
   public $submitOnce = TRUE;
 
   public function preProcess() {
-
     parent::preProcess();
     $this->setContext();
 
-    $this->setTitle(ts('Manage - Scheduled Jobs'));
+    if ($this->_action == CRM_Core_Action::DELETE) {
+      $this->setTitle(ts('Delete Scheduled Job'));
+    }
+    elseif ($this->_action == CRM_Core_Action::ADD) {
+      $this->setTitle(ts('New Scheduled Job'));
+    }
+    elseif ($this->_action == CRM_Core_Action::UPDATE) {
+      $this->setTitle(ts('Edit Scheduled Job'));
+    }
+    elseif ($this->_action == CRM_Core_Action::VIEW) {
+      $this->setTitle(ts('Execute Scheduled Job'));
+    }
+
+    CRM_Utils_System::appendBreadCrumb([
+      [
+        'title' => ts('Administer CiviCRM'),
+        'url' => CRM_Utils_System::url('civicrm/admin', 'reset=1'),
+      ],
+      [
+        'title' => ts('Scheduled Jobs'),
+        'url' => CRM_Utils_System::url('civicrm/admin/job', 'reset=1'),
+      ],
+    ]);
 
     if ($this->_id) {
       $refreshURL = CRM_Utils_System::url('civicrm/admin/job/edit',

--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -99,17 +99,13 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
    * Finally it calls the parent's run method.
    */
   public function run() {
-    // set title and breadcrumb
     CRM_Utils_System::setTitle(ts('Settings - Scheduled Jobs'));
-    $breadCrumb = [
+    CRM_Utils_System::appendBreadCrumb([
       [
-        'title' => ts('Scheduled Jobs'),
-        'url' => CRM_Utils_System::url('civicrm/admin',
-          'reset=1'
-        ),
+        'title' => ts('Administer CiviCRM'),
+        'url' => CRM_Utils_System::url('civicrm/admin', 'reset=1'),
       ],
-    ];
-    CRM_Utils_System::appendBreadCrumb($breadCrumb);
+    ]);
 
     $this->_id = CRM_Utils_Request::retrieve('id', 'String',
       $this, FALSE, 0

--- a/templates/CRM/Admin/Form/Job.tpl
+++ b/templates/CRM/Admin/Form/Job.tpl
@@ -7,10 +7,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* This template is used for adding/configuring Scheduled Jobs.  *}
-<h3>{if $action eq 1}{ts}New Scheduled Job{/ts}{elseif $action eq 2}{ts}Edit Scheduled Job{/ts}{elseif $action eq 4}{ts}Execute Scheduled Job{/ts}{else}{ts}Delete Scheduled Job{/ts}{/if}</h3>
+{* Edit/Run Scheduled Jobs *}
 <div class="crm-block crm-form-block crm-job-form-block">
- <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
 
 {if $action eq 8}
   <div class="messages status no-popup">
@@ -23,6 +21,10 @@
         {ts 1=$jobName}Are you sure you would like to execute %1 job?{/ts}
   </div>
 {else}
+  <div class="help">
+    {capture assign=docUrlText}{ts}Job parameters and command line syntax documentation{/ts}{/capture}
+    {docURL page="user/initial-set-up/scheduled-jobs" text=$docUrlText}
+  </div>
   <table class="form-layout-compressed">
     <tr class="crm-job-form-block-name">
         <td class="label">{$form.name.label}</td><td>{$form.name.html}</td>

--- a/templates/CRM/Admin/Page/Job.tpl
+++ b/templates/CRM/Admin/Page/Job.tpl
@@ -7,19 +7,18 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{capture assign=docUrlText}{ts}(Job parameters and command line syntax documentation...){/ts}{/capture}
-{capture assign=runAllURL}{crmURL p='civicrm/admin/runjobs' q="reset=1"}{/capture}
-<div class="help">
-    {ts 1=$runAllURL}You can configure scheduled jobs (cron tasks) for your CiviCRM installation. For most sites, your system administrator should set up one or more 'cron' tasks to run the enabled jobs. However, you can also <a href="%1">run all scheduled jobs manually</a>, or run specific jobs from this screen (click 'more' and then 'Execute Now').{/ts} {docURL page="sysadmin/setup/jobs" text=$docUrlText}
-</div>
 
 {if $action eq 1 or $action eq 2 or $action eq 8 or $action eq 4}
    {include file="CRM/Admin/Form/Job.tpl"}
 {else}
-
-<div class="crm-content-block crm-block">
-{if $rows}
-
+  {capture assign=docUrlText}{ts}(How to setup cron on the command line...){/ts}{/capture}
+  {capture assign=runAllURL}{crmURL p='civicrm/admin/runjobs' q="reset=1"}{/capture}
+  <div class="help">
+    {ts}CiviCRM relies on a number of scheduled jobs that run automatically on a regular basis. These jobs keep data up-to-date and perform other important tasks.{/ts}
+    {ts 1=$runAllURL}For most sites, your system administrator should set up one or more 'cron' tasks to run the enabled jobs. You can also <a href="%1">run all scheduled jobs manually</a>, or run specific jobs from this screen.{/ts} {docURL page="sysadmin/setup/jobs" text=$docUrlText}
+  </div>
+  <div class="crm-content-block crm-block">
+  {if $rows}
       {if $action ne 1 and $action ne 2}
         <div class="action-link">
           {crmButton p='civicrm/admin/job/add' q="action=add&reset=1" id="newJob"  icon="plus-circle"}{ts}Add New Scheduled Job{/ts}{/crmButton}


### PR DESCRIPTION
Overview
----------------------------------------

Removes a bit of clutter on the "Edit Managed Job" page:

- There were two titles on the Edit Scheduled Job page
- There was a help text that was also displayed the main Scheduled Job page, but not really appropriate for the Edit screen.
- The documentation links were wrong: the Manage Jobs page should link how to configure cron, and the Edit page should link to the page with the parameters for the jobs.
- The breadcrumb was wrong (although most admin screens don't set the breadcrumb, but this one was kind of weird)
- Subtle deleting of the top-form-buttons, which is really sneaky of me, but I think we should remove them in most places.

List of Scheduled Jobs
----------------------------------------

Before:

![image](https://github.com/civicrm/civicrm-core/assets/254741/7415637e-78cd-4d33-974b-7a84e2c8c54e)

After:

![image](https://github.com/civicrm/civicrm-core/assets/254741/ffd22137-569e-4a85-b69f-8905f7289563)

Add/Edit Scheduled Job
----------------------------------------

Before:

![image](https://github.com/civicrm/civicrm-core/assets/254741/eaf36b44-784c-4385-a91d-1dd1174d5f6a)

After:

![image](https://github.com/civicrm/civicrm-core/assets/254741/46dbbf9b-4b30-4d4e-9e28-eda6f753c155)

Delete Scheduled Job
-------------------------------

Before:

![image](https://github.com/civicrm/civicrm-core/assets/254741/0fdacd8b-7f9e-41a6-b8b1-f62cf735fb2b)

After:

![image](https://github.com/civicrm/civicrm-core/assets/254741/fc529090-ef50-45f2-b19b-b1ce62c01183)
