### PR TITLE
added details for sebalis in contributor-key.xml

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1379,6 +1379,8 @@
   organization: Coop SymbioTIC
 
 - github      : sebalis
+  name        : Sebastian Lisken
+  organization: civiservice.de
 
 - github      : simonjohnparker
   name        : Simon John Parker


### PR DESCRIPTION
I nominated myself for a credit in the next release (hope you agree) in https://github.com/civicrm/civicrm-core/pull/27037#issuecomment-1673196633 – my Github handle was here since 5.56, now adding name and organisation.