### PR TITLE
Define soon as 'in 9 years'

### DIFF
--- a/templates/CRM/common/searchResultTasks.tpl
+++ b/templates/CRM/common/searchResultTasks.tpl
@@ -41,13 +41,6 @@
   </tr>
   <tr>
     <td colspan="2">
-    {* Note print buttons were mostly removed except for Campaign search - the following lines can be removed soon CRM-12872 *}
-    {if !empty($printButtonName)}
-       {$form.$printButtonName.html} &nbsp; &nbsp;
-    {elseif !empty($form._qf_Search_next_print)}
-       {$form._qf_Search_next_print.html} &nbsp; &nbsp;
-     {/if}
-
       <span id='task-section'>
         {$form.task.html}
         {if $actionButtonName}


### PR DESCRIPTION
Overview
----------------------------------------
Define soon as 'in 9 years'

Before
----------------------------------------
9 years ago it was commented that the code could be removed soon

After
----------------------------------------
Soon has arrived

Technical Details
----------------------------------------
I did some digging around it & found some incremental removals 

The main piece of work was done by @colemanw  here https://github.com/civicrm/civicrm-core/commit/e341bbeea78a4c1d1847890146685322d15dc207  - in that work Coleman specified that all forms had been ajaxified & lost their print buttons except for campaign

It took some work to find where campaign search is called but 'reserve respondents' turns out to be the go

However, the tpl variables are no more assigned in that code path than they are from any other - ie 

![image](https://github.com/civicrm/civicrm-core/assets/336308/5315f109-54a3-4383-8e42-3b565a20b505)


![image](https://github.com/civicrm/civicrm-core/assets/336308/330cbe01-ddcb-4fd8-93fc-274e0c1e97e7)



printButtonName died out in these 2 PRs
https://github.com/civicrm/civicrm-core/pull/25889
https://github.com/civicrm/civicrm-core/commit/3b6d61f2ee4b5d66c791afa46ef168e445d5d1a0

Comments
----------------------------------------
