### PR TITLE
contribution for recurring fails when tax_amount is NULL

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -180,7 +180,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
       $params['tax_amount'] = $taxAmount;
     }
     if (isset($params['tax_amount']) && empty($params['skipLineItem'])
-      && !CRM_Utils_Money::equals($params['tax_amount'], $taxAmount, ($params['currency'] ?? Civi::settings()->get('defaultCurrency')))
+      && !CRM_Utils_Money::equals((float) $params['tax_amount'], $taxAmount, ($params['currency'] ?? Civi::settings()->get('defaultCurrency')))
     ) {
       CRM_Core_Error::deprecatedWarning('passing in incorrect tax amounts is deprecated');
     }


### PR DESCRIPTION
This error is specific to PHP >= 8.0 and fails with below error.

```bash
[Symfony\Component\Debug\Exception\FatalThrowableError]  
  Type error: Unsupported operand types: string * int
```

This is generated by CRM_Utils_Money::equals()


