### PR TITLE
dev/core#4498 Ensure that users without administer civicrm permission…

### DIFF
--- a/Civi/Api4/EntitySet.php
+++ b/Civi/Api4/EntitySet.php
@@ -48,7 +48,9 @@ class EntitySet extends Generic\AbstractEntity {
   }
 
   public static function permissions() {
-    return [];
+    return [
+      'get' => [],
+    ];
   }
 
   /**


### PR DESCRIPTION
… can use the Mailing Autocomplete

Overview
----------------------------------------
This fixes a problem where the mailing recipients autocomplete does an EntitySet.get apiv4 call and that requires administer civicrm because the permissions function doesn't correctly modify the get parameter

Before
----------------------------------------
Non Admins cannot use the CiviMail Recipients lookup

After
----------------------------------------
Non Admins can use the CiviMail Recipients look up

ping @MegaphoneJon @colemanw 