### PR TITLE
Follow up to ensure we are excluding quick config price sets as per t…

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -382,7 +382,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     if ($priceSetId) {
       // don't allow price set w/ membership.
       if ($hasMembershipBlk) {
-        $errors['price_set_id'] = ts('You cannot enable both Membership Signup and a Contribution Price Set on the same online contribution page');
+        $errors['price_set_id'] = ts('You cannot enable both Membership Signup and a Contribution Price Set on the same online contribution page.');
       }
     }
     else {

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -248,6 +248,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         ->addWhere('entity_table', '=', 'civicrm_contribution_page')
         ->addWhere('entity_id', '=', $contributionPageId)
         ->addWhere('price_set.extends:name', 'CONTAINS', 'CiviMember')
+        ->addWhere('price_set.is_quick_config', '=', 0)
         ->execute()
         ->first();
       if (!$priceSetExtendsMembership) {


### PR DESCRIPTION
…he previous function

Overview
----------------------------------------
This is a follow up to https://github.com/civicrm/civicrm-core/pull/27079 as per the old code it was setting $isQUickConfig to be 1 which meant that the SQL excluded is quick config price sets https://github.com/civicrm/civicrm-core/blob/master/CRM/Price/BAO/PriceSet.php#L273

@eileenmcnaughton 