### PR TITLE
Flush Redis `prevnext` cache when clearing `civicrm_cache`

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -345,6 +345,11 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       CRM_Core_DAO::executeQuery($query);
     }
 
+    // Clear the Redis prev-next cache, if there is one.
+    // Since we truncated the civicrm_cache table it is logical to also remove
+    // the same from the Redis cache here.
+    \Civi::service('prevnext')->deleteItem();
+
     // also delete all the import and export temp tables
     self::clearTempTables();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Flush Redis `prevnext` cache when clearing `civicrm_cache`

Before
----------------------------------------
There is actually nowhere in CiviCRM where the Redis Prev-next cache is flushed. It is possible to flush using eval - ie

```
 cv php:eval "\Civi::service('prevnext')->deleteItem();"
```

but in normal operations it is never flushed

After
----------------------------------------
It would be flushed in the same instances as the `civicrm-cache` table is cleared

Technical Details
----------------------------------------
Once we get Redis to start expiring it won't be so necessary to flush the cache - but it should be possible to flush it 'somehow' via the api/ I'm a bit on the fence between this & something a bit more opt-in. 

Comments
----------------------------------------
