### PR TITLE
Also add event confirm text as default receipt_text for edit Participant

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -66,6 +66,9 @@ class CRM_Event_Form_EventFees {
       if (!empty($details[$form->_eventId]['financial_type_id'])) {
         $defaults[$form->_pId]['financial_type_id'] = $details[$form->_eventId]['financial_type_id'];
       }
+      if (!empty($details[$form->_eventId]['confirm_email_text'])) {
+        $defaults[$form->_pId]['receipt_text'] = $details[$form->_eventId]['confirm_email_text'];
+      }
     }
 
     if ($form->_pId) {
@@ -93,11 +96,6 @@ class CRM_Event_Form_EventFees {
     }
     else {
       $defaults[$form->_pId]['send_receipt'] = (strtotime(CRM_Utils_Array::value('start_date', $details[$form->_eventId])) >= time()) ? 1 : 0;
-      if ($form->_eventId && !empty($details[$form->_eventId]['confirm_email_text'])) {
-        //set receipt text
-        $defaults[$form->_pId]['receipt_text'] = $details[$form->_eventId]['confirm_email_text'];
-      }
-
       $defaults[$form->_pId]['receive_date'] = date('Y-m-d H:i:s');
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
When you add a new offline event registration, the default receipt_text is set to the event confirm_email_text, but when you edit an event registration and want to (re-)send a confirmation, the default receipt_text is blank. It would be more useful to have the same default receipt_text, for example, if someone is missing their confirmation email and wants you to send it again. In any case, it makes sense for the default confirmation message to be the same when editing as when adding.

A small change, but I've wondered why this was blank more than a few times over the years and I'm sure I'm not the only one.

Before
----------------------------------------
receipt_text is blank by default when editing a participant.

After
----------------------------------------
receipt_text is set to the event confirm_email_text.