### PR TITLE
Re-enable any queues that were disabled for background processing, on end

### DIFF
--- a/CRM/Queue/Runner.php
+++ b/CRM/Queue/Runner.php
@@ -214,7 +214,6 @@ class CRM_Queue_Runner {
 
     if ($taskResult['numberOfItems'] === 0) {
       $result = $this->handleEnd();
-      $this->enableBackgroundExecution();
       if (!empty($result['redirect_url'])) {
         CRM_Utils_System::redirect($result['redirect_url']);
       }
@@ -353,6 +352,7 @@ class CRM_Queue_Runner {
     if (!empty($this->onEndUrl)) {
       $result['redirect_url'] = $this->onEndUrl;
     }
+    $this->enableBackgroundExecution();
     return $result;
   }
 


### PR DESCRIPTION
… 


Overview
----------------------------------------

This addresses what is likely an artificial scenario but

essentially if these steps are followed twice in separate processes
- create a queue
- run the queue via runAll

The second time will fail because the queue was disabled & no re-enabled, despite being perisistent

Before
----------------------------------------


After
----------------------------------------
Persistent queues are more re-usable

Technical Details
----------------------------------------

Comments
----------------------------------------
