### PR TITLE
[PHP Deprecation] trim(): Passing null to parameter #1 () of type string

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -162,7 +162,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       $params['contact_sub_type_a'] = $cTypeA[1] ? $cTypeA[1] : 'null';
       $params['contact_sub_type_b'] = $cTypeB[1] ? $cTypeB[1] : 'null';
 
-      if (!strlen(trim(CRM_Utils_Array::value('label_b_a', $params)))) {
+      if (!strlen(trim($params['label_b_a'] ?? ''))) {
         $params['label_b_a'] = $params['label_a_b'] ?? NULL;
       }
 

--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -324,7 +324,7 @@ class CRM_Contact_Page_AJAX {
     }
 
     $config = CRM_Core_Config::singleton();
-    $username = trim(CRM_Utils_Array::value('cms_name', $_REQUEST));
+    $username = trim($_REQUEST['cms_name'] ?? '');
 
     $params = ['name' => $username];
 

--- a/CRM/Contribute/Form/ContributionPage/ThankYou.php
+++ b/CRM/Contribute/Form/ContributionPage/ThankYou.php
@@ -84,7 +84,7 @@ class CRM_Contribute_Form_ContributionPage_ThankYou extends CRM_Contribute_Form_
     // if is_email_receipt is set, the receipt message must be non-empty
     if (!empty($fields['is_email_receipt'])) {
       //added for CRM-1348
-      $email = trim(CRM_Utils_Array::value('receipt_from_email', $fields));
+      $email = trim($fields['receipt_from_email'] ?? '');
       if (empty($email) || !CRM_Utils_Rule::email($email)) {
         $errors['receipt_from_email'] = ts('A valid Receipt From Email address must be specified if Email Receipt to Contributor is enabled');
       }

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -863,7 +863,7 @@ AND    option_group_id = %2";
 
     $filter = 'null';
     if ($params['data_type'] == 'ContactReference' && !empty($params['filter_selected'])) {
-      if ($params['filter_selected'] == 'Advance' && trim(CRM_Utils_Array::value('filter', $params))) {
+      if ($params['filter_selected'] == 'Advance' && trim($params['filter'] ?? '')) {
         $filter = trim($params['filter']);
       }
       elseif ($params['filter_selected'] == 'Group' && !empty($params['group_id'])) {

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -648,7 +648,7 @@ class CRM_Utils_System {
    */
   public static function authenticateKey($abort = TRUE) {
     // also make sure the key is sent and is valid
-    $key = trim(CRM_Utils_Array::value('key', $_REQUEST));
+    $key = trim($_REQUEST['key'] ?? '');
 
     $docAdd = "More info at: " . CRM_Utils_System::docURL2('sysadmin/setup/jobs', TRUE);
 
@@ -701,8 +701,8 @@ class CRM_Utils_System {
     // auth to make sure the user has a login/password to do a shell operation
     // later on we'll link this to acl's
     if (!$name) {
-      $name = trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $name = trim($_REQUEST['name'] ?? '');
+      $pass = trim($_REQUEST['pass'] ?? '');
     }
 
     // its ok to have an empty password

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -605,8 +605,8 @@ AND    u.status = 1
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       // Load the user we need to check Backdrop permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $name = !empty($params['name']) ? $params['name'] : trim($_REQUEST['name'] ?? '');
+      $pass = !empty($params['pass']) ? $params['pass'] : trim($_REQUEST['pass'] ?? '');
 
       if ($name) {
         $uid = user_authenticate($name, $pass);

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -522,8 +522,8 @@ AND    u.status = 1
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
       //load user, we need to check drupal permissions.
-      $name = CRM_Utils_Array::value('name', $params, FALSE) ? $params['name'] : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = CRM_Utils_Array::value('pass', $params, FALSE) ? $params['pass'] : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $name = !empty($params['name']) ? $params['name'] : trim($_REQUEST['name'] ?? '');
+      $pass = !empty($params['pass']) ? $params['pass'] : trim($_REQUEST['pass'] ?? '');
 
       if ($name) {
         $uid = user_authenticate($name, $pass);

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -762,8 +762,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     // Maybe login user.
     $uid = $params['uid'] ?? NULL;
     if (!$uid) {
-      $name = $name ? $name : trim(CRM_Utils_Array::value('name', $_REQUEST));
-      $pass = $pass ? $pass : trim(CRM_Utils_Array::value('pass', $_REQUEST));
+      $name = $name ?: trim($_REQUEST['name'] ?? '');
+      $pass = $pass ?: trim($_REQUEST['pass'] ?? '');
       if ($name) {
         $uid = wp_authenticate($name, $pass);
         if (!$uid) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a php deprecation warning (passing NULL into `trim()`)
