### PR TITLE
Search kit action links cleanup

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -453,7 +453,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
   private function formatLink(array $link, array $data, string $text = NULL, $index = 0): ?array {
     $link = $this->getLinkInfo($link, $data, $index);
-    if (empty($link['path']) && empty($link['task'])) {
+    if (!$this->checkLinkAccess($link, $data, $index)) {
       return NULL;
     }
     $link['text'] = $text ?? $this->replaceTokens($link['text'], $data, 'view');
@@ -466,6 +466,37 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     }
     $link = array_intersect_key($link, array_flip($keys));
     return array_filter($link);
+  }
+
+  private function checkLinkAccess(array $link, array $data, int $index = 0): bool {
+    if (empty($link['path']) && empty($link['task'])) {
+      return FALSE;
+    }
+    // Check access for edit/update/delete links
+    // (presumably if a record is shown in SearchKit the user already has view access, and the check is expensive)
+    if ($link['entity'] && $link['action'] && !in_array($link['action'], ['view', 'preview'], TRUE)) {
+      $idField = CoreUtil::getIdFieldName($link['entity']);
+      $idKey = $this->getIdKeyName($link['entity']);
+      $id = $data[$link['prefix'] . $idKey] ?? NULL;
+      $id = is_array($id) ? $id[$index] ?? NULL : $id;
+      if ($id) {
+        $values = [$idField => $id];
+        // If not aggregated, add other values to help checkAccess be efficient
+        if (!is_array($data[$link['prefix'] . $idKey])) {
+          $values += \CRM_Utils_Array::filterByPrefix($data, $link['prefix']);
+        }
+        $isApiAction = civicrm_api4($link['entity'], 'getActions', [
+          'checkPermissions' => FALSE,
+          'where' => [['name', '=', $link['action']]],
+        ])->count();
+        return civicrm_api4($link['entity'], 'checkAccess', [
+          // Fudge links with funny action names to check 'update'
+          'action' => $isApiAction ? $link['action'] : 'update',
+          'values' => $values,
+        ], 0)['access'];
+      }
+    }
+    return TRUE;
   }
 
   /**
@@ -494,87 +525,74 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
   /**
    * @param array{path: string, entity: string, action: string, task: string, join: string, target: string, style: string, icon: string, title: string, text: string} $link
-   * @param array $data
-   * @param int $index
-   * @return array{path: string, entity: string, action: string, task: string, join: string, target: string, style: string, icon: string, title: string, text: string, tokens: array}
+   * @return array{path: string, entity: string, action: string, task: string, join: string, target: string, style: string, icon: string, title: string, text: string, prefix: string}
    */
