### PR TITLE
[REF] Ensure that url that is stored as context is generated correctl…

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -94,7 +94,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
    */
   public function preProcess() {
     parent::preProcess();
-    CRM_Core_Session::singleton()->pushUserContext('civicrm/admin/paymentProcessor?reset=1');
+    CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/admin/paymentProcessor', ['reset' => 1], FALSE, NULL, FALSE));
 
     $this->setPaymentProcessorTypeID();
     $this->setPaymentProcessor();


### PR DESCRIPTION
…y for backend usage in wordpress

Overview
----------------------------------------
On a client site I found that I was being redirected to a front end style url wp-admin/civicrm/admin/ which didn't work but running this through url() fixed the problem

Before
----------------------------------------
url not correctly formatted when pushed into pushScope

After
----------------------------------------
Wrap the url in a call to url() function to ensure backend url is correctly formatted

ping @kcristiano @eileenmcnaughton 