### PR TITLE
standalone: Redirect to login

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -566,8 +566,15 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   public function permissionDenied() {
-    http_response_code(403);
-    echo "403 Forbidden: You do not have permission to access this resource.\n";
+    // If not logged in, they need to.
+    if (CRM_Core_Session::singleton()->get('ufID')) {
+      // They are logged in; they're just not allowed this page.
+      CRM_Core_Error::statusBounce(ts("Access denied"), CRM_Utils_System::url('civicrm'));
+    }
+    else {
+      CRM_Utils_System::redirect('/civicrm/login?anonAccessDenied');
+    }
+
     // TODO: Prettier error page
   }
 

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -1,5 +1,6 @@
 <?php
 use CRM_Standaloneusers_ExtensionUtil as E;
+use Civi\Standalone\Security;
 
 class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
 
@@ -10,6 +11,8 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     // // Example: Assign a variable for use in a template
     // $this->assign('currentTime', date('Y-m-d H:i:s'));
     $this->assign('logoUrl', E::url('images/civicrm-logo.png'));
+    // Remove breadcrumb for login page.
+    $this->assign('breadcrumb', NULL);
 
     parent::run();
   }
@@ -18,8 +21,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
    * Log out.
    */
   public function logout() {
-    // Same as CRM_Authx_Page_AJAX::logout()
-    _authx_uf()->logoutSession();
+    Security::singleton()->logoutUser();
     // Dump them back on the log-IN page.
     CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');
   }

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -138,9 +138,11 @@ class Security {
   }
 
   /**
+   *
    */
   public function logoutUser() {
-    // @todo
+    // This is the same call as in CRM_Authx_Page_AJAX::logout()
+    _authx_uf()->logoutSession();
   }
 
   /**

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -72,6 +72,7 @@
     --text-colour: #222;
     --text-size: 0.9rem;
     --error-colour: #a00;
+    --warning-colour: #fbb862;
     --success-colour: #86c66c;
     --label-colour: #464354;
     --background-colour: rgb(242,242,237);
@@ -224,6 +225,14 @@ a:hover, a:focus {
   margin: 1rem 0;
   border-radius: var(--box-roundness);
 }
+#anonAccessDenied {
+  text-align: center;
+  font-weight: bold;
+  padding: var(--box-padding);
+  background-color: var(--warning-colour);
+  margin: 1rem 0;
+  border-radius: var(--box-roundness);
+}
 
 @media  (min-width: 768px) {
     #crm-container.standalone-entry {
@@ -242,7 +251,8 @@ a:hover, a:focus {
 <div id="crm-container" class="crm-container standalone-entry">
   <div class="mid-block">
     <img src="{$logoUrl}" alt="logo for CiviCRM, with an intersecting blue and green triangle">
-    <div class="message info" style="display:none;" id="loggedOutNotice">You have been logged out.</div>
+    <div class="message info" style="display:none;" id="loggedOutNotice">{ts}You have been logged out.{/ts}</div>
+    <div class="message warning" style="display:none;" id="anonAccessDenied">{ts}You may need to login to access that.{/ts}</div>
     <form>
       <div>
         <label for="exampleInputEmail1" class="form-label">Username</label>
@@ -269,13 +279,14 @@ document.addEventListener('DOMContentLoaded', () => {
         password = document.getElementById('passwordInput'),
         loggedOutNotice = document.getElementById('loggedOutNotice');
 
+  // Special messages.
   if (window.location.search === '?justLoggedOut') {
     loggedOutNotice.style.display = '';
     console.log("successful logout");
   }
-  else {
-    console.log("no successful logout");
-    }
+  else if (window.location.search === '?anonAccessDenied') {
+    anonAccessDenied.style.display = '';
+  }
 
   submitBtn.addEventListener('click', async e => {
     e.preventDefault();

--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -1,34 +1,31 @@
 <?php
 
 function invoke() {
-  // Redirect to the dashboard for discoverability
-  // but in the future we may want a login page or something else.
-  if ($_SERVER['REQUEST_URI'] == '/') {
-    CRM_Utils_System::redirect('/civicrm');
-  }
+  $requestUri = $_SERVER['REQUEST_URI'] ?? '';
 
-  if (!empty($_SERVER['REQUEST_URI'])) {
-    // Required so that the userID is set before generating the menu
-    \CRM_Core_Session::singleton()->initialize();
-    // Add CSS, JS, etc. that is required for this page.
-    \CRM_Core_Resources::singleton()->addCoreResources();
+  // Required so that the userID is set before generating the menu
+  \CRM_Core_Session::singleton()->initialize();
+  // Add CSS, JS, etc. that is required for this page.
+  \CRM_Core_Resources::singleton()->addCoreResources();
+  $parts = explode('?', $requestUri);
+  $args = explode('/', $parts[0] ?? '');
+  // Remove empty path segments, a//b becomes equivalent to a/b
+  $args = array_values(array_filter($args));
+  if (!$args) {
+    // This is a request for the site's homepage. See if we have one.
+    $item = CRM_Core_Invoke::getItem('/');
+    if (!$item) {
+      // We have no public homepage, so send them to login.
+      // This doesn't allow for /civicrm itself to be public,
+      // but that's got to be a pretty edge case, right?!
+      CRM_Utils_System::redirect('/civicrm/login');
+    }
+  }
+  // This IS required for compatibility. e.g. the extensions (at least) quickform uses it for the form's action attribute.
+  $_GET['q'] = implode('/', $args);
 
-    $parts = explode('?', $_SERVER['REQUEST_URI']);
-    $args = explode('/', $parts[0]);
-    // Remove empty values
-    $args = array_values(array_filter($args));
-    // Set this for compatibility
-    $_GET['q'] = implode('/', $args);
-    // And finally render the page
-    print CRM_Core_Invoke::invoke($args);
-  }
-  else {
-    // @todo Is it necessary to support this?
-    // Apache has not been tested yet, but presumably not required.
-    $config = CRM_Core_Config::singleton();
-    $urlVar = $config->userFrameworkURLVar;
-    print CRM_Core_Invoke::invoke(explode('/', $_GET[$urlVar]));
-  }
+  // Render the page
+  print CRM_Core_Invoke::invoke($args);
 }
 
 function findStandaloneSettings(): string {


### PR DESCRIPTION
Overview
----------------------------------------

Politeness around logging in etc.

Before
----------------------------------------

- On install, visiting / redirected to /civicrm
- On visiting /civicrm gave a rude unauthorised page
- You had to know to visit /civicrm/login

After
----------------------------------------

- If you are not logged in, then visiting a page that you don't have permission for will send you to /civicrm/login?anonAccessDenied which will present the login page and a message saying you gotta login for that.
- If you access / then it will first check if Civi has a menu item for / (e.g. form builder / extension) and if not, default to /civicrm, which, if you're not logged in will in turn redirect you to the login page.
- If you are logged in and get permission denied, you are bounced to the civi homepage with a message.
