### PR TITLE
dev/core#4530 - Change email fields to text in search mode

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/EmailGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EmailGetSpecProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * This applies to all entities with an email field.
+ *
+ * In the contact of "get", email validation doesn't make sense so change it to text.
+ *
+ * @service
+ * @internal
+ */
+class EmailGetSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    foreach ($spec->getFields() as $field) {
+      if ($field->getInputType() === 'Email') {
+        $field->setInputType('Text');
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $action === 'get';
+  }
+
+}

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -24,6 +24,7 @@ use Civi\Api4\Activity;
 use Civi\Api4\Campaign;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
+use Civi\Api4\Email;
 use Civi\Api4\EntityTag;
 use Civi\Test\TransactionalInterface;
 
@@ -71,6 +72,20 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
       ->addWhere('name', 'CONTAINS', 'campaign')
       ->execute();
     $this->assertCount(1, $fields);
+  }
+
+  public function testEmailFields() {
+    $getFields = Email::getFields(FALSE)
+      ->setAction('get')
+      ->execute()->indexBy('name');
+
+    $this->assertEquals('Text', $getFields['email']['input_type']);
+
+    $createFields = Email::getFields(FALSE)
+      ->setAction('create')
+      ->execute()->indexBy('name');
+
+    $this->assertEquals('Email', $createFields['email']['input_type']);
   }
 
   public function testInternalPropsAreHidden() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4530](https://lab.civicrm.org/dev/core/-/issues/4530)

Before
----------------------------------------
Email validation kicks in when it shouldn't.

After
----------------------------------------
Only validates when it should.