### PR TITLE
Standardize title as Administer in breadcrumbs and on main Administer page

### DIFF
--- a/CRM/Admin/Page/Job.php
+++ b/CRM/Admin/Page/Job.php
@@ -102,7 +102,7 @@ class CRM_Admin_Page_Job extends CRM_Core_Page_Basic {
     CRM_Utils_System::setTitle(ts('Settings - Scheduled Jobs'));
     CRM_Utils_System::appendBreadCrumb([
       [
-        'title' => ts('Administer CiviCRM'),
+        'title' => ts('Administer'),
         'url' => CRM_Utils_System::url('civicrm/admin', 'reset=1'),
       ],
     ]);

--- a/CRM/Admin/Page/JobLog.php
+++ b/CRM/Admin/Page/JobLog.php
@@ -60,7 +60,7 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
     CRM_Utils_System::setTitle(ts('Settings - Scheduled Jobs Log'));
     CRM_Utils_System::appendBreadCrumb([
       [
-        'title' => ts('Administration'),
+        'title' => ts('Administer'),
         'url' => CRM_Utils_System::url('civicrm/admin',
           'reset=1'
         ),

--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -44,7 +44,7 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
     CRM_Utils_System::setTitle(ts('Settings - Payment Processor'));
     $breadCrumb = [
       [
-        'title' => ts('Administration'),
+        'title' => ts('Administer'),
         'url' => CRM_Utils_System::url('civicrm/admin',
           'reset=1'
         ),

--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -65,7 +65,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
   public function preProcess() {
     $this->setTitle(ts('Organization Address and Contact Info'));
     $breadCrumbPath = CRM_Utils_System::url('civicrm/admin', 'reset=1');
-    CRM_Utils_System::appendBreadCrumb(ts('Administer CiviCRM'), $breadCrumbPath);
+    CRM_Utils_System::appendBreadCrumb(ts('Administer'), $breadCrumbPath);
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin', 'reset=1'));
 

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -631,7 +631,7 @@
   </item>
   <item>
      <path>civicrm/admin</path>
-     <title>Administer CiviCRM</title>
+     <title>Administer</title>
      <access_arguments>administer CiviCRM system,administer CiviCRM data,access CiviCRM</access_arguments>
      <page_type>1</page_type>
      <page_callback>CRM_Admin_Page_Admin</page_callback>

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -26,7 +26,7 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
       // If the user has "admin civicrm" & the admin extension is enabled
       if (CRM_Core_Permission::check('administer CiviCRM')) {
         if (($pagePath[1] ?? NULL) === 'admin') {
-          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Admin'), 'url' => CRM_Utils_System::url('civicrm/admin')]]);
+          CRM_Utils_System::appendBreadCrumb([['title' => E::ts('Administer'), 'url' => CRM_Utils_System::url('civicrm/admin')]]);
         }
         if ($afform['type'] !== 'system' &&
           \CRM_Extension_System::singleton()->getMapper()->isActiveModule('afform_admin')


### PR DESCRIPTION
Overview
----------------------------------------
Just a little cleanup to standardize the name of the admin page.

Before
----------------------------------------
Breadcrumbs use "Administer", "Administration", "Administer CiviCRM" and "Admin" to refer to the same path.

Main administration page is titled "Administer CiviCRM".

After
----------------------------------------
All breadcrumbs and the title of the main admin page match the menu: "Administer".

Comments
----------------------------------------
There are also ~5 help texts that include "Administer CiviCRM", but I don't think it is worth forcing these all to be retranslated for such a minor change.