### PR TITLE
[Ref] [php8] Unshare shared function `CRM_Custom_Form_CustomData::setGroupTree` in order to clean-up

### DIFF
--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -181,7 +181,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
       $groupParams = [];
       $groupParams['title'] = $params['title'];
       $groupParams['description'] = $params['description'];
-      $groupParams['visibility'] = "User and User Admin Only";
+      $groupParams['visibility'] = 'User and User Admin Only';
       $groupParams['group_type'] = array_keys($params['group_type'] ?? []);
       $groupParams['is_active'] = 1;
       $groupParams['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, 'Group');

--- a/tests/phpunit/CRM/Contact/Form/Task/AddToGroupTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/AddToGroupTest.php
@@ -9,23 +9,21 @@
  +--------------------------------------------------------------------+
  */
 
- /**
-  * @group headless
-  */
-class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
+use Civi\Api4\Group;
+use Civi\Api4\GroupContact;
 
-  protected function setUp(): void {
-    parent::setUp();
-  }
+/**
+ * @group headless
+ */
+class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
 
   /**
    * @param array $formValues
    * @return CRM_Contact_Form_Task_AddToGroup
    */
-  protected function getSearchTaskFormObject(array $formValues) {
+  protected function getSearchTaskFormObject(array $formValues): CRM_Contact_Form_Task_AddToGroup {
     $_POST = $formValues;
     $_SERVER['REQUEST_METHOD'] = 'GET';
-    /** @var CRM_Core_Form $form */
     $form = new CRM_Contact_Form_Task_AddToGroup();
     $form->controller = new CRM_Contact_Controller_Search();
     $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
@@ -35,8 +33,10 @@ class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
 
   /**
    * Test delete to trash.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testAddToGroup() {
+  public function testAddToGroup(): void {
     $contact = $this->callAPISuccess('Contact', 'create', [
       'contact_type' => 'Individual',
       'first_name' => 'John',
@@ -52,7 +52,7 @@ class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
     $form->setDefaultValues();
     $form->postProcess();
 
-    $groupCount = \Civi\Api4\GroupContact::get()
+    $groupCount = GroupContact::get()
       ->addWhere('group_id', '=', $existingGroupId)
       ->addWhere('status', '=', 'Added')
       ->execute()
@@ -62,8 +62,10 @@ class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
 
   /**
    * Test delete to trash.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testAddToNewGroupWithCustomField() {
+  public function testAddToNewGroupWithCustomField(): void {
     $contact = $this->callAPISuccess('Contact', 'create', [
       'contact_type' => 'Individual',
       'first_name' => 'Pete',
@@ -88,7 +90,7 @@ class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
     $form->setDefaultValues();
     $form->postProcess();
 
-    $group = \Civi\Api4\Group::get()
+    $group = Group::get()
       ->addSelect('custom.*', 'id')
       ->addWhere('title', '=', 'Test Group With Custom Field')
       ->execute();
@@ -97,7 +99,7 @@ class CRM_Contact_Form_Task_AddToGroupTest extends CiviUnitTestCase {
     $this->assertArrayKeyExists('new_custom_group.Custom_Field', $group);
     $this->assertEquals('Custom Value ABC', $group['new_custom_group.Custom_Field']);
 
-    $groupCount = \Civi\Api4\GroupContact::get()
+    $groupCount = GroupContact::get()
       ->addWhere('group_id', '=', $group['id'])
       ->addWhere('status', '=', 'Added')
       ->execute()


### PR DESCRIPTION
Overview
----------------------------------------
Unshare shared function `CRM_Custom_Form_CustomData::setGroupTree` in order to clean-up

Before
----------------------------------------
`CRM_Custom_Form_CustomData::setGroupTree` is shared for the purposes of re-using the CustomData form code in other forms - but it expects all sorts of variables to be passed via form properties that are relevant to the original class rather than the forms - so a tonne of work is done to re-use it

After
----------------------------------------
The 2 places that use it have their own copies (one copied inline into the calling function). It is deprecated

Technical Details
----------------------------------------
Towards fixing https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=bknix-tmp-edge/2843/testReport/junit/(root)/CRM_Contact_Form_Task_AddToGroupTest/testAddToGroup/

Comments
----------------------------------------
I created an issue on gdpr https://github.com/veda-consulting-company/uk.co.vedaconsulting.gdpr/issues/330
