### PR TITLE
[PHP8.2] Remove undefined property in favour of calc-as-needed

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1201,7 +1201,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     if (!empty($this->_ccid)) {
-      $this->set('lineItem', $this->_lineItem);
+      $this->set('lineItem', [$this->getPriceSetID() => $this->getExistingContributionLineItems()]);
     }
     elseif ($priceSetId = CRM_Utils_Array::value('priceSetId', $params)) {
       $lineItem = [];
@@ -1383,8 +1383,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $lineItems = $this->getExistingContributionLineItems();
-    // Is this used?
-    $this->_lineItem[$this->getPriceSetID()] = $lineItems;
     $this->assign('lineItem', [$this->getPriceSetID() => $lineItems]);
     $this->assign('is_quick_config', $this->isQuickConfig());
     $this->assign('priceSetID', $this->getPriceSetID());


### PR DESCRIPTION
This appears to be one of those cases where they wanted to 'save the code the effort' of calculating twice - but it is a trivial calculation balanced
against the confusion of setting an undefined
property in one place to use later


Note the Confirm form makes more extensive use of a property for line items but is unrelated