### PR TITLE
dev/core#4473 - Add/edit financial type screen broken

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -173,13 +173,14 @@ trait CRM_Core_Form_EntityFormTrait {
     $this->applyFilter('__ALL__', 'trim');
     $this->addEntityFieldsToTemplate();
     foreach ($this->entityFields as $index => $fields) {
-      $this->entityFields[$index] = array_merge([
+      $this->entityFields[$index] = array_replace_recursive([
         'template' => '',
-        'help' => [],
+        'help' => ['id' => '', 'file' => ''],
         'pre_html_text' => '',
         'post_html_text' => '',
         'description' => '',
-        'documentation_link' => '',
+        'documentation_link' => ['page' => '', 'resource' => ''],
+        'place_holder' => '',
       ], $fields);
     }
     $this->assign('entityFields', $this->entityFields);

--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -7,16 +7,16 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if array_key_exists('template', $fieldSpec)}
+{if $fieldSpec.template}
   {include file=$fieldSpec.template}
 {else}
   <td class="label">{$form.$fieldName.label}
-    {if array_key_exists('help', $fieldSpec)}{assign var=help value=$fieldSpec.help}{help id=$help.id file=$help.file}{/if}
+    {if $fieldSpec.help.id}{help id=$fieldSpec.help.id file=$fieldSpec.help.file}{/if}
     {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>
   <td>
-    {if array_key_exists('pre_html_text', $fieldSpec)}{$fieldSpec.pre_html_text}{/if}{if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if array_key_exists('post_html_text', $fieldSpec)}{$fieldSpec.post_html_text}{/if}<br />
-    {if array_key_exists('description', $fieldSpec)}<span class="description">{$fieldSpec.description}</span>{/if}
-    {if array_key_exists('documentation_link', $fieldSpec)}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
+    {if $fieldSpec.pre_html_text}{$fieldSpec.pre_html_text}{/if}{if $form.$fieldName.html}{$form.$fieldName.html}{else}{$fieldSpec.place_holder}{/if}{if $fieldSpec.post_html_text}{$fieldSpec.post_html_text}{/if}<br />
+    {if $fieldSpec.description}<span class="description">{$fieldSpec.description}</span>{/if}
+    {if $fieldSpec.documentation_link.page}{docURL page=$fieldSpec.documentation_link.page resource=$fieldSpec.documentation_link.resource}{/if}
   </td>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4473

Before
----------------------------------------
Go to add or edit a financial type.
Not much appears.

After
----------------------------------------
More like old times.

Technical Details
----------------------------------------
* array_key_exists is sometimes pretty different than empty().
* also some of the defaults don't match the type or have default subkeys.

Comments
----------------------------------------
* One followup that could be done in master is `place_holder` only seems used in one place, and could maybe go in description instead. (To see it, disable any payment processors you have and go to add a membership type and look at auto_renew.)
* I also only see one place that post_html_text is used, and nowhere that pre_html_text is used.
