### PR TITLE
dev/core#4487 Alternative option: Fix paymentBlock url concat

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -76,35 +76,35 @@
       var $form = $('#billing-payment-block').closest('form');
       {/literal}
       {if !$isBackOffice && $contributionPageID}
-        {capture assign='contributionPageID'}id={$contributionPageID}&{/capture}
+        {capture assign='contributionPageID'}&id={$contributionPageID}{/capture}
       {else}
         {capture assign='contributionPageID'}{/capture}
       {/if}
       {if !$isBackOffice && $custom_pre_id}
-        {capture assign='preProfileID'}pre_profile_id={$custom_pre_id}&{/capture}
+        {capture assign='preProfileID'}&pre_profile_id={$custom_pre_id}{/capture}
       {else}
         {capture assign='preProfileID'}{/capture}
       {/if}
       {if $urlPathVar}
-        {capture assign='urlPathVar'}{$urlPathVar}&{/capture}
+        {capture assign='urlPathVar'}&{$urlPathVar}{/capture}
       {else}
         {capture assign='urlPathVar'}{/capture}
       {/if}
-      // Billing profile ID is only ever set on front end forms, to force entering address for pay later.
+      {* Billing profile ID is only ever set on front end forms, to force entering address for pay later. *}
       {if !$isBackOffice && $billing_profile_id}
-        {capture assign='profilePathVar'}billing_profile_id={$billing_profile_id}&{/capture}
+        {capture assign='profilePathVar'}&billing_profile_id={$billing_profile_id}{/capture}
       {else}
         {capture assign='profilePathVar'}{/capture}
       {/if}
 
-      {capture assign='isBackOfficePathVar'}&is_back_office={$isBackOffice}&{/capture}
+      {capture assign='isBackOfficePathVar'}&is_back_office={$isBackOffice}{/capture}
 
       var payment_instrument_id = $('#payment_instrument_id').val();
 
       var currency = '{$currency}';
       currency = currency == '' ? $('#currency').val() : currency;
 
-      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`processor_id="}" + type;
+      var dataUrl = "{crmURL p='civicrm/payment/form' h=0 q="formName=`$form.formName``$urlPathVar``$isBackOfficePathVar``$profilePathVar``$contributionPageID``$preProfileID`"}";
       {literal}
       if (typeof(CRM.vars) != "undefined") {
         if (typeof(CRM.vars.coreForm) != "undefined") {
@@ -117,7 +117,7 @@
           }
         }
       }
-      dataUrl =  dataUrl + "&payment_instrument_id=" + payment_instrument_id + "&currency=" + currency;
+      dataUrl = dataUrl + "&processor_id=" + type + "&payment_instrument_id=" + payment_instrument_id + "&currency=" + currency;
 
       // Processors like pp-express will hide the form submit buttons, so re-show them when switching
       $('.crm-submit-buttons', $form).show().find('input').prop('disabled', true);


### PR DESCRIPTION
Overview
----------------------------------------
Alternate for #27031. I think this is little more readable and maintainable.

Before
----------------------------------------
Funky JS plus Smarty concatenation breaks if additional URL params are present

After
----------------------------------------
Less funky concatenation. Also simplified the ampersand situation a bit.