### PR TITLE
[Draft] don't reload searchkit on edit

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,4 +1,4 @@
-<crm-search-display-editable row="row" col="colData" do-save="$ctrl.runSearch({inPlaceEdit: apiCall}, {}, row)" cancel="$ctrl.editing = null;" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
+<crm-search-display-editable row="row" col="colData" do-save="$ctrl.updateRow(value, record, row, colData)" cancel="$ctrl.editing = null" ng-if="colData.edit && $ctrl.editing && $ctrl.editing[0] === rowIndex && $ctrl.editing[1] === colIndex"></crm-search-display-editable>
 <span ng-if="::!colData.links" ng-class="{'crm-editable-enabled': colData.edit && !$ctrl.editing, 'crm-editable-disabled': colData.edit && $ctrl.editing}" ng-click="colData.edit && !$ctrl.editing && ($ctrl.editing = [rowIndex, colIndex])">
   <i ng-repeat="icon in colData.icons" ng-if="icon.side === 'left'" class="crm-i {{:: icon['class'] }}"></i>
   {{:: $ctrl.formatFieldValue(colData) }}

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -6,8 +6,8 @@
 
   angular.module('crmSearchDisplay').component('crmSearchDisplayEditable', {
     bindings: {
-      row: '<',
-      col: '<',
+      row: '=',
+      col: '=',
       cancel: '&',
       doSave: '&'
     },
@@ -54,10 +54,11 @@
           ctrl.cancel();
           return;
         }
+        ctrl.col.edit.value = ctrl.col.val = ctrl.value;
         var record = _.cloneDeep(col.edit.record);
         record[col.edit.value_key] = ctrl.value;
-        $('input', $element).attr('disabled', true);
-        ctrl.doSave({apiCall: [col.edit.entity, col.edit.action, {values: record}]});
+        ctrl.doSave({value: ctrl.value, record: record});
+        $scope.timeout();
       };
 
       function loadOptions() {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -201,6 +201,12 @@
       },
       formatFieldValue: function(colData) {
         return angular.isArray(colData.val) ? colData.val.join(', ') : colData.val;
+      },
+
+      updateRow: function(value, record, row, col) {
+        record[col.edit.value_key] = value;
+        crmApi4(col.edit.entity, col.edit.action, {values: record});
+        this.editing = false;
       }
     };
   });


### PR DESCRIPTION
Overview
----------------------------------------
When an inline edit field in SearchKit is modified, the entire query is reloaded.  This aims to make the UI snappier.

To test, you can create any SK query with in-line edit fields - though the difference will be far more pronounced with more columns/results.  You can see in the Network tab that the call to `SearchDisplay.run` doesn't occur.

Before
----------------------------------------
Modifying a field results in several seconds' wait (if you have enough columns).

After
----------------------------------------
Super-fast.

Comments
----------------------------------------
This successfully updates the database, and if you go to edit again, your value will be present.  But the new value doesn't display on screen post-save, even though my AngularJS plugin says the scope is updated.

I've been trying to learn AngularJS but I've spent more hours than I'd like to say trying to finish this - any pointers on this last part would be helpful.
