### PR TITLE
[PHP8.2] move property declaration form CRM_Member_Form_Membership to parent

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -24,10 +24,29 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   use CRM_Core_Form_EntityFormTrait;
 
   /**
+   * Membership created or edited on this form.
+   *
+   * If a price set creates multiple this will be the last one created.
+   *
+   * This 'last' bias reflects historical code - but it's mostly used in the receipt
+   * and there is all sorts of weird and wonderful handling that potentially compensates.
+   *
+   * @var array
+   */
+  protected $membership = [];
+
+  /**
    * Membership Type ID
    * @var int
    */
   protected $_memType;
+
+  /**
+   * IDs of relevant entities.
+   *
+   * @var array
+   */
+  protected $ids = [];
 
   /**
    * Array of from email ids
@@ -43,7 +62,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   protected $allMembershipTypeDetails = [];
 
   /**
-   * Array of membership type IDs and whether they permit autorenewal.
+   * Array of membership type IDs and whether they permit auto-renewal.
    *
    * @var array
    */
@@ -79,11 +98,62 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
   /**
    * Array of the payment fields to be displayed in the payment fieldset (pane) in billingBlock.tpl
-   * this contains all the information to describe these fields from quickform. See CRM_Core_Form_Payment getPaymentFormFieldsMetadata
+   * this contains all the information to describe these fields from QuickForm. See CRM_Core_Form_Payment getPaymentFormFieldsMetadata
    *
    * @var array
    */
   public $_paymentFields = [];
+
+  /**
+   * Display name of the member.
+   *
+   * @var string
+   */
+  protected $_memberDisplayName;
+
+  /**
+   * email of the person paying for the membership (used for receipts)
+   * @var string
+   */
+  protected $_memberEmail;
+
+  protected $_recurMembershipTypes;
+
+  /**
+   * Keep a class variable for ALL membership IDs so
+   * postProcess hook function can do something with it
+   *
+   * @var array
+   */
+  protected $_membershipIDs = [];
+
+  /**
+   * Display name of the person paying for the membership (used for receipts)
+   *
+   * @var string
+   */
+  protected $_contributorDisplayName;
+
+  /**
+   * Email of the person paying for the membership (used for receipts).
+   *
+   * @var string
+   */
+  protected $_contributorEmail;
+
+  /**
+   * email of the person paying for the membership (used for receipts)
+   *
+   * @var int
+   */
+  protected $_contributorContactID;
+
+  /**
+   * ID of the person the receipt is to go to.
+   *
+   * @var int
+   */
+  protected $_receiptContactId;
 
   /**
    * @return string
@@ -95,7 +165,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
   /**
    * Explicitly declare the entity api name.
    */
