### PR TITLE
Incoming SMS replies are not linked to CiviCRM Contacts

### DIFF
--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -170,7 +170,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
     if (!$message->fromContactID) {
       // find sender by phone number if $fromContactID not set by hook
       $formatFrom = '%' . $this->formatPhone($this->stripPhone($message->from), $like, "like");
-      $message->fromContactID = CRM_Core_DAO::singleValueQuery("SELECT contact_id FROM civicrm_phone JOIN civicrm_contact ON civicrm_contact.id = civicrm_phone.contact_id WHERE !civicrm_contact.is_deleted AND phone LIKE %1", [
+      $message->fromContactID = CRM_Core_DAO::singleValueQuery("SELECT contact_id FROM civicrm_phone JOIN civicrm_contact ON civicrm_contact.id = civicrm_phone.contact_id WHERE !civicrm_contact.is_deleted AND phone_numeric LIKE %1", [
         1 => [$formatFrom, 'String'],
       ]);
     }
@@ -207,7 +207,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
     if (!$message->toContactID) {
       // find recipient if $toContactID not set by hook
       if ($message->to) {
-        $message->toContactID = CRM_Core_DAO::singleValueQuery("SELECT contact_id FROM civicrm_phone JOIN civicrm_contact ON civicrm_contact.id = civicrm_phone.contact_id WHERE !civicrm_contact.is_deleted AND phone LIKE %1", [
+        $message->toContactID = CRM_Core_DAO::singleValueQuery("SELECT contact_id FROM civicrm_phone JOIN civicrm_contact ON civicrm_contact.id = civicrm_phone.contact_id WHERE !civicrm_contact.is_deleted AND phone_numeric LIKE %1", [
           1 => ['%' . $message->to, 'String'],
         ]);
       }
@@ -226,6 +226,7 @@ INNER JOIN civicrm_mailing_job mj ON mj.mailing_id = m.id AND mj.id = %1";
         'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
         'details' => $message->body,
         'phone_number' => $message->from,
+        'subject' => ts("Inbound SMS from %1", [1 => $message->from]),
       ];
       if ($message->trackID) {
         $activityParams['result'] = CRM_Utils_Type::escape($message->trackID, 'String');


### PR DESCRIPTION
Overview
----------------------------------------
Incoming SMS replies are not linked to CiviCRM Contacts because the formatted phone number is used for a like comparison, whereas the phone_numeric provides a match.

Before
----------------------------------------
SMS reply is not linked to the correct CiviCRM Contact.
Related Activity is created with no subject line.

After
----------------------------------------
SMS reply is linked to the correct CiviCRM Contact.
Related Activity is created with useful subject line.

Technical Details
----------------------------------------
This PR has been in our PROD build for 3 years. Would be interested to know why no one else has found this problem.

Comments
----------------------------------------
Agileware Ref: CIVICRM-1521
