### PR TITLE
(dev/core#4433) - Implement Civi::url() with prefixes and OOP enhancements

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -207,6 +207,9 @@ class CRM_Core_Invoke {
     self::registerPharHandler();
 
     $config = CRM_Core_Config::singleton();
+
+    // WISHLIST: if $item is a web-service route, swap prepend to $civicrm_url_defaults
+
     if ($config->userFramework == 'Joomla' && $item) {
       $config->userFrameworkURLVar = 'task';
 

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -281,6 +281,44 @@ class CRM_Core_Menu {
   }
 
   /**
+   * Determine whether a route should canonically use a frontend or backend UI.
+   *
+   * @param string $path
+   *   Ex: 'civicrm/contribute/transact'
+   * @return bool
+   *   TRUE if the route is marked with 'is_public=1'.
+   * @internal
+   *   We may wish to revise the metadata to allow more distinctions. In that case, `isPublicRoute()`
+   *   would probably get replaced by something else.
+   */
+  public static function isPublicRoute(string $path): bool {
+    // A page-view may include hundreds of links - so don't hit DB for every link. Use cache.
+    // In default+demo builds, the list of public routes is much smaller than the list of
+    // private routes (roughly 1:10; ~50 entries vs ~450 entries). Cache the smaller list.
+    $cache = Civi::cache('long');
+    $index = $cache->get('PublicRouteIndex');
+    if ($index === NULL) {
+      $routes = CRM_Core_DAO::executeQuery('SELECT id, path FROM civicrm_menu WHERE is_public = 1')
+        ->fetchMap('id', 'path');
+      if (empty($routes)) {
+        Civi::log()->warning('isPublicRoute() should not be called before the menu has been built.');
+        return FALSE;
+      }
+      $index = array_fill_keys(array_values($routes), TRUE);
+      $cache->set('PublicRouteIndex', $index);
+    }
+
+    $parts = explode('/', $path);
+    while (count($parts) > 1) {
+      if (isset($index[implode('/', $parts)])) {
+        return TRUE;
+      }
+      array_pop($parts);
+    }
+    return FALSE;
+  }
+
+  /**
    * This function recomputes menu from xml and populates civicrm_menu.
    *
    * @param bool $truncate
@@ -291,6 +329,7 @@ class CRM_Core_Menu {
       $query = 'TRUNCATE civicrm_menu';
       CRM_Core_DAO::executeQuery($query);
     }
+    Civi::cache('long')->delete('PublicRouteIndex');
     $menuArray = self::items($truncate);
 
     self::build($menuArray);

--- a/CRM/Core/Smarty/plugins/block.url.php
+++ b/CRM/Core/Smarty/plugins/block.url.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Generate a URL. This is thin wrapper for the Civi::url() helper.
+ *
+ * @see Civi::url()
+ *
+ * Ex: Generate a backend URL.
+ *     {url}backend://civicrm/admin?reset=1{/url}
+ *
+ * Ex: Generate a backend URL. Assign it to a Smarty variable.
+ *     {url assign=tmpVar}backend://civicrm/admin?reset=1{/url}
+ *
+ * Ex: Generate a backend URL. Set optional flags: (t)ext, (s)sl, (a)bsolute.
+ *     {url flags=tsa}backend://civicrm/admin?reset=1{/url}
+ *
+ * Ex: Generate a URL in the current (active) routing scheme. Add named variables. (Values are escaped).
+ *     {url verb="Eat" target="Apples and bananas"}//civicrm/fruit?method=[verb]&data=[target]{/url}
+ *
+ * Ex: As above, but use numerical variables.
+ *     {url 1="Eat" 2="Apples and bananas"}//civicrm/fruit?method=[1]&data=[2]{/url}
+ *
+ * Ex: Generate a URL. Add some pre-escaped variables using Smarty {$foo}.
+ *     {assign var=myEscapedAction value="Eat"}
+ *     {assign var=myEscapedData value="Apples+and+bananas"}
+ *     {url}//civicrm/fruit?method={$myEscapedAction}&data={$myEscapedData}{/url}
+ *
+ * @param array $params
+ *   The following parameters have specific meanings:
+ *   - "assign" (string) - Assign output to a Smarty variable
+ *   - "flags" (string) - List of options, as per `Civi::url(...$flags)`
+ *   All other parameters will be passed-through as variables for the URL.
+ * @param string $text
+ *   Contents of block.
+ * @param CRM_Core_Smarty $smarty
+ *   The Smarty object.
+ * @return string
+ */
+function smarty_block_url($params, $text, &$smarty) {
+  if ($text === NULL) {
+    return NULL;
+  }
+
+  $flags = 'h' . ($params['flags'] ?? '');
+  $assign = $params['assign'] ?? NULL;
+  unset($params['flags'], $params['assign']);
+
+  $url = (string) Civi::url($text, $flags)->addVars($params);
+
+  // This could be neat, but see discussion in CRM_Core_Smarty_plugins_UrlTest for why it's currently off.
+  // $url->setVarsCallback([$smarty, 'get_template_vars']);
+
+  if ($assign !== NULL) {
+    $smarty->assign([$assign => $url]);
+    return '';
+  }
+  else {
+    return $url;
+  }
+}

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -135,6 +135,7 @@
     <path>civicrm/asset/builder</path>
     <page_callback>\Civi\Core\AssetBuilder::pageRun</page_callback>
     <access_arguments>*always allow*</access_arguments>
+    <is_public>1</is_public>
   </item>
   <item>
      <path>civicrm/contribute/ajax/tableview</path>

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -137,6 +137,42 @@ abstract class CRM_Utils_System_Base {
   );
 
   /**
+   * Compose the URL for a page/route.
+   *
+   * @internal
+   * @see \Civi\Core\Url::__toString
+   * @param string $scheme
+   *   Ex: 'frontend', 'backend', 'service'
+   * @param string $path
+   *   Ex: 'civicrm/event/info'
+   * @param string|null $query
+   *   Ex: 'id=100&msg=Hello+world'
+   * @return string|null
+   *   Absolute URL, or NULL if scheme is unsupported.
+   *   Ex: 'https://subdomain.example.com/index.php?q=civicrm/event/info&id=100&msg=Hello+world'
+   */
+  public function getRouteUrl(string $scheme, string $path, ?string $query): ?string {
+    switch ($scheme) {
+      case 'frontend':
+        return $this->url($path, $query, TRUE, NULL, TRUE, FALSE, FALSE);
+
+      case 'service':
+        // The original `url()` didn't have an analog for "service://". But "frontend" is probably the closer bet?
+        // Or maybe getNotifyUrl() makes sense?
+        return $this->url($path, $query, TRUE, NULL, TRUE, FALSE, FALSE);
+
+      case 'backend':
+        return $this->url($path, $query, TRUE, NULL, FALSE, TRUE, FALSE);
+
+      // If the UF defines other major UI/URL conventions, then you might hypothetically handle
+      // additional schemes.
+
+      default:
+        return NULL;
+    }
+  }
+
+  /**
    * Return the Notification URL for Payments.
    *
    * The default is to pass the params through to `url()`. However the WordPress

--- a/Civi.php
+++ b/Civi.php
@@ -251,27 +251,22 @@ class Civi {
    *   $url = Civi::url('frontend://civicrm/ajax/api4/[entity]/[action]')
    *      ->addVars(['entity' => 'Foo', 'action' => 'bar']);
    *
-   * NOTE: CiviCRM is integrated into many environments, and they handle URL-construction different ways.
-   * For example, in Joomla+WordPress, there are separate sub-applications for the public-facing
-   * frontend UI (`/`) and the staff-facing backend UI (`/wp-admin/` or `/administrator/`) -- each follows
-   * a different URL-formula. But in Drupal, all use the same formula. To
-   *
    * @param string $logicalUri
    *   Logical URI. The scheme of the URI may be one of:
    *     - 'frontend://' (Front-end page-route for constituents)
    *     - 'backend://' (Back-end page-route for staff)
    *     - 'service://` (Web-service page-route for automated integrations; aka webhooks and IPNs)
    *     - 'current://' (Whichever UI is currently active)
-   *     - 'assetBuilder://' (Dynamically-generated asset-file)
+   *     - 'assetBuilder://' (Dynamically-generated asset-file; see \Civi\Core\AssetBuilder)
    *     - 'ext://' (Static asset-file provided by an extension)
    *   An empty scheme (`//hello.txt`) is equivalent to `current://hello.txt`.
    * @param string|null $flags
    *   List of flags. Some combination of the following:
-   *   - 'a': absolute
-   *   - 'r': relative
-   *   - 'h': html
-   *   - 'p': plain text
-   *   - 's': ssl
+   *   - 'a': absolute (aka `setPreferFormat('absolute')`)
+   *   - 'r': relative (aka `setPreferFormat('relative')`)
+   *   - 'h': html (aka `setHtmlEscape(TRUE)`)
+   *   - 'p': plain text (aka `setHtmlEscape(FALSE)`)
+   *   - 's': ssl (aka `setSsl(TRUE)`)
    *   FIXME: Should we have a flag for appending 'resCacheCode'?
    * @return \Civi\Core\Url
    *   URL object which may be modified or rendered as text.

--- a/Civi.php
+++ b/Civi.php
@@ -244,6 +244,9 @@ class Civi {
    * Ex: Link to a dynamically generated asset-file.
    *   $url = Civi::url('assetBuilder://crm-l10n.js?locale=en_US');
    *
+   * Ex: Link to a static asset (resource-file) in one of core's configurable paths.
+   *   $url = Civi::url('[civicrm.root]/js/Common.js');
+   *
    * Ex: Link to a static asset (resource-file) in an extension.
    *   $url = Civi::url('ext://org.civicrm.search_kit/css/crmSearchTasks.css');
    *
@@ -257,6 +260,7 @@ class Civi {
    *     - 'backend://' (Back-end page-route for staff)
    *     - 'service://` (Web-service page-route for automated integrations; aka webhooks and IPNs)
    *     - 'current://' (Whichever UI is currently active)
+   *     - 'asset://' (Static asset-file; see \Civi::paths())
    *     - 'assetBuilder://' (Dynamically-generated asset-file; see \Civi\Core\AssetBuilder)
    *     - 'ext://' (Static asset-file provided by an extension)
    *   An empty scheme (`//hello.txt`) is equivalent to `current://hello.txt`.

--- a/Civi.php
+++ b/Civi.php
@@ -219,21 +219,35 @@ class Civi {
   }
 
   /**
-   * Construct a URL based on a logical service address. URL building follows a few rules:
+   * Construct a URL based on a logical service address. For example:
    *
-   * 1. You should initialize with a baseline URL (e.g. 'frontend://civicrm/profile/view?id=123&gid=456').
+   *   Civi::url('frontend://civicrm/user?reset=1');
+   *
+   *   Civi::url()
+   *     ->setScheme('frontend')
+   *     ->setPath(['civicrm', 'user'])
+   *     ->setQuery(['reset' => 1])
+   *
+   * URL building follows a few rules:
+   *
+   * 1. You may initialize with a baseline URL.
    * 2. The scheme indicates the general type of URL ('frontend://', 'backend://', 'asset://', 'assetBuilder://').
-   * 3. The URL object provides getters, setters, and adders (e.g. `getScheme()`, `setPath(...)`, `addQuery(...)`)
+   * 3. The result object provides getters, setters, and adders (e.g. `getScheme()`, `setPath(...)`, `addQuery(...)`)
    * 4. Strings are raw. Arrays are auto-encoded. (`addQuery('name=John+Doughnut')` or `addQuery(['name' => 'John Doughnut'])`)
    * 5. You may use variable expressions (`id=[contact]&gid=[profile]`).
    * 6. The URL can be cast to string (aka `__toString()`).
    *
+   * If you are converting from `CRM_Utils_System::url()` to `Civi::url()`, then be sure to:
+   *
+   * - Pay attention to the scheme (eg 'current://' vs 'frontend://')
+   * - Pay attention to HTML escaping, as the behavior changed:
+   *      - Civi::url() returns plain URLs (eg "id=100&gid=200") by default
+   *      - CRM_Utils_System::url() returns HTML-escaped URLs (eg "id=100&amp;gid=200") by default
+   *
    * Here are several examples:
    *
-   * Ex: Link to constituent's dashboard (specifically on frontend UI)
-   *   $url = Civi::url('frontend://civicrm/user?reset=1');
-   *
    * Ex: Link to constituent's dashboard (on frontend UI or backend UI -- based on the active scheme of current page-view)
+   *   $url = Civi::url('current://civicrm/user?reset=1');
    *   $url = Civi::url('//civicrm/user?reset=1');
    *
    * Ex: Link to constituent's dashboard (with method calls - good for dynamic options)
@@ -263,13 +277,13 @@ class Civi {
    *   $url = Civi::url('frontend://civicrm/ajax/api4/[entity]/[action]')
    *      ->addVars(['entity' => 'Foo', 'action' => 'bar']);
    *
-   * @param string $logicalUri
+   * @param string|null $logicalUri
    *   Logical URI. The scheme of the URI may be one of:
    *     - 'frontend://' (Front-end page-route for constituents)
    *     - 'backend://' (Back-end page-route for staff)
-   *     - 'service://` (Web-service page-route for automated integrations; aka webhooks and IPNs)
+   *     - 'service://' (Web-service page-route for automated integrations; aka webhooks and IPNs)
    *     - 'current://' (Whichever UI is currently active)
-   *     - 'default://'(Whichever UI is recorded in the metadata)
+   *     - 'default://' (Whichever UI is recorded in the metadata)
    *     - 'asset://' (Static asset-file; see \Civi::paths())
    *     - 'assetBuilder://' (Dynamically-generated asset-file; see \Civi\Core\AssetBuilder)
    *     - 'ext://' (Static asset-file provided by an extension)
@@ -282,11 +296,10 @@ class Civi {
    *   - 't': text (aka `setHtmlEscape(FALSE)`)
    *   - 's': ssl (aka `setSsl(TRUE)`)
    *   - 'c': cache code for resources (aka Civi::resources()->addCacheCode())
-   *   FIXME: Should we have a flag for appending 'resCacheCode'?
    * @return \Civi\Core\Url
    *   URL object which may be modified or rendered as text.
    */
-  public static function url(string $logicalUri, ?string $flags = NULL): \Civi\Core\Url {
+  public static function url(?string $logicalUri = NULL, ?string $flags = NULL): \Civi\Core\Url {
     return new \Civi\Core\Url($logicalUri, $flags);
   }
 

--- a/Civi.php
+++ b/Civi.php
@@ -269,6 +269,7 @@ class Civi {
    *     - 'backend://' (Back-end page-route for staff)
    *     - 'service://` (Web-service page-route for automated integrations; aka webhooks and IPNs)
    *     - 'current://' (Whichever UI is currently active)
+   *     - 'default://'(Whichever UI is recorded in the metadata)
    *     - 'asset://' (Static asset-file; see \Civi::paths())
    *     - 'assetBuilder://' (Dynamically-generated asset-file; see \Civi\Core\AssetBuilder)
    *     - 'ext://' (Static asset-file provided by an extension)

--- a/Civi.php
+++ b/Civi.php
@@ -219,12 +219,21 @@ class Civi {
   }
 
   /**
-   * Construct a URL based on a logical service address.
+   * Construct a URL based on a logical service address. URL building follows a few rules:
    *
-   * Ex: Link to constituent's dashboard (on frontend UI)
+   * 1. You should initialize with a baseline URL (e.g. 'frontend://civicrm/profile/view?id=123&gid=456').
+   * 2. The scheme indicates the general type of URL ('frontend://', 'backend://', 'asset://', 'assetBuilder://').
+   * 3. The URL object provides getters, setters, and adders (e.g. `getScheme()`, `setPath(...)`, `addQuery(...)`)
+   * 4. Strings are raw. Arrays are auto-encoded. (`addQuery('name=John+Doughnut')` or `addQuery(['name' => 'John Doughnut'])`)
+   * 5. You may use variable expressions (`id=[contact]&gid=[profile]`).
+   * 6. The URL can be cast to string (aka `__toString()`).
+   *
+   * Here are several examples:
+   *
+   * Ex: Link to constituent's dashboard (specifically on frontend UI)
    *   $url = Civi::url('frontend://civicrm/user?reset=1');
    *
-   * Ex: Link to constituent's dashboard (on frontend UI or backend UI -- whatever matches current page-view)
+   * Ex: Link to constituent's dashboard (on frontend UI or backend UI -- based on the active scheme of current page-view)
    *   $url = Civi::url('//civicrm/user?reset=1');
    *
    * Ex: Link to constituent's dashboard (with method calls - good for dynamic options)

--- a/Civi.php
+++ b/Civi.php
@@ -265,7 +265,7 @@ class Civi {
    *   - 'a': absolute (aka `setPreferFormat('absolute')`)
    *   - 'r': relative (aka `setPreferFormat('relative')`)
    *   - 'h': html (aka `setHtmlEscape(TRUE)`)
-   *   - 'p': plain text (aka `setHtmlEscape(FALSE)`)
+   *   - 't': text (aka `setHtmlEscape(FALSE)`)
    *   - 's': ssl (aka `setSsl(TRUE)`)
    *   FIXME: Should we have a flag for appending 'resCacheCode'?
    * @return \Civi\Core\Url

--- a/Civi.php
+++ b/Civi.php
@@ -218,4 +218,62 @@ class Civi {
     return \Civi\Core\Container::getBootService('settings_manager')->getBagByDomain($domainID);
   }
 
+  /**
+   * Construct a URL based on a logical service address.
+   *
+   * Ex: Link to constituent's dashboard (on frontend UI)
+   *   $url = Civi::url('frontend://civicrm/user?reset=1');
+   *
+   * Ex: Link to constituent's dashboard (on frontend UI or backend UI -- whatever matches current page-view)
+   *   $url = Civi::url('//civicrm/user?reset=1');
+   *
+   * Ex: Link to constituent's dashboard (with method calls - good for dynamic options)
+   *   $url = Civi::url('frontend:')
+   *     ->setPath('civicrm/user')
+   *     ->addQuery(['reset' => 1]);
+   *
+   * Ex: Link to constituent's dashboard (with quick flags: absolute URL, SSL required, HTML escaping)
+   *   $url = Civi::url('frontend://civicrm/user?reset=1', 'ash');
+   *
+   * Ex: Link to constituent's dashboard (with method flags - good for dynamic options)
+   *   $url = Civi::url('frontend://civicrm/user?reset=1')
+   *     ->setPreferFormat('absolute')
+   *     ->setSsl(TRUE)
+   *     ->setHtmlEscape(TRUE);
+   *
+   * Ex: Link to a dynamically generated asset-file.
+   *   $url = Civi::url('assetBuilder://crm-l10n.js?locale=en_US');
+   *
+   * Ex: Link to a static asset (resource-file) in an extension.
+   *   $url = Civi::url('ext://org.civicrm.search_kit/css/crmSearchTasks.css');
+   *
+   * NOTE: CiviCRM is integrated into many environments, and they handle URL-construction different ways.
+   * For example, in Joomla+WordPress, there are separate sub-applications for the public-facing
+   * frontend UI (`/`) and the staff-facing backend UI (`/wp-admin/` or `/administrator/`) -- each follows
+   * a different URL-formula. But in Drupal, all use the same formula. To
+   *
+   * @param string $logicalUri
+   *   Logical URI. The scheme of the URI may be one of:
+   *     - 'frontend://' (Front-end page-route for constituents)
+   *     - 'backend://' (Back-end page-route for staff)
+   *     - 'service://` (Web-service page-route for automated integrations; aka webhooks and IPNs)
+   *     - 'current://' (Whichever UI is currently active)
+   *     - 'assetBuilder://' (Dynamically-generated asset-file)
+   *     - 'ext://' (Static asset-file provided by an extension)
+   *   An empty scheme (`//hello.txt`) is equivalent to `current://hello.txt`.
+   * @param string|null $flags
+   *   List of flags. Some combination of the following:
+   *   - 'a': absolute
+   *   - 'r': relative
+   *   - 'h': html
+   *   - 'p': plain text
+   *   - 's': ssl
+   *   FIXME: Should we have a flag for appending 'resCacheCode'?
+   * @return \Civi\Core\Url
+   *   URL object which may be modified or rendered as text.
+   */
+  public static function url(string $logicalUri, ?string $flags = NULL): \Civi\Core\Url {
+    return new \Civi\Core\Url($logicalUri, $flags);
+  }
+
 }

--- a/Civi.php
+++ b/Civi.php
@@ -247,6 +247,10 @@ class Civi {
    * Ex: Link to a static asset (resource-file) in an extension.
    *   $url = Civi::url('ext://org.civicrm.search_kit/css/crmSearchTasks.css');
    *
+   * Ex: Link with variable substitution
+   *   $url = Civi::url('frontend://civicrm/ajax/api4/[entity]/[action]')
+   *      ->addVars(['entity' => 'Foo', 'action' => 'bar']);
+   *
    * NOTE: CiviCRM is integrated into many environments, and they handle URL-construction different ways.
    * For example, in Joomla+WordPress, there are separate sub-applications for the public-facing
    * frontend UI (`/`) and the staff-facing backend UI (`/wp-admin/` or `/administrator/`) -- each follows

--- a/Civi.php
+++ b/Civi.php
@@ -267,6 +267,7 @@ class Civi {
    *   - 'h': html (aka `setHtmlEscape(TRUE)`)
    *   - 't': text (aka `setHtmlEscape(FALSE)`)
    *   - 's': ssl (aka `setSsl(TRUE)`)
+   *   - 'c': cache code for resources (aka Civi::resources()->addCacheCode())
    *   FIXME: Should we have a flag for appending 'resCacheCode'?
    * @return \Civi\Core\Url
    *   URL object which may be modified or rendered as text.

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace Civi\Core;
+
+/**
+ * Generate a URL.
+ *
+ * As input, this class takes a *logical URI*, which may include a range of configurable sub-parts (path, query, fragment, etc).
+ *
+ * As output, it provides a *concrete URL* that can be used by a web-browser to make requests.
+ */
+class Url {
+
+  /**
+   * @var string
+   *   Ex: 'frontend', 'backend'
+   */
+  private $scheme;
+
+  /**
+   * @var string
+   *   Ex: 'civicrm/dashboard'
+   */
+  private $path;
+
+  /**
+   * @var string
+   *   Ex: abc=123&xyz=456
+   */
+  private $query;
+
+  /**
+   * @var string|null
+   */
+  private $fragment;
+
+  /**
+   * Preferred format.
+   *
+   * Note that this is not strictly guaranteed. It may sometimes return absolute URLs even if you
+   * prefer relative URLs (e.g. if there's no easy/correct way to form a relative URL).
+   *
+   * @var string|null
+   *   'relative' or 'absolute'
+   *   NULL means "decide automatically"
+   */
+  private $preferFormat;
+
+  /**
+   * Whether to HTML-encode the output.
+   *
+   * Note: Why does this exist? It's insane, IMHO. There's nothing intrinsically HTML-y about URLs.
+   * However, practically speaking, this class aims to replace `CRM_Utils_System::url()` which
+   * performed HTML encoding by default. Retaining some easy variant of this flag should make the
+   * off-ramp a bit smoother.
+   *
+   * @var bool
+   */
+  private $htmlEscape = FALSE;
+
+  /**
+   * @var bool|null
+   *    NULL means "decide automatically"
+   */
+  private $ssl = NULL;
+
+  /**
+   * @param string $logicalUri
+   * @param string|null $flags
+   * @see \Civi::url()
+   */
+  public function __construct(string $logicalUri, ?string $flags = NULL) {
+    if ($logicalUri[0] === '/') {
+      $logicalUri = 'current:' . $logicalUri;
+    }
+
+    $parsed = parse_url($logicalUri);
+    $this->scheme = $parsed['scheme'] ?? NULL;
+    $this->path = $parsed['host'] ?? NULL;
+    if (isset($parsed['path'])) {
+      $this->path .= $parsed['path'];
+    }
+    $this->query = $parsed['query'] ?? NULL;
+    $this->fragment = $parsed['fragment'] ?? NULL;
+
+    if ($flags !== NULL) {
+      $this->useFlags($flags);
+    }
+  }
+
+  /**
+   * @return string
+   */
+  public function getScheme() {
+    return $this->scheme;
+  }
+
+  /**
+   * @param string $scheme
+   */
+  public function setScheme(string $scheme): Url {
+    $this->scheme = $scheme;
+    return $this;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getPath() {
+    return $this->path;
+  }
+
+  /**
+   * @param string $path
+   */
+  public function setPath(string $path): Url {
+    $this->path = $path;
+    return $this;
+  }
+
+  /**
+   * @param string|string[] $pathParts
+   * @return $this
+   */
+  public function addPath($pathParts): Url {
+    $suffix = implode('/', (array) $pathParts);
+    if ($this->path === NULL) {
+      $this->path = $suffix;
+    }
+    else {
+      $this->path = rtrim($this->path, '/') . '/' . $suffix;
+    }
+    return $this;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getQuery(): ?string {
+    return $this->query;
+  }
+
+  /**
+   * @param string|array|null $query
+   */
+  public function setQuery($query): Url {
+    $this->query = \CRM_Utils_System::makeQueryString($query);
+    return $this;
+  }
+
+  /**
+   * @param string|array $query
+   * @return $this
+   */
+  public function addQuery($query): Url {
+    if ($this->query === NULL) {
+      $this->query = \CRM_Utils_System::makeQueryString($query);
+    }
+    else {
+      $this->query .= '&' . \CRM_Utils_System::makeQueryString($query);
+    }
+    return $this;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getFragment(): ?string {
+    return $this->fragment;
+  }
+
+  /**
+   * @param string|null $fragment
+   */
+  public function setFragment(?string $fragment): Url {
+    $this->fragment = \CRM_Utils_System::makeQueryString($fragment);
+    return $this;
+  }
+
+  /**
+   * @param string|array $fragment
+   * @return $this
+   */
+  public function addFragment($fragment): Url {
+    if ($this->fragment === NULL) {
+      $this->fragment = \CRM_Utils_System::makeQueryString($fragment);
+    }
+    else {
+      $this->fragment .= '&' . \CRM_Utils_System::makeQueryString($fragment);
+    }
+    return $this;
+  }
+
+  /**
+   * @return string|null
+   *   'relative' or 'absolute'
+   */
+  public function getPreferFormat(): ?string {
+    return $this->preferFormat;
+  }
+
+  /**
+   * @param string|null $preferFormat
+   */
+  public function setPreferFormat(?string $preferFormat): Url {
+    $this->preferFormat = $preferFormat;
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getHtmlEscape(): bool {
+    return $this->htmlEscape;
+  }
+
+  /**
+   * @param bool $htmlEscape
+   */
+  public function setHtmlEscape(bool $htmlEscape): Url {
+    $this->htmlEscape = $htmlEscape;
+    return $this;
+  }
+
+  /**
+   * @return bool|null
+   */
+  public function getSsl(): ?bool {
+    return $this->ssl;
+  }
+
+  /**
+   * @param bool|null $ssl
+   */
+  public function setSsl(?bool $ssl): Url {
+    $this->ssl = $ssl;
+    return $this;
+  }
+
+  /**
+   * @param string $flags
+   *   A series of flag-letters. Any of the following:
+   *   - [a]bsolute
+   *   - [r]elative
+   *   - [h]tml
+   *   - [s]sl
+   * @return $this
+   */
+  public function useFlags(string $flags): Url {
+    $len = strlen($flags);
+    for ($i = 0; $i < $len; $i++) {
+      switch ($flags[$i]) {
+        // (a)bsolute url
+        case 'a':
+          $this->preferFormat = 'absolute';
+          break;
+
+        // (r)elative url
+        case 'r':
+          $this->preferFormat = 'relative';
+          break;
+
+        // (h)tml encoding
+        case 'h':
+          $this->htmlEscape = TRUE;
+          break;
+
+        // (p)lain text encoding
+        case 'p':
+          $this->htmlEscape = FALSE;
+          break;
+
+        // (s)sl
+        case 's';
+          $this->ssl = TRUE;
+          break;
+      }
+    }
+    return $this;
+  }
+
+  /**
+   * Render the final URL as a string.
+   *
+   * @return string
+   */
+  public function __toString(): string {
+    $userSystem = \CRM_Core_Config::singleton()->userSystem;
+    $scheme = $this->getScheme();
+    $preferFormat = $this->getPreferFormat();
+
+    // Translate subjective values to real values.
+    switch ($scheme) {
+      case 'current':
+        $preferFormat = $preferFormat ?: 'relative';
+        $scheme = $userSystem->isFrontEndPage() ? 'frontend' : 'backend';
+        // The current call could actually be a 'service' request, but we treat those as equivalent to 'frontend', so maybe it doesn't matter.
+        break;
+
+      case 'default':
+        // $preferFormat = $preferFormat ?: 'absolute';
+        // TODO pick $scheme = 'frontend' or 'backend' or 'service';
+        throw new \RuntimeException("FIXME: Implement lookup for default ");
+
+      default:
+        $preferFormat = $preferFormat ?: 'absolute';
+    }
+
+    switch ($scheme) {
+      case 'frontend':
+      case 'service':
+        $result = $userSystem->url($this->getPath(), $this->getQuery(), $preferFormat === 'absolute', $this->getFragment(), TRUE, FALSE, FALSE);
+        break;
+
+      case 'backend':
+        $result = $userSystem->url($this->getPath(), $this->getQuery(), $preferFormat === 'absolute', $this->getFragment(), FALSE, TRUE, FALSE);
+        break;
+
+      case 'assetBuilder':
+        $assetName = $this->getPath();
+        $assetParams = [];
+        parse_str('' . $this->getQuery(), $assetParams);
+        $result = \Civi::service('asset_builder')->getUrl($assetName, $assetParams);
+        break;
+
+      case 'ext':
+        $parts = explode('/', $this->getPath(), 2);
+        $result = \Civi::resources()->getUrl($parts[0], $parts[1] ?? NULL, FALSE);
+        if ($this->query) {
+          $result .= '?' . $this->query;
+        }
+        if ($this->fragment) {
+          $result .= '#' . $this->fragment;
+        }
+        break;
+
+      default:
+        throw new \RuntimeException("Unknown URL scheme: {$this->getScheme()}");
+    }
+
+    // TODO decide if the current default is good enough for future
+    $ssl = $this->getSsl() ?: \CRM_Utils_System::isSSL();
+    if ($ssl && str_starts_with($result, 'http:')) {
+      $result = 'https:' . substr($result, 5);
+    }
+    elseif (!$ssl && str_starts_with($result, 'https:')) {
+      $result = 'http:' . substr($result, 6);
+    }
+
+    return $this->htmlEscape ? htmlentities($result) : $result;
+  }
+
+}

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -426,7 +426,7 @@ final class Url implements \JsonSerializable {
    * @return $this
    */
   public function addVars(array $vars): Url {
-    $this->vars = array_merge($this->vars ?: [], $vars);
+    $this->vars = $vars + ($this->vars ?: []);
     return $this;
   }
 

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -65,6 +65,13 @@ final class Url {
   private $ssl = NULL;
 
   /**
+   * List of values to mix-in to the final/rendered URL.
+   *
+   * @var string[]|null
+   */
+  private $vars;
+
+  /**
    * @param string $logicalUri
    * @param string|null $flags
    * @see \Civi::url()
@@ -238,6 +245,31 @@ final class Url {
   }
 
   /**
+   * @return string[]|null
+   */
+  public function getVars(): ?array {
+    return $this->vars;
+  }
+
+  /**
+   * @param string[]|null $vars
+   */
+  public function setVars(?array $vars): Url {
+    $this->vars = $vars;
+    return $this;
+  }
+
+  /**
+   * @param string[] $vars
+   *
+   * @return $this
+   */
+  public function addVars(array $vars): Url {
+    $this->vars = array_merge($this->vars ?: [], $vars);
+    return $this;
+  }
+
+  /**
    * @param string $flags
    *   A series of flag-letters. Any of the following:
    *   - [a]bsolute
@@ -337,6 +369,14 @@ final class Url {
     }
     elseif (!$ssl && str_starts_with($result, 'https:')) {
       $result = 'http:' . substr($result, 6);
+    }
+
+    if ($this->vars !== NULL) {
+      // Replace variables
+      $result = preg_replace_callback('/\[(\w+)\]/', function($m) {
+        $var = $m[1];
+        return isset($this->vars[$var]) ? urlencode($this->vars[$var]) : "[$var]";
+      }, $result);
     }
 
     return $this->htmlEscape ? htmlentities($result) : $result;

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -330,8 +330,8 @@ final class Url {
           $this->htmlEscape = TRUE;
           break;
 
-        // (p)lain text encoding
-        case 'p':
+        // (t)ext encoding (canonical URL form)
+        case 't':
           $this->htmlEscape = FALSE;
           break;
 

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -33,7 +33,7 @@ namespace Civi\Core;
  * This cl
  * @see \Civi::url()
  */
-final class Url {
+final class Url implements \JsonSerializable {
 
   /**
    * @var string
@@ -558,6 +558,11 @@ final class Url {
     }
 
     return $this->htmlEscape ? htmlentities($result) : $result;
+  }
+
+  #[\ReturnTypeWillChange]
+  public function jsonSerialize() {
+    return $this->__toString();
   }
 
   private function composeSuffix(): string {

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -520,8 +520,7 @@ final class Url implements \JsonSerializable {
     }
 
     if ($scheme === 'default') {
-      // TODO Use metadata to pick $scheme = 'frontend' or 'backend' or 'service';
-      throw new \RuntimeException("FIXME: Implement lookup for default ");
+      $scheme = \CRM_Core_Menu::isPublicRoute($this->getPath()) ? 'frontend' : 'backend';
     }
 
     switch ($scheme) {

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -40,6 +40,14 @@ final class Url {
   private $fragment;
 
   /**
+   * Whether to auto-append the cache-busting resource code.
+   *
+   * @var bool|null
+   *    NULL definition TBD (either "off" or "automatic"?)
+   */
+  private $cacheCode;
+
+  /**
    * Preferred format.
    *
    * Note that this is not strictly guaranteed. It may sometimes return absolute URLs even if you
@@ -204,6 +212,26 @@ final class Url {
   }
 
   /**
+   * @return bool|null
+   */
+  public function getCacheCode(): ?bool {
+    return $this->cacheCode;
+  }
+
+  /**
+   * Specify whether to append a cache-busting code.
+   *
+   * @param bool|null $cacheCode
+   *   TRUE: Do append
+   *   FALSE: Do not append
+   * @return $this;
+   */
+  public function setCacheCode(?bool $cacheCode) {
+    $this->cacheCode = $cacheCode;
+    return $this;
+  }
+
+  /**
    * @return string|null
    *   'relative' or 'absolute'
    */
@@ -339,6 +367,11 @@ final class Url {
         case 's';
           $this->ssl = TRUE;
           break;
+
+        // (c)ache code for resources
+        case 'c':
+          $this->cacheCode = TRUE;
+          break;
       }
     }
     return $this;
@@ -393,6 +426,10 @@ final class Url {
 
       default:
         throw new \RuntimeException("Unknown URL scheme: {$this->getScheme()}");
+    }
+
+    if ($this->cacheCode) {
+      $result = \Civi::resources()->addCacheCode($result);
     }
 
     // TODO decide if the current default is good enough for future

--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -8,6 +8,11 @@ namespace Civi\Core;
  * As input, this class takes a *logical URI*, which may include a range of configurable sub-parts (path, query, fragment, etc).
  *
  * As output, it provides a *concrete URL* that can be used by a web-browser to make requests.
+ *
+ * The typical way to construct a URL object is through `Civi::url()`, which features more
+ * documentation and examples.
+ *
+ * @see \Civi::url()
  */
 final class Url {
 
@@ -207,7 +212,13 @@ final class Url {
   }
 
   /**
+   * Specify whether to prefer absolute or relative formatting.
+   *
    * @param string|null $preferFormat
+   *   One of:
+   *   - 'relative': Prefer relative format, if available
+   *   - 'absolute': Prefer absolute format
+   *   - NULL: Decide format based on current environment/request. (Ordinary web UI requests prefer 'relative'.)
    */
   public function setPreferFormat(?string $preferFormat): Url {
     $this->preferFormat = $preferFormat;
@@ -222,7 +233,10 @@ final class Url {
   }
 
   /**
+   * Specify whether to enable HTML escaping of the final output.
+   *
    * @param bool $htmlEscape
+   * @return $this
    */
   public function setHtmlEscape(bool $htmlEscape): Url {
     $this->htmlEscape = $htmlEscape;
@@ -237,7 +251,12 @@ final class Url {
   }
 
   /**
+   * Specify whether the hyperlink should use SSL.
+   *
    * @param bool|null $ssl
+   *   TRUE: Force SSL on. (Convert "http:" to "https:")
+   *   FALSE: Force SSL off. (Convert "https:" to "http:")
+   *   NULL: Inherit current SSL-ness
    */
   public function setSsl(?bool $ssl): Url {
     $this->ssl = $ssl;
@@ -252,7 +271,15 @@ final class Url {
   }
 
   /**
+   * Specify a list of variables. After composing all parts of the URL, variables will be replaced
+   * with their URL-encoded values.
+   *
+   * Example:
+   *   Civi::url('frontend://civicrm/greeter?cid=[contact]&msg=[message]')
+   *     ->setVars(['contact' => 123, 'message' => 'Hello to you & you & you!');
+   *
    * @param string[]|null $vars
+   * @return $this
    */
   public function setVars(?array $vars): Url {
     $this->vars = $vars;
@@ -260,8 +287,14 @@ final class Url {
   }
 
   /**
-   * @param string[] $vars
+   * Add more variables. After composing all parts of the URL, variables will be replaced
+   * with their URL-encoded values.
    *
+   * Example:
+   *   Civi::url('frontend://civicrm/greeter?cid=[contact]&msg=[message]')
+   *     ->addVars(['contact' => 123, 'message' => 'Hello to you & you & you!');
+   *
+   * @param string[] $vars
    * @return $this
    */
   public function addVars(array $vars): Url {
@@ -270,12 +303,12 @@ final class Url {
   }
 
   /**
+   * Apply a series of flags using short-hand notation.
+   *
    * @param string $flags
-   *   A series of flag-letters. Any of the following:
-   *   - [a]bsolute
-   *   - [r]elative
-   *   - [h]tml
-   *   - [s]sl
+   *   List of flag-letters, such as (a)bsolute or (r)elative
+   *   For a full list, see Civi::url().
+   * @see Civi::url()
    * @return $this
    */
   public function useFlags(string $flags): Url {

--- a/tests/phpunit/CRM/Core/MenuTest.php
+++ b/tests/phpunit/CRM/Core/MenuTest.php
@@ -135,4 +135,9 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
     $this->assertEquals($expectedArray, $actual);
   }
 
+  public function testIsPublicRoute(): void {
+    $this->assertEquals(FALSE, \CRM_Core_Menu::isPublicRoute('civicrm/contribute'));
+    $this->assertEquals(TRUE, \CRM_Core_Menu::isPublicRoute('civicrm/contribute/transact'));
+  }
+
 }

--- a/tests/phpunit/CRM/Core/Smarty/plugins/UrlTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/UrlTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Class CRM_Core_Smarty_plugins_UrlTest
+ * @group headless
+ */
+class CRM_Core_Smarty_plugins_UrlTest extends CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    require_once 'CRM/Core/Smarty.php';
+
+    // Templates should normally be file names, but for unit-testing it's handy to use "string:" notation
+    require_once 'CRM/Core/Smarty/resources/String.php';
+    civicrm_smarty_register_string_resource();
+
+    $this->useTransaction();
+  }
+
+  /**
+   * @return array
+   */
+  public function urlCases() {
+    $literal = function(string $s) {
+      return '!' . preg_quote($s, '!') . '!';
+    };
+
+    $cases = [];
+    $cases[] = [
+      // Generate an ordinary, HTML-style URL.
+      $literal('q=civicrm/profile/view&amp;id=123&amp;gid=456'),
+      '{url}//civicrm/profile/view?id=123&gid=456{/url}',
+    ];
+    $cases[] = [
+      // Here, we assign the plain-text variable and then use it for JS expression
+      '!window.location = ".*q=civicrm/profile/view&id=123&gid=456"!',
+      '{url assign=myUrl flags=t}//civicrm/profile/view?id=123&gid=456{/url}' .
+      'window.location = "{$myUrl}";',
+    ];
+    $cases[] = [
+      $literal('q=civicrm/profile/view&amp;id=999&amp;message=hello+world'),
+      '{url 1="999" 2="hello world"}//civicrm/profile/view?id=[1]&message=[2]{/url}',
+    ];
+    $cases[] = [
+      $literal('q=civicrm/profile/view&amp;id=123&amp;message=hello+world'),
+      '{url msg="hello world"}//civicrm/profile/view?id=123&message=[msg]{/url}',
+    ];
+    $cases[] = [
+      // Define a temporary variable for use in the URL.
+      $literal('q=civicrm/profile/view&amp;id=123&amp;message=this+%26+that'),
+      '{url msg="this & that"}//civicrm/profile/view?id=123&message=[msg]{/url}',
+    ];
+    $cases[] = [
+      // We have a Smarty variable which already included escaped data. Smarty should do substitution.
+      $literal('q=civicrm/profile/view&amp;id=123&amp;message=this+%2B+that'),
+      '{assign var=msg value="this+%2B+that"}' .
+      '{url flags=%}//civicrm/profile/view?id=123&message={$msg}{/url}',
+    ];
+    $cases[] = [
+      // Generate client-side route (with Angular path and params)
+      $literal('q=civicrm/a/#/mailing/100?angularDebug=1'),
+      '{url id=100}backend://civicrm/a/#/mailing/[id]?angularDebug=1{/url}',
+    ];
+
+    // This example is neat - you just replace `{$msg}` with `[msg]`, and then you get encoded URL data.
+    // But... it's pretty shallow. You can't use Smarty expressions or modifiers. Additionally,
+    // enabling this mode increases the risk of accidental collisions between Smarty variables
+    // and deep-form-params. So I've left it disabled for now.
+    //
+    // $cases[] = [
+    //   // We have a Smarty variable with canonical (unescaped) data. Use it as URL variable.
+    //   $literal('q=civicrm/profile/view&amp;id=123&amp;message=this+%2B+that'),
+    //   '{assign var=msg value="this + that"}' .
+    //   '{url}//civicrm/profile/view?id=123&message=[msg]{/url}',
+    // ];
+
+    // return CRM_Utils_Array::subset($cases, [2]);
+    return $cases;
+  }
+
+  /**
+   * @dataProvider urlCases
+   * @param string $expected
+   * @param string $input
+   */
+  public function testUrl($expected, $input) {
+    $smarty = CRM_Core_Smarty::singleton();
+    $actual = $smarty->fetch('string:' . $input);
+    $this->assertRegExp($expected, $actual, "Process input=[$input]");
+  }
+
+}

--- a/tests/phpunit/Civi/Core/UrlTest.php
+++ b/tests/phpunit/Civi/Core/UrlTest.php
@@ -127,4 +127,26 @@ class UrlTest extends \CiviUnitTestCase {
     }
   }
 
+  public function testVars(): void {
+    $vars = ['hi' => 'hello world?', 'contact' => 123];
+
+    $examples = [];
+    $examples[] = ['civicrm/admin/hello+world%3F', Civi::url('backend://civicrm/admin/[hi]?x=1')];
+    $examples[] = ['msg=hello+world%3F&id=123', Civi::url('backend://civicrm/admin?msg=[hi]&id=[contact]')];
+    $examples[] = ['a=123&b=456', Civi::url('backend://civicrm/admin?a=[1]&b=[2]')->addVars([1 => 123, 2 => 456])];
+    $examples[] = ['#/page?msg=hello+world%3F', Civi::url('backend://civicrm/a/#/page?msg=[hi]')];
+    $examples[] = ['a=hello+world%3F&b=Au+re%2Fvoir', Civi::url('frontend://civicrm/user?a=[hi]&b=[bye]')->addVars(['bye' => 'Au re/voir'])];
+    $examples[] = ['some_xyz=123', Civi::url('//civicrm/foo?some_[key]=123')->addVars(['key' => 'xyz'])];
+
+    // Unrecognized []'s are preserved as literals, which allows interop with deep form fields
+    $examples[] = ['some[key]=123', Civi::url('//civicrm/foo?some[key]=123')];
+
+    foreach ($examples as $key => $example) {
+      /** @var \Civi\Core\Url $url */
+      [$expected, $url] = $example;
+      $url->addVars($vars);
+      $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+    }
+  }
+
 }

--- a/tests/phpunit/Civi/Core/UrlTest.php
+++ b/tests/phpunit/Civi/Core/UrlTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Civi\Core;
+
+use Civi;
+
+/**
+ * Test generation of URLs via `Civi::url()` (`Civi\Core\Url`).
+ *
+ * This class is focused on portable aspects of the functionality.
+ * There is also some coverage of the UF-specific parts in the E2E suite.
+ *
+ * @see \E2E\Core\PathUrlTest
+ * @group headless
+ */
+class UrlTest extends \CiviUnitTestCase {
+
+  public function setUp(): void {
+    $parts = explode('/', CIVICRM_UF_BASEURL);
+    $this->assertRegexp(';^[a-z0-9\.\-]+(:\d+)?$;', $parts[2], 'CIVICRM_UF_BASEURL should have domain name and/or port');
+    $tmpVars['_SERVER']['HTTP_HOST'] = $parts[2];
+    \CRM_Utils_GlobalStack::singleton()->push($tmpVars);
+
+    parent::setUp();
+    $this->useTransaction();
+  }
+
+  protected function tearDown(): void {
+    parent::tearDown();
+    \CRM_Utils_GlobalStack::singleton()->pop();
+  }
+
+  public function testAbsoluteRelative() {
+    $absolutes = [];
+    $absolutes['flag'] = Civi::url('backend://civicrm/admin', 'a');
+    $absolutes['method'] = Civi::url('backend://civicrm/admin')->setPreferFormat('absolute');
+
+    $relatives = [];
+    $relatives['default'] = Civi::url('backend://civicrm/admin');
+    $relatives['flag'] = Civi::url('backend://civicrm/admin', 'r');
+    $relatives['method'] = Civi::url('backend://civicrm/admin')->setPreferFormat('relative');
+
+    foreach ($absolutes as $key => $url) {
+      $this->assertRegExp(';^https?://;', (string) $url, "absolutes[$key] should be absolute URL");
+    }
+    foreach ($relatives as $key => $url) {
+      $this->assertNotRegExp(';^https?://;', (string) $url, "relatives[$key] should be relative URL");
+    }
+  }
+
+  public function testPath() {
+    $examples = [];
+    $examples[] = ['civicrm/ajax/api4', Civi::url('service://civicrm/ajax/api4')];
+    $examples[] = ['civicrm/ajax/api4/Contact/get', Civi::url('service://civicrm/ajax/api4')->addPath('Contact/get')];
+    $examples[] = ['civicrm/ajax/api4/Contact/get', Civi::url('service://civicrm/ajax/api4')->addPath('Contact')->addPath('get')];
+    $examples[] = ['civicrm/new-path', Civi::url('service://civicrm/old-path')->setPath('civicrm/new-path')];
+
+    foreach ($examples as $key => $example) {
+      /** @var \Civi\Core\Url $url */
+      [$expected, $url] = $example;
+      $this->assertEquals($expected, $url->getPath());
+      $this->assertStringContainsString($expected, (string) $url);
+    }
+  }
+
+  public function testQuery() {
+    $examples = [];
+    $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view?reset=1&id=9')];
+    $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view')->addQuery('reset=1&id=9')];
+    $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view')->addQuery(['reset' => 1, 'id' => 9])];
+    $examples[] = ['noise=Hello+world%3F', Civi::url('frontend://civicrm/profile/view?noise=Hello+world%3F')];
+    $examples[] = ['noise=Hello+world%3F', Civi::url('frontend://civicrm/profile/view')->addQuery(['noise' => 'Hello world?'])];
+    $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view?forget=this')->setQuery('reset=1&id=9')];
+    $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view?forget=this')->setQuery('reset=1')->addQuery('id=9')];
+
+    foreach ($examples as $key => $example) {
+      /** @var \Civi\Core\Url $url */
+      [$expected, $url] = $example;
+      $this->assertEquals($expected, $url->getQuery());
+      $this->assertStringContainsString($expected, (string) $url);
+    }
+  }
+
+}

--- a/tests/phpunit/Civi/Core/UrlTest.php
+++ b/tests/phpunit/Civi/Core/UrlTest.php
@@ -153,4 +153,36 @@ class UrlTest extends \CiviUnitTestCase {
     }
   }
 
+  public function testFunkyStartPoints(): void {
+    $baseline = (string) \Civi::url('frontend://civicrm/event/info?id=1');
+    $this->assertStringContainsString('event/info', $baseline);
+
+    $alternatives = [
+      // Start with nothing!
+      \Civi::url()
+        ->setScheme('frontend')
+        ->setPath(['civicrm', 'event', 'info'])
+        ->addQuery(['id' => 1]),
+
+      // Start with nothing! And build it backwards!
+      \Civi::url()
+        ->addQuery(['id' => 1])
+        ->addPath('civicrm')->addPath('event')->addPath('info')
+        ->setScheme('frontend'),
+
+      // Start with just the scheme
+      \Civi::url('frontend:')
+        ->addPath('civicrm/event/info')
+        ->addQuery('id=1'),
+
+      // Start with just the path
+      \Civi::url('civicrm/event/info')
+        ->setScheme('frontend')
+        ->addQuery(['id' => 1]),
+    ];
+    foreach ($alternatives as $key => $alternative) {
+      $this->assertEquals($baseline, (string) $alternative, "Alternative #$key should match baseline");
+    }
+  }
+
 }

--- a/tests/phpunit/Civi/Core/UrlTest.php
+++ b/tests/phpunit/Civi/Core/UrlTest.php
@@ -51,15 +51,17 @@ class UrlTest extends \CiviUnitTestCase {
   public function testPath() {
     $examples = [];
     $examples[] = ['civicrm/ajax/api4', Civi::url('service://civicrm/ajax/api4')];
-    $examples[] = ['civicrm/ajax/api4/Contact/get', Civi::url('service://civicrm/ajax/api4')->addPath('Contact/get')];
-    $examples[] = ['civicrm/ajax/api4/Contact/get', Civi::url('service://civicrm/ajax/api4')->addPath('Contact')->addPath('get')];
+    $examples[] = ['civicrm/ajax/api4/Contact/get+stuff', Civi::url('service://civicrm/ajax/api4/Contact/get+stuff')];
+    $examples[] = ['civicrm/ajax/api4/Contact/get+stuff', Civi::url('service://civicrm/ajax/api4')->addPath(['Contact', 'get stuff'])];
+    $examples[] = ['civicrm/ajax/api4/Contact/get+stuff', Civi::url('service://civicrm/ajax/api4/Contact')->addPath('get+stuff')];
+    $examples[] = ['civicrm/ajax/api4/Contact/get+stuff', Civi::url('service://civicrm/ajax/api4/Contact')->addPath(['get stuff'])];
     $examples[] = ['civicrm/new-path', Civi::url('service://civicrm/old-path')->setPath('civicrm/new-path')];
 
     foreach ($examples as $key => $example) {
       /** @var \Civi\Core\Url $url */
       [$expected, $url] = $example;
-      $this->assertEquals($expected, $url->getPath());
-      $this->assertStringContainsString($expected, (string) $url);
+      $this->assertEquals($expected, $url->getPath(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
+      $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
     }
   }
 
@@ -69,15 +71,59 @@ class UrlTest extends \CiviUnitTestCase {
     $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view')->addQuery('reset=1&id=9')];
     $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view')->addQuery(['reset' => 1, 'id' => 9])];
     $examples[] = ['noise=Hello+world%3F', Civi::url('frontend://civicrm/profile/view?noise=Hello+world%3F')];
+    $examples[] = ['noise=Hello+world%3F', Civi::url('frontend://civicrm/profile/view')->addQuery('noise=Hello+world%3F')];
     $examples[] = ['noise=Hello+world%3F', Civi::url('frontend://civicrm/profile/view')->addQuery(['noise' => 'Hello world?'])];
     $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view?forget=this')->setQuery('reset=1&id=9')];
+    $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view?forget=this')->setQuery(['reset' => 1, 'id' => 9])];
     $examples[] = ['reset=1&id=9', Civi::url('frontend://civicrm/profile/view?forget=this')->setQuery('reset=1')->addQuery('id=9')];
 
     foreach ($examples as $key => $example) {
       /** @var \Civi\Core\Url $url */
       [$expected, $url] = $example;
-      $this->assertEquals($expected, $url->getQuery());
-      $this->assertStringContainsString($expected, (string) $url);
+      $this->assertEquals($expected, $url->getQuery(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
+      $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+    }
+  }
+
+  public function testFragment() {
+    $examples = [];
+    $examples[] = ['/mailing/new', Civi::url('frontend://civicrm/a/#/mailing/new')];
+    $examples[] = ['/mailing/new', Civi::url('frontend://civicrm/a/#/')->addFragment('mailing/new')];
+    $examples[] = ['/mailing/new', Civi::url('frontend://civicrm/a/#/')->addFragment('/mailing/new')];
+    $examples[] = ['/mailing/new', Civi::url('frontend://civicrm/a/#/')->addFragment(['mailing', 'new'])];
+    $examples[] = [NULL, Civi::url('frontend://civicrm/a/#/mailing/new')->setFragment(NULL)];
+    $examples[] = ['/mailing/new+stuff', Civi::url('frontend://civicrm/a/#/mailing/new+stuff?extra=1')];
+    $examples[] = ['/mailing/new+stuff', Civi::url('frontend://civicrm/a/#/mailing?extra=1')->addFragment('new+stuff')];
+    $examples[] = ['/mailing/new+stuff', Civi::url('frontend://civicrm/a/#/mailing?extra=1')->addFragment(['new stuff'])];
+    $examples[] = ['/mailing/new+stuff', Civi::url('frontend://civicrm/a/#/ignore?extra=1')->setFragment('/mailing/new+stuff')];
+    $examples[] = ['/mailing/new+stuff', Civi::url('frontend://civicrm/a/#/ignore?extra=1')->setFragment(['', 'mailing', 'new stuff'])];
+
+    foreach ($examples as $key => $example) {
+      /** @var \Civi\Core\Url $url */
+      [$expected, $url] = $example;
+      $this->assertEquals($expected, $url->getFragment(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
+      if ($expected !== NULL) {
+        $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+      }
+    }
+  }
+
+  public function testFragmentQuery() {
+    $examples = [];
+    $examples[] = ['angularDebug=1&extra=hello+world%3F', Civi::url('frontend://civicrm/a/#/mailing/new?angularDebug=1&extra=hello+world%3F')];
+    $examples[] = ['angularDebug=1&extra=hello+world%3F', Civi::url('frontend://civicrm/a/#/mailing/new?angularDebug=1')->addFragmentQuery('extra=hello+world%3F')];
+    $examples[] = ['angularDebug=1&extra=hello+world%3F', Civi::url('frontend://civicrm/a/#/mailing/new')->addFragmentQuery('angularDebug=1&extra=hello+world%3F')];
+    $examples[] = ['angularDebug=1&extra=hello+world%3F', Civi::url('frontend://civicrm/a/#/mailing/new')->addFragmentQuery(['angularDebug' => 1, 'extra' => 'hello world?'])];
+    $examples[] = ['angularDebug=1&extra=hello+world%3F', Civi::url('frontend://civicrm/a/#/mailing/new')->setFragmentQuery('angularDebug=1&extra=hello+world%3F')];
+    $examples[] = ['angularDebug=1&extra=hello+world%3F', Civi::url('frontend://civicrm/a/#/mailing/new')->setFragmentQuery(['angularDebug' => 1, 'extra' => 'hello world?'])];
+
+    foreach ($examples as $key => $example) {
+      /** @var \Civi\Core\Url $url */
+      [$expected, $url] = $example;
+      $this->assertEquals($expected, $url->getFragmentQuery(), sprintf("%s at %d should be have matching property", __FUNCTION__, $key));
+      if ($expected !== NULL) {
+        $this->assertStringContainsString($expected, (string) $url, sprintf("%s at %d should be have matching output", __FUNCTION__, $key));
+      }
     }
   }
 

--- a/tests/phpunit/Civi/Core/UrlTest.php
+++ b/tests/phpunit/Civi/Core/UrlTest.php
@@ -34,11 +34,15 @@ class UrlTest extends \CiviUnitTestCase {
     $absolutes = [];
     $absolutes['flag'] = Civi::url('backend://civicrm/admin', 'a');
     $absolutes['method'] = Civi::url('backend://civicrm/admin')->setPreferFormat('absolute');
+    $absolutes['ext'] = Civi::url('ext://org.civicrm.search_kit/js/foobar.js', 'a');
+    $absolutes['asset'] = Civi::url('asset://[civicrm.packages]/js/foobar.js', 'a');
 
     $relatives = [];
     $relatives['default'] = Civi::url('backend://civicrm/admin');
     $relatives['flag'] = Civi::url('backend://civicrm/admin', 'r');
     $relatives['method'] = Civi::url('backend://civicrm/admin')->setPreferFormat('relative');
+    $relatives['ext'] = Civi::url('ext://org.civicrm.search_kit/js/foobar.js', 'r');
+    $relatives['asset'] = Civi::url('asset://[civicrm.packages]/js/foobar.js', 'r');
 
     foreach ($absolutes as $key => $url) {
       $this->assertRegExp(';^https?://;', (string) $url, "absolutes[$key] should be absolute URL");

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -139,6 +139,16 @@ class PathUrlTest extends \CiviEndToEndTestCase {
     // For purposes of this test, it doesn't matter if "current" is frontend or backend - as long as it's consistent.
   }
 
+  public function testUrl_DefaultUI(): void {
+    $adminDefault = (string) \Civi::url('default://civicrm/admin');
+    $adminBackend = (string) \Civi::url('backend://civicrm/admin');
+    $this->assertEquals($adminBackend, $adminDefault, "civicrm/admin should default to backend");
+
+    $userDefault = (string) \Civi::url('default://civicrm/user');
+    $userBackend = (string) \Civi::url('frontend://civicrm/user');
+    $this->assertEquals($userBackend, $userDefault, "civicrm/user should default to frontend");
+  }
+
   /**
    * @param string $expectContentRegex
    * @param string $url

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -107,6 +107,10 @@ class PathUrlTest extends \CiviEndToEndTestCase {
 
     $urlPats[] = [';^https?://.*civicrm;', \Civi::url('frontend://civicrm/event/info?reset=1', 'a')];
     $urlPats[] = [';^https://.*civicrm;', \Civi::url('frontend://civicrm/event/info?reset=1', 'as')];
+    $urlPats[] = [';civicrm(/|%2F)a(/|%2F).*#/mailing/new\?angularDebug=1;', \Civi::url('backend://civicrm/a/#/mailing/new?angularDebug=1')];
+    $urlPats[] = [';/jquery.timeentry.js\?r=.*#foo;', \Civi::url('asset://[civicrm.packages]/jquery/plugins/jquery.timeentry.js', 'c')->addFragment('foo')];
+    $urlPats[] = [';/stuff.js\?r=.*#foo;', \Civi::url('ext://org.civicrm.search_kit/stuff.js', 'c')->addFragment('foo')];
+    $urlPats[] = [';#foo;', \Civi::url('assetBuilder://crm-l10n.js?locale=en_US')->addFragment('foo')];
 
     // Some test-harnesses have HTTP_HOST. Some don't. It's pre-req for truly relative URLs.
     if (!empty($_SERVER['HTTP_HOST'])) {


### PR DESCRIPTION
Overview
----------------------------------------

This is a concrete demonstration of some ideas from https://lab.civicrm.org/dev/core/-/issues/4433.

Before
----------------------------------------

This function exists:

```php
CRM_Utils_System::url(NULL, NULL, FALSE, 1, '', TRUE, __CLASS__, NULL, TRUE);
```

And that does... something. Have fun figuring it out...

After
----------------------------------------

```php
echo Civi::url('frontend://civicrm/event/info?id=123&reset=1');

echo Civi::url('//civicrm/profile/view?reset=1')
  ->addQuery(['gid' => $x, 'id' => $y])

echo Civi::url('assetBuilder://crm-l10n.js')
  ->addQuery(['locale' => $x])
```

(*Docblock has more examples...*)

Technical Details
----------------------------------------

In this rendition:

* The entry-point (frontend/backend/etc) is a URI scheme (`frontend://`).
* It respects URI convention for inheriting current scheme (`//foo.txt` means "get `foo.txt` with current scheme)
* The list of URI schemes is borrowed from other places in core -- e.g. the Guzzle-test system has `frontend://ROUTE` and `backend://ROUTE`. Some of the asset/resource management supports `assetBuilder://NAME` and `ext://EXT/FILE`.
