### PR TITLE
Stop setting undeclared property in previously shared code

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -772,11 +772,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
                 $memType['current_membership'] = $membership['end_date'];
                 if (!$endDate) {
                   $endDate = $memType['current_membership'];
-                  $this->_defaultMemTypeId = $memType['id'];
                 }
                 if ($memType['current_membership'] < $endDate) {
                   $endDate = $memType['current_membership'];
-                  $this->_defaultMemTypeId = $memType['id'];
                 }
               }
             }

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -403,11 +403,9 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
                 $memType['current_membership'] = $membership['end_date'];
                 if (!$endDate) {
                   $endDate = $memType['current_membership'];
-                  $this->_defaultMemTypeId = $memType['id'];
                 }
                 if ($memType['current_membership'] < $endDate) {
                   $endDate = $memType['current_membership'];
-                  $this->_defaultMemTypeId = $memType['id'];
                 }
               }
             }


### PR DESCRIPTION
Overview
----------------------------------------
Stop setting undeclared property in previously shared code

Follow on from https://github.com/civicrm/civicrm-core/pull/25458

Before
----------------------------------------
This code used to be shared but is no longer, only `Main.php` uses the  `_defaultMemTypeId ` property

![image](https://github.com/civicrm/civicrm-core/assets/336308/f63543bd-9d5c-4a38-9e55-106647856a81)

After
----------------------------------------
Removed from other copies

Technical Details
----------------------------------------

Comments
----------------------------------------
