### PR TITLE
Deprecate probably never true condition

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -360,6 +360,9 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->order = new CRM_Financial_BAO_Order();
       $this->order->setPriceSetID($this->getPriceSetID());
     }
+    else {
+      CRM_Core_Error::deprecatedFunctionWarning('forms require a price set it');
+    }
     $this->_priceSet = $this->get('priceSet');
 
     if (!$this->_values) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -361,7 +361,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $this->order->setPriceSetID($this->getPriceSetID());
     }
     else {
-      CRM_Core_Error::deprecatedFunctionWarning('forms require a price set it');
+      CRM_Core_Error::deprecatedFunctionWarning('forms require a price set ID');
     }
     $this->_priceSet = $this->get('priceSet');
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -12,6 +12,7 @@
 use Civi\Api4\MembershipBlock;
 use Civi\Api4\PriceField;
 use Civi\Api4\PriceSet;
+use Civi\Api4\PriceSetEntity;
 
 /**
  *  Test APIv3 civicrm_contribute_* functions
@@ -1383,11 +1384,12 @@ Paid By: Check',
       'receipt_from_name' => 'Ego Freud',
     ];
 
+    $_REQUEST['id'] = $this->callAPISuccess('ContributionPage', 'create', $params)['id'];
+    PriceSetEntity::create(FALSE)->setValues(['entity_id' => $_REQUEST['id'], 'entity_table' => 'civicrm_contribution_page', 'price_set_id:name' => 'default_contribution_amount'])->execute();
     // Execute CRM_Contribute_Form_ContributionBase preProcess (via child class).
     // Check the assignment of payment processors.
     /* @var \CRM_Contribute_Form_Contribution_Main $form */
     $form = $this->getFormObject('CRM_Contribute_Form_Contribution_Main', ['payment_processor_id' => 0]);
-    $_REQUEST['id'] = $this->callAPISuccess('ContributionPage', 'create', $params)['id'];
 
     $form->preProcess();
     $this->assertEquals('pay_later', $form->_paymentProcessor['name']);


### PR DESCRIPTION
If we can clarify that price set is ALWAYS set it will simplify stuff
- comments suggest that the exception has been weird test config
