### PR TITLE
Unit tests - replace deprecated function with newer one

### DIFF
--- a/tests/phpunit/CRM/Core/ErrorTest.php
+++ b/tests/phpunit/CRM/Core/ErrorTest.php
@@ -38,23 +38,23 @@ class CRM_Core_ErrorTest extends CiviUnitTestCase {
   /**
    * Make sure that formatBacktrace() accepts values from debug_backtrace()
    */
-  public function testFormatBacktrace_debug() {
+  public function testFormatBacktraceDebug(): void {
     $bt = debug_backtrace();
     $msg = CRM_Core_Error::formatBacktrace($bt);
-    $this->assertRegexp('/CRM_Core_ErrorTest->testFormatBacktrace_debug/', $msg);
+    $this->assertMatchesRegularExpression('/CRM_Core_ErrorTest->testFormatBacktraceDebug/', $msg);
   }
 
   /**
    * Make sure that formatBacktrace() accepts values from Exception::getTrace()
    */
-  public function testFormatBacktrace_exception() {
+  public function testFormatBacktraceException(): void {
     $e = new Exception('foo');
     $msg = CRM_Core_Error::formatBacktrace($e->getTrace());
-    $this->assertRegexp('/CRM_Core_ErrorTest->testFormatBacktrace_exception/', $msg);
+    $this->assertMatchesRegularExpression('/CRM_Core_ErrorTest->testFormatBacktraceException/', $msg);
   }
 
-  public function testExceptionLogging() {
-    $e = new \Exception("the exception");
+  public function testExceptionLogging(): void {
+    $e = new \Exception('the exception');
     Civi::log()->notice('There was an exception!', [
       'exception' => $e,
     ]);

--- a/tests/phpunit/CRM/Utils/CacheTest.php
+++ b/tests/phpunit/CRM/Utils/CacheTest.php
@@ -6,11 +6,11 @@
  */
 class CRM_Utils_CacheTest extends CiviUnitTestCase {
 
-  public function testNack() {
+  public function testNack(): void {
     $values = [];
     for ($i = 0; $i < 5; $i++) {
       $nack = CRM_Utils_Cache::nack();
-      $this->assertRegExp('/^NACK:[a-z0-9]+$/', $nack);
+      $this->assertMatchesRegularExpression('/^NACK:[a-z0-9]+$/', $nack);
       $values[] = $nack;
     }
     sort($values);

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -17,8 +17,7 @@
  */
 class api_v3_SystemTest extends CiviUnitTestCase {
 
-  const TEST_CACHE_GROUP = 'SystemTest';
-  const TEST_CACHE_PATH = 'api/v3/system';
+  private const TEST_CACHE_PATH = 'api/v3/system';
 
   /**
    * Sets up the fixture, for example, opens a network connection.
@@ -27,18 +26,18 @@ class api_v3_SystemTest extends CiviUnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->useTransaction(TRUE);
+    $this->useTransaction();
   }
 
   /**
    * Test system flush.
    */
-  public function testFlush() {
+  public function testFlush(): void {
     // Note: this operation actually flushes several different caches; we don't
     // check all of them -- just enough to make sure that the API is doing
     // something
 
-    $this->assertTrue(NULL === Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
+    $this->assertNull(Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
 
     $data = 'abc';
     Civi::cache()->set(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH), $data);
@@ -46,47 +45,47 @@ class api_v3_SystemTest extends CiviUnitTestCase {
     $this->assertEquals('abc', Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
 
     $params = [];
-    $result = $this->callAPIAndDocument('system', 'flush', $params, __FUNCTION__, __FILE__, "Flush all system caches", 'Flush');
+    $this->callAPIAndDocument('system', 'flush', $params, __FUNCTION__, __FILE__, 'Flush all system caches', 'Flush');
 
-    $this->assertTrue(NULL === Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
+    $this->assertNull(Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
   }
 
   /**
    * Test system log function.
    */
-  public function testSystemLog() {
+  public function testSystemLog(): void {
     $this->callAPISuccess('system', 'log', ['level' => 'info', 'message' => 'We wish you a merry Christmas']);
     $result = $this->callAPISuccess('SystemLog', 'getsingle', [
       'sequential' => 1,
       'message' => ['LIKE' => '%Chris%'],
     ]);
-    $this->assertEquals($result['message'], 'We wish you a merry Christmas');
-    $this->assertEquals($result['level'], 'info');
+    $this->assertEquals('We wish you a merry Christmas', $result['message']);
+    $this->assertEquals('info', $result['level']);
   }
 
   /**
    * Test system log function.
    */
-  public function testSystemLogNoLevel() {
+  public function testSystemLogNoLevel(): void {
     $this->callAPISuccess('system', 'log', ['message' => 'We wish you a merry Christmas', 'level' => 'alert']);
     $result = $this->callAPISuccess('SystemLog', 'getsingle', [
       'sequential' => 1,
       'message' => ['LIKE' => '%Chris%'],
     ]);
-    $this->assertEquals($result['message'], 'We wish you a merry Christmas');
-    $this->assertEquals($result['level'], 'alert');
+    $this->assertEquals('We wish you a merry Christmas', $result['message']);
+    $this->assertEquals('alert', $result['level']);
   }
 
-  public function testSystemGet() {
+  public function testSystemGet(): void {
     $result = $this->callAPISuccess('system', 'get', []);
-    $this->assertRegExp('/^[0-9]+\.[0-9]+\.[0-9a-z\-]+$/', $result['values'][0]['version']);
+    $this->assertMatchesRegularExpression('/^[0-9]+\.[0-9]+\.[0-9a-z\-]+$/', $result['values'][0]['version']);
     $this->assertEquals('UnitTests', $result['values'][0]['uf']);
   }
 
   /**
    * @throws \CRM_Core_Exception
    */
-  public function testSystemUTFMB8Conversion() {
+  public function testSystemUTFMB8Conversion(): void {
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), '5.7', '>=')) {
       $this->callAPISuccess('System', 'utf8conversion', []);
       $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -43,6 +43,9 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
     $this->assertTrue(isset($result['case_activity']));
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function testRenderDefaultTemplate(): void {
     $ex = ExampleData::get(FALSE)
       ->addWhere('name', '=', 'workflow/case_activity/CaseModelExample')
@@ -53,10 +56,13 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
       ->execute()
       ->single();
     $result = $ex['render'][0];
-    $this->assertRegExp('/Case ID : 1234/', $result['text']);
+    $this->assertMatchesRegularExpression('/Case ID : 1234/', $result['text']);
   }
 
-  public function testRenderCustomTemplate() {
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testRenderCustomTemplate(): void {
     $ex = ExampleData::get(0)
       ->addWhere('name', '=', 'workflow/case_activity/CaseModelExample')
       ->addSelect('data')
@@ -70,10 +76,10 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
       ])
       ->execute()
       ->single();
-    $this->assertRegExp('/The role is myrole./', $result['text']);
+    $this->assertMatchesRegularExpression('/The role is myrole./', $result['text']);
   }
 
-  public function testRenderExamplesBaseline() {
+  public function testRenderExamplesBaseline(): void {
     $examples = $this->getRenderExamples();
     $this->assertTrue(isset($examples['workflow/contribution_recurring_edit/AlexCancelled']));
   }
@@ -132,7 +138,7 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
     foreach ($example['asserts']['default'] as $num => $assert) {
       $msg = sprintf('Check assertion(%s) on example (%s)', $num, $example['name']);
       if (isset($assert['regex'])) {
-        $this->assertRegExp($assert['regex'], $result[$assert['for']], $msg);
+        $this->assertMatchesRegularExpression($assert['regex'], $result[$assert['for']], $msg);
       }
       else {
         $this->fail('Unrecognized assertion: ' . json_encode($assert));


### PR DESCRIPTION


Overview
----------------------------------------
Unit tests - replace deprecated function with newer one
Also minor clean ups

Before
----------------------------------------
`$this->assertRegexp` is deprecated

After
----------------------------------------
` $this->assertMatchesRegularExpression`

Technical Details
----------------------------------------
I think we are on COMMAND: phpunit9 (/home/jenkins/bknix-dfl/bin/phpunit9)
> PHPUnit 9.6.5 by Sebastian Bergmann and contributors.
 - which would allow us to use forward friendly functions

Comments
----------------------------------------
PHP 10 is min version 8.1 - so we should prepare for it but can't switch to it