### PR TITLE
Use token for tax_amount, quick config mode

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -269,13 +269,13 @@
         </tr>
        {/foreach}
       {/if}
-      {if $totalTaxAmount}
+      {if {contribution.tax_amount|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Total Tax Amount{/ts}
         </td>
         <td {$valueStyle}>
-         {$totalTaxAmount|crmMoney:$currency}
+          {contribution.tax_amount}
         </td>
        </tr>
       {/if}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -139,8 +139,8 @@
 {/foreach}
 {/if}
 
-{if $totalTaxAmount}
-{ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
+{if {contribution.tax_amount|boolean}}
+{ts}Total Tax Amount{/ts}: {contribution.tax_amount}
 {/if}
 {if {event.is_monetary|boolean}}
 


### PR DESCRIPTION
Overview
----------------------------------------
Use token for tax_amount, quick config mode

Before
----------------------------------------
e-notices when `$totalTaxAmount` is not assigned in quick-config mode

After
----------------------------------------
Follow general approach of using the token. The contribution is already being set so that part is sorted

![image](https://github.com/civicrm/civicrm-core/assets/336308/ac513b31-1c45-4297-b0f5-0f856c158292)

Technical Details
----------------------------------------
Note the tokens have handling for formatting with currency so we don't need that here

Comments
----------------------------------------
