### PR TITLE
Remove unusable assigns (copy & paste I believe)

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1235,11 +1235,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     // Would be nice to someday understand the point of this set.
     $this->set('is_pay_later', $params['is_pay_later']);
-    // assign pay later stuff
-    $this->_params['is_pay_later'] = $params['is_pay_later'];
-    $this->assign('is_pay_later', $params['is_pay_later']);
-    $this->assign('pay_later_text', $params['is_pay_later'] ? $this->_values['pay_later_text'] : NULL);
-    $this->assign('pay_later_receipt', ($params['is_pay_later'] && isset($this->_values['pay_later_receipt'])) ? $this->_values['pay_later_receipt'] : NULL);
 
     if ($this->_membershipBlock && $this->_membershipBlock['is_separate_payment'] && !empty($params['separate_amount'])) {
       $this->set('amount', $params['separate_amount']);


### PR DESCRIPTION
Overview
----------------------------------------
Remove unusable assigns (copy & paste I believe)

Before
----------------------------------------
It makes no sense to assign values to the tpl in the postProcess of Main.tpl as it is not re-rendered after postProcess - instead Confirm is loaded. The assigns here appear to be copy & paste & the one that is used in the tpl is assigned more logically in build form

It also makes no sense to transfer is_pay_later to `$this->_params` because we can see from https://github.com/civicrm/civicrm-core/pull/26951 that `$this->_params` is only used by the payment processor which ALSO gets `$params` anyway

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
