### PR TITLE
Separate getStatusMessage function

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1400,20 +1400,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {
-      if ($this->_single) {
-        $statusMsg = ts('Event registration for %1 has been added.', [1 => $this->_contributorDisplayName]);
-        if (!empty($params['send_receipt']) && $numberSent) {
-          $statusMsg .= ' ' . ts('A confirmation email has been sent to %1.', [1 => $this->_contributorEmail]);
-        }
-      }
-      else {
-        $statusMsg = ts('Total Participant(s) added to event: %1.', [1 => count($this->_contactIds)]);
-        if ($numberNotSent > 0) {
-          $statusMsg .= ' ' . ts('Email has NOT been sent to %1 contact(s) - communication preferences specify DO NOT EMAIL OR valid Email is NOT present. ', [1 => $numberNotSent]);
-        }
-        elseif (isset($params['send_receipt'])) {
-          $statusMsg .= ' ' . ts('A confirmation email has been sent to ALL participants');
-        }
+      $statusMsg = ts('Event registration for %1 has been added.', [1 => $this->_contributorDisplayName]);
+      if (!empty($params['send_receipt']) && $numberSent) {
+        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1.', [1 => $this->_contributorEmail]);
       }
     }
     return $statusMsg;

--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -155,6 +155,30 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
   }
 
   /**
+   * Get status message
+   *
+   * @param array $params
+   * @param int $numberSent
+   * @param int $numberNotSent
+   * @param string $updateStatusMsg
+   *
+   * @return string
+   */
+  protected function getStatusMsg(array $params, int $numberSent, int $numberNotSent, string $updateStatusMsg): string {
+    $statusMsg = '';
+    if ($this->_action & CRM_Core_Action::ADD) {
+      $statusMsg = ts('Total Participant(s) added to event: %1.', [1 => count($this->_contactIds)]);
+      if ($numberNotSent > 0) {
+        $statusMsg .= ' ' . ts('Email has NOT been sent to %1 contact(s) - communication preferences specify DO NOT EMAIL OR valid Email is NOT present. ', [1 => $numberNotSent]);
+      }
+      elseif (isset($params['send_receipt'])) {
+        $statusMsg .= ' ' . ts('A confirmation email has been sent to ALL participants');
+      }
+    }
+    return $statusMsg;
+  }
+
+  /**
    * Add local and global form rules.
    *
    * @return void


### PR DESCRIPTION


Overview
----------------------------------------
Separate `getStatusMessage` function

Before
----------------------------------------
Parent & child class use the same `getStatusMessage` function but follow different paths within it

After
----------------------------------------
Child class implements the function itself, functionality separated

Technical Details
----------------------------------------
The  CRM_Event_Form_Task_Register form was once part of CRM_Event_Form_Participant

It now extends it & the goal is to disentangle it from the parent.

In general _single is only set for the parent & describes actions for that whereas the Register form is a task that can act on many

Comments
----------------------------------------