### PR TITLE
(REF) civicrm_data.tpl - Stop using Smarty's {php}

### DIFF
--- a/CRM/Core/Smarty/plugins/function.crmSqlData.php
+++ b/CRM/Core/Smarty/plugins/function.crmSqlData.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Evaluate a `*.sqldata.php` file.
+ *
+ * @param array $params
+ *   'file' => Glob expression pointing to 0+ files
+ *   'exclude' => Regex of files to exclude
+ * @param CRM_Core_Smarty $smarty
+ * @return string
+ *   The generated SQL
+ * @internal
+ */
+function smarty_function_crmSqlData($params, &$smarty) {
+  if ($smarty->security) {
+    throw new \CRM_Core_Exception("crmSqlData not allowed in secure mode");
+    // In theory, there's nothing actually wrong with running in secure more. We just don't need it.
+    // If that changes, then be sure to double-check that the file-name sanitization is good.
+  }
+
+  $civicrmDir = dirname(__DIR__, 4);
+  $files = glob($civicrmDir . DIRECTORY_SEPARATOR . $params['file']);
+  if (!empty($params['exclude'])) {
+    $files = preg_grep($params['exclude'], $files, PREG_GREP_INVERT);
+  }
+  foreach ($files as $file) {
+    if (!CRM_Utils_File::isChildPath($civicrmDir . DIRECTORY_SEPARATOR . 'sql', $file) || !str_ends_with($file, '.sqldata.php') ||!file_exists($file)) {
+      throw new \CRM_Core_Exception("Invalid sqldata file: $file");
+    }
+  }
+
+  $items = [];
+  $classes = [];
+  foreach ($files as $file) {
+    /** @var CRM_Core_CodeGen_AbstractSqlData $sqlData */
+    $sqlData = include $file;
+    $items[] = $sqlData;
+    $classes[get_class($sqlData)] = 1;
+  }
+
+  if (count($items) > 1) {
+    if (count($classes) > 1) {
+      throw new \CRM_Core_Exception("Can only batch-load sqldata files with same type. (Batch: " . $params['file'] . ')');
+    }
+    uasort($items, [array_keys($classes)[0], 'compare']);
+  }
+
+  $result = '';
+  foreach ($items as $item) {
+    $result .= $item->toSQL();
+  }
+  return $result;
+}

--- a/xml/templates/civicrm_data.tpl
+++ b/xml/templates/civicrm_data.tpl
@@ -43,62 +43,54 @@ VALUES
 INSERT INTO civicrm_domain (name, version, contact_id) VALUES (@domainName, '2.2', @contactID);
 SELECT @domainID := id FROM civicrm_domain where name = 'Default Domain Name';
 
