### PR TITLE
add Note as an afformEntity

### DIFF
--- a/ext/afform/admin/afformEntities/Note.php
+++ b/ext/afform/admin/afformEntities/Note.php
@@ -1,0 +1,5 @@
+<?php
+return [
+  'type' => 'join',
+  'repeat_max' => NULL,
+];

--- a/ext/afform/core/ang/afblockContactNote.aff.html
+++ b/ext/afform/core/ang/afblockContactNote.aff.html
@@ -1,0 +1,5 @@
+<div class="af-container af-layout-inline">
+    <af-field name="note" />
+    <af-field name="subject" />
+  </div>
+  

--- a/ext/afform/core/ang/afblockContactNote.aff.json
+++ b/ext/afform/core/ang/afblockContactNote.aff.json
@@ -1,0 +1,7 @@
+{
+    "title": "Contact Note(s)",
+    "type": "block",
+    "entity_type": "Contact",
+    "join_entity": "Note"
+  }
+  


### PR DESCRIPTION
Overview
----------------------------------------
In continuing to expand FormBuilder's use cases, this PR is in response to a [feature request](https://lab.civicrm.org/dev/core/-/issues/4493) to add the Note entity on afforms, so that users can have a place to enter text without having to create a custom field. 

Before
----------------------------------------
The Note entity is not currently available to add to an afform.

After
----------------------------------------
Note Fields are now available for the Contact entity. 

![Selection_027](https://github.com/civicrm/civicrm-core/assets/87245718/e2ee613b-1850-42a1-bde5-d9b8ca369857)


Comments
----------------------------------------
This PR only allows for Notes to be added to a Contact. This PR's approach could be used to also make the Note entity available for other "higher level" entities, such as Contributions. 
