### PR TITLE
dev/core4466 Handle edge login cases

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -570,6 +570,12 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     // If not logged in, they need to.
     if (CRM_Core_Session::singleton()->get('ufID')) {
       // They are logged in; they're just not allowed this page.
+
+      // Check the (misconfiguration?) case that they're not allowed the civi homepage.
+      $item = CRM_Core_Invoke::getItem('civicrm/');
+      if (!CRM_Core_Permission::checkMenuItem($item)) {
+        throw new RuntimeException("User is allowed to login but does not have the requisite 'access CiviCRM' permission.");
+      }
       CRM_Core_Error::statusBounce(ts("Access denied"), CRM_Utils_System::url('civicrm'));
     }
     else {
@@ -604,6 +610,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       'use_only_cookies' => 1,
       'use_strict_mode'  => 1,
     ]);
+    CRM_Utils_System::redirect('/civicrm/login?anonAccessDenied');
   }
 
 }

--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -10,13 +10,27 @@ function invoke() {
   // Remove empty path segments, a//b becomes equivalent to a/b
   $args = array_values(array_filter($args));
   if (!$args) {
-    // This is a request for the site's homepage. See if we have one.
+    // This is a request for the site's homepage. See if we have one...
     $item = CRM_Core_Invoke::getItem('/');
     if (!$item) {
-      // We have no public homepage, so send them to login.
-      // This doesn't allow for /civicrm itself to be public,
-      // but that's got to be a pretty edge case, right?!
-      CRM_Utils_System::redirect('/civicrm/login');
+      if (!($parts[0] === 'civicrm' && $parts[1] === 'ajax')
+          && ($_REQUEST['METHOD'] === 'GET')
+      ) {
+        // Looks like a browser request to a non-existant homepage.
+        // If logged in, send them to civi, otherwise send them to login.
+        // (This doesn't allow for /civicrm itself to be public,
+        // but that's got to be a pretty edge case, right?!)
+        $destination = empty(CRM_Core_Session::singleton()->get('ufID'))
+        ? '/civicrm/login'
+        : '/civicrm';
+
+        CRM_Utils_System::redirect($destination);
+      }
+      else {
+        // Looks like a webservice request, give raw 403.
+        http_response_code(403);
+        CRM_Utils_System::civiExit();
+      }
     }
   }
   // This IS required for compatibility. e.g. the extensions (at least) quickform uses it for the form's action attribute.


### PR DESCRIPTION
Overview
----------------------------------------

- Allow anon users permission to login (!)
- create a `staff_user` role with some sensible permissions - suitable for a non-admin user (e.g. the demo user) to have, for example.

https://lab.civicrm.org/dev/core/-/issues/4466

Before
----------------------------------------

- non-super users not able to login
- people sent in infinite redirect loops if they configured their permissions wrong.

After
----------------------------------------

none of that silliness.

Technical Details
----------------------------------------

I think it's fairly sensible to create a default 'staff user' role, but purists might argue that CRM admins should have to make all those choices themselves. But this should make testing easier.
