### PR TITLE
(dev/core#4531) Afform Mail Tokens - Fix rendering for localized/individual email

### DIFF
--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -12,8 +12,10 @@
 namespace Civi\Afform;
 
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoService;
 use Civi\Crypto\Exception\CryptoException;
 use CRM_Afform_ExtensionUtil as E;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Every afform with the property `is_token=true` should have a corresponding
@@ -21,8 +23,21 @@ use CRM_Afform_ExtensionUtil as E;
  *
  * @see MockPublicFormTest
  * @package Civi\Afform
+ * @service civi.afform.tokens
  */
-class Tokens {
+class Tokens extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
+      return [];
+    }
+
+    return [
+      'hook_civicrm_alterMailContent' => 'applyCkeditorWorkaround',
+      'hook_civicrm_tokens' => 'hook_civicrm_tokens',
+      'hook_civicrm_tokenValues' => 'hook_civicrm_tokenValues',
+    ];
+  }
 
   /**
    * CKEditor makes it hard to set an `href` to a token, so we often get

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -58,13 +58,6 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('hook_civicrm_alterAngular', ['\Civi\Afform\AfformMetadataInjector', 'preprocess']);
   $dispatcher->addListener('hook_civicrm_check', ['\Civi\Afform\StatusChecks', 'hook_civicrm_check']);
   $dispatcher->addListener('civi.afform.get', ['\Civi\Api4\Action\Afform\Get', 'getCustomGroupBlocks']);
-
-  // Register support for email tokens
-  if (CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
-    $dispatcher->addListener('hook_civicrm_alterMailContent', ['\Civi\Afform\Tokens', 'applyCkeditorWorkaround']);
-    $dispatcher->addListener('hook_civicrm_tokens', ['\Civi\Afform\Tokens', 'hook_civicrm_tokens']);
-    $dispatcher->addListener('hook_civicrm_tokenValues', ['\Civi\Afform\Tokens', 'hook_civicrm_tokenValues']);
-  }
 }
 
 /**


### PR DESCRIPTION
Backport of https://github.com/civicrm/civicrm-core/pull/27134/ from 5.65-rc to 5.64-stable