### PR TITLE
[REF] Ensure that getActions respects any modifications by event list…

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -79,7 +79,8 @@ class GetActions extends BasicGetAction {
     try {
       if (!isset($this->_actions[$actionName]) && (!$this->_actionsToGet || in_array($actionName, $this->_actionsToGet))) {
         $action = \Civi\API\Request::create($this->getEntityName(), $actionName, ['version' => 4]);
-        if (is_object($action) && (!$this->checkPermissions || $action->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID()))) {
+        $authorized = \Civi::service('civi_api_kernel')->runAuthorize($this->getEntityName(), $actionName, ['version' => 4]);
+        if (is_object($action) && (!$this->checkPermissions || $authorized)) {
           $this->_actions[$actionName] = ['name' => $actionName];
           if ($this->_isFieldSelected('description', 'comment', 'see')) {
             $vars = ['entity' => $this->getEntityName(), 'action' => $actionName];

--- a/tests/phpunit/api/v4/Action/GetActionsTest.php
+++ b/tests/phpunit/api/v4/Action/GetActionsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Membership;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class GetActionsTest extends Api4TestBase implements HookInterface, TransactionalInterface {
+
+  /**
+   * Listens for civi.api4.authorize event to manually permit any user to use membership.get api
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public function on_civi_api_authorize(GenericHookEvent $e): void {
+    $apiRequest = $e->getApiRequest();
+    if ($apiRequest['version'] == 4 && $apiRequest->getEntityName() === 'Membership' && $apiRequest->getActionName() === 'get') {
+      $e->authorize();
+      $e->stopPropagation();
+    }
+  }
+
+  public function testContactIconAutocomplete(): void {
+    $contact = $this->createTestRecord('Contact', [
+      'first_name' => 'GetActions',
+      'last_name' => 'testContact',
+      'contact_type' => 'Individual',
+    ]);
+    $membershipType = $this->createTestRecord('MembershipType', [
+      'label' => 'Student',
+    ]);
+    $this->createTestRecord('Membership', [
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $membershipType['id'],
+      'start_date' => date('Y-m-d'),
+      'join_date' => date('Y-m-d'),
+    ]);
+    $this->createLoggedInUser();
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+    $actions = Membership::getActions()->setSelect(['name'])->execute()->column('name');
+    $this->assertTrue(in_array('get', $actions));
+    $this->assertFalse(in_array('create', $actions));
+  }
+
+}


### PR DESCRIPTION
…erners modifying permissions

Overview
----------------------------------------
An Extension can create an event listener listing to the civi.api.authorize event to modify e.g. perhaps they want to remove the access CiviCRM guard or something on a Membership.get api call. This works but if you do something like contact.get with an explicit join on Membership.get this can fail because getActions API which is used to determine in v4 if a user can access the Joined entity does not respect the authorize listener overriding 

Before
----------------------------------------
Get Actions may not show an action that a user is permitted to do or visa versa

After
----------------------------------------
Get actions is more correct in its checking of permissions

ping @johntwyman @colemanw 