### PR TITLE
Standalone: implement basic breadcrumb

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -107,9 +107,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function appendBreadCrumb($breadcrumbs) {
-    if (!isset(\Civi::$statics[__CLASS__]['breadcrumb'])) {
-      \Civi::$statics[__CLASS__]['breadcrumb'] = [];
-    }
     \Civi::$statics[__CLASS__]['breadcrumb'][] = $breadcrumbs;
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -107,12 +107,17 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function appendBreadCrumb($breadcrumbs) {
+    if (!isset(\Civi::$statics[__CLASS__]['breadcrumb'])) {
+      \Civi::$statics[__CLASS__]['breadcrumb'] = [];
+    }
+    \Civi::$statics[__CLASS__]['breadcrumb'][] = $breadcrumbs;
   }
 
   /**
    * @inheritDoc
    */
   public function resetBreadCrumb() {
+    \Civi::$statics[__CLASS__]['breadcrumb'] = [];
   }
 
   /**
@@ -257,6 +262,18 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     if ($maintenance) {
       $smarty = CRM_Core_Smarty::singleton();
       echo implode('', $smarty->_tpl_vars['pageHTMLHead']);
+    }
+
+    // Show the breadcrumb
+    if (!empty(\Civi::$statics[__CLASS__]['breadcrumb'])) {
+      print '<nav aria-label="' . htmlspecialchars(ts('Breadcrumb')) . '" class="breadcrumb"><ol>';
+      print '<li><a href="' . CRM_Utils_System::url('civicrm/dashboard', 'reset=1') . '">' . htmlspecialchars(ts('Home')) . '</a></li>';
+      foreach (\Civi::$statics[__CLASS__]['breadcrumb'] as $breadcrumb) {
+        foreach ($breadcrumb as $item) {
+          print '<li><a href="' . $item['url'] . '">' . htmlspecialchars($item['title']) . '</a></li>';
+        }
+      }
+      print '</ol></nav>';
     }
 
     // @todo Add variables from the body tag? (for Shoreditch)

--- a/css/menubar-standalone.css
+++ b/css/menubar-standalone.css
@@ -22,3 +22,11 @@
   }
 
 }
+
+.breadcrumb ol li {
+  display: inline;
+  list-style-type: none;
+}
+.breadcrumb ol li:not(:first-child)::before {
+  content: " \BB ";
+}


### PR DESCRIPTION
Overview
----------------------------------------

Implements a rudimentary breadcrumb for CiviCRM Standalone.

Before
----------------------------------------

No breadcrumb displayed at the top of pages.

After
----------------------------------------

Breadcrumb somewhat equivalent to what we have on other CMSes:

![image](https://github.com/civicrm/civicrm-core/assets/254741/7a1e95f9-d2bb-4843-b539-2bb19629f4da)

![image](https://github.com/civicrm/civicrm-core/assets/254741/e21be778-ec5d-4dc0-a646-9e27ce51f52a)

Technical Details
----------------------------------------

Ugly code :grimacing: 

Comments
----------------------------------------

I wanted to fix feedback from #26767, and realized Standalone does not have a breadcrumb, and also CiviCRM oddly doesn't really leverage the breadcrumb much. Many pages don't have one (on Drupal9/WordPress).