### PR TITLE
Fix undeclared property - use locally scoped variable

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -191,35 +191,28 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
     // Set Done button URL and breadcrumb. Templates go back to Manage Templates,
     // otherwise go to Manage Event for new event or ManageEventEdit if event if exists.
-    $breadCrumb = [];
     if (!$this->_isTemplate) {
+      $breadCrumb = ['title' => ts('Manage Events')];
       if ($this->_id) {
-        $this->_doneUrl = CRM_Utils_System::url(CRM_Utils_System::currentPath(),
+        $breadCrumb['url'] = CRM_Utils_System::url(CRM_Utils_System::currentPath(),
           "action=update&reset=1&id={$this->_id}"
         );
       }
       else {
-        $this->_doneUrl = CRM_Utils_System::url('civicrm/event/manage',
+        $breadCrumb['url'] = CRM_Utils_System::url('civicrm/event/manage',
           'reset=1'
         );
-        $breadCrumb = [
-          [
-            'title' => ts('Manage Events'),
-            'url' => $this->_doneUrl,
-          ],
-        ];
       }
+      CRM_Utils_System::appendBreadCrumb($breadCrumb);
     }
     else {
-      $this->_doneUrl = CRM_Utils_System::url('civicrm/admin/eventTemplate', 'reset=1');
-      $breadCrumb = [
+      CRM_Utils_System::appendBreadCrumb([
         [
           'title' => ts('Manage Event Templates'),
-          'url' => $this->_doneUrl,
+          'url' => CRM_Utils_System::url('civicrm/admin/eventTemplate', 'reset=1'),
         ],
-      ];
+      ]);
     }
-    CRM_Utils_System::appendBreadCrumb($breadCrumb);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Addresses

CRM_Event_Form_ManageEvent_LocationTest::testSubmit
Creation of dynamic property CRM_Event_Form_ManageEvent_Location::$_doneUrl is deprecated

/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/CRM/Event/Form/ManageEvent.php:197
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/CRM/Event/Form/ManageEvent/Location.php:67
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php:281
/home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php:28
/home/homer/buildkit/build/build-0/web/sites/all/modules/ci

Before
----------------------------------------
Undeclared property

After
----------------------------------------
locally scoped variable

Technical Details
----------------------------------------
The undeclared property is not used outside the function - I also moved the breadcrumbing function into the if so less variable wrangling was needed

Comments
----------------------------------------