-  public function getDefaultEntity() {
+  public function getDefaultEntity(): string {
     return 'Membership';
   }
 
@@ -109,7 +179,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @param string $message
    */
-  protected function addStatusMessage($message) {
+  protected function addStatusMessage(string $message): void {
     $this->statusMessage[] = $message;
   }
 
@@ -118,7 +188,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @return string
    */
-  protected function getStatusMessage() {
+  protected function getStatusMessage(): string {
     return implode(' ', $this->statusMessage);
   }
 
@@ -166,6 +236,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @return array
    *   defaults
+   * @throws \CRM_Core_Exception
    */
   public function setDefaultValues() {
     $defaults = [];
@@ -219,6 +290,8 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     $this->assignSalesTaxMetadataToTemplate();
@@ -311,7 +384,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *  - contact_id
    *  - soft_credit_contact_id
    */
-  public function storeContactFields($formValues) {
+  public function storeContactFields(array $formValues): void {
     // in a 'standalone form' (contact id not in the url) the contact will be in the form values
     if (!empty($formValues['contact_id'])) {
       $this->_contactID = $formValues['contact_id'];
@@ -359,8 +432,10 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * This is part of refactoring for unit testability on the submit function.
    *
    * @param array $params
+   *
+   * @throws \CRM_Core_Exception
    */
-  protected function setContextVariables($params) {
+  protected function setContextVariables(array $params): void {
     $variables = [
       'action' => '_action',
       'context' => '_context',
@@ -391,7 +466,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function processRecurringContribution($contributionRecurParams, $membershipTypeID) {
+  protected function processRecurringContribution(array $contributionRecurParams, int $membershipTypeID): array {
 
     $mapping = [
       'frequency_interval' => 'duration_interval',
@@ -421,9 +496,9 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    *
    * @param array $formValues
    */
-  protected function ensurePriceParamsAreSet(&$formValues) {
+  protected function ensurePriceParamsAreSet(array &$formValues): void {
     foreach ($formValues as $key => $value) {
-      if ((substr($key, 0, 6) == 'price_') && is_numeric(substr($key, 6))) {
+      if ((strpos($key, 'price_') === 0) && is_numeric(substr($key, 6))) {
         return;
       }
     }
@@ -501,6 +576,8 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * Wrapper function for unit tests.
    *
    * @param array $formValues
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testSubmit(array $formValues = []): void {
     if (empty($formValues)) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -23,15 +23,6 @@ use Civi\Api4\ContributionRecur;
 class CRM_Member_Form_Membership extends CRM_Member_Form {
 
   /**
-   * IDs of relevant entities.
-   *
-   * @var array
-   */
-  protected $ids = [];
-
-  protected $_memType = NULL;
-
-  /**
    * If this is set (to 'test' or 'live') then the payment processor will be shown on the form to take a payment.
    *
    * @var string|null
@@ -40,22 +31,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
 
   public $_contributeMode = 'direct';
 
-  protected $_recurMembershipTypes;
-
   protected $_memTypeSelected;
-
-  /**
-   * Display name of the member.
-   *
-   * @var string
-   */
-  protected $_memberDisplayName = NULL;
-
-  /**
-   * email of the person paying for the membership (used for receipts)
-   * @var string
-   */
-  protected $_memberEmail = NULL;
 
   /**
    * Contact ID of the member.
@@ -63,54 +39,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    * @var int
    */
   public $_contactID = NULL;
-
-  /**
-   * Display name of the person paying for the membership (used for receipts)
-   *
-   * @var string
-   */
-  protected $_contributorDisplayName = NULL;
-
-  /**
-   * Email of the person paying for the membership (used for receipts).
-   *
-   * @var string
-   */
-  protected $_contributorEmail;
-
-  /**
-   * email of the person paying for the membership (used for receipts)
-   *
-   * @var int
-   */
-  protected $_contributorContactID = NULL;
-
-  /**
-   * ID of the person the receipt is to go to.
-   *
-   * @var int
-   */
-  protected $_receiptContactId = NULL;
-
-  /**
-   * Keep a class variable for ALL membership IDs so
-   * postProcess hook function can do something with it
-   *
-   * @var array
-   */
-  protected $_membershipIDs = [];
-
-  /**
-   * Membership created or edited on this form.
-   *
-   * If a price set creates multiple this will be the last one created.
-   *
-   * This 'last' bias reflects historical code - but it's mostly used in the receipt
-   * and there is all sorts of weird and wonderful handling that potentially compensates.
-   *
-   * @var array
-   */
-  protected $membership = [];
 
   /**
    * Set entity fields to be assigned to the form.


### PR DESCRIPTION
Overview
----------------------------------------
[PHP8.2] move property declaration form CRM_Member_Form_Membership to parent

Before
----------------------------------------
Fails like CRM_Member_Form_MembershipRenewalTest::testSubmit
Creation of dynamic property CRM_Member_Form_MembershipRenewal::$_membershipIDs is deprecated
 because it shares code with `CRM_Member_Form_Membership` in shared parent `CRM_Member_Form` but the declarations are in `CRM_Member_Form_Membership`

After
----------------------------------------
Declarations moved to shared parent

Technical Details
----------------------------------------

Comments
----------------------------------------
