### PR TITLE
dev/core#4427 - Fix broken deleted filter checkbox on Manage Case

### DIFF
--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -552,7 +552,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form {
     $form->add('datepicker', 'activity_date_high_' . $form->_caseID, ts('To'), [], FALSE, ['time' => FALSE]);
 
     if (CRM_Core_Permission::check('administer CiviCRM')) {
-      $form->add('checkbox', 'activity_deleted', ts('Deleted Activities'), '', FALSE, ['id' => 'activity_deleted_' . $form->_caseID]);
+      $form->add('checkbox', 'activity_deleted', ts('Deleted Activities'), ['id' => 'activity_deleted_' . $form->_caseID], FALSE);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4427

Before
----------------------------------------
1. Delete a case activity.
1. On manage case expand the activity search filters and click the deleted checkbox.
1. Shows the same thing as when unchecked.

After
----------------------------------------


Technical Details
----------------------------------------
Broke in 5.64 in https://github.com/civicrm/civicrm-core/commit/7ea7b0883a16dcc9cd4a274ae53e15434c4e60f0, but see also https://lab.civicrm.org/dev/core/-/issues/4388

Comments
----------------------------------------

