### PR TITLE
dev/core#4519 SearchKit - Fix tasks when ID column is not present

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -147,8 +147,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         'columns' => $columns,
         'cssClass' => implode(' ', $style),
       ];
-      if (isset($data[$keyName])) {
-        $row['key'] = $data[$keyName];
+      if (isset($record[$keyName])) {
+        $row['key'] = $record[$keyName];
       }
       $rows[] = $row;
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -543,6 +543,8 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     ];
     $result = civicrm_api4('SearchDisplay', 'run', $params);
 
+    $this->assertEquals($contacts[0], $result[0]['key']);
+
     // Contact 1 first name can be updated
     $this->assertEquals('One', $result[0]['columns'][0]['val']);
     $this->assertEquals($contacts[0], $result[0]['columns'][0]['edit']['record']['id']);
@@ -1507,6 +1509,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     // Second Individual
     $expectedFirstNameEdit['record']['id'] = $contact[1]['id'];
     $expectedFirstNameEdit['value'] = NULL;
+    $this->assertEquals($contact[1]['id'], $result[1]['key']);
     $this->assertEquals($expectedFirstNameEdit, $result[1]['columns'][0]['edit']);
     $this->assertTrue(!isset($result[1]['columns'][1]['edit']));
     $this->assertTrue(!isset($result[1]['columns'][2]['edit']));
@@ -1741,6 +1744,49 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('fa-user', $result[1]['columns'][0]['icons'][0]['class']);
     $this->assertEquals('Starry', $result[2]['columns'][0]['val']);
     $this->assertEquals('fa-star', $result[2]['columns'][0]['icons'][0]['class']);
+  }
+
+  public function testKeyIsReturned(): void {
+    $id = $this->createTestRecord('Email')['id'];
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Email',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['email'],
+          'where' => [
+            ['id', 'IN', [$id]],
+          ],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'limit' => 20,
+          'pager' => TRUE,
+          'actions' => TRUE,
+          'columns' => [
+            [
+              'key' => 'email',
+              'label' => 'Email',
+              'dataType' => 'String',
+              'type' => 'field',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+      'afform' => NULL,
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+    $this->assertEquals($id, $result[0]['key']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug described in https://lab.civicrm.org/dev/core/-/issues/4519 which appears to have regressed in [#21929](https://github.com/civicrm/civicrm-core/pull/21929)

Before
----------------------------------------
All checkboxes selected when you click one. Bulk actions don't work.

After
----------------------------------------
Fixed.