### PR TITLE
wrong AJAX URL constructed in buildPaymentBlock if extra GET paramete…

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -104,7 +104,7 @@
       var currency = '{$currency}';
       currency = currency == '' ? $('#currency').val() : currency;
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id=__type__"}".replace("__type__", type);;
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {

--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -104,7 +104,7 @@
       var currency = '{$currency}';
       currency = currency == '' ? $('#currency').val() : currency;
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id=__type__"}".replace("__type__", type);;
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id=__type__"}".replace("processor_id=__type__", "processor_id=" + type);
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {


### PR DESCRIPTION
Full title: Wrong AJAX URL constructed in buildPaymentBlock if extra GET parameters are present

See https://lab.civicrm.org/dev/core/-/issues/4487 for details.

Overview
----------------------------------------
If contribution pages are used with an extra URL parameter (such as the Drupal-specific but very useful `language`), users encounter an error when they choose a payment option.

Before
----------------------------------------
As users click a radio button to choose their payment provider, an alert pops up with an unhelpful message and payment cannot proceed.

After
----------------------------------------
Donations can work in foreign languages :-)
