### PR TITLE
Fix Import Template path to be dynamic, depending on the entity

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/UserJobSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/UserJobSpecProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service
+ * @internal
+ */
+class UserJobSpecProvider extends AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    $spec->getFieldByName('job_type')
+      ->setSuffixes(['name', 'label', 'url']);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action): bool {
+    return $entity === 'UserJob';
+  }
+
+}

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -30,7 +30,7 @@ class FormattingUtil {
   /**
    * @var string[]
    */
-  public static $pseudoConstantSuffixes = ['name', 'abbr', 'label', 'color', 'description', 'icon', 'grouping'];
+  public static $pseudoConstantSuffixes = ['name', 'abbr', 'label', 'color', 'description', 'icon', 'grouping', 'url'];
 
   /**
    * Massage values into the format the BAO expects for a write operation

--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -138,7 +138,7 @@ return [
               'label' => E::ts('Import Name'),
               'sortable' => TRUE,
               'link' => [
-                'path' => 'civicrm/import/contribution?reset=1&template_id=[id]',
+                'path' => '[job_type:url]?reset=1&template_id=[id]',
                 'entity' => '',
                 'action' => '',
                 'join' => '',
@@ -264,7 +264,7 @@ return [
               'label' => E::ts('Import Name'),
               'sortable' => TRUE,
               'link' => [
-                'path' => 'civicrm/import/contribution?reset=1&template_id=[id]',
+                'path' => '[job_type:url]?reset=1&template_id=[id]',
                 'entity' => '',
                 'action' => '',
                 'join' => '',


### PR DESCRIPTION
Overview
----------------------------------------
Fix Import Template path to be dynamic, depending on the entity

Before
----------------------------------------
url for import templates hard-coded to contribution template

After
----------------------------------------
Contribution remains the only one to be truly working - but if you do hack-create others the url points to the right place

![image](https://github.com/civicrm/civicrm-core/assets/336308/7cc2b9ac-f8dc-4cd8-802f-fdfbef8397d4)

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw there is this bit of hard-coding - https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:import_url?expand=1#diff-133358fd7e10f52f2120bedbd3d31f2f697121d1f5011665f44f87570ef7cbb9R33