### PR TITLE
SearchKit - Remove irrelevant link from default display

### DIFF
--- a/ext/search_kit/Civi/Search/Display.php
+++ b/ext/search_kit/Civi/Search/Display.php
@@ -69,7 +69,7 @@ class Display {
     }
     // If addLabel is false the placeholder needs to be passed through to javascript
     $label = $addLabel ?: '%1';
-    unset($paths['add']);
+    unset($paths['add'], $paths['browse']);
     foreach (array_keys($paths) as $actionName) {
       $actionKey = \CRM_Core_Action::mapItem($actionName);
       $link = [


### PR DESCRIPTION
Overview
----------------------------------------
Just removing a link that doesn't make sense.

Technical Details
--------
This doesn't affect core (yet) but the ECK Extension includes a `<browse>` link here and it doesn't make sense to include it in a search results table:

https://github.com/systopia/de.systopia.eck/blob/7be09fcd04b03b98e168641c030210578ce5a36d/Civi/Eck/API/Entity.php#L78C1-L79