### PR TITLE
Use `isQuickConfig()` to determine isQuickConfig (towards php8.x fix)

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -753,14 +753,14 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $previousId = $otherAmount = FALSE;
       while ($priceField->fetch()) {
 
-        if ($self->isQuickConfig() && ($priceField->name == 'contribution_amount' || $priceField->name == 'membership_amount')) {
+        if ($self->isQuickConfig() && ($priceField->name === 'contribution_amount' || $priceField->name === 'membership_amount')) {
           $previousId = $priceField->id;
-          if ($priceField->name == 'membership_amount' && !$priceField->is_active) {
+          if ($priceField->name === 'membership_amount' && !$priceField->is_active) {
             $membershipIsActive = FALSE;
           }
         }
-        if ($priceField->name == 'other_amount') {
-          if ($self->_quickConfig && empty($fields["price_{$priceField->id}"]) &&
+        if ($priceField->name === 'other_amount') {
+          if ($self->isQuickConfig() && empty($fields["price_{$priceField->id}"]) &&
             array_key_exists("price_{$previousId}", $fields) && isset($fields["price_{$previousId}"]) && $self->_values['fee'][$previousId]['name'] == 'contribution_amount' && empty($fields["price_{$previousId}"])
           ) {
             $otherAmount = $priceField->id;
@@ -833,7 +833,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $priceFieldMemTypes = [];
 
         foreach ($self->_priceSet['fields'] as $priceId => $value) {
-          if (!empty($fields['price_' . $priceId]) || ($self->_quickConfig && $value['name'] == 'membership_amount' && empty($self->_membershipBlock['is_required']))) {
+          if (!empty($fields['price_' . $priceId]) || ($self->isQuickConfig() && $value['name'] === 'membership_amount' && empty($self->_membershipBlock['is_required']))) {
             if (!empty($fields['price_' . $priceId]) && is_array($fields['price_' . $priceId])) {
               foreach ($fields['price_' . $priceId] as $priceFldVal => $isSet) {
                 if ($isSet) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -823,9 +823,6 @@ WHERE  id = %1";
     }
 
     $form->assign('quickConfig', $quickConfig);
-    if ($className == 'CRM_Contribute_Form_Contribution_Main') {
-      $form->_quickConfig = $quickConfig;
-    }
 
     // Mark which field should have the auto-renew checkbox, if any. CRM-18305
     if (!empty($form->_membershipTypeValues) && is_array($form->_membershipTypeValues)) {


### PR DESCRIPTION
Overview
----------------------------------------
Use `isQuickConfig()` to determine isQuickConfig

Before
----------------------------------------
Is quick config is checked twice within a few lines - once using the (preferred) function and the second time using the property. It is then called again a bit further down in the same function


After
----------------------------------------
consistent

![image](https://github.com/civicrm/civicrm-core/assets/336308/8469ad00-dbda-48c2-a8e0-8f5b1c871250)

Technical Details
----------------------------------------

With these gone the form no longer uses the (undefined) property & we don't need to super-specially set it in the price set class

![image](https://github.com/civicrm/civicrm-core/assets/336308/d66b28b4-63ec-48d8-8090-95e1dcd19d8a)

Comments
----------------------------------------
