### PR TITLE
Afform - Enable creating event from a template

### DIFF
--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -26,7 +26,7 @@ class AutocompleteFieldSubscriber extends AutoService implements EventSubscriber
    */
   public static function getSubscribedEvents() {
     return [
-      'civi.api.prepare' => ['onApiPrepare', -50],
+      'civi.api.prepare' => ['onApiPrepare', 150],
     ];
   }
 

--- a/Civi/Api4/Service/Autocomplete/EventAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/EventAutocompleteProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Autocomplete;
+
+use Civi\API\Events;
+use Civi\Core\Event\GenericHookEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service
+ * @internal
+ */
+class EventAutocompleteProvider extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api.prepare' => ['onApiPrepare', 140],
+      'civi.search.defaultDisplay' => ['alterDefaultDisplay', Events::W_LATE],
+    ];
+  }
+
+  /**
+   * Add is_template filter to event template autocompletes
+   * @param \Civi\API\Event\PrepareEvent $event
+   */
+  public function onApiPrepare(\Civi\API\Event\PrepareEvent $event): void {
+    $apiRequest = $event->getApiRequest();
+    if (is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
+      [$entityName, $fieldName] = array_pad(explode('.', (string) $apiRequest->getFieldName(), 2), 2, '');
+
+      if ($entityName === 'Event' && $fieldName === 'template_id') {
+        $apiRequest->addFilter('is_template', TRUE);
+      }
+    }
+  }
+
+  /**
+   * Alter default display of events based on the is_template filter.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function alterDefaultDisplay(GenericHookEvent $e) {
+    if ($e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Event') {
+      return;
+    }
+    $filters = $e->context['filters'] ?? [];
+    if (!empty($filters['is_template'])) {
+      $e->display['settings']['columns'][0]['key'] = 'template_title';
+    }
+  }
+
+}

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -129,7 +129,8 @@ class AfformAdminMeta {
       $idField = CoreUtil::getIdFieldName($entityName);
       $fields[$idField]['readonly'] = FALSE;
       $fields[$idField]['input_type'] = 'EntityRef';
-      $fields[$idField]['is_id'] = TRUE;
+      // Afform-only (so far) metadata tells the form to update an existing entity autofilled from this value
+      $fields[$idField]['input_attrs']['autofill'] = 'update';
       $fields[$idField]['fk_entity'] = $entityName;
       $fields[$idField]['label'] = E::ts('Existing %1', [1 => CoreUtil::getInfoItem($entityName, 'title')]);
       // Mix in alterations declared by afform entities

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -1,4 +1,4 @@
-<li ng-if="!$ctrl.fieldDefn.is_id">
+<li ng-if="!$ctrl.fieldDefn.input_attrs || !$ctrl.fieldDefn.input_attrs.autofill">
   <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Type:') }}</label>
     <select class="form-control" ng-model="getSet('input_type')" ng-model-options="{getterSetter: true}" title="{{:: ts('Field type') }}">
@@ -50,7 +50,7 @@
     {{:: ts('Required') }}
   </a>
 </li>
-<li ng-if="!$ctrl.fieldDefn.is_id">
+<li ng-if="!$ctrl.fieldDefn.input_attrs || !$ctrl.fieldDefn.input_attrs.autofill">
   <a href ng-click="toggleDefaultValue(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Pre-fill this field with a value') }}">
     <i class="crm-i fa-{{ $ctrl.hasDefaultValue ? 'check-' : '' }}square-o"></i>
     {{:: ts('Default value') }}

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -138,7 +138,7 @@ class AfformMetadataInjector {
     if ($inputType === 'Select' || $inputType === 'ChainSelect') {
       $fieldInfo['input_attrs']['placeholder'] = E::ts('Select');
     }
-    elseif ($inputType === 'EntityRef' && empty($field['is_id'])) {
+    elseif ($inputType === 'EntityRef' && empty($field['input_attrs']['placeholder'])) {
       $info = civicrm_api4('Entity', 'get', [
         'where' => [['name', '=', $fieldInfo['fk_entity']]],
         'checkPermissions' => FALSE,

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -123,9 +123,10 @@ class FormDataModel {
       return TRUE;
     }
 
-    // "Update" effectively means "read+save".
+    // "Get" is used for autofilling entities in "update" mode, but also for
+    // pre-populating fields from a template in "create" mode.
     if ($action === 'get') {
-      $action = 'update';
+      return TRUE;
     }
 
     $result = !empty($entityDefn['actions'][$action]);
@@ -237,8 +238,9 @@ class FormDataModel {
       $entityTitle = CoreUtil::getInfoItem($entityName, 'title');
       $field['input_type'] = 'EntityRef';
       $field['fk_entity'] = $entityName;
-      $field['is_id'] = TRUE;
       $field['label'] = E::ts('Existing %1', [1 => $entityTitle]);
+      // Afform-only (so far) metadata tells the form to update an existing entity autofilled from this value
+      $field['input_attrs']['autofill'] = 'update';
       $field['input_attrs']['placeholder'] = E::ts('Select %1', [1 => $entityTitle]);
     }
     // If this is an implicit join, get new field from fk entity

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -31,13 +31,6 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   protected $args = [];
 
   /**
-   * Used by prefill action to indicate if the entire form or just one entity is being filled.
-   * @var string
-   * @options form,entity
-   */
-  protected $fillMode = 'form';
-
-  /**
    * @var array
    */
   protected $_afform;
