### PR TITLE
[REF][PHP8.2] Apply PR patch to mimetyper to fix deprecated dynamic p…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -272,7 +272,8 @@
     },
     "patches": {
       "adrienrn/php-mimetyper": {
-        "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch"
+        "Update gitignore to ensure that sites that manage via git don't miss out on the important db.json file": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/15.patch",
+        "Apply patch to fix php8.2 deprecation notice on dynamic property $filename": "https://patch-diff.githubusercontent.com/raw/adrienrn/php-mimetyper/pull/17.patch"
       },
       "html2text/html2text": {
         "Fix deprecation warning in php8.1 on html_entity_decode": "https://raw.githubusercontent.com/civicrm/civicrm-core/e758d20e9f613ca6c4cf652c23d2cd7e5d3af3ce/tools/scripts/composer/html2text_html2_text_php81_deprecation.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4769b4b0e2f12a788978d616edb74b1",
+    "content-hash": "ed6c7efbc6ca47fc573d6e59234dcfdb",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5587,5 +5587,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
…roperty

Overview
----------------------------------------
This applies the following PR https://github.com/adrienrn/php-mimetyper/pull/17 via patches to fix this test failure

```
CRM_Utils_FileTest::testMimeTypeToExtension with data set #0 ('text/plain', array('txt', 'text', 'conf', 'def', 'list', 'log', 'in', 'ini'))
Creation of dynamic property MimeTyper\Repository\MimeDbRepository::$filename is deprecated
```

Before
----------------------------------------
Test fails on php8.2 due to deprecation warning

After
----------------------------------------
Test passes on php8.2

ping @demeritcowboy @eileenmcnaughton 