### PR TITLE
Fix checkbox JS regression for import data selection and email new te…

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -86,7 +86,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
     $this->assign('urlPath', 'civicrm/import/datasource');
     $this->assign('urlPathVar', 'snippet=4&user_job_id=' . $this->get('user_job_id'));
     if ($this->isImportDataUploaded()) {
-      $this->add('checkbox', 'use_existing_upload', ts('Use data already uploaded'), NULL, FALSE, [
+      $this->add('checkbox', 'use_existing_upload', ts('Use data already uploaded'), [
         'onChange' => "
           CRM.$('.crm-import-datasource-form-block-dataSource').toggle();
           CRM.$('#data-source-form-block').toggle()",

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2580,10 +2580,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
         );
       }
       $form->add('checkbox', "{$prefix}updateTemplate", ts('Update Template'), NULL);
-
-      $form->add('checkbox', "{$prefix}saveTemplate", ts('Save As New Template'), NULL, FALSE,
-        ['onclick' => "showSaveDetails(this, '{$prefix}');"]
-      );
+      $form->add('checkbox', "{$prefix}saveTemplate", ts('Save As New Template'), ['onclick' => "showSaveDetails(this, '{$prefix}');"]);
       $form->add('text', "{$prefix}saveTemplateName", ts('Template Title'));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Regression from #26598. That PR changed the signature of add() for a checkbox, breaking these two checkboxes which no longer had their onchange added as it was in $extra, which is now ignored.
These are the only two that show up by searching.

Before
----------------------------------------
1. On Contact - New Email, clicking the Save as New Template doesn't show the template name field.
2. In Import, if you add a data file, go to the next step, then go back, the Use data already uploaded checkbox doesn't show/hide fields below it as intended.

After
----------------------------------------
Show/hide works as intended.