### PR TITLE
Standalone: Fix ACL help/links, tweak Users and Permissions menu

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -574,7 +574,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    */
   public function getCMSPermissionsUrlParams() {
     if ($this->missingStandaloneExtension()) {
-      return ['ufAccessURL' => '/fixme/standalone/permissions/url/params'];
+      return ['ufAccessURL' => '/civicrm/admin/roles'];
     }
     return Security::singleton()->getCMSPermissionsUrlParams();
   }

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -295,7 +295,7 @@ class Security {
    * @return array
    */
   public function getCMSPermissionsUrlParams() {
-    return ['ufAccessURL' => '/fixme/standalone/permissions/url/params'];
+    return ['ufAccessURL' => '/civicrm/admin/roles'];
   }
 
   /**

--- a/ext/standaloneusers/ang/afsearchAdministerUserAccounts.aff.json
+++ b/ext/standaloneusers/ang/afsearchAdministerUserAccounts.aff.json
@@ -16,8 +16,8 @@
     "redirect": null,
     "create_submission": false,
     "navigation": {
-        "parent": "Administer",
-        "label": "Administer User Accounts",
+        "parent": "Users and Permissions",
+        "label": "User Accounts",
         "weight": 0
     }
 }

--- a/ext/standaloneusers/ang/afsearchUserRoles.aff.json
+++ b/ext/standaloneusers/ang/afsearchUserRoles.aff.json
@@ -6,7 +6,7 @@
     "server_route": "civicrm/admin/roles",
     "permission": "cms:administer users",
     "navigation": {
-        "parent": "Administer",
+        "parent": "Users and Permissions",
         "label": "User Roles",
         "weight": 0
     },

--- a/templates/CRM/Admin/Page/Access.tpl
+++ b/templates/CRM/Admin/Page/Access.tpl
@@ -10,29 +10,36 @@
 {capture assign=docUrlText}{ts}Access Control Documentation{/ts}{/capture}
 {capture assign=docLink}{docURL page="user/initial-set-up/permissions-and-access-control/" text=$docUrlText}{/capture}
 <div class="help">
-    <p>{ts 1=$docLink}ACLs (Access Control Lists) allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of Data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}
-    {if $config->userSystem->is_drupal EQ '1'}{ts}Note that a CiviCRM ACL Role is not related to the Drupal Role.{/ts}{/if}</p>
-    <p>{ts}<strong>EXAMPLE:</strong> 'Team Leaders' (<em>ACL Role</em>) can 'Edit' (<em>Operation</em>) all contacts in the 'Active Volunteers Group' (<em>Data</em>).{/ts}</p>
-    <p>{ts 1=$ufAccessURL|smarty:nodefaults 2=$jAccessParams 3=$config->userFramework}Use <a href='%1' %2>%3 Access Control</a> to manage basic access to CiviCRM components and menu items. Use CiviCRM ACLs to control access to specific CiviCRM contact groups. You can also configure ACLs to grant or deny access to specific Events, Profiles, and/or Custom Data Fields.{/ts}</p>
-   <p>{ts 1=$config->userFramework}Note that %1 Access Control permissions take precedence over CiviCRM ACLs. If you wish to use CiviCRM ACLs, first disable the related permission in %1 Access control for a user role, and then gradually add ACLs to replace that permission for certain groups of contacts.{/ts}
+  <p>{ts 1=$docLink}ACLs (Access Control Lists) allow you control access to CiviCRM data. An ACL consists of an <strong>Operation</strong> (e.g. 'View' or 'Edit'), a <strong>set of Data</strong> that the operation can be performed on (e.g. a group of contacts), and a <strong>Role</strong> that has permission to do this operation. Refer to the %1 for more info.{/ts}
+  {if $config->userSystem->is_drupal EQ '1'}{ts}Note that a CiviCRM ACL Role is not related to the Drupal Role.{/ts}{/if}</p>
+  <p>{ts}<strong>EXAMPLE:</strong> 'Team Leaders' (<em>ACL Role</em>) can 'Edit' (<em>Operation</em>) all contacts in the 'Active Volunteers Group' (<em>Data</em>).{/ts}</p>
+  <p>{ts}CiviCRM ACLs can control access to specific CiviCRM contact groups. You can also configure ACLs to grant or deny access to specific Events, Profiles or Custom Data Fields.{/ts}</p>
+  {if $config->userFramework == 'Standalone'}
+    <p>{ts 1=$ufAccessURL|smarty:nodefaults}Note that <a href="%1">User Role</a> permissions take precedence over CiviCRM ACLs. If you wish to use CiviCRM ACLs, first disable the related permission in User Roles, and then gradually add ACLs to replace that permission for certain groups of contacts.{/ts}
+  {else}
+    <p>{ts 1=$ufAccessURL|smarty:nodefaults 2=$jAccessParams 3=$config->userFramework}Note that <a href='%1' %2>%3 permissions</a> take precedence over CiviCRM ACLs. If you wish to use CiviCRM ACLs, first disable the related permission in %3 for a user role, and then gradually add ACLs to replace that permission for certain groups of contacts.{/ts}
+  {/if}
 </div>
-
-    <table class="report">
-        <tr>
-            <td class="nowrap"><a href="{$ufAccessURL|smarty:nodefaults}" {$jAccessParams} id="adminAccess"><i class="crm-i fa-chevron-right fa-fw" aria-hidden="true"></i> {ts 1=$config->userFramework}%1 Access Control{/ts}</a></td>
-            <td>{ts}Grant access to CiviCRM components and other CiviCRM permissions.{/ts}</td>
-        </tr>
-        <tr><td colspan="2" class="separator"><strong>{ts}Use following steps if you need to control View and/or Edit permissions for specific contact groups, specific profiles or specific custom data fields.{/ts}</strong></td></tr>
-    <tr>
-        <td class="nowrap"><a href="{crmURL p='civicrm/admin/options/acl_role' q="reset=1"}" id="editACLRoles"><i class="crm-i fa-users fa-fw" aria-hidden="true"></i> {ts}1. Manage Roles{/ts}</a></td>
-        <td>{ts}Each CiviCRM ACL Role is assigned a set of permissions. Use this link to create or edit the different roles needed for your site.{/ts}</td>
-    </tr>
-    <tr>
-        <td class="nowrap"><a href="{crmURL p='civicrm/acl/entityrole' q="reset=1"}" id="editRoleAssignments"><i class="crm-i fa-user-plus fa-fw" aria-hidden="true"></i> {ts}2. Assign Users to CiviCRM ACL Roles{/ts}</a></td>
-        <td>{ts}Once you have defined CiviCRM ACL Roles and granted ACLs to those Roles, use this link to assign users to role(s).{/ts}</td>
-    </tr>
-    <tr>
-        <td class="nowrap"><a href="{crmURL p='civicrm/acl' q="reset=1"}" id="editACLs"><i class="crm-i fa-id-card-o fa-fw" aria-hidden="true"></i> {ts}3. Manage ACLs{/ts}</a></td>
-        <td>{ts}ACLs define permission to do an operation on a set of data, and grant that permission to a CiviCRM ACL Role. Use this link to create or edit the ACLs for your site.{/ts}</td>
-    </tr>
-    </table>
+<table class="report">
+  <tr>
+    {if $config->userFramework == 'Standalone'}
+      <td class="nowrap"><a href="{$ufAccessURL|smarty:nodefaults}" id="adminAccess"><i class="crm-i fa-chevron-right fa-fw" aria-hidden="true"></i>{ts}User Roles{/ts}</a></td>
+    {else}
+      <td class="nowrap"><a href="{$ufAccessURL|smarty:nodefaults}" {$jAccessParams} id="adminAccess"><i class="crm-i fa-chevron-right fa-fw" aria-hidden="true"></i> {ts 1=$config->userFramework}%1 Permissions{/ts}</a></td>
+    {/if}
+    <td>{ts}Grant access to CiviCRM components and other CiviCRM permissions.{/ts}</td>
+  </tr>
+  <tr><td colspan="2" class="separator"><strong>{ts}Use following steps if you need to control View and/or Edit permissions for specific contact groups, specific profiles or specific custom data fields.{/ts}</strong></td></tr>
+  <tr>
+    <td class="nowrap"><a href="{crmURL p='civicrm/admin/options/acl_role' q="reset=1"}" id="editACLRoles"><i class="crm-i fa-users fa-fw" aria-hidden="true"></i> {ts}1. Manage Roles{/ts}</a></td>
+    <td>{ts}Each CiviCRM ACL Role is assigned a set of permissions. Use this link to create or edit the different roles needed for your site.{/ts}</td>
+  </tr>
+  <tr>
+    <td class="nowrap"><a href="{crmURL p='civicrm/acl/entityrole' q="reset=1"}" id="editRoleAssignments"><i class="crm-i fa-user-plus fa-fw" aria-hidden="true"></i> {ts}2. Assign Users to CiviCRM ACL Roles{/ts}</a></td>
+    <td>{ts}Once you have defined CiviCRM ACL Roles and granted ACLs to those Roles, use this link to assign users to role(s).{/ts}</td>
+  </tr>
+  <tr>
+    <td class="nowrap"><a href="{crmURL p='civicrm/acl' q="reset=1"}" id="editACLs"><i class="crm-i fa-id-card-o fa-fw" aria-hidden="true"></i> {ts}3. Manage ACLs{/ts}</a></td>
+    <td>{ts}ACLs define permission to do an operation on a set of data, and grant that permission to a CiviCRM ACL Role. Use this link to create or edit the ACLs for your site.{/ts}</td>
+  </tr>
+</table>

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -344,8 +344,8 @@ SET @usersPermslastID:=LAST_INSERT_ID();
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
-    ( @domainID, 'civicrm/admin/access?reset=1',       '{ts escape="sql" skip="true"}Permissions (Access Control){/ts}',    'Permissions (Access Control)',     'administer CiviCRM', '', @usersPermslastID, '1', NULL, 1 ),
-    ( @domainID, 'civicrm/admin/synchUser?reset=1',    '{ts escape="sql" skip="true"}Synchronize Users to Contacts{/ts}',   'Synchronize Users to Contacts',    'administer CiviCRM', '', @usersPermslastID, '1', NULL, 2 );
+    ( @domainID, 'civicrm/admin/access?reset=1',       '{ts escape="sql" skip="true"}Access Control Lists{/ts}',    'Permissions (Access Control)',     'administer CiviCRM', '', @usersPermslastID, '1', NULL, 5 ),
+    ( @domainID, 'civicrm/admin/synchUser?reset=1',    '{ts escape="sql" skip="true"}Synchronize Users to Contacts{/ts}',   'Synchronize Users to Contacts',    'administer CiviCRM', '', @usersPermslastID, '1', NULL, 10 );
 
 INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )


### PR DESCRIPTION
Overview
----------------------------------------

On CiviCRM Standalone:

- Go to Administer > Users and Permissions > Permissions
- the "Standalone Access Control" link leads to a "fixme" 404

Also, the "Manage Users" and Roles links are not under "Users and Permissions".

This PR changes the following:

- sets the `ufAccessURL` so that it leads to lead to manage "User roles"
- tweaks the wording a bit on the Manage ACL page, so that it's less awkward when using Standalone. After all, it's not "Standalone Foo", it's just Foo. Users are aware that they are using CiviCRM, not that they are using CiviCRM Standalone.
- moves the User Roles and User Accounts menu items under "Users and Permissions"

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/9ec481e9-bdb0-4221-867e-3c8433dbdd99)

Navigation menu:

![image](https://github.com/civicrm/civicrm-core/assets/254741/1694b372-f280-4bd8-bf18-1af7e13fe707)

After
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/254741/ae9bb543-9942-4975-903e-8864ab3be242)

![image](https://github.com/civicrm/civicrm-core/assets/254741/30bc7442-0de0-4b16-a408-58f98e3840ce)


Comments
----------------------------------------

Moving the menu items: I realize this hinders discoverability a bit, but I think it also declutters, therefore making menu navigation easier.

Reported by dsp3926 on the [standalone chat](https://chat.civicrm.org/civicrm/channels/standalone/)

cc @artfulrobot 