### PR TITLE
php8.x fatal fix + bonus smarty consistency

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1271,7 +1271,7 @@ WHERE civicrm_event.is_active = 1
    * Add the custom fields OR array of participant's profile info.
    *
    * @param int $id
-   * @param string $name
+   * @param string $name eg. customPre or additionalCustomPost to denote the profile location.
    * @param int $cid
    * @param \CRM_Core_Smarty $template
    * @param int $participantId
@@ -1443,22 +1443,15 @@ WHERE civicrm_event.is_active = 1
       }
     }
 
-    if (count($val)) {
-      $template->assign($name, $val);
-    }
-
-    if (count($groupTitles)) {
-      $template->assign($name . '_grouptitle', $groupTitles);
-    }
+    $template->assign($name, $val);
+    $template->assign($name . '_grouptitle', $groupTitles);
 
     //return if we only require array of participant's info.
     if ($returnResults) {
-      if (count($val)) {
+      if ($val) {
         return [$val, $groupTitles];
       }
-      else {
-        return NULL;
-      }
+      return NULL;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/27073/files

Before
----------------------------------------
the `countable` check that causes the problems is used to decide whether to assign the value to the template

After
----------------------------------------
The value is always assigned, as null if need be

Technical Details
----------------------------------------
Ensuring smarty vars are assigned regardless of the flow is one of our practices we are working towards

Comments
----------------------------------------
