### PR TITLE
[NFC] New Event: remove empty table row

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -123,10 +123,6 @@
         </td>
       </tr>
     {/if}
-    <tr>
-      <td>&nbsp;</td>
-      <td>&nbsp;</td>
-    </tr>
   </table>
   {include file="CRM/common/customDataBlock.tpl"}
   <div class="crm-submit-buttons">


### PR DESCRIPTION
Overview
----------------------------------------

On the New Event form, there is a mysterious empty table row. It looks like a bug when we hover, and there is row highlighting.

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/55c94164-c8e5-4e03-bb0b-0e93d53d7a15)

After
----------------------------------------

No empty row:

![image](https://github.com/civicrm/civicrm-core/assets/254741/cd8b5ad8-2bdd-4346-8960-85f176368789)

Comments
----------------------------------------

According to `git blame`, this has been there since forever.

https://github.com/civicrm/civicrm-svn/blame/master/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl#L143

I did some spot checks to find more, but it's not easy to grep.