### PR TITLE
admin_ui: Sched Jobs language tweaks and add button

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
@@ -1,5 +1,9 @@
 <div class="af-markup">
-  <div class="help">{{:: ts('You can configure scheduled jobs (cron tasks) for your CiviCRM installation. For most sites, your system administrator should set up one or more "cron" tasks to run the enabled jobs. However, you can also run all scheduled jobs manually using the button below, or specific jobs from this screen using the "Execute Now" buttons.')}} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/sysadmin/en/latest/setup/jobs" target="_blank" title="Opens documentation in a new window.">(Job parameters and command line syntax documentation...)</a></div>
+  <div class="help">
+    {{:: ts('CiviCRM relies on a number of scheduled jobs that run automatically on a regular basis. These jobs keep data up-to-date and perform other important tasks.') }}
+    {{:: ts('For most sites, your system administrator should set up one or more "cron" tasks to run the enabled jobs. You can also run all scheduled jobs using the button below, or specific jobs from this screen using the "Execute Now" buttons.') }}
+    <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/sysadmin/en/latest/setup/jobs" target="_blank" title="{{:: ts('Opens documentation in a new window.', {'escape': 'js'}) }}">{{:: ts('(How to setup cron on the command line...)') }}</a>
+  </div>
 </div>
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
@@ -8,13 +12,17 @@
     <af-field name="is_active" defn="{input_type: 'Radio', input_attrs: {}}" />
   </div>
   <div class="btn-group pull-right">
+    <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/job', {reset: 1, action: 'add'}) }}">
+      <i class="crm-i fa-plus-circle"/>
+      {{:: ts('Add Scheduled Job') }}
+    </a>
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/runjobs', {reset: 1}) }}">
       <i class="crm-i fa-forward"/>
-      {{:: ts('Execute All Scheduled Jobs Now') }}
+      {{:: ts('Execute All Scheduled Jobs') }}
     </a>
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/joblog', {reset: 1}) }}">
       <i class="crm-i fa-list-alt"/>
-      {{:: ts('View Log (all jobs)') }}
+      {{:: ts('View Log') }}
     </a>
   </div>
   <crm-search-display-table search-name="Scheduled_Jobs" display-name="Scheduled_Jobs_Table_2"></crm-search-display-table>


### PR DESCRIPTION
Overview
----------------------------------------

Updates the help text to be like in #26767

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/cbc32702-d5bc-4b53-8898-455158dedd0a)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/014435fe-77c2-4b52-95d0-908e060b7d15)

- Help text updated
- Doc link is more accurate (note that when we edit/add job, it links to the page where it talks about job params)
- Added "Add Scheduled Job" button, to be like before (I'm fine with removing that, if it was intentionally removed, because I guess there are not many use-cases for adding these manually)
- Shortened the button labels a bit

cc @aydun @samuelsov 