### PR TITLE
Follow on cleanup - remove unused assign

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -762,11 +762,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
                 ->execute()
                 ->first();
 
-              if ($membership) {
-                if ($membership["membership_type_id.duration_unit:name"] === 'lifetime') {
-                  $this->assign('islifetime', TRUE);
-                  continue;
-                }
+              if ($membership && $membership['membership_type_id.duration_unit:name'] !== 'lifetime') {
                 $this->assign('renewal_mode', TRUE);
                 $this->_currentMemberships[$membership['membership_type_id']] = $membership['membership_type_id'];
                 $memType['current_membership'] = $membership['end_date'];

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -15,6 +15,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Membership;
+
 /**
  * Form for thank-you / success page - 3rd step of online contribution process.
  */
@@ -383,7 +385,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
             if ($cid) {
               //show current membership, skip pending and cancelled membership records,
               //because we take first membership record id for renewal
-              $membership = \Civi\Api4\Membership::get(FALSE)
+              $membership = Membership::get(FALSE)
                 ->addSelect('end_date', 'membership_type_id', 'membership_type_id.duration_unit:name')
                 ->addWhere('contact_id', '=', $cid)
                 ->addWhere('membership_type_id', '=', $memType['id'])
@@ -393,11 +395,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
                 ->execute()
                 ->first();
 
-              if ($membership) {
-                if ($membership["membership_type_id.duration_unit:name"] === 'lifetime') {
-                  $this->assign('islifetime', TRUE);
-                  continue;
-                }
+              if ($membership && $membership['membership_type_id.duration_unit:name'] !== 'lifetime') {
                 $this->assign('renewal_mode', TRUE);
                 $this->_currentMemberships[$membership['membership_type_id']] = $membership['membership_type_id'];
                 $memType['current_membership'] = $membership['end_date'];


### PR DESCRIPTION
Overview
----------------------------------------
Per @MegaphoneJon's observation in https://github.com/civicrm/civicrm-core/pull/25458#event-9893790808 `  $this->assign('islifetime', TRUE);` does nothing in the Confirm & ThankYou flows & is legacy from previously shared code

Before
----------------------------------------
Now you see it

![image](https://github.com/civicrm/civicrm-core/assets/336308/92486f4e-c146-4d87-8546-14168b49a75f)


After
----------------------------------------
Now you don't

Technical Details
----------------------------------------
With that assign gone the if just has a continue - so we can merge it with the parent ID

Comments
----------------------------------------
