### PR TITLE
Add start date back to recurring contributions display on contact

### DIFF
--- a/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecurSelector.tpl
@@ -13,12 +13,9 @@
     <tr class="columnheader">
       <th scope="col">{ts}Amount{/ts}</th>
       <th scope="col">{ts}Frequency{/ts}</th>
-      <th scope="col">
-        {if $recurType EQ 'active'}{ts}Next Scheduled Date{/ts}
-        {elseif $recurType EQ 'inactive'}{ts}End or Modified Date{/ts}
-        {else}{ts}Start Date{/ts}
-        {/if}
-      </th>
+      <th scope="col">{ts}Start Date{/ts}</th>
+      {if $recurType EQ 'active'}<th scope="col">{ts}Next Scheduled Date{/ts}</th>{/if}
+      {if $recurType EQ 'inactive'}<th scope="col">{ts}End or Modified Date{/ts}</th>{/if}
       <th scope="col">{ts}Installments{/ts}</th>
       <th scope="col">{ts}Payment Processor{/ts}</th>
       <th scope="col">{ts}Status{/ts}</th>
@@ -30,16 +27,16 @@
       <tr id="contribution_recur-{$row.id}" data-action="cancel" class="crm-entity {cycle values="even-row,odd-row"}{if NOT $row.is_active} disabled{/if}">
         <td>{$row.amount|crmMoney:$row.currency}{if $row.is_test} ({ts}test{/ts}){/if}</td>
         <td>{ts}Every{/ts} {$row.frequency_interval} {$row.frequency_unit} </td>
-        <td>
-          {if $recurType EQ 'active'}{$row.next_sched_contribution_date|crmDate}
-          {elseif $recurType EQ 'inactive'}
+        <td>{$row.start_date|crmDate}</td>
+        {if $recurType EQ 'active'}<td>{$row.next_sched_contribution_date|crmDate}</td>{/if}
+        {if $recurType EQ 'inactive'}
+          <td>
             {if $row.cancel_date}{$row.cancel_date|crmDate}
             {elseif $row.end_date}{$row.end_date|crmDate}
             {else}{$row.modified_date|crmDate}
             {/if}
-          {else}{$row.start_date|crmDate}
-          {/if}
-        </td>
+          </td>
+        {/if}
         <td>{$row.installments}</td>
         <td>{$row.payment_processor}</td>
         <td>{$row.contribution_status}</td>

--- a/templates/CRM/Member/Page/RecurringContributions.tpl
+++ b/templates/CRM/Member/Page/RecurringContributions.tpl
@@ -2,5 +2,5 @@
   <div class="solid-border-top">
     <br /><label>{ts 1=$displayName}Recurring Contributions{/ts}</label>
   </div>
-  {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" action=16}
+  {include file="CRM/Contribute/Page/ContributionRecurSelector.tpl" action=16 recurType='both'}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Follow up adding start date back  to recurring contributions on contact due to user feedback, see #26151. Don't love that this breaks onto two lines, but not sure there's a way around that, hopefully folks who care about this have set a more reasonable date format.

Before
----------------------------------------
<img width="1006" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/c0678ebb-4fa4-4ed1-93cb-f95fa4d25871">

After
----------------------------------------
<img width="1000" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/deb3d5ca-10dd-4634-a1fb-b5c8ff6cd766">
