### PR TITLE
Fix Standalone error handler: remove 5th argument

### DIFF
--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -68,8 +68,7 @@ function standaloneErrorHandler(
     int $errno,
     string $errstr,
     ?string $errfile,
-    ?int $errline,
-    ?array $errcontext) {
+    ?int $errline) {
   static $handlingError = FALSE;
   if ($handlingError) {
     throw new \RuntimeException("Died: error was thrown during error handling");


### PR DESCRIPTION
Prevents PHP error: Uncaught ArgumentCountError: Too few arguments to function standaloneErrorHandler()
See https://chat.civicrm.org/civicrm/pl/ysuikezzu7ytmbw91hcegfeenr

