### PR TITLE
[REF] Move event subscribers out of container; make AutoSubscriber an interface

### DIFF
--- a/CRM/Contribute/ActionMapping.php
+++ b/CRM/Contribute/ActionMapping.php
@@ -15,8 +15,6 @@
  * entities. It is useful for sending a reminder based on:
  *  - The receipt-date, cancel-date, or thankyou-date.
  *  - The type of contribution.
- * @service
- * @internal
  */
 abstract class CRM_Contribute_ActionMapping extends \Civi\ActionSchedule\MappingBase {
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -24,7 +24,7 @@ use Civi\Core\Event\PostEvent;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution implements Civi\Test\HookInterface {
+class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution implements Civi\Core\HookInterface {
 
   /**
    * Static field for all the contribution information that we can potentially import

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -19,7 +19,7 @@ use Civi\Api4\LineItem;
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_ContributionRecur implements Civi\Test\HookInterface {
+class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_ContributionRecur implements Civi\Core\HookInterface {
 
   /**
    * Create recurring contribution.

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -15,8 +15,14 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag {
+class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag implements \Civi\Core\Service\AutoSubscriber {
   use CRM_Core_DynamicFKAccessTrait;
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.dao.preDelete' => 'preDeleteOtherEntity',
+    ];
+  }
 
   /**
    * Given a contact id, it returns an array of tag id's the contact belongs to.

--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -11,6 +11,7 @@
  */
 
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Class CRM_Core_Permission_List
@@ -22,7 +23,17 @@ use Civi\Core\Event\GenericHookEvent;
  *
  * @see \Civi\Api4\Action\Permission\Get
  */
-class CRM_Core_Permission_List {
+class CRM_Core_Permission_List implements AutoSubscriber {
+
+  public static function getSubscribedEvents() {
+    return [
+      'hook_civicrm_permissionList' => [
+        ['findConstPermissions', 975],
+        ['findCiviPermissions', 950],
+        ['findCmsPermissions', 925],
+      ],
+    ];
+  }
 
   /**
    * Enumerate concrete permissions that originate in CiviCRM (core or extension).

--- a/Civi/ActionSchedule/MappingBase.php
+++ b/Civi/ActionSchedule/MappingBase.php
@@ -20,7 +20,7 @@ use Civi\Core\Service\AutoSubscriber;
  * Extend this class to register a new type of ActionSchedule mapping.
  * Note: When choosing a value to return from `getId()`, use a "machine name" style string.
  */
-abstract class MappingBase extends AutoSubscriber implements MappingInterface {
+abstract class MappingBase implements AutoSubscriber, MappingInterface {
 
   public static function getSubscribedEvents(): array {
     return [

--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -16,7 +16,7 @@ use Civi\Core\Service\AutoSubscriber;
 /**
  * Preprocess api autocomplete requests
  */
-class AutocompleteFieldSubscriber extends AutoSubscriber {
+class AutocompleteFieldSubscriber implements AutoSubscriber {
 
   /**
    * @return array

--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -11,15 +11,12 @@
 
 namespace Civi\Api4\Event\Subscriber;
 
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Preprocess api autocomplete requests
- * @service
- * @internal
  */
-class AutocompleteFieldSubscriber extends AutoService implements EventSubscriberInterface {
+class AutocompleteFieldSubscriber extends AutoSubscriber {
 
   /**
    * @return array

--- a/Civi/Api4/Provider/CustomEntityProvider.php
+++ b/Civi/Api4/Provider/CustomEntityProvider.php
@@ -14,14 +14,11 @@ namespace Civi\Api4\Provider;
 use Civi\Api4\CustomValue;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 use Civi\Core\Event\GenericHookEvent;
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
- * @service
- * @internal
  */
-class CustomEntityProvider extends AutoService implements EventSubscriberInterface {
+class CustomEntityProvider extends AutoSubscriber {
 
   /**
    * @return array

--- a/Civi/Api4/Provider/CustomEntityProvider.php
+++ b/Civi/Api4/Provider/CustomEntityProvider.php
@@ -18,7 +18,7 @@ use Civi\Core\Service\AutoSubscriber;
 
 /**
  */
-class CustomEntityProvider extends AutoSubscriber {
+class CustomEntityProvider implements AutoSubscriber {
 
   /**
    * @return array

--- a/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
@@ -17,7 +17,7 @@ use Civi\Core\Service\AutoSubscriber;
 /**
  * Provide autocomplete searches tailored to the CiviMail recipients widget
  */
-class MailingRecipientsAutocompleteProvider extends AutoSubscriber {
+class MailingRecipientsAutocompleteProvider implements AutoSubscriber {
 
   /**
    * @return array

--- a/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
@@ -12,15 +12,12 @@
 namespace Civi\Api4\Service\Autocomplete;
 
 use Civi\Core\Event\GenericHookEvent;
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Provide autocomplete searches tailored to the CiviMail recipients widget
- * @service
- * @internal
  */
-class MailingRecipientsAutocompleteProvider extends AutoService implements EventSubscriberInterface {
+class MailingRecipientsAutocompleteProvider extends AutoSubscriber {
 
   /**
    * @return array

--- a/Civi/CCase/Events.php
+++ b/Civi/CCase/Events.php
@@ -10,12 +10,14 @@
  */
 namespace Civi\CCase;
 
+use Civi\Core\Service\AutoSubscriber;
+
 /**
  * Class Events
  *
  * @package Civi\CCase
  */
-class Events {
+class Events implements AutoSubscriber {
 
   /**
    * List of cases for which we are actively firing case-change event
@@ -26,6 +28,14 @@ class Events {
    * @var array
    */
   public static $isActive = [];
+
+  public static function getSubscribedEvents() {
+    return [
+      'hook_civicrm_post::Activity' => 'fireCaseChange',
+      'hook_civicrm_post::Case' => 'fireCaseChange',
+      'hook_civicrm_caseChange' => 'delegateToXmlListeners',
+    ];
+  }
 
   /**
    * Following a change to an activity or case, fire the case-change event.

--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -1,17 +1,25 @@
 <?php
 namespace Civi\CCase;
 
+use Civi\Core\Service\AutoSubscriber;
+
 /**
  * The sequence-listener looks for CiviCase XML tags with "<sequence>". If
  * a change is made to any record in case-type which uses "<sequence>", then
  * it attempts to add the next step in the sequence.
  */
-class SequenceListener implements CaseChangeListener {
+class SequenceListener implements CaseChangeListener, AutoSubscriber {
 
   /**
    * @var SequenceListener
    */
   private static $singleton;
+
+  public static function getSubscribedEvents() {
+    return [
+      'hook_civicrm_caseChange' => 'onCaseChange_static',
+    ];
+  }
 
   /**
    * @param bool $reset

--- a/Civi/Core/Compiler/AutoSubscriberScannerPass.php
+++ b/Civi/Core/Compiler/AutoSubscriberScannerPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Civi\Core\Compiler;
+
+use Civi\Core\ClassScanner;
+use Civi\Core\Service\AutoDefinition;
+use Civi\Core\Service\AutoSubscriber;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Scan the source-tree for implementations of `AutoSubscriber` interface. Load them.
+ *
+ * Note: This will scan the core codebase as well as active extensions. For fully automatic
+ * support in an extension, the extension must enable the mixin `scan-classes@1`.
+ */
+class AutoSubscriberScannerPass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container) {
+    $autoSubscribers = ClassScanner::get(['interface' => AutoSubscriber::class]);
+    foreach ($autoSubscribers as $autoSubscriber) {
+      $reflection = new \ReflectionClass($autoSubscriber);
+      $file = $reflection->getFileName();
+      $container->addResource(new \Symfony\Component\Config\Resource\FileResource($file));
+      $definition = new Definition($reflection->getName());
+      $definition->setPublic(TRUE);
+      AutoDefinition::applyTags($definition, $reflection, ['internal' => TRUE]);
+      $container->setDefinition($reflection->getName(), $definition);
+    }
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -449,10 +449,6 @@ class Container {
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('hook_civicrm_post', $aliasEvent('hook_civicrm_post', 'entity'), 100);
-    $dispatcher->addListener('hook_civicrm_post::Activity', ['\Civi\CCase\Events', 'fireCaseChange']);
-    $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);
-    $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\Events', 'delegateToXmlListeners']);
-    $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\SequenceListener', 'onCaseChange_static']);
     $dispatcher->addListener('hook_civicrm_cryptoRotateKey', ['\Civi\Crypto\RotateKeys', 'rotateSmtp']);
     $dispatcher->addListener('hook_civicrm_eventDefs', ['\Civi\Core\CiviEventInspector', 'findBuiltInEvents']);
     // TODO We need a better code-convention for metadata about non-hook events.

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -2,6 +2,7 @@
 namespace Civi\Core;
 
 use Civi\Core\Compiler\AutoServiceScannerPass;
+use Civi\Core\Compiler\AutoSubscriberScannerPass;
 use Civi\Core\Compiler\EventScannerPass;
 use Civi\Core\Compiler\SpecProviderPass;
 use Civi\Core\Event\EventScanner;
@@ -100,6 +101,7 @@ class Container {
     $civicrm_base_path = dirname(dirname(__DIR__));
     $container = new ContainerBuilder();
     $container->addCompilerPass(new AutoServiceScannerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
+    $container->addCompilerPass(new AutoSubscriberScannerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 999);
     $container->addCompilerPass(new EventScannerPass());
     $container->addCompilerPass(new SpecProviderPass());
     $container->addCompilerPass(new RegisterListenersPass());

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -464,9 +464,6 @@ class Container {
     $dispatcher->addListener('hook_civicrm_alterExternUrl', ['\CRM_Utils_System', 'migrateExternUrl'], 1000);
     // Not a BAO class so it can't implement hookInterface
     $dispatcher->addListener('hook_civicrm_post', ['CRM_Utils_Recent', 'on_hook_civicrm_post']);
-    $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findConstPermissions'], 975);
-    $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCiviPermissions'], 950);
-    $dispatcher->addListener('hook_civicrm_permissionList', ['CRM_Core_Permission_List', 'findCmsPermissions'], 925);
 
     $dispatcher->addListener('hook_civicrm_postSave_civicrm_domain', ['\CRM_Core_BAO_Domain', 'onPostSave']);
     $dispatcher->addListener('hook_civicrm_unhandled_exception', [

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -449,7 +449,6 @@ class Container {
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('hook_civicrm_post', $aliasEvent('hook_civicrm_post', 'entity'), 100);
-    $dispatcher->addListener('hook_civicrm_cryptoRotateKey', ['\Civi\Crypto\RotateKeys', 'rotateSmtp']);
     $dispatcher->addListener('hook_civicrm_eventDefs', ['\Civi\Core\CiviEventInspector', 'findBuiltInEvents']);
     // TODO We need a better code-convention for metadata about non-hook events.
     $dispatcher->addListener('hook_civicrm_eventDefs', ['\Civi\API\Events', 'hookEventDefs']);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -448,7 +448,6 @@ class Container {
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\LocalizationInitializer', 'initialize']);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
-    $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);
     $dispatcher->addListener('hook_civicrm_post', $aliasEvent('hook_civicrm_post', 'entity'), 100);
     $dispatcher->addListener('hook_civicrm_post::Activity', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);

--- a/Civi/Core/Service/AutoDefinition.php
+++ b/Civi/Core/Service/AutoDefinition.php
@@ -26,10 +26,6 @@ class AutoDefinition {
     $result = [];
 
     $classDoc = ReflectionUtils::parseDocBlock($class->getDocComment());
-    // AutoSubscriber is an internal service by default
-    if (is_a($className, AutoSubscriber::class, TRUE)) {
-      $classDoc += ['service' => TRUE, 'internal' => TRUE];
-    }
     if (!empty($classDoc['service'])) {
       $serviceName = static::pickName($classDoc, $class->getName());
       $def = static::createBaseline($class, $classDoc);
@@ -114,7 +110,7 @@ class AutoDefinition {
    * @param \ReflectionClass $class
    * @param array $docBlock
    */
-  protected static function applyTags(Definition $def, \ReflectionClass $class, array $docBlock): void {
+  public static function applyTags(Definition $def, \ReflectionClass $class, array $docBlock): void {
     if (!empty($docBlock['internal'])) {
       $def->addTag('internal');
     }

--- a/Civi/Core/Service/AutoSubscriber.php
+++ b/Civi/Core/Service/AutoSubscriber.php
@@ -13,15 +13,13 @@ namespace Civi\Core\Service;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * AutoSubscriber allows child classes to listen to events.
+ * AutoSubscriber allows classes to listen to events.
  *
- * Child classes must implement the `getSubscribedEvents` method, and the callbacks
+ * Classes must implement the `getSubscribedEvents` method, and the callbacks
  * it returns will be automatically registered.
  *
- * This class implies @service @internal on all subclasses.
+ * This is like `AutoServiceInterface` with @service @internal on all impl.
  */
-abstract class AutoSubscriber implements AutoServiceInterface, EventSubscriberInterface {
-
-  use AutoServiceTrait;
+interface AutoSubscriber extends EventSubscriberInterface {
 
 }

--- a/Civi/Crypto/RotateKeys.php
+++ b/Civi/Crypto/RotateKeys.php
@@ -12,13 +12,20 @@
 namespace Civi\Crypto;
 
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Class RotateKeys
  *
  * @package Civi\Crypto
  */
-class RotateKeys {
+class RotateKeys implements AutoSubscriber {
+
+  public static function getSubscribedEvents() {
+    return [
+      'hook_civicrm_cryptoRotateKey' => 'rotateSmtp',
+    ];
+  }
 
   /**
    * The SMTP password is stored inside of the 'mailing_backend' setting.

--- a/Civi/WorkflowMessage/TestBanner.php
+++ b/Civi/WorkflowMessage/TestBanner.php
@@ -13,17 +13,14 @@
 namespace Civi\WorkflowMessage;
 
 use Civi\Api4\MessageTemplate;
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * If someone sends an automated message for a test record (e.g. Contribution with `is_test=1`),
  * then we add a banner to the automated message.
  *
- * @service
- * @internal
  */
-class TestBanner extends AutoService implements EventSubscriberInterface {
+class TestBanner extends AutoSubscriber {
 
   public static function getSubscribedEvents() {
     return [

--- a/Civi/WorkflowMessage/TestBanner.php
+++ b/Civi/WorkflowMessage/TestBanner.php
@@ -20,7 +20,7 @@ use Civi\Core\Service\AutoSubscriber;
  * then we add a banner to the automated message.
  *
  */
-class TestBanner extends AutoSubscriber {
+class TestBanner implements AutoSubscriber {
 
   public static function getSubscribedEvents() {
     return [

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -20,7 +20,7 @@ use Civi\Api4\Utils\CoreUtil;
 /**
  * Preprocess api autocomplete requests
  */
-class AfformAutocompleteSubscriber extends AutoSubscriber {
+class AfformAutocompleteSubscriber implements AutoSubscriber {
 
   /**
    * @return array

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -11,19 +11,16 @@
 
 namespace Civi\Api4\Subscriber;
 
-use Civi\Core\Service\AutoService;
+use Civi\Core\Service\AutoSubscriber;
 use Civi\Afform\FormDataModel;
 use Civi\Api4\Afform;
 use Civi\Api4\Generic\AutocompleteAction;
 use Civi\Api4\Utils\CoreUtil;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Preprocess api autocomplete requests
- * @service
- * @internal
  */
-class AfformAutocompleteSubscriber extends AutoService implements EventSubscriberInterface {
+class AfformAutocompleteSubscriber extends AutoSubscriber {
 
   /**
    * @return array

--- a/ext/recaptcha/Civi/AfformReCaptcha2.php
+++ b/ext/recaptcha/Civi/AfformReCaptcha2.php
@@ -11,7 +11,7 @@ use Civi\Core\Service\AutoSubscriber;
 /**
  * Provides ReCaptcha2 validation element to Afform
  */
-class AfformReCaptcha2 extends AutoSubscriber {
+class AfformReCaptcha2 implements AutoSubscriber {
 
   /**
    * @return array

--- a/ext/recaptcha/Civi/AfformReCaptcha2.php
+++ b/ext/recaptcha/Civi/AfformReCaptcha2.php
@@ -6,15 +6,12 @@ use CRM_Recaptcha_ExtensionUtil as E;
 use Civi\Afform\AHQ;
 use Civi\Afform\Event\AfformValidateEvent;
 use Civi\Core\Event\GenericHookEvent;
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Provides ReCaptcha2 validation element to Afform
- * @internal
- * @service
  */
-class AfformReCaptcha2 extends AutoService implements EventSubscriberInterface {
+class AfformReCaptcha2 extends AutoSubscriber {
 
   /**
    * @return array

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -21,7 +21,7 @@ use Civi\Core\Service\AutoSubscriber;
  *
  * Other extensions can override or modify these defaults on a per-type or per-entity basis.
  */
-class DefaultDisplaySubscriber extends AutoSubscriber {
+class DefaultDisplaySubscriber implements AutoSubscriber {
 
   /**
    * @return array

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -14,17 +14,14 @@ namespace Civi\Api4\Event\Subscriber;
 use Civi\API\Request;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Provides default display for type 'table' and type 'autocomplete'
  *
  * Other extensions can override or modify these defaults on a per-type or per-entity basis.
- *
- * @service
- * @internal
  */
-class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+class DefaultDisplaySubscriber extends AutoSubscriber {
 
   /**
    * @return array

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -18,15 +18,12 @@ use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Core\Event\PostEvent;
 use Civi\Core\Event\PreEvent;
-use Civi\Core\Service\AutoService;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Manages tables and API entities created from search displays of type "entity"
- * @service
- * @internal
  */
-class SKEntitySubscriber extends AutoService implements EventSubscriberInterface {
+class SKEntitySubscriber extends AutoSubscriber {
 
   use SavedSearchInspectorTrait;
 

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -23,7 +23,7 @@ use Civi\Core\Service\AutoSubscriber;
 /**
  * Manages tables and API entities created from search displays of type "entity"
  */
-class SKEntitySubscriber extends AutoSubscriber {
+class SKEntitySubscriber implements AutoSubscriber {
 
   use SavedSearchInspectorTrait;
 

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -17,7 +17,7 @@ use Civi\Core\Service\AutoSubscriber;
 /**
  * Event subscriber to filter search display tasks
  */
-class SearchDisplayTasksSubscriber extends AutoSubscriber {
+class SearchDisplayTasksSubscriber implements AutoSubscriber {
 
   /**
    * Filter tasks with a priority of -50, which allows W_MIDDLE & W_EARLY to go first, but W_LATE to go after.

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -12,14 +12,12 @@
 namespace Civi\Api4\Event\Subscriber;
 
 use Civi\Core\Event\GenericHookEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Civi\Core\Service\AutoSubscriber;
 
 /**
  * Event subscriber to filter search display tasks
- * @service
- * @internal
  */
-class SearchDisplayTasksSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+class SearchDisplayTasksSubscriber extends AutoSubscriber {
 
   /**
    * Filter tasks with a priority of -50, which allows W_MIDDLE & W_EARLY to go first, but W_LATE to go after.


### PR DESCRIPTION
Overview
----------------------------------------
Automates more event listeners.
See #26923

Technical Details
------------------
As an abstract class, `AutoSubscriber` had limited application because a class can only have one base-class. This makes it an interface, which can be added to any class.

@totten 