### PR TITLE
dev/core#4494 Fix e-notice by removing unused variables

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1350,7 +1350,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     if (!empty($params['send_receipt'])) {
-      $result = $this->sendReceipts($params, $contributionParams['total_amount'], $customFields, $participants, $lineItem[0], $line, $value, $additionalParticipantDetails);
+      $result = $this->sendReceipts($params, $contributionParams['total_amount'], $customFields, $participants, $lineItem[0], $additionalParticipantDetails);
     }
 
     // set the participant id if it is not set
@@ -2106,14 +2106,12 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    * @param array $customFields
    * @param array $participants
    * @param $lineItem
-   * @param $line
-   * @param $value
    * @param $additionalParticipantDetails
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function sendReceipts($params, $total_amount, array $customFields, array $participants, $lineItem, $line, $value, $additionalParticipantDetails): array {
+  protected function sendReceipts($params, $total_amount, array $customFields, array $participants, $lineItem, $additionalParticipantDetails): array {
     $sent = [];
     $notSent = [];
     $this->assign('module', 'Event Registration');


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4494 Fix e-notice by removing unused variables

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/4494 these variables may not be defined and, it turns out, they are unused (`$value` is never used and `$line` is overwritten)

After
----------------------------------------
Removed from signature

Technical Details
----------------------------------------
Regression in 5.63

Comments
----------------------------------------
@demeritcowboy 