### PR TITLE
Fix #4467 - Import caching issue

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -67,6 +67,11 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $this->assign('highlightedFields', $this->getHighlightedFields());
     $this->assign('dataValues', array_values($this->getDataRows([], 2)));
     $this->_mapperFields = $this->getAvailableFields();
+    $fieldMappings = $this->getFieldMappings();
+    // Check if the import file headers match the selected import mappings, throw an error if it doesn't.
+    if (empty($_POST) && count($fieldMappings) > 0 && count($this->getColumnHeaders()) !== count($fieldMappings)) {
+      CRM_Core_Session::singleton()->setStatus(ts('The data columns in this import file appear to be different from the saved mapping. Please verify that you have selected the correct saved mapping before continuing.'));
+    }
     asort($this->_mapperFields);
     parent::preProcess();
   }
@@ -228,7 +233,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       // Eventually we hope to phase out the use of the civicrm_mapping data &
       // just use UserJob and Import Templates (UserJob records with 'is_template' = 1
       $mappedFieldData = $this->userJob['metadata']['import_mappings'][$columnNumber];
-      $mappedField = array_intersect_key(array_fill_keys(['name', 'column_number', 'entity_data'], TRUE), $mappedFieldData);
+      $mappedField = array_intersect_key($mappedFieldData, array_fill_keys(['name', 'column_number', 'entity_data'], TRUE));
       $mappedField['mapping_id'] = $mappingID;
     }
     else {
@@ -296,9 +301,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
         ->execute()
         ->indexBy('column_number');
 
-      if ((count($this->getColumnHeaders()) !== count($fieldMappings))) {
-        CRM_Core_Session::singleton()->setStatus(ts('The data columns in this import file appear to be different from the saved mapping. Please verify that you have selected the correct saved mapping before continuing.'));
-      }
       return (array) $fieldMappings;
     }
     return [];


### PR DESCRIPTION
Overview
----------------------------------------
This PR aims to fix issue [4467](https://lab.civicrm.org/dev/core/-/issues/4467) reported by @eileenmcnaughton and @larssandergreen.

Before
----------------------------------------
Here's an example of the saved mapping before the PR: https://etherpad.wikimedia.org/p/import-map-weirdness, the array doubles in size + any additional field anytime an update is made to the mapping. Due to this data inconsistency, the status would always be set whenever the map is updated and the MapField page is loaded.

After
----------------------------------------
Here's an example of the saved mapping after the PR: https://etherpad.wikimedia.org/p/import-map-fix, the array is only updated with new values that does not already exist in the mapping. The Status text is only set in the MapField page before the update. The Status text only shows in the preview page if the mapping isn't updated with the new values.

Technical Details
----------------------------------------
The bug seemed to be caused by an incorrect use of the `array_intersect_key` php method. This led to the creation of new fields whenever an update is made to the mapping, causing the data to be inconsistent.

Rearranging the parameters of the method fixes this, here's an example: https://etherpad.wikimedia.org/p/import-map-weirdness. The fields with value '1' or 1 are being set because instead of the actual values, the method is setting the fields to `true`. Can be tested with the test instruction from the [issue](https://lab.civicrm.org/dev/core/-/issues/4467).

Also, this patch removes the status set from within the `getFieldMappings` to ensure that the conditional is only checked on initial load of the `MapField` and `Preview` pages, not everytime the method is called.

Comments
----------------------------------------
This method `CRM_Core_Session::singleton()->getStatus(true);` was used to reset the status, is there a recommended approach to achieve the same result?