### PR TITLE
Don't scan QuickForm classes

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -142,7 +142,7 @@ class ClassScanner {
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
     // Most older CRM_ stuff doesn't implement event listeners & services so can be skipped.
-    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen);');
+    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Controller|_StateMachine|_Selector|_CodeGen|_QuickForm);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 
     $cache->set($cacheKey, $classes, static::TTL);


### PR DESCRIPTION
Overview
----------------------------------------
For reasons that are not entirely clear to me, the recent change in #26923 enabling global class scanning causes a QuickForm error if you civibuild rebuild a site (but not on a fresh install). Excluding the QuickForm classes from the global scanning (per @totten) fixes the problem.

Before
----------------------------------------
QuickForm error everywhere.

After
----------------------------------------
No more error.