### PR TITLE
In smarty, TRUE is not true

### DIFF
--- a/templates/CRM/Admin/Page/Options.tpl
+++ b/templates/CRM/Admin/Page/Options.tpl
@@ -64,7 +64,7 @@
     </div>
   {/if}
 {foreach from=$rows item=row}
-  {if !empty($row.icon)}{assign var='hasIcons' value=TRUE}{/if}
+  {if !empty($row.icon)}{assign var='hasIcons' value=true}{/if}
 {/foreach}
 <div id={$gName}>
         {strip}

--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 <div id="membership" class="crm-group membership-group">
-    {if TRUE}
+    {if true}
       <div id="priceset">
         <fieldset>
             {if $renewal_mode}

--- a/templates/CRM/Custom/Form/CustomData.tpl
+++ b/templates/CRM/Custom/Form/CustomData.tpl
@@ -9,11 +9,12 @@
 *}
 {* Custom Data form*}
 {foreach from=$groupTree item=cd_edit key=group_id name=custom_sets}
+    {* Note this `if` looks like it's needlessly assigning a var but it's also used in the included file Edit/CustomData.tpl *}
     {if $cd_edit.is_multiple and $multiRecordDisplay eq 'single'}
-      {assign var="isSingleRecordEdit" value=TRUE}
+      {assign var="isSingleRecordEdit" value=true}
     {else}
       {* always assign to prevent leakage*}
-      {assign var="isSingleRecordEdit" value=''}
+      {assign var="isSingleRecordEdit" value=false}
     {/if}
     {if $isSingleRecordEdit}
       <div class="custom-group custom-group-{$cd_edit.name}">


### PR DESCRIPTION
Overview
----------------------------------------
Trying to get at the truth.

Before
----------------------------------------
TRUE is evaluated as a string, which since it's not an empty string gets coerced to be boolean true, but it's not really valid.

After
----------------------------------------
true is true

Technical Details
----------------------------------------
You can verify this by looking at the compiled template in templates_c. Or if running in strict mode it gives a warning, e.g. 

`cv ev 'echo CRM_Core_Smarty::singleton()->fetch("string:{if TRUE}hi{else}bye{/if}");'`

gives `[PHP User Error] Smarty error: [in string:{if TRUE}hi{else}bye{/if} line 1]: syntax error: (secure mode) &#039;TRUE&#039; not allowed in if statement (Smarty_Compiler.class.php, line 1398)`

Comments
----------------------------------------

