### PR TITLE
Remove use of sometimes-php8-warning causing `_quickConfig` property…(use `isQuickConfig()` function)

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -35,13 +35,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   protected $_requireApprovalMsg;
 
   /**
-   * Deprecated parameter that we hope to remove.
-   *
-   * @var bool
-   */
-  public $_quickConfig;
-
-  /**
    * Skip duplicate check.
    *
    * This can be set using hook_civicrm_buildForm() to override the registration dupe check.
@@ -596,10 +589,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
       //format price set fields across option full.
       self::formatFieldsForOptionFull($form);
-
-      if (!empty($form->_priceSet['is_quick_config'])) {
-        $form->_quickConfig = $form->_priceSet['is_quick_config'];
-      }
       $form->add('hidden', 'priceSetId', $form->_priceSetId);
 
       // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -814,12 +814,7 @@ WHERE  id = %1";
     $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
     $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
     $validPriceFieldIds = array_keys($form->_priceSet['fields']);
-    $form->_quickConfig = $quickConfig = 0;
-    if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config')) {
-      $quickConfig = 1;
-    }
-
-    $form->assign('quickConfig', $quickConfig);
+    $form->assign('quickConfig', (int) CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config'));
 
     // Mark which field should have the auto-renew checkbox, if any. CRM-18305
     if (!empty($form->_membershipTypeValues) && is_array($form->_membershipTypeValues)) {

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -598,8 +598,7 @@ London,',
    */
   public function testSubmitPendingAddPayment(bool $isQuickConfig): void {
     $mailUtil = new CiviMailUtils($this, TRUE);
-    $form = $this->getForm(['is_monetary' => 1, 'start_date' => '2023-02-15 15:00', 'end_date' => '2023-02-15 18:00']);
-    $this->callAPISuccess('PriceSet', 'create', ['is_quick_config' => $isQuickConfig, 'id' => $this->getPriceSetID('PaidEvent')]);
+    $form = $this->getForm(['is_monetary' => 1, 'start_date' => '2023-02-15 15:00', 'end_date' => '2023-02-15 18:00'], [], $isQuickConfig);
     $paymentInstrumentID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check');
     $form->postProcess();
     $this->callAPISuccess('Payment', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Remove use of sometimes-php8-warning causing `_quickConfig` property…(use `isQuickConfig()` function)

Before
----------------------------------------
This property is used on a single form, others implement a (public) method `isQuickConfig()`

The property is not accessed outside of core

![image](https://github.com/civicrm/civicrm-core/assets/336308/2b83f0f7-1433-446e-9e99-79c0d37dfd38)


After
----------------------------------------
 `isQuickConfig()`

Technical Details
----------------------------------------
May fail until https://github.com/civicrm/civicrm-core/pull/27067 is merged

This also adds 2 the supporting `getPriceSetID()` function and `getDiscountID()` which is added in open PRs https://github.com/civicrm/civicrm-core/pull/27049 & https://github.com/civicrm/civicrm-core/pull/27050 & will otherwise cause conflicts if merged out of order

Comments
----------------------------------------
