### PR TITLE
Fold private `setGroupTree` function back into caller

### DIFF
--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -48,25 +48,6 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     if (array_key_exists($this->_type, $contactTypes)) {
       $this->assign('contactId', $this->_entityId);
     }
-    $this->setGroupTree($this, $subType, $groupID, $onlySubType);
-
-    $this->assign('suppressForm', TRUE);
-    $this->controller->_generateQFKey = FALSE;
-  }
-
-  /**
-   * Add the group data as a formatted array to the form.
-   *
-   * This was split off from a shared function.
-   *
-   * @param self $form
-   * @param string $subType
-   * @param int $gid
-   * @param bool $onlySubType
-   *
-   * @throws \CRM_Core_Exception
-   */
-  private function setGroupTree(&$form, $subType, $gid, $onlySubType = NULL) {
     $singleRecord = NULL;
     if (!empty($form->_groupCount) && !empty($form->_multiRecordDisplay) && $form->_multiRecordDisplay == 'single') {
       $singleRecord = $form->_groupCount;
@@ -81,7 +62,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     $groupTree = CRM_Core_BAO_CustomGroup::getTree($form->_type,
       NULL,
       $form->_entityId,
-      $gid,
+      $groupID,
       $subType,
       $form->_subName,
       TRUE,
@@ -106,6 +87,9 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
     else {
       $form->_groupTree = $groupTree;
     }
+
+    $this->assign('suppressForm', TRUE);
+    $this->controller->_generateQFKey = FALSE;
   }
 
   /**

--- a/CRM/Custom/Form/CustomDataByType.php
+++ b/CRM/Custom/Form/CustomDataByType.php
@@ -34,7 +34,6 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
 
     $this->_type = $this->_cdType = CRM_Utils_Request::retrieve('type', 'String', CRM_Core_DAO::$_nullObject, TRUE);
     $subType = CRM_Utils_Request::retrieve('subType', 'String');
-    $this->_subName = CRM_Utils_Request::retrieve('subName', 'String');
     $this->_groupCount = CRM_Utils_Request::retrieve('cgcount', 'Positive');
     $this->_entityId = CRM_Utils_Request::retrieve('entityID', 'Positive');
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive');
@@ -64,7 +63,7 @@ class CRM_Custom_Form_CustomDataByType extends CRM_Core_Form {
       $form->_entityId,
       $groupID,
       $subType,
-      $form->_subName,
+      CRM_Utils_Request::retrieve('subName', 'String'),
       TRUE,
       $onlySubType,
       FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Fold private `setGroupTree` function back into caller

Before
----------------------------------------
Previously shared `setGroupTree` only called from one place & that place 

After
----------------------------------------
function folded into the called

Technical Details
----------------------------------------
The caller passed values as properties, unnecessarily - this addresses

Comments
----------------------------------------