-  private function getLinkInfo($link, $data = NULL, $index = 0): ?array {
+  private function getLinkInfo(array $link): array {
     $link += [
       'path' => '',
       'target' => '',
       'entity' => '',
       'text' => '',
       'title' => '',
-      'tokens' => [],
+      'prefix' => '',
     ];
     $entity = $link['entity'];
+    $idKey = $this->getIdKeyName($link['entity']);
     if ($entity) {
-      $idField = $idKey = CoreUtil::getIdFieldName($entity);
       // Hack to support links to relationships
       if ($entity === 'Relationship') {
         $entity = 'RelationshipCache';
-        $idKey = 'relationship_id';
       }
-    }
-    if (!$link['path'] && $entity && !empty($link['action'])) {
-      $link['path'] = CoreUtil::getInfoItem($entity, 'paths')[$link['action']] ?? NULL;
-      $prefix = '';
-      if ($link['path'] && !empty($link['join'])) {
-        $prefix = $link['join'] . '.';
+      if (!empty($link['join'])) {
+        $link['prefix'] = $link['join'] . '.';
       }
-      // This is a bit clunky, the function_join_field gets un-munged later by $this->getJoinFromAlias()
-      if ($this->canAggregate($prefix . $idKey)) {
-        $prefix = 'GROUP_CONCAT_' . str_replace('.', '_', $prefix);
+      // Get path from action
+      if (!$link['path'] && !empty($link['action'])) {
+        $link['path'] = CoreUtil::getInfoItem($entity, 'paths')[$link['action']] ?? NULL;
+        // This is a bit clunky, the function_join_field gets un-munged later by $this->getJoinFromAlias()
+        if ($this->canAggregate($link['prefix'] . $idKey)) {
+          $link['prefix'] = 'GROUP_CONCAT_' . str_replace('.', '_', $link['prefix']);
+        }
+        if ($link['prefix']) {
+          $link['path'] = str_replace('[', '[' . $link['prefix'], $link['path']);
+        }
       }
-      if ($prefix) {
-        $link['path'] = str_replace('[', '[' . $prefix, $link['path']);
-      }
-      // Check access for edit/update/delete links
-      // (presumably if a record is shown in SearchKit the user already has view access, and the check is expensive)
-      if ($link['path'] && isset($data) && !in_array($link['action'], ['view', 'preview'], TRUE)) {
-        $id = $data[$prefix . $idKey] ?? NULL;
-        $id = is_array($id) ? $id[$index] ?? NULL : $id;
-        if ($id) {
-          $values = [$idField => $id];
-          // If not aggregated, add other values to help checkAccess be efficient
-          if (!is_array($data[$prefix . $idKey])) {
-            $values += \CRM_Utils_Array::filterByPrefix($data, $prefix);
+      elseif (!$link['path'] && !empty($link['task'])) {
+        $task = $this->getTask($link['task']);
+        // Convert legacy tasks (which have a url)
+        if (!empty($task['crmPopup'])) {
+          $idField = CoreUtil::getIdFieldName($link['entity']);
+          $link['path'] = \CRM_Utils_JS::decode($task['crmPopup']['path']);
+          $data = \CRM_Utils_JS::getRawProps($task['crmPopup']['data']);
+          // Find the special key that combines selected ids and replace it with id token
+          $idsKey = array_search("ids.join(',')", $data);
+          unset($data[$idsKey]);
+          $amp = strpos($link['path'], '?') ? '&' : '?';
+          $link['path'] .= $amp . $idField . '=[' . $link['prefix'] . $idKey . ']';
+          // Add the rest of the data items
+          foreach ($data as $dataKey => $dataRaw) {
+            $link['path'] .= '&' . $dataKey . '=' . \CRM_Utils_JS::decode($dataRaw);
           }
-          $access = civicrm_api4($link['entity'], 'checkAccess', [
-            // Fudge links with funny action names to check 'update'
-            'action' => $link['action'] === 'delete' ? 'delete' : 'update',
-            'values' => $values,
-          ], 0)['access'];
-          if (!$access) {
-            return NULL;
-          }
+        }
+        elseif (!empty($task['apiBatch']) || !empty($task['uiDialog'])) {
+          $link['title'] = $link['title'] ?: $task['title'];
+          // Fill in the api action if known, for the sake of $this->checkLinkAccess
+          $link['action'] = $task['apiBatch']['action'] ?? NULL;
+          $link['task'] = array_intersect_key($task, ['apiBatch' => 1, 'uiDialog' => 1]);
         }
       }
     }
-    elseif (!$link['path'] && $entity && !empty($link['task'])) {
-      $task = $this->getTask($link['task']);
-      // Convert legacy tasks (which have to a url)
-      if (!empty($task['crmPopup'])) {
-        $link['path'] = \CRM_Utils_JS::decode($task['crmPopup']['path']);
-        $amp = strpos($link['path'], '?') ? '&' : '?';
-        $data = \CRM_Utils_JS::getRawProps($task['crmPopup']['data']);
-        // Find the special key that combines selected ids and replace it with id token
-        $idsKey = array_search("ids.join(',')", $data);
-        unset($data[$idsKey]);
-        $link['path'] .= $amp . $idsKey . '=[' . $idField . ']';
-        // Add the rest of the data items
-        foreach ($data as $dataKey => $dataRaw) {
-          $link['path'] .= '&' . $dataKey . '=' . \CRM_Utils_JS::decode($dataRaw);
-        }
-      }
-      elseif (!empty($task['apiBatch']) || !empty($task['uiDialog'])) {
-        $link['tokens'][] = $idKey;
-        $link['title'] = $link['title'] ?: $task['title'];
-        $link['task'] = array_intersect_key($task, ['apiBatch' => 1, 'uiDialog' => 1]);
-      }
-    }
-    $link['tokens'] = array_merge($link['tokens'], $this->getTokens($link['path'] . $link['text'] . $link['title']));
+    $link['key'] = $link['prefix'] . $idKey;
     return $link;
+  }
+
+  private function getLinkTokens(array $link): array {
+    $link = $this->getLinkInfo($link);
+    $tokens = [];
+    if (!$link['path'] && !empty($link['task'])) {
+      $tokens[] = $link['prefix'] . $this->getIdKeyName($link['entity']);
+    }
+    return array_merge($tokens, $this->getTokens($link['path'] . $link['text'] . $link['title']));
   }
 
   /**
@@ -984,12 +1002,12 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $possibleTokens .= ($column['empty_value'] ?? '');
 
       if (!empty($column['link'])) {
-        foreach ($this->getLinkInfo($column['link'])['tokens'] as $token) {
+        foreach ($this->getLinkTokens($column['link']) as $token) {
           $this->addSelectExpression($token);
         }
       }
       foreach ($column['links'] ?? [] as $link) {
-        foreach ($this->getLinkInfo($link)['tokens'] as $token) {
+        foreach ($this->getLinkTokens($link) as $token) {
           $this->addSelectExpression($token);
         }
       }
@@ -1335,6 +1353,19 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       }
     }
     return $values;
+  }
+
+  /**
+   * Given an entity name, returns the data fieldName used to identify it.
+   * @param string|null $entityName
+   * @return string
+   */
+  protected function getIdKeyName(?string $entityName) {
+    // Hack to support links to relationships
+    if ($entityName === 'Relationship') {
+      return 'relationship_id';
+    }
+    return CoreUtil::getIdFieldName($entityName);
   }
 
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -474,7 +474,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     }
     // Check access for edit/update/delete links
     // (presumably if a record is shown in SearchKit the user already has view access, and the check is expensive)
-    if ($link['entity'] && $link['action'] && !in_array($link['action'], ['view', 'preview'], TRUE)) {
+    if ($link['entity'] && !empty($link['action']) && !in_array($link['action'], ['view', 'preview'], TRUE)) {
       $idField = CoreUtil::getIdFieldName($link['entity']);
       $idKey = $this->getIdKeyName($link['entity']);
       $id = $data[$link['prefix'] . $idKey] ?? NULL;
@@ -578,7 +578,6 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           $link['title'] = $link['title'] ?: $task['title'];
           // Fill in the api action if known, for the sake of $this->checkLinkAccess
           $link['action'] = $task['apiBatch']['action'] ?? NULL;
-          $link['task'] = array_intersect_key($task, ['apiBatch' => 1, 'uiDialog' => 1]);
         }
       }
     }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -468,12 +468,22 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     return array_filter($link);
   }
 
+  /**
+   * Check access for edit/update/delete links
+   *
+   * (presumably if a record is shown in SearchKit the user already has view access, and the check is expensive)
+   *
+   * @param array $link
+   * @param array $data
+   * @param int $index
+   * @return bool
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
+   */
   private function checkLinkAccess(array $link, array $data, int $index = 0): bool {
     if (empty($link['path']) && empty($link['task'])) {
       return FALSE;
     }
-    // Check access for edit/update/delete links
-    // (presumably if a record is shown in SearchKit the user already has view access, and the check is expensive)
     if ($link['entity'] && !empty($link['action']) && !in_array($link['action'], ['view', 'preview'], TRUE)) {
       $idField = CoreUtil::getIdFieldName($link['entity']);
       $idKey = $this->getIdKeyName($link['entity']);
@@ -585,11 +595,20 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     return $link;
   }
 
+  /**
+   * Get fields needed by a link which should be added to the SELECT clause
+   *
+   * @param array $link
+   * @return array
+   */
   private function getLinkTokens(array $link): array {
     $link = $this->getLinkInfo($link);
     $tokens = [];
     if (!$link['path'] && !empty($link['task'])) {
       $tokens[] = $link['prefix'] . $this->getIdKeyName($link['entity']);
+    }
+    if (!empty($link['condition'][0])) {
+      $tokens[] = $link['condition'][0];
     }
     return array_merge($tokens, $this->getTokens($link['path'] . $link['text'] . $link['title']));
   }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -33,6 +33,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
 
     // Adding checkPermissions filters out actions the user is not allowed to perform
     $entityName = $this->savedSearch['api_entity'];
+    // Hack to support relationships
     $entityName = ($entityName === 'RelationshipCache') ? 'Relationship' : $entityName;
     $entity = Entity::get($this->checkPermissions)->addWhere('name', '=', $entityName)
       ->addSelect('name', 'title_plural')
@@ -243,6 +244,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
 
     foreach ($tasks[$entity['name']] as $name => &$task) {
       $task['name'] = $name;
+      $task['entity'] = $entity['name'];
       // Add default for number of rows action requires
       $task += ['number' => '> 0'];
     }
@@ -270,6 +272,9 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       ],
       [
         'name' => 'number',
+      ],
+      [
+        'name' => 'entity',
       ],
       [
         'name' => 'apiBatch',

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -257,7 +257,7 @@
                   text: task.title,
                   icon: task.icon,
                   task: task.name,
-                  entity: ctrl.savedSearch.api_entity,
+                  entity: task.entity,
                   target: 'crm-popup',
                   join: '',
                   style: task.name === 'delete' ? 'danger' : 'default'

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -41,6 +41,9 @@
       this.isDisplayReady = function() {
         return !displayCtrl.loading && displayCtrl.results && displayCtrl.results.length;
       };
+      this.getTaskInfo = function(taskName) {
+        return _.findWhere(mngr.tasks, {name: taskName});
+      };
 
       this.doTask = function(task, ids) {
         var data = {
@@ -192,7 +195,7 @@
           const mngr = this.taskManager;
           event.preventDefault();
           mngr.getMetadata().then(function() {
-            mngr.doTask(_.extend({title: link.title}, link.task), [id]);
+            mngr.doTask(_.extend({title: link.title}, mngr.getTaskInfo(link.task)), [id]);
           });
         }
       },
@@ -220,6 +223,15 @@
           if (index > -1 && !_.findWhere(apiResults.run, {key: editedRow.key})) {
             this.selectedRows.splice(index, 1);
           }
+        }
+        else if (status === 'success' && !editedRow && apiResults.run && apiResults.run[0]) {
+          const mngr = this.taskManager;
+          // If results contain a link to a task, prefetch task info to prevent latency when clicking the link
+          _.each(apiResults.run[0].columns, function(column) {
+            if ((column.link && column.link.task) || _.find(column.links || [], 'task')) {
+              mngr.getMetadata();
+            }
+          });
         }
       }]
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -305,6 +305,85 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('crm-popup', $result[0]['columns'][1]['links'][2]['target']);
   }
 
