### PR TITLE
Clarify use of `params` in `Contribution_Main::postProcess`, fix preApproval to use frontend_title

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -276,6 +276,27 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * @return string
+   */
+  protected function getInvoiceID(): string {
+    if (!$this->get('invoiceID')) {
+      $this->setInvoiceID();
+
+    }
+    return $this->get('invoiceID');
+  }
+
+  /**
+   * @return string
+   */
+  protected function setInvoiceID(): string {
+    // generate and set an invoiceID for this transaction
+    $invoiceID = md5(uniqid(mt_rand(), TRUE));
+    $this->set('invoiceID', $invoiceID);
+    return $invoiceID;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Contribute_Exception_InactiveContributionPageException


### PR DESCRIPTION

Overview
----------------------------------------
Clarify use of `params` in `Contribution_Main::postProcess`, fix preApproval to use frontend_title

This moves the setting of variables that are set to support the preApproval into that function, which clarifies the point of them and, in doing so, allows us to try to get to the bottom of the other work the function is doing
around determining amount


Before
----------------------------------------
It is hard to see why the various params are being set at the end of the function. Fall back to title present

After
----------------------------------------
They are clearly tied with the fact they are being passed to preApproval (this is tested here https://github.com/civicrm/civicrm-core/pull/26949)

Technical Details
----------------------------------------

Comments
----------------------------------------
