### PR TITLE
5.65.alpha1 - Define pre-upgrade snapshots (Option A)

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyFive.php
@@ -45,6 +45,10 @@ class CRM_Upgrade_Incremental_php_FiveSixtyFive extends CRM_Upgrade_Incremental_
     $this->addSnapshotTask('loctype', CRM_Utils_SQL_Select::from('civicrm_location_type')
       ->select(['id', 'name', 'display_name', 'is_reserved', 'is_active', 'is_default'])
     );
+    $this->addSnapshotTask('contribution', CRM_Utils_SQL_Select::from('civicrm_contribution')
+      ->select(['id', 'tax_amount'])
+      ->where('tax_amount IS NULL')
+    );
 
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     // These should run after the sql file.

--- a/CRM/Upgrade/Incremental/php/FiveSixtyFive.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyFive.php
@@ -28,6 +28,24 @@ class CRM_Upgrade_Incremental_php_FiveSixtyFive extends CRM_Upgrade_Incremental_
    *   The version number matching this function name
    */
   public function upgrade_5_65_alpha1($rev): void {
+    $this->addSnapshotTask('group', CRM_Utils_SQL_Select::from('civicrm_group')
+      ->select(['id', 'name', 'title', 'frontend_title', 'description', 'frontend_description'])
+      ->where('name IS NULL OR `frontend_title` IS NULL OR `frontend_title` = "" OR `frontend_description` IS NULL OR `frontend_description` = ""')
+    );
+    $this->addSnapshotTask('job', CRM_Utils_SQL_Select::from('civicrm_job')
+      ->select(['id', 'api_entity'])
+    );
+    $this->addSnapshotTask('schedule', CRM_Utils_SQL_Select::from('civicrm_action_schedule')
+      ->select(['id', 'limit_to'])
+    );
+    $this->addSnapshotTask('mailcomp', CRM_Utils_SQL_Select::from('civicrm_mailing_component')
+      ->select(['id', 'component_type', 'body_html', 'body_text', 'subject'])
+      ->where('component_type IN ("Welcome", "Subscribe")')
+    );
+    $this->addSnapshotTask('loctype', CRM_Utils_SQL_Select::from('civicrm_location_type')
+      ->select(['id', 'name', 'display_name', 'is_reserved', 'is_active', 'is_default'])
+    );
+
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     // These should run after the sql file.
     $this->addTask('Make LocationType.name required', 'alterColumn', 'civicrm_location_type', 'name', "varchar(64) NOT NULL COMMENT 'Location Type Name.'");


### PR DESCRIPTION
Overview
----------------------------------------

For data-structures that are modified by the 5.65.alpha1 upgrade, create some snapshots (just in case we discover some schema problem later on).

This is one of two options. Option A uses the existing PHP methods for creating the snapshot. It supports paginating the operations. However, this doesn't seem very important since these datasets are generally fairly small (dozens of records -- at a stretch, maybe a couple thousand records).

(For Option B, see #26999.)

Before
----------------------------------------

* No snapshots

After
----------------------------------------

* Some snapshots
 
Comments
----------------------------------------

There's an open PR #26993 which would add another upgrade test.since these datasets are generally fairly small (dozens of records -- at a stretch, maybe a couple thousand records).

Before
----------------------------------------

* No snapshots

After
----------------------------------------

* Some snapshots
 
Comments
----------------------------------------

There's an open PR #26993 which would add another upgrade test. I included the corresponding snapshot for that as well - but it's a separate commit (in case we need some cherry-picking/reconsideration of that one). 