### PR TITLE
Standalone - Web-based installation for PHP built-in server 

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1222,7 +1222,7 @@ class CRM_Core_SelectValues {
     \CRM_Utils_Hook::permissionList($perms);
 
     foreach ($perms as $machineName => $details) {
-      if ($details['is_active']) {
+      if (!empty($details['is_active'])) {
         $options[$machineName] = $details['title'];
       }
     }

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -152,16 +152,17 @@ class Security {
    *    - 'cms_name'
    *    - 'cms_pass' plaintext password
    *    - 'notify' boolean
-   * @param string $mail
-   *   Email address for cms user.
+   * @param string $mailParam
+   *   Name of the $param which contains the email address.
    *
    * @return int|bool
    *   uid if user was created, false otherwise
    */
-  public function createUser(&$params, $mail) {
+  public function createUser(&$params, $mailParam) {
     try {
       // Q. should this be in the api for User.create?
       $hashedPassword = $this->_password_crypt(static::$hashMethod, $params['cms_pass'], $this->_password_generate_salt());
+      $mail = $params[$mailParam];
 
       $userID = \Civi\Api4\User::create(FALSE)
         ->addValue('username', $params['cms_name'])

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -132,10 +132,10 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
       ])->execute()->first()['id'];
 
     $security = Security::singleton();
-    $params = ['cms_name' => 'user_one', 'cms_pass' => 'secret1', 'notify' => FALSE, 'contactID' => $contactID, 'user_one@example.org' => 'user_one@example.org'];
+    $params = ['cms_name' => 'user_one', 'cms_pass' => 'secret1', 'notify' => FALSE, 'contactID' => $contactID, 'email' => 'user_one@example.org'];
 
     $this->switchToOurUFClasses();
-    $userID = \CRM_Core_BAO_CMSUser::create($params, 'user_one@example.org');
+    $userID = \CRM_Core_BAO_CMSUser::create($params, 'email');
     $this->switchBackFromOurUFClasses();
 
     $this->assertGreaterThan(0, $userID);

--- a/setup/plugins/blocks/admin.civi-setup.php
+++ b/setup/plugins/blocks/admin.civi-setup.php
@@ -1,0 +1,32 @@
+<?php
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setupui.boot', function (\Civi\Setup\UI\Event\UIBootEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Register blocks', basename(__FILE__)));
+
+    /**
+     * @var \Civi\Setup\UI\SetupController $ctrl
+     */
+    $ctrl = $e->getCtrl();
+
+    $ctrl->blocks['admin'] = [
+      'is_active' => ($e->getModel()->cms === 'Standalone'),
+      'file' => __DIR__ . DIRECTORY_SEPARATOR . 'admin.tpl.php',
+      'class' => 'if-no-errors',
+      'weight' => 35,
+    ];
+
+    if ($ctrl->blocks['admin']['is_active'] && $e->getMethod() === 'POST') {
+      if ($e->getField('adminUser')) {
+        $e->getModel()->extras['adminUser'] = $e->getField('adminUser');
+      }
+      if ($e->getField('adminPass')) {
+        $e->getModel()->extras['adminPassWasSpecified'] = TRUE;
+        $e->getModel()->extras['adminPass'] = $e->getField('adminPass');
+      }
+    }
+
+  }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/blocks/admin.tpl.php
+++ b/setup/plugins/blocks/admin.tpl.php
@@ -1,0 +1,14 @@
+<?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
+endif; ?>
+
+<h2><?php echo ts('Administrator'); ?></h2>
+
+<p style="margin-left: 2em">
+  <label for="adminUser"><span><?php echo ts('Administrative User:'); ?></span></label>
+  <input type="text" id="adminUser" name="civisetup[adminUser]" value="<?php echo htmlentities($model->extras['adminUser'] ?? '') ?>">
+</p>
+
+<p style="margin-left: 2em">
+  <label for="adminPass"><span><?php echo ts('Administrative Password:'); ?></span></label>
+  <input type="password" id="adminPass" name="civisetup[adminPass]" value="<?php echo htmlentities($model->extras['adminPass'] ?? '') ?>">
+</p>

--- a/setup/plugins/blocks/advanced.tpl.php
+++ b/setup/plugins/blocks/advanced.tpl.php
@@ -9,6 +9,7 @@ endif; ?>
 <div style="">
   <table class="settingsTable">
     <tbody>
+    <?php if ($model->cms !== 'Standalone'): ?>
     <tr>
       <th><?php echo ts('CMS Database'); ?></th>
       <td>
@@ -44,6 +45,7 @@ endif; ?>
         </div>
       </td>
     </tr>
+    <?php endif; ?>
     <tr>
       <th><?php echo ts('CiviCRM Settings File'); ?></th>
       <td><code><?php echo htmlentities($model->settingsPath); ?></code></td>

--- a/setup/plugins/blocks/database.civi-setup.php
+++ b/setup/plugins/blocks/database.civi-setup.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setupui.boot', function (\Civi\Setup\UI\Event\UIBootEvent $e) {
+    \Civi\Setup::log()->info(sprintf('[%s] Register blocks', basename(__FILE__)));
+
+    /**
+     * @var \Civi\Setup\UI\SetupController $ctrl
+     */
+    $ctrl = $e->getCtrl();
+
+    $ctrl->blocks['database'] = [
+      'is_active' => ($e->getModel()->cms === 'Standalone'),
+      'file' => __DIR__ . DIRECTORY_SEPARATOR . 'database.tpl.php',
+      'class' => '',
+      'weight' => 15,
+    ];
+    if (empty($ctrl->blocks['database']['is_active'])) {
+      return;
+    }
+
+    $webDefault = ['server' => '127.0.0.1:3306', 'database' => 'civicrm', 'username' => '', 'password' => ''];
+
+    if ($e->getMethod() === 'GET') {
+      $e->getModel()->db = $webDefault;
+    }
+    elseif ($e->getMethod() === 'POST') {
+      $db = $e->getField('db', $webDefault);
+
+      foreach (['server', 'database', 'username', 'password'] as $field) {
+        $e->getModel()->db[$field] = $db[$field];
+      }
+    }
+
+  }, \Civi\Setup::PRIORITY_PREPARE);

