### PR TITLE
[PHP8.x] Stop setting undeclared, unused property in test

### DIFF
--- a/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
@@ -28,7 +28,7 @@ class CRM_Member_Form_Task_LabelTest extends CiviUnitTestCase {
     $this->assertArrayHasKey(201, $tasks, print_r($tasks, TRUE));
     $tasks = CRM_Member_Task::permissionedTaskTitles(CRM_Core_Permission::EDIT);
     $this->assertArrayHasKey(201, $tasks);
-    $membershipID = $this->contactMembershipCreate(['contact_id' => $this->individualCreate()]);
+    $this->contactMembershipCreate(['contact_id' => $this->individualCreate()]);
     /** @var CRM_Member_Form_Task_Label $form */
     $form = $this->getFormObject('CRM_Member_Form_Task_Label', [
       'task' => 201,
@@ -40,7 +40,6 @@ class CRM_Member_Form_Task_LabelTest extends CiviUnitTestCase {
       'label_name' => 3475,
     ];
     $form->preProcess();
-    $form->ids = [$membershipID => $membershipID];
     $form->buildForm();
     try {
       $form->postProcess();


### PR DESCRIPTION
The ids property is not only undeclared - it is meaningless....