### PR TITLE
E-notice fix, don't skip loading NULL fields

### DIFF
--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -458,7 +458,7 @@ AND ( expire_on IS NULL OR expire_on >= {$currentTime} )
       $setTree[$setID]['fields'][$fieldID]['id'] = $fieldID;
 
       foreach ($priceFields as $field) {
-        if ($field == 'id' || is_null($dao->$field)) {
+        if ($field === 'id') {
           continue;
         }
 


### PR DESCRIPTION
This addresses e-notices (e.g) when help_pre is NULL & assigned to the template


![image](https://github.com/civicrm/civicrm-core/assets/336308/29a29023-b91c-4498-9823-3624fd42b595)
