### PR TITLE
Smarty-notice fix - use array_key_exists

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -36,7 +36,7 @@
           {/if}
         </div>
         <div class="crm-content">
-          {if !empty($sharedAddresses.$locationIndex.shared_address_display.name)}
+          {if array_key_exists($locationIndex, $sharedAddresses) && !empty($sharedAddresses.$locationIndex.shared_address_display.name)}
             <strong>{ts 1=$sharedAddresses.$locationIndex.shared_address_display.name}Address belongs to %1{/ts}</strong><br />
           {/if}
           {$add.display|smarty:nodefaults|purify|nl2br}


### PR DESCRIPTION
Overview
----------------------------------------
Smarty-notice fix - use array_key_exists

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/4418b95a-bd28-4e20-b85e-e85f1b7f25c6)


After
----------------------------------------
poof

Technical Details
----------------------------------------


Comments
----------------------------------------
