### PR TITLE
Remove old broken code

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -182,32 +182,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           $paymentAmount += $value['scheduled_amount'];
           $duePayment = TRUE;
         }
-        elseif ($value['status'] == 'Completed' && $value['contribution_id']) {
-          $completedContributionIds[] = $value['contribution_id'];
-        }
       }
       $this->_defaults['price_' . $this->_priceSetId] = $paymentAmount;
-
-      if (count($completedContributionIds)) {
-        $softCredit = [];
-        foreach ($completedContributionIds as $id) {
-          $softCredit = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($id);
-        }
-        if (isset($softCredit['soft_credit'])) {
-          $this->_defaults['soft_credit_type_id'] = $softCredit['soft_credit'][1]['soft_credit_type'];
-
-          //since honoree profile fieldname of fields are prefixed with 'honor'
-          //we need to reformat the fieldname to append prefix during setting default values
-          CRM_Core_BAO_UFGroup::setProfileDefaults(
-            $softCredit['soft_credit'][1]['contact_id'],
-            CRM_Core_BAO_UFGroup::getFields($this->_honoreeProfileId),
-            $defaults
-          );
-          foreach ($defaults as $fieldName => $value) {
-            $this->_defaults['honor[' . $fieldName . ']'] = $value;
-          }
-        }
-      }
     }
     elseif (!empty($this->_values['pledge_block_id'])) {
       //set default to one time contribution.


### PR DESCRIPTION
Overview
----------------------------------------
Remove old broken code

This code is

1) passing a non variable to a pass by reference
2) accessing a non-existant never-set property (`_honoreeProfileId`)

I think it is likely this code has been broken [since 2014](https://github.com/civicrm/civicrm-core/pull/2372) but it's really obscure & hence probably never hit.

To hit this code it is necessary to attempt to add a pledge payment to an existing pledge via a contribution page by putting the pledgeId in the url along with the contact ID (e.g https://dmaster.localhost:32353/civicrm/contribute/transact?reset=1&id=3&pledgeId=4&cid=204). However, the pledge MUST HAVE existing completed payment/s AND at least one of those MUST have a soft credit. I hacked out the checksum lookup to get past that

Note there are multiple reasons why this might not work on your site if you try to test it - it looks up the wrong option group set to get valid statuses for example. But the worst that could happen is that a default value is not set in a very very obscure place

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/b9985f88-2170-49de-98fa-1ee284c62e0a)


![image](https://github.com/civicrm/civicrm-core/assets/336308/0309fe09-45be-480c-a947-eea7b02059a3)

After
----------------------------------------
poof

![image](https://github.com/civicrm/civicrm-core/assets/336308/e9a4956f-978f-4f39-8caa-9461468b2380)


Technical Details
----------------------------------------

Comments
----------------------------------------
