### PR TITLE
ScheduledJob - Clean up form code & improve validation

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -19,7 +19,6 @@
  * Class for configuring jobs.
  */
 class CRM_Admin_Form_Job extends CRM_Admin_Form {
-  public $_id = NULL;
 
   /**
    * @var bool
@@ -146,23 +145,20 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
    * @throws CRM_Core_Exception
    */
   public static function formRule($fields) {
-
     $errors = [];
 
-    require_once 'api/api.php';
-
-    /** @var \Civi\API\Kernel $apiKernel */
-    $apiKernel = \Civi::service('civi_api_kernel');
-    $apiRequest = \Civi\API\Request::create($fields['api_entity'], $fields['api_action'], ['version' => 3]);
     try {
+      $apiParams = CRM_Core_BAO_Job::parseParameters($fields['parameters']);
+      /** @var \Civi\API\Kernel $apiKernel */
+      $apiKernel = \Civi::service('civi_api_kernel');
+      $apiRequest = \Civi\API\Request::create($fields['api_entity'], $fields['api_action'], $apiParams);
       $apiKernel->resolve($apiRequest);
     }
     catch (\Civi\API\Exception\NotImplementedException $e) {
       $errors['api_action'] = ts('Given API command is not defined.');
     }
-
-    if (!empty($errors)) {
-      return $errors;
+    catch (CRM_Core_Exception $e) {
+      $errors['parameters'] = ts('Parameters must be formatted as key=value on separate lines');
     }
 
     return empty($errors) ? TRUE : $errors;
@@ -249,7 +245,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
     $dao->api_entity = $values['api_entity'];
     $dao->api_action = $values['api_action'];
     $dao->description = $values['description'];
-    $dao->is_active = CRM_Utils_Array::value('is_active', $values, 0);
+    $dao->is_active = $values['is_active'] ?? 0;
 
     // CRM-17686
     $ts = strtotime($values['scheduled_run_date']);

--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -248,10 +248,6 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       $errors['_qf_default'] = ts('You must have at least the test or live section filled');
     }
 
-    if (!empty($errors)) {
-      return $errors;
-    }
-
     return empty($errors) ? TRUE : $errors;
   }
 

--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -117,4 +117,25 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
     return $copy;
   }
 
+  /**
+   * Parse multi-line `$parameters` string into an array
+   *
+   * @param string|null $parameters
+   * @return array
+   * @throws CRM_Core_Exception
+   */
+  public static function parseParameters(?string $parameters): array {
+    $result = ['version' => 3];
+    $lines = $parameters ? explode("\n", $parameters) : [];
+
+    foreach ($lines as $line) {
+      $pair = explode("=", $line);
+      if ($pair === FALSE || count($pair) !== 2 || !trim($pair[0]) || trim($pair[1]) === '') {
+        throw new CRM_Core_Exception('Malformed API parameters in scheduled job');
+      }
+      $result[trim($pair[0])] = trim($pair[1]);
+    }
+    return $result;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Updates some old form code with better validation of job params.

Before
----------------------------------------
Api entity only validated against APIv3.
No validation of the api params input, even though it's easy to make mistakes since it's nothing but a textarea!

After
----------------------------------------
Api params are validated (at least to ensure the input is parseable)
Api entity is validated against whatever version is given in the params

Technical Details
----------------------------------------
There was no function to parse these params (because, of course there wasn't) so I extracted one from the scheduled job runner for re-use on the form.
While poking around in that `CRM_Core_ScheduledJob` I noticed that it relies heavily on setting undeclared class properties (watch out PHP8!) so added a few and left a TODO comment about the rest.
Removed a very large outdated comment block about APIv2.