### PR TITLE
Make import parser external ID error message more helpful

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2219,7 +2219,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     }
     //check if external identifier exists in database
     if ($contactID && $foundContact['id'] !== $contactID) {
-      throw new CRM_Core_Exception(ts('Existing external ID does not match the imported contact ID.'), CRM_Import_Parser::ERROR);
+      throw new CRM_Core_Exception(
+        ts('Imported external ID already belongs to an existing contact with a different contact ID than the imported contact ID or than the contact ID of the contact matched on the entity imported.'),
+        CRM_Import_Parser::ERROR);
     }
     return (int) $foundContact['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
It turns out that you can hit this external contact mismatch error in more than one way.
1) By importing a contact id and an external id that don't match existing data. This is covered by the current message.
2) By importing, for example, a contribution with a trxn id that matches to an existing contribution, but the external id provided in the import doesn't match the contact id of the contributor.

Before
----------------------------------------
Weird error message if you hit it in case 2.

After
----------------------------------------
Message hopefully is a little more helpful as to what the problem might be.