### PR TITLE
Remove line that gives error & does nothing

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2207,9 +2207,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
           $this->assign('taxTerm', $this->getSalesTaxTerm());
           $this->assign('dataArray', $dataArray);
         }
-        if (!empty($additionalParticipantDetails)) {
-          $params['amount_level'] = preg_replace('//', '', $params['amount_level']) . ' - ' . $this->_contributorDisplayName;
-        }
 
         $eventAmount[$num] = [
           'label' => preg_replace('//', '', $params['amount_level']),


### PR DESCRIPTION

Overview
----------------------------------------
Remove line that gives error & does nothing

I went back to 5.55 & did receipt testing and
1) this notice is there already back then
2) it results in a resolved value of 'Array - Display name 3) it does not appear anywhere in the final receipt


See https://lab.civicrm.org/dev/core/-/issues/4496#note_150006

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/05d2f90d-c777-4cca-b855-4342e665201e)

After
----------------------------------------
Lines removed as they don't do anything useful

Technical Details
----------------------------------------

Comments
----------------------------------------
