### PR TITLE
Standalone civi-setup: grant more permissions to anon, use ts

### DIFF
--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -47,13 +47,13 @@ if (!defined('CIVI_SETUP')) {
       ->setRecords([
         [
           'name' => 'everyone',
-          'label' => 'Everyone, including anonymous users',
+          'label' => ts('Everyone, including anonymous users'),
           // Provide default open permissions
-          'permissions' => ['CiviMail subscribe/unsubscribe pages', 'make online contributions'],
+          'permissions' => ['CiviMail subscribe/unsubscribe pages', 'make online contributions', 'view event info', 'register for events'],
         ],
         [
           'name' => 'admin',
-          'label' => 'Administrator',
+          'label' => ts('Administrator'),
           'permissions' => array_keys(\CRM_Core_SelectValues::permissions()),
         ],
       ])


### PR DESCRIPTION
Overview
----------------------------------------

In the default Standalone install, also grant the permissions to:

- view event info
- register for online events

This also aims to help with the demo sites, but also towards providing sane out-of-the-box defaults (I forget if "view profiles" and "view all custom data" is required for contribution/event pages, but I guess it works without).

Also used `ts` for the role labels.

cc @artfulrobot