### PR TITLE
Move form-specific check to form

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -427,7 +427,11 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // will only work until that is done.
       // https://github.com/civicrm/civicrm-core/pull/19151
       $this->assign('moneyFormat', CRM_Utils_Money::format(1234.56));
-      self::buildAmount($this);
+      // build amount only when needed, skip incase of event full and waitlisting is enabled
+      // and few other conditions check preProcess()
+      if (!$this->_noFees) {
+        self::buildAmount($this);
+      }
       if (!$this->showPaymentOnConfirm) {
         CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
         $this->addPaymentProcessorFieldsToForm();
@@ -549,12 +553,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    * @throws \CRM_Core_Exception
    */
   public static function buildAmount(&$form, $required = TRUE, $discountId = NULL) {
-    // build amount only when needed, skip incase of event full and waitlisting is enabled
-    // and few other conditions check preProcess()
-    if (property_exists($form, '_noFees') && $form->_noFees) {
-      return;
-    }
-
     //if payment done, no need to build the fee block.
     if (!empty($form->_paymentId)) {
       //fix to display line item in update mode.


### PR DESCRIPTION
Overview
----------------------------------------
Move form-specific check to form

Before
----------------------------------------
`CRM_Event_Form_Registration_Register::buildAmount(`

is called from 

`CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form` 
`CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment`
`CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_Registration`
`CRM_Event_Form_Registration_Register`

is early returns if `$_noFees` exists as a property and is truthy

- which is only every true for `CRM_Event_Form_Registration_Register`

![image](https://github.com/civicrm/civicrm-core/assets/336308/5a652d6e-0606-4e08-b6c4-38e67af02ee9)


![image](https://github.com/civicrm/civicrm-core/assets/336308/d3aaf758-7be5-469f-87a1-832297d9bae2)

After
----------------------------------------
The check is moved from the shared function to the form function

Technical Details
----------------------------------------


Comments
----------------------------------------
