### PR TITLE
Bump search_autocomplete_count default from 10 to 15

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -168,7 +168,7 @@ class AutocompleteAction extends AbstractAction {
       if (!empty($this->display['settings']['columns'][0]['rewrite'])) {
         $searchFields = array_merge($searchFields, $this->getTokens($this->display['settings']['columns'][0]['rewrite']));
       }
-      $this->display['settings']['limit'] = $this->display['settings']['limit'] ?? \Civi::settings()->get('search_autocomplete_count') ?: 10;
+      $this->display['settings']['limit'] = $this->display['settings']['limit'] ?? \Civi::settings()->get('search_autocomplete_count');
       $this->display['settings']['pager'] = [];
       $return = 'scroll:' . $this->page;
       // SearchKit treats comma-separated fieldnames as OR clauses

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -25,7 +25,7 @@ return [
     'type' => 'Integer',
     'quick_form_type' => 'Element',
     'html_type' => 'number',
-    'default' => 10,
+    'default' => 15,
     'add' => '4.3',
     'title' => ts('Autocomplete Results'),
     'is_domain' => 1,

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -200,6 +200,7 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
   }
 
   public function testAutocompletePager() {
+    \Civi::settings()->set('search_autocomplete_count', 10);
     MockBasicEntity::delete()->addWhere('identifier', '>', 0)->execute();
     $sampleData = [];
     foreach (range(1, 21) as $num) {


### PR DESCRIPTION
Overview
----------------------------------------
Improves the overall responsiveness of Autocompletes by fetching more results at a time.

Before
----------------------------------------
Ajax requests can be slow.

After
----------------------------------------
Fetching 50% more will add a negligible amount of time to each request, but cut down on the number of requests.

Comments
------------
Bikesheddy question of whether it should be 15 or 20 but I think it's safe to say that 10 is too few so at least this is better.
