### PR TITLE
[REF] Fix CRM_Utils_Array calls that return potentially incorrect value types

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -456,7 +456,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         );
       }
       else {
-        $q = "action=view&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . CRM_Utils_Array::value('source_contact_id', $params) . "&context=home";
+        $q = "action=view&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . ($params['source_contact_id'] ?? '') . "&context=home";
         if ($activity->activity_type_id != CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email')) {
           $url = CRM_Utils_System::url('civicrm/activity', $q);
           if ($activity->activity_type_id == CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Print PDF Letter')) {
@@ -466,13 +466,13 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
           }
           else {
             $recentOther['editUrl'] = CRM_Utils_System::url('civicrm/activity/add',
-              "action=update&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . CRM_Utils_Array::value('source_contact_id', $params) . "&context=home"
+              "action=update&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . ($params['source_contact_id'] ?? '') . "&context=home"
             );
           }
 
           if (CRM_Core_Permission::check("delete activities")) {
             $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/activity',
-              "action=delete&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . CRM_Utils_Array::value('source_contact_id', $params) . "&context=home"
+              "action=delete&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . ($params['source_contact_id'] ?? '') . "&context=home"
             );
           }
         }
@@ -480,7 +480,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
           $url = CRM_Utils_System::url('civicrm/activity/view', $q);
           if (CRM_Core_Permission::check('delete activities')) {
             $recentOther['deleteUrl'] = CRM_Utils_System::url('civicrm/activity',
-              "action=delete&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . CRM_Utils_Array::value('source_contact_id', $params) . "&context=home"
+              "action=delete&reset=1&id={$activity->id}&atype={$activity->activity_type_id}&cid=" . ($params['source_contact_id'] ?? '') . "&context=home"
             );
           }
         }

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -398,7 +398,7 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
       $row = &$rows[$k];
 
       // add class to this row if overdue
