### PR TITLE
[REF] Stop passing `result` into `getContributionParams` to get one value from it, in one code path

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -171,9 +171,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       'skipLineItem' => $params['skipLineItem'] ?? 0,
     ];
 
-    if ($paymentProcessorOutcome) {
-      $contributionParams['payment_processor'] = $paymentProcessorOutcome['payment_processor'] ?? NULL;
-    }
     if (!empty($params["is_email_receipt"])) {
       $contributionParams += [
         'receipt_date' => $receiptDate,
@@ -1083,9 +1080,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (isset($params['amount'])) {
       $contributionParams = array_merge(self::getContributionParams(
         $params, $financialType->id,
-        $result, $receiptDate,
+        NULL, $receiptDate,
         $recurringContributionID), $contributionParams
       );
+
+      $contributionParams['payment_processor'] = $result ? ($result['payment_processor'] ?? NULL) : NULL;
       $contributionParams['non_deductible_amount'] = self::getNonDeductibleAmount($params, $financialType, TRUE, $form);
       $contributionParams['skipCleanMoney'] = TRUE;
       // @todo this is the wrong place for this - it should be done as close to form submission


### PR DESCRIPTION

Overview
----------------------------------------

Stop passing `result` into `getContributionParams` to get one value from it, in one code path

Before
----------------------------------------

`getContributionParams` is called from 2 places.  We can see [here](https://github.com/civicrm/civicrm-core/pull/26774/files#diff-74e8144a14bfd4d8bf9cf4279c90cded28c43351c70a338d4502612d6e0f1c36R1300) that one of them always passes null - so we are passing in a vague array  to extract one value in one flow


After
----------------------------------------
The calling function extracts the one value, in the one flow that uses it

Technical Details
----------------------------------------

Comments
----------------------------------------