+  public function testRelationshipCacheLinks():void {
+    $relationships = $this->saveTestRecords('Relationship', [
+      'records' => [
+        ['contact_id_a' => $this->createTestRecord('Contact')['id'], 'is_active' => TRUE],
+        ['contact_id_a' => $this->createTestRecord('Contact')['id'], 'is_active' => FALSE],
+      ],
+    ]);
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'RelationshipCache',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['near_contact_id.display_name'],
+          'where' => [['relationship_id', 'IN', $relationships->column('id')]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'actions' => TRUE,
+          'pager' => [],
+          'columns' => [
+            [
+              'key' => 'near_contact_id.display_name',
+              'label' => 'Contact',
+              'dataType' => 'String',
+              'type' => 'field',
+            ],
+            [
+              'type' => 'links',
+              'links' => [
+                [
+                  'entity' => 'Relationship',
+                  'action' => 'view',
+                  'icon' => 'fa-external-link',
+                ],
+                [
+                  'entity' => 'Relationship',
+                  'task' => 'delete',
+                  'icon' => 'fa-trash',
+                ],
+                [
+                  'entity' => 'Relationship',
+                  'task' => 'enable',
+                  'condition' => ['is_active', '=', FALSE],
+                ],
+                [
+                  'entity' => 'Relationship',
+                  'task' => 'disable',
+                  'condition' => ['is_active', '=', TRUE],
+                ],
+              ],
+            ],
+          ],
+          'sort' => [
+            ['relationship_id', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(4, $result);
+    $this->assertCount(3, $result[0]['columns'][1]['links']);
+    // 1st link is to a quickform-based action
+    $this->assertArrayNotHasKey('task', $result[0]['columns'][1]['links'][0]);
+    $this->assertStringContainsString('id=' . $relationships[0]['id'], $result[0]['columns'][1]['links'][0]['url']);
+    // 2nd link is to the native SK bulk-delete task
+    $this->assertArrayNotHasKey('url', $result[0]['columns'][1]['links'][1]);
+    $this->assertEquals('delete', $result[0]['columns'][1]['links'][1]['task']);
+    // 3rd link is the disable task for active relationships or the enable task for inactive ones
+    $this->assertEquals('disable', $result[0]['columns'][1]['links'][2]['task']);
+    $this->assertEquals('disable', $result[1]['columns'][1]['links'][2]['task']);
+    $this->assertEquals('enable', $result[2]['columns'][1]['links'][2]['task']);
+    $this->assertEquals('enable', $result[3]['columns'][1]['links'][2]['task']);
+  }
+
   /**
    * Test smarty rewrite syntax.
    */

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -299,7 +299,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertStringContainsString('id=' . $contributions[0]['id'] . '&qfKey=', $result[0]['columns'][1]['links'][0]['url']);
     // 2nd link is to the native SK bulk-update task
     $this->assertArrayNotHasKey('url', $result[0]['columns'][1]['links'][1]);
-    $this->assertArrayHasKey('uiDialog', $result[0]['columns'][1]['links'][1]['task']);
+    $this->assertEquals('update', $result[0]['columns'][1]['links'][1]['task']);
     // 3rd link is a popup link to the delete contribution quickform
     $this->assertStringContainsString('action=delete&id=' . $contributions[0]['id'], $result[0]['columns'][1]['links'][2]['url']);
     $this->assertEquals('crm-popup', $result[0]['columns'][1]['links'][2]['target']);


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #26794 with some improvements to the code to make it more efficient and responsive. Also improves the UX by hiding links the user can't actually click on.

Technical Details
----------------------------------------
- Breaks a large function apart that was doing too many things.
- Reduces ajax bloat by only sending the name of the action per row rather than the entire action definition.
- Improves responsiveness by pre-fetching action metadata when action links are present in the results.
- Improves UX by hiding action links the user does not have permission to run (previously was only checking coarse-grained permissions, now it's checking fine-grained ACLs per row).
- Fixes links for RelationshipCache-based searches.