### PR TITLE
hide view only custom fields on merge screen

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1642,12 +1642,16 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       $checkPermissions ? CRM_Core_Permission::EDIT : FALSE
     );
 
+    $ignoredCustomFields = self::ignoredFields('custom');
     foreach ($otherTree as $gid => $group) {
       if (!isset($group['fields'])) {
         continue;
       }
 
       foreach ($group['fields'] as $fid => $field) {
+        if (in_array($group['name'] . '.' . $field['name'], $ignoredCustomFields)) {
+          continue;
+        }
         $mainContactValue = $mainTree[$gid]['fields'][$fid]['customValue'] ?? NULL;
         $otherContactValue = $otherTree[$gid]['fields'][$fid]['customValue'] ?? NULL;
         if (in_array($fid, $compareFields['custom'])) {
@@ -2031,8 +2035,6 @@ ORDER BY civicrm_custom_group.weight,
       $submitted = [];
     }
 
-    // Move view only custom fields CRM-5362
-    $viewOnlyCustomFields = [];
     foreach ($submitted as $key => $value) {
       if (strpos($key, 'custom_') === 0) {
         $fieldID = (int) substr($key, 7);
@@ -2041,18 +2043,11 @@ ORDER BY civicrm_custom_group.weight,
           $htmlType = (string) $fieldMetadata['html_type'];
           $isSerialized = CRM_Core_BAO_CustomField::isSerialized($fieldMetadata);
           $isView = (bool) $fieldMetadata['is_view'];
-          if ($isView) {
-            $viewOnlyCustomFields[$key] = $value;
+          if (!$isView) {
+            $submitted = self::processCustomFields($mainId, $key, $submitted, $value, $fieldID, $isView, $htmlType, $isSerialized);
           }
-          $submitted = self::processCustomFields($mainId, $key, $submitted, $value, $fieldID, $isView, $htmlType, $isSerialized);
         }
       }
-    }
-
-    // special case to set values for view only, CRM-5362
-    if (!empty($viewOnlyCustomFields)) {
-      $viewOnlyCustomFields['entityID'] = $mainId;
-      CRM_Core_BAO_CustomValueTable::setValues($viewOnlyCustomFields);
     }
 
     // dev/core#996 Ensure that the earliest created date is stored against the kept contact id
@@ -2761,7 +2756,18 @@ ORDER BY civicrm_custom_group.weight,
         'postal_greeting_display',
         'addressee_display',
       ],
+      'custom' => [],
     ];
+
+    $readOnlyCustomFields = \Civi\Api4\CustomField::get(FALSE)
+      ->addSelect('custom_group_id.name', 'name')
+      ->addWhere('is_view', '=', TRUE)
+      ->addWhere('custom_group_id.extends', 'IN', ['Individual', 'Household', 'Organization', 'Contact'])
+      ->execute();
+    foreach ($readOnlyCustomFields as $field) {
+      $keysToIgnore['custom'][] = $field['custom_group_id.name'] . '.' . $field['name'];
+    }
+
     return $keysToIgnore[$type];
   }
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1047,6 +1047,42 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
   }
 
   /**
+   * Verifies that when two contacts with view only custom fields are merged,
+   * the view only field of the record being deleted is not merged, it is
+   * simply deleted (it should also not be visible on the page).
+   */
+  public function testMigrationOfViewOnlyCustomData() {
+    // Create Custom Fields
+    $createGroup = $this->setupCustomGroupForIndividual();
+    $customField = $this->setupCustomField('TestField', $createGroup);
+
+    // Contacts setup
+    $this->setupMatchData();
+    $originalContactID = $this->contacts[0]['id'];
+    $duplicateContactID = $this->contacts[1]['id'];
+
+    // Update the text custom fields for duplicate contact
+    $this->callAPISuccess('Contact', 'create', [
+      'id' => $duplicateContactID,
+      "custom_{$customField['id']}" => 'abc',
+    ]);
+    $this->assertCustomFieldValue($duplicateContactID, 'abc', "custom_{$customField['id']}");
+
+    // Change custom field to view only.
+    $this->callAPISuccess('CustomField', 'update', ['id' => $customField['id'], 'is_view' => TRUE]);
+
+    // Merge, and ensure that no value was migrated
+    $this->mergeContacts($originalContactID, $duplicateContactID, [
+      "move_custom_{$customField['id']}" => NULL,
+    ]);
+    $this->assertCustomFieldValue($originalContactID, '', "custom_{$customField['id']}");
+
+    // cleanup created custom set
+    $this->callAPISuccess('CustomField', 'delete', ['id' => $customField['id']]);
+    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $createGroup['id']]);
+  }
+
+  /**
    * Calls merge method on given contacts, with values given in $params array.
    *
    * @param $originalContactID

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -1070,7 +1070,8 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test the batch merge copes with view only custom data field.
+   * Test the batch merge copes with view only custom data field. View Only custom fields
+   * should never be merged.
    */
   public function testBatchMergeCustomDataViewOnlyField(): void {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit my contact'];
@@ -1085,7 +1086,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->assertCount(1, $result['values']['merged']);
     $mouseParams['return'] = 'custom_' . $customField['id'];
     $mouse = $this->callAPISuccess('Contact', 'getsingle', $mouseParams);
-    $this->assertEquals('blah', $mouse['custom_' . $customField['id']]);
+    $this->assertEquals('', $mouse['custom_' . $customField['id']]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Hide and do not merge view only custom fields. View only fields should not be edited by users, so allowing them to be merged can cause errors at worst, or just incorrect values at best.

Before
----------------------------------------

When merging two records with different values in one or more custom fields that are set to "is_view", CiviCRM provides the user with the option to merge those records. The merge sometimes causes an error (see below) and other times just doesn't work.

Here are the conditions to generate the error:

When:

 * merging two contacts
 * with different view only custom fields 
 * in which one of the custom fields is a date field
 * and that custom field is selected to merge

We get a backtrace:

```
$Fatal Error Details = array:3 [
  "message" => "value: 2023-06-02 13:43:00 is not of the right field data type: Date"
  "code" => null
  "exception" => CRM_Core_Exception {#1590
    -errorData: array:1 [
      "error_code" => 0
    ]
    #cause: null
    -_trace: null
    #message: "value: 2023-06-02 13:43:00 is not of the right field data type: Date"
    #code: 0
    #file: "/var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomValueTable.php"
    #line: 657
    trace: {
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomValueTable.php:657 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Dedupe/Merger.php:2056 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Contact/Form/Merge.php:324 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Form.php:612 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/StateMachine.php:144 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Next.php:43 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-packages/HTML/QuickForm/Controller.php:203 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-packages/HTML/QuickForm/Page.php:103 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Controller.php:355 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Utils/Wrapper.php:98 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:292 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:69 { …}
      /var/www/powerbase/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php:36 { …}
      /var/www/powerbase/web/modules/contrib/civicrm/src/Civicrm.php:88 {
```

After
----------------------------------------

The custom fields that are view only are hidden from the merge screen and if, somehow they are included, they will not be merged.

Technical Details
----------------------------------------

This PR extends the `ignoredFields` function currently used to ignore certain location and contact fields.

Comments
----------------------------------------

This is admittedly quiet a corner case (but came up because [two people experienced it](https://github.com/progressivetech/net.ourpowerbase.sumfields/issues/98). 

See original PR: #26416 