### PR TITLE
dev/core#4425 Override currentPath for Standalone

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -39,6 +39,7 @@
  * @method static void appendCoreResources(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_coreResourceList.
  * @method static void alterAssetUrl(\Civi\Core\Event\GenericHookEvent $e) Callback for hook_civicrm_getAssetUrl.
  * @method static bool shouldExitAfterFatal() Should the current execution exit after a fatal error?
+ * @method static string|null currentPath() Path of the current page e.g. 'civicrm/contact/view'
  */
 class CRM_Utils_System {
 
@@ -431,17 +432,6 @@ class CRM_Utils_System {
   ) {
     $url = self::url($path, $query, $absolute, $fragment, $htmlize, $frontend, $forceBackend);
     return "<a href=\"$url\">$text</a>";
-  }
-
-  /**
-   * Path of the current page e.g. 'civicrm/contact/view'
-   *
-   * @return string|null
-   *   the current menu path
-   */
-  public static function currentPath() {
-    $config = CRM_Core_Config::singleton();
-    return isset($_GET[$config->userFrameworkURLVar]) ? trim($_GET[$config->userFrameworkURLVar], '/') : NULL;
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -173,6 +173,17 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Path of the current page e.g. 'civicrm/contact/view'
+   *
+   * @return string|null
+   *   the current menu path
+   */
+  public static function currentPath() {
+    $config = CRM_Core_Config::singleton();
+    return isset($_GET[$config->userFrameworkURLVar]) ? trim($_GET[$config->userFrameworkURLVar], '/') : NULL;
+  }
+
+  /**
    * Authenticate the user against the CMS db.
    *
    * @param string $name

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -206,6 +206,20 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
+   * Path of the current page e.g. 'civicrm/contact/view'
+   *
+   * @return string|null
+   *   the current menu path
+   */
+  public static function currentPath() {
+    $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    if ($path[0] == '/') {
+      $path = substr($path, 1);
+    }
+    return $path;
+  }
+
+  /**
    * @inheritDoc
    * Authenticate the user against the CMS db.
    *


### PR DESCRIPTION
Overview
----------------------------------------

On CiviCRM Standalone, `CRM_Utils_System::currenPath()` always returns empty.

Related to: https://lab.civicrm.org/dev/core/-/issues/4425 - in that the language-switcher extension cannot work without the `currentPath` function.

Before
----------------------------------------

bad chaos

After
----------------------------------------

fun chaos

Technical Details
----------------------------------------

I re-used bits of #15267

Comments
----------------------------------------

:coffee: 