### PR TITLE
Remove last reference to undefined property `_subType`

### DIFF
--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -33,13 +33,13 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
   public function preProcess() {
 
     $this->_type = $this->_cdType = CRM_Utils_Request::retrieve('type', 'String', CRM_Core_DAO::$_nullObject, TRUE);
-    $this->_subType = CRM_Utils_Request::retrieve('subType', 'String');
+    $subType = CRM_Utils_Request::retrieve('subType', 'String');
     $this->_subName = CRM_Utils_Request::retrieve('subName', 'String');
     $this->_groupCount = CRM_Utils_Request::retrieve('cgcount', 'Positive');
     $this->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive');
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive');
     $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive');
-    $this->_onlySubtype = CRM_Utils_Request::retrieve('onlySubtype', 'Boolean');
+    $onlySubType = CRM_Utils_Request::retrieve('onlySubtype', 'Boolean');
     $this->_action = CRM_Utils_Request::retrieve('action', 'Alphanumeric');
     $this->assign('cdType', FALSE);
     $this->assign('cgCount', $this->_groupCount);
@@ -48,7 +48,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     if (array_key_exists($this->_type, $contactTypes)) {
       $this->assign('contactId', $this->_entityId);
     }
-    $this->setGroupTree($this, $this->_subType, $this->_groupID, $this->_onlySubtype);
+    $this->setGroupTree($this, $subType, $this->_groupID, $onlySubType);
 
     $this->assign('suppressForm', TRUE);
     $this->controller->_generateQFKey = FALSE;

--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -38,7 +38,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     $this->_groupCount = CRM_Utils_Request::retrieve('cgcount', 'Positive');
     $this->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive');
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive');
-    $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive');
+    $this->_groupID = $groupID = CRM_Utils_Request::retrieve('groupID', 'Positive');
     $onlySubType = CRM_Utils_Request::retrieve('onlySubtype', 'Boolean');
     $this->_action = CRM_Utils_Request::retrieve('action', 'Alphanumeric');
     $this->assign('cdType', FALSE);
@@ -48,7 +48,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     if (array_key_exists($this->_type, $contactTypes)) {
       $this->assign('contactId', $this->_entityId);
     }
-    $this->setGroupTree($this, $subType, $this->_groupID, $onlySubType);
+    $this->setGroupTree($this, $subType, $groupID, $onlySubType);
 
     $this->assign('suppressForm', TRUE);
     $this->controller->_generateQFKey = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Remove last reference to undefined property `_subType`

Before
----------------------------------------
Property declared but only used in function

Same with onlySubType, I'm a bit less sure with groupID so using an internal var but have not removed it

![image](https://github.com/civicrm/civicrm-core/assets/336308/74399860-c50e-456b-910a-4598f5e56c9e)


After
----------------------------------------
variable used - no more references

![image](https://github.com/civicrm/civicrm-core/assets/336308/679a78b9-6a44-4b42-9951-693bd0860bba)

Technical Details
----------------------------------------

Comments
----------------------------------------