### PR TITLE
Afform - Enhance returned values from AfformSubmission.afform_name options

### DIFF
--- a/ext/afform/core/CRM/Afform/BAO/AfformSubmission.php
+++ b/ext/afform/core/CRM/Afform/BAO/AfformSubmission.php
@@ -8,12 +8,28 @@ class CRM_Afform_BAO_AfformSubmission extends CRM_Afform_DAO_AfformSubmission {
    * @return array
    */
   public static function getAllAfformsByName() {
-    return \Civi\Api4\Afform::get(FALSE)
-      ->addSelect('name', 'title')
+    $suffixMap = [
+      'id' => 'name',
+      'name' => 'module_name',
+      'abbr' => 'directive_name',
+      'label' => 'title',
+      'description' => 'description',
+      'icon' => 'icon',
+      'url' => 'server_route',
+    ];
+    $afforms = \Civi\Api4\Afform::get(FALSE)
+      ->setSelect(array_values($suffixMap))
       ->addOrderBy('title')
-      ->execute()
-      ->indexBy('name')
-      ->column('title');
+      ->execute();
+    $result = [];
+    foreach ($afforms as $afform) {
+      $formattedAfform = [];
+      foreach ($suffixMap as $suffix => $field) {
+        $formattedAfform[$suffix] = $afform[$field] ?? NULL;
+      }
+      $result[] = $formattedAfform;
+    }
+    return $result;
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Service/Spec/Provider/AfformSubmissionSpecProvider.php
+++ b/ext/afform/core/Civi/Api4/Service/Spec/Provider/AfformSubmissionSpecProvider.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class AfformSubmissionSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('afform_name')->setSuffixes(['name', 'label', 'description', 'abbr', 'icon', 'url']);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'AfformSubmission';
+  }
+
+}

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformSubmissionTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformSubmissionTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Civi\Afform;
+
+use Civi\Api4\AfformSubmission;
+use Civi\Test\HeadlessInterface;
+
+/**
+ * @group headless
+ */
+class AfformSubmissionTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->install(['org.civicrm.search_kit', 'org.civicrm.afform', 'org.civicrm.afform_admin'])->apply();
+  }
+
+  public function testGetFields():void {
+    $fields = AfformSubmission::getFields(FALSE)
+      ->setAction('get')
+      ->execute()->indexBy('name');
+    $this->assertTrue($fields['afform_name']['options']);
+    $this->assertEquals(['name', 'label', 'description', 'abbr', 'icon', 'url'], $fields['afform_name']['suffixes']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Improves the psueudoconstant options list returned from `AfformSubmission.afform_name` so that more attributes of the afform can be accessed.

Before
----------------------------------------
Flat `name->title` list

After
----------------------------------------
`'name', 'label', 'description', 'abbr', 'icon', 'url'` all returned.
