### PR TITLE
dev/user-interface#53 Reduce presence of Save and Done/New on forms

### DIFF
--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -235,14 +235,6 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
         'isDefault' => TRUE,
       ],
     ];
-    // Skip this button when adding a new campaign from an entityRef
-    if (empty($_GET['snippet']) || empty($_GET['returnExtra'])) {
-      $buttons[] = [
-        'type' => 'upload',
-        'name' => ts('Save and New'),
-        'subName' => 'new',
-      ];
-    }
     $buttons[] = [
       'type' => 'cancel',
       'name' => ts('Cancel'),

--- a/CRM/Campaign/Form/Survey.php
+++ b/CRM/Campaign/Form/Survey.php
@@ -101,17 +101,6 @@ class CRM_Campaign_Form_Survey extends CRM_Core_Form {
           'name' => ts('Save'),
           'isDefault' => TRUE,
         ],
-        [
-          'type' => 'upload',
-          'name' => ts('Save and Done'),
-          'subName' => 'done',
-        ],
-        [
-          'type' => 'upload',
-          'name' => ts('Save and Next'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'subName' => 'next',
-        ],
       ];
     }
     else {

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -892,7 +892,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         'isDefault' => TRUE,
       ],
     ];
-    if (CRM_Core_Permission::check('add contacts')) {
+    if (!$this->_contactId && CRM_Core_Permission::check('add contacts')) {
       $buttons[] = [
         'type' => 'upload',
         'name' => ts('Save and New'),

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -884,24 +884,27 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $mailingInfo = Civi::settings()->get('mailing_backend');
     $this->assign('outBound_option', $mailingInfo['outBound_option']);
 
-    $this->addButtons([
+    $buttons = [
       [
         'type' => 'upload',
         'name' => ts('Save'),
         'js' => $js,
         'isDefault' => TRUE,
       ],
-      [
+    ];
+    if (!$this->_id) {
+      $buttons[] = [
         'type' => 'upload',
         'name' => ts('Save and New'),
         'js' => $js,
         'subName' => 'new',
-      ],
-      [
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-      ],
-    ]);
+      ];
+    }
+    $buttons[] = [
+      'type' => 'cancel',
+      'name' => ts('Cancel'),
+    ];
+    $this->addButtons($buttons);
 
     // if contribution is related to membership or participant freeze Financial Type, Amount
     if ($this->_id) {

--- a/CRM/Contribute/Form/ContributionPage.php
+++ b/CRM/Contribute/Form/ContributionPage.php
@@ -35,25 +35,11 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
   protected $_pledgeBlockID;
 
   /**
-   * Are we in single form mode or wizard mode?
-   *
-   * @var bool
-   */
-  protected $_single;
-
-  /**
    * Is this the first page?
    *
    * @var bool
    */
   protected $_first = FALSE;
-
-  /**
-   * Is this the last page?
-   *
-   * @var bool
-   */
-  protected $_last = FALSE;
 
   /**
    * Store price set id.
@@ -97,10 +83,6 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
     // setting title and 3rd level breadcrumb for html page if contrib page exists
     if ($this->_id) {
       $title = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage', $this->_id, 'title');
-
-      if ($this->_action == CRM_Core_Action::UPDATE) {
-        $this->_single = TRUE;
-      }
     }
 
     // CRM-16776 - show edit/copy/create buttons on Profiles Tab if user has required permission.
@@ -166,57 +148,18 @@ class CRM_Contribute_Form_ContributionPage extends CRM_Core_Form {
       $this->addElement('hidden', 'cancelURL', $this->_cancelURL);
     }
 
-    if ($this->_single) {
-      $buttons = [
-        [
-          'type' => 'next',
-          'name' => ts('Save'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-        ],
-        [
-          'type' => 'upload',
-          'name' => ts('Save and Done'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'subName' => 'done',
-        ],
-      ];
-      if (!$this->_last) {
-        $buttons[] = [
-          'type' => 'submit',
-          'name' => ts('Save and Next'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'subName' => 'savenext',
-        ];
-      }
-      $buttons[] = [
-        'type' => 'cancel',
-        'name' => ts('Cancel'),
-      ];
-      $this->addButtons($buttons);
-    }
-    else {
-      $buttons = [];
-      if (!$this->_first) {
-        $buttons[] = [
-          'type' => 'back',
-          'name' => ts('Previous'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-        ];
-      }
-      $buttons[] = [
+    $buttons = [
+      [
         'type' => 'next',
-        'name' => ts('Continue'),
-        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'name' => ts('Save'),
         'isDefault' => TRUE,
-      ];
-      $buttons[] = [
+      ],
+      [
         'type' => 'cancel',
         'name' => ts('Cancel'),
-      ];
-
-      $this->addButtons($buttons);
-    }
+      ],
+    ];
+    $this->addButtons($buttons);
 
     $session->replaceUserContext($this->_cancelURL);
 

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -389,15 +389,6 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     if ($this->_action & CRM_Core_Action::ADD) {
       $url = 'civicrm/admin/contribute/amount';
       $urlParams = "action=update&reset=1&id={$dao->id}";
-      // special case for 'Save and Done' consistency.
-      if ($this->controller->getButtonName('submit') == '_qf_Amount_upload_done') {
-        $url = 'civicrm/admin/contribute';
-        $urlParams = 'reset=1';
-        CRM_Core_Session::setStatus(ts("'%1' information has been saved.",
-          [1 => $this->getTitle()]
-        ), ts('Saved'), 'success');
-      }
-
       CRM_Utils_System::redirect(CRM_Utils_System::url($url, $urlParams));
     }
     parent::endPostProcess();

--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -270,12 +270,6 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
           'isDefault' => TRUE,
         ],
         [
-          'type' => 'upload',
-          'name' => ts('Save and Done'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'subName' => 'done',
-        ],
-        [
           'type' => 'cancel',
           'name' => ts('Cancel'),
         ],

--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -244,22 +244,11 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     }
 
     $this->set('id', $event->id);
-
     $this->postProcessHook();
 
     if ($this->_action & CRM_Core_Action::ADD) {
-      $url = 'civicrm/event/manage/location';
-      $urlParams = "action=update&reset=1&id={$event->id}";
-      // special case for 'Save and Done' consistency.
-      if ('_qf_EventInfo_upload_done' === $this->controller->getButtonName('submit')) {
-        $url = 'civicrm/event/manage';
-        $urlParams = 'reset=1';
-        CRM_Core_Session::setStatus(ts("'%1' information has been saved.",
-          [1 => $this->getTitle()]
-        ), ts('Saved'), 'success');
-      }
-
-      CRM_Utils_System::redirect(CRM_Utils_System::url($url, $urlParams));
+      $url = CRM_Utils_System::url('civicrm/event/manage/location', "action=update&reset=1&id={$event->id}");
+      CRM_Utils_System::redirect($url);
     }
 
     parent::endPostProcess();

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -765,7 +765,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'civicrm/contact/search',
       'civicrm/group/search',
     ];
-    if (!in_array($path, $excludeForPaths)) {
+    if (!$this->getParticipantID() && !in_array($path, $excludeForPaths)) {
       $buttons[] = [
         'type' => 'upload',
         'name' => ts('Save and New'),

--- a/CRM/Financial/Form/FinancialBatch.php
+++ b/CRM/Financial/Form/FinancialBatch.php
@@ -78,11 +78,6 @@ class CRM_Financial_Form_FinancialBatch extends CRM_Contribute_Form {
           'isDefault' => TRUE,
         ],
         [
-          'type' => 'next',
-          'name' => ts('Save and New'),
-          'subName' => 'new',
-        ],
-        [
           'type' => 'cancel',
           'name' => ts('Cancel'),
         ],

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -346,22 +346,25 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       ]);
     }
     else {
-      $this->addButtons([
+      $buttons = [
         [
           'type' => 'upload',
           'name' => ts('Save'),
           'isDefault' => TRUE,
         ],
-        [
+      ];
+      if (!$this->_id) {
+        $buttons[] = [
           'type' => 'upload',
           'name' => ts('Save and New'),
           'subName' => 'new',
-        ],
-        [
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ],
-      ]);
+        ];
+      };
+      $buttons[] = [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ];
+      $this->addButtons($buttons);
     }
   }
 

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -72,11 +72,8 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
    * @return void
    */
   public function buildQuickForm() {
-    $this->_last = TRUE;
     CRM_PCP_BAO_PCP::buildPCPForm($this);
-
     $this->addElement('checkbox', 'pcp_active', ts('Enable Personal Campaign Pages? (for this contribution page)'), NULL, ['onclick' => "return showHideByValue('pcp_active',true,'pcpFields','table-row','radio',false);"]);
-
     parent::buildQuickForm();
     $this->addFormRule(['CRM_PCP_Form_Contribute', 'formRule'], $this);
   }

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -358,25 +358,28 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     // make this form an upload since we dont know if the custom data injected dynamically
     // is of type file etc $uploadNames = $this->get( 'uploadNames' );
-    $this->addButtons([
-        [
-          'type' => 'upload',
-          'name' => ts('Save'),
-          'js' => ['onclick' => 'return verify( );'],
-          'isDefault' => TRUE,
-        ],
-        [
-          'type' => 'upload',
-          'name' => ts('Save and New'),
-          'js' => ['onclick' => 'return verify( );'],
-          'subName' => 'new',
-        ],
-        [
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ],
-    ]);
+    $buttons = [
+      [
+        'type' => 'upload',
+        'name' => ts('Save'),
+        'js' => ['onclick' => 'return verify();'],
+        'isDefault' => TRUE,
+      ],
+    ];
+    if (!$this->_id) {
+      $buttons[] = [
+        'type' => 'upload',
+        'name' => ts('Save and New'),
+        'js' => ['onclick' => 'return verify();'],
+        'subName' => 'new',
+      ];
+    }
+    $buttons[] = [
+      'type' => 'cancel',
+      'name' => ts('Cancel'),
+    ];
 
+    $this->addButtons($buttons);
     $this->addFormRule(['CRM_Pledge_Form_Pledge', 'formRule'], $this);
 
     if ($this->_action & CRM_Core_Action::VIEW) {

--- a/templates/CRM/Core/Form/RecurringEntity.tpl
+++ b/templates/CRM/Core/Form/RecurringEntity.tpl
@@ -13,11 +13,6 @@
     {ts 1=$recurringEntityType}Repeat %1{/ts}
   </div>
   <div class="crm-accordion-body">
-    {if !$recurringFormIsEmbedded}
-      <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl" location="top"}
-      </div>
-    {/if}
     <table class="form-layout-compressed">
       <tr class="crm-core-form-recurringentity-block-repetition_frequency">
         <td class="label">{$form.repetition_frequency_unit.label}&nbsp;<span class="crm-marker">*</span>  {help id="id-repeats" entityType=$recurringEntityType file="CRM/Core/Form/RecurringEntity.hlp"}</td>

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -10,9 +10,6 @@
 {* Step 1 of New Event Wizard, and Edit Event Info form. *}
 
 <div class="crm-block crm-form-block crm-event-manage-eventinfo-form-block">
-  <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl" location="top"}
-  </div>
   <table class="form-layout-compressed">
     {if !empty($form.template_id)}
       <tr class="crm-event-manage-eventinfo-form-block-template_id">

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -17,10 +17,6 @@
         </div>
     {/if}
 <div class="crm-block crm-form-block crm-event-manage-fee-form-block">
-  <div class="crm-submit-buttons">
-   {include file="CRM/common/formButtons.tpl" location="top"}
-  </div>
-
     <table class="form-layout">
        <tr class="crm-event-manage-fee-form-block-title">
     <td class="label">{$form.title.label}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -13,9 +13,6 @@
 </div>
 
 <div class="crm-block crm-form-block crm-event-manage-location-form-block">
-  <div class="crm-submit-buttons">
-    {include file="CRM/common/formButtons.tpl" location="top"}
-  </div>
   {if $locEvents}
     <table class="form-layout-compressed">
       <tr id="optionType" class="crm-event-manage-location-form-block-location_option">
@@ -71,8 +68,11 @@
     </tr>
   </table>
 
-  {if $locEvents}
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
 
+  {if $locEvents}
     <script type="text/javascript">
       {literal}
       CRM.$(function($) {

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -25,9 +25,6 @@
     {help id="id-event-reg"}
   </div>
 <div class="crm-block crm-form-block crm-event-manage-registration-form-block">
-<div class="crm-submit-buttons">
-{include file="CRM/common/formButtons.tpl" location="top"}
-</div>
 
 <div id="register">
   <table class="form-layout">


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/user-interface/-/issues/53

Removes less useful variants of "Save" buttons on some forms in an attempt to make the interface less overwhelming.

It also removes the "top" buttons from Manage Events pages, which, for some reason, had slipped under my radar when working on #26886.

Some more details here explaining why I removed "Save and Next", and why sometimes keep "Save and New":  
https://lab.civicrm.org/dev/user-interface/-/issues/53#note_149879

Forms modified:

- Manage Contribution Page
- Manage Event
- New Campaign
- New Financial Batch
- Edit existing contact (New Contact keep the current behaviour, with Save and New available)
- ~~Contact Record > New Contribution (but standalone New Contribution forms keeps old behaviour)~~
- ~~Contact Record > New Membership (same as above)~~
- ~~Contact Record > New Participant (same as above)~~
- ~~Contact Record > New Pledge (same as above)~~

Before/After
-------------------------

### Manage Contribution Page

Before:

![image](https://github.com/civicrm/civicrm-core/assets/254741/a1ffaa85-71b5-4977-b9e4-b0fcc9a46374)

After:

![image](https://github.com/civicrm/civicrm-core/assets/254741/a9bf2e2f-40e5-44df-821e-86109beabe6e)

### Edit existing contact

Before:

![image](https://github.com/civicrm/civicrm-core/assets/254741/2f41a35f-f224-4a43-842e-4dde4116fee4)

After:

![image](https://github.com/civicrm/civicrm-core/assets/254741/0594f873-c1b5-4ad5-a630-3075c224c10f)

Note that for New contacts, the "Save and New" is still there, for people who do batch data entry.

### New Contribution (for a contact)

Before:

![image](https://github.com/civicrm/civicrm-core/assets/254741/fb300b45-9d3f-44df-8920-019e262af66e)

After:

![image](https://github.com/civicrm/civicrm-core/assets/254741/4256ecec-a446-4228-aebf-421027eefebf)

(for Contribution > New Contribution, not associated to a contact, the "Save and New" will still be there)

The same logic applies to:

- New Membership
- New Pledge
- New Participant

Comments
----------------

What's  with ` 'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',` ? Seems to have no effect.

cc @larssandergreen @joshgowans @agileware-justin @vingle 