### PR TITLE
Extract `getDiscountID()`

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -524,8 +524,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       $this->_eventTypeId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $eventID, 'event_type_id', 'id');
 
-      $this->_discountId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_id, 'discount_id');
-      if ($this->_discountId) {
+      if ($this->getDiscountID()) {
+        // This doesn't seem used....
         $this->set('discountId', $this->_discountId);
       }
     }
@@ -1436,8 +1436,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       //retrieve custom information
       $form->_values = [];
-      CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE);
-      CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->_discountId);
+      CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE, $form->getDiscountID());
+      CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->getDiscountID());
       $lineItem = [];
       $totalTaxAmount = 0;
       if (!CRM_Utils_System::isNull($form->_values['line_items'] ?? NULL)) {
@@ -2264,6 +2264,30 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       }
     }
     return ['sent' => count($sent), 'not_sent' => count($notSent)];
+  }
+
+  /**
+   * Get the discount ID.
+   *
+   * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getDiscountID(): ?int {
+    if ($this->_discountId === NULL) {
+      if ($this->getParticipantID()) {
+        $this->_discountId = (int) CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->getParticipantID(), 'discount_id');
+      }
+      else {
+        $this->_discountId = (int) CRM_Core_BAO_Discount::findSet($this->getEventID(), 'civicrm_event');
+      }
+    }
+    return $this->_discountId ?: NULL;
   }
 
 }

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -172,7 +172,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     //retrieve custom information
     $this->_values = [];
 
-    CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE);
+    CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE, $this->getDiscountID());
     CRM_Event_Form_Registration_Register::buildAmount($this, TRUE);
 
     if (!CRM_Utils_System::isNull($this->_values['line_items'] ?? NULL)) {
@@ -223,6 +223,23 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
 
     $this->addButtons($buttons);
     $this->addFormRule(['CRM_Event_Form_ParticipantFeeSelection', 'formRule'], $this);
+  }
+
+  /**
+   * Get the discount ID.
+   *
+   * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpDocMissingThrowsInspection
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function getDiscountID(): ?int {
+    $discountID = (int) CRM_Core_BAO_Discount::findSet($this->getEventID(), 'civicrm_event');
+    return $discountID ?: NULL;
   }
 
   /**
@@ -388,6 +405,25 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     }
 
     CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+  }
+
+  /**
+   * Get the event ID.
+   *
+   * This function is supported for use outside of core.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  public function getEventID(): int {
+    if (!$this->_eventId) {
+      $this->_eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_participantId, 'event_id');
+    }
+    return $this->_eventId;
   }
 
 }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -297,8 +297,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         ));
         $this->assignPaymentProcessor($isPayLater);
       }
-      //init event fee.
-      self::initEventFee($this, $this->_eventId);
+
+      $discountId = $this->getDiscountID();
+      self::initEventFee($this, $this->_eventId, TRUE, $discountId);
 
       // get the profile ids
       $ufJoinParams = [
@@ -570,18 +571,15 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @param int $eventID
    * @param bool $doNotIncludeExpiredFields
    *   See CRM-16456.
+   * @param int|null $discountId
+   *   ID of any discount in use.
    *
    * @throws Exception
    */
-  public static function initEventFee(&$form, $eventID, $doNotIncludeExpiredFields = TRUE) {
+  public static function initEventFee(&$form, $eventID, $doNotIncludeExpiredFields = TRUE, $discountId = NULL) {
     // get price info
 
     // retrive all active price set fields.
-    $discountId = CRM_Core_BAO_Discount::findSet($eventID, 'civicrm_event');
-    if (property_exists($form, '_discountId') && $form->_discountId) {
-      $discountId = $form->_discountId;
-    }
-
     if ($discountId) {
       $priceSetId = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Discount', $discountId, 'price_set_id');
     }
@@ -892,7 +890,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $participantParams['custom'] = [];
     foreach ($form->_params as $paramName => $paramValue) {
       if (strpos($paramName, 'custom_') === 0) {
-        list($customFieldID, $customValueID) = CRM_Core_BAO_CustomField::getKeyID($paramName, TRUE);
+        [$customFieldID, $customValueID] = CRM_Core_BAO_CustomField::getKeyID($paramName, TRUE);
         CRM_Core_BAO_CustomField::formatCustomField($customFieldID, $participantParams['custom'], $paramValue, 'Participant', $customValueID);
 
       }
@@ -1715,6 +1713,23 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     return CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $this->getEventID(),
       FALSE, NULL, FALSE, TRUE
     );
+  }
+
+  /**
+   * Get the discount ID.
+   *
+   * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  protected function getDiscountID(): ?int {
+    $id = CRM_Core_BAO_Discount::findSet($this->getEventID(), 'civicrm_event');
+    return $id ?: NULL;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Extract `getDiscountID()`

Before
----------------------------------------
`CRM_Event_Form_Registration::initEventFee()` does some weird magic checking if the property discountId is configured on the form & using that, if the property exists. This is a pretty clear code smell that we should pass in the value rather than have the function find it on the form.

`CRM_Event_Form_Registration::initEventFee()`  is called from 3 places in universe : 


`CRM_Event_Form_ParticipantFeeSelection::buildQuickForm()` (non-static, called only from the form)
`CRM_Event_Form_Registration::preProcess()` (non-static, called only from the form)
`CRM_Event_Form_Participant::buildEventFeeForm()`

This last one was made static/public to be used in unit tests. There are no core tests that do this anymore but @mlutfy wrote a test `CRM_Taxcalculator_BackendEventWebinarTest` that calls it from an extension. That test would be as likely to work after as before but it follows a pattern we ditched in core tests.

The function only handles one form `CRM_Event_Form_Participant` - and this is the only form that would ever have the `$_discountId` property

![image](https://github.com/civicrm/civicrm-core/assets/336308/6c7bca89-0145-41df-948a-b7010870a4fd)



![image](https://github.com/civicrm/civicrm-core/assets/336308/c52cd9de-7d66-4e83-a777-60052cc7082e)


After
----------------------------------------
Each of the forms above
1) passes the discount ID into `CRM_Event_Form_Registration::initEventFee()`
2) implements a public function which is annotated with `@api` called `getDiscountID()` 
3) the function types the ID to an int, or to NULL

Technical Details
----------------------------------------
This is part of a general cleanup to stop passing the form into functions & then checking the form for a possible property. 

I'm also trying add consistent functions to retrieve ids from the various forms and to support those functions for extension users (where we can be confident the value would have a consistent meaning over time - even if we changed the internals of the function at some point).

Note I was actually trying to give getPriceSetID this treatment but discountID was in the way so I've done it first...

 In general I'm trying to make some consisent public functions available on forms for retrieving relevant entity IDs rather than the current property / form variable patchwork

Comments
----------------------------------------