### PR TITLE
CiviContribute - Expand availability of Smarty tokens ($currency, $taxTerm)

### DIFF
--- a/CRM/Contribute/WorkflowMessage/ContributionInvoiceReceipt.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionInvoiceReceipt.php
@@ -23,16 +23,4 @@ class CRM_Contribute_WorkflowMessage_ContributionInvoiceReceipt extends GenericW
 
   public const WORKFLOW = 'contribution_invoice_receipt';
 
-  /**
-   * Specify any tokens that should be exported as smarty variables.
-   *
-   * @todo it might be that this should be moved to the trait as we
-   * we work through these.
-   *
-   * @param array $export
-   */
-  protected function exportExtraTokenContext(array &$export): void {
-    $export['smartyTokenAlias']['currency'] = 'contribution.currency';
-  }
-
 }

--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -219,4 +219,14 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
     $export['isShowTax'] = (bool) Civi::settings()->get('invoicing');
   }
 
+  /**
+   * Specify any tokens that should be exported as smarty variables.
+   *
+   * @param array $export
+   */
+  protected function exportExtraTokenContext(array &$export): void {
+    $export['smartyTokenAlias']['currency'] = 'contribution.currency';
+    $export['smartyTokenAlias']['taxTerm'] = 'domain.tax_term';
+  }
+
 }

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -112,6 +112,8 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
   protected function exportExtraTokenContext(array &$export): void {
     // Tax term is exposed at the generic level as so many templates use it
     // (e.g. Membership, participant, pledge as well as contributions).
+    // However, these basically now all implement the ContributionTrait so we
+    // can hopefully remove from here (after some checking).
     $export['smartyTokenAlias']['taxTerm'] = 'domain.tax_term';
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Do the todo (move the function to the trait as suggested

This makes the currency of the contribution available to the template for other templates - notably offline event receipts


Before
----------------------------------------
template variable `$currency` assigned to some templates based on the contribution, but not to all templates that use the trait

After
----------------------------------------
Assigned to all

Technical Details
----------------------------------------
`$currency` is used in formatting line items, which are assigned as an array of raw api values, even though is it not required for contribution token usages

Comments
----------------------------------------
