### PR TITLE
SearchKit - Improve performance of checking link permissions

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -569,7 +569,7 @@ abstract class CRM_Utils_Hook {
    * visibility of contacts to the logged in user
    *
    * @param int $type
-   *   The type of permission needed.
+   *   Action being taken (CRM_Core_Permission::VIEW or CRM_Core_Permission::EDIT)
    * @param array $tables
    *   (reference ) add the tables that are needed for the select clause.
    * @param array $whereTables

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -15,6 +15,7 @@ namespace Civi\Api4\Utils;
 use Civi\API\Exception\NotImplementedException;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\API\Request;
+use Civi\Api4\Generic\AbstractAction;
 use CRM_Core_DAO_AllCoreTables as AllCoreTables;
 
 class CoreUtil {
@@ -172,14 +173,13 @@ class CoreUtil {
    *
    * @param \Civi\Api4\Generic\AbstractAction $apiRequest
    * @param array $record
-   * @param int|string $userID
-   *   Contact ID of the user we are testing,. 0 for the anonymous user.
+   * @param int|null $userID
+   *   Contact ID of the user we are testing, 0 for the anonymous user.
    * @return bool
    * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\NotImplementedException
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function checkAccessRecord(\Civi\Api4\Generic\AbstractAction $apiRequest, array $record, int $userID) {
+  public static function checkAccessRecord(AbstractAction $apiRequest, array $record, int $userID = NULL) {
+    $userID = $userID ?? \CRM_Core_Session::getLoggedInContactID() ?? 0;
 
     // Super-admins always have access to everything
     if (\CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userID)) {


### PR DESCRIPTION
Overview
----------------------------------------
Speeds up search display performance by checking link permissions more efficiently.

Before
----------------------------------------
Link permissions checked one-at-a-time, resulting in hundreds of internal calls to the `checkAccess` api per request.

After
----------------------------------------
Gatekeeper permissions checked once in bulk. Fine-grained ACLs checked without the overhead of the api wrapper. Test coverage added to make sure it still works.

@eileenmcnaughton 