### PR TITLE
Add test & fix for getOptions on options with a domain id

### DIFF
--- a/CRM/Core/BAO/Discount.php
+++ b/CRM/Core/BAO/Discount.php
@@ -78,7 +78,7 @@ class CRM_Core_BAO_Discount extends CRM_Core_DAO_Discount {
     $dao->entity_table = $entityTable;
     $dao->find();
     while ($dao->fetch()) {
-      $optionGroupIDs[$dao->id] = $dao->price_set_id;
+      $optionGroupIDs[$dao->id] = (int) $dao->price_set_id;
     }
     return $optionGroupIDs;
   }

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -1531,7 +1531,7 @@ WHERE  id = %1
     }
     // Filter domain specific options
     if (in_array('domain_id', $availableFields)) {
-      $wheres[] = 'domain_id = ' . CRM_Core_Config::domainID() . ' OR  domain_id is NULL';
+      $wheres[] = '(domain_id = ' . CRM_Core_Config::domainID() . ' OR  domain_id is NULL)';
     }
     $queryParams = [
       1 => [$params['keyColumn'], 'String', CRM_Core_DAO::QUERY_FORMAT_NO_QUOTES],

--- a/tests/phpunit/CRM/Core/BAO/DiscountTest.php
+++ b/tests/phpunit/CRM/Core/BAO/DiscountTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Civi\Api4\Discount;
+use Civi\Test\EventTestTrait;
+
+/**
+ * Class CRM_Core_BAO_DiscountTest
+ * @group headless
+ */
+class CRM_Core_BAO_DiscountTest extends CiviUnitTestCase {
+
+  use EventTestTrait;
+
+  /**
+   * Test the discount getOptions filters by event.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testDiscountGetOptions(): void {
+    $this->eventCreatePaid();
+    $this->addDiscountPriceSet();
+    $options = Discount::getFields(TRUE)
+      ->setLoadOptions(TRUE)
+      ->addValue('entity_id', 1)
+      ->addValue('entity_table', 'civicrm_event')
+      ->addWhere('name', '=', 'price_set_id')
+      ->execute()->first()['options'];
+    $this->assertEquals([$this->ids['PriceSet']['discount']], array_keys($options));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow on to https://github.com/civicrm/civicrm-core/pull/27122 - the efforts to make `getOptions` consider a condition (the entity) were being stymied by the addition of the clause 'AND domain_id = 1 OR domain_id IS NULL' - there appears to be an (unused?) column for domain_id in civicrm_price_set

Before
----------------------------------------
The loadOptions api call [in this test](https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:discount?expand=1#diff-9547f388493a4b4fb6539de6a8e9625a9eabe8a89f447b640cdd0dafb30f39b0R23-R29) returns all price set id titles

After
----------------------------------------
Only the relevant one is returned

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw 