### PR TITLE
windows fix for CRM_Utils_File::isChildPath

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -794,6 +794,11 @@ HTACCESS;
         return FALSE;
       }
     }
+
+    // windows fix
+    $parent = str_replace(DIRECTORY_SEPARATOR, '/', $parent);
+    $child = str_replace(DIRECTORY_SEPARATOR, '/', $child);
+
     $parentParts = explode('/', rtrim($parent, '/'));
     $childParts = explode('/', rtrim($child, '/'));
     while (($parentPart = array_shift($parentParts)) !== NULL) {


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Hard crash on `cv core:install` since it doesn't think sql/civicrm_data/civicrm_location_type.sqldata.php is a valid file.

After
----------------------------------------
Always `/`

Technical Details
----------------------------------------
The change is a no-op on unix, but matters on windows.

Comments
----------------------------------------
This must be something semi-recent since it hard-crashes now on `cv core:install`. 5.65 is ok, so is a 5.66-only problem. Probably https://github.com/civicrm/civicrm-core/pull/27052/files