### PR TITLE
hook_civicrm_config: Add extra information to distinguish invocations

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -91,7 +91,10 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
 
         unset($errorScope);
 
-        CRM_Utils_Hook::config(self::$_singleton);
+        CRM_Utils_Hook::config(self::$_singleton, [
+          'civicrm' => TRUE,
+          'uf' => self::$_singleton->userSystem->isLoaded(),
+        ]);
         self::$_singleton->authenticate();
 
         // Extreme backward compat: $config binds to active domain at moment of setup.

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -642,6 +642,7 @@ AND    u.status = 1
 
     // CRM-8655: Backdrop wasn't available during bootstrap, so
     // hook_civicrm_config() never executes.
+    // FIXME: This call looks redundant with the earlier call in the same function. Consider removing it.
     CRM_Utils_Hook::config($config);
 
     return FALSE;

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -596,7 +596,7 @@ AND    u.status = 1
     // all the modules that are listening on it, does not apply
     // to J! and WP as yet
     // CRM-8655
-    CRM_Utils_Hook::config($config);
+    CRM_Utils_Hook::config($config, ['uf' => TRUE]);
 
     if (!$loadUser) {
       return TRUE;

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -56,6 +56,16 @@ abstract class CRM_Utils_System_Base {
     }
   }
 
+  /**
+   * Determine if the UF/CMS has been loaded already.
+   *
+   * This is generally TRUE. If using the "extern" boot protocol, then this may initially be false (until loadBootStrap runs).
+   *
+   * @internal
+   * @return bool
+   */
+  abstract public function isLoaded(): bool;
+
   abstract public function loadBootStrap($params = [], $loadUser = TRUE, $throwError = TRUE, $realPath = NULL);
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -556,6 +556,7 @@ AND    u.status = 1
     $config->cleanURL = (int) variable_get('clean_url', '0');
 
     // CRM-8655: Drupal wasn't available during bootstrap, so hook_civicrm_config never executes
+    // FIXME: This call looks redundant with the earlier call in the same function. Consider removing it.
     CRM_Utils_Hook::config($config);
 
     return FALSE;

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -513,7 +513,7 @@ AND    u.status = 1
     // all the modules that are listening on it, does not apply
     // to J! and WP as yet
     // CRM-8655
