### PR TITLE
Support retention of locale on links

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -300,7 +300,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $forceBackend = FALSE
   ) {
     $config = CRM_Core_Config::singleton();
-    $script = '';
+    $frontend_url = '';
     $separator = '&';
     $fragment = isset($fragment) ? ('#' . $fragment) : '';
     $path = CRM_Utils_String::stripPathChars($path);
@@ -318,8 +318,8 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       // Try and find the "calling" page/post.
       global $post;
       if ($post) {
-        $script = get_permalink($post->ID);
-        if ($config->wpBasePage == $post->post_name) {
+        $frontend_url = get_permalink($post->ID);
+        if (civi_wp()->basepage->is_match($post->ID)) {
           $basepage = TRUE;
         }
       }
@@ -329,7 +329,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
       // Get the Base Page URL for building front-end URLs.
       if ($frontend && !$forceBackend) {
-        $script = $this->getBasePageUrl();
+        $frontend_url = $this->getBasePageUrl();
         $basepage = TRUE;
       }
 
@@ -339,12 +339,22 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     $base = $this->getBaseUrl($absolute, $frontend, $forceBackend);
 
     // Overwrite base URL if we already have a front-end URL.
-    if (!$forceBackend && $script != '') {
-      $base = $script;
+    if (!$forceBackend && $frontend_url != '') {
+      $base = $frontend_url;
     }
 
     $queryParts = [];
     $admin_request = ((is_admin() && !$frontend) || $forceBackend);
+
+    /**
+     * Filter the Base URL.
+     *
+     * @since 5.66
+     *
+     * @param str $base The Base URL.
+     * @param bool $admin_request True if building an admin URL, false otherwise.
+     */
+    $base = apply_filters('civicrm/core/url/base', $base, $admin_request);
 
     if (
       // If not using Clean URLs.
@@ -352,7 +362,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       // Or requesting an admin URL.
       || $admin_request
       // Or this is a Shortcode.
-      || (!$basepage && $script != '')
+      || (!$basepage && $frontend_url != '')
     ) {
 
       // Build URL according to pre-existing logic.
@@ -431,37 +441,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    *   The Base Page URL, or false on failure.
    */
   public function getBasePageUrl() {
-    static $basepage_url = '';
-    if ($basepage_url === '') {
-
-      // Get the Base Page config setting.
-      $config = CRM_Core_Config::singleton();
-      $basepage_slug = $config->wpBasePage;
-
-      // Did we get a value?
-      if (!empty($basepage_slug)) {
-
-        // Query for our Base Page.
-        $pages = get_posts([
-          'post_type' => 'page',
-          'name' => strtolower($basepage_slug),
-          'post_status' => 'publish',
-          'posts_per_page' => 1,
-        ]);
-
-        // Find the Base Page object and set the URL.
-        if (!empty($pages) && is_array($pages)) {
-          $basepage = array_pop($pages);
-          if ($basepage instanceof WP_Post) {
-            $basepage_url = get_permalink($basepage->ID);
-          }
-        }
-
-      }
-
-    }
-
-    return $basepage_url;
+    return civi_wp()->basepage->url_get();
   }
 
   /**
@@ -636,11 +616,14 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function getUFLocale() {
-    // Bail early if method is called when WordPress isn't bootstrapped.
-    // Additionally, the function checked here is located in pluggable.php
-    // and is required by wp_get_referer() - so this also bails early if it is
-    // called too early in the request lifecycle.
-    // @see https://core.trac.wordpress.org/ticket/25294
+    /*
+     * Bail early if method is called when WordPress isn't bootstrapped.
+     * Additionally, the function checked here is located in pluggable.php
+     * and is required by wp_get_referer() - so this also bails early if it is
+     * called too early in the request lifecycle.
+     *
+     * @see https://core.trac.wordpress.org/ticket/25294
+     */
     if (!function_exists('wp_validate_redirect')) {
       return NULL;
     }
@@ -662,28 +645,16 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       // Default to WordPress locale.
       $locale = get_locale();
 
-      // Maybe override with the locale that Polylang reports.
-      if (function_exists('pll_current_language')) {
-        $pll_locale = pll_current_language('locale');
-        if (!empty($pll_locale)) {
-          $locale = $pll_locale;
-        }
-      }
-
-      // Maybe override with the locale that WPML reports.
-      elseif (defined('ICL_LANGUAGE_CODE')) {
-        $languages = apply_filters('wpml_active_languages', NULL);
-        foreach ($languages as $language) {
-          if ($language['active']) {
-            $locale = $language['default_locale'];
-            break;
-          }
-        }
-      }
-
-      // TODO: Set locale for other WordPress plugins.
-      // @see https://wordpress.org/plugins/tags/multilingual/
-      // A hook would be nice here.
+      /**
+       * Filter the default WordPress locale.
+       *
+       * The CiviCRM-WordPress plugin supports Polylang and WPML via this filter.
+       *
+       * @since 5.66
+       *
+       * @param str $locale The WordPress locale.
+       */
+      $locale = apply_filters('civicrm/core/locale', $locale);
 
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Solves [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/143).

Before
----------------------------------------
1. The method to generate URLs for WordPress could not accommodate plugins that alter the structure of the URL to encode locale information on the front-end.
2. Locale support on the front-end was implemented directly in the `getUFLocale()` method.

After
----------------------------------------
1. A filter enables the `url()` method to generate front-end URLs that contain locale information as defined by 3rd party plugins.
2. A filter enables the `getUFLocale()` method to support front-end locales as defined by 3rd party plugins. 

Technical Details
----------------------------------------
Requires [this PR on CiviCRM-WordPress](https://github.com/civicrm/civicrm-wordpress/pull/301).