### PR TITLE
(REF) CMSUser::create - Rename misleading parameter

### DIFF
--- a/CRM/Core/BAO/CMSUser.php
+++ b/CRM/Core/BAO/CMSUser.php
@@ -28,16 +28,17 @@ class CRM_Core_BAO_CMSUser {
    * Create CMS user using Profile.
    *
    * @param array $params
-   * @param string $mail
-   *   Email id for cms user.
+   * @param string $mailParam
+   *   Name of the param which contains the email address.
+   *   Because. Right. OK. That's what it is.
    *
    * @return int
    *   contact id that has been created
    */
-  public static function create(&$params, $mail) {
+  public static function create(&$params, $mailParam) {
     $config = CRM_Core_Config::singleton();
 
-    $ufID = $config->userSystem->createUser($params, $mail);
+    $ufID = $config->userSystem->createUser($params, $mailParam);
 
     //if contact doesn't already exist create UF Match
     if ($ufID !== FALSE &&
@@ -46,7 +47,7 @@ class CRM_Core_BAO_CMSUser {
       // create the UF Match record
       $ufmatch['uf_id'] = $ufID;
       $ufmatch['contact_id'] = $params['contactID'];
-      $ufmatch['uf_name'] = $params[$mail];
+      $ufmatch['uf_name'] = $params[$mailParam];
       CRM_Core_BAO_UFMatch::create($ufmatch);
     }
 

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -23,12 +23,12 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     $form_state = form_state_defaults();
 
     $form_state['input'] = [
       'name' => $params['cms_name'],
-      'mail' => $params[$mail],
+      'mail' => $params[$mailParam],
       'op' => 'Create new account',
     ];
 

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -363,13 +363,14 @@ abstract class CRM_Utils_System_Base {
    * Create a user in the CMS.
    *
    * @param array $params
-   * @param string $mail
-   *   Email id for cms user.
+   * @param string $mailParam
+   *   Name of the $param which contains the email address.
+   *   Because. Right. OK. That's what it is.
    *
    * @return int|bool
    *   uid if user exists, false otherwise
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     return FALSE;
   }
 

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -23,12 +23,12 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     $form_state = form_state_defaults();
 
     $form_state['input'] = [
       'name' => $params['cms_name'],
-      'mail' => $params[$mail],
+      'mail' => $params[$mailParam],
       'op' => 'Create new account',
     ];
 

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -23,7 +23,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   /**
    * @inheritDoc
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     $user = \Drupal::currentUser();
     $user_register_conf = \Drupal::config('user.settings')->get('register');
     $verify_mail_conf = \Drupal::config('user.settings')->get('verify_mail');
@@ -35,7 +35,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     /** @var \Drupal\user\Entity\User $account */
     $account = \Drupal::entityTypeManager()->getStorage('user')->create();
-    $account->setUsername($params['cms_name'])->setEmail($params[$mail]);
+    $account->setUsername($params['cms_name'])->setEmail($params[$mailParam]);
 
     // Allow user to set password only if they are an admin or if
     // the site settings don't require email verification.

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -36,7 +36,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     $baseDir = JPATH_SITE;
     $userParams = JComponentHelper::getParams('com_users');
 
@@ -72,7 +72,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $values['name'] = $fullname;
     $values['username'] = trim($params['cms_name']);
     $values['password1'] = $values['password2'] = $params['cms_pass'];
-    $values['email1'] = $values['email2'] = trim($params[$mail]);
+    $values['email1'] = $values['email2'] = trim($params[$mailParam]);
 
     $lang = JFactory::getLanguage();
     $lang->load('com_users', $baseDir);

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -60,17 +60,18 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    *    - 'cms_name'
    *    - 'cms_pass' plaintext password
    *    - 'notify' boolean
-   * @param string $mail
-   *   Email id for cms user.
+   * @param string $mailParam
+   *   Name of the param which contains the email address.
+   *   Because. Right. OK. That's what it is.
    *
    * @return int|bool
    *   uid if user was created, false otherwise
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     if ($this->missingStandaloneExtension()) {
       return FALSE;
     }
-    return Security::singleton()->createUser($params, $mail);
+    return Security::singleton()->createUser($params, $mailParam);
   }
 
   /**

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -874,11 +874,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     $user_data = [
       'ID' => '',
       'user_login' => $params['cms_name'],
-      'user_email' => $params[$mail],
+      'user_email' => $params[$mailParam],
       'nickname' => $params['cms_name'],
       'role' => get_option('default_role'),
     ];


### PR DESCRIPTION
Overview
----------------------------------------

The parameter name `$mail` is misleading and led to a bug in `Standalone`. (This PR only fixes the name -- the bug will be part of another PR.)

Before
---------

The second parameter is very confusing:

* The name `$mail` suggests that the parameter is an email address.
* The content of `$mail` is actually *the name of the field* which has the email address.

This is a weird contract, and it's replicated `CRM_Utils_System_*::createUser()` - so it's confusing everywhere.

After
-------

The parameter is substantively the same. But the name is clearer.

Comments
-----------------

To confirm that `$mail` has actually represent the parameter-name (*rather than the raw email address*), note that:

1. `create()` actually looks for `$params[$mail]`
2. Downstream consumers like `CRM_Utils_System_Joomla::createUser()` also look at `$params[$mail]`.
3. Upstream callers like `CRM/Contact/Form/Task/Useradd.php` actually give a parameter name
