### PR TITLE
Path fixes

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -598,10 +598,8 @@
      <path>civicrm/admin/job/add</path>
      <title>Add Scheduled Job</title>
      <desc>Add a periodially running task.</desc>
-     <page_callback>CRM_Admin_Page_Job</page_callback>
+     <page_callback>CRM_Admin_Form_Job</page_callback>
      <access_arguments>access CiviCRM,administer CiviCRM system</access_arguments>
-     <adminGroup>System Settings</adminGroup>
-     <weight>1371</weight>
   </item>
   <item>
      <path>civicrm/admin/job/edit</path>

--- a/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
@@ -12,7 +12,7 @@
     <af-field name="is_active" defn="{input_type: 'Radio', input_attrs: {}}" />
   </div>
   <div class="btn-group pull-right">
-    <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/job', {reset: 1, action: 'add'}) }}">
+    <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/job/add', {reset: 1, action: 'add'}) }}">
       <i class="crm-i fa-plus-circle"/>
       {{:: ts('Add Scheduled Job') }}
     </a>

--- a/templates/CRM/Contact/Form/Search/Intro.tpl
+++ b/templates/CRM/Contact/Form/Search/Intro.tpl
@@ -24,7 +24,7 @@
       {if $ssID}{help id="id-add-to-smartGroup"}{/if}
   {/if}
   {if $permissionEditSmartGroup}
-    {capture assign=groupSettingsURL}{crmURL p='civicrm/group' q="action=update&id=`$group.id`&reset=1"}{/capture}
+    {capture assign=groupSettingsURL}{crmURL p='civicrm/group/edit' q="action=update&id=`$group.id`&reset=1"}{/capture}
         <a href="{$groupSettingsURL}" class="action-item button"><span><i class="crm-i fa-wrench" aria-hidden="true"></i> {ts}Edit Group Settings{/ts}</span></a>
   {/if}
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
A few path fixes resulting from recent changes for AdminUI

Before
----------------------------------------
1) Go to Manage Groups, then Contacts of a group, click 'Edit Settings' -> goes to group listing, not edit settings.
2) With AdminUI enabled, go to Managed Scheduled Jobs, then Add Scheduled Jobs -> goes to wrong page.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------


Comments
----------------------------------------

