### PR TITLE
AutoDefinition - Inherit service-tags from interfaces, traits, and parent classes

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/Generic/SpecProviderInterface.php
+++ b/Civi/Api4/Service/Spec/Provider/Generic/SpecProviderInterface.php
@@ -14,6 +14,9 @@ namespace Civi\Api4\Service\Spec\Provider\Generic;
 
 use Civi\Api4\Service\Spec\RequestSpec;
 
+/**
+ * @serviceTags spec_provider
+ */
 interface SpecProviderInterface {
 
   /**

--- a/Civi/Core/HookInterface.php
+++ b/Civi/Core/HookInterface.php
@@ -33,6 +33,7 @@ namespace Civi\Core;
  * If you need more advanced registration abilities, consider using `Civi::dispatcher()`
  * or `EventDispatcherInterface`.
  *
+ * @serviceTags event_subscriber
  * @see \Civi\Core\Event\EventScanner::findListeners
  */
 interface HookInterface {

--- a/Civi/Core/Service/AutoDefinition.php
+++ b/Civi/Core/Service/AutoDefinition.php
@@ -2,14 +2,21 @@
 
 namespace Civi\Core\Service;
 
-use Civi\Api4\Service\Spec\Provider\Generic\SpecProviderInterface;
 use Civi\Api4\Utils\ReflectionUtils;
-use Civi\Core\HookInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class AutoDefinition {
+
+  /**
+   * Oddballs - AutoDefinition can apply a tag to a third-party class/interface. But it's better
+   * for classes/interfaces to declare `serviceTags` for themselves.
+   *
+   * @var string[]
+   */
+  protected static $forceServiceTags = [
+    'Symfony\Component\EventDispatcher\EventSubscriberInterface' => 'event_subscriber',
+  ];
 
   /**
    * Identify any/all service-definitions for the given class.
@@ -117,18 +124,49 @@ class AutoDefinition {
     if (!empty($docBlock['internal'])) {
       $def->addTag('internal');
     }
-    if ($class->implementsInterface(HookInterface::class) || $class->implementsInterface(EventSubscriberInterface::class)) {
-      $def->addTag('event_subscriber');
+
+    $tags = static::findTags($class, $docBlock, FALSE);
+    foreach ($tags as $tag) {
+      $def->addTag($tag);
     }
-    if ($class->implementsInterface(SpecProviderInterface::class)) {
-      $def->addTag('spec_provider');
+  }
+
+  /**
+   * Find all `serviceTags` annotations that apply to a class -- either
+   * directly or indirectly (via interface, trait, or parent-class).
+   *
+   * @param \ReflectionClass $class
+   * @param array|null $docBlock
+   * @param bool $isTransitiveLookup
+   * @return array|mixed
+   */
+  public static function findTags(\ReflectionClass $class, ?array $docBlock, bool $isTransitiveLookup) {
+    $className = $class->getName();
+    $cache = &\Civi::$statics[__CLASS__]['tagidx'];
+    if (isset($cache[$className])) {
+      return $cache[$className];
     }
 
-    if (!empty($classDoc['serviceTags'])) {
-      foreach (static::splitSymbols($classDoc['serviceTags']) as $extraTag) {
-        $def->addTag($extraTag);
+    $docBlock = $docBlock ?: ReflectionUtils::parseDocBlock($class->getDocComment());
+    $result = isset($docBlock['serviceTags']) ? static::splitSymbols($docBlock['serviceTags']) : [];
+    if (isset(static::$forceServiceTags[$className])) {
+      $result[] = static::$forceServiceTags[$className];
+    }
+    $parents = array_merge($class->getInterfaces(), $class->getTraits(), [$class->getParentClass()]);
+    foreach ($parents as $parent) {
+      if ($parent) {
+        $result = array_merge($result, static::findTags($parent, NULL, TRUE));
+        // Aside: The recursion might theoretically visit an interface multiple times, but ancestral
+        // lookups are cached... so not really...
       }
     }
+    $result = array_unique($result);
+
+    // We cache info about common/re-usable classes (interfaces, traits, parents).
+    if ($isTransitiveLookup) {
+      $cache[$className] = $result;
+    }
+    return $result;
   }
 
   /**

--- a/Civi/Core/Service/AutoDefinition.php
+++ b/Civi/Core/Service/AutoDefinition.php
@@ -83,7 +83,6 @@ class AutoDefinition {
   }
 
   protected static function createBaseline(\ReflectionClass $class, ?array $docBlock = []): Definition {
-    $class = is_string($class) ? new \ReflectionClass($class) : $class;
     $def = new Definition($class->getName());
     $def->setPublic(TRUE);
     self::applyTags($def, $class, $docBlock);


### PR DESCRIPTION
Overview
----------------------------------------

This makes it easier for `AutoService`s to use new interfaces and tags (e.g. including interfaces and tags defined by third-parties). It's inspired by a suggestion from @colemanw.

Before
----------------------------------------

* `AutoService` has hard-coded support for 3 interfaces (e.g. `HookInterface`)
* `AutoService` has buggy support for the annotation `@serviceTags` (but only on the concrete class)

After
----------------------------------------

* `AutoService`s can use `@serviceTags` annotations directly or indirectly (by way of interfaces, traits, or parent-classes). And this is used for some core interfaces (e.g. `HookInterface`).

Technical Details
----------------------------------------

For example:

```php
/**
 * @serviceTags event_subscriber
 */
interface HookInterface {}

/**
 * @service esm.import_map
 */
class ImportMap extends AutoService implements HookInterface {}
```

The net result is a service (`esm.import_map`) which is tagged for `event_subscriber`.

```
$  cv service /import/ -v
The debug command ignores the container cache.
+-----------------------------------+---------------------------------------+
| key                               | value                                 |
+-----------------------------------+---------------------------------------+
| service                           | esm.import_map                        |
| class                             | Civi\Esm\ImportMap                    |
| class-file                        | [civicrm.root]/Civi/Esm/ImportMap.php |
| tag[event_subscriber]             | [[]]                                  |
| event[&hook_civicrm_esmImportMap] | [["hook_civicrm_esmImportMap",0]]     |
+-----------------------------------+---------------------------------------+
```

Comments
----------------------------------------

This shouldn't change any outcomes - the only purpose is to simplify further changes.

In my understanding of Symfony DI/Container, they loosely-couple the way you write the service-definition (YAML, XML, PHP) from the things that services can do ("Event Subscribers", "Spec Providers", "Search Actions"). The "service-tag" is central to this -- any service-definition (YAML, XML, PHP) can declare any mix of tags; and then various consumers (*like `Civi\Core\Compiler\EventScannerPass`*) can read those tags.

The existing code in `AutoDefinition` follows that model generally (*it's just another way to write a service-definition*), but it deviates in the handling of tags.  It has/had conditionals (re: `HookInterface`, `EventSubscriberInterface`, `SpecProviderInterface`) represent tight-coupling -- if you define a service via `AutoService`, and if you want to use more tags/interfaces, then you  must specifically teach `AutoDefinition` about each. That seems silly -- and it's impossible if you're writing an add-on (*Civi extension*) with its own interface or base-class or tags.
