### PR TITLE
5.65.alpha1 - Define pre-upgrade snapshots (Option B)

### DIFF
--- a/CRM/Core/Smarty/plugins/block.crmUpgradeSnapshot.php
+++ b/CRM/Core/Smarty/plugins/block.crmUpgradeSnapshot.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Generate a pre-upgrade data-snapshot -- if the local policy supports them.
+ *
+ * (Rule of thumb: Small databases enable snapshots. Large databases and multi-lingual
+ * databases do not. Some sysadmins may force-enable or force-disable snapshots.)
+ *
+ * Example: Before modifying `civicrm_foobar.some_field`, make a snapshot of that column
+ *
+ *   {crmUpgradeSnapshot name=foobar}
+ *     SELECT id, some_field FROM civicrm_foobar
+ *   {/crmUpgradeSnapshot}
+ *   UPDATE civicrm_foobar SET some_field = 999 WHERE some_field = 666;
+ *
+ * TIP: If you are modifying a large table (like `civicrm_contact` or `civicrm_mailing_event_queue`),
+ * then you probably shouldn't use `*.mysql.tpl` because it doesn't paginate operations. Similarly,
+ * `{crmUpgradeSnapshot}` doesn't paginate. For pagination, use non-Smarty upgrade-tasks.
+ *
+ * @see \CRM_Upgrade_Snapshot
+ *
+ * @param array $params
+ * @param string|null $text
+ *   The SELECT query which supplies the interesting data to be stored in the snapshot.
+ * @param CRM_Core_Smarty $smarty
+ * @return string|null
+ * @throws \CRM_Core_Exception
+ */
+function smarty_block_crmUpgradeSnapshot($params, $text, &$smarty) {
+  if ($text === NULL) {
+    return NULL;
+  }
+
+  if (empty($params['name'])) {
+    throw new \CRM_Core_Exception('Failed to process {crmUpgradeSnapshot}: Missing name');
+  }
+  if (empty($smarty->get_template_vars('upgradeRev'))) {
+    throw new \CRM_Core_Exception('Failed to process {crmUpgradeSnapshot}: Upgrade context required. $upgradeRev missing.');
+  }
+  if (!preg_match(';^\s*select\s;i', $text)) {
+    throw new \CRM_Core_Exception('Failed to process {crmUpgradeSnapshot}: Query does not look valid');
+  }
+
+  $owner = $params['owner'] ?? 'civicrm';
+  $revParts = explode('.', $smarty->get_template_vars('upgradeRev'));
+  $queries = CRM_Upgrade_Snapshot::createSingleTask($owner, $revParts[0] . '.' . $revParts[1], $params['name'], $text);
+  return $queries ? (implode(";\n", $queries) . ";\n") : "";
+}

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -289,8 +289,11 @@ SET    version = '$version'
   public function processLocales($tplFile, $rev) {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('domainID', CRM_Core_Config::domainID());
+    $tempVars = [
+      'upgradeRev' => $rev,
+    ];
 
-    $this->source($smarty->fetch($tplFile), TRUE);
+    $this->source($smarty->fetchWith($tplFile, $tempVars), TRUE);
 
     if ($this->multilingual) {
       CRM_Core_I18n_Schema::rebuildMultilingualSchema($this->locales, $rev);

--- a/CRM/Upgrade/Incremental/sql/5.65.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.65.alpha1.mysql.tpl
@@ -1,9 +1,19 @@
 {* file to handle db changes in 5.65.alpha1 during upgrade *}
 
+-- 5.65.alpha1 has multiple changes to civicrm_group table. Snapshot for all of them.
+{crmUpgradeSnapshot name=group}
+  SELECT id, name, title, frontend_title, description, frontend_description
+  FROM civicrm_group
+  WHERE name IS NULL OR frontend_title IS NULL OR frontend_title = "" OR frontend_description IS NULL OR frontend_description = ""
+{/crmUpgradeSnapshot}
+
 -- Ensure new name field is not null/unique. Setting to ID is a bit lazy - but it works.
 UPDATE civicrm_group SET `name` = `id` WHERE name IS NULL;
 
 -- Ensure API entity names always start with uppercase
+{crmUpgradeSnapshot name=job}
+  SELECT id, api_entity FROM civicrm_job
+{/crmUpgradeSnapshot}
 UPDATE `civicrm_job` SET `api_entity` = CONCAT(UPPER(SUBSTRING(`api_entity`, 1 ,1)), SUBSTRING(`api_entity`, 2));
 
 -- Add name field, make frontend_title required (in conjunction with php function)
@@ -27,8 +37,15 @@ UPDATE `civicrm_job` SET `api_entity` = CONCAT(UPPER(SUBSTRING(`api_entity`, 1 ,
   WHERE (`frontend_description` IS NULL OR `frontend_description` = '') AND description <> '';
 {/if}
 
+{crmUpgradeSnapshot name=schedule}
+  SELECT id, limit_to FROM civicrm_action_schedule
+{/crmUpgradeSnapshot}
 UPDATE `civicrm_action_schedule` SET `limit_to` = 2 WHERE `limit_to` = 0;
 
+{crmUpgradeSnapshot name=mailcomp}
+  SELECT id, body_html, body_text, subject FROM civicrm_mailing_component
+  WHERE component_type IN ('Welcome', 'Subscribe')
+{/crmUpgradeSnapshot}
 {literal}
 UPDATE civicrm_mailing_component
 SET body_html = REPLACE(body_html, '{welcome.group}', '{group.frontend_title}'),
@@ -43,6 +60,9 @@ subject = REPLACE(subject, '{subscribe.group}', '{group.frontend_title}')
 WHERE component_type = 'Subscribe';
 {/literal}
 
+{crmUpgradeSnapshot name=loctype}
+  SELECT id, name, display_name, is_reserved, is_active, is_default FROM civicrm_location_type
+{/crmUpgradeSnapshot}
 UPDATE `civicrm_location_type` SET `is_reserved` = 0 WHERE `is_reserved` IS NULL;
 UPDATE `civicrm_location_type` SET `is_active` = 0 WHERE `is_active` IS NULL;
 UPDATE `civicrm_location_type` SET `is_default` = 0 WHERE `is_default` IS NULL;

--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -166,6 +166,37 @@ class CRM_Upgrade_Snapshot {
   }
 
   /**
+   * Generate the query/queries for storing a snapshot (if the local policy supports snapshotting).
+   *
+   * This method does all updates in one go. It is suitable for small/moderate data-sets. If you need to support
+   * larger data-sets, use createTasks() instead.
+   *
+   * @param string $owner
+   *   Name of the component/module/extension that owns the snapshot.
+   *   Ex: 'civicrm'
+   * @param string $version
+   *   Ex: '5.50'
+   * @param string $name
+   * @param string $select
+   *   Raw SQL SELECT for finding data.
+   * @throws \CRM_Core_Exception
+   * @return string[]
+   *   SQL statements to execute.
+   *   May be array if there no statements to execute.
+   */
+  public static function createSingleTask(string $owner, string $version, string $name, string $select): array {
+    $destTable = static::createTableName($owner, $version, $name);
+    if (!empty(CRM_Upgrade_Snapshot::getActivationIssues())) {
+      return [];
+    }
+
+    $result = [];
+    $result[] = "DROP TABLE IF EXISTS `{$destTable}`";
+    $result[] = "CREATE TABLE `{$destTable}` ROW_FORMAT=COMPRESSED AS {$select}";
+    return $result;
+  }
+
+  /**
    * @param \CRM_Queue_TaskContext $ctx
    * @param string $sql
    *


### PR DESCRIPTION
Overview
----------------------------------------

For data-structures that are modified by the 5.65.alpha1 upgrade, create some snapshots (just in case we discover some schema problem later on).

This is one of two options. Option B uses a new Smarty helper (`{crmUpgradeSnapshot}`) and puts the calls inline (*adjacent to the actual upgrade steps*). This should be an easier exemplar to follow in the future. It gives up support for pagination (*which shouldn't matter for the relatively small data-sets involved*).

(For Option A, see #26998.)

Before
----------------------------------------

* No snapshots
* To make snapshots, you must use PHP API in the upgrade class.

After
----------------------------------------

* Some snapshots
* To make snapshots, you may use Smarty API in the `*.mysql.tpl` file.
 