### PR TITLE
Remove never-true-if in backoffice event receipt

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -260,15 +260,6 @@
        {/if}
       {/if}
 
-      {if !empty($amount) && !$lineItem}
-       {foreach from=$amount item=amnt key=level}
-        <tr>
-         <td colspan="2" {$valueStyle}>
-          {$amnt.amount|crmMoney} {$amnt.label}
-         </td>
-        </tr>
-       {/foreach}
-      {/if}
       {if $totalTaxAmount}
        <tr>
         <td {$labelStyle}>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -134,11 +134,6 @@
 {/if}
 {/if}
 
-{if !empty($amount) && !$lineItem}
-{foreach from=$amount item=amnt key=level}{$amnt.amount|crmMoney} {$amnt.label}
-{/foreach}
-{/if}
-
 {if $totalTaxAmount}
 {ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------

`$amounts` would be assigned if there are multiple participants and the participant the receipt is being sent for is the primary

It is only USED if `$lineItem` is false - but it never is because we have (for a long time) expected `lineItem`

To test whether this conclusion is valid I went back to 5.55 and tested a pending registration with multiple participants and recorded the screen shots here

https://lab.civicrm.org/dev/core/-/issues/4496#note_150004

Before
----------------------------------------
`$amounts` is referenced in the receipts - but along with a never-true condition `!$lineItem`

After
----------------------------------------
Code removed, way cleared for a 'real' fix

Technical Details
----------------------------------------


There is much wrong with the receipt - but none of which is solved by fixing this value & removing it adds the way to improve & simplify

Comments
----------------------------------------
