### PR TITLE
Link between Label Page Formats and Address Settings

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Address.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Address.tpl
@@ -18,7 +18,10 @@
                 {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp"}
               </div>
                 {$form.mailing_format.html|crmAddClass:huge12}<br />
-                <span class="description">{ts}Content and format for mailing labels.{/ts}</span>
+                <span class="description">{ts}Content and format for mailing labels.{/ts}<br />
+                  {capture assign=labelFormats}href="{crmURL p='civicrm/admin/labelFormats' q='reset=1'}"{/capture}
+                  {ts 1=$labelFormats}You can change the size and layout of labels at <a %1>Label Page Formats</a>.{/ts}
+                </span>
             </td>
         </tr>
          <tr class="crm-preferences-address-form-block-hideCountryMailingLabels">

--- a/templates/CRM/Admin/Page/LabelFormats.tpl
+++ b/templates/CRM/Admin/Page/LabelFormats.tpl
@@ -26,7 +26,9 @@
 *}
 {* this template is for configuring label formats *}
 <div class="help">
-  {ts}You can configure one or more Label Formats for your CiviCRM installation. Label Formats are used when creating mailing labels.{/ts}
+  {ts}You can configure one or more Label Formats for your CiviCRM installation. Label Formats are used when creating mailing labels.{/ts}<br />
+  {capture assign=addressSettings}href="{crmURL p='civicrm/admin/setting/preferences/address' q='reset=1'}"{/capture}
+  {ts 1=$addressSettings}You can change which fields are printed on each label in <a %1>Address Settings</a>.{/ts}
 </div>
 {if $action eq 1 or $action eq 2 or $action eq 8 or $action eq 16384}
   {include file="CRM/Admin/Form/LabelFormats.tpl"}

--- a/templates/CRM/Badge/Form/Layout.hlp
+++ b/templates/CRM/Badge/Form/Layout.hlp
@@ -7,12 +7,10 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{htxt id="id-label_format-text"}
+{htxt id="id-label_format-title"}
   {ts}Label Formats{/ts}
 {/htxt}
 {htxt id="id-label_format"}
-  {capture assign=labelURL}{crmURL p='civicrm/admin/labelFormats' q='reset=1&action=browse'}{/capture}
-  <p>
-    {ts 1=$labelURL}Select a pre-defined name badge label format from the list. Label formats control paper size and page configuration (e.g. 2 labels per row, 4 per column). New label formats may require additional programming to produce expected results for event badges.{/ts}
-  </p>
+  {capture assign=labelURL}href="{crmURL p='civicrm/admin/labelFormats' q='reset=1&action=browse'}"{/capture}
+  {ts 1=$labelURL}Select a pre-defined name badge label format from the list. <a %1>Label formats</a> control paper size and page configuration (e.g. 2 labels per row, 4 per column). New label formats may require additional programming to produce expected results for event badges.{/ts}
 {/htxt}

--- a/templates/CRM/Badge/Form/Layout.tpl
+++ b/templates/CRM/Badge/Form/Layout.tpl
@@ -23,7 +23,7 @@
       </tr>
       <tr class="crm-badge-layout-form-block-label_format_name">
         <td class="label">{$form.label_format_name.label}</td>
-        <td>{$form.label_format_name.html} {help id="id-label_format"}</td>
+        <td>{$form.label_format_name.html} {help id="id-label_format" file="CRM/Badge/Form/Layout.hlp"}</td>
       </tr>
       <tr class="crm-badge-layout-form-block-description">
         <td class="label">{$form.description.label}</td>

--- a/templates/CRM/Contact/Form/Task/Label.hlp
+++ b/templates/CRM/Contact/Form/Task/Label.hlp
@@ -29,6 +29,6 @@
 {/htxt}
 {htxt id="id-select-label"}
   <p>{ts}Select a label format from the dropdown list.{/ts}</p>
-  {capture assign="mailingLabelURL"}{crmURL p="civicrm/admin/labelFormats" q="reset=1"}{/capture}
-  <p>{ts 1=$mailingLabelURL}Go to <strong><a href="%1">Administer CiviCRM &raquo; Communications &raquo; Label Formats</a></strong> to add or edit labels or set the default label format.{/ts}</p>
+  {capture assign="mailingLabelURL"}href="{crmURL p='civicrm/admin/labelFormats' q='reset=1'}"{/capture}
+  <p>{ts 1=$mailingLabelURL}Go to <strong><a %1>Administer CiviCRM &raquo; Communications &raquo; Label Page Formats</a></strong> to add or edit labels or set the default label format.{/ts}</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
Follow up on #26865, adding links between Label Page Formats and Address Settings per @demeritcowboy's suggestion. Also some minor help file cleanup otherwise.

Before
----------------------------------------
No links.

After
----------------------------------------
<img width="928" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/fabc1744-a9aa-4c78-ac81-ddc24546334f">
<img width="564" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/94b83edb-f762-4a65-a7ed-55ac39a5e23e">
