### PR TITLE
Api4 - Remove unused key from getFields

### DIFF
--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -139,10 +139,6 @@ class DAOGetFieldsAction extends BasicGetFieldsAction {
       'data_type' => 'Integer',
     ];
     $fields[] = [
-      'name' => 'custom_group_id',
-      'data_type' => 'Integer',
-    ];
-    $fields[] = [
       'name' => 'sql_filters',
       'data_type' => 'Array',
       '@internal' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Removes the unused `custom_group_id` key from APIv4 getFields, which was never populated.

Before
----------------------------------------
APIv4 getFields includes `custom_group_id: null` for every field, even custom fields. Obviously it doesn't work so safe to remove.

After
----------------------------------------
Removed.

Comments
------------
It's not important enough for anyone to have noticed, we're better off without it.
Note that the name of the custom group *is* returned, which is more useful.