### PR TITLE
(dev/core#4433) Fix unit test failure on WordPress by specifying --entry=backend

### DIFF
--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -103,7 +103,7 @@ class PathUrlTest extends \CiviEndToEndTestCase {
     // WORKAROUND: There's some issue where the URL gets a diff value in WP E2E env
     // than in normal WP env. The `cv url` command seems to behave more
     // representatively, though this technique is harder to inspect with xdebug.
-    $url = cv('url civicrm/contribute?reset=1');
+    $url = cv('url civicrm/contribute?reset=1 --entry=backend');
     // $url = \CRM_Utils_System::url('civicrm/contribute', 'reset=1', TRUE, NULL, FALSE);
 
     $parts = parse_url($url);


### PR DESCRIPTION
…g of URLs

(See also: https://lab.civicrm.org/dev/core/-/issues/4433)

Overview
----------------------------------------
This fixes a unit test failure that was happening on WordPress due to a change in cv's generating of urls. This commit https://github.com/civicrm/cv/commit/c0e770daa2b065662c8e8f0f52bf323065a71eb6  changed the handling of urls with specific to WordPress, the previous situation had been forcing backend generation of urls, now it doesn't force either for frontend or backend whereas we need to make it do backend as CRM_Utils_System_WordPress;:url will generate frontend url likely

Before
----------------------------------------
Unit Test fails on WordPress PRs

After
----------------------------------------
Unit Tess pass on WordPress PRs

ping @totten @kcristiano @haystack 