### PR TITLE
Fix permission check on Contribution form, clarify underlying functions

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -148,12 +148,12 @@ WHERE  id IN ( $idString )
     }
 
     if (!$hash) {
-      if ($entityType == 'contact') {
+      if ($entityType === 'contact') {
         $hash = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact',
           $entityId, 'hash'
         );
       }
-      elseif ($entityType == 'mailing') {
+      elseif ($entityType === 'mailing') {
         $hash = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing',
           $entityId, 'hash'
         );

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -138,8 +138,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   public $_contactID;
 
-  protected $_userID;
-
   /**
    * The Membership ID for membership renewal
    *
@@ -293,9 +291,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     }
     $this->_emailExists = $this->get('emailExists');
 
-    // this was used prior to the cleverer this_>getContactID - unsure now
-    $this->_userID = CRM_Core_Session::getLoggedInContactID();
-
     $this->_contactID = $this->_membershipContactID = $this->getContactID();
     $this->getRenewalMembershipID();
 
@@ -307,7 +302,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         $this->_defaultMemTypeId = $membership->membership_type_id;
         if ($membership->contact_id != $this->_contactID) {
           $validMembership = FALSE;
-          $organizations = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->_userID, NULL, NULL, 'Organization');
+          $organizations = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), NULL, NULL, 'Organization');
           if (!empty($organizations) && array_key_exists($membership->contact_id, $organizations)) {
             $this->_membershipContactID = $membership->contact_id;
             $this->assign('membershipContactID', $this->_membershipContactID);
@@ -321,7 +316,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
               // CRM-14051 - membership_type.relationship_type_id is a CTRL-A padded string w one or more ID values.
               // Convert to comma separated list.
               $inheritedRelTypes = implode(',', CRM_Utils_Array::explodePadded($membershipType->relationship_type_id));
-              $permContacts = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->_userID, $membershipType->relationship_type_id);
+              $permContacts = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), $membershipType->relationship_type_id);
               if (array_key_exists($membership->contact_id, $permContacts)) {
                 $this->_membershipContactID = $membership->contact_id;
                 $validMembership = TRUE;
@@ -1122,8 +1117,11 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     ];
 
     $validUser = FALSE;
-    if ($this->_userID &&
-      $this->_userID == $pledgeValues['contact_id']
+    // @todo - override getRequestedContactID to add in checking pledge values, then
+    // getContactID will do all this.
+    $userID = CRM_Core_Session::getLoggedInContactID();
+    if ($userID &&
+      $userID == $pledgeValues['contact_id']
     ) {
       //check for authenticated  user.
       $validUser = TRUE;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2478,6 +2478,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *  - the logged in user
    *  - 0 for none.
    *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
    * @return int
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/Core/FormTest.php
+++ b/tests/phpunit/CRM/Core/FormTest.php
@@ -109,4 +109,26 @@ class CRM_Core_FormTest extends CiviUnitTestCase {
     $this->callAPISuccess('PriceSet', 'delete', ['id' => $priceSetId]);
   }
 
+  /**
+   * Test the getAuthenticatedUser function.
+   *
+   * It should return a checksum validated user, falling back to the logged in user.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetAuthenticatedUser(): void {
+    $_REQUEST['cid'] = $this->individualCreate();
+    $_REQUEST['cs'] = CRM_Contact_BAO_Contact_Utils::generateChecksum($_REQUEST['cid']);
+    $form = $this->getFormObject('CRM_Core_Form');
+    $this->assertEquals($_REQUEST['cid'], $form->getAuthenticatedContactID());
+
+    $_REQUEST['cs'] = 'abc';
+    $form = $this->getFormObject('CRM_Core_Form');
+    $this->assertEquals(0, $form->getAuthenticatedContactID());
+
+    $form = $this->getFormObject('CRM_Core_Form');
+    $this->createLoggedInUser();
+    $this->assertEquals($this->ids['Contact']['logged_in'], $form->getAuthenticatedContactID());
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is a reviewer response to https://github.com/civicrm/civicrm-core/pull/22951

In that PR it seeks to set UserID to something derived from a function that is doing a lot of work. I dug into that function which someone (ahem) wrote many years ago and teased out some of the underlying chunks & cleaned up the variable names for clarity along with a doc block cleanup.

I decided that rather than set _userID in contributionBase we should remove it (it is only referred to in 4 places) and call the more specific function at each usage.

Otherwise we change the meaning of userID that is used somewhat differently later.

Also I rather prefer functions that will perform the same whenever called over relying on a variable having been set correctly the first time

Before
----------------------------------------
It is not possible to load from the mid on the contribution page if checksum authentication has been used

After
----------------------------------------
If the checksum user can view a membership it can be loaded

Technical Details
----------------------------------------
->_userID only used in a test with these changes

![image](https://github.com/civicrm/civicrm-core/assets/336308/88f1fd17-615b-4442-806d-8b5d1970c856)

Comments
----------------------------------------

