### PR TITLE
phpunit.xml.dist - Update extensions to use phpunit9 format

### DIFF
--- a/ext/afform/core/phpunit.xml.dist
+++ b/ext/afform/core/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/afform/core/phpunit.xml.dist
+++ b/ext/afform/core/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/afform/mock/phpunit.xml.dist
+++ b/ext/afform/mock/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,6 +12,11 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
@@ -18,11 +25,6 @@
       <directory suffix=".test.php">./ang</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/afform/mock/phpunit.xml.dist
+++ b/ext/afform/mock/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/authx/phpunit.xml.dist
+++ b/ext/authx/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/authx/phpunit.xml.dist
+++ b/ext/authx/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/civigrant/phpunit.xml.dist
+++ b/ext/civigrant/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,17 +10,18 @@
          convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="tests/phpunit/bootstrap.php">
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/civigrant/phpunit.xml.dist
+++ b/ext/civigrant/phpunit.xml.dist
@@ -1,5 +1,14 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/civiimport/phpunit.xml.dist
+++ b/ext/civiimport/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         cacheResult="false"
+         bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/civiimport/phpunit.xml.dist
+++ b/ext/civiimport/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,18 +10,18 @@
          convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         cacheResult="false"
-         bootstrap="tests/phpunit/bootstrap.php">
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/contributioncancelactions/phpunit.xml.dist
+++ b/ext/contributioncancelactions/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/contributioncancelactions/phpunit.xml.dist
+++ b/ext/contributioncancelactions/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/elavon/phpunit.xml.dist
+++ b/ext/elavon/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         cacheResult="false"
+         bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/elavon/phpunit.xml.dist
+++ b/ext/elavon/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,18 +10,18 @@
          convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         cacheResult="false"
-         bootstrap="tests/phpunit/bootstrap.php">
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/ewaysingle/phpunit.xml.dist
+++ b/ext/ewaysingle/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/ewaysingle/phpunit.xml.dist
+++ b/ext/ewaysingle/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/financialacls/phpunit.xml.dist
+++ b/ext/financialacls/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/financialacls/phpunit.xml.dist
+++ b/ext/financialacls/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/flexmailer/phpunit.xml.dist
+++ b/ext/flexmailer/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/flexmailer/phpunit.xml.dist
+++ b/ext/flexmailer/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/legacycustomsearches/phpunit.xml.dist
+++ b/ext/legacycustomsearches/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="Legacy custom searches">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/legacycustomsearches/phpunit.xml.dist
+++ b/ext/legacycustomsearches/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="Legacy custom searches">
       <directory>./tests/phpunit</directory>

--- a/ext/oauth-client/phpunit.xml.dist
+++ b/ext/oauth-client/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/oauth-client/phpunit.xml.dist
+++ b/ext/oauth-client/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/payflowpro/phpunit.xml.dist
+++ b/ext/payflowpro/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/payflowpro/phpunit.xml.dist
+++ b/ext/payflowpro/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/search_kit/phpunit.xml.dist
+++ b/ext/search_kit/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="SearchKit Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/search_kit/phpunit.xml.dist
+++ b/ext/search_kit/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="SearchKit Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/sequentialcreditnotes/phpunit.xml.dist
+++ b/ext/sequentialcreditnotes/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,16 +12,16 @@
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php"
          cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/ext/sequentialcreditnotes/phpunit.xml.dist
+++ b/ext/sequentialcreditnotes/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" cacheResult="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/standaloneusers/phpunit.xml.dist
+++ b/ext/standaloneusers/phpunit.xml.dist
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         cacheResult="false"
+         bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/ext/standaloneusers/phpunit.xml.dist
+++ b/ext/standaloneusers/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,18 +10,18 @@
          convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         cacheResult="false"
-         bootstrap="tests/phpunit/bootstrap.php">
+         bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>


### PR DESCRIPTION
Overview
----------------------------------------

Since we're switch the core extensions to run tests on phpunit9 (https://github.com/civicrm/civicrm-buildkit/pull/811), we should also update format.

cc @seamuslee001 

Before
----------------------------------------

```
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/financialacls] phpunit9 
PHPUnit 9.6.5 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

After
----------------------------------------

Quiet
