### PR TITLE
Fix mis-cased apiVersion causing php8.x fails in SavedSearchTest

### DIFF
--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -41,7 +41,7 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   public function setUp(): void {
     parent::setUp();
 
-    // The line below makes it unneccessary to do cleanup after a test,
+    // The line below makes it unnecessary to do cleanup after a test,
     // because the transaction of the test will be rolled back.
     // see http://forum.civicrm.org/index.php/topic,35627.0.html
     $this->useTransaction();
@@ -88,8 +88,6 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   /**
    * Create a saved search, retrieve it again, and check for ID and one of
    * the field values.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCreateAndGetSavedSearch(): void {
     // Arrange:
@@ -114,16 +112,14 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   /**
    * Create a saved search, and test whether it can be used for a smart
    * group.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testCreateSavedSearchWithSmartGroup(): void {
     // First create a volunteer for the default organization
 
     [$contact_id, $params] = $this->setupContactInSmartGroup();
 
-    $create_result = $this->callAPIAndDocument(
-        $this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $create_result = $this->callAPISuccess(
+        'SavedSearch', 'create', $params);
 
     $created_search = CRM_Utils_Array::first($create_result['values']);
     $group_id = $created_search['api.Group.create']['id'];
@@ -140,13 +136,8 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
    * Create a saved search, and test whether it can be used for a smart
    * group. Also check that when the Group is deleted the associated saved
    * search gets deleted.
-   *
-   * @dataProvider versionThreeAndFour
-   * @throws \CRM_Core_Exception
    */
-  public function testSavedSearchIsDeletedWhenSmartGroupIs($apiVersion): void {
-    $this->_apiVersion = $apiVersion;
-    // First create a volunteer for the default organization
+  public function testSavedSearchIsDeletedWhenSmartGroupIs(): void {
 
     [$contact_id, $params] = $this->setupContactInSmartGroup();
 
@@ -155,11 +146,11 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
     $created_search = CRM_Utils_Array::first($create_result['values']);
     $group_id = $created_search['api.Group.create']['id'];
 
-    $get_result = $this->callAPISuccess('Contact', 'get', ['group' => $group_id]);
+    $result = $this->callAPISuccess('Contact', 'get', ['group' => $group_id]);
 
     // Expect our contact to be there.
-    $this->assertEquals(1, $get_result['count']);
-    $this->assertEquals($contact_id, $get_result['values'][$contact_id]['id']);
+    $this->assertEquals(1, $result['count']);
+    $this->assertEquals($contact_id, $result['values'][$contact_id]['id']);
 
     $this->callAPISuccess('Group', 'delete', ['id' => $group_id]);
     $savedSearch = $this->callAPISuccess('SavedSearch', 'get', ['id' => $created_search['id']]);
@@ -167,27 +158,12 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
   }
 
   /**
-   * @throws \CRM_Core_Exception
-   */
-  public function testDeleteSavedSearch(): void {
-    // Create saved search, delete it again, and try to get it
-    $create_result = $this->callAPISuccess($this->_entity, 'create', $this->params);
-    $delete_params = ['id' => $create_result['id']];
-    $this->callAPIAndDocument(
-        $this->_entity, 'delete', $delete_params, __FUNCTION__, __FILE__);
-    $get_result = $this->callAPISuccess($this->_entity, 'get', []);
-
-    $this->assertEquals(0, $get_result['count']);
-  }
-
-  /**
    * @return array
-   * @throws \CRM_Core_Exception
    */
   protected function setupContactInSmartGroup(): array {
     $result = $this->callAPISuccess('Contact', 'create', [
       'first_name' => 'Joe',
-      'last_name' => 'Schmoe',
+      'last_name' => 'Schmidt',
       'contact_type' => 'Individual',
       'api.Relationship.create' => [
         'contact_id_a' => '$value.id',


### PR DESCRIPTION
I also removed the delete test - it really isn't adding anything
