### PR TITLE
DAO - Normalize null values in the writeRecord function to avoid subtle bugs

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -935,6 +935,13 @@ class CRM_Core_DAO extends DB_DataObject {
     }
     $entityName = CRM_Core_DAO_AllCoreTables::getBriefName($className);
 
+    // For legacy reasons, empty values would sometimes be passed around as the string 'null'.
+    // The DAO treats 'null' the same as '', and an empty string makes a lot more sense!
+    // For the sake of hooks, normalize these values.
+    $record = array_map(function ($value) {
+      return $value === 'null' ? '' : $value;
+    }, $record);
+
     \CRM_Utils_Hook::pre($op, $entityName, $record[$idField] ?? NULL, $record);
     $fields = static::getSupportedFields();
     $instance = new static();


### PR DESCRIPTION
Overview
----------------------------------------
Make sure `hook_civicrm_pre` and `hook_civicrm_post` don't get tripped up by weird `'null'` strings.

Technical Details
----------------------------------------
Passing around the string 'null' was a terrible practice and can lead to bugs when you use an operator like `empty()` on the value.