### PR TITLE
(dev/core#4409) Fix failure to fall back to site default language, if configured

### DIFF
--- a/Civi/WorkflowMessage/Traits/LocalizationTrait.php
+++ b/Civi/WorkflowMessage/Traits/LocalizationTrait.php
@@ -31,7 +31,9 @@ trait LocalizationTrait {
    * 1. Your organization serves many similar locales (eg es_MX+es_CR+es_HN or en_GB+en_US+en_NZ).
    * 2. You want to write one message (es_MX) for several locales (es_MX+es_CR+es_HN)
    * 3. You want to include some conditional content that adapts the recipient's requested locale
-   *    (es_CR) -- _even though_ the template was stored as es_MX.
+   *    (es_CR) -- _even though_ the template was stored as es_MX. For example your front end
+   *    website has more nuanced translations than your workflow messages and you wish
+   *    to redirect the user to a page on your website.
    *
    * @var string|null
    * @scope tokenContext

--- a/ext/message_admin/ang/crmMsgadm/ListCtrl.js
+++ b/ext/message_admin/ang/crmMsgadm/ListCtrl.js
@@ -32,13 +32,17 @@
     });
 
     var $ctrl = this;
-    $ctrl.records = _.map(
-      [].concat(prefetch.records, _.map(prefetch.translations || [], simpleKeys)),
-      function(r) {
-        r._is_translation = (r.tx_language !== undefined);
-        return r;
-      }
-    );
+    var allRecords = [].concat(prefetch.records, _.map(prefetch.translations || [], simpleKeys));
+    $ctrl.records = _.map(allRecords, function(r) {
+      r._is_translation = (r.tx_language !== undefined);
+
+      // If there is a translation in the system-default-locale, then it replaces the "Standard" tpl as the primary/visible item entry.
+      const defaultLocaleTpl = _.find(allRecords, {workflow_name: r.workflow_name, tx_language: CRM.config.lcMessages});
+      r._is_primary = defaultLocaleTpl ? (r === defaultLocaleTpl) : (!r._is_translation);
+      r._is_visible = (r._is_translation || r._is_primary);
+
+      return r;
+    });
 
     function findTranslations(record) {
       return _.reduce($ctrl.records, function(existing, rec){

--- a/ext/message_admin/ang/crmMsgadm/Workflow.js
+++ b/ext/message_admin/ang/crmMsgadm/Workflow.js
@@ -14,11 +14,11 @@
           prefetch: function(crmApi4, crmStatus) {
             var q = crmApi4({
               records: ['MessageTemplate', 'get', {
-                select: ["id", "msg_title", "is_default", "is_active"],
+                select: ["id", "msg_title", "is_default", "is_active", "workflow_name"],
                 where: [["workflow_name", "IS NOT EMPTY"], ["is_reserved", "=", "0"]]
               }],
               translations: ['MessageTemplate', 'get', {
-                select: ["id", "msg_title", "is_default", "is_active", "tx.language:label", "tx.language"],
+                select: ["id", "msg_title", "is_default", "is_active", "workflow_name", "tx.language:label", "tx.language"],
                 join: [["Translation AS tx", "INNER", null, ["tx.entity_table", "=", "'civicrm_msg_template'"], ["tx.entity_id", "=", "id"]]],
                 where: [["workflow_name", "IS NOT EMPTY"], ["is_reserved", "=", "0"]],
                 groupBy: ["id", "tx.language"],

--- a/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
+++ b/ext/message_admin/ang/crmMsgadm/WorkflowTranslated.html
@@ -19,7 +19,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="record in $ctrl.records | filter:filters.text | orderBy:['msg_title','_is_translation','tx_language_label']">
+    <tr ng-repeat="record in $ctrl.records | filter:filters.text | filter:{_is_visible: true} | orderBy:['msg_title','!_is_primary','tx_language_label']">
       <td>{{record.msg_title}}</td>
       <td>{{record.tx_language_label || ts('Standard')}}</td>
       <td>
@@ -39,7 +39,7 @@
         </span>
       </td>
       <td>
-        <span ng-if="!record.tx_language">
+        <span ng-if="record._is_primary">
           <a href crm-icon="fa-plus" ng-click="$ctrl.addTranslation(record)" title="{{ts('Add translation, &quot;%1&quot;', {1: record.msg_title})}}">{{:: ts('Translate') }}</a>
         </span>
       </td>


### PR DESCRIPTION


Overview
----------------------------------------
Fix failure to fall back to site default language, if configured

This addresses scenario 6 here
https://github.com/civicrm/civicrm-core/pull/26232#issuecomment-1624455432

Before
----------------------------------------
When a site default language translation is configured it is used in some sceanrios but not others - the detailed description at 
https://github.com/civicrm/civicrm-core/pull/26232#issuecomment-1624455432 is the best way to understand this

After
----------------------------------------
A translaiton for the site default language is always used, if configured.

Technical Details
----------------------------------------
This addresses a gap identified in the previous PR. I have put it against the rc as the previous PR hit that branch & it feels less confusing if this does too. It is also low risk of having impact outside the specific scenario

I'm still looking at the point re styling

Comments
----------------------------------------
@totten can you take a look - note that for testing this extension https://github.com/eileenmcnaughton/send_message_action is helpful - it adds a send_workflow action where you can see how the offline contribution receipt or invoice would display
![image](https://github.com/civicrm/civicrm-core/assets/336308/c50b75b0-7d62-42c1-bdbd-f90feeade71e)

