### PR TITLE
Distmaker: add CiviCRM Standalone support

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -42,6 +42,7 @@ J5PACK=0
 WP5PACK=0
 PATCHPACK=0
 SK5PACK=0
+STANDALONEPACK=0
 L10NPACK=0
 REPOREPORT=0
 
@@ -62,6 +63,7 @@ display_usage()
   echo "  WordPress|wp5  - generate Wordpress PHP5 module"
   echo "  patchset       - generate a tarball with patch files"
   echo "  sk             - generate Drupal StarterKit module"
+  echo "  standalone     - generate CiviCRM Standalone"
   echo
   echo "You also need to have distmaker.conf file in place."
   echo "See distmaker.conf.dist for example contents."
@@ -123,7 +125,7 @@ check_conf()
     echo "Current directory is : $THIS_DIR";
     exit 1
   else
-    export DM_SOURCEDIR DM_GENFILESDIR DM_TMPDIR DM_TARGETDIR DM_PHP DM_RSYNC DM_ZIP DM_VERSION DM_REF_CORE DM_REF_DRUPAL DM_REF_DRUPAL8 DM_REF_JOOMLA DM_REF_WORDPRESS DM_REF_PACKAGES
+    export DM_SOURCEDIR DM_GENFILESDIR DM_TMPDIR DM_TARGETDIR DM_PHP DM_RSYNC DM_ZIP DM_VERSION DM_REF_CORE DM_REF_DRUPAL DM_REF_DRUPAL8 DM_REF_JOOMLA DM_REF_WORDPRESS DM_REF_STANDALONE DM_REF_PACKAGES
     if [ ! -d "$DM_SOURCEDIR" ]; then
       echo; echo "ERROR! " DM_SOURCEDIR "directory not found!"; echo "(if you get empty directory name, it might mean that one of necessary variables is not set)"; echo;
     fi
@@ -187,6 +189,12 @@ case $1 in
   WP5PACK=1
   ;;
 
+  # STANDALONE
+  standalone|Standalone)
+  echo; echo "Generating CiviCRM Standalone"; echo;
+  STANDALONEPACK=1
+  ;;
+
   ## PATCHSET export
   patchset)
   echo; echo "Generating patchset"; echo;
@@ -208,6 +216,7 @@ case $1 in
   WP5PACK=1
   PATCHPACK=1
   SKPACK=1
+  STANDALONEPACK=1
   L10NPACK=1
   REPOREPORT=1
   ;;
@@ -293,6 +302,11 @@ if [ "$WP5PACK" = 1 ]; then
   bash $P/dists/wordpress_php5.sh
 fi
 
+if [ "$STANDALONEPACK" = 1 ]; then
+  echo; echo "Packaging for CiviCRM Standalone"; echo;
+  bash $P/dists/standalone.sh
+fi
+
 if [ "$PATCHPACK" = 1 ]; then
   echo; echo "Packaging for patchset tarball"; echo;
   bash $P/dists/patchset.sh
@@ -308,6 +322,7 @@ if [ "$REPOREPORT" = 1 ]; then
     SKPACK="$SKPACK" \
     J5PACK="$J5PACK" \
     WP5PACK="$WP5PACK" \
+    STANDALONEPACK="$STANDALONEPACK" \
     bash $P/dists/repo-report.sh
 fi
 

--- a/distmaker/dists/standalone.sh
+++ b/distmaker/dists/standalone.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+
+P=`dirname $0`
+CFFILE=$P/../distmaker.conf
+if [ ! -f $CFFILE ] ; then
+	echo "NO DISTMAKER.CONF FILE!"
+	exit 1
+else
+	. $CFFILE
+fi
+. "$P/common.sh"
+
+SRC=$DM_SOURCEDIR
+TRG=$DM_TMPDIR/civicrm
+
+# copy all the stuff
+dm_reset_dirs "$TRG" "$TRG/civicrm/web/core"
+dm_install_core "$SRC" "$TRG/civicrm/web/core"
+dm_install_coreext "$SRC" "$TRG/civicrm/web/core" $(dm_core_exts)
+dm_install_packages "$SRC/packages" "$TRG/civicrm/web/core/packages"
+dm_install_vendor "$SRC/vendor" "$TRG/civicrm/web/core/vendor"
+dm_install_bower "$SRC/bower_components" "$TRG/civicrm/web/core/bower_components"
+dm_install_cvext com.iatspayments.civicrm "$TRG/civicrm/web/core/ext/iatspayments"
+$SRC/tools/standalone/bin/scaffold $TRG/civicrm
+
+# gen tarball
+cd $TRG/civicrm
+tar czf $DM_TARGETDIR/civicrm-$DM_VERSION-standalone.tar.gz .
+
+# clean up
+rm -rf $TRG

--- a/setup/plugins/checkRequirements/CheckDbWellFormed.civi-setup.php
+++ b/setup/plugins/checkRequirements/CheckDbWellFormed.civi-setup.php
@@ -13,7 +13,12 @@ if (!defined('CIVI_SETUP')) {
   ->addListener('civi.setup.checkRequirements', function (\Civi\Setup\Event\CheckRequirementsEvent $e) {
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'checkRequirements'));
 
-    $dbFields = array('db', 'cmsDb');
+    $dbFields = ['db'];
+
+    if ($e->getModel()->cms !== 'Standalone') {
+      $dbFields[] = 'cmsDb';
+    }
+
     foreach ($dbFields as $dbField) {
       $errors = 0;
       $db = $e->getModel()->{$dbField};

--- a/setup/res/index.php.txt
+++ b/setup/res/index.php.txt
@@ -118,8 +118,6 @@ if (file_exists(findStandaloneSettings())) {
   invoke();
 }
 else {
-  $coreUrl = '/assets/civicrm/core';
-
   \Civi\Setup::assertProtocolCompatibility(1.0);
 
   \Civi\Setup::init([
@@ -127,8 +125,10 @@ else {
     'cms'     => 'Standalone',
     'srcPath' => $civiCorePath,
   ]);
-  $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
 
+  $coreUrl = \Civi\Setup::instance()->getModel()->mandatorySettings['userFrameworkResourceURL'];
+
+  $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
   $ctrl->setUrls([
     // The URL of this setup controller. May be used for POST-backs
     'ctrl'             => '/civicrm', /* @todo this had url('civicrm') ? */


### PR DESCRIPTION
Overview
----------------------------------------

Adds support for building CiviCRM Standalone tar.gz archives for nightly/rc/stable releases.

Before
----------------------------------------

No CiviCRM Standalone builds.

After
----------------------------------------

`civicrm-standalone-5.66-standalone.tar.gz` :sunrise_over_mountains: 

Technical Details
----------------------------------------

I wasn't too sure what directory structure to follow.

Based on [civicrm standalone installation docs](https://docs.civicrm.org/installation/en/latest/standalone/), I figured it would be best to not use the composer template, and use the more minimal method. It still supports hosting civicrm and private files outside the webroot.

Comments
-------------------

This may be of a surprise, but I did test locally:

```
./src/distmaker/distmaker.sh standalone
```

and then I checked the resulting tar, but I did not yet test using the tar to install CiviCRM from scratch.