### PR TITLE
[WIP]

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -56,7 +56,7 @@ class CRM_Core_Invoke {
     }
     // CRM-15901: Turn off PHP errors display for all ajax calls
     if (($args[1] ?? NULL) == 'ajax' || !empty($_REQUEST['snippet'])) {
-      ini_set('display_errors', 0);
+//      ini_set('display_errors', 0);
     }
 
     if (!defined('CIVICRM_SYMFONY_PATH')) {

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -56,7 +56,7 @@ class CRM_Core_Invoke {
     }
     // CRM-15901: Turn off PHP errors display for all ajax calls
     if (($args[1] ?? NULL) == 'ajax' || !empty($_REQUEST['snippet'])) {
-//      ini_set('display_errors', 0);
+      // ini_set('display_errors', 0);
     }
 
     if (!defined('CIVICRM_SYMFONY_PATH')) {


### PR DESCRIPTION
Overview
----------------------------------------
I don't think much will come up in this test run but just curious.

The motivation is that:
1. Errors get swallowed in ajax, even on dev sites.
2. Civi is more and more ignoring the setting at administer - customize - display prefs and using popups even when it's turned off. That also hides errors, even on dev sites.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
