### PR TITLE
Fix issue 4486: Cannot change membership price set on contribution pages

### DIFF
--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -241,15 +241,18 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       }
     }
     if (!empty($params['member_is_active'])) {
-
-      // don't allow price set w/ membership signup, CRM-5095
-      if ($contributionPageId && ($setID = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $contributionPageId, NULL, 1))) {
-
-        $extends = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $setID, 'extends');
-        if ($extends != CRM_Core_Component::getComponentID('CiviMember')) {
-          $errors['member_is_active'] = ts('You cannot enable both Membership Signup and a Contribution Price Set on the same online contribution page.');
-          return $errors;
-        }
+      // Don't allow Contribution price set w/ membership signup, CRM-5095.
+      $priceSetExtendsMembership = \Civi\Api4\PriceSetEntity::get(FALSE)
+        ->addSelect('id')
+        ->addJoin('PriceSet AS price_set', 'LEFT', ['entity_id', '=', 'price_set.id'])
+        ->addWhere('entity_table', '=', 'civicrm_contribution_page')
+        ->addWhere('entity_id', '=', $contributionPageId)
+        ->addWhere('price_set.extends:name', 'CONTAINS', 'CiviMember')
+        ->execute()
+        ->first();
+      if (!$priceSetExtendsMembership) {
+        $errors['member_is_active'] = ts('You cannot enable both Membership Signup and a Contribution Price Set on the same online contribution page.');
+        return $errors;
       }
 
       if (!empty($params['member_price_set_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This patch resolves the [issue](https://lab.civicrm.org/dev/core/-/issues/4486) reported on lab.civicrm regarding the inability to change membership price set on contribution pages/

Before
----------------------------------------
A user cannot switch the options for the Membership Price Set field, and instead get the follow error, despite that the Amounts tab is configured correctly:
```
You cannot enable both Membership Signup and a Contribution Price Set on the same online contribution page.
```

After
----------------------------------------
A user should be able to switch the options for the Membership Price Set without error.

Technical Details
----------------------------------------
This issue is being caused by a comparison value problem on line 249 in `CRM/Member/Form/MembershipBlock.php`. `getFieldValue()` is returning a string padded with non printable characters, and the following `if` statement is trying to compare that to a string without those additional characters, so the two values are determined to be unequal and this error is thrown.