### PR TITLE
standalone: move breadcrumb rendering into template

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -249,7 +249,7 @@ class CRM_Core_Invoke {
         CRM_Utils_System::setTitle($item['title']);
       }
 
-      if (isset($item['breadcrumb']) && !isset($item['is_public'])) {
+      if (isset($item['breadcrumb']) && empty($item['is_public'])) {
         CRM_Utils_System::appendBreadCrumb($item['breadcrumb']);
       }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -108,7 +108,11 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function appendBreadCrumb($breadcrumbs) {
-    \Civi::$statics[__CLASS__]['breadcrumb'][] = $breadcrumbs;
+    if (!isset(\Civi::$statics[__CLASS__]['breadcrumb'])) {
+      \Civi::$statics[__CLASS__]['breadcrumb'] = [];
+    }
+    \Civi::$statics[__CLASS__]['breadcrumb'] += $breadcrumbs;
+    CRM_Core_Smarty::singleton()->assign('breadcrumb', \Civi::$statics[__CLASS__]['breadcrumb']);
   }
 
   /**
@@ -116,6 +120,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function resetBreadCrumb() {
     \Civi::$statics[__CLASS__]['breadcrumb'] = [];
+    CRM_Core_Smarty::singleton()->assign('breadcrumb', NULL);
   }
 
   /**
@@ -123,6 +128,9 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function addHTMLHead($header) {
     $template = CRM_Core_Smarty::singleton();
+    // Smarty's append function does not check for the existence of the var before appending to it.
+    // So this prevents a stupid notice error:
+    $template->ensureVariablesAreAssigned(['pageHTMLHead']);
     $template->append('pageHTMLHead', $header);
     return;
   }
@@ -259,18 +267,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     if ($maintenance) {
       $smarty = CRM_Core_Smarty::singleton();
       echo implode('', $smarty->_tpl_vars['pageHTMLHead']);
-    }
-
-    // Show the breadcrumb
-    if (!empty(\Civi::$statics[__CLASS__]['breadcrumb'])) {
-      print '<nav aria-label="' . htmlspecialchars(ts('Breadcrumb')) . '" class="breadcrumb"><ol>';
-      print '<li><a href="' . CRM_Utils_System::url('civicrm/dashboard', 'reset=1') . '">' . htmlspecialchars(ts('Home')) . '</a></li>';
-      foreach (\Civi::$statics[__CLASS__]['breadcrumb'] as $breadcrumb) {
-        foreach ($breadcrumb as $item) {
-          print '<li><a href="' . $item['url'] . '">' . htmlspecialchars($item['title']) . '</a></li>';
-        }
-      }
-      print '</ol></nav>';
     }
 
     // @todo Add variables from the body tag? (for Shoreditch)

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -108,10 +108,9 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function appendBreadCrumb($breadcrumbs) {
-    if (!isset(\Civi::$statics[__CLASS__]['breadcrumb'])) {
-      \Civi::$statics[__CLASS__]['breadcrumb'] = [];
-    }
-    \Civi::$statics[__CLASS__]['breadcrumb'] += $breadcrumbs;
+    $crumbs = \Civi::$statics[__CLASS__]['breadcrumb'] ?? [];
+    $crumbs = array_merge($crumbs, $breadcrumbs);
+    \Civi::$statics[__CLASS__]['breadcrumb'] = $crumbs;
     CRM_Core_Smarty::singleton()->assign('breadcrumb', \Civi::$statics[__CLASS__]['breadcrumb']);
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -109,7 +109,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function appendBreadCrumb($breadcrumbs) {
     $crumbs = \Civi::$statics[__CLASS__]['breadcrumb'] ?? [];
-    $crumbs += array_column($breadcrumbs, null, 'url');
+    $crumbs += array_column($breadcrumbs, NULL, 'url');
     \Civi::$statics[__CLASS__]['breadcrumb'] = $crumbs;
     CRM_Core_Smarty::singleton()->assign('breadcrumb', array_values($crumbs));
   }

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -109,9 +109,21 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function appendBreadCrumb($breadcrumbs) {
     $crumbs = \Civi::$statics[__CLASS__]['breadcrumb'] ?? [];
-    $crumbs = array_merge($crumbs, $breadcrumbs);
+
+    foreach ($breadcrumbs as $crumb) {
+      $duplicate = FALSE;
+      foreach ($crumbs as $existingCrumb) {
+        if ($existingCrumb['url'] === $crumb['url']) {
+          $duplicate = TRUE;
+          break;
+        }
+      }
+      if (!$duplicate) {
+        $crumbs[] = $crumb;
+      }
+    }
     \Civi::$statics[__CLASS__]['breadcrumb'] = $crumbs;
-    CRM_Core_Smarty::singleton()->assign('breadcrumb', \Civi::$statics[__CLASS__]['breadcrumb']);
+    CRM_Core_Smarty::singleton()->assign('breadcrumb', $crumbs);
   }
 
   /**

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -109,21 +109,9 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function appendBreadCrumb($breadcrumbs) {
     $crumbs = \Civi::$statics[__CLASS__]['breadcrumb'] ?? [];
-
-    foreach ($breadcrumbs as $crumb) {
-      $duplicate = FALSE;
-      foreach ($crumbs as $existingCrumb) {
-        if ($existingCrumb['url'] === $crumb['url']) {
-          $duplicate = TRUE;
-          break;
-        }
-      }
-      if (!$duplicate) {
-        $crumbs[] = $crumb;
-      }
-    }
+    $crumbs += array_column($breadcrumbs, null, 'url');
     \Civi::$statics[__CLASS__]['breadcrumb'] = $crumbs;
-    CRM_Core_Smarty::singleton()->assign('breadcrumb', $crumbs);
+    CRM_Core_Smarty::singleton()->assign('breadcrumb', array_values($crumbs));
   }
 
   /**

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -24,21 +24,18 @@
   <title>{$docTitle}</title>
 </head>
 <body>
-
   {if $config->debug}
   {include file="CRM/common/debug.tpl"}
   {/if}
 
   <div id="crm-container" class="crm-container" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
     {if $breadcrumb}
-      <div class="breadcrumb">
+      <nav aria-label="{ts}Breadcrumb{/ts}" class="breadcrumb"><ol>
+        <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>
         {foreach from=$breadcrumb item=crumb key=key}
-          {if $key != 0}
-            &raquo;
-          {/if}
-          <a href="{$crumb.url}">{$crumb.title}</a>
+          <li><a href="{$crumb.url}">{$crumb.title}</a></li>
         {/foreach}
-      </div>
+      </ol></nav>
     {/if}
 
     {if $pageTitle}


### PR DESCRIPTION
Before
----------------------------------------

Breadcrumbs were output by `print` calls, and got spat out before `<doctype html>` etc.

After
----------------------------------------

Breadcrumbs now rendered by Smarty as part of template.

