### PR TITLE
Fix event fee help

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Fee.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.hlp
@@ -7,38 +7,24 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{htxt id="id-payment_processor-title"}
-  {ts}Payment Processor{/ts}
-{/htxt}
-{htxt id="id-payment_processor-text"}
+
+{htxt id="id-payment_processor"}
  {ts}If this is a paid event and you want users to be able to register and pay online, select a payment processor to use.{/ts}
 {ts}NOTE: Alternatively, you can enable the <strong>Pay Later</strong> feature below without setting up a payment processor. All users will then be asked to submit payment offline (e.g. mail in a check, call in a credit card, etc.).{/ts} {docURL page="user/contributions/payment-processors"}
 {/htxt}
 
-{htxt id="id-pay-later-text-title"}
-  {ts}Pay Later Label{/ts}
-{/htxt}
 {htxt id="id-pay-later-text"}
 {ts}Text displayed next to the checkbox for the 'pay later' option on the contribution form. You may include HTML formatting tags.{/ts}
 {/htxt}
 
-{htxt id="id-is_billing_required-title"}
-  {ts}Billing address required{/ts}
-{/htxt}
 {htxt id="id-is_billing_required"}
 {ts}Check this box to require users who select the pay later option to provide billing name and address.{/ts}
 {/htxt}
 
-{htxt id="id-is-discount-title"}
-  {ts}Discounts by Signup Date?{/ts}
-{/htxt}
-{htxt id="id-is-discount"}
+{htxt id="id-financial_type_id"}
  {ts}This financial type will be assigned to payments made by participants when they register online. If using a price set below note that the contribution record will have this financial type, however line items will be processed using the actual financial type selected for the price set item.{/ts}
 {/htxt}
 
-{htxt id="id-financial_type_id-title"}
-  {ts}Financial Type{/ts}
-{/htxt}
-{htxt id="id-financial_type_id"}
+{htxt id="id-is-discount"}
 {ts}Check this box if you want to offer discounted fees based on registration date (e.g. 'early-registration discounts').{/ts}
 {/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -42,7 +42,7 @@
         {if $paymentProcessor}
          <table id="paymentProcessor" class="form-layout">
              <tr class="crm-event-manage-fee-form-block-payment_processor">
-                <td class="label">{$form.payment_processor.label} {help id="id-payment_processor-text"}</td>
+                <td class="label">{$form.payment_processor.label} {help id="id-payment_processor"}</td>
               <td>{$form.payment_processor.html}</td>
              </tr>
          </table>


### PR DESCRIPTION
Overview
----------------------------------------
I managed to mix up two help texts in #26291. This fixes that regression so the right help texts come up. Also removed the now unneeded titles and fixed the missing title for Payment Processor.