### PR TITLE
Fix dev/core#4483 SearchKit crash when in-place-editing a field in a joined entity

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -446,7 +446,7 @@ class FormattingUtil {
    * @return array
    */
   public static function filterByPath(array $values, string $fieldPath, string $fieldName): array {
-    $prefix = substr($fieldPath, 0, strpos($fieldPath, $fieldName));
+    $prefix = substr($fieldPath, 0, strrpos($fieldPath, $fieldName));
     return \CRM_Utils_Array::filterByPrefix($values, $prefix);
   }
 

--- a/tests/phpunit/api/v4/Utils/FormattingUtilTest.php
+++ b/tests/phpunit/api/v4/Utils/FormattingUtilTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace api\v4\Utils;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Utils\FormattingUtil;
+
+/**
+ * @group headless
+ */
+class FormattingUtilTest extends Api4TestBase {
+
+  /**
+   * @dataProvider getFilterByPathExamples
+   * @param string $fieldPath
+   * @param string $fieldName
+   * @param array $originalValues
+   * @param array $expectedValues
+   */
+  public function testFilterByPath(string $fieldPath, string $fieldName, array $originalValues, array $expectedValues): void {
+    $this->assertEquals($expectedValues, FormattingUtil::filterByPath($originalValues, $fieldPath, $fieldName));
+  }
+
+  public function getFilterByPathExamples(): array {
+    $originalValueSets = [
+      [
+        'id' => 'a',
+        'name' => 'a_name',
+        'id_foo.id' => 'b',
+        'id_foo.name' => 'b_name',
+        'id.id_foo.id' => 'c',
+        'id.id_foo.name' => 'c_name',
+      ],
+    ];
+    return [
+      ['id', 'id', $originalValueSets[0], $originalValueSets[0]],
+      ['id_foo.id', 'id', $originalValueSets[0], ['id' => 'b', 'name' => 'b_name']],
+      ['id.id_foo.id', 'id', $originalValueSets[0], ['id' => 'c', 'name' => 'c_name']],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes SearchKit crash when in-place-editing a field in a joined entity (under certain conditions).

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4483

After
----------------------------------------
Fixed