### PR TITLE
[REF] [PHP8.2] Post unshare cleanup

### DIFF
--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -48,10 +48,6 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     if (array_key_exists($this->_type, $contactTypes)) {
       $this->assign('contactId', $this->_entityId);
     }
-    if (!is_array($this->_subType) && strstr($this->_subType ?? '', CRM_Core_DAO::VALUE_SEPARATOR)) {
-      CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType on civicrm/custom route is deprecated, use a comma-separated string instead.');
-      $this->_subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($this->_subType, CRM_Core_DAO::VALUE_SEPARATOR));
-    }
     $this->setGroupTree($this, $this->_subType, $this->_groupID, $this->_onlySubtype);
 
     $this->assign('suppressForm', TRUE);
@@ -67,12 +63,10 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
    * @param string $subType
    * @param int $gid
    * @param bool $onlySubType
-   * @param bool $getCachedTree
    *
-   * @return array
    * @throws \CRM_Core_Exception
    */
-  private function setGroupTree(&$form, $subType, $gid, $onlySubType = NULL, $getCachedTree = TRUE) {
+  private function setGroupTree(&$form, $subType, $gid, $onlySubType = NULL) {
     $singleRecord = NULL;
     if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
       $singleRecord = $form->_groupCount;
@@ -90,7 +84,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
       $gid,
       $subType,
       $form->_subName,
-      $getCachedTree,
+      TRUE,
       $onlySubType,
       FALSE,
       CRM_Core_Permission::EDIT,
@@ -108,11 +102,9 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
       foreach ($keys as $key) {
         $form->_groupTree[$key] = $groupTree[$key];
       }
-      return [$form, $groupTree];
     }
     else {
       $form->_groupTree = $groupTree;
-      return [$form, $groupTree];
     }
   }
 


### PR DESCRIPTION
This stops passing & returning unused values from the previously shared function & removes a deprecated chunk.


Before
==== 

`getCachedTree` is always TRUE and the return is never used

After
====

The above are removed - I ALSO removed a deprecated chunk


This deprecation was very precautionary IMHO as it relates to custom separators in the urls  - so 6 months is long enough


![image](https://github.com/civicrm/civicrm-core/assets/336308/92c7dc76-5ad9-470b-a79f-ec47c55fc947)