### PR TITLE
dev/core#4434 - Don't allow uploading giant attachments to mailings

### DIFF
--- a/CRM/Core/Page/AJAX/Attachment.php
+++ b/CRM/Core/Page/AJAX/Attachment.php
@@ -49,6 +49,8 @@ class CRM_Core_Page_AJAX_Attachment {
     $config = CRM_Core_Config::singleton();
     $results = [];
 
+    $maxFileSize = \Civi::settings()->get('maxFileSize');
+
     foreach ($files as $key => $file) {
       if (!$config->debug && !self::checkToken($post['crm_attachment_token'])) {
         require_once 'api/v3/utils.php';
@@ -60,6 +62,10 @@ class CRM_Core_Page_AJAX_Attachment {
             'reason' => 'CSRF suspected',
           ]
         );
+      }
+      elseif ($file['size'] > $maxFileSize * 1024 * 1024) {
+        require_once 'api/v3/utils.php';
+        $results[$key] = civicrm_api3_create_error(ts('Each file must be less than %1M in size.', [1 => $maxFileSize]));
       }
       elseif ($file['error']) {
         require_once 'api/v3/utils.php';


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4434

Before
----------------------------------------
Regardless of the setting at administer - system settings - misc, civimail allows uploading giant attachments. The mail then bounces and the average office staffer doesn't know why.

After
----------------------------------------
Popup error while composing the mailing.

Technical Details
----------------------------------------
Note if your php.ini max_file_size is smaller than or equal to the setting at adminster - system settings - misc, then this issue doesn't come up because you get a generic upload failed error at compose time. I'm not sure how to improve that with a better error since it's happening in either php or the js lib, and $file['size'] is 0. Anyway that isn't the main problem I'm trying to solve, which is when php.ini has a greater value.

Comments
----------------------------------------
There's a weird pause before you see the error, but that isn't specific to this error. I guess it's the nature of the widget.

The `ts` wording is identical to the description text on the form, so it's already translated.