### PR TITLE
Bump recommended PHP version to 8.1, min recommendation to 8.0

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -26,14 +26,14 @@ class CRM_Upgrade_Incremental_General {
    * The point release will be dropped in recommendations unless it's .1 or
    * higher.
    */
-  const RECOMMENDED_PHP_VER = '7.4.0';
+  const RECOMMENDED_PHP_VER = '8.1.0';
 
   /**
    * The minimum recommended PHP version.
    *
    * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '7.4.0';
+  const MIN_RECOMMENDED_PHP_VER = '8.0.0';
 
   /**
    * The minimum PHP version required to install Civi.


### PR DESCRIPTION
Overview
----------------------------------------
According to [php.net supported versions](https://www.php.net/supported-versions.php), 7.4 is already EOL and 8.0 will be EOL in 3 months.

Technical Details
---------------
This changes the recommendations but not the requirements for CiviCRM to run. Hopefully these notices encourage people to upgrade in a timely fashion.