### PR TITLE
Improve initialization crash message

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -468,53 +468,57 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *
    * @param string $name name of debug section
    * @param mixed $variable reference to variables that we need a trace of
-   * @param bool $log should we call error_log and echo a reference, or return the output
-   * @param bool $html whether to generate a HTML-escaped output (not relevant if $log is truthy)
+   * @param bool $log
+   *    - TRUE: log to error_log and echo one of: everything / a code / nothing, depending on permissions.
+   *    - FALSE: only return the output as a string. Nothing to error_log or echo.
+   * @param bool $html whether to HTML-escape output (typically use TRUE unless you know your $variable is safe)
    * @param bool $checkPermission should we check permissions before displaying output
-   *                useful when we die during initialization and permissioning
-   *                subsystem is not initialized - CRM-13765
+   *    useful when we die during initialization and permissioning
+   *    subsystem is not initialized - CRM-13765
    *
    * @return string
    *   the generated output
+   *
+   * @deprecated prefer Civi::log().
+   * @see https://github.com/civicrm/civicrm-core/pull/27138
    */
   public static function debug($name, $variable = NULL, $log = TRUE, $html = TRUE, $checkPermission = TRUE) {
-    $error = self::singleton();
-
     if ($variable === NULL) {
       $variable = $name;
       $name = NULL;
     }
 
-    if ($log) {
-      // We don't want html crud in our text file logs.
-      $html = FALSE;
+    $out = print_r($variable, TRUE);
+    $outHTML = htmlspecialchars($out);
+
+    if ($name) {
+      $outHTML = "<p>" . htmlspecialchars($name) . "</p><p><pre>$outHTML</pre></p>";
+      $out = "$name:\n$out";
     }
 
-    $out = print_r($variable, TRUE);
-    $prefix = NULL;
-    if ($html) {
-      $out = htmlspecialchars($out);
-      if ($name) {
-        $prefix = "<p>$name</p>";
-      }
-      $out = "{$prefix}<p><pre>$out</pre></p><p></p>";
-    }
-    else {
-      if ($name) {
-        $prefix = "$name:\n";
-      }
-      $out = "{$prefix}$out\n";
-    }
-    if (
-      $log &&
-      (!$checkPermission || CRM_Core_Permission::check('view debug output'))
-    ) {
+    if ($log) {
+      // Log the output to error_log with a unique reference.
       $unique = substr(md5(random_bytes(32)), 0, 12);
       error_log("errorID:$unique\n$out");
-      echo "Critical error. Please see server logs for errorID:$unique";
+
+      if (!$checkPermission) {
+        // Permission system inactive, only emit a reference to content in logfile
+        echo "Critical error. Please see server logs for errorID:$unique";
+      }
+      else {
+        if (CRM_Core_Permission::check('view debug output')) {
+          // We are outputting to the browser.
+          echo $html ? $outHTML : $out;
+        }
+        else {
+          // No permission; show nothing visible, but include the error in an HTML
+          // comment in case a dev wants to inspect.
+          echo $html ? "<!-- critical error reference $unique -->" : '';
+        }
+      }
     }
 
-    return $out;
+    return $html ? $outHTML : $out;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

If there's an initialization crash, Civi will bring the whole site down and output an error message. This is rare, but a lot of eyes see the error on a busy website if it does happen.

Before
----------------------------------------

The output included dumped variables and error messages.


After
----------------------------------------

The output is simply an error reference which can be looked up wherever `error_log` outputs.


Technical Details
----------------------------------------

This changes the behaviour of `CRM_Core_Error::debug()` which is deprecated anyway.

It's really about avoiding public vardumps rather than a sensible logging improvement.

Using error_log because we might not have Civi::log() available in these weird/bad/early crashes.