--- a/setup/plugins/blocks/database.tpl.php
+++ b/setup/plugins/blocks/database.tpl.php
@@ -1,0 +1,24 @@
+<?php if (!defined('CIVI_SETUP')): exit("Installation plugins must only be loaded by the installer.\n");
+endif; ?>
+
+<h2><?php echo ts('Database'); ?></h2>
+
+<p style="margin-left: 2em">
+  <label for="server"><span><?php echo ts('Server:'); ?></span></label>
+  <input type="text" id="dbServer" name="civisetup[db][server]" value="<?php echo htmlentities($model->db['server'] ?? '') ?>">
+</p>
+
+<p style="margin-left: 2em">
+  <label for="database"><span><?php echo ts('Database:'); ?></span></label>
+  <input type="text" id="dbDatabase" name="civisetup[db][database]" value="<?php echo htmlentities($model->db['database'] ?? '') ?>">
+</p>
+
+<p style="margin-left: 2em">
+  <label for="username"><span><?php echo ts('Username:'); ?></span></label>
+  <input type="text" id="dbUsername" name="civisetup[db][username]" value="<?php echo htmlentities($model->db['username'] ?? '') ?>">
+</p>
+
+<p style="margin-left: 2em">
+  <label for="password"><span><?php echo ts('Password:'); ?></span></label>
+  <input type="password" id="dbPassword" name="civisetup[db][password]" value="<?php echo htmlentities($model->db['password'] ?? '') ?>">
+</p>

--- a/setup/plugins/init/Standalone.civi-setup.php
+++ b/setup/plugins/init/Standalone.civi-setup.php
@@ -9,6 +9,17 @@ if (!defined('CIVI_SETUP')) {
   exit("Installation plugins must only be loaded by the installer.\n");
 }
 
