### PR TITLE
Builds on #27049 to extract getPriceSetID()

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1428,7 +1428,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       //retrieve custom information
       $form->_values = [];
-      CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE, $form->getDiscountID());
+      CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE, $this->getPriceSetID());
       //if payment done, no need to build the fee block.
       if (!empty($form->_paymentId)) {
         //fix to display line item in update mode.

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1435,7 +1435,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $form->assign('priceSet', $form->_priceSet ?? NULL);
       }
       else {
-        CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->getDiscountID());
+        CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->getDiscountID(), $this->getPriceSetID());
       }
       $lineItem = [];
       $totalTaxAmount = 0;

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1429,6 +1429,23 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       //retrieve custom information
       $form->_values = [];
       CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE, $this->getPriceSetID());
+      if ($form->_context === 'standalone' || $form->_context === 'participant') {
+        $discountedEvent = CRM_Core_BAO_Discount::getOptionGroup($event['id'], 'civicrm_event');
+        if (is_array($discountedEvent)) {
+          foreach ($discountedEvent as $key => $discountedPriceSetID) {
+            $discountedPriceSet = CRM_Price_BAO_PriceSet::getSetDetail($discountedPriceSetID);
+            $discountedPriceSet = $discountedPriceSet[$discountedPriceSetID] ?? NULL;
+            $form->_values['discount'][$key] = $discountedPriceSet['fields'] ?? NULL;
+            $fieldID = key($form->_values['discount'][$key]);
+            // @todo  - this may be unused.
+            $form->_values['discount'][$key][$fieldID]['name'] = CRM_Core_DAO::getFieldValue(
+              'CRM_Price_DAO_PriceSet',
+              $discountedPriceSetID,
+              'title'
+            );
+          }
+        }
+      }
       //if payment done, no need to build the fee block.
       if (!empty($form->_paymentId)) {
         //fix to display line item in update mode.

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -172,7 +172,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $this->_values = [];
 
     CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE, $this->getPriceSetID());
-    CRM_Event_Form_Registration_Register::buildAmount($this, TRUE);
+    CRM_Event_Form_Registration_Register::buildAmount($this, TRUE, NULL, $this->getPriceSetID());
 
     if (!CRM_Utils_System::isNull($this->_values['line_items'] ?? NULL)) {
       $lineItem[] = $this->_values['line_items'];

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -124,7 +124,6 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     $params = ['id' => $this->_participantId];
 
     CRM_Event_BAO_Participant::getValues($params, $defaults, $ids);
-    $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $this->_eventId);
 
     $priceSetValues = CRM_Event_Form_EventFees::setDefaultPriceSet($this->_participantId, $this->_eventId, FALSE);
     $priceFieldId = (array_keys($this->_values['fee']));
@@ -172,7 +171,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     //retrieve custom information
     $this->_values = [];
 
-    CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE, $this->getDiscountID());
+    CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE, $this->getPriceSetID());
     CRM_Event_Form_Registration_Register::buildAmount($this, TRUE);
 
     if (!CRM_Utils_System::isNull($this->_values['line_items'] ?? NULL)) {
@@ -424,6 +423,32 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
       $this->_eventId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $this->_participantId, 'event_id');
     }
     return $this->_eventId;
