### PR TITLE
dev/core#4445 Only show templates upgrade message when templates have changed

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -476,6 +476,15 @@ class CRM_Upgrade_Incremental_MessageTemplates {
    */
   public function getUpgradeMessages() {
     $updates = $this->getTemplatesToUpdate();
+
+    // workflow_name is not available pre-5.26, so we won't check if templates are changed or not pre-5.26
+    try {
+      $uneditedTemplates = $this->getUneditedTemplates();
+    }
+    catch (Exception $e) {
+      $uneditedTemplates = [];
+    }
+
     $messages = [];
     $templateLabel = '';
     foreach ($updates as $key => $value) {
@@ -491,7 +500,9 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           $templateLabel = $value['label'];
         }
       }
-      $messages[$templateLabel] = $value['upgrade_descriptor'];
+      if (!(array_key_exists($key, $uneditedTemplates))) {
+        $messages[$templateLabel] = $value['upgrade_descriptor'];
+      }
     }
     return $messages;
   }
@@ -592,8 +603,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
    * Get all the is_default templates that are the unchanged from their is_reserved counterpart, which
    * at the time this runs was the version shipped with core when it was last changed.
    *
-   * @todo have pulled this out since want to re-use it to get the preUpgrade message right. Currently
-   * it always tells you all the ones in the hardcoded per-version list have been customized.
+   * This cannot be used before 5.26, as workflow_name was only added in 5.26.
    *
    * @return array
    */
@@ -601,7 +611,7 @@ class CRM_Upgrade_Incremental_MessageTemplates {
     $templates = [];
     foreach (['html', 'text', 'subject'] as $type) {
       $dao = CRM_Core_DAO::executeQuery("
-        SELECT default_template.id, default_template.workflow_id FROM civicrm_msg_template reserved
+        SELECT default_template.id, default_template.workflow_id, default_template.workflow_name FROM civicrm_msg_template reserved
         LEFT JOIN civicrm_msg_template default_template
           ON reserved.workflow_id = default_template.workflow_id
         WHERE reserved.is_reserved = 1 AND default_template.is_default = 1 AND reserved.id <> default_template.id
@@ -609,10 +619,11 @@ class CRM_Upgrade_Incremental_MessageTemplates {
       ");
       while ($dao->fetch()) {
         // Note the same id can appear multiple times, e.g. you might change the html but not the subject.
-        $templates[] = [
+        $templates[$dao->workflow_name . '_' . $type] = [
           'id' => $dao->id,
           'type' => $type,
           'workflow_id' => $dao->workflow_id,
+          'workflow_name' => $dao->workflow_name,
         ];
       }
     }

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -133,12 +133,15 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
    * Test function for messages on upgrade.
    */
   public function testMessageTemplateGetUpgradeMessages() {
+    \Civi\Api4\MessageTemplate::update(FALSE)
+      ->addValue('msg_text', 'Edited text')
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addWhere('is_default', '=', TRUE)
+      ->execute();
     $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.4.alpha1');
     $messages = $messageTemplateObject->getUpgradeMessages();
     $this->assertEquals([
-      'Memberships - Receipt (on-line)' => 'Use email greeting at top where available',
       'Contributions - Receipt (on-line)' => 'Use email greeting at top where available',
-      'Events - Registration Confirmation and Receipt (on-line)' => 'Use email greeting at top where available',
     ], $messages);
   }
 


### PR DESCRIPTION
Before
----------------------------------------
On upgrade, message about customized templates is shown even when the templates aren't customized.

After
----------------------------------------
Message only shown for templates that have been customized.

Technical Details
----------------------------------------
This check won't work pre-5.26 as workflow_name was only added then, so we'll continue to show the message even if customized for upgrades from pre-5.26, which should be rare.

As I understand it, the changes to getUneditedTemplates() to include workflow_name won't cause issues because updateReservedAndMaybeDefaultTemplates() runs after database upgrades, so even if someone was upgrading from 5.25, workflow_name would exist by the time we got there in the upgrade process. But would appreciate a second eye on this aspect.
