### PR TITLE
Provide utility methods for creating an iCal file

### DIFF
--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -69,25 +69,7 @@ class CRM_Event_ICalendar {
       $calendar = $template->fetch('CRM/Core/Calendar/GData.tpl');
     }
     else {
-      if (count($info) > 0) {
-        $date_min = min(
-          array_map(function ($event) {
-            return strtotime($event['start_date']);
-          }, $info)
-        );
-        $date_max = max(
-          array_map(function ($event) {
-            return strtotime($event['end_date'] ?? $event['start_date']);
-          }, $info)
-        );
-        $template->assign('timezones', CRM_Utils_ICalendar::generate_timezones($timezones, $date_min, $date_max));
-      }
-      else {
-        $template->assign('timezones', NULL);
-      }
-
-      $calendar = $template->fetch('CRM/Core/Calendar/ICal.tpl');
-      $calendar = preg_replace('/(?<!\r)\n/', "\r\n", $calendar);
+      $calendar = CRM_Utils_ICalendar::createCalendarFile($info);
     }
 
     // Push output for feed or download

--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -216,7 +216,7 @@ class CRM_Utils_ICalendar {
   }
 
   /**
-   * @param array | NULL $info
+   * @param array|NULL $info
    *   Information of the events to create an iCal file for, as returned by
    *   CRM_Event_BAO_Event::getCompleteInfo().
    *
@@ -260,7 +260,7 @@ class CRM_Utils_ICalendar {
   }
 
   /**
-   * @param int | NULL $event_id
+   * @param int|NULL $event_id
    *   The CiviCRM Event ID of the event to render an iCal file for.
    *
    * @return string

--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -215,4 +215,59 @@ class CRM_Utils_ICalendar {
     return sprintf('%+03d%02d', $hours, $minutes);
   }
 
+  /**
+   * @param array | NULL $info
+   *   Information of the events to create an iCal file for, as returned by
+   *   CRM_Event_BAO_Event::getCompleteInfo().
+   *
+   * @return string
+   *   The rendered contents of the iCal file.
+   */
+  public static function createCalendarFile($info) {
+    $template = \CRM_Core_Smarty::singleton();
+
+    // Decode HTML entities in relevant fields.
+    foreach (['title', 'description', 'event_type', 'location', 'contact_email'] as $field) {
+      if (isset($info[0][$field])) {
+        $info[0][$field] = html_entity_decode($info[0][$field], ENT_QUOTES | ENT_HTML401, 'UTF-8');
+      }
+    }
+
+    // Calculate timezones.
+    if (count($info) > 0) {
+      $date_min = min(
+        array_map(function ($event) {
+          return strtotime($event['start_date']);
+        }, $info)
+      );
+      $date_max = max(
+        array_map(function ($event) {
+          return strtotime($event['end_date'] ?? $event['start_date']);
+        }, $info)
+      );
+      $template->assign('timezones', CRM_Utils_ICalendar::generate_timezones($timezones, $date_min, $date_max));
+    }
+    else {
+      $template->assign('timezones', NULL);
+    }
+    $template->assign('timezone', @date_default_timezone_get());
+
+    $template->assign('events', $info);
+    $ical_data = $template->fetch('CRM/Core/Calendar/ICal.tpl');
+    $ical_data = preg_replace('/(?<!\r)\n/', "\r\n", $ical_data);
+
+    return $ical_data;
+  }
+
+  /**
+   * @param int | NULL $event_id
+   *   The CiviCRM Event ID of the event to render an iCal file for.
+   *
+   * @return string
+   */
+  public static function createCalendarFileForEvent($event_id) {
+    $info = \CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, $event_id, NULL, FALSE);
+    return self::createCalendarFile($info);
+  }
+
 }


### PR DESCRIPTION
Follow-up to #25723, see https://github.com/civicrm/civicrm-core/pull/25723#issuecomment-1489866722

Overview
----------------------------------------
Provides utility methods for generating iCal files for events, as that is currently implemented in a page controller and can't be easily reused. Also, this adds much-requested HTML entity decoding for relevant fields in the iCal file.

Before
----------------------------------------
You'd have to copy code and adjust yourself for creating iCal files for events.

After
----------------------------------------
You can easily just call one of the two new methods and just get an iCal file (i. e. its contents)

Technical Details
----------------------------------------
New methods:
* `CRM_Utils_ICalendar::createCalendarFile()` which takes `$info` as generated by `CRM_Event_BAO_Event::getCompleteInfo()`
* `CRM_Utils_ICalendar::createCalendarFileForEvent()` which just takes an event ID

`CRM_Event_ICalendar::run()` now also uses the new method, which contains its current code, plus HTML entity decoding.

Comments
----------------------------------------
Not really tested, just wanted to get it out of the way.
