### PR TITLE
Remove gap before delete button on contact

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -1472,10 +1472,6 @@ input.crm-form-entityref {
   list-style: none;
 }
 
-#crm-container .crm-actions-ribbon li.crm-delete-action {
-  margin-left: 30px;
-}
-
 #crm-container .crm-actions-ribbon li.crm-previous-action,
 #crm-container .crm-actions-ribbon li.crm-next-action {
   float: right;

--- a/templates/CRM/Contact/Page/View/Summary.tpl
+++ b/templates/CRM/Contact/Page/View/Summary.tpl
@@ -64,7 +64,7 @@
           {/if}
 
         {elseif call_user_func(array('CRM_Core_Permission','check'), 'delete contacts')}
-          <li class="crm-delete-action crm-contact-delete">
+          <li class="crm-contact-delete">
             {crmButton p='civicrm/contact/view/delete' q="reset=1&delete=1&cid=$contactId" class="delete" icon="trash"}
               {ts}Delete Contact{/ts}
             {/crmButton}


### PR DESCRIPTION
Before
----------------------------------------
<img width="305" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/55c4cc06-b86c-419c-a27d-f026fedd1def">

After
----------------------------------------
<img width="305" alt="image" src="https://github.com/civicrm/civicrm-core/assets/25517556/e6800479-6539-4cf8-8115-b7afd7362c86">

Comments
----------------------------------------
This class is not used anywhere else in core, so it can go, no need for two classes here.