### PR TITLE
Pass in function values, rather than handling by form-name

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -542,7 +542,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       }
 
       $this->set('priceSetId', $this->_priceSetId);
-      CRM_Price_BAO_PriceSet::buildPriceSet($this);
+      CRM_Price_BAO_PriceSet::buildPriceSet($this, 'contribution', FALSE);
 
       // get only price set form elements.
       if ($getOnlyPriceSetElements) {

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -336,7 +336,7 @@ DESC limit 1");
       }
 
       $this->set('priceSetId', $this->_priceSetId);
-      CRM_Price_BAO_PriceSet::buildPriceSet($this);
+      CRM_Price_BAO_PriceSet::buildPriceSet($this, 'membership', FALSE);
 
       $optionsMembershipTypes = [];
       foreach ($this->_priceSet['fields'] as $pField) {

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -793,23 +793,18 @@ WHERE  id = %1";
    *
    * @param CRM_Core_Form $form
    * @param string|null $component
+   * @param bool $validFieldsOnly
    *
    * @return void
+   * @throws \CRM_Core_Exception
    */
-  public static function buildPriceSet(&$form, $component = NULL) {
+  public static function buildPriceSet(&$form, $component = NULL, $validFieldsOnly = TRUE) {
     $priceSetId = $form->get('priceSetId');
     if (!$priceSetId) {
       return;
     }
 
-    $validFieldsOnly = TRUE;
     $className = CRM_Utils_System::getClassName($form);
-    if (in_array($className, [
-      'CRM_Contribute_Form_Contribution',
-      'CRM_Member_Form_Membership',
-    ])) {
-      $validFieldsOnly = FALSE;
-    }
 
     $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
     $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
@@ -840,10 +835,6 @@ WHERE  id = %1";
     }
     $form->_priceSet['id'] = $form->_priceSet['id'] ?? $priceSetId;
     $form->assign('priceSet', $form->_priceSet);
-
-    if ($className == 'CRM_Member_Form_Membership') {
-      $component = 'membership';
-    }
 
     if ($className == 'CRM_Contribute_Form_Contribution_Main') {
       $feeBlock = &$form->_values['fee'];


### PR DESCRIPTION
Overview
----------------------------------------
Pass in function values, rather than handling by form-name


Before
----------------------------------------
The `buildPriceSet()` function determines some values by checking the class name of the form that called in

After
----------------------------------------
Those values are passed in as parameters

Technical Details
----------------------------------------
Function is called from a small handful of places - including 1 in universe - but this change only affects the named forms as they were hard-coded in

![image](https://github.com/civicrm/civicrm-core/assets/336308/4d32b56d-171f-44db-b733-9e9a4c752f49)

Comments
----------------------------------------
