### PR TITLE
[NFC][PHP8.2] Fix dynamic property _loggedInUser

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2068,10 +2068,10 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
       ");
     }
 
-    $this->_loggedInUser = CRM_Core_Session::singleton()->get('userID');
+    $loggedInUser = CRM_Core_Session::singleton()->get('userID');
     $this->callAPISuccess('group_contact', 'create', [
       'group_id' => $permissionedGroup,
-      'contact_id' => $this->_loggedInUser,
+      'contact_id' => $loggedInUser,
     ]);
 
     if (!$isProfile) {


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the following test failure 

```
api_v3_UFFieldTest::testACLPermissionForProfiles
Creation of dynamic property api_v3_UFFieldTest::$_loggedInUser is deprecated
``` 

Before
----------------------------------------
Test doesn't work on php8.2

After
----------------------------------------
Test passes on PHP8.2

Technical Details
----------------------------------------
I did a grep for other uses of `_loggedInUser` and all others extend off of `CiviCaseTestCase` which does declare this property

ping @demeritcowboy @eileenmcnaughton 