### PR TITLE
APIv4 Explorer - Keep list of suffixes in-sync

### DIFF
--- a/CRM/Api4/Page/Api4Explorer.php
+++ b/CRM/Api4/Page/Api4Explorer.php
@@ -30,6 +30,7 @@ class CRM_Api4_Page_Api4Explorer extends CRM_Core_Page {
       'docs' => \Civi\Api4\Utils\ReflectionUtils::parseDocBlock($apiDoc->getDocComment()),
       'functions' => CoreUtil::getSqlFunctions(),
       'authxEnabled' => $extensions->isActiveModule('authx'),
+      'suffixes' => \Civi\Api4\Utils\FormattingUtil::$pseudoConstantSuffixes,
       'restUrl' => rtrim(CRM_Utils_System::url('civicrm/ajax/api4/CRMAPI4ENTITY/CRMAPI4ACTION', NULL, TRUE, NULL, FALSE, TRUE), '/'),
     ];
     Civi::resources()

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -560,7 +560,7 @@
                 false,
                 true,
                 ['id', 'name', 'label'],
-                ['id', 'name', 'label', 'abbr', 'description', 'color', 'icon']
+                CRM.vars.api4.suffixes
               ];
               format = 'json';
               defaultVal = false;


### PR DESCRIPTION
Overview
----------------------------------------
Keeps the list of available pseudoconstant suffixes in APIv4 Explorer consistent with the master list.

Before
----------------------------------------
Hard-coded list in 2 places

After
----------------------------------------
Hard-coded list in 1 place
