### PR TITLE
[REF][PHP8.2] Fix Dynamic Property Deprecation notice in MultiRecordListing

### DIFF
--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -35,6 +35,12 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
 
   public $_contactType = NULL;
 
+  public $_customGroupId = NULL;
+
+  public $_DTparams = [];
+
+  public $_total = NULL;
+
   /**
    * Get BAO Name.
    *


### PR DESCRIPTION
Overview
----------------------------------------
This aims to resolve the following test failure 

```
CRM_Custom_Page_AJAXTest::testMultiRecordFieldList
Creation of dynamic property CRM_Profile_Page_MultipleRecordFieldsListing::$_customGroupId is deprecated

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/CRM/Custom/Page/AJAX.php:113
``` 

Before
----------------------------------------
Test failure because of dynamic properties on the class

After
----------------------------------------
Test passes on 8.2

ping @eileenmcnaughton @demeritcowboy 