### PR TITLE
[REF][PHP8.2] Fix Deprectation notice due to dynamic properties on th…

### DIFF
--- a/CRM/Report/Form/Contribute/History.php
+++ b/CRM/Report/Form/Contribute/History.php
@@ -20,6 +20,12 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
    */
   protected $_relationshipColumns = [];
 
+  protected $_relationshipFrom = '';
+
+  protected $_relationshipWhere = '';
+
+  protected $_contributionClauses = [];
+
   protected $_customGroupExtends = [
     'Contact',
     'Individual',
@@ -397,8 +403,6 @@ class CRM_Report_Form_Contribute_History extends CRM_Report_Form {
 
   public function where() {
     $whereClauses = $havingClauses = $relationshipWhere = [];
-    $this->_relationshipWhere = '';
-    $this->_contributionClauses = [];
 
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('filters', $table)) {


### PR DESCRIPTION
…e Contribute History report

Overview
----------------------------------------
This aims to resolve deprecation issue as found by unit tests on edge

```
api_v3_ReportTemplateTest::testReportTemplateGetRowsAllReports with data set #40 ('contribute/history')
Failure in api call for report_template getrows:  Creation of dynamic property CRM_Report_Form_Contribute_History::$_relationshipFrom is deprecated
```

Before
----------------------------------------
Test fail on php8.2

After
----------------------------------------
Test passes

ping @eileenmcnaughton @demeritcowboy 