### PR TITLE
[REF] Clarify loading of PriceSetID

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1360,17 +1360,17 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   /**
    * Set form variables if contribution ID is found
    */
-  public function assignFormVariablesByContributionID() {
+  public function assignFormVariablesByContributionID(): void {
     $dummyTitle = 0;
     foreach ($this->_paymentProcessors as $pp) {
-      if ($pp['class_name'] == 'Payment_Dummy') {
+      if ($pp['class_name'] === 'Payment_Dummy') {
         $dummyTitle = $pp['name'];
         break;
       }
     }
     $this->assign('dummyTitle', $dummyTitle);
 
-    if (empty($this->_ccid)) {
+    if (empty($this->getExistingContributionID())) {
       return;
     }
     if (!$this->getContactID()) {
@@ -1391,22 +1391,12 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->assign('taxAmount', $taxAmount);
     }
 
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->_ccid);
-    foreach (array_keys($lineItems) as $id) {
-      $lineItems[$id]['id'] = $id;
-    }
-    $itemId = key($lineItems);
-    if ($itemId && !empty($lineItems[$itemId]['price_field_id'])) {
-      $this->_priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', $lineItems[$itemId]['price_field_id'], 'price_set_id');
-    }
-
-    if (!empty($lineItems[$itemId]['price_field_id'])) {
-      $this->_lineItem[$this->_priceSetId] = $lineItems;
-    }
-    $isQuickConfig = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $this->_priceSetId, 'is_quick_config');
-    $this->assign('lineItem', $this->_lineItem);
-    $this->assign('is_quick_config', $isQuickConfig);
-    $this->assign('priceSetID', $this->_priceSetId);
+    $lineItems = $this->getExistingContributionLineItems();
+    // Is this used?
+    $this->_lineItem[$this->getPriceSetID()] = $lineItems;
+    $this->assign('lineItem', [$this->getPriceSetID() => $lineItems]);
+    $this->assign('is_quick_config', $this->isQuickConfig());
+    $this->assign('priceSetID', $this->getPriceSetID());
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -251,11 +251,21 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * Out of caution we still allow `get`, `set` to take precedence.
    *
    * @return int|null
+   * @throws \CRM_Core_Exception
    */
   public function getPriceSetID(): ?int {
     if ($this->_priceSetId === NULL) {
       if ($this->get('priceSetId')) {
         $this->_priceSetId = $this->get('priceSetId');
+      }
+      elseif ($this->getExistingContributionID()) {
+        $lineItems = $this->getExistingContributionLineItems();
+        $firstLineItem = reset($lineItems);
+        // If this IF is not true the contribution is messed up! Hopefully this
+        // could never happen.
+        if ($firstLineItem && !empty($firstLineItem['price_field_id'])) {
+          $this->_priceSetId = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceField', $firstLineItem['price_field_id'], 'price_set_id');
+        }
       }
       else {
         $this->_priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $this->_id);
@@ -384,7 +394,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
       // check for is_monetary status
       $isPayLater = $this->_values['is_pay_later'] ?? NULL;
-      if (!empty($this->_ccid)) {
+      if ($this->getExistingContributionID()) {
         $this->_values['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
           $this->_ccid,
           'financial_type_id'
@@ -1367,6 +1377,26 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       }
     }
     return $this->renewalMembershipID ?: FALSE;
+  }
+
+  /**
+   * Get the id of an existing contribution the submitter is attempting to pay.
+   *
+   * @return int|null
+   */
+  protected function getExistingContributionID(): ?int {
+    return $this->_ccid ?: CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
+  }
+
+  /**
+   * @return array
+   */
+  protected function getExistingContributionLineItems(): array {
+    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->getExistingContributionID());
+    foreach (array_keys($lineItems) as $id) {
+      $lineItems[$id]['id'] = $id;
+    }
+    return $lineItems;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Clarify loading of PriceSetID


Before
----------------------------------------
It's really unclear under what circumstances PriceSet would not be set. It looks like there are various in the code but in fact it is set in the following scenarios

1)  'normal' price set used
2) 'quick config' price set used
3)  'ccid' passed in the url - to make a payment against an existing contribution
4)  when 'is_monetary' (execute real time transactions is false).

In other words I think there is ALWAYS a priceSetID available which can be derived from the contribution page ID in all cases EXCEPT where ccid is passed in the url - where it comes from the contribution.

This means that if [`getPriceSetID`](https://github.com/civicrm/civicrm-core/pull/26778/files#diff-a387458ba3c5d92e0dcc4c0ba4a2ad97cf36844f4c9b32fcd9862df33672f1a2R256) can be a single source of truth for the priceSetID IF we move the work to derive the priceSetID in scenario 3 into that function


After
----------------------------------------
[`getPriceSetID`](https://github.com/civicrm/civicrm-core/pull/26778/files#diff-a387458ba3c5d92e0dcc4c0ba4a2ad97cf36844f4c9b32fcd9862df33672f1a2R256) always derives the price set ID from the underlying data. It can be called at any point and will return the same value

Technical Details
----------------------------------------
There is still a lot of remaining confusion in the code because when 4.1 went out & we introduced the idea that we would ALWAYs use price sets the checks for the existance of a price set were not removed - making the code hard going. This is a step towards cleaning that up

Comments
----------------------------------------