### PR TITLE
Move form specific code to relevant form (rather than access mostly-undeclared property)

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1429,7 +1429,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       //retrieve custom information
       $form->_values = [];
       CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE, $form->getDiscountID());
-      CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->getDiscountID());
+      //if payment done, no need to build the fee block.
+      if (!empty($form->_paymentId)) {
+        //fix to display line item in update mode.
+        $form->assign('priceSet', $form->_priceSet ?? NULL);
+      }
+      else {
+        CRM_Event_Form_Registration_Register::buildAmount($form, TRUE, $form->getDiscountID());
+      }
       $lineItem = [];
       $totalTaxAmount = 0;
       if (!CRM_Utils_System::isNull($form->_values['line_items'] ?? NULL)) {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -546,13 +546,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
    * @throws \CRM_Core_Exception
    */
   public static function buildAmount(&$form, $required = TRUE, $discountId = NULL) {
-    //if payment done, no need to build the fee block.
-    if (!empty($form->_paymentId)) {
-      //fix to display line item in update mode.
-      $form->assign('priceSet', $form->_priceSet ?? NULL);
-      return;
-    }
-
     $feeFields = $form->_values['fee'] ?? NULL;
 
     if (is_array($feeFields)) {


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/27068 & moves the check form `paymentId` which is only used on `CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment` to that form

Before
----------------------------------------
`CRM_Event_Form_Registration_Register::buildAmount()` does an early return if `_paymentId` is not empty. That is only possible from one form - Participant form - so it makes more sense for that form to check & not call `buildAmount` in 'do nothing mode'

![image](https://github.com/civicrm/civicrm-core/assets/336308/0c526fdd-d131-4c04-9522-edb7e86a6110)


After
----------------------------------------
Shared funciton not called where it would early return

Technical Details
----------------------------------------

Comments
----------------------------------------
