### PR TITLE
dev/core#2640 - hide latitude and longitude in address display by default

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -99,7 +99,7 @@ return [
     'pseudoconstant' => [
       'optionGroupName' => 'address_options',
     ],
-    'default' => '12345689101112',
+    'default' => '1234568910',
     'add' => '4.1',
     'title' => ts('Address Fields'),
     'is_domain' => 1,

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
@@ -95,8 +95,6 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
       'postal_code' => '01903',
       'country_id' => 1228,
       'state_province_id' => 1029,
-      'geo_code_1' => '18.219023',
-      'geo_code_2' => '-105.00973',
       'manual_geo_code' => '0',
     ], $address);
 


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2640

Before
----------------------------------------
Latitude and longitude displayed by default.

After
----------------------------------------
Lat/lon hidden on new installs.