### PR TITLE
System Requirements - Raise minimum recommended PHP to 7.4

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -33,7 +33,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '7.3.0';
+  const MIN_RECOMMENDED_PHP_VER = '7.4.0';
 
   /**
    * The minimum PHP version required to install Civi.


### PR DESCRIPTION
Overview
----------------------------------------

Per `php.net`, PHP 7.3 has been EOL since Dec 2021 (~19 months).

Before
----------------------------------------

No warnings on systems running PHP 7.3.

After
----------------------------------------

System status checks:

<img width="1030" alt="Screen Shot 2023-07-12 at 6 02 21 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/02d5087f-93ae-4f2d-8c84-d36077432b75">

Pre-upgrade message:

<img width="542" alt="Screen Shot 2023-07-12 at 6 05 46 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/be9beba9-bc22-4965-bbce-40bf3f2ac617">


