### PR TITLE
[REF][PHP8.2] Move declaration of _actionButtonName from CRM_Core_Form_Search…

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -327,6 +327,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   ];
 
   /**
+   * Name of action button
+   *
+   * @var string
+   */
+  protected $_actionButtonName;
+
+  /**
    * Constructor for the basic form page.
    *
    * We should not use QuickForm directly. This class provides a lot

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -22,13 +22,6 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   protected $_force;
 
   /**
-   * Name of action button
-   *
-   * @var string
-   */
-  protected $_actionButtonName;
-
-  /**
    * Form values that we will be using
    *
    * @var array


### PR DESCRIPTION
… to CRM_Core_Form to fix undefined property errors in Job Report tests

Overview
----------------------------------------
This aims to fix the following test notice errors on PHP8.2

```
not ok 1407 - Failure: api_v3_JobTest::testMailReportForPrint
  ---
  message: 'Failure in api call for Job mail_report:  Creation of dynamic property CRM_Report_Form_Contact_Summary::$_actionButtonName
    is deprecated'
  severity: fail
  ...
  not ok 1408 - Failure: api_v3_JobTest::testMailReportForPdf
  ---
  message: 'Failure in api call for Job mail_report:  Creation of dynamic property CRM_Report_Form_Contact_Summary::$_actionButtonName
    is deprecated'
  severity: fail
  ...
  not ok 1409 - Failure: api_v3_JobTest::testMailReportForCsv
  ---
  message: 'Failure in api call for Job mail_report:  Creation of dynamic property CRM_Report_Form_Contact_Summary::$_actionButtonName
    is deprecated'
  severity: fail
```

Before
----------------------------------------
Test generates notices

After
----------------------------------------
Tests shouldn't generate notices

ping @demeritcowboy @eileenmcnaughton 