### PR TITLE
[REF][PHP8.2] Fix deprecated dynamic properties in Logging Report Detail

### DIFF
--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -33,10 +33,13 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
   protected $raw;
   protected $tables = [];
   protected $interval = '10 SECOND';
+  protected $dblimit;
+  protected $dboffset;
 
   protected $altered_name;
   protected $altered_by;
   protected $altered_by_id;
+  protected $layout;
 
   /**
    * detail/summary report ids


### PR DESCRIPTION
Overview
----------------------------------------
This aims to resolve the following test failure caused by PHP8.2 deprecation on dynamic properties

```
api_v3_ReportTemplateTest::testReportTemplateGetRowsAllReports with data set #36 ('logging/contact/detail')
Failure in api call for report_template getrows:  Creation of dynamic property CRM_Report_Form_Contact_LoggingDetail::$dblimit is deprecated
```

Before
----------------------------------------
Test fails on php8.2 due to deprecation notice

After
----------------------------------------
Test passes on php8.2

ping @eileenmcnaughton @demeritcowboy 