### PR TITLE
ClassScanner - Re-skip `_Form` classes

### DIFF
--- a/Civi/Core/ClassScanner.php
+++ b/Civi/Core/ClassScanner.php
@@ -142,7 +142,7 @@ class ClassScanner {
     $classes = [];
     static::scanFolders($classes, $civicrmRoot, 'Civi/Test/ExampleData', '\\');
     // Most older CRM_ stuff doesn't implement event listeners & services so can be skipped.
-    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Controller|_StateMachine|_Selector|_CodeGen|_QuickForm);');
+    static::scanFolders($classes, $civicrmRoot, 'CRM', '_', ';(Upgrade|Utils|Exception|_DAO|_Page|_Form|_Controller|_StateMachine|_Selector|_CodeGen|_QuickForm);');
     static::scanFolders($classes, $civicrmRoot, 'Civi', '\\', ';\\\(Security|Test)\\\;');
 
     $cache->set($cacheKey, $classes, static::TTL);


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #26936. The prior commit was good in that it stopped scanning `CRM_Core_QuickForm_*` classes. But it also turned-on unnecessary scanning of `CRM_*_Form_*`. Flip that back.


Before and After
----------------------------------------

1. __Original__: Scan ~1000 classes
2. __Current__: Scan ~1500 classes
3. __New__: Scan ~1000 classes
