### PR TITLE
Use tokens for participant.register_date

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -329,13 +329,13 @@
         </tr>
        {/if}
 
-       {if $register_date}
+       {if {participant.register_date|boolean}}
         <tr>
          <td {$labelStyle}>
           {ts}Registration Date{/ts}
          </td>
          <td {$valueStyle}>
-          {$register_date|crmDate}
+           {participant.register_date}
          </td>
         </tr>
        {/if}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -176,8 +176,8 @@
 
 {/if}
 
-{if $register_date}
-{ts}Registration Date{/ts}: {$register_date|crmDate}
+{if {participant.register_date|boolean}}
+{ts}Registration Date{/ts}: {participant.register_date}
 {/if}
 {if $receive_date}
 {ts}Transaction Date{/ts}: {$receive_date|crmDate}


### PR DESCRIPTION
Overview
----------------------------------------
Use tokens for participant.register_date

Before
----------------------------------------
Uses smarty-assign

After
----------------------------------------
Uses token - still works

![image](https://github.com/civicrm/civicrm-core/assets/336308/6718d45f-09e0-4b1a-9d5e-8fcc4969100c)


Technical Details
----------------------------------------

Comments
----------------------------------------
