### PR TITLE
Notice fixes on CiviEvent Component settings form

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -55,8 +55,8 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
-    $this->addFieldsDefinedInSettingsMetadata();
     $this->assign('entityInClassFormat', 'setting');
+    $this->addFieldsDefinedInSettingsMetadata();
 
     // @todo - do we still like this redirect?
     CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/admin', 'reset=1'));

--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -51,9 +51,12 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
 
   /**
    * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
     $this->addFieldsDefinedInSettingsMetadata();
+    $this->assign('entityInClassFormat', 'setting');
 
     // @todo - do we still like this redirect?
     CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/admin', 'reset=1'));

--- a/CRM/Admin/Form/Preferences.php
+++ b/CRM/Admin/Form/Preferences.php
@@ -83,6 +83,7 @@ class CRM_Admin_Form_Preferences extends CRM_Core_Form {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
+    $this->assign('entityInClassFormat', 'setting');
 
     $this->addButtons([
       [

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -7,15 +7,16 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if !empty($fieldSpec.template)}
+{if array_key_exists('template', $fieldSpec)}
   {include file=$fieldSpec.template}
 {else}
   <td class="label">{$form.$fieldName.label}
-    {if !empty($fieldSpec.help|smarty:nodefaults)}{assign var=help value=$fieldSpec.help}{help id=$help.id file=$help.file}{/if}
-    {if $action == 2 && !empty($fieldSpec.is_add_translate_dialog)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
+    {if array_key_exists('help', $fieldSpec)}{assign var=help value=$fieldSpec.help}{help id=$help.id file=$help.file}{/if}
+    {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
-  <td>{if !empty($fieldSpec.pre_html_text)}{$fieldSpec.pre_html_text}{/if}{if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if !empty($fieldSpec.post_html_text)}{$fieldSpec.post_html_text}{/if}<br />
-    {if !empty($fieldSpec.description)}<span class="description">{$fieldSpec.description}</span>{/if}
-    {if !empty($fieldSpec.documentation_link)}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
+  <td>
+    {if array_key_exists('pre_html_text', $fieldSpec)}{$fieldSpec.pre_html_text}{/if}{if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html_text', $fieldSpec)}{$fieldSpec.post_html_text}{/if}<br />
+    {if array_key_exists('description', $fieldSpec)}<span class="description">{$fieldSpec.description}</span>{/if}
+    {if array_key_exists('documentation_link', $fieldSpec)}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>
 {/if}

--- a/templates/CRM/Form/basicForm.tpl
+++ b/templates/CRM/Form/basicForm.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-<div class="crm-block crm-form-block crm-{$formName}-block">
+<div class="crm-block crm-form-block crm-{$entityInClassFormat}-block">
     {include file="CRM/Form/basicFormFields.tpl"}
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Form/basicFormFields.tpl
+++ b/templates/CRM/Form/basicFormFields.tpl
@@ -12,7 +12,7 @@
 
   {foreach from=$fields item=fieldSpec}
     {assign var=fieldName value=$fieldSpec.name}
-    <tr class="crm-{if !empty($entityInClassFormat)}{$entityInClassFormat}{/if}-form-block-{$fieldName}">
+    <tr class="crm-{$entityInClassFormat}-form-block-{$fieldName}">
       {include file="CRM/Core/Form/Field.tpl"}
     </tr>
   {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
Notice fixes on CiviEvent Component settings form - secure smarty mode

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/8aae78ff-b379-4fb0-9158-390d29cb7465)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/0222cb40-4c6e-4183-a58d-15011ed5be13)


Technical Details
----------------------------------------
3 patches reflect 3 aspects
1) fix tpl to use array_key_exists rather than !empty
2) assign `[entityInClassFormat](https://github.com/civicrm/civicrm-core/pull/26957/commits/fb727d5374b2b7d6c5227a0c3c6d36c7124b22a3)`
3) use entityInClassFormat instead of not-assigned formName

Comments
----------------------------------------