-    CRM_Utils_Hook::config($config);
+    CRM_Utils_Hook::config($config, ['uf' => TRUE]);
 
     if (!$loadUser) {
       return TRUE;

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -433,7 +433,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     // We need to call the config hook again, since we now know
     // all the modules that are listening on it (CRM-8655).
     $config = CRM_Core_Config::singleton();
-    CRM_Utils_Hook::config($config);
+    CRM_Utils_Hook::config($config, ['uf' => TRUE]);
 
     if ($loadUser) {
       if (!empty($params['uid']) && $username = \Drupal\user\Entity\User::load($params['uid'])->getAccountName()) {

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -41,6 +41,14 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   }
 
   /**
+   * @internal
+   * @return bool
+   */
+  public function isLoaded(): bool {
+    return function_exists('t');
+  }
+
+  /**
    * @inheritdoc
    */
   public function getDefaultFileStorage() {

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -34,6 +34,14 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   }
 
   /**
+   * @internal
+   * @return bool
+   */
+  public function isLoaded(): bool {
+    return class_exists('JFactory');
+  }
+
+  /**
    * @inheritDoc
    */
   public function createUser(&$params, $mailParam) {

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -680,7 +680,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
 
     // CRM-14281 Joomla wasn't available during bootstrap, so hook_civicrm_config never executes.
     $config = CRM_Core_Config::singleton();
-    CRM_Utils_Hook::config($config);
+    CRM_Utils_Hook::config($config, ['uf' => TRUE]);
     return TRUE;
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -22,6 +22,14 @@ use Civi\Standalone\Security;
  */
 class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
+  /**
+   * @internal
+   * @return bool
+   */
+  public function isLoaded(): bool {
+    return TRUE;
+  }
+
   public function missingStandaloneExtension() {
     // error_log("sessionStart, " . (class_exists(\Civi\Standalone\Security::class) ? 'exists' : 'no ext'));
     return !class_exists(\Civi\Standalone\Security::class);

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -38,6 +38,14 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
   }
 
   /**
+   * @internal
+   * @return bool
+   */
+  public function isLoaded(): bool {
+    return TRUE;
+  }
+
+  /**
    * @param string $name
    * @param string $value
    */

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -708,6 +708,14 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
+   * @internal
+   * @return bool
+   */
+  public function isLoaded(): bool {
+    return function_exists('__');
+  }
+
+  /**
    * Tries to bootstrap WordPress.
    *
    * @param array $params

--- a/tests/events/hook_civicrm_config.evch.php
+++ b/tests/events/hook_civicrm_config.evch.php
@@ -1,0 +1,31 @@
+<?php
+
+use Civi\Test\EventCheck;
+use Civi\Test\HookInterface;
+
+return new class() extends EventCheck implements HookInterface {
+
+  /**
+   * Ensure that the hook data is always well-formed.
+   *
+   * @see \CRM_Utils_Hook::config()
+   */
+  public function hook_civicrm_config($config, $flags = NULL): void {
+    $msg = 'Non-conforming hook_civicrm_config(...)';
+
+    $this->assertType('CRM_Core_Config', $config, "$msg: Bad config object");
+    $this->assertType('array', $flags, "$msg: Bad flags array");
+    $this->assertType('boolean', $flags['civicrm'], "$msg: civicrm should be boolean");
+    $this->assertType('boolean', $flags['uf'], "$msg: uf should be boolean");
+    $this->assertType('integer', $flags['instances'], "$msg: instances should be integer");
+
+    static $lastInstanceCount = 1;
+    $this->assertTrue($flags['instances'] >= $lastInstanceCount, "$msg: instance count should be monotonic-increasing, starting from 1");
+    $lastInstanceCount = $flags['instances'];
+
+    $knownKeys = ['civicrm', 'uf', 'instances'];
+    $unknownKeys = array_diff(array_keys($flags), $knownKeys);
+    $this->assertEquals([], $unknownKeys, "$msg: Flags array has unknown keys: " . implode(' ', $unknownKeys));
+  }
+
+};


### PR DESCRIPTION
Overview
----------------------------------------

`hook_civicrm_config` fires multiple times. Well, sometimes it does. It's not very transparent about this.

Before
----------------------------------------

Downstream users of `hook_civicrm_config` have to be fairly guarded if they want to avoid double-execution. For example, dev-docs suggest [this pattern](https://docs.civicrm.org/dev/en/latest/hooks/usage/symfony/#example-cividispatcher) for registering Symfony-style event-listeners:

```php
function example_civicrm_config(&$config) {
  if (isset(Civi::$statics[__FUNCTION__])) { return; }
  Civi::$statics[__FUNCTION__] = 1;

  Civi::dispatcher()->addListener('hook_civicrm_alterContent', '_example_say_hello');
}
```

This idiom is probably the simplest to date, but (as we saw in dev/core#4531) there are still some edge-cases where it can get tripped-up.

After
----------------------------------------

The docblock explains some of the circumstances where `hook_civicrm_config` fires.

Additionally, every time `hook_civicrm_config` fires, it gives a new parameter (`array $flags`), as in:

* `$flags['civicrm']`: We are firing the hook for the benefit of `civicrm`-native extensions.
* `$flags['uf']`: We are firing the hook for the benefit of `uf` add-ons (Drupal modules, Joomla plugins, etc).
* `$flags['instances']`: The total number of `CRM_Core_Config` instances that have been created so far. This will be `1` on the first call. If the system is rebooted within the same request, then this will increment.

This allows simpler (and more accurate) guards. Here are a few examples:

```php
// EXAMPLE:  Guard for a Drupal module which uses addListener()
function example_civicrm_config(CRM_Core_Config $config, array $flags) {
  if ($flags['uf']) { 
    Civi::dispatcher()->addListener('hook_civicrm_alterContent', '_example_say_hello');
  }
}
```

```php
// EXAMPLE: Guard for a CiviCRM extension which uses addListener()
function example_civicrm_config(CRM_Core_Config $config, array $flags) {
  if ($flags['civicrm']) {
    Civi::dispatcher()->addListener('hook_civicrm_alterContent', '_example_say_hello');
  }
}
```

```php
// EXAMPLE: Guard for a CiviCRM extension which uses `spl_autoload_register()`
function example_civicrm_config(CRM_Core_Config $config, array $flags) {
  if ($flags['civicrm'] && $flags['instances'] === 1) {
    spl_autoload_register(...CustomAutoLoader...);
  }
}
```

Technical Details
----------------------------------------

Note that the hook still fires the same number of times (and in the same circumstances) as before -- it merely conveys more information. This is the main benefit of this approach -- it should be pretty safe in terms of [`r-tech`nical impact](https://docs.civicrm.org/dev/en/latest/standards/review/#r-tech). Existing code (with static-guards) should work just as well as before.

The new flag can allow better guards on 5.66+. If modifying an existing extension to use `$flags`, then one should either:

* Set `<compatibility><ver>5.66</ver></compatibility>` -- and then simply use `$flags` 
* Use a combined guard, such as:
    ```php
    function example_civicrm_config($config, ?array $flags = NULL) {
      if ($flags === NULL { /* Civi <= 5.65 */
        if (isset(Civi::$statics[__FUNCTION__])) return;
        Civi::$statics[__FUNCTION__] = 1;
      }
      else { /* Civi >= 5.66 */
        if (!$flags['civicrm']) return;
      }
    
      Civi::dispatcher()->addListener('hook_civicrm_alterContent', '_example_say_hello');
    }
    ```
    (*The combined guard isn't pretty - but after 6 months, it should be a niche concern.*)
