### PR TITLE
Reduce initial height of crm-popup dialog

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -351,7 +351,7 @@ if (!CRM.vars) CRM.vars = {};
    * @returns {*}
    */
   CRM.utils.adjustDialogDefaults = function(settings) {
-    settings = $.extend({width: '65%', height: '65%', modal: true}, settings || {});
+    settings = $.extend({width: '65%', height: '40%', modal: true}, settings || {});
     // Support relative height
     if (typeof settings.height === 'string' && settings.height.indexOf('%') > 0) {
       settings.height = parseInt($(window).height() * (parseFloat(settings.height)/100), 10);

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -578,7 +578,8 @@
       settings.dialog.height = 300;
     }
     else if ($el.hasClass('medium-popup')) {
-      settings.dialog.width = settings.dialog.height = '50%';
+      settings.dialog.width = '50%';
+      settings.dialog.height = '30%';
     }
     var dialog = popup(url, settings);
     // Trigger events from the dialog on the original link element


### PR DESCRIPTION
Overview
----------------------------------------
These modal dialogs will auto-adjust their height to fit the content, so they do not need to be very tall initially.

Comments
--------
Ping @larssandergreen per our discussion on https://github.com/civicrm/civicrm-core/pull/26674#issuecomment-1636402839
