### PR TITLE
[REF] [PHP8.2]Treat subType as a internal varible, not a form property

### DIFF
--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -27,7 +27,6 @@ class CRM_Contact_Form_Edit_CustomData {
    */
   public static function preProcess(&$form) {
     $form->_type = CRM_Utils_Request::retrieve('type', 'String');
-    $form->_subType = CRM_Utils_Request::retrieve('subType', 'String');
 
     //build the custom data as other blocks.
     //$form->assign( "addBlock", false );
@@ -37,7 +36,7 @@ class CRM_Contact_Form_Edit_CustomData {
       $form->assign("blockName", $form->_addBlockName);
     }
 
-    CRM_Custom_Form_CustomData::preProcess($form, NULL, $form->_subType, NULL,
+    CRM_Custom_Form_CustomData::preProcess($form, NULL, NULL, NULL,
       ($form->_type) ? $form->_type : $form->_contactType
     );
 

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -139,6 +139,7 @@ class CRM_Custom_Form_CustomData {
     $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
     $getCachedTree = $form->_getCachedTree ?? TRUE;
     if (!is_array($subType) && strstr(($subType ?? ''), CRM_Core_DAO::VALUE_SEPARATOR)) {
+      CRM_Core_Error::deprecatedWarning('Using a CRM_Core_DAO::VALUE_SEPARATOR separated subType deprecated, use a comma-separated string instead.');
       $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
     }
 

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -87,15 +87,12 @@ class CRM_Custom_Form_CustomData {
       $form->_type = CRM_Utils_Request::retrieve('type', 'String', $form);
     }
 
-    if (isset($subType)) {
-      $form->_subType = $subType;
-    }
-    else {
-      $form->_subType = CRM_Utils_Request::retrieve('subType', 'String', $form);
+    if (!isset($subType)) {
+      $subType = CRM_Utils_Request::retrieve('subType', 'String', $form);
     }
 
-    if ($form->_subType == 'null') {
-      $form->_subType = NULL;
+    if ($subType === 'null') {
+      $subType = NULL;
     }
 
     if (isset($subName)) {
@@ -141,8 +138,6 @@ class CRM_Custom_Form_CustomData {
 
     $gid = (isset($form->_groupID)) ? $form->_groupID : NULL;
     $getCachedTree = $form->_getCachedTree ?? TRUE;
-
-    $subType = $form->_subType;
     if (!is_array($subType) && strstr(($subType ?? ''), CRM_Core_DAO::VALUE_SEPARATOR)) {
       $subType = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ',', trim($subType, CRM_Core_DAO::VALUE_SEPARATOR));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Treat subType as a internal varible, not a form property

Before
----------------------------------------
->_subType not used from outside the function

![image](https://github.com/civicrm/civicrm-core/assets/336308/57d9c319-e534-43cb-ae66-2c88b80fdddb)


After
----------------------------------------
>_subType is an internal property

The only refences left are in `CustomDataByType` - which can also go but would conflict with https://github.com/civicrm/civicrm-core/pull/26832/files#diff-1a220e071c24dde6c43cc3e60d31805da72604d8774dbb7c26d6111a324c9cb4R51


![image](https://github.com/civicrm/civicrm-core/assets/336308/d55e6ebb-491b-4d8b-a444-33f223812387)


Technical Details
----------------------------------------
I also added the deprecation we had in https://github.com/civicrm/civicrm-core/pull/26832/files#diff-1a220e071c24dde6c43cc3e60d31805da72604d8774dbb7c26d6111a324c9cb4L51 so we can phase out that code

Comments
----------------------------------------
