### PR TITLE
Fix e-notice by removing conditionality

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -166,11 +166,7 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
 
     $this->_templateId = (int) CRM_Utils_Request::retrieve('template_id', 'Integer', $this);
 
-    //Is a repeating event
-    if ($this->_isRepeatingEvent) {
-      $isRepeatingEntity = TRUE;
-      $this->assign('isRepeatingEntity', $isRepeatingEntity);
-    }
+    $this->assign('isRepeatingEntity', $this->_isRepeatingEvent);
 
     // CRM-16776 - show edit/copy/create buttons for Profiles if user has required permission.
     $ufGroups = CRM_Core_PseudoConstant::get('CRM_Core_DAO_UFField', 'uf_group_id');

--- a/templates/CRM/Admin/Page/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Page/ScheduleReminders.tpl
@@ -11,12 +11,10 @@
 {if $action eq 1 or $action eq 2 or $action eq 8 or $action eq 16384}
    {include file="CRM/Admin/Form/ScheduleReminders.tpl"}
 {else}
-  {if empty($component)}
-    {capture assign=schedRemindersDocLink}{docURL page="user/email/scheduled-reminders/"}{/capture}
-    <div class="help">
-      {ts}Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.{/ts} {$schedRemindersDocLink}
-    </div>
-  {/if}
+  {capture assign=schedRemindersDocLink}{docURL page="user/email/scheduled-reminders/"}{/capture}
+  <div class="help">
+    {ts}Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.{/ts} {$schedRemindersDocLink}
+  </div>
   <div class="crm-content-block crm-block">
   {if $rows}
     <div id="reminder">


### PR DESCRIPTION
Overview
----------------------------------------
There was a conditional about whether to display the text - leading to a notice - it didn't seem that bad to just always have the text so I removed the conditional

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/8c2ecc31-8564-4ef3-a147-157da3c5e39f)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/3644a5ab-e4b2-4fa0-8e39-5ee739cd6a25)

Text also shows on manage event page now - seems like no harm no foul to me

![image](https://github.com/civicrm/civicrm-core/assets/336308/fceadda6-7700-4867-b3da-7ed4e4e3bbc1)

Technical Details
----------------------------------------

Comments
----------------------------------------
