### PR TITLE
Fix invoice being sent instead of receipt if is_pay_later is true.

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -25,7 +25,7 @@
      <p>{$receipt_text|htmlize}</p>
     {/if}
 
-    {if $is_pay_later}
+    {if '{contribution.contribution_status_id:name}' === 'Pending'}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -2,7 +2,7 @@
 {if !empty($receipt_text)}
 {$receipt_text}
 {/if}
-{if $is_pay_later}
+{if '{contribution.contribution_status_id:name}' === 'Pending'}
 
 ===========================================================
 {$pay_later_receipt}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -25,7 +25,7 @@
      <p>{$receipt_text|htmlize}</p>
     {/if}
 
-    {if $is_pay_later}
+    {if '{contribution.contribution_status_id:name}' === 'Pending'}
      <p>{$pay_later_receipt}</p> {* FIXME: this might be text rather than HTML *}
     {/if}
 

--- a/xml/templates/message_templates/membership_online_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_text.tpl
@@ -2,7 +2,7 @@
 {if !empty($receipt_text)}
 {$receipt_text}
 {/if}
-{if $is_pay_later}
+{if '{contribution.contribution_status_id:name}' === 'Pending'}
 
 ===========================================================
 {$pay_later_receipt}


### PR DESCRIPTION
Continuation of PR #26247.

Overview
----------------------------------------
Continues the change started in PR #26247, introduced in CiviCRM 5.63.0. The body of the Message Templates for `contribution_online_receipt` and `membership_online_receipt` also referenced `$is_pay_later`. So, using the same comparison check as the earlier PR. 

Before
----------------------------------------
Re-sending a Membership receipt after payment received, e.g., check payment recorded for a previously pending payment, would still show details about "send a check here" messaging. This is because `$is_pay_later` does not get reset when a payment is recorded for a pending payment.

After
----------------------------------------
Sends the **Receipt** details instead of **Invoice** details.

Technical Details
----------------------------------------
See #26207 and #26247 for discussion / more detail.

Comments
----------------------------------------
/cc @mattwire and @eileenmcnaughton since the original change was from Matt and reviewed by Eileen.

Note that other templates also still reference `$is_pay_later` and should be reviewed.
