### PR TITLE
[wip]Add type hint

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1055,7 +1055,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     $spacer = '<span class="child-indent"></span>',
     $titleOnly = FALSE,
     $public = FALSE
-  ) {
+  ): array {
     if (empty($groupIDs)) {
       return [];
     }

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -746,7 +746,7 @@ AND    contact_id IN ( $contactStr )
    *
    * @return array|bool
    */
-  public static function buildOptions($fieldName, $context = NULL, $props = []) {
+  public static function buildOptions($fieldName, $context = NULL, $props = []): array {
     $options = CRM_Core_PseudoConstant::get(__CLASS__, $fieldName, [], $context);
 
     // Sort group list by hierarchy

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -211,7 +211,7 @@ class CRM_Core_Permission {
    * @return array
    *   array reference of all groups.
    */
-  public static function group($groupType, $excludeHidden = TRUE) {
+  public static function group($groupType, $excludeHidden = TRUE): array {
     $config = CRM_Core_Config::singleton();
     return $config->userPermissionClass->group($groupType, $excludeHidden);
   }


### PR DESCRIPTION
All these places SHOULD always return arrays but  we are seeing a clue they might not

Warning: array_flip(): Can only flip STRING and INTEGER values! in _civicrm_api3_contact_get_supportanomalies() (line 413 of /srv/org.wikimedia.civicrm/drupal/sites/all/modules/civicrm/api/v3/Contact.php)