### PR TITLE
dev/core#4488 Fix PCP validation error on Contribution Pages & Events

### DIFF
--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -391,7 +391,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
       $form->assign('profile', $profile);
     }
 
-    $form->add('select', 'supporter_profile_id', ts('Supporter Profile'), ['' => ts('- select -')] + $profile, TRUE, ['class' => 'crm-select2']);
+    $form->add('select', 'supporter_profile_id', ts('Supporter Profile'), ['' => ts('- select -')] + $profile, FALSE, ['class' => 'crm-select2']);
 
     //CRM-15821 - To add new option for PCP "Owner" notification
     $ownerNotifications = CRM_Core_OptionGroup::values('pcp_owner_notify');

--- a/CRM/PCP/Form/Contribute.php
+++ b/CRM/PCP/Form/Contribute.php
@@ -95,7 +95,7 @@ class CRM_PCP_Form_Contribute extends CRM_Contribute_Form_ContributionPage {
    */
   public static function formRule($params, $files, $self) {
     $errors = [];
-    if (!empty($params['is_active'])) {
+    if (!empty($params['pcp_active'])) {
 
       if (!empty($params['is_tellfriend_enabled']) &&
         (CRM_Utils_Array::value('tellfriend_limit', $params) <= 0)

--- a/CRM/PCP/Form/Event.php
+++ b/CRM/PCP/Form/Event.php
@@ -125,13 +125,19 @@ class CRM_PCP_Form_Event extends CRM_Event_Form_ManageEvent {
    */
   public static function formRule($params, $files, $self) {
     $errors = [];
-    if (!empty($params['is_active'])) {
+    if (!empty($params['pcp_active'])) {
 
-      if (!empty($params['is_tellfriend_enabled']) &&
-        (CRM_Utils_Array::value('tellfriend_limit', $params) <= 0)
-      ) {
-        $errors['tellfriend_limit'] = ts('if Tell Friend is enable, Maximum recipients limit should be greater than zero.');
+      if (!empty($params['is_tellfriend_enabled']) && ($params['is_tellfriend_enabled'] <= 0)) {
+        $errors['tellfriend_limit'] = ts('If Tell a Friend is enabled, maximum recipients limit should be greater than zero.');
       }
+
+      if (empty($params['target_entity_type'])) {
+        $errors['target_entity_type'] = ts('Campaign Type is a required field.');
+      }
+      elseif (($params['target_entity_type'] === 'contribute') && (empty($params['target_entity_id']))) {
+        $errors['target_entity_id'] = ts('Online Contribution Page is a required field.');
+      }
+
       if (empty($params['supporter_profile_id'])) {
         $errors['supporter_profile_id'] = ts('Supporter profile is a required field.');
       }

--- a/templates/CRM/PCP/Form/PCP.tpl
+++ b/templates/CRM/PCP/Form/PCP.tpl
@@ -45,7 +45,7 @@
         <td>{$form.notify_email.html} {help id="id-notify"}</td>
      </tr>
      <tr class="crm-contribution-contributionpage-pcp-form-block-supporter_profile_id">
-        <td class="label">{$form.supporter_profile_id.label}</td>
+        <td class="label">{$form.supporter_profile_id.label} <span class="crm-marker"> *</span></td>
         <td>{$form.supporter_profile_id.html} {help id="id-supporter_profile"}</td>
      </tr>
      <tr class="crm-contribution-contributionpage-pcp-form-block-owner_notify_id">


### PR DESCRIPTION
Overview
----------------------------------------
If you edited a Contribution Page or Event and saved on the PCP tab, you get a validation error even when PCPs were not enabled.

Before
----------------------------------------
Incorrect validation error. Validation not working as intended as well.

After
----------------------------------------
No more validation error. Validation works as intended.