### PR TITLE
dev/core#4430 Fix regression on searching for emails

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1788,12 +1788,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
 
     // Core field - get metadata.
-    $fieldSpec = civicrm_api3($props['entity'], 'getfield', $props);
-    $fieldSpec = $fieldSpec['values'];
+    $fieldSpec = civicrm_api3($props['entity'], 'getfield', $props)['values'];
     $label = $props['label'] ?? $fieldSpec['html']['label'] ?? $fieldSpec['title'];
 
     $widget = $props['type'] ?? $fieldSpec['html']['type'];
-    if ($widget == 'TextArea' && $context == 'search') {
+    if (in_array($widget, ['TextArea', 'Email'], TRUE) && $context == 'search') {
+      // Don't require a full email to be entered in search mode.
+      // See https://lab.civicrm.org/dev/core/-/issues/4430.
       $widget = 'Text';
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4430 Fix regression on searching for emails

See screenshots in https://lab.civicrm.org/dev/core/-/issues/4430

Before
----------------------------------------
Not possible to search for a partial email in (e.g)advanced search fails because the email fails html-layer validation & won't submit

See https://dmaster.demo.civicrm.org/civicrm/contact/search/advanced?reset=1

![image](https://github.com/civicrm/civicrm-core/assets/336308/7f9867ae-bfe6-4db9-a8cf-1a45503b88f3)


Note settings 

![image](https://github.com/civicrm/civicrm-core/assets/336308/cc4e4cb2-5828-4357-b345-afb96508af1b)


After
----------------------------------------
html type is rendered as 'Text' not 'Email'

Technical Details
----------------------------------------
We hit this in the 5.64rc & I believe it does not need to go back to stable - https://github.com/civicrm/civicrm-core/pull/26705


Comments
----------------------------------------
