### PR TITLE
Scheduled Job Admin: fix breadcrumb

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -45,10 +45,6 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
 
     CRM_Utils_System::appendBreadCrumb([
       [
-        'title' => ts('Administer CiviCRM'),
-        'url' => CRM_Utils_System::url('civicrm/admin', 'reset=1'),
-      ],
-      [
         'title' => ts('Scheduled Jobs'),
         'url' => CRM_Utils_System::url('civicrm/admin/job', 'reset=1'),
       ],


### PR DESCRIPTION
Overview
----------------------------------------

Quickfix followup to #26767

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/3068e20f-48ee-4de3-8a42-406efd35da20)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/f5b31120-cae7-4e83-9871-dcbf9821af59)

Technical Details
----------------------------------------

On Drupal9/10, the cache needs to be flushed.