-{php}echo (include "sql/civicrm_data/civicrm_location_type.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_relationship_type.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_tag.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_component.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_financial_type.sqldata.php")->toSQL();{/php}
-{php}
-  $optionGroups = include 'sql/civicrm_data/civicrm_option_group.php';
-  $laterGroups = ['encounter_medium', 'soft_credit_type', 'recent_items_providers'];
-  foreach ($optionGroups as $groupName => $group) {
-    if (!in_array($groupName, $laterGroups)) {
-      echo $group->toSQL();
-    }
-  }
-{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_location_type.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_relationship_type.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_tag.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_component.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_financial_type.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_option_group/*.sqldata.php" exclude=';(encounter_medium|soft_credit_type|recent_items_providers).sqldata.php$;'}
 
 -- CRM-6138
 {include file='languages.tpl'}
 
-{php}echo (include "sql/civicrm_data/civicrm_option_group/encounter_medium.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_option_group/encounter_medium.sqldata.php"}
 
-{php}echo (include "sql/civicrm_data/civicrm_membership_status.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_preferences_date.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_payment_processor_type.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_membership_status.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_preferences_date.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_payment_processor_type.sqldata.php"}
 
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/IndividualSupervised.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/OrganizationSupervised.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/HouseholdSupervised.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/IndividualUnsupervised.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/OrganizationUnsupervised.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/HouseholdUnsupervised.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_dedupe_rule/IndividualGeneral.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/IndividualSupervised.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/OrganizationSupervised.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/HouseholdSupervised.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/IndividualUnsupervised.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/OrganizationUnsupervised.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/HouseholdUnsupervised.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_dedupe_rule/IndividualGeneral.sqldata.php"}
 
-{php}echo (include "sql/civicrm_data/civicrm_county.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_county.sqldata.php"}
 
 -- Bounce classification patterns
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/AOL.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Away.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Dns.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Host.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Inactive.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Invalid.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Loop.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Quota.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Relay.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Spam.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_mailing_bounce_type/Syntax.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/AOL.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Away.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Dns.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Host.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Inactive.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Invalid.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Loop.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Quota.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Relay.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Spam.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_mailing_bounce_type/Syntax.sqldata.php"}
 
-{php}echo (include "sql/civicrm_data/civicrm_uf_group.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_uf_join.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_uf_field.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_participant_status_type.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_contact_type.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_uf_group.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_uf_join.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_uf_field.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_participant_status_type.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_contact_type.sqldata.php"}
 
 {include file='civicrm_msg_template.tpl'}
 
-{php}echo (include "sql/civicrm_data/civicrm_job.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_job.sqldata.php"}
 
 -- financial accounts
 SELECT @option_group_id_fat            := max(id) from civicrm_option_group where name = 'financial_account_type';
@@ -107,7 +99,7 @@ SELECT @opexp := value FROM civicrm_option_value WHERE name = 'Expenses' and opt
 SELECT @opAsset := value FROM civicrm_option_value WHERE name = 'Asset' and option_group_id = @option_group_id_fat;
 SELECT @opLiability := value FROM civicrm_option_value WHERE name = 'Liability' and option_group_id = @option_group_id_fat;
 SELECT @opCost := value FROM civicrm_option_value WHERE name = 'Cost of Sales' and option_group_id = @option_group_id_fat;
-{php}echo (include "sql/civicrm_data/civicrm_financial_account.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_financial_account.sqldata.php"}
 
 SELECT @option_group_id_arel           := max(id) from civicrm_option_group where name = 'account_relationship';
 SELECT @option_value_rel_id  := value FROM civicrm_option_value WHERE option_group_id = @option_group_id_arel AND name = 'Income Account is';
@@ -188,6 +180,6 @@ SELECT @fieldID := max(id) FROM civicrm_price_field WHERE name = 'contribution_a
 INSERT INTO `civicrm_price_field_value` (  `price_field_id`, `name`, `label`, `amount`, `weight`, `is_default`, `is_active`, `financial_type_id`)
 VALUES ( @fieldID, 'contribution_amount', 'Contribution Amount', '1', '1', '0', '1', 1);
 
-{php}echo (include "sql/civicrm_data/civicrm_extension.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_option_group/soft_credit_type.sqldata.php")->toSQL();{/php}
-{php}echo (include "sql/civicrm_data/civicrm_option_group/recent_items_providers.sqldata.php")->toSQL();{/php}
+{crmSqlData file="sql/civicrm_data/civicrm_extension.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_option_group/soft_credit_type.sqldata.php"}
+{crmSqlData file="sql/civicrm_data/civicrm_option_group/recent_items_providers.sqldata.php"}


### PR DESCRIPTION
Overview
----------------------------------------

Tweak the generation of install data (with an eye toward forward compatibility).

Before
----------------------------------------

Load data file with inline `{php}`

```smarty
{php}echo (include "sql/civicrm_data/civicrm_location_type.sqldata.php")->toSQL();{/php}
```

After
----------------------------------------

Load data file with `{crmSqlData}` helper

```smarty
{crmSqlData file="sql/civicrm_data/civicrm_relationship_type.sqldata.php"}
```

Comments
----------------------------------------

This is a pre-req to trying out newer Smarty versions.

To test, I used this approach:

```
./bin/setup.sh -g
cp sql/civicrm_data.mysql{,-orig}
./bin/setup.sh -g
diff -u sql/civicrm_data.mysql{-orig,}
```

The only changes were a few blank newlines.

Note that `{crmSqlData}` is more locked-down than `{php}` -- i.e. it only reads from the `sql/` folder, and it only reads `*.sqldata.php` files. Anything else is rejected.