### PR TITLE
Fix #4463 - authentication session already exists

### DIFF
--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -259,7 +259,7 @@ class Authenticator extends AutoService implements HookInterface {
    */
   protected function login(AuthenticatorTarget $tgt) {
     $isSameValue = function($a, $b) {
-      return !empty($a) && (string) $a === (string) $b;
+      return (is_null($a) && is_null($b)) || (!empty($a) && (string) $a === (string) $b);
     };
 
     if (\CRM_Core_Session::getLoggedInContactID() || $this->authxUf->getCurrentUserId()) {

--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -259,7 +259,7 @@ class Authenticator extends AutoService implements HookInterface {
    */
   protected function login(AuthenticatorTarget $tgt) {
     $isSameValue = function($a, $b) {
-      return (is_null($a) && is_null($b)) || (!empty($a) && (string) $a === (string) $b);
+      return ((string) $a === (string) $b);
     };
 
     if (\CRM_Core_Session::getLoggedInContactID() || $this->authxUf->getCurrentUserId()) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the situation where a user is already authenticated (from an emailed URL), but clicks again and gets an error message.
See https://lab.civicrm.org/dev/core/-/issues/4463

Before
----------------------------------------
User gets `HTTP 401 Cannot login. Session already active.`

After
----------------------------------------
Users continues with session.

Technical Details
----------------------------------------
The existing looks like it intended to handle this situation but wasn't expecting nulls.

Comments
----------------------------------------

