### PR TITLE
Remove `_subName` property

### DIFF
--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -67,7 +67,9 @@ class CRM_Custom_Form_CustomData {
 
   /**
    * @param CRM_Core_Form $form
-   * @param null|string $subName
+   * @param null|string $extendsEntityColumn
+   *   Additional filter on the type of custom data to retrieve - e.g for
+   *   participant data this could be a value representing role.
    * @param null|string $subType
    * @param null|int $groupCount
    * @param string $type
@@ -77,7 +79,7 @@ class CRM_Custom_Form_CustomData {
    * @throws \CRM_Core_Exception
    */
   public static function preProcess(
-    &$form, $subName = NULL, $subType = NULL,
+    &$form, $extendsEntityColumn = NULL, $subType = NULL,
     $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL
   ) {
     if ($type) {
@@ -90,20 +92,14 @@ class CRM_Custom_Form_CustomData {
     if (!isset($subType)) {
       $subType = CRM_Utils_Request::retrieve('subType', 'String', $form);
     }
-
     if ($subType === 'null') {
+      // Is this reachable?
       $subType = NULL;
     }
-
-    if (isset($subName)) {
-      $form->_subName = $subName;
-    }
-    else {
-      $form->_subName = CRM_Utils_Request::retrieve('subName', 'String', $form);
-    }
-
-    if ($form->_subName == 'null') {
-      $form->_subName = NULL;
+    $extendsEntityColumn = $extendsEntityColumn ?: CRM_Utils_Request::retrieve('subName', 'String', $form);
+    if ($extendsEntityColumn === 'null') {
+      // Is this reachable?
+      $extendsEntityColumn = NULL;
     }
 
     if ($groupCount) {
@@ -159,7 +155,7 @@ class CRM_Custom_Form_CustomData {
       $form->_entityId,
       $gid,
       $subType,
-      $form->_subName,
+      $extendsEntityColumn,
       $getCachedTree,
       $onlySubType,
       FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Remove `_subName` property

Before
----------------------------------------
subName only accessed from this function & the places being removed in https://github.com/civicrm/civicrm-core/pull/26844/files#diff-1a220e071c24dde6c43cc3e60d31805da72604d8774dbb7c26d6111a324c9cb4L37

![image](https://github.com/civicrm/civicrm-core/assets/336308/6c3f0ca7-028b-46e9-8e6d-9c5bfba9b00f)

After
----------------------------------------
Internal variables ued

Technical Details
----------------------------------------

Comments
----------------------------------------
