### PR TITLE
Remove excessive data handling & some unused variables

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2172,8 +2172,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       // Retrieve the name and email of the contact - this will be the TO for receipt email
       [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($contactID);
 
-      $this->_contributorDisplayName = ($this->_contributorDisplayName == ' ') ? $this->_contributorEmail : $this->_contributorDisplayName;
-
       $waitStatus = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Waiting'");
       $waitingStatus = $waitStatus[$params['status_id']] ?? NULL;
       if ($waitingStatus) {
@@ -2257,13 +2255,11 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       }
 
       //send email with pdf invoice
-      $template = CRM_Core_Smarty::singleton();
-      $taxAmt = $template->get_template_vars('dataArray');
       if (Civi::settings()->get('invoice_is_email_pdf')) {
         $sendTemplateParams['isEmailPdf'] = TRUE;
         $sendTemplateParams['contributionId'] = $contributionID;
       }
-      [$mailSent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+      [$mailSent] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
       if ($mailSent) {
         $sent[] = $contactID;
         foreach ($participants as $ids => $values) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove excessive data handling & some unused variables

Before
----------------------------------------
This form, but  other forms, has special handling to use the email as the display name in emails if the display name is a single space

After
----------------------------------------
We use the display name as saved

Technical Details
----------------------------------------
This feels like code in the wrong place for something that is a non issue. If we were really worried we need to fix when saving to display name

Comments
----------------------------------------
Unused variables

![image](https://github.com/civicrm/civicrm-core/assets/336308/b4388881-5232-4bec-81c9-cea64ade4d94)

