### PR TITLE
Issue dev/backdrop#80: global $language should be an object.

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -490,7 +490,7 @@ AND    u.status = 1
     global $language;
 
     $langcode = substr($civicrm_language, 0, 2);
-    $languages = language_list(FALSE, TRUE);
+    $languages = language_list();
 
     if (isset($languages[$langcode])) {
       $language = $languages[$langcode];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/backdrop/-/issues/80.

Before
----------------------------------------
In Backdrop CMS, the global variable `$language` was set to a string (e.g., `"English"`), rather than an object, as it is supposed to be set.

This causes warnings and incorrect results whenever the objects variables are accessed, e.g., `$langcode = $language->langcode;`.

After
----------------------------------------
It is now set to the appropriate object.

Technical Details
----------------------------------------
The function whose call is being changed is [documented here](https://docs.backdropcms.org/api/backdrop/core%21includes%21bootstrap.inc/function/language_list/1).
