### PR TITLE
System Requirements - Raise minimum recommended PHP to 7.4

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -33,7 +33,7 @@ class CRM_Upgrade_Incremental_General {
    *
    * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '7.3.0';
+  const MIN_RECOMMENDED_PHP_VER = '7.4.0';
 
   /**
    * The minimum PHP version required to install Civi.


### PR DESCRIPTION
Overview
----------------------------------------

Backport #26799 from 5.64-rc to 5.63-stable.

Comments
----------------------------------------

This is a bit debatable:

* On one hand, it's not fixing a regression.
* On the other hand, it doesn't really change behavior -- it merely improves communication about the future. The *substance* of the message is true whether 5.63 displays or not. The question is whether we *tell users on 5.63*.
