### PR TITLE
Check `isBackOffice` before checking `billing_profile_id` (e-notice fix)

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -90,7 +90,8 @@
       {else}
         {capture assign='urlPathVar'}{/capture}
       {/if}
-      {if $billing_profile_id}
+      // Billing profile ID is only ever set on front end forms, to force entering address for pay later.
+      {if !$isBackOffice && $billing_profile_id}
         {capture assign='profilePathVar'}billing_profile_id={$billing_profile_id}&{/capture}
       {else}
         {capture assign='profilePathVar'}{/capture}


### PR DESCRIPTION


Overview
----------------------------------------
Check `isBackOffice` before checking `billing_profile_id` (e-notice fix)

It won't be set from back office forms & will e-notice...

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f1b084a5-c708-4566-88c2-1a77f76871a8)


After
----------------------------------------
Still rough..

![image](https://github.com/civicrm/civicrm-core/assets/336308/b1ca40b8-4478-43cc-848d-d284356c17ae)

Technical Details
----------------------------------------
I'ts only assigned in `preProcessPaymentOptions`

![image](https://github.com/civicrm/civicrm-core/assets/336308/d7fe17f4-d893-4d0e-a161-68aaad8e404a)

which is only called from the front end forms

![image](https://github.com/civicrm/civicrm-core/assets/336308/0e5fb5d8-6f35-46cd-a905-4fc996b74b0b)


Comments
----------------------------------------
