### PR TITLE
hook_civicrm_copy: Pass the original id when available

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -711,7 +711,7 @@ WHERE entity_table = 'civicrm_contribution_page'
 
     $copy->save();
 
-    CRM_Utils_Hook::copy('ContributionPage', $copy);
+    CRM_Utils_Hook::copy('ContributionPage', $copy, $id);
 
     return $copy;
   }

--- a/CRM/Core/BAO/Job.php
+++ b/CRM/Core/BAO/Job.php
@@ -112,7 +112,7 @@ class CRM_Core_BAO_Job extends CRM_Core_DAO_Job {
     ];
     $copy = CRM_Core_DAO::copyGeneric('CRM_Core_DAO_Job', ['id' => $id], NULL, $fieldsFix);
     $copy->save();
-    CRM_Utils_Hook::copy('Job', $copy);
+    CRM_Utils_Hook::copy('Job', $copy, $id);
 
     return $copy;
   }

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2648,7 +2648,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       $params = [1 => [$copy->id, 'Integer']];
       CRM_Core_DAO::executeQuery($query, $params);
     }
-    CRM_Utils_Hook::copy('UFGroup', $copy);
+    CRM_Utils_Hook::copy('UFGroup', $copy, $id);
 
     return $copy;
   }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1017,7 +1017,7 @@ WHERE civicrm_event.is_active = 1
     }
 
     CRM_Utils_System::flushCache();
-    CRM_Utils_Hook::copy('Event', $copyEvent);
+    CRM_Utils_Hook::copy('Event', $copyEvent, $id);
 
     return $copyEvent;
   }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -1060,7 +1060,7 @@ WHERE  id = %1";
     }
     $copy->save();
 
-    CRM_Utils_Hook::copy('Set', $copy);
+    CRM_Utils_Hook::copy('Set', $copy, $id);
     unset(\Civi::$statics['CRM_Core_PseudoConstant']);
     return $copy;
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -993,13 +993,15 @@ abstract class CRM_Utils_Hook {
    *   Name of the object.
    * @param object $object
    *   Reference to the copy.
+   * @param int $original_id
+   *   Original entity ID.
    *
    * @return null
    */
-  public static function copy($objectName, &$object) {
+  public static function copy($objectName, &$object, $original_id = NULL) {
     $null = NULL;
-    return self::singleton()->invoke(['objectName', 'object'], $objectName, $object,
-      $null, $null, $null, $null,
+    return self::singleton()->invoke(['objectName', 'object'], $objectName, $object, $original_id,
+      $null, $null, $null,
       'civicrm_copy'
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------

`hook_civicrm_copy` can be useful sometimes when an extension adds extra data/settings to an entity and then that entity gets copied.

However, the hook does not receive the original entity ID, which makes it difficult to copy data from extensions.

Example: https://lab.civicrm.org/extensions/formaccessrestrictions/-/blob/master/formaccessrestrictions.php#L151

Before
----------------------------------------

Original ID is not passed.

After
----------------------------------------

ID is passed, if available.

Technical Details
----------------------------------------

- I could not fix `CRM/Core/BAO/RecurringEntity.php`  because it works differently - it uses `$fromCriteria`, so the ID can be hard to guess.
- Added the new `$original_id` argument as an optional arg, to avoid breaking any existing implementations.

Comments
----------------------------------------

- Looked at phpunit tests, but didn't seem very testable?
- docs PR: https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1102