### PR TITLE
[REF] Use internal variable rather than property to pass variable

### DIFF
--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -24,20 +24,20 @@ class CRM_Contact_Form_Edit_CustomData {
    * Build all the data structures needed to build the form.
    *
    * @param CRM_Core_Form $form
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function preProcess(&$form) {
-    $form->_type = CRM_Utils_Request::retrieve('type', 'String');
+    $customDataType = CRM_Utils_Request::retrieve('type', 'String');
 
-    //build the custom data as other blocks.
-    //$form->assign( "addBlock", false );
-    if ($form->_type) {
+    if ($customDataType) {
       $form->_addBlockName = 'CustomData';
       $form->assign("addBlock", TRUE);
       $form->assign("blockName", $form->_addBlockName);
     }
 
     CRM_Custom_Form_CustomData::preProcess($form, NULL, NULL, NULL,
-      ($form->_type) ? $form->_type : $form->_contactType
+      $customDataType ?: $form->_contactType
     );
 
     //assign group tree after build.


### PR DESCRIPTION
As with https://github.com/civicrm/civicrm-core/pull/26833 the type value is set in the function is it is calling from what is passed in - so there is no need to set it