### PR TITLE
Remove 'browse' link that shouldn't be there

### DIFF
--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -39,7 +39,7 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
       Civi::$statics[$baoName]['actionLinks'] = [];
       $title = $baoName::getEntityTitle();
       $paths = $baoName::getEntityPaths();
-      unset($paths['add']);
+      unset($paths['add'], $paths['browse']);
       foreach ($paths as $action => $path) {
         $actionKey = CRM_Core_Action::map($action);
         if ($actionKey) {


### PR DESCRIPTION
Overview
----------------------------------------
Same as #26798 but for core pages.

Before
----------------------------------------
Recently added 'browse' metadata pops up where it shouldn't, e.g. the "Scheduled Reminders" page has an extra "Browse" link on every row.

After
----------------------------------------
Fixed.
