### PR TITLE
(WIP) FormBuilder: settings for token timeout and redirection url

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.ang.php
+++ b/ext/afform/admin/ang/afGuiEditor.ang.php
@@ -14,4 +14,7 @@ return [
   'exports' => [
     'af-gui-editor' => 'E',
   ],
+  'permissions' => [
+    'all CiviCRM permissions and ACLs',
+  ],
 ];

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -21,6 +21,8 @@
     controller: function($scope, crmApi4, afGui, $parse, $timeout, $location) {
       var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
 
+      this.isSuperAdmin = CRM.checkPerm('all CiviCRM permissions and ACLs');
+
       this.afform = null;
       $scope.saving = false;
       $scope.selectedEntityName = null;

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -34,7 +34,7 @@
       <label for="af_config_form_server_route">
         {{:: ts('Page Route') }}
       </label>
-      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" ng-model-options="editor.debounceMode">
+      <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" ng-model-options="editor.debounceMode">
       <p class="help-block">{{:: ts('Expose the form as a standalone webpage. (Example: "civicrm/my-form")') }}</p>
     </div>
 
@@ -45,21 +45,6 @@
       </label>
     </div>
 
-    <div class="form-group" ng-if="!!editor.afform.server_route">
-      <label>
-        <input type="checkbox" ng-model="editor.afform.is_token">
-        {{:: ts('Provide Email Token') }}
-      </label>
-      <p class="help-block">{{:: ts('Allows CiviMail authors to easily link to this page') }}</p>
-    </div>
-
-    <div class="form-group" ng-if="!!editor.afform.is_token">
-      <label>
-        {{:: ts('Token Redirect') }}
-      </label>
-      <input ng-model="editor.afform.authx_redirect" class="form-control">
-      <p class="help-block">{{:: ts('Redirect URL if authentication via token fails. (Example: "civicrm/authfailed")') }}</p>
-    </div>
 
     <div class="form-group">
       <div class="form-inline">
@@ -116,6 +101,31 @@
         {{:: ts('Add to Dashboard') }}
       </label>
       <p class="help-block">{{:: ts('Allow CiviCRM users to add the form to their home dashboard.') }}</p>
+    </div>
+
+    <div class="form-group">
+      <label ng-class="{disabled: !editor.afform.server_route}">
+        <input type="checkbox" ng-model="editor.afform.is_token" ng-disabled="!editor.afform.server_route">
+        {{:: ts('Provide Email Token') }}
+      </label>
+      <p class="help-block">{{:: ts('Allows CiviMail authors to easily link to this page') }}</p>
+      <p class="help-block disabled" ng-if="!editor.afform.server_route">{{:: ts('Requires a page route') }}</p>
+    </div>
+
+    <div class="form-group" ng-if="!!editor.afform.is_token && !!editor.afform.server_route">
+      <label>
+        {{:: ts('Token Timeout') }}
+      </label>
+      <input class="form-control" type="number" placeholder="{{:: ts('Days') }}" min="0" step="1" ng-model="editor.afform.authx_timeout">
+      <p class="help-block">{{:: ts('Number of days token is valid for.  Uses system default if not specfied.') }}</p>
+    </div>
+
+    <div class="form-group" ng-if="!!editor.afform.is_token && !!editor.afform.server_route">
+      <label>
+        {{:: ts('Token Redirect') }}
+      </label>
+      <input ng-model="editor.afform.authx_redirect" class="form-control">
+      <p class="help-block">{{:: ts('Redirect URL if authentication via token fails. (Example: "civicrm/authfailed")') }}</p>
     </div>
 
   </fieldset>

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -53,6 +53,14 @@
       <p class="help-block">{{:: ts('Allows CiviMail authors to easily link to this page') }}</p>
     </div>
 
+    <div class="form-group" ng-if="!!editor.afform.is_token">
+      <label>
+        {{:: ts('Token Redirect') }}
+      </label>
+      <input ng-model="editor.afform.authx_redirect" class="form-control">
+      <p class="help-block">{{:: ts('Redirect URL if authentication via token fails. (Example: "civicrm/authfailed")') }}</p>
+    </div>
+
     <div class="form-group">
       <div class="form-inline">
         <label ng-class="{disabled: !editor.afform.server_route}">

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -112,7 +112,7 @@
       <p class="help-block disabled" ng-if="!editor.afform.server_route">{{:: ts('Requires a page route') }}</p>
     </div>
 
-    <div class="form-group" ng-if="!!editor.afform.is_token && !!editor.afform.server_route">
+    <div class="form-group" ng-if="!!editor.isSuperAdmin && !!editor.afform.is_token && !!editor.afform.server_route">
       <label>
         {{:: ts('Token Timeout') }}
       </label>

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -149,7 +149,7 @@ class CRM_Afform_AfformScanner {
       'is_dashlet' => FALSE,
       'is_public' => FALSE,
       'is_token' => FALSE,
-      'authx_timeout' => 0,
+      'authx_timeout' => NULL,
       'authx_redirect' => '',
       'permission' => 'access CiviCRM',
       'type' => 'system',

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -149,6 +149,7 @@ class CRM_Afform_AfformScanner {
       'is_dashlet' => FALSE,
       'is_public' => FALSE,
       'is_token' => FALSE,
+      'authx_redirect' => '',
       'permission' => 'access CiviCRM',
       'type' => 'system',
     ];

--- a/ext/afform/core/CRM/Afform/AfformScanner.php
+++ b/ext/afform/core/CRM/Afform/AfformScanner.php
@@ -149,6 +149,7 @@ class CRM_Afform_AfformScanner {
       'is_dashlet' => FALSE,
       'is_public' => FALSE,
       'is_token' => FALSE,
+      'authx_timeout' => 0,
       'authx_redirect' => '',
       'permission' => 'access CiviCRM',
       'type' => 'system',

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -194,7 +194,8 @@ class Tokens {
     ]);
 
     $url = \CRM_Utils_System::url($afform['server_route'],
-      ['_authx' => $bearerToken, '_authxSes' => 1, '_authxRedir' => $afform['authx_redirect'] ?? ''],
+      ['_authx' => $bearerToken, '_authxSes' => 1] +
+        (!empty($afform['authx_redirect']) ? ['_authxRedir' => $afform['authx_redirect']] : []),
       TRUE,
       NULL,
       FALSE,

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -194,7 +194,7 @@ class Tokens {
     ]);
 
     $url = \CRM_Utils_System::url($afform['server_route'],
-      ['_authx' => $bearerToken, '_authxSes' => 1],
+      ['_authx' => $bearerToken, '_authxSes' => 1, '_authxRedir' => $afform['authx_redirect'] ?? ''],
       TRUE,
       NULL,
       FALSE,

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -181,8 +181,8 @@ class Tokens {
    * @throws \Civi\Crypto\Exception\CryptoException
    */
   public static function createUrl($afform, $contactId): string {
-    $expires = \CRM_Utils_Time::time() +
-      (\Civi::settings()->get('checksum_timeout') * 24 * 60 * 60);
+    $timeout = $afform['authx_timeout'] ?? \Civi::settings()->get('checksum_timeout');
+    $expires = \CRM_Utils_Time::time() + $timeout * 24 * 60 * 60;
 
     /** @var \Civi\Crypto\CryptoJwt $jwt */
     $jwt = \Civi::service('crypto.jwt');

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -171,6 +171,7 @@ class Afform extends Generic\AbstractEntity {
         [
           'name' => 'authx_timeout',
           'data_type' => 'Integer',
+          'permission' => ['all CiviCRM permissions and ACLs'],
         ],
         [
           'name' => 'authx_redirect',

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -169,6 +169,10 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Boolean',
         ],
         [
+          'name' => 'authx_timeout',
+          'data_type' => 'Integer',
+        ],
+        [
           'name' => 'authx_redirect',
         ],
         [

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -169,6 +169,9 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'Boolean',
         ],
         [
+          'name' => 'authx_redirect',
+        ],
+        [
           'name' => 'contact_summary',
           'data_type' => 'String',
           'options' => [

--- a/ext/afform/html/ang/afHtmlEditor.aff.html
+++ b/ext/afform/html/ang/afHtmlEditor.aff.html
@@ -49,10 +49,17 @@
               <p class="help-block">{{ts('Allow email authors to easily link to this form')}}</p>
             </div>
             <div class="form-group" ng-if="!!resultForm.is_token">
+              <label for="af_config_form_authx_timeout">
+                {{ ts('Token timeout') }}
+              </label>
+              <input id="af_config_form_authx_timeout" ng-model="resultForm.authx_timeout">
+              <p class="help-block">{{ts('Timeout period for authentication token (days)')}}</p>
+            </div>
+            <div class="form-group" ng-if="!!resultForm.is_token">
               <label for="af_config_form_authx_redirect">
-                <input id="af_config_form_authx_redirect" ng-model="resultForm.authx_redirect">
                 {{ ts('Token redirect') }}
               </label>
+              <input id="af_config_form_authx_redirect" ng-model="resultForm.authx_redirect">
               <p class="help-block">{{ts('Allow form authors to redirect if authentication by token fails')}}</p>
             </div>
             <div class="form-group">

--- a/ext/afform/html/ang/afHtmlEditor.aff.html
+++ b/ext/afform/html/ang/afHtmlEditor.aff.html
@@ -48,6 +48,13 @@
               </label>
               <p class="help-block">{{ts('Allow email authors to easily link to this form')}}</p>
             </div>
+            <div class="form-group" ng-if="!!resultForm.is_token">
+              <label for="af_config_form_authx_redirect">
+                <input id="af_config_form_authx_redirect" ng-model="resultForm.authx_redirect">
+                {{ ts('Token redirect') }}
+              </label>
+              <p class="help-block">{{ts('Allow form authors to redirect if authentication by token fails')}}</p>
+            </div>
             <div class="form-group">
               <label for="af_config_form_is_dashlet">
                 <input type="checkbox" id="af_config_form_is_dashlet" ng-model="resultForm.is_dashlet">

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -68,6 +68,7 @@ function _authx_redact(array $keys) {
  * Reload the current page-view.
  *
  * @param string $route
+ *   Ex: 'civicrm/foobar'
  * @param string $queryString
  */
 function _authx_reload($route, $queryString) {
@@ -77,6 +78,7 @@ function _authx_reload($route, $queryString) {
       unset($query[$key]);
     }
   }
+  // The $route may be open-ended. $absolute==TRUE prevents malicious values like `/example.com` from working. https://learn.snyk.io/lesson/open-redirect/
   $url = CRM_Utils_System::url($route, $query, TRUE, NULL, FALSE, CRM_Core_Config::singleton()->userSystem->isFrontEndPage());
   CRM_Utils_System::redirect($url);
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allow authentication token validity period to be set on form and redirect to an alternative URL if authentication token fails.

Create a FormBuilder form.  
Tick the 'Provide Email Token'.  
Create an email and include the token.

Before
----------------------------------------
All tokens use the system default setting for checksums.
If a user clicks on a URL with an expired token (for example in an old email), they get a terse error message.

After
----------------------------------------
If the 'Provide Email Token' is ticked in FormBuilder UI, 2 new fields appear:
- Token Timeout: specifies the number of days the token will be valid for.
- Token Redirect: specifies a URL to redirect to if the authentication fails - for example, if the token is expired.  This URL could be a simple page with instructions about how to get a new URL or another form suitable for unauthenticated user.

The token will include `_authxRedir=civicrm/blah` parameter.  If authentication fails, the user is redirected to that page.  The error message is passed as a parameter to that page and could be used to explain why the user has been redirected.

The token will use the specified timeout if set, otherwise the system-wide value.

Technical Details
----------------------------------------
New `authx_redirect` and `authx_timeout` fields on afform entity and FormBuilder UI


Comments
----------------------------------------

