### PR TITLE
standalone: add error handler

### DIFF
--- a/css/menubar-standalone.css
+++ b/css/menubar-standalone.css
@@ -1,3 +1,4 @@
+/* The title of this file is menubar-standalone, but the CSS is more general than that. @todo fixme */
 @media (min-width: $breakMin) {
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu {
@@ -29,4 +30,18 @@
 }
 .breadcrumb ol li:not(:first-child)::before {
   content: " \BB ";
+}
+
+.standalone-errors {
+  background: #ffe8e4;
+  color: #422;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.standalone-errors code {
+  color: #004e81;
+}
+.standalone-errors .backtrace {
+  font-size: 0.825rem;
 }

--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -64,8 +64,54 @@ $classLoader = implode(DIRECTORY_SEPARATOR, [$civiCorePath, 'CRM', 'Core', 'Clas
 require_once $classLoader;
 CRM_Core_ClassLoader::singleton()->register();
 
+function standaloneErrorHandler(
+    int $errno,
+    string $errstr,
+    ?string $errfile,
+    ?int $errline,
+    ?array $errcontext) {
+  static $handlingError = FALSE;
+  if ($handlingError) {
+    throw new \RuntimeException("Died: error was thrown during error handling");
+  }
+  $handlingError = TRUE;
+
+  $trace = '';
+  // Might be nice to offer something like this to trace down errors.
+  $debug = CRM_Core_Config::singleton()->debug;
+  if ($debug) {
+    $trace = [];
+    foreach (array_slice(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), 1) as $item) {
+      $_ = '';
+      if (!empty($item['function'])) {
+        if (!empty($item['class']) && !empty($item['type'])) {
+          $_ = htmlspecialchars("$item[class]$item[type]$item[function]() ");
+        }
+        else {
+          $_ = htmlspecialchars("$item[function]() ");
+        }
+      }
+      $_ .= "<code>" . htmlspecialchars($item['file']) . '</code> line ' . $item['line'];
+      $trace[] = $_;
+    }
+    $trace = '<pre class=backtrace>' . implode("\n", $trace) . '</pre>';
+  }
+
+  if (!isset(Civi::$statics[__FUNCTION__])) {
+    Civi::$statics[__FUNCTION__] = [];
+  }
+  Civi::$statics[__FUNCTION__][] = '<li style="white-space:pre-wrap">'
+    . htmlspecialchars("$errstr [$errno]\n") . '<code>' . htmlspecialchars($errfile) . "</code> line $errline"
+    . $trace
+    . '</li>';
+  CRM_Core_Smarty::singleton()->assign('standaloneErrors', implode("\n", Civi::$statics[__FUNCTION__]));
+
+  $handlingError = FALSE;
+}
+
 if (file_exists(findStandaloneSettings())) {
   require_once findStandaloneSettings();
+  set_error_handler('standaloneErrorHandler', E_ALL);
   invoke();
 }
 else {

--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -74,12 +74,16 @@ function standaloneErrorHandler(
   if ($handlingError) {
     throw new \RuntimeException("Died: error was thrown during error handling");
   }
-  $handlingError = TRUE;
+  $config = CRM_Core_Config::singleton();
+  if (!$config->debug) {
+    // For these errors to show, we must be debugging.
+    return;
+  }
 
+  $handlingError = TRUE;
   $trace = '';
-  // Might be nice to offer something like this to trace down errors.
-  $debug = CRM_Core_Config::singleton()->debug;
-  if ($debug) {
+  if ($config->backtrace) {
+    // Backtrace is configured for errors.
     $trace = [];
     foreach (array_slice(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), 1) as $item) {
       $_ = '';

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -38,6 +38,12 @@
       </ol></nav>
     {/if}
 
+    {if $standaloneErrors}
+      <div class="standalone-errors">
+        <ul>{$standaloneErrors}</ul>
+      </div>
+    {/if}
+
     {if $pageTitle}
       <div class="crm-title">
         <h1 class="title">{if $isDeleted}<del>{/if}{$pageTitle}{if $isDeleted}</del>{/if}</h1>


### PR DESCRIPTION
Before
----------------------------------------

No error handling on standalone, so any php emitted errors got chucked before the start of the HTML output.

After
----------------------------------------

We have an error handler and errors are presented in-page.


Technical Details
----------------------------------------

This only touches standalone code. There's a few opinions represented in this PR - none of which I hold very dear to:

- Currently it listens for `E_ALL` 
- It has code to guard against some error in the error handler causing a loop; an exception is thrown.
- It is not an exception handler - but we have that ugly yellow page for that, right?
- It only outputs if debugging is on.
- It outputs a pretty and simplified stack trace so you can actually see what's causing those pesky `E_NOTICE` things!



