### PR TITLE
dev/core#4481 - View-only custom fields should be merged during merges

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2041,10 +2041,10 @@ ORDER BY civicrm_custom_group.weight,
           $htmlType = (string) $fieldMetadata['html_type'];
           $isSerialized = CRM_Core_BAO_CustomField::isSerialized($fieldMetadata);
           $isView = (bool) $fieldMetadata['is_view'];
-          if ($isView) {
-            $viewOnlyCustomFields[$key] = $value;
-          }
           $submitted = self::processCustomFields($mainId, $key, $submitted, $value, $fieldID, $isView, $htmlType, $isSerialized);
+          if ($isView) {
+            $viewOnlyCustomFields[$key] = $submitted[$key];
+          }
         }
       }
     }

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1047,42 +1047,6 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
   }
 
   /**
-   * Verifies that when two contacts with view only custom fields are merged,
-   * the view only field of the record being deleted is not merged, it is
-   * simply deleted (it should also not be visible on the page).
-   */
-  public function testMigrationOfViewOnlyCustomData() {
-    // Create Custom Fields
-    $createGroup = $this->setupCustomGroupForIndividual();
-    $customField = $this->setupCustomField('TestField', $createGroup);
-
-    // Contacts setup
-    $this->setupMatchData();
-    $originalContactID = $this->contacts[0]['id'];
-    $duplicateContactID = $this->contacts[1]['id'];
-
-    // Update the text custom fields for duplicate contact
-    $this->callAPISuccess('Contact', 'create', [
-      'id' => $duplicateContactID,
-      "custom_{$customField['id']}" => 'abc',
-    ]);
-    $this->assertCustomFieldValue($duplicateContactID, 'abc', "custom_{$customField['id']}");
-
-    // Change custom field to view only.
-    $this->callAPISuccess('CustomField', 'update', ['id' => $customField['id'], 'is_view' => TRUE]);
-
-    // Merge, and ensure that no value was migrated
-    $this->mergeContacts($originalContactID, $duplicateContactID, [
-      "move_custom_{$customField['id']}" => NULL,
-    ]);
-    $this->assertCustomFieldValue($originalContactID, '', "custom_{$customField['id']}");
-
-    // cleanup created custom set
-    $this->callAPISuccess('CustomField', 'delete', ['id' => $customField['id']]);
-    $this->callAPISuccess('CustomGroup', 'delete', ['id' => $createGroup['id']]);
-  }
-
-  /**
    * Calls merge method on given contacts, with values given in $params array.
    *
    * @param $originalContactID

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -37,6 +37,13 @@ class api_v3_JobTest extends CiviUnitTestCase {
   private $originalValues = [];
 
   /**
+   * Make sure triggers are rebuilt even if test fails. We don't need to do it
+   * for every test, so use this to signal tearDown.
+   * @var bool
+   */
+  private $rebuildTriggers = FALSE;
+
+  /**
    * Set up for tests.
    */
   public function setUp(): void {
@@ -58,6 +65,12 @@ class api_v3_JobTest extends CiviUnitTestCase {
    */
   public function tearDown(): void {
     $this->resetHooks();
+    if ($this->rebuildTriggers) {
+      \Civi::service('sql_triggers')->rebuild();
+      // not sure if this is necessary but clear it to be sure
+      CRM_Core_DAO::executeQuery('SET @CIVICRM_MERGE=NULL');
+      $this->rebuildTriggers = FALSE;
+    }
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanup(['civicrm_contact', 'civicrm_address', 'civicrm_email', 'civicrm_relationship', 'civicrm_website', 'civicrm_phone', 'civicrm_job', 'civicrm_action_log', 'civicrm_action_schedule', 'civicrm_group', 'civicrm_group_contact'], TRUE);
     foreach ($this->originalValues as $entity => $entities) {
@@ -1087,6 +1100,108 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $mouseParams['return'] = 'custom_' . $customField['id'];
     $mouse = $this->callAPISuccess('Contact', 'getsingle', $mouseParams);
     $this->assertEquals('', $mouse['custom_' . $customField['id']]);
+  }
+
+  /**
+   * hook_civicrm_merge implementation for testBatchMergeCustomDataViewOnlyDateField
+   */
+  public function hookMergeViewOnly($type, &$data, $mainId = NULL, $otherId = NULL, $tables = NULL) {
+    if ($mainId && $otherId) {
+      if ($type = 'sqls' && isset($tables)) {
+        // prevent DB trigger from forcing our view-only date field to CURRENT_TIMESTAMP
+        CRM_Core_DAO::executeQuery('SET @CIVICRM_MERGE=1');
+      }
+    }
+  }
+
+  /**
+   * Similar to testBatchMergeCustomDataViewOnlyField but with a hook and it's a date field.
+   * This is based on a real-world example and demonstrates one reason we're enforcing view-only custom fields get merged.
+   * There are two fields that go together, and it doesn't make sense to merge one but not the other, and the view-only date field is not easily recomputable.
+   */
+  public function testBatchMergeCustomDataViewOnlyDateField(): void {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit my contact'];
+
+    $customGroup = $this->customGroupCreate();
+    $customGroup = $this->callAPISuccess('CustomGroup', 'getsingle', ['id' => $customGroup['id'], 'return' => ['id', 'table_name']]);
+    $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id']]);
+    $customField = $this->callAPISuccess('CustomField', 'getsingle', ['id' => $customField['id'], 'return' => ['id', 'column_name']]);
+    $customFieldDate = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'Custom Last Updated',
+      'data_type' => 'Date',
+      'html_type' => 'Select Date',
+      'is_view' => 1,
+      // It seems like it creates db errors if we don't specify these? Don't feel like looking into that right now.
+      'is_searchable' => 0,
+      'date_format' => 'mm/dd/yy',
+      'time_format' => 1,
+      'default_value' => NULL,
+    ]);
+    $customFieldDate = $this->callAPISuccess('CustomField', 'getsingle', ['id' => $customFieldDate['id'], 'return' => ['id', 'column_name']]);
+
+    $this->hookClass->setHook('civicrm_merge', [$this, 'hookMergeViewOnly']);
+    $this->hookClass->setHook('civicrm_triggerInfo', function(&$info, $tableName) use ($customGroup, $customField, $customFieldDate) {
+      // code styling is complaining so do it this way
+      $sqlinsert = <<<ENDSQLINSERT
+        IF (isnull(@CIVICRM_MERGE)) THEN
+          IF (NEW.{$customField['column_name']} IS NOT NULL AND NEW.{$customField['column_name']} <> '') THEN
+            SET NEW.{$customFieldDate['column_name']} = CURRENT_TIMESTAMP;
+          END IF;
+        END IF;
+ENDSQLINSERT;
+      $sqlupdate = <<<ENDSQLUPDATE
+        IF (isnull(@CIVICRM_MERGE)) THEN
+          IF (NEW.{$customField['column_name']} IS NOT NULL AND NEW.{$customField['column_name']} <> '' AND (NEW.{$customField['column_name']} <> OLD.{$customField['column_name']} OR OLD.{$customField['column_name']} IS NULL)) THEN
+          SET NEW.{$customFieldDate['column_name']} = CURRENT_TIMESTAMP;
+          END IF;
+        END IF;
+ENDSQLUPDATE;
+      $info[] = [
+        'table' => $customGroup['table_name'],
+        'when' => 'BEFORE',
+        'event' => ['INSERT'],
+        'sql' => $sqlinsert,
+      ];
+      $info[] = [
+        'table' => $customGroup['table_name'],
+        'when' => 'BEFORE',
+        'event' => ['UPDATE'],
+        'sql' => $sqlupdate,
+      ];
+    });
+    // let tearDown know about us to reset the triggers after
+    $this->rebuildTriggers = TRUE;
+    \Civi::service('sql_triggers')->rebuild();
+
+    // create first contact, without the (regular) custom field value.
+    $mouseParams = ['first_name' => 'Mickey', 'last_name' => 'Mouse', 'email' => 'tha_mouse@mouse.com'];
+    $mouseContactId = $this->individualCreate($mouseParams);
+
+    // Check that the date field was NOT set
+    // See comment at bottom why this is important
+    $datevalue = $this->callAPISuccess('Contact', 'getsingle', ['id' => $mouseContactId, 'return' => ['custom_' . $customFieldDate['id']]]);
+    $datevalue = $datevalue['custom_' . $customFieldDate['id']];
+    $this->assertEmpty($datevalue);
+
+    // create second contact, with a value.
+    $duplicateId = $this->individualCreate(array_merge($mouseParams, ['custom_' . $customField['id'] => 'blah']));
+
+    // get the view-only field's current value for the 2nd contact which should have been set by trigger
+    $viewOnlyFieldValue = $this->callAPISuccess('Contact', 'getsingle', ['id' => $duplicateId, 'return' => ['custom_' . $customFieldDate['id']]]);
+    $viewOnlyFieldValue = $viewOnlyFieldValue['custom_' . $customFieldDate['id']];
+    $this->assertNotEmpty($viewOnlyFieldValue);
+
+    // Merge. Since the date field and regular field go together, we want those merged, and our hooks are set up so that the triggers won't update the date field during merge.
+    $result = $this->callAPISuccess('Job', 'process_batch_merge', ['check_permissions' => 0, 'mode' => 'safe']);
+    $this->assertCount(1, $result['values']['merged']);
+
+    $mouse = $this->callAPISuccess('Contact', 'getsingle', ['id' => $mouseContactId, 'return' => ['custom_' . $customField['id'], 'custom_' . $customFieldDate['id']]]);
+    // check the regular field got merged just while we're here
+    $this->assertEquals('blah', $mouse['custom_' . $customField['id']]);
+    // now check the view-only field. It should be the one that was merged from the duplicate.
+    // Note that the original contact will not have a value for the custom date field because there was no corresponding regular custom field value, so we don't have to worry about a timing issue where both date fields happen to have the same timestamp. We've already checked above that both the original is blank and the duplicate has a nonempty value.
+    $this->assertEquals($viewOnlyFieldValue, $mouse['custom_' . $customFieldDate['id']]);
   }
 
   /**

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -1083,8 +1083,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test the batch merge copes with view only custom data field. View Only custom fields
-   * should never be merged.
+   * Test the batch merge copes with view only custom data field.
    */
   public function testBatchMergeCustomDataViewOnlyField(): void {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit my contact'];
@@ -1099,7 +1098,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
     $this->assertCount(1, $result['values']['merged']);
     $mouseParams['return'] = 'custom_' . $customField['id'];
     $mouse = $this->callAPISuccess('Contact', 'getsingle', $mouseParams);
-    $this->assertEquals('', $mouse['custom_' . $customField['id']]);
+    $this->assertEquals('blah', $mouse['custom_' . $customField['id']]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/26791

In #26791 view-only custom fields were changed so that they didn't merge. There was a prior unit test enforcing that they do merge, but the history was not clear on why. It mentioned hooks, but never which hook, and the test didn't use a hook. And there was some discussion that they shouldn't merge, so it got changed.

This puts it back, and then pulls in the alternate fix from #26416 which makes date fields not crash.

Before
----------------------------------------
View-only custom fields not merged

After
----------------------------------------
1. Commit [6af79676](https://github.com/civicrm/civicrm-core/pull/26969/commits/6af796768a00d5bcb3923145809b7aeb3b0e3206) adds a test based on real-world usage. It's overcomplicated in that it's maybe not the minimal example, but the key part of it is that the view-only field is not easily recomputable, and so demonstrates why view-only fields need to be merged. It was failing with
    ```
    api_v3_JobTest::testBatchMergeCustomDataViewOnlyDateField
    Failed asserting that two strings are equal.
    --- Expected
    +++ Actual
    @@ @@
    -'2023-07-29 02:54:50'
    +''
    /home/homer/buildkit/build/build-4/web/sites/all/modules/civicrm/tests/phpunit/api/v3/JobTest.php:1204
    ```
1. Commit https://github.com/civicrm/civicrm-core/pull/26969/commits/91c8f0147ed902d961158a028187bb8bc4db00da is a straight revert of #26791
1. Commit https://github.com/civicrm/civicrm-core/pull/26969/commits/08b0677fd1a8a03518dd3ceb93c347349e6fddbe pulls in the fix from #26416 and updates the additional test from #26791.

Technical Details
----------------------------------------


Comments
----------------------------------------

