### PR TITLE
Add suffix to sort name

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -155,7 +155,7 @@ return [
     'name' => 'sort_name_format',
     'type' => 'String',
     'html_type' => 'textarea',
-    'default' => '{contact.last_name}{, }{contact.first_name}',
+    'default' => '{contact.last_name}{, }{contact.first_name}{ }{contact.individual_suffix}',
     'add' => '4.1',
     'title' => ts('Individual Sort Name Format'),
     'is_domain' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
@colemanw mentioned that sort_name doesn't allow you to distinguish between Bob Smith Jr. and Bob Smith Sr., making it hard to select the right one from an autocomplete.

Before
----------------------------------------
Sort name is `Smith, Bob` for both.

After
----------------------------------------
For new installs only, sort name is `Smith, Bob Jr.` and `Smith, Bob Sr.`