### PR TITLE
[NFC] setup/plugins/init/StandaloneUsers: fix missing closing quote in log message

### DIFF
--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -84,7 +84,7 @@ if (!defined('CIVI_SETUP')) {
 
     $message = "Created new user \"{$e->getModel()->extras['adminUser']}\" (user ID #$userID, contact ID #$contactID) with 'admin' role and ";
     $message .= empty($e->getModel()->extras['adminPassWasSpecified'])
-    ? "random password \"" . ($e->getModel()->extras['adminPass'])
+    ? "random password \"" . ($e->getModel()->extras['adminPass']) . '"'
     : "specified password";
     \Civi::log()->notice($message);
 


### PR DESCRIPTION
This is silly, but had me confused for a minute, since I thought the generated password had a quote in it.

Before:

> Created new user "admin" (user ID #1, contact ID #203) with 'admin' role and random password "AbCd

After:

> Created new user "admin" (user ID #1, contact ID #203) with 'admin' role and random password "AbCd"