### PR TITLE
Managed - Log errors instead of throwing exceptions unless in debug mode

### DIFF
--- a/CRM/Core/Error/Log.php
+++ b/CRM/Core/Error/Log.php
@@ -59,9 +59,17 @@ class CRM_Core_Error_Log extends \Psr\Log\AbstractLogger {
       if (isset($context['exception'])) {
         $context['exception'] = CRM_Core_Error::formatTextException($context['exception']);
       }
-      $message .= "\n" . print_r($context, 1);
+      $fullContext = "\n" . print_r($context, 1);
+      $seeLog = sprintf(' (<em>%s</em>)', ts('See log for details.'));
     }
-    CRM_Core_Error::debug_log_message($message, FALSE, '', $this->map[$level]);
+    else {
+      $fullContext = $seeLog = '';
+    }
+    $pearPriority = $this->map[$level];
+    CRM_Core_Error::debug_log_message($message . $fullContext, FALSE, '', $pearPriority);
+    if ($pearPriority <= PEAR_LOG_ERR && CRM_Core_Config::singleton()->debug && isset($_SESSION['CiviCRM'])) {
+      CRM_Core_Session::setStatus($message . $seeLog, ts('Error'), 'error');
+    }
   }
 
 }

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -89,7 +89,7 @@ class CRM_Core_ManagedEntities {
         $result = civicrm_api3($dao->entity_type, 'getsingle', $params);
       }
       catch (Exception $e) {
-        $this->onApiError($dao->entity_type, 'getsingle', $params, $result);
+        $this->onApiError($dao->name, 'getsingle', $result['error_message']);
       }
       return $result;
     }
@@ -182,14 +182,21 @@ class CRM_Core_ManagedEntities {
       // Use "save" instead of "create" action to accommodate a "match" param
       $params['records'] = [$params['values']];
       unset($params['values']);
-      $result = civicrm_api4($item['entity_type'], 'save', $params);
+      try {
+        $result = civicrm_api4($item['entity_type'], 'save', $params);
+      }
+      catch (CRM_Core_Exception $e) {
+        $this->onApiError($item['name'], 'save', $e->getMessage());
+        return;
+      }
       $id = $result->first()['id'];
     }
     // APIv3
     else {
       $result = civicrm_api($item['entity_type'], 'create', $params);
       if (!empty($result['is_error'])) {
-        $this->onApiError($item['entity_type'], 'create', $params, $result);
+        $this->onApiError($item['name'], 'create', $result['error_message']);
+        return;
       }
       $id = $result['id'];
     }