+function _standalone_setup_scheme(): string {
+  if ((!empty($_SERVER['REQUEST_SCHEME']) && $_SERVER['REQUEST_SCHEME'] == 'https') ||
+    (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ||
+    (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == '443')) {
+    return 'https';
+  }
+  else {
+    return 'http';
+  }
+}
+
 \Civi\Setup::dispatcher()
   ->addListener('civi.setup.checkAuthorized', function (\Civi\Setup\Event\CheckAuthorizedEvent $e) {
     $model = $e->getModel();
@@ -82,7 +93,7 @@ if (!defined('CIVI_SETUP')) {
     // original: $model->cmsBaseUrl = $_SERVER['HTTP_ORIGIN'] ?: $_SERVER['HTTP_REFERER'];
     if (empty($model->cmsBaseUrl)) {
       // A buildkit install (which uses cv core:install) sets this correctly. But a standard composer-then-website type install does not.
-      $model->cmsBaseUrl = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'];
+      $model->cmsBaseUrl = _standalone_setup_scheme() . '://' . $_SERVER['HTTP_HOST'];
     }
 
     // These paths get set as

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -71,10 +71,11 @@ if (!defined('CIVI_SETUP')) {
     $params = [
       'cms_name'   => $e->getModel()->extras['adminUser'],
       'cms_pass'   => $e->getModel()->extras['adminPass'],
+      'email'       => $adminEmail,
       'notify'     => FALSE,
       'contactID'  => $contactID,
     ];
-    $userID = \CRM_Core_BAO_CMSUser::create($params, $adminEmail);
+    $userID = \CRM_Core_BAO_CMSUser::create($params, 'email');
 
     // Assign 'admin' role to user
     \Civi\Api4\User::update(FALSE)

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -30,7 +30,7 @@ class DbUtil {
     return array(
       'server' => $server,
       'username' => $parsed['user'] ?: NULL,
-      'password' => $parsed['pass'] ?: NULL,
+      'password' => $parsed['pass'] ?? NULL,
       'database' => $database,
       'ssl_params' => self::parseSSL($parsed['query'] ?? NULL),
     );

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -87,6 +87,11 @@ class DbUtil {
    * @throws SqlException
    */
   public static function connect($db) {
+    // During installation, we need to test proposed credentials. Ensure that tests report failure the same way on php7+php8.
+    if (version_compare(PHP_VERSION, '8', '>=')) {
+      mysqli_report(MYSQLI_REPORT_OFF);
+    }
+
     $conn = self::softConnect($db);
     if (mysqli_connect_errno()) {
       throw new SqlException(sprintf("Connection failed: %s\n", mysqli_connect_error()));

--- a/setup/src/Setup/SettingsUtil.php
+++ b/setup/src/Setup/SettingsUtil.php
@@ -15,7 +15,7 @@ class SettingsUtil {
     $params['frontEnd'] = 0;
     $params['baseURL'] = addslashes(rtrim($m->cmsBaseUrl, '/'));
     $params['dbUser'] = addslashes(urlencode($m->db['username']));
-    $params['dbPass'] = addslashes(urlencode($m->db['password']));
+    $params['dbPass'] = addslashes(urlencode($m->db['password'] ?? ''));
     $params['dbHost'] = addslashes(implode(':', array_map('urlencode', explode(':', $m->db['server']))));
     $params['dbName'] = addslashes(urlencode($m->db['database']));
     // The '&' prefix is awkward, but we don't know what's already in the file.

--- a/setup/src/Setup/UI/SetupResponse.php
+++ b/setup/src/Setup/UI/SetupResponse.php
@@ -64,10 +64,11 @@ class SetupResponse implements \ArrayAccess {
     ];
   }
 
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->oldFieldMap[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function &offsetGet($offset) {
     if (isset($this->oldFieldMap[$offset])) {
       $field = $this->oldFieldMap[$offset];
@@ -78,14 +79,14 @@ class SetupResponse implements \ArrayAccess {
     }
   }
 
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     if (isset($this->oldFieldMap[$offset])) {
       $field = $this->oldFieldMap[$offset];
       $this->{$field} = $value;
     }
   }
 
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     if (isset($this->oldFieldMap[$offset])) {
       $field = $this->oldFieldMap[$offset];
       unset($this->{$field});

--- a/tools/standalone/router.php
+++ b/tools/standalone/router.php
@@ -29,12 +29,21 @@ class StandaloneRouter {
   public function __construct() {
     // Note: Routing rules are processed sequentially, until one handles the request.
 
+    // The above would be prettier in php74's `fn()` notation.
+
     // Redirect common entry points
-    $this->addRoute(';^/$;', fn($m) => $this->sendRedirect('/civicrm/'));
-    $this->addRoute(';^/civicrm$;', fn($m) => $this->sendRedirect('/civicrm/'));
+    $this->addRoute(';^/$;', function($m) {
+      return $this->sendRedirect('/civicrm/');
+    });
+
+    $this->addRoute(';^/civicrm$;', function($m) {
+      return $this->sendRedirect('/civicrm/');
+    });
 
     // If it looks like a Civi route, then call CRM_Core_Invoke.
-    $this->addRoute(';^/(civicrm/.*)$;', fn($m) => $this->invoke($m[1]));
+    $this->addRoute(';^/(civicrm/.*)$;', function($m) {
+      return $this->invoke($m[1]);
+    });
 
     // If there's a concrete file in HTTP root (`web/`), then serve that.
     $this->addRoute(';/(.*);', function($m) {
@@ -43,17 +52,26 @@ class StandaloneRouter {
     });
 
     // Virtually mount civicrm-{core,packages}. This allows us to serve their static assets directly (even on systems that lack symlinks).
-    // TODO: Decide which convention we like more...
 
-    $this->addRoute(';^/core/packages/(.*);', fn($m) => $this->sendFileFromFolder($this->findPackages(), $m[1]));
-    $this->addRoute(';^/core/vendor/(.*);', fn($m) => $this->sendFileFromFolder($this->findVendor(), $m[1]));
-    $this->addRoute(';^/core/(.*);', fn($m) => $this->sendFileFromFolder($this->findCore(), $m[1]));
+    $this->addRoute(';^/core/packages/(.*);', function($m) {
+      return $this->sendFileFromFolder($this->findPackages(), $m[1]);
+    });
+    $this->addRoute(';^/core/vendor/(.*);', function($m) {
+      return $this->sendFileFromFolder($this->findVendor(), $m[1]);
+    });
+    $this->addRoute(';^/core/(.*);', function($m) {
+      return $this->sendFileFromFolder($this->findCore(), $m[1]);
+    });
 
-    $this->addRoute(';^/civicrm-packages/(.*);', fn($m) => $this->sendFileFromFolder($this->findPackages(), $m[1]));
-    $this->addRoute(';^/civicrm-core/(.*);', fn($m) => $this->sendFileFromFolder($this->findCore(), $m[1]));
+    // $this->addRoute(';^/core/packages/(.*);', fn($m) => $this->sendFileFromFolder($this->findPackages(), $m[1]));
+    // $this->addRoute(';^/core/vendor/(.*);', fn($m) => $this->sendFileFromFolder($this->findVendor(), $m[1]));
+    // $this->addRoute(';^/core/(.*);', fn($m) => $this->sendFileFromFolder($this->findCore(), $m[1]));
 
-    $this->addRoute(';^/assets/civicrm/core/(.*);', fn($m) => $this->sendFileFromFolder($this->findPackages(), $m[1]));
-    $this->addRoute(';^/assets/civicrm/packages/(.*);', fn($m) => $this->sendFileFromFolder($this->findCore(), $m[1]));
+    // $this->addRoute(';^/civicrm-packages/(.*);', fn($m) => $this->sendFileFromFolder($this->findPackages(), $m[1]));
+    // $this->addRoute(';^/civicrm-core/(.*);', fn($m) => $this->sendFileFromFolder($this->findCore(), $m[1]));
+    //
+    // $this->addRoute(';^/assets/civicrm/core/(.*);', fn($m) => $this->sendFileFromFolder($this->findPackages(), $m[1]));
+    // $this->addRoute(';^/assets/civicrm/packages/(.*);', fn($m) => $this->sendFileFromFolder($this->findCore(), $m[1]));
 
     // TODO: Consider allowing CRM_Core_Invoke to handle any route. May affect UF interop.
   }


### PR DESCRIPTION
Overview
----------------------------------------

This extends support for PHP built-in web-server (SRV profile from #26771) and enables installation through the web UI.

ping @artfulrobot @mlutfy 

Context
----------------------------------------

Suppose you download the core repo and start the PHP built-in server:

```
git clone https://github.com/civicrm/civicrm-core ~/src/civicrm
git clone https://github.com/civicrm/civicrm-packages ~/src/civicrm/packages

cd ~/src/civicrm
composer install
./tools/standalone/bin/serve
```

At this point, you need to install.

Before
----------------------------------------

Install via CLI:

```bash
cv core:install -v -f \
  --db=mysql://root:@127.0.0.1:3307/civi  \
  --cms-base-url='http://localhost:8000' \
  -m extras.adminPass=TOPSECRET
```

After
----------------------------------------

Install via web UI -- open `localhost:8000` and fill out the form:

![Screenshot from 2023-07-15 23-12-51](https://github.com/civicrm/civicrm-core/assets/1336047/5241f3cf-e2c2-4ac1-9d4e-d0aad88cbf48)

This also fixes several issues that came up in testing the above, eg

* Fix an Apache-specific variable
* Fix handling of empty MySQL password
* Fix issues on php73 (CiviCRM's `min`) and  php81(CiviCRM's `max`)

Comments
---------------

There are probably more quirks to address in future updates to the installation UX - e.g. maybe "Localization" should be higher up; e.g. don't validate DB credentials on first page-load (*for standalone*); e.g. the post-install screen should direct you to the login screen. But this still looks like progress IMHO.