### PR TITLE
Api4 Autocomplete - Search by exact id match more effieciently

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -156,13 +156,13 @@ class AutocompleteAction extends AbstractAction {
       // Always search on the first line of the display
       $searchFields = [$labelField];
       // If input is an integer, search by id
-      if (\CRM_Utils_Rule::positiveInteger($this->input)) {
-        $searchFields[] = $idField;
-        // Add a sort clause to place exact ID match at the top
-        array_unshift($this->display['settings']['sort'], [
-          "($idField = $this->input)",
-          'DESC',
-        ]);
+      $numericInput = $this->page == 1 && \CRM_Utils_Rule::positiveInteger($this->input);
+      if ($numericInput) {
+        $searchFields = [$idField];
+      }
+      // For subsequent pages when searching numeric input
+      elseif ($this->page > 1 && \CRM_Utils_Rule::positiveInteger($this->input)) {
+        $this->page -= 1;
       }
       // If first line uses a rewrite, search on those fields too
       if (!empty($this->display['settings']['columns'][0]['rewrite'])) {
@@ -198,6 +198,10 @@ class AutocompleteAction extends AbstractAction {
       $result[] = $item;
     }
     $result->setCountMatched($apiResult->count());
+    if (!empty($numericInput)) {
+      // Trigger "more results" after searching by exact id
+      $result->setCountMatched($apiResult->count() + 1);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4423](https://lab.civicrm.org/dev/core/-/issues/4423)

Before
----------------------------------------
Less efficient query when searching by exact id. When typing a number in the autocomplete, it used an OR clause to search by name OR id.

After
----------------------------------------
Should be much faster. When typing a number in the autocomplete, it does an exact match search on the first request, then subsequent requests search by name.


@eileenmcnaughton 