### PR TITLE
Update tests to ignore packaged saved searches

### DIFF
--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/SampleTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/SampleTest.php
@@ -237,7 +237,7 @@ class SampleTest extends TestCase implements HeadlessInterface, HookInterface, T
         'Household - CA - 2',
       ]),
     ];
-    $searches = SavedSearch::get()->addSelect('*')->execute();
+    $searches = SavedSearch::get()->addSelect('*')->addWhere('has_base', '=', FALSE)->execute();
     foreach ($searches as $index => $search) {
       $formValues = CRM_Contact_BAO_SavedSearch::getFormValues($search['id']);
       $obj = new CRM_Contact_Form_Search_Custom_Sample($formValues);

--- a/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
@@ -44,7 +44,7 @@ class CRM_Mailing_Form_Task_AdhocMailingTest extends CiviUnitTestCase {
     catch (CRM_Core_Exception_PrematureExitException $e) {
       // Nothing to see here.
     }
-    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', []);
+    $savedSearch = $this->callAPISuccessGetSingle('SavedSearch', ['where' => [['has_base', '=', FALSE]]]);
     $this->assertEquals($formValues, $savedSearch['form_values']);
   }
 

--- a/tests/phpunit/api/v4/Action/CurrentFilterTest.php
+++ b/tests/phpunit/api/v4/Action/CurrentFilterTest.php
@@ -150,9 +150,9 @@ class CurrentFilterTest extends Api4TestBase implements TransactionalInterface {
       'name' => 'expired',
     ])->execute()->first();
 
-    $getCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', TRUE)->execute()->indexBy('id');
-    $notCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', FALSE)->execute()->indexBy('id');
-    $getAll = (array) SavedSearch::get()->addSelect('is_current')->execute()->indexBy('id');
+    $getCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', TRUE)->addWhere('has_base', '=', FALSE)->execute()->indexBy('id');
+    $notCurrent = (array) SavedSearch::get()->addWhere('is_current', '=', FALSE)->addWhere('has_base', '=', FALSE)->execute()->indexBy('id');
+    $getAll = (array) SavedSearch::get()->addSelect('is_current')->addWhere('has_base', '=', FALSE)->execute()->indexBy('id');
 
     $this->assertTrue($getAll[$current['id']]['is_current']);
     $this->assertTrue($getAll[$indefinite['id']]['is_current']);


### PR DESCRIPTION
Overview
----------------------------------------
Just a small update to ignore any existing packaged saved searches when getting saved searches in tests. Aren't causing failures now, but did in different circumstances and may come up again, so belt and braces...

Pulled out from #26722.