### PR TITLE
dev/core#4492 Ensure that when determining if tokens should be show c…

### DIFF
--- a/CRM/Contribute/Tokens.php
+++ b/CRM/Contribute/Tokens.php
@@ -55,6 +55,9 @@ class CRM_Contribute_Tokens extends CRM_Core_EntityTokens {
    */
   protected function getRelatedTokens(): array {
     $tokens = [];
+    if (!in_array('ContributionRecur', array_keys(\Civi::service('action_object_provider')->getEntities()))) {
+      return $tokens;
+    }
     $hiddenTokens = ['modified_date', 'create_date', 'trxn_id', 'invoice_id', 'is_test', 'payment_token_id', 'payment_processor_id', 'payment_instrument_id', 'cycle_day', 'installments', 'processor_id', 'next_sched_contribution_date', 'failure_count', 'failure_retry_date', 'auto_renew', 'is_email_receipt', 'contribution_status_id'];
     $contributionRecurFields = ContributionRecur::getFields(FALSE)->setLoadOptions(TRUE)->execute();
     foreach ($contributionRecurFields as $contributionRecurField) {

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -348,10 +348,10 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @return bool
    */
   public function checkActive(TokenProcessor $processor) {
-    return (!empty($processor->context['actionMapping'])
+    return ((!empty($processor->context['actionMapping'])
         // This makes the 'schema context compulsory - which feels accidental
         // since recent discu
-      && $processor->context['actionMapping']->getEntityTable()) || in_array($this->getEntityIDField(), $processor->context['schema']);
+      && $processor->context['actionMapping']->getEntityTable()) || in_array($this->getEntityIDField(), $processor->context['schema'])) && in_array($this->getApiEntityName(), array_keys(\Civi::service('action_object_provider')->getEntities()));
   }
 
   /**

--- a/CRM/Member/Tokens.php
+++ b/CRM/Member/Tokens.php
@@ -129,6 +129,9 @@ class CRM_Member_Tokens extends CRM_Core_EntityTokens {
    */
   protected function getRelatedTokens(): array {
     $tokens = [];
+    if (!in_array('ContributionRecur', array_keys(\Civi::service('action_object_provider')->getEntities()))) {
+      return $tokens;
+    }
     $hiddenTokens = ['modified_date', 'create_date', 'trxn_id', 'invoice_id', 'is_test', 'payment_token_id', 'payment_processor_id', 'payment_instrument_id', 'cycle_day', 'installments', 'processor_id', 'next_sched_contribution_date', 'failure_count', 'failure_retry_date', 'auto_renew', 'is_email_receipt', 'contribution_status_id'];
     $contributionRecurFields = ContributionRecur::getFields(FALSE)->setLoadOptions(TRUE)->execute();
     foreach ($contributionRecurFields as $contributionRecurField) {


### PR DESCRIPTION
…heck if the Entity is in list of Avaliable Entities

Overview
----------------------------------------
This aims to fix a hard crash when creating new scheduled reminders due to missing entity ContributionRecur

Before
----------------------------------------
Hard crash if the civi_contribute extension is disabled

After
----------------------------------------
No hard crash

Technical Details
----------------------------------------
This PR aims to address 2 thins 1. make the EntityTokens more respectful of if the entity is avaliable in the API and 2. Add in conditional especially for Membership tokens  in the given example

ping @eileenmcnaughton @MegaphoneJon @colemanw 
