### PR TITLE
Fix adding onclick for other_amount in pricesets

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -311,20 +311,20 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         ]);
 
         $extra = [];
-        if (!empty($qf->_membershipBlock) && $isQuickConfig && $field->name == 'other_amount') {
-          $useRequired = 0;
-        }
-        elseif (!empty($fieldOptions[$optionKey]['label'])) {
+        if (!empty($fieldOptions[$optionKey]['label'])) {
           //check for label.
           $label = $fieldOptions[$optionKey]['label'];
-          if ($isQuickConfig && $field->name === 'contribution_amount' && strtolower($fieldOptions[$optionKey]['name']) == 'other_amount') {
-            $label .= '  ' . $currencySymbol;
-            $qf->assign('priceset', $elementName);
-            $extra = [
-              'onclick' => 'useAmountOther();',
-              'autocomplete' => 'off',
-            ];
+        }
+        if ($isQuickConfig && $field->name === 'other_amount') {
+          if (!empty($qf->_membershipBlock)) {
+            $useRequired = 0;
           }
+          $label .= '  ' . $currencySymbol;
+          $qf->assign('priceset', $elementName);
+          $extra = [
+            'onclick' => 'useAmountOther();',
+            'autocomplete' => 'off',
+          ];
         }
 
         $element = &$qf->add('text', $elementName, $label,


### PR DESCRIPTION
Overview
----------------------------------------
#26441 caused a regression so that adding an other amount on a contribution page no longer unselected the radio options above, leading to contributors paying for both the selected amount and the other amount.
Additionally, it looks like this never worked for additional contributions with memberships.

Before
----------------------------------------
Adding an other amount leaves the radio option selected.

After
----------------------------------------
Adding an other amount selects other and unselects any priced options above.

Technical Details
----------------------------------------
Slightly simplified by removing the other_amount logic from the label conditional. I don't see how there would be a connection between those two things.