### PR TITLE
getEntitySpecificJoins sometimes returns NULL, triggering deprecation warning for trim() in php 8.1

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -2665,7 +2665,7 @@ class CRM_Contact_BAO_Query {
    * @param string $primaryLocation
    * @return string
    */
-  protected static function getEntitySpecificJoins($name, $mode, $side, $primaryLocation) {
+  protected static function getEntitySpecificJoins($name, $mode, $side, $primaryLocation): string {
     $limitToPrimaryClause = $primaryLocation ? "AND {$name}.is_primary = 1" : '';
     switch ($name) {
       case 'civicrm_address':
@@ -2727,7 +2727,7 @@ class CRM_Contact_BAO_Query {
       case 'civicrm_activity_contact':
       case 'source_contact':
       case 'activity_priority':
-        return CRM_Activity_BAO_Query::from($name, $mode, $side);
+        return CRM_Activity_BAO_Query::from($name, $mode, $side) ?? '';
 
       case 'civicrm_entity_tag':
         $from = " $side JOIN civicrm_entity_tag ON ( civicrm_entity_tag.entity_table = 'civicrm_contact'";


### PR DESCRIPTION

Discovered this in the wild where an api3 Contact.getcount call for a particular smartgroup was causing this. The smartgroup otherwise works fine.

Looking at the code, it's clear that getEntitySpecificJoins is supposed to return a string, but in the case of civicrm_activity_contact it was returning from another function which may return NULL. I have coalesced NULL to empty string.


Before
----------------------------------------

Errors raised.


After
----------------------------------------

Errors not raised.



Technical Details
----------------------------------------

I added a return type hint because this would have flagged the function as incorrectly coded due to the possible null return value.


