### PR TITLE
Fold `preProcess` into `run`

### DIFF
--- a/CRM/Contact/Page/View/CustomData.php
+++ b/CRM/Contact/Page/View/CustomData.php
@@ -28,9 +28,12 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
   public $_groupId;
 
   /**
-   * Add a few specific things to view contact.
+   * Run the page.
+   *
+   * This method is called after the page is created. It checks for the
+   * type of action and executes that action.
    */
-  public function preProcess() {
+  public function run() {
     $this->_groupId = CRM_Utils_Request::retrieve('gid', 'Positive', $this, TRUE);
     $this->assign('groupId', $this->_groupId);
 
@@ -58,16 +61,6 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
 
     $this->_multiRecordDisplay = CRM_Utils_Request::retrieve('multiRecordDisplay', 'String', $this, FALSE);
     $this->_cgcount = CRM_Utils_Request::retrieve('cgcount', 'Positive', $this, FALSE);
-  }
-
-  /**
-   * Run the page.
-   *
-   * This method is called after the page is created. It checks for the
-   * type of action and executes that action.
-   */
-  public function run() {
-    $this->preProcess();
 
     //set the userContext stack
     $doneURL = 'civicrm/contact/view';


### PR DESCRIPTION

Overview
----------------------------------------
Fold `preProcess` into `run`

there are properties that appear to be being set solely to pass variables from preProcess to run - but they could just be one function.

preProcess is called from run and that is the only way it is accessed.


Before
----------------------------------------


![image](https://github.com/civicrm/civicrm-core/assets/336308/a87e012c-461a-475b-a4d1-fca234abe177)

After
----------------------------------------
They are one function (no other changes)

Technical Details
----------------------------------------
There are some forms that use the pageRun hook in the universe but this has no impact on them as the hook is called at the same time


![image](https://github.com/civicrm/civicrm-core/assets/336308/2061adfc-f72a-4b4c-ad95-bff1d2f4e84b)


Comments
----------------------------------------

