### PR TITLE
dev/core#4435 Fix e-notice with Manual processor

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -500,8 +500,7 @@ abstract class CRM_Core_Payment {
   /**
    * Default payment instrument validation.
    *
-   * Implement the usual Luhn algorithm via a static function in the CRM_Core_Payment_Form if it's a credit card
-   * Not a static function, because I need to check for payment_type.
+   * Payment processors should override this.
    *
    * @param array $values
    * @param array $errors

--- a/CRM/Core/Payment/Manual.php
+++ b/CRM/Core/Payment/Manual.php
@@ -294,4 +294,14 @@ class CRM_Core_Payment_Manual extends CRM_Core_Payment {
     return TRUE;
   }
 
+  /**
+   * Override default payment instrument validation, as recommended.
+   *
+   * We have nothing to validate here.
+   *
+   * @param array $values
+   * @param array $errors
+   */
+  public function validatePaymentInstrument($values, &$errors): void {}
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/26425

Before
----------------------------------------
e-notice on pay later

After
----------------------------------------
fixes

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/26425 got complicated - but it is also worth noting that we generally want payment processors to implement the validate function themselves, the function that is in `Core_Payment` reflected the fact they historically didn't - so this also prods processor writers in the right direction

Comments
----------------------------------------
@larssandergreen this might be an easier way to sort it...