-      if (CRM_Utils_Date::overdue(CRM_Utils_Array::value('activity_date_time', $row))
+      if (CRM_Utils_Date::overdue($row['activity_date_time'] ?? '')
         && ($row['status_id'] ?? NULL) == 1
       ) {
         $row['overdue'] = 1;

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -321,7 +321,7 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
       $errors['sms_text_message'] = ts('The SMS message is a required field.');
     }
 
-    if (empty($self->getContext()) && CRM_Utils_System::isNull(CRM_Utils_Array::value(1, $fields['entity']))) {
+    if (empty($self->getContext()) && CRM_Utils_System::isNull($fields['entity'][1] ?? NULL)) {
       $errors['entity'] = ts('Please select entity value');
     }
 

--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -70,7 +70,7 @@ class CRM_Admin_Page_AJAX {
       if (!empty($props['label'])) {
         $item['label'] = _ts($props['label'], ['context' => 'menu']);
       }
-      $item['name'] = !empty($props['name']) ? $props['name'] : CRM_Utils_String::munge(CRM_Utils_Array::value('label', $props));
+      $item['name'] = !empty($props['name']) ? $props['name'] : CRM_Utils_String::munge($props['label'] ?? '');
       if (!empty($item['child'])) {
         self::formatMenuItems($item['child']);
       }

--- a/CRM/Badge/BAO/Badge.php
+++ b/CRM/Badge/BAO/Badge.php
@@ -199,7 +199,7 @@ class CRM_Badge_BAO_Badge {
 
     if (!empty($formattedRow['participant_image'])) {
       $imageAlign = 0;
-      switch (CRM_Utils_Array::value('alignment_participant_image', $formattedRow)) {
+      switch ($formattedRow['alignment_participant_image'] ?? NULL) {
         case 'R':
           $imageAlign = 68;
           break;

--- a/CRM/Campaign/Page/Petition/Confirm.php
+++ b/CRM/Campaign/Page/Petition/Confirm.php
@@ -58,10 +58,12 @@ class CRM_Campaign_Page_Petition_Confirm extends CRM_Core_Page {
     $pparams['id'] = $petition_id;
     $this->petition = [];
     CRM_Campaign_BAO_Survey::retrieve($pparams, $this->petition);
-    $this->assign('is_share', CRM_Utils_Array::value('is_share', $this->petition));
-    $this->assign('thankyou_title', CRM_Utils_Array::value('thankyou_title', $this->petition));
-    $this->assign('thankyou_text', CRM_Utils_Array::value('thankyou_text', $this->petition));
-    CRM_Utils_System::setTitle(CRM_Utils_Array::value('thankyou_title', $this->petition));
+    $this->assign('is_share', $this->petition['is_share'] ?? FALSE);
+    $this->assign('thankyou_title', $this->petition['thankyou_title'] ?? '');
+    $this->assign('thankyou_text', $this->petition['thankyou_text'] ?? '');
+    if (!empty($this->petition['thankyou_title'])) {
+      CRM_Utils_System::setTitle($this->petition['thankyou_title']);
+    }
 
     // send thank you email
     $params['contactId'] = $contact_id;

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -706,7 +706,7 @@ HERESQL;
             $casesList[$key]['date'] = sprintf('<a class="action-item crm-hover-button" href="%s" title="%s">%s</a>',
               CRM_Utils_System::url('civicrm/case/activity/view', ['reset' => 1, 'cid' => $case['contact_id'], 'aid' => $case['activity_id']]),
               ts('View activity'),
-              CRM_Utils_Array::value($case['activity_type_id'], $activityTypeLabels)
+              $activityTypeLabels[$case['activity_type_id']] ?? ''
             );
           }
           else {
@@ -715,7 +715,7 @@ HERESQL;
               $status,
               CRM_Utils_System::url('civicrm/case/activity/view', ['reset' => 1, 'cid' => $case['contact_id'], 'aid' => $case['activity_id']]),
               ts('View activity'),
-              CRM_Utils_Array::value($case['activity_type_id'], $activityTypeLabels)
+              $activityTypeLabels[$case['activity_type_id']] ?? ''
             );
           }
         }

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -398,7 +398,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     }
 
     //set parent id if its edit mode
-    if ($parentId = CRM_Utils_Array::value('parent_id', $this->_defaults)) {
+    if ($parentId = $this->_defaults['parent_id'] ?? NULL) {
       $params['parent_id'] = $parentId;
     }
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -87,7 +87,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
     $standardTimeline = $params['standardTimeline'] ?? NULL;
     $activitySetName = $params['activitySetName'] ?? NULL;
 
-    if ('Open Case' == CRM_Utils_Array::value('activityTypeName', $params)) {
+    if ('Open Case' == ($params['activityTypeName'] ?? '')) {
       // create relationships for the ones that are required
       foreach ($xml->CaseRoles as $caseRoleXML) {
         foreach ($caseRoleXML->RelationshipType as $relationshipTypeXML) {
@@ -109,7 +109,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
       }
     }
 
-    if ('Change Case Start Date' == CRM_Utils_Array::value('activityTypeName', $params)) {
+    if ('Change Case Start Date' == ($params['activityTypeName'] ?? '')) {
       // delete all existing activities which are non-empty
       $this->deleteEmptyActivity($params);
     }
@@ -136,7 +136,7 @@ class CRM_Case_XMLProcessor_Process extends CRM_Case_XMLProcessor {
    * @param array $params
    */
   public function processStandardTimeline($activitySetXML, &$params) {
-    if ('Change Case Type' == CRM_Utils_Array::value('activityTypeName', $params)
+    if ('Change Case Type' == ($params['activityTypeName'] ?? '')
       && CRM_Utils_Array::value('resetTimeline', $params, TRUE)
     ) {
       // delete all existing activities which are non-empty

--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -301,8 +301,8 @@ ACOS(
     }
 
     if (
-      !is_numeric(CRM_Utils_Array::value('geo_code_1', $proximityAddress)) ||
-      !is_numeric(CRM_Utils_Array::value('geo_code_2', $proximityAddress))
+      !is_numeric($proximityAddress['geo_code_1'] ?? '') ||
+      !is_numeric($proximityAddress['geo_code_2'] ?? '')
     ) {
       // we are setting the where clause to 0 here, so we wont return anything
       $qill .= ': ' . ts('We could not geocode the destination address.');

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -890,7 +890,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       CRM_Contact_BAO_Contact::processImageParams($params);
     }
 
-    if (is_numeric(CRM_Utils_Array::value('current_employer_id', $params)) && !empty($params['current_employer'])) {
+    if (is_numeric($params['current_employer_id'] ?? '') && !empty($params['current_employer'])) {
       $params['current_employer'] = $params['current_employer_id'];
     }
 

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -809,7 +809,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             $result->contact_id
           );
         }
-        elseif ((is_numeric(CRM_Utils_Array::value('geo_code_1', $row))) ||
+        elseif ((is_numeric($row['geo_code_1'] ?? '')) ||
           (!empty($row['city']) && !empty($row['state_province']))
         ) {
           $row['action'] = CRM_Core_Action::formLink(
@@ -942,7 +942,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
         $mask = CRM_Core_Action::mask(array_merge([CRM_Core_Permission::VIEW], $basicPermissions));
       }
 
-      if ((!is_numeric(CRM_Utils_Array::value('geo_code_1', $row))) &&
+      if ((!is_numeric($row['geo_code_1'] ?? '')) &&
         (empty($row['city']) || empty($row['state_province']))
       ) {
         $mask = $mask & 4095;

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -425,7 +425,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       }
 
       if ($values['is_email_receipt']) {
-        $sendTemplateParams['from'] = CRM_Utils_Array::value('receipt_from_name', $values) . ' <' . $values['receipt_from_email'] . '>';
+        $sendTemplateParams['from'] = ($values['receipt_from_name'] ?? '') . ' <' . $values['receipt_from_email'] . '>';
         $sendTemplateParams['toName'] = $displayName;
         $sendTemplateParams['toEmail'] = $email;
         $sendTemplateParams['cc'] = $values['cc_receipt'] ?? NULL;

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -849,7 +849,7 @@ INNER JOIN civicrm_contribution       con ON ( con.id = mp.contribution_id )
     $form->assign('contribution_recur_pane_open', FALSE);
     foreach (self::getRecurringFields() as $key) {
       if ($key === 'contribution_recur_payment_made' && !empty($form->_formValues) &&
-        !CRM_Utils_System::isNull(CRM_Utils_Array::value($key, $form->_formValues))
+        !CRM_Utils_System::isNull($form->_formValues[$key] ?? NULL)
       ) {
         $form->assign('contribution_recur_pane_open', TRUE);
         break;

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1741,7 +1741,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
       if (CRM_Contribute_BAO_Contribution::isContributionStatusNegative($params['contribution_status_id'])
       ) {
-        if (CRM_Utils_System::isNull(CRM_Utils_Array::value('cancel_date', $params))) {
+        if (CRM_Utils_System::isNull($params['cancel_date'] ?? NULL)) {
           $params['cancel_date'] = date('YmdHis');
         }
       }

--- a/CRM/Contribute/Form/SoftCredit.php
+++ b/CRM/Contribute/Form/SoftCredit.php
@@ -150,7 +150,7 @@ class CRM_Contribute_Form_SoftCredit {
       $pcpId = $pcpInfo['pcp_id'] ?? NULL;
       $pcpTitle = CRM_Core_DAO::getFieldValue('CRM_PCP_DAO_PCP', $pcpId, 'title');
       $contributionPageTitle = CRM_PCP_BAO_PCP::getPcpPageTitle($pcpId, 'contribute');
-      $defaults['pcp_made_through'] = CRM_Utils_Array::value('sort_name', $pcpInfo) . " :: " . $pcpTitle . " :: " . $contributionPageTitle;
+      $defaults['pcp_made_through'] = ($pcpInfo['sort_name'] ?? '') . " :: " . $pcpTitle . " :: " . $contributionPageTitle;
       $defaults['pcp_made_through_id'] = $pcpInfo['pcp_id'] ?? NULL;
       $defaults['pcp_display_in_roll'] = $pcpInfo['pcp_display_in_roll'] ?? NULL;
       $defaults['pcp_roll_nickname'] = $pcpInfo['pcp_roll_nickname'] ?? NULL;

--- a/CRM/Contribute/Form/Task/Batch.php
+++ b/CRM/Contribute/Form/Task/Batch.php
@@ -143,7 +143,7 @@ class CRM_Contribute_Form_Task_Batch extends CRM_Contribute_Form_Task {
           }
 
           if (!empty($entityColumnValue[$typeId]) ||
-            CRM_Utils_System::isNull(CRM_Utils_Array::value($typeId, $entityColumnValue))
+            CRM_Utils_System::isNull($entityColumnValue[$typeId] ?? NULL)
           ) {
             CRM_Core_BAO_UFGroup::buildProfile($this, $field, NULL, $contributionId);
           }

--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -118,7 +118,7 @@ class CRM_Core_BAO_Block {
    */
   public static function dataExists($blockFields, &$params) {
     foreach ($blockFields as $field) {
-      if (CRM_Utils_System::isNull(CRM_Utils_Array::value($field, $params))) {
+      if (CRM_Utils_System::isNull($params[$field] ?? NULL)) {
         return FALSE;
       }
     }
@@ -232,7 +232,7 @@ class CRM_Core_BAO_Block {
       // if in some cases (eg. email used in Online Conribution Page, Profiles, etc.) id is not set
       // lets try to add using the previous method to avoid any false creation of existing data.
       foreach ($blockIds as $blockId => $blockValue) {
-        if (empty($value['id']) && $blockValue['locationTypeId'] == CRM_Utils_Array::value('location_type_id', $value) && !$isIdSet) {
+        if (empty($value['id']) && $blockValue['locationTypeId'] == ($value['location_type_id'] ?? NULL) && !$isIdSet) {
           $valueId = FALSE;
           if ($blockName == 'phone') {
             $phoneTypeBlockValue = $blockValue['phoneTypeId'] ?? NULL;

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -249,7 +249,7 @@ class CRM_Core_BAO_CustomValueTable {
             || $fieldExtends === 'Organization'
             || $fieldExtends === 'Household'
           ) {
-            $paramFieldsExtendContactForEntities[$entityID]['custom_' . CRM_Utils_Array::value('custom_field_id', $field)] = $field['custom_field_id'] ?? NULL;
+            $paramFieldsExtendContactForEntities[$entityID]['custom_' . ($field['custom_field_id'] ?? '')] = $field['custom_field_id'] ?? NULL;
           }
         }
 

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -198,7 +198,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     if (!empty($params['instanceURL'])) {
       $query = "SELECT id
                         FROM `civicrm_dashboard`
-                        WHERE url LIKE '" . CRM_Utils_Array::value('instanceURL', $params) . "&%'";
+                        WHERE url LIKE '" . ($params['instanceURL'] ?? '') . "&%'";
       $dashboardID = CRM_Core_DAO::singleValueQuery($query);
     }
 

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -42,7 +42,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File {
 
     $op = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($op, 'File', CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($op, 'File', $params['id'] ?? NULL, $params);
 
     $fileDAO->copyValues($params);
 

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -483,14 +483,14 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
           $saveMappingFields['name'] = $v['4'] ?? NULL;
         }
 
-        if (is_numeric(CRM_Utils_Array::value('3', $v))) {
+        if (is_numeric($v['3'] ?? '')) {
           $locationTypeId = $v['3'] ?? NULL;
         }
-        elseif (is_numeric(CRM_Utils_Array::value('5', $v))) {
+        elseif (is_numeric($v['5'] ?? '')) {
           $locationTypeId = $v['5'] ?? NULL;
         }
 
-        if (is_numeric(CRM_Utils_Array::value('4', $v))) {
+        if (is_numeric($v['4'] ?? '')) {
           if ($saveMappingFields['name'] === 'im') {
             $saveMappingFields['im_provider_id'] = $v[4];
           }
@@ -498,7 +498,7 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
             $saveMappingFields['phone_type_id'] = $v['4'] ?? NULL;
           }
         }
-        elseif (is_numeric(CRM_Utils_Array::value('6', $v))) {
+        elseif (is_numeric($v['6'] ?? '')) {
           $saveMappingFields['phone_type_id'] = $v['6'] ?? NULL;
         }
 

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -787,7 +787,7 @@ SELECT  id
 
     if (!empty($index) && (
         // it's empty so we set it OR
-        !CRM_Utils_Array::value($prefixName, $profileAddressFields)
+        empty($profileAddressFields[$prefixName])
         //we are dealing with billing id (precedence)
         || $index == $billing_id
         // we are dealing with primary & billing not set

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2381,7 +2381,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public static function validateMandatoryFields($fields, $values, &$errors) {
     foreach ($fields as $name => $fld) {
-      if (!empty($fld['is_required']) && CRM_Utils_System::isNull(CRM_Utils_Array::value($name, $values))) {
+      if (!empty($fld['is_required']) && CRM_Utils_System::isNull($values[$name] ?? NULL)) {
         $errors[$name] = ts('%1 is a required field.', [1 => $fld['title']]);
       }
     }

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -996,7 +996,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   protected function prepareParamsForPaymentProcessor($params) {
     // also add location name to the array
-    $params["address_name-{$this->_bltID}"] = CRM_Utils_Array::value('billing_first_name', $params) . ' ' . CRM_Utils_Array::value('billing_middle_name', $params) . ' ' . CRM_Utils_Array::value('billing_last_name', $params);
+    $params["address_name-{$this->_bltID}"] = ($params['billing_first_name'] ?? '') . ' ' . ($params['billing_middle_name'] ?? '') . ' ' . ($params['billing_last_name'] ?? '');
     $params["address_name-{$this->_bltID}"] = trim($params["address_name-{$this->_bltID}"]);
     // Add additional parameters that the payment processors are used to receiving.
     if (!empty($params["billing_state_province_id-{$this->_bltID}"])) {

--- a/CRM/Cxn/ApiRouter.php
+++ b/CRM/Cxn/ApiRouter.php
@@ -32,7 +32,7 @@ class CRM_Cxn_ApiRouter {
     // FIXME: Shouldn't the X-Forwarded-Proto check be part of CRM_Utils_System::isSSL()?
     if (Civi::settings()->get('enableSSL') &&
       !CRM_Utils_System::isSSL() &&
-      strtolower(CRM_Utils_Array::value('X_FORWARDED_PROTO', CRM_Utils_System::getRequestHeaders())) != 'https'
+      strtolower(CRM_Utils_System::getRequestHeaders()['X_FORWARDED_PROTO'] ?? '') != 'https'
     ) {
       return civicrm_api3_create_error('System policy requires HTTPS.');
     }

--- a/CRM/Dedupe/BAO/QueryBuilder/IndividualGeneral.php
+++ b/CRM/Dedupe/BAO/QueryBuilder/IndividualGeneral.php
@@ -16,9 +16,9 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualGeneral extends CRM_Dedupe_BAO_Query
     $civicrm_address = $rg->params['civicrm_address'] ?? NULL;
 
     // Since definitely have first and last name, escape them upfront.
-    $first_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('first_name', $civicrm_contact, ''));
-    $last_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('last_name', $civicrm_contact, ''));
-    $street_address = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('street_address', $civicrm_address, ''));
+    $first_name = CRM_Core_DAO::escapeString($civicrm_contact['first_name'] ?? '');
+    $last_name = CRM_Core_DAO::escapeString($civicrm_contact['last_name'] ?? '');
+    $street_address = CRM_Core_DAO::escapeString($civicrm_address['street_address'] ?? '');
 
     $query = "
             SELECT contact1.id id1, {$rg->threshold} as weight
@@ -30,15 +30,15 @@ class CRM_Dedupe_BAO_QueryBuilder_IndividualGeneral extends CRM_Dedupe_BAO_Query
               AND address1.street_address = '$street_address'
               ";
 
-    if ($birth_date = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('birth_date', $civicrm_contact, ''))) {
+    if ($birth_date = CRM_Core_DAO::escapeString($civicrm_contact['birth_date'] ?? '')) {
       $query .= " AND (contact1.birth_date IS NULL or contact1.birth_date = '$birth_date')\n";
     }
 
-    if ($suffix_id = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('suffix_id', $civicrm_contact, ''))) {
+    if ($suffix_id = CRM_Core_DAO::escapeString($civicrm_contact['suffix_id'] ?? '')) {
       $query .= " AND (contact1.suffix_id IS NULL or contact1.suffix_id = $suffix_id)\n";
     }
 
-    if ($middle_name = CRM_Core_DAO::escapeString(CRM_Utils_Array::value('middle_name', $civicrm_contact, ''))) {
+    if ($middle_name = CRM_Core_DAO::escapeString($civicrm_contact['middle_name'] ?? '')) {
       $query .= " AND (contact1.middle_name IS NULL or contact1.middle_name = '$middle_name')\n";
     }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -470,7 +470,7 @@ $event_summary_limit
               $ids = [];
               $params = ['entity_id' => $dao->id, 'entity_table' => 'civicrm_event'];
               $values['location'] = CRM_Core_BAO_Location::getValues($params, TRUE);
-              if (is_numeric(CRM_Utils_Array::value('geo_code_1', $values['location']['address'][1])) ||
+              if (is_numeric($values['location']['address'][1]['geo_code_1'] ?? '') ||
                 (
                   !empty($values['location']['address'][1]['city']) &&
                   !empty($values['location']['address'][1]['state_province_id'])

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1244,7 +1244,7 @@ WHERE civicrm_event.is_active = 1
           ];
         }
         else {
-          $sendTemplateParams['from'] = CRM_Utils_Array::value('confirm_from_name', $values['event']) . " <" . CRM_Utils_Array::value('confirm_from_email', $values['event']) . ">";
+          $sendTemplateParams['from'] = ($values['event']['confirm_from_name'] ?? '') . " <" . ($values['event']['confirm_from_email'] ?? '') . ">";
           $sendTemplateParams['toName'] = $displayName;
           $sendTemplateParams['toEmail'] = $notifyEmail;
           $sendTemplateParams['autoSubmitted'] = TRUE;

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1954,9 +1954,9 @@ WHERE  ce.loc_block_id = $locBlockId";
   public static function validRegistrationDate(&$values) {
     // make sure that we are between registration start date and end dates
     // and that if the event has ended, registration is still specifically open
-    $startDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('registration_start_date', $values));
-    $endDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('registration_end_date', $values));
-    $eventEnd = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('end_date', $values));
+    $startDate = CRM_Utils_Date::unixTime($values['registration_start_date'] ?? '');
+    $endDate = CRM_Utils_Date::unixTime($values['registration_end_date'] ?? '');
+    $eventEnd = CRM_Utils_Date::unixTime($values['end_date'] ?? '');
     $now = time();
     $validDate = TRUE;
     if ($startDate && $startDate >= $now) {

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -660,7 +660,7 @@ INNER JOIN  civicrm_price_field field       ON ( value.price_field_id = field.id
       $extIdentifier = $contactFields['external_identifier'] ?? NULL;
       if ($extIdentifier) {
         $tmpContactField['external_identifier'] = $extIdentifier;
-        $tmpContactField['external_identifier']['title'] = CRM_Utils_Array::value('title', $extIdentifier) . ' (match to contact)';
+        $tmpContactField['external_identifier']['title'] = ($extIdentifier['title'] ?? '') . ' (match to contact)';
       }
       $tmpFields['participant_contact_id']['title'] = $tmpFields['participant_contact_id']['title'] . ' (match to contact)';
 

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -142,11 +142,11 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     $title = NULL;
     if ($this->_id) {
       if ($this->_isTemplate) {
-        $title = ts('Edit Event Template') . ' - ' . CRM_Utils_Array::value('template_title', $eventInfo);
+        $title = ts('Edit Event Template') . ' - ' . ($eventInfo['template_title'] ?? '');
       }
       else {
         $configureText = $this->_isRepeatingEvent ? ts('Configure Repeating Event') : ts('Configure Event');
-        $title = $configureText . ' - ' . CRM_Utils_Array::value('title', $eventInfo);
+        $title = $configureText . ' - ' . ($eventInfo['title'] ?? '');
       }
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -666,7 +666,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
               $discountOptions = [];
               for ($i = 1; $i < self::NUM_OPTION; $i++) {
                 if (!empty($labels[$i]) &&
-                  !CRM_Utils_System::isNull(CRM_Utils_Array::value($j, $values[$i]))
+                  !CRM_Utils_System::isNull($values[$i][$j] ?? NULL)
                 ) {
                   $discountOptions[] = [
                     'label' => trim($labels[$i]),

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1010,8 +1010,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       // also add location name to the array
       $params["address_name-{$this->_bltID}"]
-        = CRM_Utils_Array::value('billing_first_name', $params) . ' ' .
-        CRM_Utils_Array::value('billing_middle_name', $params) . ' ' .
+        = ($params['billing_first_name'] ?? '') . ' ' .
+        ($params['billing_middle_name'] ?? '') . ' ' .
         CRM_Utils_Array::value('billing_last_name', $params);
 
       $params["address_name-{$this->_bltID}"] = trim($params["address_name-{$this->_bltID}"]);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1450,7 +1450,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->_discountId);
       $lineItem = [];
       $totalTaxAmount = 0;
-      if (!CRM_Utils_System::isNull(CRM_Utils_Array::value('line_items', $form->_values))) {
+      if (!CRM_Utils_System::isNull($form->_values['line_items'] ?? NULL)) {
         $lineItem[] = $form->_values['line_items'];
         foreach ($form->_values['line_items'] as $key => $value) {
           $totalTaxAmount = $value['tax_amount'] + $totalTaxAmount;

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -175,7 +175,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE);
     CRM_Event_Form_Registration_Register::buildAmount($this, TRUE);
 
-    if (!CRM_Utils_System::isNull(CRM_Utils_Array::value('line_items', $this->_values))) {
+    if (!CRM_Utils_System::isNull($this->_values['line_items'] ?? NULL)) {
       $lineItem[] = $this->_values['line_items'];
     }
     $this->assign('lineItem', empty($lineItem) ? FALSE : $lineItem);

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -210,7 +210,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     $this->setTitle(ts('View Event Registration for') . ' ' . $displayName);
 
     $roleId = $values[$participantID]['role_id'] ?? NULL;
-    $title = $displayName . ' (' . CRM_Utils_Array::value($roleId, $participantRoles) . ' - ' . $eventTitle . ')';
+    $title = $displayName . ' (' . ($participantRoles[$roleId] ?? '') . ' - ' . $eventTitle . ')';
 
     $sep = CRM_Core_DAO::VALUE_SEPARATOR;
     $viewRoles = [];

--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -337,7 +337,7 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
       $engineChanged = isset($tableSpec['engine']) && (strtoupper($tableSpec['engine']) != $currentEngine);
       $engineConfigChanged = isset($tableSpec['engine_config']) && (strtoupper($tableSpec['engine_config']) != $this->getEngineConfigForLogTable($logTable));
       if ($engineChanged || ($engineConfigChanged && $params['updateChangedEngineConfig'])) {
-        $alterSql[] = "ENGINE=" . $tableSpec['engine'] . " " . CRM_Utils_Array::value('engine_config', $tableSpec);
+        $alterSql[] = "ENGINE=" . $tableSpec['engine'] . " " . ($tableSpec['engine_config'] ?? '');
       }
       if (!empty($tableSpec['indexes'])) {
         $indexes = $this->getIndexesForTable($logTable);

--- a/CRM/Mailing/Event/BAO/MailingEventForward.php
+++ b/CRM/Mailing/Event/BAO/MailingEventForward.php
@@ -150,7 +150,7 @@ class CRM_Mailing_Event_BAO_MailingEventForward extends CRM_Mailing_Event_DAO_Ma
     );
     //append comment if added while forwarding.
     if (count($comment)) {
-      $message->_txtbody = CRM_Utils_Array::value('body_text', $comment) . $message->_txtbody;
+      $message->_txtbody = ($comment['body_text'] ?? '') . $message->_txtbody;
       if (!empty($comment['body_html'])) {
         $message->_htmlbody = $comment['body_html'] . '<br />---------------Original message---------------------<br />' . $message->_htmlbody;
       }

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -567,7 +567,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     // chk for renewal for multiple terms CRM-8750
     $numRenewTerms = 1;
-    if (is_numeric(CRM_Utils_Array::value('num_terms', $this->_params))) {
+    if (is_numeric($this->_params['num_terms'] ?? '')) {
       $numRenewTerms = $this->_params['num_terms'];
     }
 

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -322,11 +322,11 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         }
         elseif (empty($formatted['is_override'])) {
           if (empty($calcStatus)) {
-            throw new CRM_Core_Exception('Status in import row (' . CRM_Utils_Array::value('status_id', $formatValues) . ') does not match calculated status based on your configured Membership Status Rules. Record was not imported.', CRM_Import_Parser::ERROR);
+            throw new CRM_Core_Exception('Status in import row (' . ($formatValues['status_id'] ?? '') . ') does not match calculated status based on your configured Membership Status Rules. Record was not imported.', CRM_Import_Parser::ERROR);
           }
           if ($formatted['status_id'] != $calcStatus['id']) {
             //Status Hold" is either NOT mapped or is FALSE
-            throw new CRM_Core_Exception('Status in import row (' . CRM_Utils_Array::value('status_id', $formatValues) . ') does not match calculated status based on your configured Membership Status Rules (' . $calcStatus['name'] . '). Record was not imported.', CRM_Import_Parser::ERROR);
+            throw new CRM_Core_Exception('Status in import row (' . ($formatValues['status_id'] ?? '') . ') does not match calculated status based on your configured Membership Status Rules (' . $calcStatus['name'] . '). Record was not imported.', CRM_Import_Parser::ERROR);
           }
         }
 

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -521,13 +521,13 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
 
       // ignore startDate for events - PCP's can be active long before event start date
       $startDate = 0;
-      $endDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('end_date', $entity));
+      $endDate = CRM_Utils_Date::unixTime($entity['end_date'] ?? '');
     }
     elseif ($component == 'contribute') {
       $urlBase = 'civicrm/contribute/transact';
       //start and end date of the contribution page
-      $startDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('start_date', $entity));
-      $endDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('end_date', $entity));
+      $startDate = CRM_Utils_Date::unixTime($entity['start_date'] ?? '');
+      $endDate = CRM_Utils_Date::unixTime($entity['end_date'] ?? '');
     }
 
     // define redirect url back to contrib page or event if needed
@@ -552,8 +552,8 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
     }
     // Check if we're in range for contribution page start and end dates. for events, check if after event end date
     elseif (($startDate && $startDate > $now) || ($endDate && $endDate < $now)) {
-      $customStartDate = CRM_Utils_Date::customFormat(CRM_Utils_Array::value('start_date', $entity));
-      $customEndDate = CRM_Utils_Date::customFormat(CRM_Utils_Array::value('end_date', $entity));
+      $customStartDate = CRM_Utils_Date::customFormat($entity['start_date'] ?? '');
+      $customEndDate = CRM_Utils_Date::customFormat($entity['end_date'] ?? '');
       if ($startDate && $endDate) {
         $statusMessage = ts('The Personal Campaign Page you have just visited is only active from %1 to %2. However you can still support the campaign here.',
           [1 => $customStartDate, 2 => $customEndDate]

--- a/CRM/PCP/Page/PCPInfo.php
+++ b/CRM/PCP/Page/PCPInfo.php
@@ -219,12 +219,12 @@ class CRM_PCP_Page_PCPInfo extends CRM_Core_Page {
     }
     // make sure that we are between contribution page start and end dates OR registration start date and end dates if they are set
     if ($pcpBlock->entity_table == 'civicrm_event') {
-      $startDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('registration_start_date', $pageInfo));
-      $endDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('registration_end_date', $pageInfo));
+      $startDate = CRM_Utils_Date::unixTime($pageInfo['registration_start_date'] ?? '');
+      $endDate = CRM_Utils_Date::unixTime($pageInfo['registration_end_date'] ?? '');
     }
     else {
-      $startDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('start_date', $pageInfo));
-      $endDate = CRM_Utils_Date::unixTime(CRM_Utils_Array::value('end_date', $pageInfo));
+      $startDate = CRM_Utils_Date::unixTime($pageInfo['start_date'] ?? '');
+      $endDate = CRM_Utils_Date::unixTime($pageInfo['end_date'] ?? '');
     }
 
     $now = time();

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -184,7 +184,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
     }
 
     $contributionTypes = CRM_Contribute_PseudoConstant::financialType();
-    $title = CRM_Contact_BAO_Contact::displayName($pledge->contact_id) . ' - (' . ts('Pledged') . ' ' . CRM_Utils_Money::format($pledge->amount, $pledge->currency) . ' - ' . CRM_Utils_Array::value($pledge->financial_type_id, $contributionTypes) . ')';
+    $title = CRM_Contact_BAO_Contact::displayName($pledge->contact_id) . ' - (' . ts('Pledged') . ' ' . CRM_Utils_Money::format($pledge->amount, $pledge->currency) . ' - ' . ($contributionTypes[$pledge->financial_type_id] ?? '') . ')';
 
     // add the recently created Pledge
     CRM_Utils_Recent::add($title,

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -427,7 +427,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
       }
     }
 
-    if ((is_numeric(CRM_Utils_Array::value('count', $fields)) &&
+    if ((is_numeric($fields['count'] ?? '') &&
         empty($fields['count'])
       ) &&
       (($fields['html_type'] ?? NULL) == 'Text')

--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -428,7 +428,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
         $field = $vars[$key];
         $fieldArray = explode('-', $field['name']);
         $fieldType = $fieldArray['2'] ?? NULL;
-        if (is_numeric(CRM_Utils_Array::value('1', $fieldArray))) {
+        if (is_numeric($fieldArray['1'] ?? '')) {
           if (!in_array($fieldType, $multipleFields)) {
             $locationType = new CRM_Core_DAO_LocationType();
             $locationType->id = $fieldArray[1];

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3540,11 +3540,11 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
                 isset($field['options']) &&
                 is_array($field['options']) && !empty($field['options'])
               ) {
-                $value = CRM_Utils_Array::value($op, $pair) . " " .
+                $value = ($pair[$op] ?? '') . " " .
                   CRM_Utils_Array::value($val, $field['options'], $val);
               }
               elseif ($val || $val == '0') {
-                $value = CRM_Utils_Array::value($op, $pair) . " " . $val;
+                $value = ($pair[$op] ?? '') . " " . $val;
               }
             }
             if ($value && empty($field['no_display'])) {
@@ -3648,7 +3648,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
    */
   public function compileContent() {
     $templateFile = $this->getHookedTemplateFileName();
-    return CRM_Utils_Array::value('report_header', $this->_formValues) .
+    return ($this->_formValues['report_header'] ?? '') .
     CRM_Core_Form::$_template->fetch($templateFile) .
     CRM_Utils_Array::value('report_footer', $this->_formValues);
   }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -897,7 +897,7 @@ class CRM_Report_Form extends CRM_Core_Form {
             if ($fieldGrp == 'filters') {
               // fill operator types
               if (!array_key_exists('operatorType', $this->_columns[$tableName][$fieldGrp][$fieldName])) {
-                switch (CRM_Utils_Array::value('type', $this->_columns[$tableName][$fieldGrp][$fieldName])) {
+                switch ($this->_columns[$tableName][$fieldGrp][$fieldName]['type'] ?? NULL) {
                   case CRM_Utils_Type::T_MONEY:
                   case CRM_Utils_Type::T_FLOAT:
                     $this->_columns[$tableName][$fieldGrp][$fieldName]['operatorType'] = CRM_Report_Form::OP_FLOAT;
@@ -2834,7 +2834,7 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
             !empty($this->_params['group_bys'][$fieldName]) &&
             !empty($this->_params['group_bys_freq'])
           ) {
-            switch (CRM_Utils_Array::value($fieldName, $this->_params['group_bys_freq'])) {
+            switch ($this->_params['group_bys_freq'][$fieldName] ?? NULL) {
               case 'YEARWEEK':
                 $select[] = "DATE_SUB({$field['dbAlias']}, INTERVAL WEEKDAY({$field['dbAlias']}) DAY) AS {$tableName}_{$fieldName}_start";
                 $select[] = "YEARWEEK({$field['dbAlias']}) AS {$tableName}_{$fieldName}_subtotal";

--- a/CRM/Report/Form/Contribute/RecurSummary.php
+++ b/CRM/Report/Form/Contribute/RecurSummary.php
@@ -84,7 +84,7 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
       if (array_key_exists('group_bys', $table)) {
         foreach ($table['group_bys'] as $fieldName => $field) {
           if (!empty($this->_params['group_bys'][$fieldName])) {
-            switch (CRM_Utils_Array::value($fieldName, $this->_params['group_bys_freq'])) {
+            switch ($this->_params['group_bys_freq'][$fieldName] ?? NULL) {
               case 'YEARWEEK':
                 $select[] = "DATE_SUB({$field['dbAlias']}, INTERVAL WEEKDAY({$field['dbAlias']}) DAY) AS {$tableName}_{$fieldName}_start";
                 $select[] = "YEARWEEK({$field['dbAlias']}) AS {$tableName}_{$fieldName}_subtotal";

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -365,7 +365,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
       if (array_key_exists('group_bys', $table)) {
         foreach ($table['group_bys'] as $fieldName => $field) {
           if (!empty($this->_params['group_bys'][$fieldName])) {
-            switch (CRM_Utils_Array::value($fieldName, $this->_params['group_bys_freq'])) {
+            switch ($this->_params['group_bys_freq'][$fieldName] ?? NULL) {
               case 'YEARWEEK':
                 $select[] = "DATE_SUB({$field['dbAlias']}, INTERVAL WEEKDAY({$field['dbAlias']}) DAY) AS {$tableName}_{$fieldName}_start";
                 $select[] = "YEARWEEK({$field['dbAlias']}) AS {$tableName}_{$fieldName}_subtotal";
@@ -621,7 +621,7 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
     $statistics = parent::statistics($rows);
 
     $softCredit = $this->_params['fields']['soft_amount'] ?? NULL;
-    $onlySoftCredit = $softCredit && !CRM_Utils_Array::value('total_amount', $this->_params['fields']);
+    $onlySoftCredit = $softCredit && empty($this->_params['fields']['total_amount']);
     if (!isset($this->_groupByArray['civicrm_contribution_currency'])) {
       $this->_groupByArray['civicrm_contribution_currency'] = 'currency';
     }

--- a/CRM/Report/Form/Mailing/Detail.php
+++ b/CRM/Report/Form/Mailing/Detail.php
@@ -345,7 +345,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     }
 
     if (array_key_exists('reply_id', $this->_params['fields']) ||
-      is_numeric(CRM_Utils_Array::value('is_replied_value', $this->_params))
+      is_numeric($this->_params['is_replied_value'] ?? '')
     ) {
       if (($this->_params['is_replied_value'] ?? NULL) == 1) {
         $joinType = 'INNER';
@@ -363,7 +363,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     }
 
     if (array_key_exists('unsubscribe_id', $this->_params['fields']) ||
-      is_numeric(CRM_Utils_Array::value('is_unsubscribed_value', $this->_params))
+      is_numeric($this->_params['is_unsubscribed_value'] ?? '')
     ) {
       if (($this->_params['is_unsubscribed_value'] ?? NULL) == 1
       ) {
@@ -383,7 +383,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     }
 
     if (array_key_exists('optout_id', $this->_params['fields']) ||
-      is_numeric(CRM_Utils_Array::value('is_optout_value', $this->_params))
+      is_numeric($this->_params['is_optout_value'] ?? '')
     ) {
       if (($this->_params['is_optout_value'] ?? NULL) == 1) {
         $joinType = 'INNER';
@@ -402,7 +402,7 @@ class CRM_Report_Form_Mailing_Detail extends CRM_Report_Form {
     }
 
     if (array_key_exists('forward_id', $this->_params['fields']) ||
-      is_numeric(CRM_Utils_Array::value('is_forwarded_value', $this->_params))
+      is_numeric($this->_params['is_forwarded_value'] ?? '')
     ) {
       if (($this->_params['is_forwarded_value'] ?? NULL) == 1) {
         $joinType = 'INNER';

--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -182,7 +182,7 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
         foreach ($table['group_bys'] as $fieldName => $field) {
           if (!empty($this->_params['group_bys'][$fieldName])) {
 
-            switch (CRM_Utils_Array::value($fieldName, $this->_params['group_bys_freq'])) {
+            switch ($this->_params['group_bys_freq'][$fieldName] ?? NULL) {
               case 'YEARWEEK':
                 $select[] = "DATE_SUB({$field['dbAlias']}, INTERVAL WEEKDAY({$field['dbAlias']}) DAY) AS {$tableName}_{$fieldName}_start";
 

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -206,7 +206,7 @@ class CRM_Report_Utils_Get {
     // process only filters for now
     foreach ($fieldGrp as $tableName => $fields) {
       foreach ($fields as $fieldName => $field) {
-        switch (CRM_Utils_Array::value('type', $field)) {
+        switch ($field['type'] ?? NULL) {
           case CRM_Utils_Type::T_INT:
           case CRM_Utils_Type::T_FLOAT:
           case CRM_Utils_Type::T_MONEY:

--- a/CRM/SMS/Form/Upload.php
+++ b/CRM/SMS/Form/Upload.php
@@ -310,7 +310,7 @@ class CRM_SMS_Form_Upload extends CRM_Core_Form {
       }
     }
 
-    if (($params['upload_type'] || file_exists(CRM_Utils_Array::value('tmp_name', $files['textFile']))) ||
+    if (($params['upload_type'] || file_exists($files['textFile']['tmp_name'] ?? '')) ||
       (!$params['upload_type'] && $params['text_message'])
     ) {
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -423,10 +423,10 @@ class CRM_Utils_File {
       // munge extension so it cannot have an embbeded dot in it
       // The maximum length of a filename for most filesystems is 255 chars.
       // We'll truncate at 240 to give some room for the extension.
-      return CRM_Utils_String::munge("{$basename}_" . CRM_Utils_Array::value('extension', $info) . "_{$uniqID}", '_', 240) . ".unknown";
+      return CRM_Utils_String::munge("{$basename}_" . ($info['extension'] ?? '') . "_{$uniqID}", '_', 240) . ".unknown";
     }
     else {
-      return CRM_Utils_String::munge("{$basename}_{$uniqID}", '_', 240) . "." . CRM_Utils_Array::value('extension', $info);
+      return CRM_Utils_String::munge("{$basename}_{$uniqID}", '_', 240) . "." . ($info['extension'] ?? '');
     }
   }
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -417,9 +417,9 @@ class CRM_Utils_File {
     $uniqID = md5(uniqid(rand(), TRUE));
     $info = pathinfo($name);
     $basename = substr($info['basename'],
-      0, -(strlen(CRM_Utils_Array::value('extension', $info, '')) + (CRM_Utils_Array::value('extension', $info, '') == '' ? 0 : 1))
+      0, -(strlen($info['extension'] ?? '') + (($info['extension'] ?? '') == '' ? 0 : 1))
     );
-    if (!self::isExtensionSafe(CRM_Utils_Array::value('extension', $info, ''))) {
+    if (!self::isExtensionSafe($info['extension'] ?? '')) {
       // munge extension so it cannot have an embbeded dot in it
       // The maximum length of a filename for most filesystems is 255 chars.
       // We'll truncate at 240 to give some room for the extension.

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -445,8 +445,8 @@ class CRM_Utils_REST {
     if (!empty($requestParams['json'])) {
       $params = json_decode($requestParams['json'], TRUE);
     }
-    $entity = CRM_Utils_String::munge(CRM_Utils_Array::value('entity', $requestParams));
-    $action = CRM_Utils_String::munge(CRM_Utils_Array::value('action', $requestParams));
+    $entity = CRM_Utils_String::munge($requestParams['entity'] ?? '');
+    $action = CRM_Utils_String::munge($requestParams['action'] ?? '');
     if (!is_array($params)) {
       CRM_Utils_JSON::output([
         'is_error' => 1,

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -73,8 +73,8 @@ class CRM_Utils_String {
     // CRM-11744
     $name = preg_replace('/[^a-zA-Z0-9]+/', $char, trim($name));
 
-    //If there are no ascii characters present.
-    if ($name == $char) {
+    // If there are no ascii characters present.
+    if (!strlen(trim($name, $char))) {
       $name = self::createRandom($len, self::ALPHANUMERIC);
     }
 

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1253,7 +1253,7 @@ class CRM_Utils_System {
     // FIXME: Shouldn't the X-Forwarded-Proto check be part of CRM_Utils_System::isSSL()?
     if (Civi::settings()->get('enableSSL') &&
       !self::isSSL() &&
-      strtolower(CRM_Utils_Array::value('X_FORWARDED_PROTO', $req_headers)) != 'https'
+      strtolower($req_headers['X_FORWARDED_PROTO'] ?? '') != 'https'
     ) {
       // ensure that SSL is enabled on a civicrm url (for cookie reasons etc)
       $url = "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -40,7 +40,7 @@
  */
 function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
   static $results = [];
-  if ((CRM_Utils_Array::value('cache_clear', $apiRequest['params']))) {
+  if (!empty($apiRequest['params']['cache_clear'])) {
     $results = [];
     // we will also clear pseudoconstants here - should potentially be moved to relevant BAO classes
     CRM_Core_PseudoConstant::flush();

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -279,7 +279,7 @@ function _civicrm_api3_generic_getfield_spec(&$params, $apiRequest) {
 function civicrm_api3_generic_getcount($apiRequest) {
   $apiRequest['params']['options']['is_count'] = TRUE;
   $result = civicrm_api($apiRequest['entity'], 'get', $apiRequest['params']);
-  if (is_numeric(CRM_Utils_Array::value('values', $result))) {
+  if (is_numeric($result['values'] ?? '')) {
     return (int) $result['values'];
   }
   if (!isset($result['count'])) {

--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -193,7 +193,7 @@ function civicrm_api3_profile_submit($params) {
     $contactEntities = ['contact', 'individual', 'organization', 'household'];
     $locationEntities = ['email', 'address', 'phone', 'website', 'im'];
 
-    $entity = strtolower(CRM_Utils_Array::value('entity', $field, ''));
+    $entity = strtolower($field['entity'] ?? '');
     if ($entity && !in_array($entity, array_merge($contactEntities, $locationEntities))) {
       switch ($entity) {
         case 'note':

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -87,10 +87,10 @@ function civicrm_api3_relationship_get($params) {
   }
   else {
     $relationships = CRM_Contact_BAO_Relationship::getRelationship($params['contact_id'],
-      CRM_Utils_Array::value('status_id', $params),
+      $params['status_id'] ?? 0,
       0,
-      CRM_Utils_Array::value('is_count', $options),
-      CRM_Utils_Array::value('id', $params),
+      $options['is_count'] ?? 0,
+      $params['id'] ?? 0,
       NULL,
       NULL,
       FALSE,

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -102,7 +102,7 @@ function civicrm_api3_relationship_get($params) {
     return ['count' => $relationships];
   }
   foreach ($relationships as $relationshipId => $values) {
-    _civicrm_api3_custom_data_get($relationships[$relationshipId], CRM_Utils_Array::value('check_permissions', $params), 'Relationship', $relationshipId, NULL, CRM_Utils_Array::value('relationship_type_id', $values));
+    _civicrm_api3_custom_data_get($relationships[$relationshipId], $params['check_permissions'] ?? 0, 'Relationship', $relationshipId, NULL, $values['relationship_type_id'] ?? NULL);
   }
   return civicrm_api3_create_success($relationships, $params);
 }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1523,7 +1523,7 @@ function _civicrm_api3_validate($entity, $action, $params) {
  * @throws Exception
  */
 function _civicrm_api3_validate_switch_cases($fieldName, $fieldInfo, $entity, $params, $action) {
-  switch (CRM_Utils_Array::value('type', $fieldInfo)) {
+  switch ($fieldInfo['type'] ?? NULL) {
     case CRM_Utils_Type::T_INT:
       _civicrm_api3_validate_integer($params, $fieldName, $fieldInfo, $entity);
       break;
@@ -1585,7 +1585,7 @@ function _civicrm_api3_validate_fields($entity, $action, &$params, $fields) {
     $fields = array_merge($fields, $chainApiParams);
   }
   foreach ($fields as $fieldName => $fieldInfo) {
-    switch (CRM_Utils_Array::value('type', $fieldInfo)) {
+    switch ($fieldInfo['type'] ?? NULL) {
       case CRM_Utils_Type::T_INT:
         //field is of type integer
         _civicrm_api3_validate_integer($params, $fieldName, $fieldInfo, $entity);

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -278,8 +278,8 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
   public function formRule($fields, $files, $self) {
     $this->addGeocodingData($fields);
 
-    if (!is_numeric(CRM_Utils_Array::value('geo_code_1', $fields)) ||
-      !is_numeric(CRM_Utils_Array::value('geo_code_2', $fields)) ||
+    if (!is_numeric($fields['geo_code_1'] ?? '') ||
+      !is_numeric($fields['geo_code_2'] ?? '') ||
       !isset($fields['distance'])
     ) {
       $errorMessage = ts('Could not determine co-ordinates for provided data');

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -976,7 +976,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $keys = array_keys($contact['values']);
     $contactId = array_pop($keys);
 
-    $this->assertEquals(0, $contact['values'][$contactId]['api.address.create']['is_error'], ' error message: ' . CRM_Utils_Array::value('error_message', $contact['values'][$contactId]['api.address.create'])
+    $this->assertEquals(0, $contact['values'][$contactId]['api.address.create']['is_error'], ' error message: ' . ($contact['values'][$contactId]['api.address.create']['error_message'] ?? '')
     );
 
     $activityParams = [


### PR DESCRIPTION
Overview
----------------------------------------
Resolves a lot of current & potential-future php deprecation notices by removing `CRM_Utils_Array` calls that were passing out an incorrect data type.

Before
----------------------------------------
Lots of cases where it would have been trying to concatenate strings with NULL, or pass NULL into a function that only accepts a string, like `trim()`.

After
----------------------------------------
Fixed

Technical Details
-------------
The way it was interacting with `CRM_Utils_String::munge` was especially problematic because in a scenario like
```
CRM_Utils_String::munge(CRM_Utils_Array::value('name', $thing))
```
The default return value of NULL could get passed into munge which would then pass it into `trim()` and `preg_replace()` causing two warnings, and then would fail to recognize that it was empty because it wasn't equal to `$char`. I've cleaned that up too.