### PR TITLE
Autoload ActionMappings by enabling global class scanning

### DIFF
--- a/Civi/ActionSchedule/MappingBase.php
+++ b/Civi/ActionSchedule/MappingBase.php
@@ -12,6 +12,7 @@
 namespace Civi\ActionSchedule;
 
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Base implementation of MappingInterface.
@@ -19,7 +20,13 @@ use Civi\Api4\Utils\CoreUtil;
  * Extend this class to register a new type of ActionSchedule mapping.
  * Note: When choosing a value to return from `getId()`, use a "machine name" style string.
  */
-abstract class MappingBase implements MappingInterface {
+abstract class MappingBase extends AutoSubscriber implements MappingInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.actionSchedule.getMappings' => 'onRegisterActionMappings',
+    ];
+  }
 
   /**
    * Register this action mapping type with CRM_Core_BAO_ActionSchedule.

--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -137,11 +137,12 @@ class ClassScanner {
 
     $civicrmRoot = \Civi::paths()->getPath('[civicrm.root]/');
 
-    // TODO: Consider expanding this search.
+    // Scan all core classes that might implement an interface we're looking for.
+    // Excludes internal and legacy classes, upgraders, pages & other classes that don't need to be scanned.
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
-    static::scanFolders($classes, $civicrmRoot, 'CRM/*/WorkflowMessage', '_');
-    static::scanFolders($classes, $civicrmRoot, 'CRM/*/Import', '_');
+    // Most older CRM_ stuff doesn't implement event listeners & services so can be skipped.
+    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 
     $cache->set($cacheKey, $classes, static::TTL);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -477,14 +477,6 @@ class Container {
       'CRM_Core_LegacyErrorHandler',
       'handleException',
     ], -200);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Activity_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contact_ActionMapping', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contribute_ActionMapping_ByPage', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Contribute_ActionMapping_ByType', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping_ByType', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping_ByEvent', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Event_ActionMapping_ByTemplate', 'onRegisterActionMappings']);
-    $dispatcher->addListener('civi.actionSchedule.getMappings', ['CRM_Member_ActionMapping', 'onRegisterActionMappings']);
 
     return $dispatcher;
   }

--- a/Civi/Core/Service/AutoDefinition.php
+++ b/Civi/Core/Service/AutoDefinition.php
@@ -26,6 +26,10 @@ class AutoDefinition {
     $result = [];
 
     $classDoc = ReflectionUtils::parseDocBlock($class->getDocComment());
+    // AutoSubscriber is an internal service by default
+    if (is_a($className, AutoSubscriber::class, TRUE)) {
+      $classDoc += ['service' => TRUE, 'internal' => TRUE];
+    }
     if (!empty($classDoc['service'])) {
       $serviceName = static::pickName($classDoc, $class->getName());
       $def = static::createBaseline($class, $classDoc);

--- a/Civi/Core/Service/AutoService.php
+++ b/Civi/Core/Service/AutoService.php
@@ -45,7 +45,6 @@ namespace Civi\Core\Service;
  * = REQUIREMENTS / LIMITATIONS =
  *
  * - To scan an extension, one must use `<mixin>scan-classes@1.0.0</mixin>` or `hook_scanClasses`.
- * - At time of writing, `ClassScanner` may not scan all core folders.
  * - AutoServices are part of the container. They cannot be executed until the container has
  *   started. Consequently, the services cannot subscribe to some early/boot-time events
  *   (eg `hook_entityTypes` or `hook_container`).

--- a/Civi/Core/Service/AutoSubscriber.php
+++ b/Civi/Core/Service/AutoSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Core\Service;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * AutoSubscriber allows child classes to listen to events.
+ *
+ * Child classes must implement the `getSubscribedEvents` method, and the callbacks
+ * it returns will be automatically registered.
+ *
+ * This class implies @service @internal on all subclasses.
+ */
+abstract class AutoSubscriber implements AutoServiceInterface, EventSubscriberInterface {
+
+  use AutoServiceTrait;
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Auto-loading ActionMappings, and make the auto-loading process easier with a new `AutoSubscriber` base class.

Before
----------------------------------------
Most `CRM_*` classes cannot auto-subscribe to events.
`AutoService` base class is a little tricky to implement.

After
----------------------------------------
New `AutoSubscriber` base class facilitates easy auto-event-listening.
Scanning of almost all CRM/* directories.

Technical Details
----------------------------------------
I like this variant better than #26922 because it streamlines the most common use-case for `AutoService`, and takes the guesswork out of getting the annotations right. Note the diff is a lot less noisy than the 1st variant because the child-classes no longer need any magic annotations to listen to events.