### PR TITLE
Removes the confusing numbered participant headings from the Event Receipt emails and uses a standard "Participant Information" heading for all participants

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -359,6 +359,16 @@ class CRM_Upgrade_Incremental_MessageTemplates {
           ['name' => 'petition_sign', 'type' => 'subject'],
         ],
       ],
+      [
+        'version' => '5.66.alpha1',
+        'upgrade_descriptor' => ts('Remove numbered Participant headings'),
+        'templates' => [
+          ['name' => 'event_online_receipt', 'type' => 'html'],
+          ['name' => 'event_online_receipt', 'type' => 'text'],
+          ['name' => 'event_offline_receipt', 'type' => 'html'],
+          ['name' => 'event_offline_receipt', 'type' => 'text'],
+        ],
+      ],
     ];
   }
 

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -428,6 +428,7 @@
 
      {/if} {* End of conditional section for Paid events *}
 
+     <tr><th {$headerStyle}>{ts}Participant Information{/ts}</th></tr>
      {if !empty($customPre)}
       <tr>
        <th {$headerStyle}>
@@ -472,7 +473,7 @@
       {foreach from=$customProfile item=value key=customName}
        <tr>
         <th {$headerStyle}>
-         {ts 1=$customName+1}Participant Information - Participant %1{/ts}
+         {ts}Participant Information{/ts}
         </th>
        </tr>
        {foreach from=$value item=val key=field}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -219,6 +219,11 @@
 {/if}
 {/if} {* End of conditional section for Paid events *}
 
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
+
+{ts}Participant Information{/ts}
+
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 {if !empty($customPre)}
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 
@@ -249,7 +254,7 @@
 {foreach from=$customProfile item=value key=customName}
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 
-{ts 1=$customName+1}Participant Information - Participant %1{/ts}
+{ts}Participant Information{/ts}
 
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -417,7 +417,7 @@
 
      {/if} {* End of conditional section for Paid events *}
 
-
+<tr><th {$headerStyle}>{ts}Participant Information{/ts}</th></tr>
 {if !empty($customPre)}
 {foreach from=$customPre item=customPr key=i}
    <tr> <th {$headerStyle}>{$customPre_grouptitle.$i}</th></tr>
@@ -448,7 +448,7 @@
 
 {if !empty($customProfile)}
 {foreach from=$customProfile.profile item=eachParticipant key=participantID}
-     <tr><th {$headerStyle}>{ts 1=$participantID+2}Participant %1{/ts} </th></tr>
+     <tr><th {$headerStyle}>{ts}Participant Information{/ts} </th></tr>
      {foreach from=$eachParticipant item=eachProfile key=pid}
      <tr><th {$headerStyle}>{$customProfile.title.$pid}</th></tr>
      {foreach from=$eachProfile item=val key=field}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -221,6 +221,11 @@ You were registered by: {$payer.name}
 {/if}
 {/if} {* End of conditional section for Paid events *}
 
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
+
+{ts}Participant Information{/ts}
+
+==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 {if !empty($customPre)}
 {foreach from=$customPre item=customPr key=i}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
@@ -239,7 +244,6 @@ You were registered by: {$payer.name}
 {if !empty($customPost)}
 {foreach from=$customPost item=customPos key=j}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
-
 {$customPost_grouptitle.$j}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
@@ -255,7 +259,7 @@ You were registered by: {$payer.name}
 {foreach from=$customProfile.profile item=eachParticipant key=participantID}
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 
-{ts 1=$participantID+2}Participant Information - Participant %1{/ts}
+{ts}Participant Information{/ts}
 
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 


### PR DESCRIPTION
This PR removes the confusing numbered participant headings from the Event Receipt emails and uses a standard "Participant Information" heading for all  participants, even if there is just one.

Overview
----------------------------------------
Re-spin of https://github.com/civicrm/civicrm-core/pull/23097 based on feedback from @mlutfy 

When using CiviCRM Event and registering multiple participants. The Event Registration Receipt does not have a heading for first Participant (1) but then has numbered headings for Participant 2 and continue if more were registered.

This is confusing because:
1. The details for the first participant are not clearly segregated and any custom fields for this participant immediately follow the Event receipt detail.
2. A new heading "Participant Information - Participant 2" appears and then does show the related information and custom fields for that participant.

Before
----------------------------------------
The first participant is not clearly identified.
Headings start with "Participant Information - Participant 2" and continue to be numbered if more than 1 participant is registered.

After
----------------------------------------
The details for all participants is clearly identified with a heading "Participant Information".

Technical Details
----------------------------------------
Will require a DB generate

Comments
----------------------------------------
Agileware Ref: CIVICRM-1960