### PR TITLE
Limit Managed Entity test reconciliation to the entities in the test

### DIFF
--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -536,7 +536,12 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
       new CRM_Core_Module('legacycustomsearches', TRUE),
       new CRM_Core_Module('org.civicrm.search_kit', TRUE),
     ];
-    (new CRM_Core_ManagedEntities($allModules))->reconcile();
+    $modulesToReconcile = [
+      'unit.test.fake.ext',
+      'legacycustomsearches',
+      'org.civicrm.search_kit',
+    ];
+    (new CRM_Core_ManagedEntities($allModules))->reconcile($modulesToReconcile);
 
     $nav = Navigation::get(FALSE)
       ->addWhere('name', '=', 'Test_Parent')
@@ -587,7 +592,7 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     ];
     // If module is disabled it will not run hook_civicrm_managed.
     $this->_managedEntities = [];
-    (new CRM_Core_ManagedEntities($allModules))->reconcile();
+    (new CRM_Core_ManagedEntities($allModules))->reconcile($modulesToReconcile);
 
     // Children's weight should have been unaffected, but they should be disabled
     $children = Navigation::get(FALSE)
@@ -614,7 +619,7 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
       new CRM_Core_Module('org.civicrm.search_kit', TRUE),
     ];
     $this->_managedEntities = $managedEntities;
-    (new CRM_Core_ManagedEntities($allModules))->reconcile();
+    (new CRM_Core_ManagedEntities($allModules))->reconcile($modulesToReconcile);
 
     // Children's weight should have been unaffected, but they should be enabled
     $children = Navigation::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
See [#26674](https://github.com/civicrm/civicrm-core/pull/26674#issuecomment-1656418392).

Before
----------------------------------------
Test attempted to reconcile all managed entities, but the test CRM_Core_ManagedEntities only contained three specific extensions. It would attempt to reconcile managed entities in core extensions, but fail because the core extension was neither enabled or disabled within the test CRM_Core_ManagedEntities.

After
----------------------------------------
Reconciliation limited to the specific extensions in the test.