### PR TITLE
(dev/core#4414) Greenwich - Fix icon path

### DIFF
--- a/ext/greenwich/scss/_greenwich.scss
+++ b/ext/greenwich/scss/_greenwich.scss
@@ -79,7 +79,7 @@ $headings-color: rgb(0, 0, 0);
 //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
 
 //** Load fonts from this directory.
-$icon-font-path: "../fonts/";
+$icon-font-path: "../extern/bootstrap3/assets/fonts/bootstrap/";
 //** File name for all font files.
 $icon-font-name: "glyphicons-halflings-regular";
 //** Element ID within SVG icon file.


### PR DESCRIPTION
Overview
----------------------------------------

This fixes an issue where the Greenwich Bootstrap files include an invalid reference to their font data.

https://lab.civicrm.org/dev/core/-/issues/4414

ping @agileware-justin 

Before
----------------------------------------

If you use (e.g.) Mosaico's "New Mailing", then browser console shows a failed request for

```
http://dmaster.127.0.0.1.nip.io:8001/sites/all/modules/civicrm/ext/greenwich/fonts/glyphicons-halflings-regular.woff2
```

Visually, on the third tab ("Options"), this button is malformed:

<img width="241" alt="Screen Shot 2023-07-14 at 4 38 49 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/414083d4-16a0-4fd2-b8f4-b8d71672b581">


After
----------------------------------------

In the same use-case, the browser makes a successful request for

```
http://dmaster.127.0.0.1.nip.io:8001/sites/all/modules/civicrm/ext/greenwich/extern/bootstrap3/assets/fonts/bootstrap/glyphicons-halflings-regular.woff2
```

The button is OK.

<img width="237" alt="Screen Shot 2023-07-14 at 4 39 10 PM" src="https://github.com/civicrm/civicrm-core/assets/1336047/747c7928-9162-447d-ae8d-40ec14eda54d">

Technical Details
----------------------------------------

To apply the patch, one needs to:

1. Use the included update for `_greenwich.scss`
2. Re-run `composer compile` (or `composer install`)
3. (For D9+) Re-run  `composer civicrm:publish`