### PR TITLE
Fix event templates to use end_date token

### DIFF
--- a/Civi/Test/EventTestTrait.php
+++ b/Civi/Test/EventTestTrait.php
@@ -57,9 +57,9 @@ trait EventTestTrait {
   protected function eventCreatePaid(array $eventParameters = [], array $priceSetParameters = [], string $identifier = 'PaidEvent'): array {
     $eventParameters = array_merge($this->getEventExampleData(), $eventParameters);
     $event = $this->eventCreate($eventParameters, $identifier);
-    if (array_keys($priceSetParameters) !== ['id']) {
+    if (empty($priceSetParameters['id'])) {
       try {
-        $this->eventCreatePriceSet([], $identifier);
+        $this->eventCreatePriceSet($priceSetParameters, $identifier);
         $this->setTestEntityID('PriceSetEntity', PriceSetEntity::create(FALSE)
           ->setValues([
             'entity_table' => 'civicrm_event',

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -349,12 +349,13 @@ London,',
    *
    * @param array $eventParams
    * @param array $submittedValues
+   * @param bool $isQuickConfig
    *
    * @return CRM_Event_Form_Participant
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getForm(array $eventParams = [], array $submittedValues = []): CRM_Event_Form_Participant {
+  protected function getForm(array $eventParams = [], array $submittedValues = [], bool $isQuickConfig = FALSE): CRM_Event_Form_Participant {
     $submittedValues['contact_id'] = $this->ids['Contact']['event'] = $this->individualCreate();
 
     if (!empty($eventParams['is_monetary'])) {
@@ -365,7 +366,7 @@ London,',
         'loc_block_id' => $locationBlockID,
         'confirm_email_text' => "Just do it\n Now",
         'is_show_location' => TRUE,
-      ], $eventParams));
+      ], $eventParams), ['is_quick_config' => $isQuickConfig]);
       $submittedValues = array_merge($this->getRecordContributionParams('Partially paid', 'Pending'), $submittedValues);
     }
     else {
@@ -549,7 +550,7 @@ London,',
    */
   public function testSubmitPartialPayment(bool $isQuickConfig): void {
     $mailUtil = new CiviMailUtils($this, TRUE);
-    $form = $this->getForm(['is_monetary' => 1]);
+    $form = $this->getForm(['is_monetary' => 1, 'start_date' => '2023-02-15 15:00', 'end_date' => '2023-02-15 18:00']);
     $this->callAPISuccess('PriceSet', 'create', ['is_quick_config' => $isQuickConfig, 'id' => $this->getPriceSetID('PaidEvent')]);
     $paymentInstrumentID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
     $submitParams = [
@@ -596,8 +597,7 @@ London,',
    */
   public function testSubmitPendingPartiallyPaidAddPayment(bool $isQuickConfig): void {
     $mailUtil = new CiviMailUtils($this, TRUE);
-    $form = $this->getForm(['is_monetary' => 1]);
-    $this->callAPISuccess('PriceSet', 'create', ['is_quick_config' => $isQuickConfig, 'id' => $this->getPriceSetID('PaidEvent')]);
+    $form = $this->getForm(['is_monetary' => 1, 'start_date' => '2023-02-15 15:00', 'end_date' => '2023-02-15 18:00'], [], $isQuickConfig);
     $paymentInstrumentID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
     $form->postProcess();
     $this->callAPISuccess('Payment', 'create', [
@@ -622,7 +622,7 @@ London,',
    */
   public function testSubmitPendingAddPayment(bool $isQuickConfig): void {
     $mailUtil = new CiviMailUtils($this, TRUE);
-    $form = $this->getForm(['is_monetary' => 1]);
+    $form = $this->getForm(['is_monetary' => 1, 'start_date' => '2023-02-15 15:00', 'end_date' => '2023-02-15 18:00']);
     $this->callAPISuccess('PriceSet', 'create', ['is_quick_config' => $isQuickConfig, 'id' => $this->getPriceSetID('PaidEvent')]);
     $paymentInstrumentID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
     $form->postProcess();
@@ -728,6 +728,7 @@ London,',
       $isAmountPaidOnForm ? 'Balance: $1,530.55' : 'Balance: $1,550.55',
       'Financial Type: Event Fee',
       'Paid By: Check',
+      'February 15th, 2023  3:00 PM- 6:00 PM',
       'Check Number: 879',
     ]);
   }

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -25,6 +25,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
 
     $mut->checkMailLog([
       'Dear Kim,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
+      'Friday September 16th, 2022 12:00 PM-Saturday September 17th, 2022 12:00 PM',
     ]);
     $mut->stop();
     $mut->clearMessages();
@@ -696,7 +697,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    */
   protected function submitPaidEvent(array $submitValues = []): void {
     $this->dummyProcessorCreate();
-    $event = $this->eventCreatePaid(['payment_processor' => [$this->ids['PaymentProcessor']['dummy_live']], 'confirm_email_text' => '', 'is_pay_later' => FALSE]);
+    $event = $this->eventCreatePaid(['payment_processor' => [$this->ids['PaymentProcessor']['dummy_live']], 'confirm_email_text' => '', 'is_pay_later' => FALSE, 'start_date' => '2022-09-16 12:00', 'end_date' => '2022-09-17 12:00']);
     $this->submitForm($event['id'], array_merge([
       'email-Primary' => 'demo@example.com',
       'credit_card_number' => '4111111111111111',

--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -34,7 +34,7 @@ pay_later_receipt:::{$pay_later_receipt}
 {/if}
 event.event_title:::{$event.event_title}
 event.event_start_date:::{$event.event_start_date|crmDate:"%A"}
-event.event_end_date:::{$event.event_end_date|crmDate:"%Y%m%d"}
+event.event_end_date:::{event.end_date|crmDate:"%Y%m%d"}
 {if isset($event.is_monetary)}
 event.is_monetary:::{$event.is_monetary}
 {/if}

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -49,7 +49,7 @@
      <tr>
       <td colspan="2" {$valueStyle}>
        {event.title}<br />
-       {event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+       {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date}{/if}{/if}
       </td>
      </tr>
 

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -38,7 +38,7 @@
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 
 {event.title}
-{event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
+{event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date}{/if}{/if}
 
 {if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and empty($defaultRole)}
 {ts}Participant Role{/ts}: {$event.participant_role}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -64,7 +64,7 @@
      <tr>
       <td colspan="2" {$valueStyle}>
        {event.title}<br />
-       {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate:"%A"} {$event.event_end_date|crmDate}{/if}{/if}
+       {event.start_date|crmDate:"%A"} {event.start_date|crmDate}{if {event.end_date|boolean}}-{if '{event.end_date|crmDate:"%Y%m%d"}' === '{event.start_date|crmDate:"%Y%m%d"}'}{event.end_date|crmDate:"Time"}{else}{event.end_date|crmDate:"%A"} {event.end_date|crmDate}{/if}{/if}
       </td>
      </tr>
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix event templates to use end_date token

Before
----------------------------------------
Uses `$event.event_end_date`


After
----------------------------------------
Uses `{event.end_date}`  - note the conditional means only time shows when applicable

![image](https://github.com/civicrm/civicrm-core/assets/336308/04041a08-c336-4cd9-a409-ee3ef2dba192)


Technical Details
----------------------------------------

Comments
----------------------------------------
