### PR TITLE
dev/core#4509 Fix link conditionals when using current_domain for dom…

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -574,6 +574,15 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       }
       return TRUE;
     }
+    // Convert the conditional value of 'current_domain' into an actual value that filterCompare can work with
+    if ($item['condition'][2] === 'current_domain') {
+      if (str_ends_with($item['condition'][0], ':label') !== FALSE) {
+        $item['condition'][2] = \CRM_Core_BAO_Domain::getDomain()->name;
+      }
+      else {
+        $item['condition'][2] = \CRM_Core_Config::domainID();
+      }
+    }
     return self::filterCompare($data, $item['condition']);
   }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/AbstractRunActionTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/AbstractRunActionTest.php
@@ -7,6 +7,7 @@ use Civi\Api4\CustomField;
 use Civi\Api4\Contact;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
+use Civi\Api4\Mailing;
 
 /**
  * @group headless
@@ -203,6 +204,244 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
     $result = civicrm_api4($entity, $action, $params);
     $resultData = $result[0]['data']['Foods.I_Like:label'];
     $this->assertTrue(implode(', ', $resultData) === $result[0]['columns'][1]['val']);
+  }
+
+  public function testDomainConditional(): void {
+    Mailing::create()->setValues([
+      'title' => 'Test Mailing' . __FUNCTION__,
+      'body_html' => 'Test content',
+    ])->execute();
+    $entity = 'SearchDisplay';
+    $action = 'run';
+    $params = [
+      'return' => 'page:1',
+      'savedSearch' => [
+        'id' => 2,
+        'name' => 'Test_Mailing',
+        'label' => 'Test Mailing',
+        'form_values' => NULL,
+        'mapping_id' => NULL,
+        'search_custom_id' => NULL,
+        'api_entity' => 'Mailing',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'name',
+            'domain_id:label',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+        'created_id' => 203,
+        'modified_id' => 203,
+        'expires_date' => NULL,
+        'created_date' => '2022-08-12 13:49:17',
+        'modified_date' => '2022-08-12 17:18:24',
+        'description' => NULL,
+        'tag_id' => [],
+        'groups' => [],
+        'displays' => [
+          [
+            'id' => 2,
+            'name' => 'Test_Mailing_Table_1',
+            'label' => 'Test Mailing Table 1',
+            'saved_search_id' => 2,
+            'type' => 'table',
+            'settings' => [
+              'description' => NULL,
+              'sort' => [],
+              'limit' => 50,
+              'pager' => [],
+              'placeholder' => 5,
+              'columns' => [
+                [
+                  'type' => 'field',
+                  'key' => 'id',
+                  'dataType' => 'Integer',
+                  'label' => 'Mailing ID',
+                  'sortable' => TRUE,
+                ],
+                [
+                  'type' => 'field',
+                  'key' => 'name',
+                  'dataType' => 'String',
+                  'label' => 'Mailing Name',
+                  'sortable' => TRUE,
+                ],
+                [
+                  'type' => 'field',
+                  'key' => 'domain_id:label',
+                  'dataType' => 'Integer',
+                  'label' => 'Domain',
+                  'sortable' => TRUE,
+                ],
+                [
+                  'text' => '',
+                  'style' => 'default',
+                  'size' => 'btn-xs',
+                  'icon' => 'fa-bars',
+                  'links' => [
+                    [
+                      'entity' => 'Mailing',
+                      'action' => 'view',
+                      'join' => '',
+                      'target' => 'crm-popup',
+                      'icon' => 'fa-external-link',
+                      'text' => 'View Mailing',
+                      'style' => 'default',
+                      'path' => '',
+                      'task' => '',
+                      'condition' => [
+                        'domain_id:label',
+                        '=',
+                        'current_domain',
+                      ],
+                    ],
+                    [
+                      'entity' => 'Mailing',
+                      'action' => 'update',
+                      'join' => '',
+                      'target' => 'crm-popup',
+                      'icon' => 'fa-pencil',
+                      'text' => 'Update Mailing',
+                      'style' => 'default',
+                      'path' => '',
+                      'task' => '',
+                      'condition' => [],
+                    ],
+                    [
+                      'entity' => 'Mailing',
+                      'action' => 'preview',
+                      'join' => '',
+                      'target' => 'crm-popup',
+                      'icon' => 'fa-eye',
+                      'text' => 'Preview Mailing',
+                      'style' => 'default',
+                      'path' => '',
+                      'task' => '',
+                      'condition' => [],
+                    ],
+                  ],
+                  'type' => 'menu',
+                  'alignment' => 'text-right',
+                ],
+              ],
+              'actions' => TRUE,
+              'classes' => [
+                'table',
+                'table-striped',
+              ],
+            ],
+            'acl_bypass' => FALSE,
+          ],
+        ],
+      ],
+      'display' => [
+        'id' => 2,
+        'name' => 'Test_Mailing_Table_1',
+        'label' => 'Test Mailing Table 1',
+        'saved_search_id' => 2,
+        'type' => 'table',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'id',
+              'dataType' => 'Integer',
+              'label' => 'Mailing ID',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'name',
+              'dataType' => 'String',
+              'label' => 'Mailing Name',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'domain_id:label',
+              'dataType' => 'Integer',
+              'label' => 'Domain',
+              'sortable' => TRUE,
+            ],
+            [
+              'text' => '',
+              'style' => 'default',
+              'size' => 'btn-xs',
+              'icon' => 'fa-bars',
+              'links' => [
+                [
+                  'entity' => 'Mailing',
+                  'action' => 'view',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-external-link',
+                  'text' => 'View Mailing',
+                  'style' => 'default',
+                  'path' => '',
+                  'task' => '',
+                  'condition' => [
+                    'domain_id:label',
+                    '=',
+                    'current_domain',
+                  ],
+                ],
+                [
+                  'entity' => 'Mailing',
+                  'action' => 'update',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-pencil',
+                  'text' => 'Update Mailing',
+                  'style' => 'default',
+                  'path' => '',
+                  'task' => '',
+                  'condition' => [],
+                ],
+                [
+                  'entity' => 'Mailing',
+                  'action' => 'preview',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-eye',
+                  'text' => 'Preview Mailing',
+                  'style' => 'default',
+                  'path' => '',
+                  'task' => '',
+                  'condition' => [],
+                ],
+              ],
+              'type' => 'menu',
+              'alignment' => 'text-right',
+            ],
+          ],
+          'actions' => TRUE,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ],
+      'limit' => 50,
+      'seed' => 1660599799146,
+      'filters' => [],
+      'afform' => NULL,
+      'debug' => TRUE,
+      'checkPermissions' => TRUE,
+    ];
+    $result = civicrm_api4($entity, $action, $params);
+    $this->assertCount(3, $result[0]['columns'][3]['links']);
   }
 
 }


### PR DESCRIPTION
…ain_id columns

Overview
----------------------------------------
This fixes an issue with link conditionals where if you specify current_domain for the value it doesn't work because current_domain is passed through to the actual comparison function where it doesn't work because it hasn't been properly substituted.

Before
----------------------------------------
Link conditionals don't work with current_domain value

After
----------------------------------------
Link conditionals work with current_domain value

ping @colemanw 