### PR TITLE
Only delete contact from sub-Redis keys if the 'all' key contains the contact

### DIFF
--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -173,9 +173,12 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     }
     elseif ($id !== NULL && $cacheKey !== NULL) {
       // Delete a specific contact, within a specific cache.
-      $this->redis->zRem($this->key($cacheKey, 'all'), $id);
-      $this->redis->zRem($this->key($cacheKey, 'sel'), $id);
-      $this->redis->hDel($this->key($cacheKey, 'data'), $id);
+      $deleted = $this->redis->zRem($this->key($cacheKey, 'all'), $id);
+      if ($deleted) {
+        // If they were in the 'all' key they might be in the more specific 'sel' and 'data' keys.
+        $this->redis->zRem($this->key($cacheKey, 'sel'), $id);
+        $this->redis->hDel($this->key($cacheKey, 'data'), $id);
+      }
     }
     elseif ($id !== NULL && $cacheKey === NULL) {
       // Delete a specific contact, across all prevnext caches.


### PR DESCRIPTION
Overview
----------------------------------------
Only delete contact from sub-Redis keys if the 'all' key contains the contact

Before
----------------------------------------
3 redis deletes per prev next search in redis - regardless of whether the contact is in the keys

After
----------------------------------------
just the 1 if the contact is not in the first key

Technical Details
----------------------------------------
@totten as we expected this resulted in a 2/3 reduction of contact delete time.

I will follow up with a patch to fix the expiry not being set - I think we need to use this not-very-elegant pattern
```
-
+    $first = TRUE;
     while ($dao->fetch()) {
       [, $entity_id, $data] = array_values($dao->toArray());
       $maxScore++;
       $this->redis->zAdd($allKey, $maxScore, $entity_id);
+      if ($first) {
+        $this->redis->expire($allKey, $this->getTTL());
+      }
       $this->redis->hSet($dataKey, $entity_id, $data);
+      if ($first) {
+        $this->redis->expire($dataKey, $this->getTTL());
+      }
+      $first = FALSE;
     }
 
     return TRUE;
```

Comments
----------------------------------------
