### PR TITLE
dev/financial#216 Financial Batch: remove the Create/Edit activities

### DIFF
--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -194,38 +194,12 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
       if (empty($params['created_id'])) {
         $params['created_id'] = CRM_Core_Session::getLoggedInContactID();
       }
-      $details = "{$params['title']} batch has been created by this contact.";
-      $activityTypeName = 'Create Batch';
     }
-    elseif ($this->_action & CRM_Core_Action::UPDATE && $this->_id) {
-      $details = "{$params['title']} batch has been edited by this contact.";
-      if ($params['status_id'] === $closedStatusId) {
-        $details = "{$params['title']} batch has been closed by this contact.";
-      }
-      $activityTypeName = 'Edit Batch';
-    }
-
-    // FIXME: What happens if we get to here and no activityType is defined?
 
     $batch = CRM_Batch_BAO_Batch::writeRecord($params);
 
-    //set batch id
+    // Required for postProcess hooks
     $this->_id = $batch->id;
-
-    // create activity.
-    $activityParams = [
-      // activityTypeName - dev/core#1116-unknown-if-ok
-      'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeName),
-      'subject' => $batch->title . "- Batch",
-      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'activity_status_id', 'Completed'),
-      'priority_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_DAO_Activity', 'priority_id', 'Normal'),
-      'activity_date_time' => date('YmdHis'),
-      'source_contact_id' => CRM_Core_Session::getLoggedInContactID(),
-      'source_contact_qid' => CRM_Core_Session::getLoggedInContactID(),
-      'details' => $details,
-    ];
-
-    CRM_Activity_BAO_Activity::create($activityParams);
 
     $buttonName = $this->controller->getButtonName();
 

--- a/sql/civicrm_data/civicrm_option_group/activity_type.sqldata.php
+++ b/sql/civicrm_data/civicrm_option_group/activity_type.sqldata.php
@@ -381,28 +381,7 @@ return CRM_Core_CodeGen_OptionGroup::create('activity_type', 'a/0002')
       'value' => 41,
       'name' => 'Export Accounting Batch',
       'filter' => 1,
-      // FIXME: Shouldn't this use ts()
-      'description' => 'Export Accounting Batch',
-      'is_reserved' => 1,
-      'component_id' => 2,
-    ],
-    [
-      'label' => ts('Create Batch'),
-      'value' => 42,
-      'name' => 'Create Batch',
-      'filter' => 1,
-      // FIXME: Shouldn't this use ts()
-      'description' => 'Create Batch',
-      'is_reserved' => 1,
-      'component_id' => 2,
-    ],
-    [
-      'label' => ts('Edit Batch'),
-      'value' => 43,
-      'name' => 'Edit Batch',
-      'filter' => 1,
-      // FIXME: Shouldn't this use ts()
-      'description' => 'Edit Batch',
+      'description' => ts('Export Accounting Batch'),
       'is_reserved' => 1,
       'component_id' => 2,
     ],


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/financial/-/issues/216

Removes the creation of Activities whenever a Financial Batch is created or edited.

This does not impact the Activities created when a Batch is exported.

Before
----------------------------------------

Whenever someone creates or edits a batch, an activity is created on behalf of that person. I can only assume that the intent was to have some sort of auditing around batches, but it's not clear to me. For auditing, I would recommend using the detailed logging feature of CiviCRM.

After
----------------------------------------

Create/Edit of Batches does not create Activities.

Technical Details
----------------------------------------

- This code was in the Form layer, which is weird (and ignored by the API).
- Upgrades: delete the Activity Types if they were never used  ~~not deleting the Activity Type, since it would require deleting the activities, and that can be extremely slow on large installs. No harm in leaving them there.~~
- Need to run Gencode?

Comments
-------------------

I got side-tracked while wanting to cleanup form buttons: https://lab.civicrm.org/dev/user-interface/-/issues/53