@@ -84,11 +77,12 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     foreach ($sortedEntities as $entityName) {
       $entity = $this->_formDataModel->getEntity($entityName);
       $this->_entityIds[$entityName] = [];
-      $idField = CoreUtil::getIdFieldName($entity['type']);
-      if (!empty($entity['actions']['update'])) {
+      $matchField = $this->matchField ?? CoreUtil::getIdFieldName($entity['type']);
+      $matchFieldDefn = $this->_formDataModel->getField($entity['type'], $matchField, 'create');
+      if (!empty($entity['actions'][$matchFieldDefn['input_attrs']['autofill']])) {
         if (
           !empty($this->args[$entityName]) &&
-          (!empty($entity['url-autofill']) || isset($entity['fields'][$idField]))
+          (!empty($entity['url-autofill']) || isset($entity['fields'][$matchField]))
         ) {
           $ids = (array) $this->args[$entityName];
           $this->loadEntity($entity, $ids);

--- a/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
@@ -2,14 +2,37 @@
 
 namespace Civi\Api4\Action\Afform;
 
+use Civi\Api4\Utils\CoreUtil;
+
 /**
  * Class Prefill
  * @package Civi\Api4\Action\Afform
  */
 class Prefill extends AbstractProcessor {
 
+  /**
+   * Name of the field being matched (typically 'id')
+   * @var string
+   */
+  protected $matchField;
+
   protected function processForm() {
-    return \CRM_Utils_Array::makeNonAssociative($this->_entityValues, 'name', 'values');
+    $entityValues = $this->_entityValues;
+    foreach ($entityValues as $afformEntityName => &$valueSets) {
+      $afformEntity = $this->_formDataModel->getEntity($afformEntityName);
+      if ($this->matchField) {
+        $matchFieldDefn = $this->_formDataModel->getField($afformEntity['type'], $this->matchField, 'create');
+        // When creating an entity based on an existing one e.g. Event.template_id
+        if (($matchFieldDefn['input_attrs']['autofill'] ?? NULL) === 'create') {
+          $idField = CoreUtil::getIdFieldName($afformEntity['type']);
+          foreach ($valueSets as &$valueSet) {
+            $valueSet['fields'][$this->matchField] = $valueSet['fields'][$idField];
+            unset($valueSet['fields'][$idField]);
+          }
+        }
+      }
+    }
+    return \CRM_Utils_Array::makeNonAssociative($entityValues, 'name', 'values');
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -30,7 +30,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
    */
   public static function getSubscribedEvents() {
     return [
-      'civi.api.prepare' => ['onApiPrepare', -20],
+      'civi.api.prepare' => ['onApiPrepare', 200],
     ];
   }
 

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -208,8 +208,8 @@
       };
 
       ctrl.isReadonly = function() {
-        if (ctrl.defn.is_id) {
-          return ctrl.afFieldset.getEntity().actions.update === false;
+        if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill) {
+          return ctrl.afFieldset.getEntity().actions[ctrl.defn.input_attrs.autofill] === false;
         }
         // TODO: Not actually used, but could be used if we wanted to render displayOnly
         // fields as more than just raw data. I think we probably ought to do so for entityRef fields
@@ -220,11 +220,11 @@
 
       // ngChange callback from Existing entity field
       ctrl.onSelectEntity = function() {
-        if (ctrl.defn.is_id) {
+        if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill) {
           var val = $scope.getSetSelect();
           var entity = ctrl.afFieldset.modelName;
           var index = ctrl.getEntityIndex();
-          ctrl.afFieldset.afFormCtrl.loadData(entity, index, val);
+          ctrl.afFieldset.afFormCtrl.loadData(entity, index, val, ctrl.defn.name);
         }
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -42,13 +42,13 @@
       };
       // With no arguments this will prefill the entire form based on url args
       // With selectedEntity, selectedIndex & selectedId provided this will prefill a single entity
-      this.loadData = function(selectedEntity, selectedIndex, selectedId) {
+      this.loadData = function(selectedEntity, selectedIndex, selectedId, selectedField) {
         var toLoad = 0,
           params = {name: ctrl.getFormMeta().name, args: {}};
         // Load single entity
         if (selectedEntity) {
-          toLoad = selectedId;
-          params.fillMode = 'entity';
+          toLoad = 1;
+          params.matchField = selectedField;
           params.args[selectedEntity] = {};
           params.args[selectedEntity][selectedIndex] = selectedId;
         }

--- a/ext/civi_event/Civi/Api4/Service/Spec/Provider/EventCreationSpecProvider.php
+++ b/ext/civi_event/Civi/Api4/Service/Spec/Provider/EventCreationSpecProvider.php
@@ -30,10 +30,13 @@ class EventCreationSpecProvider extends \Civi\Core\Service\AutoService implement
     $spec->getFieldByName('start_date')->setRequiredIf('empty($values.is_template)');
     $spec->getFieldByName('template_title')->setRequiredIf('!empty($values.is_template)');
 
-    $template_id = new FieldSpec('template_id', 'Event', 'Integer');
-    $template_id
-      ->setTitle('Template Id')
-      ->setDescription('Template on which to base this new event');
+    $template_id = (new FieldSpec('template_id', 'Event', 'Integer'))
+      ->setTitle(ts('Event Template'))
+      ->setDescription(ts('Template on which to base this new event'))
+      ->setInputType('EntityRef')
+      // Afform-only (so far) metadata tells the form this field is used to create a new entity rather than update
+      ->setInputAttr('autofill', 'create')
+      ->setFkEntity('Event');
     $spec->addFieldSpec($template_id);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Enables selecting an event template when using Afform to create a new event.

Before
----------------------------------------
No "Event Template" field available on Afform.

After
----------------------------------------
How to use this feature:
1. Make an Afform for Events
2. Drag required fields to the form (at minimum, Title, Start Date, Event Type)
3. Drag the "Event Template" field to the form
4. Give the form a url, save, and visit the form.
5. Select a template from the list, the rest of the form will be autofilled from the template.
6. Update other fields as desired and save.
7. The saved event will inherit all data from the event template.

Technical Details
----------------------------------------
This expands autofill functionality to work with create actions in addition to update.