### PR TITLE
Contact Summary: Rename Delete Contact button to Delete

### DIFF
--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -66,7 +66,7 @@
         {elseif call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}
           <li class="crm-delete-action crm-contact-delete">
             {crmButton p='civicrm/contact/view/delete' q="reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
-              {ts}Delete Contact{/ts}
+              {ts}Delete{/ts}
             {/crmButton}
           </li>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------

Renames the "Delete Contact" button to just "Delete".

Other buttons all use the same short label, and "Delete" is by far not the most important button here.

- Edit (not "Edit Contact")
- Delete Permanently (not "Delete Contact Permanently")
- Restore from Trash
- Previous / Next

Before / After
----------------------------------------

Sandbox before/after:

![image](https://github.com/civicrm/civicrm-core/assets/254741/4acb156d-768d-4d56-b17f-11c042c3a4e5)

![image](https://github.com/civicrm/civicrm-core/assets/254741/100e9c53-0772-4c47-8e14-8cbd638c41b9)

[The Island theme](https://civicrm.org/extensions/island-theme) before/after:

![image](https://github.com/civicrm/civicrm-core/assets/254741/7bacc6f6-d4e2-4088-93f6-3e9d92d4b3fb)

![image](https://github.com/civicrm/civicrm-core/assets/254741/b4ca94e1-c68a-4bf3-90ea-3f66e66f01ac)

cc @larssandergreen @artfulrobot  @vingle 