### PR TITLE
Concurrency Tests - Update ExternalBatch for symfony/process v4.1+ (esp Drupal 10)

### DIFF
--- a/Civi/API/ExternalBatch.php
+++ b/Civi/API/ExternalBatch.php
@@ -217,7 +217,7 @@ class ExternalBatch {
     $env = array_merge($this->env, [
       'CIVICRM_SETTINGS' => $this->settingsPath,
     ]);
-    return new Process($command, $this->root, $env);
+    return Process::fromShellCommandline($command, $this->root, $env);
   }
 
   /**


### PR DESCRIPTION
Before
------

`api_v3_JobProcessMailingTest::testConcurrency()` and `Civi\FlexMailer\ConcurrencyTest` fail when executed on Drupal 10. The errors look like:

```
7) Civi\FlexMailer\ConcurrentDeliveryTest::testConcurrency with data set #6 (array(2, 10, 1, 5, 6), array(3, 1, 1), 20)
TypeError: Symfony\Component\Process\Process::__construct(): Argument #1 ($command) must be of type array, string given, called in /home/totten/bknix/build/d10/vendor/civicrm/civicrm-core/Civi/API/ExternalBatch.php on line 220

/home/totten/bknix/build/d10/vendor/symfony/process/Process.php:143
/home/totten/bknix/build/d10/vendor/civicrm/civicrm-core/Civi/API/ExternalBatch.php:220
/home/totten/bknix/build/d10/vendor/civicrm/civicrm-core/Civi/API/ExternalBatch.php:97
/home/totten/bknix/build/d10/vendor/civicrm/civicrm-core/tests/phpunit/api/v3/JobProcessMailingTest.php:464
/home/totten/bknix/build/d10/vendor/civicrm/civicrm-core/ext/flexmailer/tests/phpunit/Civi/FlexMailer/ConcurrentDeliveryTest.php:56
/home/totten/bknix/build/d10/vendor/civicrm/civicrm-core/tests/phpunit/CiviTest/CiviUnitTestCase.php:237
/home/totten/bknix/extern/phpunit8/phpunit8.phar:1721
```

After
-----

These tests pass in the same environment.

Technical Details
-----------------

`symfony/process` v4.1 deprecated the usage of `new Process(string)` and added `Process::fromShellCommandline(string)`. The `new Process(string)` was dropped from v5.x and v6.x. So you get an unconditional failure on D10. (On other platforms, it can also fail... depending on how you deal with deprecations.)

In `civicrm-core:composer.json`, the minimum version of `symfony/process` is `4.4`. So that means we can use the newer `Process::fromShellCommandline(string)`.
