### PR TITLE
Extension Browser: there are no standalone-specific modules

### DIFF
--- a/templates/CRM/Admin/Page/Extensions/About.tpl
+++ b/templates/CRM/Admin/Page/Extensions/About.tpl
@@ -1,5 +1,7 @@
 <div class="messages help">
     {capture assign='adminURL'}{crmURL p='civicrm/admin/setting/path' q="reset=1&civicrmDestination=$destination"}{/capture}
     <p>{ts 1=$adminURL 2="https://civicrm.org/extensions"}CiviCRM extensions allow you to install additional features for your site. This page will automatically list the available "native" extensions from the <a href="%2" target="_blank">CiviCRM.org extensions directory</a> which are compatible with this version of CiviCRM. If you install Custom Searches, Reports or Payment Processor extensions - these will automatically be available on the corresponding menus and screens.{/ts}</p>
-    {ts 1=$config->userFramework|replace:'6':'' 2="https://civicrm.org/extensions"}<p>You may also want to check the directory for <a href="%2/%1" target="_blank">native %1 modules</a> that may be useful for you (CMS-specific modules are not listed here).{/ts}</p>
+    {if $config->userFramework != "Standalone"}
+      {ts 1=$config->userFramework|replace:'6':'' 2="https://civicrm.org/extensions"}<p>You may also want to check the directory for <a href="%2/%1" target="_blank">native %1 modules</a> that may be useful for you (CMS-specific modules are not listed here).{/ts}</p>
+    {/if}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

Under Administer > System Settings > Extensions, there is a mention about native Standalone modules, which do not exist.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/5b42e9d1-ddb1-4907-9692-51392ba5fce0)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/e1d84739-7414-438e-bb38-1a004c9c5301)
