### PR TITLE
Reduce use of undeclared properties (php8.x errors) , use trait to track entities

### DIFF
--- a/CRM/Core/Form/EntityTrackingTrait.php
+++ b/CRM/Core/Form/EntityTrackingTrait.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * This trait provides a form of lazy loading for forms.
+ *
+ * It is intended to reduce the need for forms to pass values around while avoiding
+ * constantly reloading them from the database.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+trait CRM_Core_Form_EntityTrackingTrait {
+
+  /**
+   * Array of loaded entities.
+   *
+   * These are stored with keys that are consistent with apiv4 style parameters.
+   *
+   * @var array
+   */
+  private $entities = [];
+
+  /**
+   * Set the entity to the specified values.
+   *
+   * @param string $entity
+   * @param int $identifier
+   * @param array $values
+   */
+  public function setEntity(string $entity, int $identifier, array $values): void {
+    $this->entities[$entity][$identifier] = $values;
+  }
+
+  /**
+   * Get the value for a property of an entity, loading from the database if needed.
+   *
+   * Permissions are not applied to the api call.
+   *
+   * @param string $entity
+   * @param int $id
+   * @param string $key
+   *
+   * @api supported for use outside of core. Will not change in a point release.
+   *
+   * @return mixed
+   */
+  public function getEntityValue(string $entity, int $id, string $key) {
+    if (!isset($this->entities[$entity][$id]) || !array_key_exists($key, $this->entities[$entity][$id])) {
+      $this->loadEntity($entity, $id);
+    }
+    return $this->entities[$entity][$id][$key];
+  }
+
+  /**
+   * Get a value from a participant record.
+   *
+   * This function requires that the form implements `getParticipantID()`.
+   *
+   * @param string $fieldName
+   * @param int|null $id If not provided getParticipantID() is called.
+   *
+   * @api supported for use outside of core. Will not change in a point release.
+   *
+   * @return mixed
+   */
+  public function getParticipantValue(string $fieldName, ?int $id = NULL) {
+    $id = $id ?? $this->getParticipantID();
+    return $this->getEntityValue('Participant', $id, $fieldName);
+  }
+
+  /**
+   * Get a value from a contact record.
+   *
+   * This function requires that the form implements `getContactID()`.
+   *
+   * @param string $fieldName
+   * @param int|null $id If not provided getContactID() is called.
+   *
+   * @api supported for use outside of core. Will not change in a point release.
+   *
+   * @return mixed
+   */
+  public function getContactValue(string $fieldName, ?int $id = NULL) {
+    $id = $id ?? $this->getContactID();
+    return $this->getEntityValue('Contact', $id, $fieldName);
+  }
+
+  /**
+   * Load the requested entity.
+   *
+   * If we are going to load an entity we generally load all the values for it.
+   *
+   * @param string $entity
+   * @param int $id
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  protected function loadEntity(string $entity, int $id): void {
+    if ($entity === 'Contact') {
+      // If we are loading a contact we generally also want their email.
+      $select = ['email_primary.email', 'email_primary.on_hold', '*', 'custom.*'];
+    }
+    else {
+      $select = ['*', 'custom.*'];
+    }
+    $this->entities[$entity][$id] = civicrm_api4($entity, 'get', [
+      'where' => [['id', '=', $id]],
+      'checkPermissions' => FALSE,
+      // @todo - load pseudoconstants too...
+      'select' => $select,
+    ])->first();
+  }
+
+}

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -21,6 +21,8 @@
  */
 class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment {
 
+  use CRM_Core_Form_EntityTrackingTrait;
+
   /**
    * Participant ID - use getParticipantID.
    *
@@ -1382,9 +1384,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   protected function getStatusMsg(array $params, int $numberSent, int $numberNotSent, string $updateStatusMsg): string {
     $statusMsg = '';
     if (($this->_action & CRM_Core_Action::UPDATE)) {
-      $statusMsg = ts('Event registration information for %1 has been updated.', [1 => $this->_contributorDisplayName]);
+      $statusMsg = ts('Event registration information for %1 has been updated.', [1 => $this->getContactValue('display_name')]);
       if (!empty($params['send_receipt']) && $numberSent) {
-        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1', [1 => $this->_contributorEmail]);
+        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1', [1 => $this->getContactValue('email_primary.email')]);
       }
 
       if ($updateStatusMsg) {
@@ -1392,9 +1394,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {
-      $statusMsg = ts('Event registration for %1 has been added.', [1 => $this->_contributorDisplayName]);
+      $statusMsg = ts('Event registration for %1 has been added.', [1 => $this->getContactValue('display_name')]);
       if (!empty($params['send_receipt']) && $numberSent) {
-        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1.', [1 => $this->_contributorEmail]);
+        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1.', [1 => $this->getContactValue('email_primary.email')]);
       }
     }
     return $statusMsg;
@@ -1933,18 +1935,14 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   }
 
   /**
-   * Get a value from the existing participant record (applies to edits).
+   * Get the contact id that the form is being submitted for.
    *
-   * @param string $fieldName
+   * @todo consolidate Contact ID properties....
    *
-   * @return array
-   * @throws \CRM_Core_Exception
+   * @return int
    */
-  protected function getParticipantValue($fieldName) {
-    if (!$this->participantRecord) {
-      $this->participantRecord = civicrm_api3('Participant', 'getsingle', ['id' => $this->_id]);
-    }
-    return $this->participantRecord[$fieldName] ?? $this->participantRecord['participant_' . $fieldName];
+  public function getContactID() {
+    return $this->_contactId;
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Reduce use of undeclared properties (php8.x errors) , use trait to track entities

Before
----------------------------------------
Undefined property errors on useDisplayName

After
----------------------------------------
Still errors - but the genesis of an approach

Technical Details
----------------------------------------
A lot of the undeclared properties on this form & similar are just tracking values of various relevant entities. This adds some functionality for that tracking onto a trait & uses that. This reduces the need
to pass around values whose only importance is that they have been loaded from the database & would require
another db call to access them from elsewhere.

I've kept the change to use this pretty small but there are a bunch of places where properties that may or may not exist are set just to hold the values on the form 'somewhere'

I'm thinking these get functions could have the `@api` flag, allowing / encouraging their use from outside of core


Comments
----------------------------------------
@seamuslee001 