### PR TITLE
Stop setting unused property & creating notices

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -289,8 +289,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->_contactID = $this->_membershipContactID = $this->getContactID();
     $this->getRenewalMembershipID();
 
-    // @todo - this mid needs to go - just making sure references are updated first.
-    $this->_mid = $this->getRenewalMembershipID();
     if ($this->getRenewalMembershipID()) {
       $membership = new CRM_Member_DAO_Membership();
       $membership->id = $this->getRenewalMembershipID();


### PR DESCRIPTION
Overview
----------------------------------------
Stop setting unused property & creating notices

Before
----------------------------------------
Property set but not accessed from core or universe

![image](https://github.com/civicrm/civicrm-core/assets/336308/f581eb48-6c12-4abe-80ef-12206f76eea2)

After
----------------------------------------
property gone

Technical Details
----------------------------------------
Causes test fails on latest php version

Comments
----------------------------------------
