### PR TITLE
REF - Split variable assignments out of conditionals

### DIFF
--- a/CRM/Activity/Form/ActivityView.php
+++ b/CRM/Activity/Form/ActivityView.php
@@ -91,11 +91,13 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
     $values['target_contact_value'] = $values['target_contact_value'] ?? NULL;
 
     // Get the campaign.
-    if ($campaignId = CRM_Utils_Array::value('campaign_id', $defaults)) {
+    $campaignId = $defaults['campaign_id'] ?? NULL;
+    if ($campaignId) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);
       $values['campaign'] = $campaigns[$campaignId];
     }
-    if ($engagementLevel = CRM_Utils_Array::value('engagement_level', $defaults)) {
+    $engagementLevel = $defaults['engagement_level'] ?? NULL;
+    if ($engagementLevel) {
       $engagementLevels = CRM_Campaign_PseudoConstant::engagementLevel();
       $values['engagement_level'] = CRM_Utils_Array::value($engagementLevel, $engagementLevels, $engagementLevel);
     }

--- a/CRM/Activity/Selector/Activity.php
+++ b/CRM/Activity/Selector/Activity.php
@@ -411,7 +411,8 @@ class CRM_Activity_Selector_Activity extends CRM_Core_Selector_Base implements C
 
       $row['status'] = $row['status_id'] ? $activityStatus[$row['status_id']] : NULL;
 
-      if ($engagementLevel = CRM_Utils_Array::value('engagement_level', $row)) {
+      $engagementLevel = $row['engagement_level'] ?? NULL;
+      if ($engagementLevel) {
         $row['engagement_level'] = CRM_Utils_Array::value($engagementLevel, $engagementLevels, $engagementLevel);
       }
 

--- a/CRM/Activity/Selector/Search.php
+++ b/CRM/Activity/Selector/Search.php
@@ -319,7 +319,8 @@ class CRM_Activity_Selector_Search extends CRM_Core_Selector_Base implements CRM
       $row['campaign'] = $allCampaigns[$result->activity_campaign_id] ?? NULL;
       $row['campaign_id'] = $result->activity_campaign_id;
 
-      if ($engagementLevel = CRM_Utils_Array::value('activity_engagement_level', $row)) {
+      $engagementLevel = $row['activity_engagement_level'] ?? NULL;
+      if ($engagementLevel) {
         $row['activity_engagement_level'] = CRM_Utils_Array::value($engagementLevel,
           $engagementLevels, $engagementLevel
         );

--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -394,7 +394,8 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $defaults['entity'] = $entityStatus;
       }
 
-      if ($recipientListing = CRM_Utils_Array::value('recipient_listing', $defaults)) {
+      $recipientListing = $defaults['recipient_listing'] ?? NULL;
+      if ($recipientListing) {
         $defaults['recipient_listing'] = explode(CRM_Core_DAO::VALUE_SEPARATOR,
           $recipientListing
         );
@@ -411,7 +412,8 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
         $defaults['recipient'] = 'manual';
         $defaults['recipient_manual_id'] = $defaults['recipient_manual'];
       }
-      if ($contactLanguage = CRM_Utils_Array::value('filter_contact_language', $defaults)) {
+      $contactLanguage = $defaults['filter_contact_language'] ?? NULL;
+      if ($contactLanguage) {
         $defaults['filter_contact_language'] = explode(CRM_Core_DAO::VALUE_SEPARATOR, $contactLanguage);
       }
     }

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -217,7 +217,8 @@ WHERE {$clause}
     $this->_resultOptions = $this->get('resultOptions');
     if (!is_array($this->_resultOptions)) {
       $this->_resultOptions = [];
-      if ($resultOptionId = CRM_Utils_Array::value('result_id', $this->_surveyValues)) {
+      $resultOptionId = $this->_surveyValues['result_id'] ?? NULL;
+      if ($resultOptionId) {
         $this->_resultOptions = CRM_Core_OptionGroup::valuesByID($resultOptionId);
       }
       $this->set('resultOptions', $this->_resultOptions);

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -601,7 +601,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
 
             if (isset($id) && array_key_exists($id, $this->_relatedContacts) && isset($this->_relatedContacts[$id]['email'])) {
               //if email already exists in array then append with ', ' another role only otherwise add it to array.
-              if ($contactDetails = CRM_Utils_Array::value($this->_relatedContacts[$id]['email'], $mailToContacts)) {
+              $contactDetails = $mailToContacts[$this->_relatedContacts[$id]['email']] ?? NULL;
+              if ($contactDetails) {
                 $caseRole = $this->_relatedContacts[$id]['role'] ?? NULL;
                 $mailToContacts[$this->_relatedContacts[$id]['email']]['role'] = $contactDetails['role'] . ', ' . $caseRole;
               }

--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -1007,7 +1007,8 @@ INNER JOIN civicrm_contact contact_target ON ( contact_target.id = act.contact_i
         $contactIds[] = $contactID;
       }
       else {
-        if ($greetingBuffer = CRM_Utils_Array::value($filterContactFldIds[$contactID], $allGreetings)) {
+        $greetingBuffer = $allGreetings[$filterContactFldIds[$contactID]] ?? NULL;
+        if ($greetingBuffer) {
           $greetingString = $greetingBuffer;
         }
       }

--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -427,7 +427,8 @@ WHERE  subtype.name IN ('" . implode("','", $subType) . "' )";
         $typeValue = explode(CRM_Core_DAO::VALUE_SEPARATOR, $key);
         $cType = $typeValue['0'] ?? NULL;
         $typeUrl = 'ct=' . $cType;
-        if ($csType = CRM_Utils_Array::value('1', $typeValue)) {
+        $csType = $typeValue['1'] ?? NULL;
+        if ($csType) {
           $typeUrl .= "&cst=$csType";
         }
         $shortCut = [
@@ -436,7 +437,8 @@ WHERE  subtype.name IN ('" . implode("','", $subType) . "' )";
           'ref' => "new-$value",
           'title' => $value,
         ];
-        if ($csType = CRM_Utils_Array::value('1', $typeValue)) {
+        $csType = $typeValue['1'] ?? NULL;
+        if ($csType) {
           $shortCuts[$cType]['shortCuts'][] = $shortCut;
         }
         else {

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1261,7 +1261,8 @@ WHERE {$whereClause}";
       $params[5] = [$parent_id, 'Integer'];
     }
 
-    if ($createdBy = CRM_Utils_Array::value('created_by', $params)) {
+    $createdBy = $params['created_by'] ?? NULL;
+    if ($createdBy) {
       $clauses[] = "createdBy.sort_name LIKE %6";
       if (strpos($createdBy, '%') !== FALSE) {
         $params[6] = [$createdBy, 'String', FALSE];

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1643,7 +1643,8 @@ class CRM_Contact_BAO_Query {
         }
       }
       elseif ($id === 'email_on_hold') {
-        if ($onHoldValue = CRM_Utils_Array::value('email_on_hold', $formValues)) {
+        $onHoldValue = $formValues['email_on_hold'] ?? NULL;
+        if ($onHoldValue) {
           // onHoldValue should be 0 or 1 or an array. Some legacy groups may hold ''
           // so in 5.11 we have an extra if that should become redundant over time.
           // https://lab.civicrm.org/dev/core/issues/745
@@ -6021,6 +6022,7 @@ AND   displayRelType.is_active = 1
           continue;
         }
 
+        $baoName = $value['bao'] ?? NULL;
         if (CRM_Utils_System::isNull($val)) {
           $dao->$key = NULL;
         }
@@ -6052,7 +6054,7 @@ AND   displayRelType.is_active = 1
             $dao->$key = CRM_Core_PseudoConstant::getLabel($value['bao'], $value['idCol'], $val);
           }
         }
-        elseif ($baoName = CRM_Utils_Array::value('bao', $value, NULL)) {
+        elseif ($baoName) {
           //preserve id value
           $idColumn = "{$key}_id";
           $dao->$idColumn = $val;

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -787,7 +787,8 @@ WHERE  is_active = 1 AND relationship_type_id = ' . CRM_Utils_Type::escape($type
       ' AND contact_id_b = ' . CRM_Utils_Type::escape($id, 'Integer') . " ) ) ";
 
     //if caseId is provided, include it duplicate checking.
-    if ($caseId = CRM_Utils_Array::value('case_id', $params)) {
+    $caseId = $params['case_id'] ?? NULL;
+    if ($caseId) {
       $queryString .= ' AND case_id = ' . CRM_Utils_Type::escape($caseId, 'Integer');
     }
 

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -319,7 +319,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     if (!empty($_POST['hidden_custom'])) {
       $customGroupCount = $_POST['hidden_custom_group_count'] ?? NULL;
 
-      if ($contactSubType = CRM_Utils_Array::value('contact_sub_type', $_POST)) {
+      $contactSubType = $_POST['contact_sub_type'] ?? NULL;
+      if ($contactSubType) {
         $paramSubType = implode(',', $contactSubType);
       }
 
@@ -686,7 +687,8 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       ) {
         $invalidStreetNumbers = [];
         foreach ($fields['address'] as $cnt => $address) {
-          if ($streetNumber = CRM_Utils_Array::value('street_number', $address)) {
+          $streetNumber = $address['street_number'] ?? NULL;
+          if ($streetNumber) {
             $parsedAddress = CRM_Core_BAO_Address::parseStreetAddress($address['street_number']);
             if (empty($parsedAddress['street_number'])) {
               $invalidStreetNumbers[] = $cnt;

--- a/CRM/Contact/Form/Task.php
+++ b/CRM/Contact/Form/Task.php
@@ -186,7 +186,8 @@ class CRM_Contact_Form_Task extends CRM_Core_Form_Task {
 
     //contact type for pick up profiles as per selected contact types with subtypes
     //CRM-5521
-    if ($selectedTypes = CRM_Utils_Array::value('contact_type', self::$_searchFormValues)) {
+    $selectedTypes = self::$_searchFormValues['contact_type'] ?? NULL;
+    if ($selectedTypes) {
       if (!is_array($selectedTypes)) {
         $selectedTypes = explode(' ', $selectedTypes);
       }

--- a/CRM/Contact/Form/Task/Label.php
+++ b/CRM/Contact/Form/Task/Label.php
@@ -297,7 +297,8 @@ class CRM_Contact_Form_Task_Label extends CRM_Contact_Form_Task {
 
     // format the addresses according to CIVICRM_ADDRESS_FORMAT (CRM-1327)
     foreach ($rows as $id => $row) {
-      if ($commMethods = CRM_Utils_Array::value('preferred_communication_method', $row)) {
+      $commMethods = $row['preferred_communication_method'] ?? NULL;
+      if ($commMethods) {
         $val = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $commMethods));
         $comm = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method');
         $temp = [];

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -99,7 +99,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
       //Modify mapper fields title if fields are present in dedupe rule
       if (is_array($this->_dedupeFields[$contactType])) {
         foreach ($this->_dedupeFields[$contactType] as $val) {
-          if ($valTitle = CRM_Utils_Array::value($val, $this->_mapperFields)) {
+          $valTitle = $this->_mapperFields[$val] ?? NULL;
+          if ($valTitle) {
             $this->_mapperFields[$val] = $valTitle . ' (match to contact)';
           }
         }
@@ -203,7 +204,8 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
           static $cTypeArray = [];
           if ($relatedContactType !== $this->getContactType() && !in_array($relatedContactType, $cTypeArray)) {
             foreach ($this->_dedupeFields[$relatedContactType] as $val) {
-              if ($valTitle = CRM_Utils_Array::value($val, $this->_formattedFieldNames[$relatedContactType])) {
+              $valTitle = $this->_formattedFieldNames[$relatedContactType][$val] ?? NULL;
+              if ($valTitle) {
                 $this->_formattedFieldNames[$relatedContactType][$val] = $valTitle . ' (match to contact)';
               }
             }

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -291,7 +291,8 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       //profile is of Individual ( including the custom data of membership/contribution )
       //IF Individual type not present in profile then it is consider as Organization data.
       $userID = $contactID;
-      if ($preID = CRM_Utils_Array::value('custom_pre_id', $values)) {
+      $preID = $values['custom_pre_id'] ?? NULL;
+      if ($preID) {
         if (!empty($values['related_contact'])) {
           $preProfileTypes = CRM_Core_BAO_UFGroup::profileGroups($preID);
           if (in_array('Individual', $preProfileTypes) || in_array('Contact', $preProfileTypes)) {
@@ -302,7 +303,8 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         [$values['customPre_grouptitle'], $values['customPre']] = self::getProfileNameAndFields($preID, $userID, $params['custom_pre_id']);
       }
       $userID = $contactID;
-      if ($postID = CRM_Utils_Array::value('custom_post_id', $values)) {
+      $postID = $values['custom_post_id'] ?? NULL;
+      if ($postID) {
         if (!empty($values['related_contact'])) {
           $postProfileTypes = CRM_Core_BAO_UFGroup::profileGroups($postID);
           if (in_array('Individual', $postProfileTypes) || in_array('Contact', $postProfileTypes)) {
@@ -367,12 +369,14 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $tplParams['contributionTypeName'] = $tplParams['financialTypeName'];
       }
 
-      if ($contributionPageId = CRM_Utils_Array::value('id', $values)) {
+      $contributionPageId = $values['id'] ?? NULL;
+      if ($contributionPageId) {
         $tplParams['contributionPageId'] = $contributionPageId;
       }
 
       // address required during receipt processing (pdf and email receipt)
-      if ($displayAddress = CRM_Utils_Array::value('address', $values)) {
+      $displayAddress = $values['address'] ?? NULL;
+      if ($displayAddress) {
         $tplParams['address'] = $displayAddress;
       }
 

--- a/CRM/Contribute/Form.php
+++ b/CRM/Contribute/Form.php
@@ -52,7 +52,8 @@ class CRM_Contribute_Form extends CRM_Admin_Form {
         $this->assign('organisationId', $contactID);
       }
 
-      if ($parentId = CRM_Utils_Array::value('parent_id', $defaults)) {
+      $parentId = $defaults['parent_id'] ?? NULL;
+      if ($parentId) {
         $this->assign('parentId', $parentId);
       }
     }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -744,7 +744,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         if ($pledgePaymentId) {
           $buildPriceSet = FALSE;
         }
-        if ($participantID = CRM_Utils_Array::value('participant', $componentDetails)) {
+        $participantID = $componentDetails['participant'] ?? NULL;
+        if ($participantID) {
           $participantLI = CRM_Price_BAO_LineItem::getLineItems($participantID);
           if (!CRM_Utils_System::isNull($participantLI)) {
             $buildPriceSet = FALSE;
@@ -890,7 +891,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     // Do the amount validations.
     if (empty($fields['total_amount']) && empty($self->_lineItems)) {
-      if ($priceSetId = CRM_Utils_Array::value('price_set_id', $fields)) {
+      $priceSetId = $fields['price_set_id'] ?? NULL;
+      if ($priceSetId) {
         CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $fields, $errors);
       }
     }

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -104,7 +104,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $qParams = "reset=1&amp;id={$this->_id}";
-    if ($pcpId = CRM_Utils_Array::value('pcp_id', $this->_pcpInfo)) {
+    $pcpId = $this->_pcpInfo['pcp_id'] ?? NULL;
+    if ($pcpId) {
       $qParams .= "&amp;pcpId={$pcpId}";
     }
     $this->assign('qParams', $qParams);
@@ -1006,7 +1007,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
-      if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
+      $greetingType = $fields[$greeting] ?? NULL;
+      if ($greetingType) {
         $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
         if ($customizedValue == $greetingType && empty($fielse[$greeting . '_custom'])) {
           $errors[$greeting . '_custom'] = ts('Custom %1 is a required field if %1 is of type Customized.',
@@ -1176,10 +1178,11 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->set('amount_level', CRM_Utils_Array::value('amount_level', $params));
     }
 
+    $priceSetId = $params['priceSetId'] ?? NULL;
     if (!empty($this->_ccid)) {
       $this->set('lineItem', [$this->getPriceSetID() => $this->getExistingContributionLineItems()]);
     }
-    elseif ($priceSetId = CRM_Utils_Array::value('priceSetId', $params)) {
+    elseif ($priceSetId) {
       $lineItem = [];
       if ($this->isQuickConfig()) {
         foreach ($this->_values['fee'] as $key => & $val) {

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -373,7 +373,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     }
 
     // don't allow price set w/ membership signup, CRM-5095
-    if ($priceSetId = CRM_Utils_Array::value('price_set_id', $fields)) {
+    $priceSetId = $fields['price_set_id'] ?? NULL;
+    if ($priceSetId) {
       // don't allow price set w/ membership.
       if ($hasMembershipBlk) {
         $errors['price_set_id'] = ts('You cannot enable both a Contribution Price Set and Membership Signup on the same online contribution page.');
@@ -621,7 +622,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
               $priceSetId = $usedPriceSetId;
             }
             else {
-              if ($priceFieldId = CRM_Utils_Array::value('price_field_id', $params)) {
+              $priceFieldId = $params['price_field_id'] ?? NULL;
+              if ($priceFieldId) {
                 foreach ($params['price_field_value'] as $arrayID => $fieldValueID) {
                   if (empty($params['label'][$arrayID]) && empty($params['value'][$arrayID]) && !empty($fieldValueID)) {
                     CRM_Price_BAO_PriceFieldValue::setIsActive($fieldValueID, '0');
@@ -688,7 +690,8 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
 
               CRM_Price_BAO_PriceField::retrieve($editedFieldParams, $editedResults);
 
-              if (!$priceFieldID = CRM_Utils_Array::value('id', $editedResults)) {
+              $priceFieldID = $editedResults['id'] ?? NULL;
+              if (!$priceFieldID) {
                 $fieldParams = [
                   'name' => 'other_amount',
                   'label' => ts('Other Amount'),

--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -191,7 +191,8 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
 
     //do check for campaigns
     $values['campaign'] = '';
-    if ($campaignId = CRM_Utils_Array::value('campaign_id', $values)) {
+    $campaignId = $values['campaign_id'] ?? NULL;
+    if ($campaignId) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);
       $values['campaign'] = $campaigns[$campaignId];
     }

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -107,7 +107,8 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
       ];
 
       foreach ($billing as $key => $val) {
-        if ($value = CRM_Utils_Array::value($val, $params)) {
+        $value = $params[$val] ?? NULL;
+        if ($value) {
           if (!empty($params[$key])) {
             unset($params[$val]);
           }

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -753,9 +753,8 @@ AND    cf.id IN ( $fieldIDList )
     }
 
     $default = array_merge(['Contact'], CRM_Contact_BAO_ContactType::basicTypes(TRUE));
-    if (!($type = CRM_Utils_Array::value('entityType', $params)) ||
-      in_array($params['entityType'], $default)
-    ) {
+    $type = $params['entityType'] ?? NULL;
+    if (!$type || in_array($params['entityType'], $default)) {
       $type = NULL;
     }
     else {

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -86,10 +86,12 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
     ) {
       /* re/calculate the weight, if the Parent ID changed OR create new menu */
 
-      if ($navName = CRM_Utils_Array::value('name', $params)) {
+      $navName = $params['name'] ?? NULL;
+      $navLabel = $params['label'] ?? NULL;
+      if ($navName) {
         $params['name'] = $navName;
       }
-      elseif ($navLabel = CRM_Utils_Array::value('label', $params)) {
+      elseif ($navLabel) {
         $params['name'] = $navLabel;
       }
 

--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -279,7 +279,8 @@ WHERE  v.option_group_id = g.id
   public static function lookupValues(&$params, $names, $flip = FALSE) {
     foreach ($names as $postName => $value) {
       // See if $params field is in $names array (i.e. is a value that we need to lookup)
-      if ($postalName = CRM_Utils_Array::value($postName, $params)) {
+      $postalName = $params[$postName] ?? NULL;
+      if ($postalName) {
         $postValues = [];
         // params[$postName] may be a Ctrl+A separated value list
         if (is_string($postalName) &&

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -365,7 +365,8 @@ class CRM_Core_Payment_Form {
    * @return int
    */
   public static function getCreditCardExpirationMonth($src) {
-    if ($month = CRM_Utils_Array::value('M', $src['credit_card_exp_date'])) {
+    $month = $src['credit_card_exp_date']['M'] ?? NULL;
+    if ($month) {
       return $month;
     }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2078,8 +2078,10 @@ ORDER BY civicrm_custom_group.weight,
     }
 
     // CRM-15681 merge sub_types
-    if ($other_sub_types = CRM_Utils_Array::value('contact_sub_type', $migrationInfo['other_details'])) {
-      if ($main_sub_types = CRM_Utils_Array::value('contact_sub_type', $migrationInfo['main_details'])) {
+    $other_sub_types = $migrationInfo['other_details']['contact_sub_type'] ?? NULL;
+    $main_sub_types = $migrationInfo['main_details']['contact_sub_type'] ?? NULL;
+    if ($other_sub_types) {
+      if ($main_sub_types) {
         $submitted['contact_sub_type'] = array_unique(array_merge($main_sub_types, $other_sub_types));
       }
       else {

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1206,14 +1206,16 @@ WHERE civicrm_event.is_active = 1
         ];
 
         // address required during receipt processing (pdf and email receipt)
-        if ($displayAddress = CRM_Utils_Array::value('address', $values)) {
+        $displayAddress = $values['address'] ?? NULL;
+        if ($displayAddress) {
           $sendTemplateParams['tplParams']['address'] = $displayAddress;
           // The concept of contributeMode is deprecated.
           $sendTemplateParams['tplParams']['contributeMode'] = NULL;
         }
 
         // set lineItem details
-        if ($lineItem = CRM_Utils_Array::value('lineItem', $values)) {
+        $lineItem = $values['lineItem'] ?? NULL;
+        if ($lineItem) {
           // check if additional participant, if so filter only to relevant ones
           // CRM-9902
           if (!empty($values['params']['additionalParticipant'])) {
@@ -1994,10 +1996,12 @@ WHERE  ce.loc_block_id = $locBlockId";
     if ($contactID) {
       $params = ['contact_id' => $contactID];
 
-      if ($eventId = CRM_Utils_Array::value('id', $values['event'])) {
+      $eventId = $values['event']['id'] ?? NULL;
+      if ($eventId) {
         $params['event_id'] = $eventId;
       }
-      if ($roleId = CRM_Utils_Array::value('default_role_id', $values['event'])) {
+      $roleId = $values['event']['default_role_id'] ?? NULL;
+      if ($roleId) {
         $params['role_id'] = $roleId;
       }
       $alreadyRegistered = self::checkRegistration($params);

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -47,7 +47,8 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $urlParams = "id={$this->_id}&addProfileBottom=1&qfKey={$this->controller->_key}";
     $this->assign('addProfileParams', $urlParams);
 
-    if ($addProfileBottom = CRM_Utils_Array::value('custom_post_id_multiple', $_POST)) {
+    $addProfileBottom = $_POST['custom_post_id_multiple'] ?? NULL;
+    if ($addProfileBottom) {
       foreach (array_keys($addProfileBottom) as $profileNum) {
         self::buildMultipleProfileBottom($this, $profileNum);
       }
@@ -59,7 +60,8 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $urlParamsAdd = "id={$this->_id}&addProfileBottomAdd=1&qfKey={$this->controller->_key}";
     $this->assign('addProfileParamsAdd', $urlParamsAdd);
 
-    if ($addProfileBottomAdd = CRM_Utils_Array::value('additional_custom_post_id_multiple', $_POST)) {
+    $addProfileBottomAdd = $_POST['additional_custom_post_id_multiple'] ?? NULL;
+    if ($addProfileBottomAdd) {
       foreach (array_keys($addProfileBottomAdd) as $profileNum) {
         self::buildMultipleProfileBottom($this, $profileNum, 'additional_', ts('Profile for Additional Participants'));
       }
@@ -762,7 +764,8 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    * @param string $field
    */
   public static function addMultipleProfiles(&$profileIds, $values, $field) {
-    if ($multipleProfiles = CRM_Utils_Array::value($field, $values)) {
+    $multipleProfiles = $values[$field] ?? NULL;
+    if ($multipleProfiles) {
       foreach ($multipleProfiles as $profileId) {
         $profileIds[] = $profileId;
       }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -825,7 +825,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       ) ||
       ($self->_id && !$self->_paymentId && isset($self->_values['line_items']) && is_array($self->_values['line_items']))
     ) {
-      if ($priceSetId = CRM_Utils_Array::value('priceSetId', $values)) {
+      $priceSetId = $values['priceSetId'] ?? NULL;
+      if ($priceSetId) {
         CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $values, $errorMsg, TRUE);
       }
     }
@@ -2174,7 +2175,8 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       $this->_contributorDisplayName = ($this->_contributorDisplayName == ' ') ? $this->_contributorEmail : $this->_contributorDisplayName;
 
       $waitStatus = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Waiting'");
-      if ($waitingStatus = CRM_Utils_Array::value($params['status_id'], $waitStatus)) {
+      $waitingStatus = $waitStatus[$params['status_id']] ?? NULL;
+      if ($waitingStatus) {
         $this->assign('isOnWaitlist', TRUE);
       }
 

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -164,7 +164,8 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     }
 
     //do check for campaigns
-    if ($campaignId = CRM_Utils_Array::value('campaign_id', $values[$participantID])) {
+    $campaignId = $values[$participantID]['campaign_id'] ?? NULL;
+    if ($campaignId) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);
       $values[$participantID]['campaign'] = $campaigns[$campaignId];
     }

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -569,7 +569,8 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     }
 
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
-      if ($greetingType = CRM_Utils_Array::value($greeting, $self->_params[0])) {
+      $greetingType = $self->_params[0][$greeting] ?? NULL;
+      if ($greetingType) {
         $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
         if ($customizedValue == $greetingType && empty($self->_params[0][$greeting . '_custom'])) {
           return FALSE;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -898,7 +898,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
     }
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
-      if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
+      $greetingType = $fields[$greeting] ?? NULL;
+      if ($greetingType) {
         $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
         if ($customizedValue == $greetingType && empty($fields[$greeting . '_custom'])) {
           $errors[$greeting . '_custom'] = ts('Custom %1 is a required field if %1 is of type Customized.',

--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -152,7 +152,8 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
         }
         if (!empty($this->_formValues['participant_status_id'])) {
           $seatClause[] = CRM_Contact_BAO_Query::buildClause("participant.status_id", 'IN', $this->_formValues['participant_status_id'], 'Int');
-          if ($status = CRM_Utils_Array::value('IN', $this->_formValues['participant_status_id'])) {
+          $status = $this->_formValues['participant_status_id']['IN'] ?? NULL;
+          if ($status) {
             $this->_formValues['participant_status_id'] = $status;
           }
         }

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -181,7 +181,8 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     if (empty($values['total_amount']) &&
         empty($self->_values['line_items'])
       ) {
-      if ($priceSetId = CRM_Utils_Array::value('priceSetId', $values)) {
+      $priceSetId = $values['priceSetId'] ?? NULL;
+      if ($priceSetId) {
         CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $values, $errorMsg, TRUE);
       }
     }

--- a/CRM/Logging/ReportSummary.php
+++ b/CRM/Logging/ReportSummary.php
@@ -364,7 +364,8 @@ WHERE  log_date <= %1 AND id = %2 ORDER BY log_date DESC LIMIT 1";
     }
 
     $logTypeTableClause = '(1)';
-    if ($logTypeTableValue = CRM_Utils_Array::value("log_type_table_value", $this->_params)) {
+    $logTypeTableValue = $this->_params["log_type_table_value"] ?? NULL;
+    if ($logTypeTableValue) {
       $logTypeTableClause = $this->whereClause($this->_columns['log_civicrm_entity']['filters']['log_type_table'],
         $this->_params['log_type_table_op'], $logTypeTableValue, NULL, NULL);
       unset($this->_params['log_type_table_value']);

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1804,7 +1804,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     }
 
     //get the campaign
-    if ($campaignId = CRM_Utils_Array::value('campaign_id', $report['mailing'])) {
+    $campaignId = $report['mailing']['campaign_id'] ?? NULL;
+    if ($campaignId) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);
       $report['mailing']['campaign'] = $campaigns[$campaignId];
     }

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -403,7 +403,8 @@ SELECT r.id, c.id as cid, c.display_name as name, c.job_title as comment,
     $values['auto_renew'] = ($autoRenew && !$subscriptionCancelled) ? 'Yes' : 'No';
 
     //do check for campaigns
-    if ($campaignId = CRM_Utils_Array::value('campaign_id', $values)) {
+    $campaignId = $values['campaign_id'] ?? NULL;
+    if ($campaignId) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);
       $values['campaign'] = $campaigns[$campaignId];
     }

--- a/CRM/Member/Form/Task/Label.php
+++ b/CRM/Member/Form/Task/Label.php
@@ -94,7 +94,8 @@ class CRM_Member_Form_Task_Label extends CRM_Member_Form_Task {
     }
     // format the addresses according to CIVICRM_ADDRESS_FORMAT (CRM-1327)
     foreach ((array) $rows as $id => $row) {
-      if ($commMethods = CRM_Utils_Array::value('preferred_communication_method', $row)) {
+      $commMethods = $row['preferred_communication_method'] ?? NULL;
+      if ($commMethods) {
         $val = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $commMethods));
         $comm = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'preferred_communication_method');
         $temp = [];

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -705,7 +705,8 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
     );
     $tplParams['pcpInfoURL'] = $pcpInfoURL;
     $tplParams['contribPageTitle'] = $contribPageTitle;
-    if ($emails = CRM_Utils_Array::value('notify_email', $pcpBlockInfo)) {
+    $emails = $pcpBlockInfo['notify_email'] ?? NULL;
+    if ($emails) {
       $emailArray = explode(',', $emails);
       $tplParams['pcpNotifyEmailAddress'] = $emailArray[0];
     }

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -111,7 +111,8 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
         }
       }
 
-      if ($emails = CRM_Utils_Array::value('notify_email', $params)) {
+      $emails = $params['notify_email'] ?? NULL;
+      if ($emails) {
         $emailArray = explode(',', $emails);
         foreach ($emailArray as $email) {
           if ($email && !CRM_Utils_Rule::email(trim($email))) {

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -141,7 +141,8 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
         }
       }
 
-      if ($emails = CRM_Utils_Array::value('notify_email', $params)) {
+      $emails = $params['notify_email'] ?? NULL;
+      if ($emails) {
         $emailArray = explode(',', $emails);
         foreach ($emailArray as $email) {
           if ($email && !CRM_Utils_Rule::email(trim($email))) {

--- a/CRM/Pledge/Form/PledgeView.php
+++ b/CRM/Pledge/Form/PledgeView.php
@@ -102,7 +102,8 @@ class CRM_Pledge_Form_PledgeView extends CRM_Core_Form {
     $this->setTitle(ts('View Pledge by') . ' ' . $displayName);
 
     // do check for campaigns
-    if ($campaignId = CRM_Utils_Array::value('campaign_id', $values)) {
+    $campaignId = $values['campaign_id'] ?? NULL;
+    if ($campaignId) {
       $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns($campaignId);
       $values['campaign'] = $campaigns[$campaignId];
     }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -134,8 +134,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         elseif (!empty($params['financial_type_id'])) {
           $options['financial_type_id'] = $params['financial_type_id'];
         }
-        if ($opIds = CRM_Utils_Array::value('option_id', $params)) {
-          if ($opId = CRM_Utils_Array::value($index, $opIds)) {
+        $opIds = $params['option_id'] ?? NULL;
+        if ($opIds) {
+          $opId = $opIds[$index] ?? NULL;
+          if ($opId) {
             $options['id'] = $opId;
           }
           else {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -302,7 +302,8 @@ WHERE     cpf.price_set_id = %1";
   public static function getSetId(&$params) {
     $fid = NULL;
 
-    if ($oid = CRM_Utils_Array::value('oid', $params)) {
+    $oid = $params['oid'] ?? NULL;
+    if ($oid) {
       $fieldValue = new CRM_Price_DAO_PriceFieldValue();
       $fieldValue->id = $oid;
       if ($fieldValue->find(TRUE)) {

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -1057,7 +1057,8 @@ class CRM_Profile_Form extends CRM_Core_Form {
       }
     }
     foreach (CRM_Contact_BAO_Contact::$_greetingTypes as $greeting) {
-      if ($greetingType = CRM_Utils_Array::value($greeting, $fields)) {
+      $greetingType = $fields[$greeting] ?? NULL;
+      if ($greetingType) {
         $customizedValue = CRM_Core_PseudoConstant::getKey('CRM_Contact_BAO_Contact', $greeting . '_id', 'Customized');
         if ($customizedValue == $greetingType && empty($fields[$greeting . '_custom'])) {
           $errors[$greeting . '_custom'] = ts('Custom  %1 is a required field if %1 is of type Customized.',
@@ -1084,7 +1085,8 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $returnProperties = ['is_multiple', 'table_name'];
         CRM_Core_DAO::commonRetrieve("CRM_Core_DAO_CustomGroup", $filterParams, $returnValues, $returnProperties);
         if (!empty($returnValues['is_multiple'])) {
-          if ($tableName = CRM_Utils_Array::value('table_name', $returnValues)) {
+          $tableName = $returnValues['table_name'] ?? NULL;
+          if ($tableName) {
             $sql = "DELETE FROM {$tableName} WHERE id = %1 AND entity_id = %2";
             $sqlParams = [
               1 => [$this->_recordId, 'Integer'],

--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -77,7 +77,8 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
     }
 
     if (!$instanceID) {
-      if ($reportID = CRM_Utils_Array::value('report_id', $params)) {
+      $reportID = $params['report_id'] ?? NULL;
+      if ($reportID) {
         $instance->report_id = $reportID;
       }
       elseif ($instanceID) {
@@ -135,7 +136,8 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
       $navigationParams['parent_id'] = $params['parent_id'] ?? NULL;
       $navigationParams['is_active'] = 1;
 
-      if ($permission = CRM_Utils_Array::value('permission', $params)) {
+      $permission = $params['permission'] ?? NULL;
+      if ($permission) {
         $navigationParams['permission'][] = $permission;
       }
 
@@ -157,7 +159,8 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
         'label' => $params['title'],
         'is_active' => 1,
       ];
-      if ($permission = CRM_Utils_Array::value('permission', $params)) {
+      $permission = $params['permission'] ?? NULL;
+      if ($permission) {
         $dashletParams['permission'][] = $permission;
       }
     }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1062,8 +1062,8 @@ class CRM_Report_Form extends CRM_Core_Form {
           ) {
             $this->_defaults["{$fieldName}_op"] = 'mhas';
           }
-          elseif ($op = CRM_Utils_Array::value('default_op', $field)) {
-            $this->_defaults["{$fieldName}_op"] = $op;
+          elseif (!empty($field['default_op'])) {
+            $this->_defaults["{$fieldName}_op"] = $field['default_op'];
           }
         }
       }

--- a/CRM/Report/Form/Case/Detail.php
+++ b/CRM/Report/Form/Case/Detail.php
@@ -513,7 +513,8 @@ class CRM_Report_Form_Case_Detail extends CRM_Report_Form {
     $from = $select = [];
     $case = $this->_aliases['civicrm_case'];
 
-    if ($activityType = CRM_Utils_Array::value('case_activity_all_dates', $this->_params['case_detail_extra'])) {
+    $activityType = $this->_params['case_detail_extra']['case_activity_all_dates'] ?? NULL;
+    if ($activityType) {
       $select[] = "GROUP_CONCAT(DISTINCT(civireport_activity_all_{$activityType}.{$this->_caseDetailExtra['case_activity_all_dates']['name']}) ORDER BY civireport_activity_all_{$activityType}.{$this->_caseDetailExtra['case_activity_all_dates']['name']}) as case_activity_all_dates";
 
       $from[] = " LEFT JOIN civicrm_case_activity civireport_case_activity_all_{$activityType} ON ( civireport_case_activity_all_{$activityType}.case_id = {$case}.id)

--- a/CRM/Report/Form/Contact/Detail.php
+++ b/CRM/Report/Form/Contact/Detail.php
@@ -909,29 +909,34 @@ HERESQL;
         foreach ($rows as $rowNum => $row) {
           // handle contribution
           if ($component == 'contribution_civireport') {
-            if ($val = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+            $val = $row['civicrm_contribution_financial_type_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_contribution_financial_type_id'] = CRM_Contribute_PseudoConstant::financialType($val, FALSE);
             }
 
-            if ($val = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+            $val = $row['civicrm_contribution_contribution_status_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_contribution_contribution_status_id'] = CRM_Contribute_PseudoConstant::contributionStatus($val, 'label');
             }
             $entryFound = TRUE;
           }
 
           if ($component === 'membership_civireport') {
-            if ($val = CRM_Utils_Array::value('civicrm_membership_membership_type_id', $row)) {
+            $val = $row['civicrm_membership_membership_type_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_membership_membership_type_id'] = CRM_Member_PseudoConstant::membershipType($val, FALSE);
             }
 
-            if ($val = CRM_Utils_Array::value('civicrm_membership_status_id', $row)) {
+            $val = $row['civicrm_membership_status_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_membership_status_id'] = CRM_Member_PseudoConstant::membershipStatus($val, FALSE);
             }
             $entryFound = TRUE;
           }
 
           if ($component == 'participant_civireport') {
-            if ($val = CRM_Utils_Array::value('civicrm_participant_event_id', $row)) {
+            $val = $row['civicrm_participant_event_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_participant_event_id'] = CRM_Event_PseudoConstant::event($val, FALSE);
               $url = CRM_Report_Utils_Report::getNextUrl('event/income',
                 'reset=1&force=1&id_op=in&id_value=' . $val,
@@ -942,10 +947,12 @@ HERESQL;
               $entryFound = TRUE;
             }
 
-            if ($val = CRM_Utils_Array::value('civicrm_participant_participant_status_id', $row)) {
+            $val = $row['civicrm_participant_participant_status_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_participant_participant_status_id'] = CRM_Event_PseudoConstant::participantStatus($val, FALSE);
             }
-            if ($val = CRM_Utils_Array::value('civicrm_participant_role_id', $row)) {
+            $val = $row['civicrm_participant_role_id'] ?? NULL;
+            if ($val) {
               $roles = explode(CRM_Core_DAO::VALUE_SEPARATOR, $val);
               $value = [];
               foreach ($roles as $role) {
@@ -958,17 +965,20 @@ HERESQL;
           }
 
           if ($component == 'activity_civireport') {
-            if ($val = CRM_Utils_Array::value('civicrm_activity_activity_type_id', $row)) {
+            $val = $row['civicrm_activity_activity_type_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_activity_activity_type_id'] = $activityTypes[$val];
             }
-            if ($val = CRM_Utils_Array::value('civicrm_activity_activity_status_id', $row)) {
+            $val = $row['civicrm_activity_activity_status_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_activity_activity_status_id'] = $activityStatus[$val];
             }
 
             $entryFound = TRUE;
           }
           if ($component == 'membership_civireport') {
-            if ($val = CRM_Utils_Array::value('civicrm_membership_membership_status_id', $row)) {
+            $val = $row['civicrm_membership_membership_status_id'] ?? NULL;
+            if ($val) {
               $componentRows[$contactID][$component][$rowNum]['civicrm_membership_membership_status_id'] = CRM_Member_PseudoConstant::membershipStatus($val);
             }
             $entryFound = TRUE;

--- a/CRM/Report/Form/Contribute/Bookkeeping.php
+++ b/CRM/Report/Form/Contribute/Bookkeeping.php
@@ -558,20 +558,24 @@ class CRM_Report_Form_Contribute_Bookkeeping extends CRM_Report_Form {
       }
 
       // handle contribution status id
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_status_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
       }
 
       // handle payment instrument id
-      if ($value = CRM_Utils_Array::value('civicrm_financial_trxn_payment_instrument_id', $row)) {
+      $value = $row['civicrm_financial_trxn_payment_instrument_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_financial_trxn_payment_instrument_id'] = $paymentInstruments[$value];
       }
 
       // handle financial type id
-      if ($value = CRM_Utils_Array::value('civicrm_line_item_financial_type_id', $row)) {
+      $value = $row['civicrm_line_item_financial_type_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_line_item_financial_type_id'] = $contributionTypes[$value];
       }
-      if ($value = CRM_Utils_Array::value('civicrm_entity_financial_trxn_amount', $row)) {
+      $value = $row['civicrm_entity_financial_trxn_amount'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_entity_financial_trxn_amount'] = CRM_Utils_Money::format($rows[$rowNum]['civicrm_entity_financial_trxn_amount'], $rows[$rowNum]['civicrm_financial_trxn_currency']);
       }
 

--- a/CRM/Report/Form/Contribute/DeferredRevenue.php
+++ b/CRM/Report/Form/Contribute/DeferredRevenue.php
@@ -492,32 +492,37 @@ class CRM_Report_Form_Contribute_DeferredRevenue extends CRM_Report_Form {
       foreach ($entry['rows'] as $rowNum => &$row) {
 
         // convert transaction status id to status name
-        if ($status = CRM_Utils_Array::value('civicrm_financial_trxn_status_id', $row)) {
+        $status = $row['civicrm_financial_trxn_status_id'] ?? NULL;
+        if ($status) {
           $row['civicrm_financial_trxn_status_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_FinancialTrxn', 'status_id', $status);
           $entryFound = TRUE;
         }
 
         // convert batch id to batch title
-        if ($batchId = CRM_Utils_Array::value('civicrm_batch_batch_id', $row)) {
+        $batchId = $row['civicrm_batch_batch_id'] ?? NULL;
+        if ($batchId) {
           $row['civicrm_batch_batch_id'] = $this->getLabels($batchId, 'CRM_Batch_BAO_EntityBatch', 'batch_id');
           $entryFound = TRUE;
         }
 
         // add hotlink for contribution
-        if ($amount = CRM_Utils_Array::value('civicrm_financial_trxn_total_amount', $row)) {
+        $amount = $row['civicrm_financial_trxn_total_amount'] ?? NULL;
+        if ($amount) {
           $contributionUrl = CRM_Utils_System::url("civicrm/contact/view/contribution",
             'reset=1&action=view&cid=' . $row['civicrm_contact_id'] . '&id=' . $row['civicrm_contribution_contribution_id'],
             $this->_absoluteUrl
           );
           $row['civicrm_financial_trxn_total_amount'] = "<a href={$contributionUrl}>{$amount}</a>";
-          if ($contributionId = CRM_Utils_Array::value('civicrm_contribution_id', $row)) {
+          $contributionId = $row['civicrm_contribution_id'] ?? NULL;
+          if ($contributionId) {
             $row['civicrm_contribution_id'] = "<a href={$contributionUrl}>{$contributionId}</a>";
           }
           $entryFound = TRUE;
         }
 
         // add hotlink for contact
-        if ($contactName = CRM_Utils_Array::value('civicrm_contact_display_name', $row)) {
+        $contactName = $row['civicrm_contact_display_name'] ?? NULL;
+        if ($contactName) {
           $contactUrl = CRM_Utils_System::url("civicrm/contact/view",
             'reset=1&cid=' . $row['civicrm_contact_id'],
             $this->_absoluteUrl
@@ -526,7 +531,8 @@ class CRM_Report_Form_Contribute_DeferredRevenue extends CRM_Report_Form {
           $entryFound = TRUE;
         }
 
-        if ($contactId = CRM_Utils_Array::value('civicrm_contribution_contact_id', $row)) {
+        $contactId = $row['civicrm_contribution_contact_id'] ?? NULL;
+        if ($contactId) {
           $contactUrl = CRM_Utils_System::url("civicrm/contact/view",
             'reset=1&cid=' . $row['civicrm_contact_id'],
             $this->_absoluteUrl

--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -712,19 +712,23 @@ UNION ALL
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View Contact Summary for this Contact.");
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      $value = $row['civicrm_contribution_financial_type_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_status_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_page_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_page_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_page_id'] = $contributionPages[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      $value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }
@@ -738,7 +742,8 @@ UNION ALL
       }
 
       // Contribution amount links to viewing contribution
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_total_amount', $row)) {
+      $value = $row['civicrm_contribution_total_amount'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_total_amount'] = CRM_Utils_Money::format($value, $row['civicrm_contribution_currency']);
         if (CRM_Core_Permission::check('access CiviContribute')) {
           $url = CRM_Utils_System::url(
@@ -826,7 +831,8 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
       }
 
       // Contribution amount links to viewing contribution
-      if ($value = CRM_Utils_Array::value('civicrm_pledge_payment_pledge_id', $row)) {
+      $value = $row['civicrm_pledge_payment_pledge_id'] ?? NULL;
+      if ($value) {
         if (CRM_Core_Permission::check('access CiviContribute')) {
           $url = CRM_Utils_System::url(
             "civicrm/contact/view/pledge",

--- a/CRM/Report/Form/Contribute/Recur.php
+++ b/CRM/Report/Form/Contribute/Recur.php
@@ -372,11 +372,13 @@ class CRM_Report_Form_Contribute_Recur extends CRM_Report_Form {
       }
 
       // handle contribution status id
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_contribution_status_id', $row)) {
+      $value = $row['civicrm_contribution_recur_contribution_status_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_recur_contribution_status_id'] = $contributionStatus[$value];
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_amount', $row)) {
+      $value = $row['civicrm_contribution_recur_amount'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_recur_amount'] = CRM_Utils_Money::format($rows[$rowNum]['civicrm_contribution_recur_amount'], $rows[$rowNum]['civicrm_contribution_recur_currency']);
       }
 

--- a/CRM/Report/Form/Contribute/RecurSummary.php
+++ b/CRM/Report/Form/Contribute/RecurSummary.php
@@ -295,7 +295,8 @@ class CRM_Report_Form_Contribute_RecurSummary extends CRM_Report_Form {
       $total = $total + $amountDao->amount;
 
       // handle payment instrument id
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_payment_instrument_id', $row)) {
+      $value = $row['civicrm_contribution_recur_payment_instrument_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_recur_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }

--- a/CRM/Report/Form/Contribute/Summary.php
+++ b/CRM/Report/Form/Contribute/Summary.php
@@ -978,7 +978,8 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
       }
 
       // convert contribution status id to status name
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_status_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
@@ -988,7 +989,8 @@ class CRM_Report_Form_Contribute_Summary extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_page_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_page_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_page_id'] = $contributionPages[$value];
         $entryFound = TRUE;
       }

--- a/CRM/Report/Form/Event/ParticipantListCount.php
+++ b/CRM/Report/Form/Event/ParticipantListCount.php
@@ -412,7 +412,8 @@ class CRM_Report_Form_Event_ParticipantListCount extends CRM_Report_Form {
       }
     }
     //add blank column at the end
-    if ($blankcols = CRM_Utils_Array::value('blank_column_end', $this->_params)) {
+    $blankcols = $this->_params['blank_column_end'] ?? NULL;
+    if ($blankcols) {
       for ($i = 1; $i <= $blankcols; $i++) {
         $select[] = " '' as blankColumnEnd_{$i}";
         $this->_columnHeaders["blank_{$i}"]['title'] = "_ _ _ _";

--- a/CRM/Report/Form/Member/ContributionDetail.php
+++ b/CRM/Report/Form/Member/ContributionDetail.php
@@ -751,15 +751,18 @@ class CRM_Report_Form_Member_ContributionDetail extends CRM_Report_Form {
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Summary for this Contact.');
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      $value = $row['civicrm_contribution_financial_type_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_status_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      $value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }

--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -464,15 +464,18 @@ HERESQL;
         $entryFound = TRUE;
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      $value = $row['civicrm_contribution_financial_type_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'financial_type_id', $value);
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      $value = $row['civicrm_contribution_contribution_status_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $value);
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      $value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL;
+      if ($value) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $value);
         $entryFound = TRUE;
       }

--- a/CRM/Report/Utils/Get.php
+++ b/CRM/Report/Utils/Get.php
@@ -258,7 +258,8 @@ class CRM_Report_Utils_Get {
 
     if (is_array($fieldGrp)) {
       foreach ($fieldGrp as $tableName => $fields) {
-        if ($groupBys = CRM_Utils_Array::value("gby", $_GET)) {
+        $groupBys = $_GET["gby"] ?? NULL;
+        if ($groupBys) {
           $groupBys = explode(' ', $groupBys);
           if (!empty($groupBys)) {
             if (!$flag) {
@@ -283,7 +284,8 @@ class CRM_Report_Utils_Get {
   public static function processFields(&$reportFields, &$defaults) {
     //add filters from url
     if (is_array($reportFields)) {
-      if ($urlFields = CRM_Utils_Array::value("fld", $_GET)) {
+      $urlFields = $_GET["fld"] ?? NULL;
+      if ($urlFields) {
         $urlFields = explode(',', $urlFields);
       }
       if (($_GET["ufld"] ?? NULL) == 1) {

--- a/api/v3/ActivityType.php
+++ b/api/v3/ActivityType.php
@@ -57,7 +57,8 @@ function civicrm_api3_activity_type_create($params) {
 
   $action = 1;
 
-  if ($optionValueID = CRM_Utils_Array::value('option_value_id', $params)) {
+  $optionValueID = $params['option_value_id'] ?? NULL;
+  if ($optionValueID) {
     $action = 2;
   }
 

--- a/api/v3/MembershipStatus.php
+++ b/api/v3/MembershipStatus.php
@@ -129,7 +129,8 @@ function civicrm_api3_membership_status_delete(array $params): array {
  *   Array of status id and status name
  */
 function civicrm_api3_membership_status_calc($membershipParams) {
-  if (!($membershipID = CRM_Utils_Array::value('membership_id', $membershipParams))) {
+  $membershipID = $membershipParams['membership_id'] ?? NULL;
+  if (!$membershipID) {
     throw new CRM_Core_Exception('membershipParams do not contain membership_id');
   }
 

--- a/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
+++ b/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
@@ -403,7 +403,8 @@ SELECT COUNT({$this->_aliases['civicrm_grant']}.id) as count ,
         );
       }
 
-      if ($type = CRM_Utils_Array::value('civicrm_contact_contact_type', $values)) {
+      $type = $values['civicrm_contact_contact_type'] ?? NULL;
+      if ($type) {
         $grantStatistics['civicrm_contact_contact_type']['title'] = ts('By Contact Type');
         $title = "Total Number of {$type}(s)";
         self::getStatistics($grantStatistics['civicrm_contact_contact_type'], $title, $values,

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -4264,7 +4264,8 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'value' => '6',
       'is_active' => 1,
     ]);
-    if ($id = CRM_Utils_Array::value('id', $result)) {
+    $id = $result['id'] ?? NULL;
+    if ($id) {
       $this->callAPISuccess('OptionValue', 'delete', ['id' => $id]);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Regex autoformat toward eliminating a smelly anti-pattern.

Before
----------------------------------------
`CRM_Utils_Array::value()` used to assign variables inside a conditional. This is a code-smell/linting issue.

After
----------------------------------------
Assignment moved out of the conditional, coalesce operator used instead of `CRM_Utils_Array::value()`.
