### PR TITLE
SearchUI:Move 'Find Contacts' upgrader steps from AdminUI to SearchUI

### DIFF
--- a/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
+++ b/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
@@ -8,37 +8,4 @@ use CRM_CivicrmAdminUi_ExtensionUtil as E;
  */
 class CRM_CivicrmAdminUi_Upgrader extends CRM_Extension_Upgrader_Base {
 
-  protected function replaceFindContactMenuPath($path) {
-    // point Find Contacts menu to the FB/SK version or back to the original path
-    // this is temporary until everything is in FB/SK and we can use the original path
-    $results = \Civi\Api4\Navigation::update(FALSE)
-      ->addValue('url', $path)
-      ->addWhere('name', '=', 'Find Contacts')
-      ->execute();
-  }
-
-  /**
-   * @todo "install" and "uninstall" may not be needed if enable and disable are present. See https://github.com/civicrm/civicrm-core/pull/26669
-   */
-  public function install(): void {
-    $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
-  }
-
-  public function uninstall(): void {
-    $this->replaceFindContactMenuPath('civicrm/contact/search');
-  }
-
-  public function enable(): void {
-    $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
-  }
-
-  public function disable(): void {
-    $this->replaceFindContactMenuPath('civicrm/contact/search');
-  }
-
-  public function upgrade_1000(): bool {
-    $this->replaceFindContactMenuPath('civicrm/adminui/contact/search');
-    return TRUE;
-  }
-
 }

--- a/ext/civicrm_search_ui/CRM/CivicrmSearchUi/Upgrader.php
+++ b/ext/civicrm_search_ui/CRM/CivicrmSearchUi/Upgrader.php
@@ -1,0 +1,36 @@
+<?php
+// phpcs:disable
+use CRM_CivicrmSearchUi_ExtensionUtil as E;
+// phpcs:enable
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_CivicrmSearchUi_Upgrader extends CRM_Extension_Upgrader_Base {
+
+  protected function replaceFindContactMenuPath($path) {
+    // point Find Contacts menu to the FB/SK version or back to the original path
+    // this is temporary until everything is in FB/SK and we can use the original path
+    $results = \Civi\Api4\Navigation::update(FALSE)
+      ->addValue('url', $path)
+      ->addWhere('name', '=', 'Find Contacts')
+      ->execute();
+  }
+
+  /**
+   * See https://github.com/civicrm/civicrm-core/pull/26669
+   */
+  public function enable(): void {
+    $this->replaceFindContactMenuPath('civicrm/searchui/contact/search');
+  }
+
+  public function disable(): void {
+    $this->replaceFindContactMenuPath('civicrm/contact/search');
+  }
+
+  public function upgrade_1000(): bool {
+    $this->replaceFindContactMenuPath('civicrm/searchui/contact/search');
+    return TRUE;
+  }
+
+}

--- a/ext/civicrm_search_ui/ang/afsearchContactSearch.aff.json
+++ b/ext/civicrm_search_ui/ang/afsearchContactSearch.aff.json
@@ -2,7 +2,7 @@
     "type": "search",
     "title": "Find Contacts",
     "icon": "fa-list-alt",
-    "server_route": "civicrm/adminui/contact/search",
+    "server_route": "civicrm/searchui/contact/search",
     "permission": "access CiviCRM",
     "navigation": null,
     "requires": [],

--- a/ext/civicrm_search_ui/info.xml
+++ b/ext/civicrm_search_ui/info.xml
@@ -39,4 +39,5 @@
     <mixin>setting-php@1.0.0</mixin>
     <mixin>smarty-v2@1.0.1</mixin>
   </mixins>
+  <upgrader>CRM_CivicrmSearchUi_Upgrader</upgrader>
 </extension>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes issue raised in https://github.com/civicrm/civicrm-core/pull/26669 by moving the 'Find Contacts' search from AdminUI to SearchUI

Before
----------------------------------------
The search was moved to SearchUI but AdminUI still changed the menu.

After
----------------------------------------
World peace is restored.

Technical Details
----------------------------------------
Also changes the path from 'civicrm/adminui/search/contacts' to 'civicrm/searchui/search/contacts'

Comments
----------------------------------------
If AdminUI is enabled on a version with Find Contacts but SearchUI is not enabled, the menu will point to the modified, invalid link.  A simple fix is to enable and disable SearchUI.  Alternatively just leave SearchUI enabled as it currently provides this 'Find Contacts' search and others under an 'Experimental' menu.

