### PR TITLE
Fix two more broken checkboxes - PCP pages

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -429,8 +429,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $prms = ['id' => $this->_pcpId];
       CRM_Core_DAO::commonRetrieve('CRM_PCP_DAO_PCP', $prms, $pcpInfo);
       if ($pcpInfo['is_honor_roll']) {
-        $this->add('checkbox', 'pcp_display_in_roll', ts('Show my contribution in the public honor roll'), NULL, NULL,
-          ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"]
+        $this->add('checkbox', 'pcp_display_in_roll', ts('Show my contribution in the public honor roll'),
+          ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"],
+          FALSE
         );
         $extraOption = ['onclick' => "return pcpAnonymous( );"];
         $this->addRadio('pcp_is_anonymous', NULL, [ts('Include my name and message'), ts('List my contribution anonymously')], [], '&nbsp;&nbsp;&nbsp;', FALSE, [$extraOption, $extraOption]);

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -470,8 +470,9 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
     // build honor roll fields for registration form if supporter has honor roll enabled for their PCP
     if ($pcpInfo['is_honor_roll']) {
       $page->assign('is_honor_roll', TRUE);
-      $page->add('checkbox', 'pcp_display_in_roll', ts('Show my support in the public honor roll'), NULL, NULL,
-        ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"]
+      $page->add('checkbox', 'pcp_display_in_roll', ts('Show my support in the public honor roll'),
+        ['onclick' => "showHideByValue('pcp_display_in_roll','','nameID|nickID|personalNoteID','block','radio',false); pcpAnonymous( );"],
+        FALSE
       );
       $extraOption = ['onclick' => "return pcpAnonymous( );"];
       $page->addRadio('pcp_is_anonymous', '', [ts('Include my name and message'), ts('List my support anonymously')], [], '&nbsp;&nbsp;&nbsp;', FALSE, [$extraOption, $extraOption]);


### PR DESCRIPTION
Overview
----------------------------------------
Same cause as #26790.

Before
----------------------------------------
1. On a contribution page, on the personal campaign pages tab, enable PCP.
2. To speed this up uncheck the Approval Required checkbox there.
3. Donate on that page. At the end there'll be an option to make you own PCP. Do it.
4. Go to that PCP page. Click the checkbox for "Show my contribution in the public honor roll".
5. It's supposed to do something, but does nothing.

Now repeat for an Event:
1. Same steps as above, but for events.

After
----------------------------------------
The checkbox displays some other fields when clicked.

Technical Details
----------------------------------------


Comments
----------------------------------------

