### PR TITLE
ActionScheduleTest - Update for compatibility with PHPUnit 9

### DIFF
--- a/tests/phpunit/api/v4/Entity/ActionScheduleTest.php
+++ b/tests/phpunit/api/v4/Entity/ActionScheduleTest.php
@@ -28,12 +28,12 @@ class ActionScheduleTest extends Api4TestBase {
       ->execute()
       ->indexBy('name');
 
-    $this->assertContains(['id' => '1', 'name' => 'activity_type', 'label' => 'Activity', 'icon' => 'fa-tasks'], $fields['mapping_id']['options']);
-    $this->assertContains(['id' => 'contribpage', 'name' => 'contribpage', 'label' => 'Contribution Page', 'icon' => 'fa-credit-card'], $fields['mapping_id']['options']);
+    $this->assertContainsEquals(['id' => '1', 'name' => 'activity_type', 'label' => 'Activity', 'icon' => 'fa-tasks'], $fields['mapping_id']['options']);
+    $this->assertContainsEquals(['id' => 'contribpage', 'name' => 'contribpage', 'label' => 'Contribution Page', 'icon' => 'fa-credit-card'], $fields['mapping_id']['options']);
 
-    $this->assertContains(['id' => 'day', 'name' => 'day', 'label' => 'days'], $fields['start_action_unit']['options']);
-    $this->assertContains(['id' => 'week', 'name' => 'week', 'label' => 'weeks'], $fields['repetition_frequency_unit']['options']);
-    $this->assertContains(['id' => 'month', 'name' => 'month', 'label' => 'months'], $fields['end_frequency_unit']['options']);
+    $this->assertContainsEquals(['id' => 'day', 'name' => 'day', 'label' => 'days'], $fields['start_action_unit']['options']);
+    $this->assertContainsEquals(['id' => 'week', 'name' => 'week', 'label' => 'weeks'], $fields['repetition_frequency_unit']['options']);
+    $this->assertContainsEquals(['id' => 'month', 'name' => 'month', 'label' => 'months'], $fields['end_frequency_unit']['options']);
 
     $this->assertEquals('manual', $fields['recipient']['options'][0]['name']);
     $this->assertEquals('group', $fields['recipient']['options'][1]['name']);


### PR DESCRIPTION
Overview
----------------------------------------

This test was recently added. It originally passed on phpunit8 -- but while it was getting through review, the tests switched to phpunit9. So now it's failing on all PRs.