+  }
+
+  /**
+   * Get the price set ID for the event.
+   *
+   * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  public function getPriceSetID(): ?int {
+    if ($this->getDiscountID()) {
+      $priceSetID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Discount', $this->getDiscountID(), 'price_set_id');
+    }
+    else {
+      $priceSetID = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $this->getEventID());
+    }
+    // Currently some extensions, eg. civi-discount, might look for this. Once we can be
+    // sure all financial forms have the api-supported function `getPriceSetID` we can
+    // add some noise to attempts to get it & move people over.
+    $this->set('priceSetId', $priceSetID);
+    return $priceSetID;
   }
 
 }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -585,24 +585,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     }
     self::initSet($form, $doNotIncludeExpiredFields, $priceSetId);
 
-    if (property_exists($form, '_context') && ($form->_context == 'standalone'
-        || $form->_context == 'participant')
-    ) {
-      $discountedEvent = CRM_Core_BAO_Discount::getOptionGroup($eventID, 'civicrm_event');
-      if (is_array($discountedEvent)) {
-        foreach ($discountedEvent as $key => $priceSetId) {
-          $priceSet = CRM_Price_BAO_PriceSet::getSetDetail($priceSetId);
-          $priceSet = $priceSet[$priceSetId] ?? NULL;
-          $form->_values['discount'][$key] = $priceSet['fields'] ?? NULL;
-          $fieldID = key($form->_values['discount'][$key]);
-          $form->_values['discount'][$key][$fieldID]['name'] = CRM_Core_DAO::getFieldValue(
-            'CRM_Price_DAO_PriceSet',
-            $priceSetId,
-            'title'
-          );
-        }
-      }
-    }
     $eventFee = $form->_values['fee'] ?? NULL;
     if (!is_array($eventFee) || empty($eventFee)) {
       $form->_values['fee'] = [];

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -179,7 +179,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     $button = substr($this->controller->getButtonName(), -4);
 
     if ($this->_values['event']['is_monetary']) {
-      CRM_Event_Form_Registration_Register::buildAmount($this);
+      CRM_Event_Form_Registration_Register::buildAmount($this, TRUE, NULL, $this->_priceSetId);
     }
 
     //Add pre and post profiles on the form.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -540,7 +540,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *   Form object.
    * @param bool $required
    *   True if you want to add formRule.
-   * @param null $discountId
+   * @param int|null $discountId
    *   Discount id for the event.
    * @param int|null $priceSetID
    *

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -423,7 +423,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // build amount only when needed, skip incase of event full and waitlisting is enabled
       // and few other conditions check preProcess()
       if (!$this->_noFees) {
-        self::buildAmount($this);
+        self::buildAmount($this, TRUE, NULL, $this->_priceSetId);
       }
       if (!$this->showPaymentOnConfirm) {
         CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
@@ -540,12 +540,13 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    *   Form object.
    * @param bool $required
    *   True if you want to add formRule.
-   * @param int $discountId
+   * @param null $discountId
    *   Discount id for the event.
+   * @param int|null $priceSetID
    *
    * @throws \CRM_Core_Exception
    */
-  public static function buildAmount(&$form, $required = TRUE, $discountId = NULL) {
+  public static function buildAmount(&$form, $required = TRUE, $discountId = NULL, $priceSetID = NULL) {
     $feeFields = $form->_values['fee'] ?? NULL;
 
     if (is_array($feeFields)) {
@@ -578,11 +579,12 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $className = CRM_Utils_System::getClassName($form);
 
     //build the priceset fields.
-    if (isset($form->_priceSetId) && $form->_priceSetId) {
+    if ($priceSetID) {
 
       //format price set fields across option full.
       self::formatFieldsForOptionFull($form);
-      $form->add('hidden', 'priceSetId', $form->_priceSetId);
+      // This is probably not required now - normally loaded from event ....
+      $form->add('hidden', 'priceSetId', $priceSetID);
 
       // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
       $adminFieldVisible = FALSE;
@@ -650,10 +652,11 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           }
         }
       }
-      $form->_priceSet['id'] = $form->_priceSet['id'] ?? $form->_priceSetId;
+      $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetID;
       $form->assign('priceSet', $form->_priceSet);
     }
     else {
+      // Is this reachable?
       $eventFeeBlockValues = $elements = $elementJS = [];
       foreach ($form->_feeBlock as $fee) {
         if (is_array($fee)) {


### PR DESCRIPTION
Builds on https://github.com/civicrm/civicrm-core/pull/27049 to extract `getPriceSetID()`


Before
----------------------------------------
`discountID` (newly) pass in to `CRM_Event_Form_Registration::initEventFee(` - but used only to get `priceSetID`

After
------------------------------------------
`$priceSetID` passed in

Note that the `getPriceSetID` function now handles setting the form property & form value, as used. So I removed that from the shared code. I didn't put it in the setting for `ParticipantFeeSelection` because it is currently interacting with an undefined property

Technical Details
-----------------------------------------

Per https://github.com/civicrm/civicrm-core/pull/27049 the only other usage is a unit test @mlutfy wrote