### PR TITLE
dev/core#2644 Add Scheduled Communications extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 !/ext/civi_member
 !/ext/civi_pledge
 !/ext/civi_report
+!/ext/scheduled_communications
 backdrop/
 bower_components
 CRM/Case/xml/configuration

--- a/CRM/Activity/ActionMapping.php
+++ b/CRM/Activity/ActionMapping.php
@@ -108,7 +108,7 @@ class CRM_Activity_ActionMapping extends \Civi\ActionSchedule\MappingBase {
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("{$this->getEntityTable()} e")->param($defaultParams);
+    $query = \CRM_Utils_SQL_Select::from("civicrm_activity e")->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_activity e';
     $query['casContactIdField'] = 'r.contact_id';
     $query['casEntityIdField'] = 'e.id';

--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -37,7 +37,7 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
    * @inheritDoc
    */
   public function alterActionScheduleQuery(MailingQueryEvent $e): void {
-    if ($e->mapping->getEntityTable() !== $this->getExtendableTableName()) {
+    if ($e->mapping->getEntityTable($e->actionSchedule) !== $this->getExtendableTableName()) {
       return;
     }
 

--- a/CRM/Contact/ActionMapping.php
+++ b/CRM/Contact/ActionMapping.php
@@ -95,14 +95,14 @@ class CRM_Contact_ActionMapping extends \Civi\ActionSchedule\MappingBase {
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    // FIXME: This assumes that $values only has one field, but UI shows multiselect.
-    // Properly supporting multiselect would require total rewrite of this function.
+    // Only one value is allowed for this mapping type.
+    // The form and API both enforce this, so this error should never happen.
     if (count($selectedValues) != 1 || !isset($selectedValues[0])) {
       throw new \CRM_Core_Exception("Error: Scheduled reminders may only have one contact field.");
     }
     elseif (in_array($selectedValues[0], $this->contactDateFields)) {
       $dateDBField = $selectedValues[0];
-      $query = \CRM_Utils_SQL_Select::from("{$this->getEntityTable()} e")->param($defaultParams);
+      $query = \CRM_Utils_SQL_Select::from('civicrm_contact e')->param($defaultParams);
       $query->param([
         'casAddlCheckFrom' => 'civicrm_contact e',
         'casContactIdField' => 'e.id',

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -540,7 +540,7 @@ FROM civicrm_action_schedule cas
   protected static function createMailingActivity($tokenRow, $mapping, $contactID, $entityID, $caseID) {
     $session = CRM_Core_Session::singleton();
 
-    if ($mapping->getEntityTable() == 'civicrm_membership') {
+    if ($mapping->getEntityName() === 'Membership') {
       // @todo - not required with api
       $activityTypeID
         = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Membership Renewal Reminder');
@@ -585,7 +585,7 @@ FROM civicrm_action_schedule cas
         'casActionScheduleId' => $actionSchedule->id,
         'casMailingJoinType' => ($actionSchedule->limit_to == 2) ? 'LEFT JOIN' : 'INNER JOIN',
         'casMappingId' => $mapping->getId(),
-        'casMappingEntity' => $mapping->getEntityTable(),
+        'casMappingEntity' => $mapping->getEntityTable($actionSchedule),
         'casEntityJoinExpr' => 'e.id = IF(reminder.entity_table = "civicrm_contact", reminder.contact_id, reminder.entity_id)',
       ]);
 

--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -16,6 +16,7 @@
  */
 
 use Civi\ActionSchedule\Event\MappingRegisterEvent;
+use Civi\ActionSchedule\MappingBase;
 use Civi\Core\HookInterface;
 
 /**
@@ -86,10 +87,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    */
   public static function getEntityValueOptions(string $fieldName, array $params): array {
     $values = self::fillValues($params['values'], ['mapping_id']);
-    if (!$values['mapping_id']) {
-      return [];
-    }
-    return self::getMapping($values['mapping_id'])->getValueLabels();
+    $mapping = self::getMapping($values['mapping_id']);
+    return $mapping ? $mapping->getValueLabels() : [];
   }
 
   /**
@@ -98,10 +97,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    */
   public static function getLimitToOptions(string $fieldName, array $params): ?array {
     $values = self::fillValues($params['values'], ['mapping_id']);
-    if (!$values['mapping_id']) {
-      return Civi\ActionSchedule\MappingBase::getLimitToOptions();
-    }
-    return self::getMapping($values['mapping_id'])::getLimitToOptions();
+    $mapping = self::getMapping($values['mapping_id']);
+    return $mapping ? $mapping::getLimitToOptions() : MappingBase::getLimitToOptions();
   }
 
   /**
@@ -110,10 +107,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    */
   public static function getRecipientOptions(string $fieldName, array $params): ?array {
     $values = self::fillValues($params['values'], ['mapping_id']);
-    if (!$values['mapping_id']) {
-      return Civi\ActionSchedule\MappingBase::getRecipientTypes();
-    }
-    return self::getMapping($values['mapping_id'])::getRecipientTypes();
+    $mapping = self::getMapping($values['mapping_id']);
+    return $mapping ? $mapping::getRecipientTypes() : MappingBase::getRecipientTypes();
   }
 
   /**
@@ -122,10 +117,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    */
   public static function getRecipientListingOptions(string $fieldName, array $params): ?array {
     $values = self::fillValues($params['values'], ['mapping_id', 'recipient']);
-    if (!$values['mapping_id']) {
-      return [];
-    }
-    return self::getMapping($values['mapping_id'])->getRecipientListing($values['recipient']);
+    $mapping = self::getMapping($values['mapping_id']);
+    return $mapping ? $mapping->getRecipientListing($values['recipient']) : [];
   }
 
   /**
@@ -134,10 +127,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    */
   public static function getEntityStatusOptions(string $fieldName, array $params): array {
     $values = self::fillValues($params['values'], ['mapping_id', 'entity_value']);
-    if (!$values['mapping_id']) {
-      return [];
-    }
-    return self::getMapping($values['mapping_id'])->getStatusLabels($values['entity_value']);
+    $mapping = self::getMapping($values['mapping_id']);
+    return $mapping ? $mapping->getStatusLabels($values['entity_value']) : [];
   }
 
   /**
@@ -146,10 +137,8 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    */
   public static function getActionDateOptions(string $fieldName, array $params): array {
     $values = self::fillValues($params['values'], ['mapping_id', 'entity_value']);
-    if (!$values['mapping_id']) {
-      return [];
-    }
-    return self::getMapping($values['mapping_id'])->getDateFields($values['entity_value']);
+    $mapping = self::getMapping($values['mapping_id']);
+    return $mapping ? $mapping->getDateFields($values['entity_value']) : [];
   }
 
   /**

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -350,8 +350,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   public function checkActive(TokenProcessor $processor) {
     return ((!empty($processor->context['actionMapping'])
         // This makes the 'schema context compulsory - which feels accidental
-        // since recent discu
-      && $processor->context['actionMapping']->getEntityTable()) || in_array($this->getEntityIDField(), $processor->context['schema'])) && in_array($this->getApiEntityName(), array_keys(\Civi::service('action_object_provider')->getEntities()));
+      && $processor->context['actionMapping']->getEntityName()) || in_array($this->getEntityIDField(), $processor->context['schema'])) && in_array($this->getApiEntityName(), array_keys(\Civi::service('action_object_provider')->getEntities()));
   }
 
   /**
@@ -360,7 +359,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @param \Civi\ActionSchedule\Event\MailingQueryEvent $e
    */
   public function alterActionScheduleQuery(MailingQueryEvent $e): void {
-    if ($e->mapping->getEntityTable() !== $this->getExtendableTableName()) {
+    if ($e->mapping->getEntityTable($e->actionSchedule) !== $this->getExtendableTableName()) {
       return;
     }
     $e->query->select('e.id AS tokenContext_' . $this->getEntityIDField());

--- a/CRM/Event/ActionMapping.php
+++ b/CRM/Event/ActionMapping.php
@@ -138,7 +138,7 @@ abstract class CRM_Event_ActionMapping extends \Civi\ActionSchedule\MappingBase 
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("{$this->getEntityTable()} e")->param($defaultParams);
+    $query = \CRM_Utils_SQL_Select::from('civicrm_participant e')->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_event r';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';

--- a/CRM/Event/ParticipantTokens.php
+++ b/CRM/Event/ParticipantTokens.php
@@ -54,7 +54,7 @@ class CRM_Event_ParticipantTokens extends CRM_Core_EntityTokens {
   public function alterActionScheduleQuery(\Civi\ActionSchedule\Event\MailingQueryEvent $e): void {
     // When targeting `civicrm_participant` records, we enable both `{participant.*}` (per usual) and the related `{event.*}`.
     parent::alterActionScheduleQuery($e);
-    if ($e->mapping->getEntityTable() === $this->getExtendableTableName()) {
+    if ($e->mapping->getEntityTable($e->actionSchedule) === $this->getExtendableTableName()) {
       $e->query->select('e.event_id AS tokenContext_eventId');
     }
   }

--- a/CRM/Member/ActionMapping.php
+++ b/CRM/Member/ActionMapping.php
@@ -80,7 +80,7 @@ class CRM_Member_ActionMapping extends \Civi\ActionSchedule\MappingBase {
     $selectedValues = (array) \CRM_Utils_Array::explodePadded($schedule->entity_value);
     $selectedStatuses = (array) \CRM_Utils_Array::explodePadded($schedule->entity_status);
 
-    $query = \CRM_Utils_SQL_Select::from("{$this->getEntityTable()} e")->param($defaultParams);
+    $query = \CRM_Utils_SQL_Select::from('civicrm_membership e')->param($defaultParams);
     $query['casAddlCheckFrom'] = 'civicrm_membership e';
     $query['casContactIdField'] = 'e.contact_id';
     $query['casEntityIdField'] = 'e.id';

--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -647,4 +647,11 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
       $freeDAO, $i18nRewrite, $trapException);
   }
 
+  /**
+   * @return string
+   */
+  public function getFrom(): string {
+    return $this->from;
+  }
+
 }

--- a/Civi/ActionSchedule/MappingBase.php
+++ b/Civi/ActionSchedule/MappingBase.php
@@ -41,7 +41,7 @@ abstract class MappingBase extends AutoSubscriber implements MappingInterface {
     $registrations->register(new static());
   }
 
-  public function getEntityTable(): string {
+  public function getEntityTable(\CRM_Core_DAO_ActionSchedule $actionSchedule): string {
     return \CRM_Core_DAO_AllCoreTables::getTableForEntityName($this->getEntityName());
   }
 
@@ -52,7 +52,7 @@ abstract class MappingBase extends AutoSubscriber implements MappingInterface {
    */
   public function getEntity(): string {
     \CRM_Core_Error::deprecatedFunctionWarning('getEntityTable');
-    return $this->getEntityTable();
+    return \CRM_Core_DAO_AllCoreTables::getTableForEntityName($this->getEntityName());
   }
 
   public function getLabel(): string {

--- a/Civi/ActionSchedule/MappingInterface.php
+++ b/Civi/ActionSchedule/MappingInterface.php
@@ -38,9 +38,10 @@ interface MappingInterface extends SpecProviderInterface {
 
   /**
    * Name of the table belonging to the main entity e.g. `civicrm_activity`
+   * @param \CRM_Core_DAO_ActionSchedule $actionSchedule
    * @return string
    */
-  public function getEntityTable(): string;
+  public function getEntityTable(\CRM_Core_DAO_ActionSchedule $actionSchedule): string;
 
   /**
    * Main entity name e.g. `Activity`

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -190,9 +190,9 @@ class RecipientBuilder {
       ->merge($this->prepareAddlFilter('c.id'))
       ->where("c.id NOT IN (
              SELECT rem.contact_id
-             FROM civicrm_action_log rem INNER JOIN {$this->mapping->getEntityTable()} e ON rem.entity_id = e.id
+             FROM civicrm_action_log rem INNER JOIN {$this->getMappingTable()} e ON rem.entity_id = e.id
              WHERE rem.action_schedule_id = {$this->actionSchedule->id}
-             AND rem.entity_table = '{$this->mapping->getEntityTable()}'
+             AND rem.entity_table = '{$this->getMappingTable()}'
              )")
       // Where does e.id come from here? ^^^
       ->groupBy("c.id")
@@ -276,7 +276,7 @@ class RecipientBuilder {
     $defaultParams = [
       'casActionScheduleId' => $this->actionSchedule->id,
       'casMappingId' => $this->mapping->getId(),
-      'casMappingEntity' => $this->mapping->getEntityTable(),
+      'casMappingEntity' => $this->getMappingTable(),
       'casNow' => $this->now,
     ];
 
@@ -402,7 +402,7 @@ class RecipientBuilder {
       $date = $operator . "(!casDateField, INTERVAL {$actionSchedule->start_action_offset} {$actionSchedule->start_action_unit})";
       $startDateClauses[] = "'!casNow' >= {$date}";
       // This is weird. Waddupwidat?
-      if ($this->mapping->getEntityTable() == 'civicrm_participant') {
+      if ($this->getMappingTable() == 'civicrm_participant') {
         $startDateClauses[] = $operator . "(!casNow, INTERVAL 1 DAY ) {$op} " . '!casDateField';
       }
       else {
@@ -566,7 +566,7 @@ WHERE      $group.id = {$groupId}
     switch ($for) {
       case 'rel':
         $contactIdField = $query['casContactIdField'];
-        $entityName = $this->mapping->getEntityTable();
+        $entityName = $this->getMappingTable();
         $entityIdField = $query['casEntityIdField'];
         break;
 
@@ -606,6 +606,10 @@ reminder.action_schedule_id = {$this->actionSchedule->id}";
    */
   protected function resetOnTriggerDateChange() {
     return $this->mapping->resetOnTriggerDateChange($this->actionSchedule);
+  }
+
+  protected function getMappingTable(): string {
+    return $this->mapping->getEntityTable($this->actionSchedule);
   }
 
 }

--- a/Civi/Api4/Query/Api4EntitySetQuery.php
+++ b/Civi/Api4/Query/Api4EntitySetQuery.php
@@ -119,7 +119,7 @@ class Api4EntitySetQuery extends Api4Query {
       $expr = SqlExpression::convert($item, TRUE);
       $alias = $expr->getAlias();
       $this->selectAliases[$alias] = $expr->getExpr();
-      $this->query->select($expr->render($this) . " AS `$alias`");
+      $this->query->select($expr->render($this, TRUE));
     }
   }
 

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -198,7 +198,7 @@ class Api4SelectQuery extends Api4Query {
           throw new \CRM_Core_Exception('Cannot use existing field name as alias');
         }
         $this->selectAliases[$alias] = $expr->getExpr();
-        $this->query->select($expr->render($this) . " AS `$alias`");
+        $this->query->select($expr->render($this, TRUE));
       }
     }
   }

--- a/Civi/Api4/Query/SqlBool.php
+++ b/Civi/Api4/Query/SqlBool.php
@@ -21,8 +21,8 @@ class SqlBool extends SqlExpression {
   protected function initialize() {
   }
 
-  public function render(Api4Query $query): string {
-    return $this->expr === 'TRUE' ? '1' : '0';
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
+    return ($this->expr === 'TRUE' ? '1' : '0') . ($includeAlias ? " AS `{$this->getAlias()}`" : '');
   }
 
   public static function getTitle(): string {

--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -133,11 +133,10 @@ class SqlEquation extends SqlExpression {
    * Change $dataType according to operator used in equation
    *
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string
+   * @param string|null $dataType
+   * @param array $values
    */
-  public function formatOutputValue($value, &$dataType) {
+  public function formatOutputValue(?string &$dataType, array &$values) {
     foreach (self::$comparisonOperators as $op) {
       if (strpos($this->expr, " $op ")) {
         $dataType = 'Boolean';
@@ -148,7 +147,6 @@ class SqlEquation extends SqlExpression {
         $dataType = 'Float';
       }
     }
-    return $value;
   }
 
   public static function getTitle(): string {

--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -77,9 +77,10 @@ class SqlEquation extends SqlExpression {
    * Render the expression for insertion into the sql query
    *
    * @param \Civi\Api4\Query\Api4Query $query
+   * @param bool $includeAlias
    * @return string
    */
-  public function render(Api4Query $query): string {
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
     $output = [];
     foreach ($this->args as $i => $arg) {
       // Just an operator
@@ -98,7 +99,7 @@ class SqlEquation extends SqlExpression {
         $output[] = $arg->render($query);
       }
     }
-    return '(' . implode(' ', $output) . ')';
+    return '(' . implode(' ', $output) . ')' . ($includeAlias ? " AS `{$this->getAlias()}`" : '');
   }
 
   /**

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -145,9 +145,12 @@ abstract class SqlExpression {
    * Renders expression to a sql string, replacing field names with column names.
    *
    * @param \Civi\Api4\Query\Api4Query $query
+   * @param bool $includeAlias
    * @return string
    */
-  abstract public function render(Api4Query $query): string;
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
+    return $this->expr . ($includeAlias ? " AS `{$this->getAlias()}`" : '');
+  }
 
   /**
    * @return string

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -25,13 +25,13 @@ class SqlField extends SqlExpression {
     $this->fields[] = $this->expr;
   }
 
-  public function render(Api4Query $query): string {
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
     $field = $query->getField($this->expr, TRUE);
+    $rendered = $field['sql_name'];
     if (!empty($field['sql_renderer'])) {
-      $renderer = $field['sql_renderer'];
-      return $renderer($field, $query);
+      $rendered = $field['sql_renderer']($field, $query);
     }
-    return $field['sql_name'];
+    return $rendered . ($includeAlias ? " AS `{$this->getAlias()}`" : '');
   }
 
   public static function getTitle(): string {

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -141,9 +141,10 @@ abstract class SqlFunction extends SqlExpression {
    * Render the expression for insertion into the sql query
    *
    * @param \Civi\Api4\Query\Api4Query $query
+   * @param bool $includeAlias
    * @return string
    */
-  public function render(Api4Query $query): string {
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
     $output = '';
     foreach ($this->args as $arg) {
       $rendered = $this->renderArg($arg, $query);
@@ -151,7 +152,7 @@ abstract class SqlFunction extends SqlExpression {
         $output .= (strlen($output) ? ' ' : '') . $rendered;
       }
     }
-    return $this->renderExpression($output);
+    return $this->renderExpression($output) . ($includeAlias ? " AS `{$this->getAlias()}`" : '');
   }
 
   /**
@@ -160,7 +161,7 @@ abstract class SqlFunction extends SqlExpression {
    * @param string $output
    * @return string
    */
-  protected function renderExpression($output): string {
+  protected function renderExpression(string $output): string {
     return $this->getName() . '(' . $output . ')';
   }
 

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -109,34 +109,32 @@ abstract class SqlFunction extends SqlExpression {
   /**
    * Set $dataType and convert value by suffix
    *
+   * @param string|null $dataType
+   * @param array $values
+   * @param string $key
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
-   * @param string $value
-   * @param string $dataType
-   * @return string
    */
-  public function formatOutputValue($value, &$dataType) {
+  public function formatOutputValue(?string &$dataType, array &$values, string $key): void {
     if (static::$dataType) {
       $dataType = static::$dataType;
     }
-    if (isset($value) && $this->suffix && $this->suffix !== 'id') {
+    if (isset($values[$key]) && $this->suffix && $this->suffix !== 'id') {
       $dataType = 'String';
+      $value =& $values[$key];
       $option = $this->getOptions()[$value] ?? NULL;
       // Option contains an array of suffix keys
       if (is_array($option)) {
-        return $option[$this->suffix] ?? NULL;
+        $value = $option[$this->suffix] ?? NULL;
       }
       // Flat arrays are name/value pairs
       elseif ($this->suffix === 'label') {
-        return $option;
+        $value = $option;
       }
-      elseif ($this->suffix === 'name') {
-        return $value;
-      }
-      else {
-        return NULL;
+      // Name needs no transformation, and any other suffix is invalid
+      elseif ($this->suffix !== 'name') {
+        $value = NULL;
       }
     }
-    return $value;
   }
 
   /**

--- a/Civi/Api4/Query/SqlFunctionDAYSTOANNIV.php
+++ b/Civi/Api4/Query/SqlFunctionDAYSTOANNIV.php
@@ -46,7 +46,7 @@ class SqlFunctionDAYSTOANNIV extends SqlFunction {
   /**
    * @inheritDoc
    */
-  protected function renderExpression($output): string {
+  protected function renderExpression(string $output): string {
     return "DATEDIFF(
       IF(
           DATE(CONCAT(YEAR(CURDATE()), '-', MONTH({$output}), '-', DAY({$output}))) < CURDATE(),

--- a/Civi/Api4/Query/SqlNull.php
+++ b/Civi/Api4/Query/SqlNull.php
@@ -19,10 +19,6 @@ class SqlNull extends SqlExpression {
   protected function initialize() {
   }
 
-  public function render(Api4Query $query): string {
-    return 'NULL';
-  }
-
   public static function getTitle(): string {
     return ts('Null');
   }

--- a/Civi/Api4/Query/SqlNumber.php
+++ b/Civi/Api4/Query/SqlNumber.php
@@ -22,10 +22,6 @@ class SqlNumber extends SqlExpression {
     \CRM_Utils_Type::validate($this->expr, 'Float');
   }
 
-  public function render(Api4Query $query): string {
-    return $this->expr;
-  }
-
   public static function getTitle(): string {
     return ts('Number');
   }

--- a/Civi/Api4/Query/SqlString.php
+++ b/Civi/Api4/Query/SqlString.php
@@ -27,8 +27,8 @@ class SqlString extends SqlExpression {
     $this->expr = str_replace(['\\\\', "\\$quot", $backslash], [$backslash, $quot, '\\\\'], $str);
   }
 
-  public function render(Api4Query $query): string {
-    return '"' . \CRM_Core_DAO::escapeString($this->expr) . '"';
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
+    return '"' . \CRM_Core_DAO::escapeString($this->expr) . '"' . ($includeAlias ? " AS `{$this->getAlias()}`" : '');
   }
 
   /**

--- a/Civi/Api4/Query/SqlWild.php
+++ b/Civi/Api4/Query/SqlWild.php
@@ -19,10 +19,6 @@ class SqlWild extends SqlExpression {
   protected function initialize() {
   }
 
-  public function render(Api4Query $query): string {
-    return '*';
-  }
-
   public static function getTitle(): string {
     return ts('Wild');
   }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -237,9 +237,10 @@ class FormattingUtil {
       $baseName = $fieldName ? \CRM_Utils_Array::first(explode(':', $fieldName)) : NULL;
       $field = $fields[$fieldName] ?? $fields[$baseName] ?? NULL;
       $dataType = $field['data_type'] ?? ($fieldName == 'id' ? 'Integer' : NULL);
-      // Allow Sql Functions to do special formatting and/or alter the $dataType
+      // Allow Sql Functions to do alter the value and/or $dataType
       if (method_exists($fieldExpr, 'formatOutputValue') && is_string($value)) {
-        $result[$key] = $value = $fieldExpr->formatOutputValue($value, $dataType);
+        $fieldExpr->formatOutputValue($dataType, $result, $key);
+        $value = $result[$key];
       }
       if (!empty($field['output_formatters'])) {
         self::applyFormatters($result, $fieldName, $field, $value);

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -232,6 +232,10 @@ class FormattingUtil {
       }
     }
     foreach ($result as $key => $value) {
+      // Skip null values or values that have already been unset by `formatOutputValue` functions
+      if (!isset($result[$key])) {
+        continue;
+      }
       $fieldExpr = SqlExpression::convert($selectAliases[$key] ?? $key);
       $fieldName = \CRM_Utils_Array::first($fieldExpr->getFields() ?? '');
       $baseName = $fieldName ? \CRM_Utils_Array::first(explode(':', $fieldName)) : NULL;

--- a/distmaker/core-ext.txt
+++ b/distmaker/core-ext.txt
@@ -34,3 +34,4 @@ civi_mail
 civi_member
 civi_pledge
 civi_report
+scheduled_communications

--- a/ext/scheduled_communications/Civi/Search/ActionMapping.php
+++ b/ext/scheduled_communications/Civi/Search/ActionMapping.php
@@ -1,0 +1,180 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\Search;
+
+use Civi\Api4\Generic\Traits\SavedSearchInspectorTrait;
+use Civi\Api4\Query\Api4Query;
+use Civi\Api4\Query\SqlExpression;
+use Civi\Api4\SavedSearch;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * This enables scheduled-reminders to be run based on a SavedSearch.
+ */
+class ActionMapping extends \Civi\ActionSchedule\MappingBase {
+
+  use SavedSearchInspectorTrait;
+
+  /**
+   * @return string
+   */
+  public function getName(): string {
+    return 'saved_search';
+  }
+
+  public function getEntityName(): string {
+    return 'SavedSearch';
+  }
+
+  public function getEntityTable(\CRM_Core_DAO_ActionSchedule $actionSchedule): string {
+    $this->loadSavedSearch($actionSchedule->entity_value);
+    return \CRM_Core_DAO_AllCoreTables::getTableForEntityName($this->savedSearch['api_entity']);
+  }
+
+  public function modifySpec(\Civi\Api4\Service\Spec\RequestSpec $spec) {
+    $spec->getFieldByName('entity_value')
+      ->setLabel(ts('Saved Search'))
+      ->setInputAttr('multiple', FALSE);
+    $spec->getFieldByName('entity_status')
+      ->setLabel(ts('Contact ID Field'))
+      ->setInputAttr('multiple', FALSE)
+      ->setRequired(TRUE);
+  }
+
+  /**
+   *
+   * @return array
+   */
+  public function getValueLabels(): array {
+    return SavedSearch::get(FALSE)
+      ->addSelect('id', 'name', 'label')
+      ->addOrderBy('label')
+      ->addWhere('api_entity', 'IS NOT NULL')
+      ->addWhere('is_current', '=', TRUE)
+      // Limit to searches that have something to do with contacts
+      // FIXME: Matching `api_params LIKE %contact%` is a cheap trick with no real understanding of the appropriateness of the SavedSearch for use as a Scheduled Reminder.
+      ->addClause('OR', ['api_entity', '=', 'Contact'], ['api_params', 'LIKE', '%contact%'])
+      ->execute()->getArrayCopy();
+  }
+
+  /**
+   * @param array|null $entityValue
+   * @return array
+   */
+  public function getStatusLabels(?array $entityValue): array {
+    if (!$entityValue) {
+      return [];
+    }
+    $this->loadSavedSearch(\CRM_Utils_Array::first($entityValue));
+    $fieldNames = [];
+    foreach ($this->getSelectClause() as $columnAlias => $columnInfo) {
+      // TODO: It would be nice to return only fields with an FK to contact.id
+      // For now returning fields of type Int or unknown
+      if (in_array($columnInfo['dataType'], ['Integer', NULL], TRUE)) {
+        $fieldNames[$columnAlias] = $this->getColumnLabel($columnInfo['expr']);
+      }
+    }
+    return $fieldNames;
+  }
+
+  /**
+   * @param array|null $entityValue
+   * @return array
+   */
+  public function getDateFields(?array $entityValue = NULL): array {
+    if (!$entityValue) {
+      return [];
+    }
+    $this->loadSavedSearch(\CRM_Utils_Array::first($entityValue));
+    $fieldNames = [];
+    foreach ($this->getSelectClause() as $columnAlias => $columnInfo) {
+      // Only return date fields
+      // For now also including fields of unknown type since SQL functions sometimes don't know their return type
+      if (in_array($columnInfo['dataType'], ['Date', 'Timestamp', NULL], TRUE)) {
+        $fieldNames[$columnAlias] = $this->getColumnLabel($columnInfo['expr']);
+      }
+    }
+    return $fieldNames;
+  }
+
+  /**
+   * @param $schedule
+   * @return bool
+   */
+  public function resetOnTriggerDateChange($schedule): bool {
+    return FALSE;
+  }
+
+  /**
+   * Generate a query to locate recipients.
+   *
+   * @param \CRM_Core_DAO_ActionSchedule $schedule
+   *   The schedule as configured by the administrator.
+   * @param string $phase
+   *   See, e.g., RecipientBuilder::PHASE_RELATION_FIRST.
+   *
+   * @param array $defaultParams
+   *
+   * @return \CRM_Utils_SQL_Select
+   * @see RecipientBuilder
+   */
+  public function createQuery($schedule, $phase, $defaultParams): \CRM_Utils_SQL_Select {
+    $this->loadSavedSearch($schedule->entity_value);
+    $this->savedSearch['api_params']['checkPermissions'] = FALSE;
+    $mainTableAlias = Api4Query::MAIN_TABLE_ALIAS;
+    // This mapping type requires exactly one 'entity_status': the name of the contact.id field.
+    $contactIdFieldName = $schedule->entity_status;
+    // The RecipientBuilder needs to know the name of the Contact table.
+    // Check if Contact is the main table or an explicit join
+    if ($contactIdFieldName === 'id' || str_ends_with($contactIdFieldName, '.id')) {
+      $contactPrefix = substr($contactIdFieldName, 0, strrpos($contactIdFieldName, 'id'));
+      $contactJoin = $this->getJoin($contactPrefix);
+      $contactTable = $contactJoin['alias'] ?? $mainTableAlias;
+    }
+    // Else if contact id is an FK field, use implicit join syntax
+    else {
+      $contactPrefix = $contactIdFieldName . '.';
+    }
+    // Exclude deceased and deleted contacts
+    $this->savedSearch['api_params']['where'][] = [$contactPrefix . 'is_deceased', '=', FALSE];
+    $this->savedSearch['api_params']['where'][] = [$contactPrefix . 'is_deleted', '=', FALSE];
+    // Refresh search query with new api params
+    $this->loadSavedSearch();
+    $apiQuery = $this->getQuery();
+    // If contact id is an FK field, find table name by rendering the id field and stripping off the field name
+    if (!isset($contactTable)) {
+      $contactIdSql = SqlExpression::convert($contactPrefix . 'id')->render($apiQuery);
+      $contactTable = str_replace('.`id`', '', $contactIdSql);
+    }
+    $apiQuery->getSql();
+    $sqlSelect = \CRM_Utils_SQL_Select::from($apiQuery->getQuery()->getFrom());
+    $sqlSelect->merge($apiQuery->getQuery(), ['joins', 'wheres']);
+    $sqlSelect->param($defaultParams);
+    $sqlSelect['casAddlCheckFrom'] = $sqlSelect->getFrom();
+    $sqlSelect['casContactIdField'] = SqlExpression::convert($contactIdFieldName)->render($apiQuery);
+    $sqlSelect['casEntityIdField'] = '`' . $mainTableAlias . '`.`' . CoreUtil::getIdFieldName($this->savedSearch['api_entity']) . '`';
+    $sqlSelect['casContactTableAlias'] = $contactTable;
+    if ($schedule->absolute_date) {
+      $sqlSelect['casDateField'] = "'" . \CRM_Utils_Type::escape($schedule->absolute_date, 'String') . "'";
+    }
+    else {
+      $sqlSelect['casDateField'] = SqlExpression::convert($schedule->start_action_date)->render($apiQuery);
+    }
+    return $sqlSelect;
+  }
+
+}

--- a/ext/scheduled_communications/info.xml
+++ b/ext/scheduled_communications/info.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<extension key="scheduled_communications" type="module">
+  <file>scheduled_communications</file>
+  <name>Scheduled Communications</name>
+  <description>Schedule communications using SearchKit</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Chat">https://chat.civicrm.org/civicrm/channels/search-improvements</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-09-04</releaseDate>
+  <version>5.66.alpha1</version>
+  <develStage>beta</develStage>
+  <compatibility>
+    <ver>5.66</ver>
+  </compatibility>
+  <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/ScheduledCommunications</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmScheduledCommunications</angularModule>
+  </civix>
+  <mixins>
+    <mixin>scan-classes@1.0.0</mixin>
+  </mixins>
+</extension>

--- a/ext/scheduled_communications/scheduled_communications.civix.php
+++ b/ext/scheduled_communications/scheduled_communications.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_ScheduledCommunications_ExtensionUtil {
+  const SHORT_NAME = 'scheduled_communications';
+  const LONG_NAME = 'scheduled_communications';
+  const CLASS_PREFIX = 'CRM_ScheduledCommunications';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_ScheduledCommunications_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _scheduled_communications_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _scheduled_communications_civix_civicrm_install() {
+  _scheduled_communications_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _scheduled_communications_civix_civicrm_enable(): void {
+  _scheduled_communications_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _scheduled_communications_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _scheduled_communications_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _scheduled_communications_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _scheduled_communications_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _scheduled_communications_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _scheduled_communications_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _scheduled_communications_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _scheduled_communications_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/scheduled_communications/scheduled_communications.php
+++ b/ext/scheduled_communications/scheduled_communications.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once 'scheduled_communications.civix.php';
+use CRM_ScheduledCommunications_ExtensionUtil as E;
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
+ */
+function scheduled_communications_civicrm_config(&$config): void {
+  _scheduled_communications_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function scheduled_communications_civicrm_install(): void {
+  _scheduled_communications_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function scheduled_communications_civicrm_enable(): void {
+  _scheduled_communications_civix_civicrm_enable();
+}

--- a/ext/scheduled_communications/scheduled_communications.php
+++ b/ext/scheduled_communications/scheduled_communications.php
@@ -29,3 +29,19 @@ function scheduled_communications_civicrm_install(): void {
 function scheduled_communications_civicrm_enable(): void {
   _scheduled_communications_civix_civicrm_enable();
 }
+
+/**
+ * Implements hook_civicrm_post().
+ */
+function scheduled_communications_civicrm_post($op, $entity, $id, $object): void {
+  // Delete scheduled communications linked to a deleted saved search
+  if ($entity === 'SavedSearch' && $op === 'delete' && $id) {
+    civicrm_api4('ActionSchedule', 'delete', [
+      'checkPermissions' => FALSE,
+      'where' => [
+        ['mapping_id', '=', 'saved_search'],
+        ['entity_value', '=', $id],
+      ],
+    ]);
+  }
+}

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/communications.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/communications.html
@@ -1,0 +1,20 @@
+<div class="btn-group">
+  <button type="button" ng-click="row.openScheduleMenu = true" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    {{:: row.data.schedule_id.length === 1 ? ts('1 Communication') : ts('%1 Communications', {1: row.data.schedule_id ? row.data.schedule_id.length : 0}) }} <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" ng-if=":: row.openScheduleMenu">
+    <li ng-repeat="schedule_id in row.data.schedule_id" title="{{:: ts('Edit Scheduled Communication') }}">
+      <a ng-href="{{ crmUrl('civicrm/admin/scheduleReminders/edit?reset=1&action=update&mapping_id=saved_search&id=' + schedule_id + '&entity_value=' + row.data.id) }}" target="crm-popup">
+        <i class="crm-i fa-pencil"></i>
+        {{ row.data.schedule_title[$index] }}
+      </a>
+    </li>
+    <li class="divider" role="separator"></li>
+    <li title="{{:: ts('Add Scheduled Communication') }}">
+      <a ng-href="{{ crmUrl('civicrm/admin/scheduleReminders/edit?reset=1&action=add&mapping_id=saved_search&entity_value=' + row.data.id) }}" target="crm-popup">
+        <i class="crm-i fa-plus"></i>
+        {{:: ts('New Communication') }}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -14,11 +14,13 @@
         ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplaySortableTrait)),
         afformLoad;
 
+      $scope.crmUrl = CRM.url;
       this.searchDisplayPath = CRM.url('civicrm/search');
       this.afformPath = CRM.url('civicrm/admin/afform');
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
       this.afformAdminEnabled = (CRM.checkPerm('administer CiviCRM') || CRM.checkPerm('administer afform')) &&
         'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
+      const scheduledCommunicationsEnabled = 'scheduled_communications' in CRM.crmSearchAdmin.modules;
 
       this.apiEntity = 'SavedSearch';
       this.search = {
@@ -45,13 +47,16 @@
             'DATE(created_date) AS date_created',
             'DATE(modified_date) AS date_modified',
             'DATE(expires_date) AS expires',
-            'GROUP_CONCAT(display.name ORDER BY display.id) AS display_name',
-            'GROUP_CONCAT(display.label ORDER BY display.id) AS display_label',
-            'GROUP_CONCAT(display.type:icon ORDER BY display.id) AS display_icon',
-            'GROUP_CONCAT(display.acl_bypass ORDER BY display.id) AS display_acl_bypass',
+            // Get all search displays
+            'GROUP_CONCAT(UNIQUE display.name ORDER BY display.label) AS display_name',
+            'GROUP_CONCAT(UNIQUE display.label ORDER BY display.label) AS display_label',
+            'GROUP_CONCAT(UNIQUE display.type:icon ORDER BY display.label) AS display_icon',
+            'GROUP_CONCAT(UNIQUE display.acl_bypass ORDER BY display.label) AS display_acl_bypass',
             'tags', // Not a selectable field but this hacks around the requirement that filters be in the select clause
-            'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id',
-            'GROUP_CONCAT(DISTINCT group.title) AS groups'
+            'GROUP_CONCAT(UNIQUE entity_tag.tag_id) AS tag_id',
+            // Really there can only be 1 smart group per saved-search; aggregation is just for the sake of the query
+            'GROUP_CONCAT(UNIQUE group.id) AS group_id',
+            'GROUP_CONCAT(UNIQUE group.title) AS groups'
           ],
           join: [
             ['SearchDisplay AS display', 'LEFT', ['id', '=', 'display.saved_search_id']],
@@ -62,6 +67,13 @@
           groupBy: ['id']
         }
       };
+
+      // Add scheduled communication to query if extension is enabled
+      if (scheduledCommunicationsEnabled) {
+        this.search.api_params.select.push('GROUP_CONCAT(UNIQUE schedule.id ORDER BY schedule.title) AS schedule_id');
+        this.search.api_params.select.push('GROUP_CONCAT(UNIQUE schedule.title ORDER BY schedule.title) AS schedule_title');
+        this.search.api_params.join.push(['ActionSchedule AS schedule', 'LEFT', ['schedule.mapping_id', '=', '"saved_search"'], ['id', '=', 'schedule.entity_value']]);
+      }
 
       this.$onInit = function() {
         buildDisplaySettings();
@@ -228,8 +240,16 @@
             path: '~/crmSearchAdmin/searchListing/afforms.html'
           });
         }
+        // Add scheduled communication column if extension is enabled
+        if (scheduledCommunicationsEnabled) {
+          ctrl.display.settings.columns.push({
+            type: 'include',
+            label: ts('Communications'),
+            path: '~/crmSearchAdmin/searchListing/communications.html'
+          });
+        }
         ctrl.display.settings.columns.push(
-          searchMeta.fieldToColumn('GROUP_CONCAT(DISTINCT group.title) AS groups', {
+          searchMeta.fieldToColumn('GROUP_CONCAT(UNIQUE group.title) AS groups', {
             label: ts('Smart Group')
           })
         );

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -148,6 +148,9 @@
             _.each(search.groups, function (smartGroup) {
               msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle"></i> ' + _.escape(ts('Smart group "%1" will also be deleted.', {1: smartGroup})) + '</li>';
             });
+            _.each(search.schedule_title, (communication) => {
+              msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle"></i> ' + _.escape(ts('Communication "%1" will also be deleted.', {1: communication})) + '</li>';
+            });
             if (row.afform_count) {
               _.each(ctrl.afforms[search.name], function (afform) {
                 msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle"></i> ' + _.escape(ts('Form "%1" will also be deleted because it contains an embedded display from this search.', {1: afform.title})) + '</li>';

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTest.php
@@ -273,12 +273,16 @@ abstract class AbstractMappingTest extends \CiviUnitTestCase {
    *
    * @throws \Exception
    */
-  public function testDefault($targetDate, $setupFuncs, $expectMessages) {
+  public function testDefault(string $targetDate, string $setupFuncs, array $expectMessages) {
     $this->targetDate = $targetDate;
 
     foreach (explode(' ', $setupFuncs) as $setupFunc) {
       $this->{$setupFunc}();
     }
+    $this->runScheduleAndExpectMessages($expectMessages);
+  }
+
+  public function runScheduleAndExpectMessages(array $expectMessages): void {
     $this->schedule->save();
 
     $actualMessages = [];

--- a/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
+++ b/tests/phpunit/Civi/ActionSchedule/SavedSearchMappingTest.php
@@ -1,0 +1,166 @@
+<?php
+namespace Civi\ActionSchedule;
+
+use Civi\Api4\Contact;
+
+/**
+ * Test scheduled-communications based on SavedSearches.
+ *
+ * @group ActionSchedule
+ * @see \Civi\ActionSchedule\AbstractMappingTest
+ * @group headless
+ */
+class SavedSearchMappingTest extends AbstractMappingTest {
+
+  protected array $savedSearch = [];
+
+  protected function setUp(): void {
+    parent::setUp();
+    \CRM_Extension_System::singleton()->getManager()->enable('scheduled_communications');
+    $this->useHelloFirstName();
+    $this->savedSearch = [
+      'label' => __CLASS__,
+      'api_params' => [
+        'select' => [],
+        'where' => [],
+      ],
+    ];
+  }
+
+  protected function tearDown(): void {
+    parent::tearDown();
+    $this->quickCleanup([], TRUE);
+  }
+
+  public function testContactBirthDate(): void {
+    $this->targetDate = '2015-02-01 00:00:00';
+
+    $this->savedSearch['api_entity'] = 'Contact';
+    $this->savedSearch['api_params']['where'] = [
+      ['id', 'IN', array_column($this->contacts, 'id')],
+    ];
+
+    $this->startWeekAfter();
+    $this->setIdField('id');
+    $this->setDateField('birth_date');
+    Contact::save(FALSE)
+      ->addRecord(['birth_date' => '20150201', 'id' => $this->contacts['alice']['id']])
+      ->addRecord(['birth_date' => '20150202', 'id' => $this->contacts['bob']['id']])
+      // Deceased contact
+      ->addRecord(['birth_date' => '20150202', 'id' => $this->contacts['edith']['id']])
+      // Date too far in future
+      ->addRecord(['birth_date' => '20160201', 'id' => $this->contacts['carol']['id']])
+      // Francis email on hold
+      ->addRecord(['birth_date' => '20150201', 'id' => $this->contacts['francis']['id']])
+      // Do not mail dave
+      ->addRecord(['birth_date' => '20150201', 'id' => $this->contacts['dave']['id']])
+      ->execute();
+
+    $this->runScheduleAndExpectMessages([
+      [
+        'time' => '2015-02-08 00:00:00',
+        'to' => ['alice@example.org'],
+        'subject' => '/Hello, Alice.*via subject/',
+      ],
+      [
+        'time' => '2015-02-09 00:00:00',
+        'to' => ['bob@example.org'],
+        'subject' => '/Hello, Bob.*via subject/',
+      ],
+    ]);
+  }
+
+  public function testContactCustomDateField(): void {
+    $customGroup = $this->customGroupCreate();
+    $customField = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'data_type' => 'Date',
+      'html_type' => 'Select Date',
+      'default_value' => NULL,
+    ]);
+    $customFieldName = \CRM_Utils_Array::first($customGroup['values'])['name'] . '.' . \CRM_Utils_Array::first($customField['values'])['name'];
+
+    $this->targetDate = '2015-02-01 00:00:00';
+
+    $this->savedSearch['api_entity'] = 'Contact';
+
+    $this->startOnTime();
+    $this->setIdField('id');
+    $this->setDateField($customFieldName);
+    Contact::save(FALSE)
+      ->addRecord([$customFieldName => '20150201', 'id' => $this->contacts['alice']['id']])
+      ->execute();
+
+    $this->runScheduleAndExpectMessages([
+      [
+        'time' => '2015-02-01 00:00:00',
+        'to' => ['alice@example.org'],
+        'subject' => '/Hello, Alice.*via subject/',
+      ],
+    ]);
+  }
+
+  public function testContactAsEntityReferenceField(): void {
+    $customGroup = $this->customGroupCreate([
+      'extends' => 'Activity',
+    ]);
+    $customField = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'html_type' => 'Autocomplete-Select',
+      'data_type' => 'EntityReference',
+      'fk_entity' => 'Contact',
+      'default_value' => NULL,
+    ]);
+    $customFieldName = \CRM_Utils_Array::first($customGroup['values'])['name'] . '.' . \CRM_Utils_Array::first($customField['values'])['name'];
+
+    $this->targetDate = '2015-02-01 00:00:00';
+
+    $this->startOnTime();
+    $this->setIdField($customFieldName);
+    $this->setDateField('activity_date_time');
+    $activity = $this->createTestEntity('Activity', [
+      'activity_type_id:name' => 'Meeting',
+      $customFieldName => $this->contacts['carol']['id'],
+      'activity_date_time' => $this->targetDate,
+      'source_contact_id' => $this->contacts['dave']['id'],
+    ]);
+
+    $this->savedSearch['api_entity'] = 'Activity';
+    $this->savedSearch['api_params']['where'] = [
+      ['id', '=', $activity['id']],
+    ];
+
+    $this->runScheduleAndExpectMessages([
+      [
+        'time' => '2015-02-01 00:00:00',
+        'to' => ['carol@example.org'],
+        'subject' => '/Hello, Carol.*via subject/',
+      ],
+    ]);
+  }
+
+  public function runScheduleAndExpectMessages(array $expectMessages): void {
+    $savedSearch = $this->createTestEntity('SavedSearch', $this->savedSearch);
+    $this->schedule->mapping_id = 'saved_search';
+    $this->schedule->entity_value = $savedSearch['id'];
+    parent::runScheduleAndExpectMessages($expectMessages);
+  }
+
+  protected function setIdField(string $fieldName): void {
+    $this->schedule->entity_status = $fieldName;
+    $this->savedSearch['api_params']['select'][] = $fieldName;
+  }
+
+  protected function setDateField(string $fieldName): void {
+    $this->schedule->start_action_date = $fieldName;
+    $this->savedSearch['api_params']['select'][] = $fieldName;
+  }
+
+  /**
+   * Disable testDefault by returning no test cases
+   */
+  public function createTestCases() {
+    return [];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Allows Scheduled Reminders to be created from SearchKit with an optional extension.

Before
-------
Only a handful of Scheduled Reminder entities available (Contact, Participant, Member, Activity), with narrowly-restricted criteria.

After
--------
When enabled, the "Scheduled Communications" extension allows any SearchKit search with a date column and a contact id column can be used for scheduled reminders.

Comments
---------
See https://lab.civicrm.org/dev/core/-/issues/2644