### PR TITLE
Mark admin_ui extension as 'beta'

### DIFF
--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -16,7 +16,7 @@
   </urls>
   <releaseDate>2022-01-02</releaseDate>
   <version>5.65.alpha1</version>
-  <develStage>alpha</develStage>
+  <develStage>beta</develStage>
   <compatibility>
     <ver>5.65</ver>
   </compatibility>


### PR DESCRIPTION
Overview
----------------------------------------
Advertises the new AdminUI extension as beta.

Before
----------------------------------------
"alpha"

After
----------------------------------------
"beta"

Comments
---------
I think it's graduated to at least beta by now. Arguably "stable", but definitely no longer alpha.