### PR TITLE
[REF][PHP8.2] Ref fix deprecation in PHP8.2 about dynamic property _ssID

### DIFF
--- a/CRM/Activity/Form/Search.php
+++ b/CRM/Activity/Form/Search.php
@@ -53,13 +53,6 @@ class CRM_Activity_Form_Search extends CRM_Core_Form_Search {
   protected $_prefix = 'activity_';
 
   /**
-   * The saved search ID retrieved from the GET vars.
-   *
-   * @var int
-   */
-  protected $_ssID;
-
-  /**
    * @return string
    */
   public function getDefaultEntity(): string {

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -90,6 +90,13 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
   protected $_reset;
 
   /**
+   * Saved Search ID retrieved from the GET vars.
+   *
+   * @var int
+   */
+  protected $_ssID;
+
+  /**
    * @return array
    */
   public function getSearchFieldMetadata() {

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -48,13 +48,6 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
   protected $_prefix = "event_";
 
   /**
-   * The saved search ID retrieved from the GET vars.
-   *
-   * @var int
-   */
-  protected $_ssID;
-
-  /**
    * Metadata of all fields to include on the form.
    *
    * @var array


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the following PHP8.2 deprecation caused by dynamic property _ssID

```
CRM_Case_Form_SearchTest::testOpeningFindCaseForm
Creation of dynamic property CRM_Case_Form_Search::$_ssID is deprecated

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/CRM/Core/Form/Search.php:499
```

Before
----------------------------------------
Test fails on PHP8.2

After
----------------------------------------
Test still fails but on a different property

I did a grep in universe 
and the only references outside of core to this were here

```
ext/uk.co.vedaconsulting.civisubscription/CRM/Subscription/Form/Search.php:      if (isset($this->_ssID)) {
ext/uk.co.vedaconsulting.civisubscription/CRM/Subscription/Form/Search.php:        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
ext/uk.co.vedaconsulting.civisubscription/CRM/Subscription/Form/Search.php:    if (isset($this->_ssID) && empty($_POST)) {
ext/uk.co.vedaconsulting.civisubscription/CRM/Subscription/Form/Search.php:      $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
ext/dataprocessor/CRM/Contact/Form/DataProcessorContactSearch.php:      $taskParams['ssID'] = $this->_ssID ?? NULL;
ext/uk.co.compucorp.civicrm.booking/CRM/Booking/Form/Search.php:    $this->_ssID    = CRM_Utils_Request::retrieve('ssID', 'Positive', $this);
ext/grant_program/CRM/Grant/Form/PaymentSearch.php:      if (isset($this->_ssID)) {
ext/grant_program/CRM/Grant/Form/PaymentSearch.php:        $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
ext/grant_program/CRM/Grant/Form/PaymentSearch.php:    if (isset($this->_ssID) && empty($_POST)) {
ext/grant_program/CRM/Grant/Form/PaymentSearch.php:      $this->_formValues = CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID);
ext/advanced-events/CRM/AdvancedEvents/Form/Search.php:  protected $_ssID;
```
all except for the dataprocessor extend CRM_Core_Form_Search and this declaration is the same visibility level as in the AdvancedEvents one

ping @demeritcowboy @eileenmcnaughton 