### PR TITLE
dev/core#4521 Fix issue with installing core extensions as part of up…

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyThree.php
@@ -43,7 +43,7 @@ class CRM_Upgrade_Incremental_php_FiveSixtyThree extends CRM_Upgrade_Incremental
 
     $enabledComponents = Civi::settings()->get('enable_components');
     $extensions = array_map(['CRM_Utils_String', 'convertStringToSnakeCase'], $enabledComponents);
-    $this->addExtensionTask('Enable component extensions', $extensions);
+    $this->addExtensionTask('Enable component extensions', $extensions, 999);
 
     $this->addTask('Make ContributionPage.name required', 'alterColumn', 'civicrm_contribution_page', 'name', "varchar(255) NOT NULL COMMENT 'Unique name for identifying contribution page'");
     $this->addTask('Make ContributionPage.title required', 'alterColumn', 'civicrm_contribution_page', 'title', "varchar(255) NOT NULL COMMENT 'Contribution Page title. For top of page display'", TRUE);


### PR DESCRIPTION
…grade due to order issue

Overview
----------------------------------------
This tries to fix an issue with core extensions not being installed. On a site that hit this I found that in the database the extensions queue task was still queued but was after doCoreFinish which seemed to crash out and it has a weight of 1000 https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Form.php#L564 I think setting a weight to under 1000 but higher than 990 is probably sensible

Before
----------------------------------------
Depending on your set up you might hard fail

After
----------------------------------------
Less chance of hard fail

ping @colemanw @eileenmcnaughton @totten @agileware-justin @MegaphoneJon 