### PR TITLE
fix PHP8 fatal error

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1304,7 +1304,7 @@ WHERE civicrm_event.is_active = 1
       $profileIds = $id;
     }
 
-    $val = $groupTitles = NULL;
+    $val = $groupTitles = [];
     foreach ($profileIds as $gid) {
       if (CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid)) {
         $values = [];


### PR DESCRIPTION
Overview
----------------------------------------
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in CRM_Event_BAO_Event::buildCustomDisplay() (line 1443 of /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Event/BAO/Event.php).