### PR TITLE
Fix js error on CiviImport when csv has additional fields

### DIFF
--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -79,8 +79,12 @@
               }
               var fieldDefault = null;
 
-              if (Boolean(importMappings)) {
+              if (Boolean(importMappings) && importMappings.hasOwnProperty(index)) {
                 // If this form has already been used for the job, load from what it saved.
+                // Note we also checked the importMapping was defined. This would be FALSE
+                // if a csv is being imported with more fields than the are in the original
+                // mapping. We check for that so it will skip gracefully.
+                // (The user will see a warning.)
                 fieldName = importMappings[index].name;
                 fieldDefault = importMappings[index].default_value;
               }


### PR DESCRIPTION
Overview
----------------------------------------
Fix js error on CiviImport when csv has additional fields

Before
----------------------------------------
1) enable civi-import
2) import a csv file with a csv file such as  tests/phpunit/CRM/Contribute/Import/Parser/data/contributions.csv
![image](https://github.com/civicrm/civicrm-core/assets/336308/c0eb3dcc-b538-4f3e-a434-29aa6259b0f0)

3) be sure to save the import as a template
![image](https://github.com/civicrm/civicrm-core/assets/336308/12d3fe20-4157-4d56-9aea-7ea4e999bae3)
4) edit the csv to have one MORE column
5) attempt to import it using the template - the url can be found here
![image](https://github.com/civicrm/civicrm-core/assets/336308/1a2fdc43-0963-469a-8f08-dd9aa1ba320c)
6) on the mapping screen a js error will break the screen

![image](https://github.com/civicrm/civicrm-core/assets/336308/48e1dce9-4082-4734-8bbd-0d1dd1871b0c)


After
----------------------------------------
The page loads, with a warning

![image](https://github.com/civicrm/civicrm-core/assets/336308/cf49ab8e-0d0a-4d6a-b52e-157f2107056f)


Technical Details
----------------------------------------

Comments
----------------------------------------