@@ -247,7 +254,8 @@ class CRM_Core_ManagedEntities {
 
       $result = civicrm_api($item['entity_type'], 'create', $params);
       if ($result['is_error']) {
-        $this->onApiError($item['entity_type'], 'create', $params, $result);
+        $this->onApiError($item['name'], 'create', $result['error_message']);
+        return;
       }
     }
     elseif ($doUpdate && $item['params']['version'] == 4) {
@@ -255,7 +263,13 @@ class CRM_Core_ManagedEntities {
       $params['values']['id'] = $item['entity_id'];
       // 'match' param doesn't apply to "update" action
       unset($params['match']);
-      civicrm_api4($item['entity_type'], 'update', $params);
+      try {
+        civicrm_api4($item['entity_type'], 'update', $params);
+      }
+      catch (CRM_Core_Exception $e) {
+        $this->onApiError($item['name'], 'update', $e->getMessage());
+        return;
+      }
     }
 
     if (isset($item['cleanup']) || $doUpdate) {
@@ -287,7 +301,8 @@ class CRM_Core_ManagedEntities {
       ];
       $result = civicrm_api($item['entity_type'], 'create', $params);
       if ($result['is_error']) {
-        $this->onApiError($item['entity_type'], 'create', $params, $result);
+        $this->onApiError($item['name'], 'create', $result['error_message']);
+        return;
       }
       // Reset the `entity_modified_date` timestamp to indicate that the entity has not been modified by the user.
       $dao = new CRM_Core_DAO_Managed();
@@ -339,29 +354,24 @@ class CRM_Core_ManagedEntities {
 
     // Delete the entity and the managed record
     if ($doDelete) {
-      // APIv4 delete
-      if (CRM_Core_BAO_Managed::isApi4ManagedType($item['entity_type'])) {
-        civicrm_api4($item['entity_type'], 'delete', [
-          'checkPermissions' => FALSE,
-          'where' => [['id', '=', $item['entity_id']]],
-        ]);
-      }
-      // APIv3 delete
-      else {
-        $params = [
-          'version' => 3,
-          'id' => $item['entity_id'],
-        ];
-        $check = civicrm_api3($item['entity_type'], 'get', $params);
-        if ($check['count']) {
-          $result = civicrm_api($item['entity_type'], 'delete', $params);
-          if ($result['is_error']) {
-            if (isset($item['name'])) {
-              $params['name'] = $item['name'];
-            }
-            $this->onApiError($item['entity_type'], 'delete', $params, $result);
+      try {
+        // APIv4 delete
+        if (CRM_Core_BAO_Managed::isApi4ManagedType($item['entity_type'])) {
+          civicrm_api4($item['entity_type'], 'delete', [
+            'checkPermissions' => FALSE,
+            'where' => [['id', '=', $item['entity_id']]],
+          ]);
+        }
+        // APIv3 delete
+        else {
+          $check = civicrm_api3($item['entity_type'], 'get', ['id' => $item['entity_id']]);
+          if ($check['count']) {
+            civicrm_api3($item['entity_type'], 'delete', ['id' => $item['entity_id']]);
           }
         }
+      }
+      catch (CRM_Core_Exception $e) {
+        $this->onApiError($item['name'], 'delete', $e->getMessage());
       }
       // Ensure managed record is deleted.
       // Note: in many cases CRM_Core_BAO_Managed::on_hook_civicrm_post() will take care of
@@ -465,23 +475,23 @@ class CRM_Core_ManagedEntities {
   }
 
   /**
-   * @param string $entity
-   * @param string $action
-   * @param array $params
-   * @param array $result
+   * @param string $managedEntityName
+   * @param string $actionName
+   * @param string $errorMessage
    *
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
-  protected function onApiError($entity, $action, $params, $result) {
-    CRM_Core_Error::debug_var('ManagedEntities_failed', [
-      'entity' => $entity,
-      'action' => $action,
-      'params' => $params,
-      'result' => $result,
-    ]);
-    throw new Exception('API error: ' . $result['error_message'] . ' on ' . $entity . '.' . $action
-      . (!empty($params['name']) ? '( entity name ' . $params['name'] . ')' : '')
-    );
+  protected function onApiError(string $managedEntityName, string $actionName, string $errorMessage): void {
+    $message = "Unable to $actionName managed entity '$managedEntityName'. $errorMessage";
+    // During upgrade  this problem might be due to an about-to-be-installed extension
+    // So only log the error if it persists outside of upgrade mode
+    if (!CRM_Core_Config::isUpgradeMode()) {
+      Civi::log()->error($message);
+    }
+    // Errors should be very loud when debugging
+    if (Civi::settings()->get('debug_enabled')) {
+      throw new CRM_Core_Exception($message);
+    }
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -688,13 +688,15 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     ];
     $this->_managedEntities = [$managed];
 
+    \CRM_Core_Session::singleton()->getStatus(TRUE);
+    $this->assertEquals([], \CRM_Core_Session::singleton()->getStatus());
+
     // Without "match" in the params, it will try and fail to add a duplicate managed record
-    try {
-      CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
-    }
-    catch (\Exception $e) {
-    }
-    $this->assertStringContainsString('already exists', $e->getMessage());
+    CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+
+    $status = \CRM_Core_Session::singleton()->getStatus(TRUE);
+    $this->assertStringContainsString('already exists', $status[0]['text']);
+    $this->assertEquals('error', $status[0]['type']);
 
     // Now reconcile using a match param
     $managed['params']['match'] = ['name'];

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -49,7 +49,14 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
 
   public function setUp(): void {
     $this->_managedEntities = [];
+    // Ensure exceptions get thrown
+    \Civi::settings()->set('debug_enabled', TRUE);
     parent::setUp();
+  }
+
+  public function tearDown(): void {
+    \Civi::settings()->revert('debug_enabled');
+    parent::tearDown();
   }
 
   public function setUpHeadless(): CiviEnvBuilder {


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to #26849, this aims to minimize hard crashes and appropriately log errors when reconciling managed entities.

Before
----------------------------------------
When reconciling managed entities, the system would throw an uncaught exception (hard crash) if it encountered an api error.

After
----------------------------------------
- Exceptions are caught and logged during normal conditions.
- During upgrade mode, no error is logged (it may be temporary).
- In debug mode, the exception is thrown (hard crash) to alert developers of the problem (this is the current status-quo).

Comments
----------------------------------------
@totten per our discussion
