### PR TITLE
Status check - Use guzzle instead to avoid slowness reading zero-length file

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -414,6 +414,12 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       return FALSE;
     }
 
+    // Since this can be confusing as to how this works:
+    // $url corresponds to $dir not $file, but we're not checking if we can
+    // retrieve $file, we're checking if retrieving $url gives us a LISTING of
+    // the files in $dir. So $content is that listing, and then the stristr
+    // is checking if $file, which is the bare filename (e.g. "delete-this-123")
+    // is contained in that listing (which would be undesirable).
     $content = '';
     try {
       $response = (new \GuzzleHttp\Client())->request('GET', $url, [

--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -414,7 +414,15 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       return FALSE;
     }
 
-    $content = @file_get_contents("$url");
+    $content = '';
+    try {
+      $response = (new \GuzzleHttp\Client())->request('GET', $url, [
+        'timeout' => \Civi::settings()->get('http_timeout'),
+      ]);
+      $content = $response->getBody()->getContents();
+    }
+    catch (\GuzzleHttp\Exception\GuzzleException $e) {
+    }
     if (stristr($content, $file)) {
       $result = TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/26771#issuecomment-1629756698

Before
----------------------------------------
When using the built-in php web server, e.g. `php -S 127.0.0.1:8080`, which is not uncommon when running front-end/E2E tests, `CRM_Utils_Check_Component_Security::isBrowsable()` gets hung up on reading zero-length files until it times out, causing unnecessary slowness, repeated for every test. The above-mentioned PR skips the test on php 7.4, but this happens on e.g. php 8.1 too.

After
----------------------------------------
Slowness gone

Technical Details
----------------------------------------
Something about how the internet works.

Comments
----------------------------------------
* You can see an example of the speedup at these links, if you look at the runtime for "Run phpunit". I had run this earlier too when this first came up and got similar results. This is php 8.1.
  * With the PR: 5 minutes: https://github.com/SemperIT/CiviCARROT/actions/runs/5614218950/job/15211885562#step:22:1
  * Without: 13.7 minutes: https://github.com/SemperIT/CiviCARROT/actions/runs/5614288936/job/15212244665#step:22:1
* If you want to see that the check is still working, you'll need to do the following since to have this check come back positive in real life requires purposely desecuring a couple things:
  * First, comment out [this line](https://github.com/civicrm/civicrm-core/blob/86658d7fd45616fd5e5438da23b96f2f513900b2/CRM/Utils/Check/Component/Security.php#L197), which adds an empty index.html in sites/default/files/civicrm/persist/contribute
  * Then, remove the existing index.html from sites/default/files/civicrm/persist/contribute
  * Then, in sites/default/files, edit .htaccess and add `Options +Indexes` at the top.
  * Also comment out the SetHandler lines.
  * Now if you visit the status check you should see the error.
* An alternative is expand [the restriction recently added](https://github.com/civicrm/civicrm-core/blob/86658d7fd45616fd5e5438da23b96f2f513900b2/CRM/Utils/Check/Component/Security.php#L389) to include all versions of php, since if you're running the built-in server do you care about security? But at the same time, test runs should approximate real situations as much as possible, so I think that function should now be removed, since the reason it was added was to work around this slowness. But that doesn't have to be in this PR, it just means you need to run php 8+ to test this.