### PR TITLE
dev/core#4501 Redis - fix ttl on prev-next cache

### DIFF
--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -173,9 +173,12 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     }
     elseif ($id !== NULL && $cacheKey !== NULL) {
       // Delete a specific contact, within a specific cache.
-      $this->redis->zRem($this->key($cacheKey, 'all'), $id);
-      $this->redis->zRem($this->key($cacheKey, 'sel'), $id);
-      $this->redis->hDel($this->key($cacheKey, 'data'), $id);
+      $deleted = $this->redis->zRem($this->key($cacheKey, 'all'), $id);
+      if ($deleted) {
+        // If they were in the 'all' key they might be in the more specific 'sel' and 'data' keys.
+        $this->redis->zRem($this->key($cacheKey, 'sel'), $id);
+        $this->redis->hDel($this->key($cacheKey, 'data'), $id);
+      }
     }
     elseif ($id !== NULL && $cacheKey === NULL) {
       // Delete a specific contact, across all prevnext caches.

--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -37,10 +37,9 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
 
   /**
    * CRM_Core_PrevNextCache_Redis constructor.
-   *
    * @param array $settings
    */
-  public function __construct(array $settings) {
+  public function __construct($settings) {
     $this->redis = CRM_Utils_Cache_Redis::connect($settings);
     $this->prefix = $settings['prefix'] ?? '';
     $this->prefix .= \CRM_Utils_Cache::DELIMITER . 'prevnext' . \CRM_Utils_Cache::DELIMITER;
@@ -57,16 +56,23 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     return self::TTL;
   }
 
-  public function fillWithSql($cacheKey, $sql, $sqlParams = []): bool {
+  public function fillWithSql($cacheKey, $sql, $sqlParams = []) {
     $dao = CRM_Core_DAO::executeQuery($sql, $sqlParams, FALSE);
 
     [$allKey, $dataKey, , $maxScore] = $this->initCacheKey($cacheKey);
-
+    $first = TRUE;
     while ($dao->fetch()) {
       [, $entity_id, $data] = array_values($dao->toArray());
       $maxScore++;
       $this->redis->zAdd($allKey, $maxScore, $entity_id);
+      if ($first) {
+        $this->redis->expire($allKey, $this->getTTL());
+      }
       $this->redis->hSet($dataKey, $entity_id, $data);
+      if ($first) {
+        $this->redis->expire($dataKey, $this->getTTL());
+      }
+      $first = FALSE;
     }
 
     return TRUE;
@@ -74,11 +80,18 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
 
   public function fillWithArray($cacheKey, $rows) {
     [$allKey, $dataKey, , $maxScore] = $this->initCacheKey($cacheKey);
-
+    $first = TRUE;
     foreach ($rows as $row) {
       $maxScore++;
       $this->redis->zAdd($allKey, $maxScore, $row['entity_id1']);
+      if ($first) {
+        $this->redis->expire($allKey, $this->getTTL());
+      }
       $this->redis->hSet($dataKey, $row['entity_id1'], $row['data']);
+      if ($first) {
+        $this->redis->expire($dataKey, $this->getTTL());
+      }
+      $first = FALSE;
     }
 
     return TRUE;
@@ -94,9 +107,14 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     $selKey = $this->key($cacheKey, 'sel');
 
     if ($action === 'select') {
+      $first = TRUE;
       foreach ((array) $ids as $id) {
         $score = $this->redis->zScore($allKey, $id);
         $this->redis->zAdd($selKey, $score, $id);
+        if ($first) {
+          $this->redis->expire($selKey, $this->getTTL());
+        }
+        $first = FALSE;
       }
     }
     elseif ($action === 'unselect' && $ids === NULL) {
@@ -124,16 +142,14 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
       }
       return [$cacheKey => $result];
     }
-    elseif ($action === 'getall') {
+    if ($action === 'getall') {
       $result = [];
       foreach ($this->redis->zRange($allKey, 0, -1) as $entity_id) {
         $result[$entity_id] = 1;
       }
       return [$cacheKey => $result];
     }
-    else {
-      throw new \CRM_Core_Exception("Unrecognized action: $action");
-    }
+    throw new \CRM_Core_Exception("Unrecognized action: $action");
   }
 
   public function getPositions($cacheKey, $id1) {
@@ -242,10 +258,6 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     $allKey = $this->key($cacheKey, 'all');
     $selKey = $this->key($cacheKey, 'sel');
     $dataKey = $this->key($cacheKey, 'data');
-
-    $this->redis->expire($allKey, $this->getTTL());
-    $this->redis->expire($dataKey, $this->getTTL());
-    $this->redis->expire($selKey, $this->getTTL());
 
     $maxScore = 0;
     foreach ($this->redis->zRange($allKey, -1, -1, TRUE) as $lastElem => $lastScore) {


### PR DESCRIPTION
Overview
----------------------------------------
Redis - fix ttl on prev-next cache

Before
----------------------------------------
The ttl is not being set on the prevnext keys when the cache in use is `Redis`. This can been seen by doing a search in the UI via basic search or advanced search (but not search kit) and then opening up `redis-cli`.

In redis-cli you can find the keys created using the keys command

![image](https://github.com/civicrm/civicrm-core/assets/336308/69fd2f5f-1626-4ce8-82a1-2e13f3555035)

The ttpl for those keys can be seen with the ttl command - ie 

```
 ttl  "/prevnext/civicrm search CRMContactControllerSearch1v64jxfujuckw4g4o40kg8wcck0wscs4wskcwkck0g4gg48wws_8715/all"
```

Without this patch the `ttl` is always -1

After
----------------------------------------
Afterwards the ttl should have a value at all times - note that I testing searching along with selecting & unselecting specific contacts and deleting a contact from within the set

Technical Details
----------------------------------------
The expires was being set on the key before it was created - not doing anything. I could not find any evidence that it is possible to create an empty key & hence concluded we have to set expires first key-add. It seems redis-cli accepts expires as part of the `set` command and I think our php library supports that for the basic set - but not all the variants

Comments
----------------------------------------
tips
1) if using Redis on docker it is good to add redis-cli & redis-monitor to .bash_aliases like

```
alias redis-monitor='docker-compose --file /home/eileen/dev/fundraising-dev/docker-compose.yml exec queues redis-cli monitor'
alias redis-cli='docker-compose --file /home/eileen/dev/fundraising-dev/docker-compose.yml exec queues redis-cli'
```
2) if using `Redis` on a system with a password try something like this in .profile

```
export REDIS_PWD=totally_secret_password
alias redis-monitor='redis-cli -a $REDIS_PWD monitor'
alias redis-cli='redis-cli -a $REDIS_PWD'
```

3) you can count the keys that are on your system like this
You can also count them like this ....

```
redis-cli keys *prevnext* | wc -l
```

4) if you have had Redis running for a while you may have a build up of keys from prev-next searches (we have 35k) - there is no api action to clear these but you can use eval (via cv or drush) to clear them out

```
 cv php:eval "\Civi::service('prevnext')->deleteItem();"
```
