### PR TITLE
Use phpunit9 when running on php 7.3+

### DIFF
--- a/tools/scripts/phpunit
+++ b/tools/scripts/phpunit
@@ -92,6 +92,9 @@ function pickPhpunitCommand() {
   if (getenv('PHPUNIT')) {
     return getenv('PHPUNIT');
   }
+  elseif (version_compare(PHP_VERSION, '7.3', '>=')) {
+    return 'phpunit9';
+  }
   elseif (version_compare(PHP_VERSION, '7.2', '>=')) {
     return 'phpunit8';
   }


### PR DESCRIPTION
Overview
----------------------------------------
We don't support php7.2 now so let's start updating our constructs - https://docs.civicrm.org/installation/en/latest/general/requirements/

Before
----------------------------------------
use phpunit8

After
----------------------------------------
use phpunit9

Technical Details
----------------------------------------

Comments
----------------------------------------
