### PR TITLE
Show which extension has a parse error in info.xml

### DIFF
--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -214,10 +214,11 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
             $info = CRM_Extension_Info::loadFromFile($infoPath);
           }
           catch (CRM_Extension_Exception_ParseException $e) {
-            CRM_Core_Session::setStatus(ts('Parse error in extension: %1', [
-              1 => $e->getMessage(),
+            CRM_Core_Session::setStatus(ts('Parse error in extension %1: %2', [
+              1 => ltrim($relPath, '/'),
+              2 => $e->getMessage(),
             ]), '', 'error');
-            CRM_Core_Error::debug_log_message("Parse error in extension: " . $e->getMessage());
+            CRM_Core_Error::debug_log_message("Parse error in extension " . ltrim($relPath, '/') . ": " . $e->getMessage());
             continue;
           }
           $visible = TRUE;

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -452,10 +452,11 @@ class CRM_Extension_Mapper {
         $this->keyToInfo($key);
       }
       catch (CRM_Extension_Exception_ParseException $e) {
-        CRM_Core_Session::setStatus(ts('Parse error in extension: %1', [
-          1 => $e->getMessage(),
+        CRM_Core_Session::setStatus(ts('Parse error in extension %1: %2', [
+          1 => $key,
+          2 => $e->getMessage(),
         ]), '', 'error');
-        CRM_Core_Error::debug_log_message("Parse error in extension: " . $e->getMessage());
+        CRM_Core_Error::debug_log_message("Parse error in extension " . $key . ": " . $e->getMessage());
         continue;
       }
     }
@@ -515,7 +516,7 @@ class CRM_Extension_Mapper {
   }
 
   /**
-   * Given te class, provides the template name.
+   * Given the class, provides the template name.
    * @todo consider multiple templates, support for one template for now
    *
    *
@@ -576,10 +577,11 @@ class CRM_Extension_Mapper {
         $info = $this->keyToInfo($key);
       }
       catch (CRM_Extension_Exception_ParseException $e) {
-        CRM_Core_Session::setStatus(ts('Parse error in extension: %1', [
-          1 => $e->getMessage(),
+        CRM_Core_Session::setStatus(ts('Parse error in extension %1: %2', [
+          1 => $key,
+          2 => $e->getMessage(),
         ]), '', 'error');
-        CRM_Core_Error::debug_log_message("Parse error in extension: " . $e->getMessage());
+        CRM_Core_Error::debug_log_message("Parse error in extension " . $key . ": " . $e->getMessage());
         return NULL;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This came up on chat recently.

Before
----------------------------------------
Error message and log says there is a parse error in an info.xml file, but we don't know which extension.

After
----------------------------------------
We get the path to the offending file in the error.

Comments
----------------------------------------
These errors could also come from `CRM/Extensions/Mapper.php`, but I think that is basically deprecated, so haven't bothered. Can add the same to that if there is some reason to do so.