### PR TITLE
Fix multi-value custom fields on participant import

### DIFF
--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -123,21 +123,11 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         throw new CRM_Core_Exception($formatError['error_message']);
       }
 
-      if (!$this->isUpdateExisting()) {
-        $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-          NULL,
-          'Participant'
-        );
-      }
-      else {
+      if ($this->isUpdateExisting()) {
         if (!empty($formatValues['participant_id'])) {
           $dao = new CRM_Event_BAO_Participant();
           $dao->id = $formatValues['participant_id'];
 
-          $formatted['custom'] = CRM_Core_BAO_CustomField::postProcess($formatted,
-            $formatValues['participant_id'],
-            'Participant'
-          );
           if ($dao->find(TRUE)) {
             $ids = [
               'participant' => $formatValues['participant_id'],
@@ -276,27 +266,6 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
       // ignore empty values or empty arrays etc
       if (CRM_Utils_System::isNull($value)) {
         continue;
-      }
-
-      // Handling Custom Data
-      if ($customFieldID = CRM_Core_BAO_CustomField::getKeyID($key)) {
-        $values[$key] = $value;
-        $type = $customFields[$customFieldID]['html_type'];
-        if (CRM_Core_BAO_CustomField::isSerialized($customFields[$customFieldID])) {
-          $values[$key] = self::unserializeCustomValue($customFieldID, $value, $type);
-        }
-        elseif ($type == 'Select' || $type == 'Radio') {
-          $customOption = CRM_Core_BAO_CustomOption::getCustomOption($customFieldID, TRUE);
-          foreach ($customOption as $customFldID => $customValue) {
-            $val = $customValue['value'] ?? NULL;
-            $label = $customValue['label'] ?? NULL;
-            $label = strtolower($label);
-            $value = strtolower(trim($value));
-            if (($value == $label) || ($value == strtolower($val))) {
-              $values[$key] = $val;
-            }
-          }
-        }
       }
 
       switch ($key) {

--- a/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
+++ b/tests/phpunit/CRM/Event/Import/Parser/data/participant_with_ext_id.csv
@@ -1,2 +1,2 @@
-Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import
-Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,
+Event Title,Campaign ID,External Identifier,Fee Amount,Fee Currency,Fee level,Is Pay Later,Participant Role,Participant Source,Participant Status,Register date,Do not import,Color
+Rain-forest Cup Youth Soccer Tournament,Soccer Cup,ref-77,5000.55,USD,High,No,"Attendee, Volunteer",Phoned up,Registered,2022-12-07,,"Purple, Mauve"


### PR DESCRIPTION
Reviewer's commit of https://github.com/civicrm/civicrm-core/pull/26000- the original PR was failing a test because a column was added to the csv that was used by the new test and by an existing test. The latter needed to have a corresponding mapping added