### PR TITLE
Core - Autoload ActionMappings by enabling global class scanning (Variant 1)

### DIFF
--- a/CRM/Activity/ActionMapping.php
+++ b/CRM/Activity/ActionMapping.php
@@ -19,6 +19,8 @@
  * This defines the scheduled-reminder functionality for Activities.
  * It is useful for, e.g., sending a reminder based on scheduled
  * date or other custom dates on the activity record.
+ * @service
+ * @internal
  */
 class CRM_Activity_ActionMapping extends \Civi\ActionSchedule\MappingBase {
 

--- a/CRM/Contact/ActionMapping.php
+++ b/CRM/Contact/ActionMapping.php
@@ -15,6 +15,8 @@
  * entities. It is useful for, e.g., sending a reminder based on
  * birth date, modification date, or other custom dates on
  * the contact record.
+ * @service
+ * @internal
  */
 class CRM_Contact_ActionMapping extends \Civi\ActionSchedule\MappingBase {
 

--- a/CRM/Contribute/ActionMapping/ByPage.php
+++ b/CRM/Contribute/ActionMapping/ByPage.php
@@ -17,6 +17,8 @@
  * entities. It is useful for sending a reminder based on:
  *  - The receipt-date, cancel-date, or thankyou-date.
  *  - The page on which the contribution was made.
+ * @service
+ * @internal
  */
 class CRM_Contribute_ActionMapping_ByPage extends CRM_Contribute_ActionMapping {
 

--- a/CRM/Contribute/ActionMapping/ByType.php
+++ b/CRM/Contribute/ActionMapping/ByType.php
@@ -17,6 +17,8 @@
  * entities. It is useful for sending a reminder based on:
  *  - The receipt-date, cancel-date, or thankyou-date.
  *  - The type of contribution.
+ * @service
+ * @internal
  */
 class CRM_Contribute_ActionMapping_ByType extends CRM_Contribute_ActionMapping {
 

--- a/CRM/Event/ActionMapping/ByEvent.php
+++ b/CRM/Event/ActionMapping/ByEvent.php
@@ -12,6 +12,8 @@
 /**
  * This defines the scheduled-reminder functionality for CiviEvent
  * participants with filtering by event-type.
+ * @service
+ * @internal
  */
 class CRM_Event_ActionMapping_ByEvent extends CRM_Event_ActionMapping {
 

--- a/CRM/Event/ActionMapping/ByTemplate.php
+++ b/CRM/Event/ActionMapping/ByTemplate.php
@@ -12,6 +12,8 @@
 /**
  * This defines the scheduled-reminder functionality for CiviEvent
  * participants with filtering by event-type.
+ * @service
+ * @internal
  */
 class CRM_Event_ActionMapping_ByTemplate extends CRM_Event_ActionMapping {
 

--- a/CRM/Event/ActionMapping/ByType.php
+++ b/CRM/Event/ActionMapping/ByType.php
@@ -12,6 +12,8 @@
 /**
  * This defines the scheduled-reminder functionality for CiviEvent
  * participants with filtering by event-type.
+ * @service
+ * @internal
  */
 class CRM_Event_ActionMapping_ByType extends CRM_Event_ActionMapping {
 

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -14,6 +14,8 @@
  * This defines the scheduled-reminder functionality for CiviMember
  * memberships. It allows one to target reminders based on join date
  * or end date, with additional filtering based on membership-type.
+ * @service
+ * @internal
  */
 class CRM_Member_ActionMapping extends \Civi\ActionSchedule\MappingBase {
 

--- a/Civi/ActionSchedule/MappingBase.php
+++ b/Civi/ActionSchedule/MappingBase.php
@@ -12,6 +12,8 @@
 namespace Civi\ActionSchedule;
 
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Base implementation of MappingInterface.
@@ -19,7 +21,13 @@ use Civi\Api4\Utils\CoreUtil;
  * Extend this class to register a new type of ActionSchedule mapping.
  * Note: When choosing a value to return from `getId()`, use a "machine name" style string.
  */
-abstract class MappingBase implements MappingInterface {
+abstract class MappingBase extends AutoService implements MappingInterface, EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.actionSchedule.getMappings' => 'onRegisterActionMappings',
+    ];
+  }
 
   /**
    * Register this action mapping type with CRM_Core_BAO_ActionSchedule.

--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -140,8 +140,7 @@ class ClassScanner {
     // TODO: Consider expanding this search.
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
-    static::scanFolders($classes, $civicrmRoot, 'CRM/*/WorkflowMessage', '_');
-    static::scanFolders($classes, $civicrmRoot, 'CRM/*/Import', '_');
+    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 
     $cache->set($cacheKey, $classes, static::TTL);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -477,14 +477,6 @@ class Container {
       'CRM_Core_LegacyErrorHandler',
       'handleException',
     ], -200);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Activity_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contact_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contribute_ActionMapping_ByPage', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping_ByType', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping_ByEvent', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping_ByTemplate', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Member_ActionMapping', 'onRegisterActionMappings']);
 
     return $dispatcher;
   }

--- a/Civi/Core/Service/AutoService.php
+++ b/Civi/Core/Service/AutoService.php
@@ -45,7 +45,6 @@ namespace Civi\Core\Service;
  * = REQUIREMENTS / LIMITATIONS =
  *
  * - To scan an extension, one must use `<mixin>scan-classes@1.0.0</mixin>` or `hook_scanClasses`.
- * - At time of writing, `ClassScanner` may not scan all core folders.
  * - AutoServices are part of the container. They cannot be executed until the container has
  *   started. Consequently, the services cannot subscribe to some early/boot-time events
  *   (eg `hook_entityTypes` or `hook_container`).


### PR DESCRIPTION
Overview
----------------------------------------
1st, most literal take on auto-loading ActionMappings, using the AutoService base class.

Before
----------------------------------------
Most CRM_* classes cannot use `AutoService`

After
----------------------------------------
Now they can.

Technical Details
----------------------------------------
What I don't like about this variant is all the noise required to add `@service @internal` to every class. That feels like it should be the default rather than throwing an exception if it's missing. But maybe that's a mismatch between the design of AutoService (intended to help define a service) and what it mostly gets used for (just need to listen to events, don't care about the service).
To that end I've made [Variant 2](https://github.com/civicrm/civicrm-core/pull/26923)...