### PR TITLE
menubar: hide toggleButton when using Standalone

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -8,7 +8,7 @@
     data: null,
     settings: {collapsibleBehavior: 'accordion'},
     position: 'over-cms-menu',
-    toggleButton: true,
+    toggleButton: (CRM.config.userFramework != 'Standalone'),
     attachTo: (CRM.menubar && CRM.menubar.position === 'above-crm-container') ? '#crm-container' : 'body',
     initialize: function() {
       var cache = CRM.cache.get('menubar');


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM Standalone does not need this:

![image](https://github.com/civicrm/civicrm-core/assets/254741/bbb2229d-8b3d-445a-a66a-3bc0de3fa978)

Reported by @colemanw in #26789.