### PR TITLE
Add userEnteredText as generic workflow template smarty variable

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -427,6 +427,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         'tplParams' => $tplParams,
         'PDFFilename' => $pdfFileName,
         'tokenContext' => ['contributionId' => $contribution->id, 'contactId' => $contribution->contact_id],
+        'modelProps' => [
+          'userEnteredText' => $params['email_comment'] ?? NULL,
+        ],
       ];
 
       // from email address
@@ -495,10 +498,10 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         $fileName = self::putFile($html, $pdfFileName, $pdfFormat);
         self::addActivities($subject, $contribution->contact_id, $fileName, $params, $contribution->id);
       }
-      elseif ($component == 'event') {
+      elseif ($component === 'event') {
         $email = CRM_Contact_BAO_Contact::getPrimaryEmail($contribution->contact_id);
 
-        $sendTemplateParams['tplParams'] = array_merge($tplParams, ['email_comment' => $params['email_comment']]);
+        $sendTemplateParams['tplParams'] = $tplParams;
         $sendTemplateParams['from'] = $fromEmailAddress;
         $sendTemplateParams['toEmail'] = $email;
         $sendTemplateParams['cc'] = $values['cc_confirm'] ?? NULL;

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -448,7 +448,14 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
           $params['attachments'] = [];
         }
         $params['attachments'][] = CRM_Utils_Mail::appendPDF($params['PDFFilename'], $params['html'], $mailContent['format']);
+        // This specifically allows the invoice code to attach an invoice & have
+        // a different message body. It will be removed & replaced with something
+        // saner so avoid trying to leverage this. There are no universe usages outside
+        // the core invoice task as of Dec 2023
         if (isset($params['tplParams']['email_comment'])) {
+          if ($params['workflow'] !== 'contribution_invoice_receipt') {
+            CRM_Core_Error::deprecatedWarning('unsupported parameter email_comment used');
+          }
           $params['html'] = $params['tplParams']['email_comment'];
           $params['text'] = strip_tags($params['tplParams']['email_comment']);
         }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1837,6 +1837,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         'PDFFilename' => ts('confirmation') . '.pdf',
         'modelProps' => [
           'participantID' => $participantID,
+          'userEnteredText' => $this->getSubmittedValue('receipt_text'),
           'eventID' => $params['event_id'],
           'contributionID' => $contributionID,
         ],

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -909,7 +909,7 @@ DESC limit 1");
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'isTest' => (bool) ($this->_action & CRM_Core_Action::PREVIEW),
         'modelProps' => [
-          'receiptText' => $this->getSubmittedValue('receipt_text'),
+          'userEnteredText' => $this->getSubmittedValue('receipt_text'),
           'contributionID' => $formValues['contribution_id'],
           'contactID' => $this->_receiptContactId,
           'membershipID' => $this->getMembershipID(),

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -700,6 +700,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       }
     }
 
+    // This is being replaced by userEnteredText.
+    $this->assign('receipt_text', $this->getSubmittedValue('receipt_text'));
     [$this->isMailSent] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'workflow' => 'membership_offline_receipt',
@@ -710,7 +712,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         'PDFFilename' => ts('receipt') . '.pdf',
         'isEmailPdf' => Civi::settings()->get('invoice_is_email_pdf'),
         'modelProps' => [
-          'receiptText' => $this->getSubmittedValue('receipt_text'),
+          'userEnteredText' => $this->getSubmittedValue('receipt_text'),
           'contactID' => $this->_receiptContactId,
           'contributionID' => $this->getContributionID(),
           'membershipID' => $this->getMembershipID(),

--- a/CRM/Member/WorkflowMessage/MembershipOfflineReceipt.php
+++ b/CRM/Member/WorkflowMessage/MembershipOfflineReceipt.php
@@ -25,13 +25,4 @@ class CRM_Member_WorkflowMessage_MembershipOfflineReceipt extends GenericWorkflo
   use CRM_Contribute_WorkflowMessage_ContributionTrait;
   public const WORKFLOW = 'membership_offline_receipt';
 
-  /**
-   * Additional text to include in the receipt.
-   *
-   * @var string
-   *
-   * @scope tplParams as receipt_text
-   */
-  protected $receiptText;
-
 }

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -26,6 +26,8 @@ use Civi\WorkflowMessage\Traits\TemplateTrait;
  * @method int|null getContactID()
  * @method $this setContact(array|null $contact)
  * @method array|null getContact()
+ * @method $this setUserEnteredText(string $text)
+ * @method $this setUserEnteredHTML(string $html)
  *
  * @support template-only
  * GenericWorkflowMessage should aim for "full" support, but it's prudent to keep
@@ -115,6 +117,32 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
     // However, these basically now all implement the ContributionTrait so we
     // can hopefully remove from here (after some checking).
     $export['smartyTokenAlias']['taxTerm'] = 'domain.tax_term';
+  }
+
+  /**
+   * Additional text to include in the receipt.
+   *
+   * @var string
+   *
+   * @scope tplParams as userTextPlain
+   */
+  protected $userEnteredText;
+
+  /**
+   * Additional html to include in the receipt.
+   *
+   * @var string
+   *
+   * @scope tplParams as userText
+   */
+  protected $userEnteredHTML;
+
+  public function getUserEnteredText(): ?string {
+    return $this->userEnteredText ?: ($this->userEnteredHTML ? \CRM_Utils_String::htmlToText($this->userEnteredHTML) : NULL);
+  }
+
+  public function getUserEnteredHTML(): ?string {
+    return \CRM_Utils_String::purifyHTML($this->userEnteredHTML ?: ($this->userEnteredText ? nl2br($this->userEnteredText) : ''));
   }
 
 }

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -401,8 +401,15 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'receipt_text',
     'pay_later_receipt',
     'payment_processor_id',
+    'model',
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
+  if (!isset($input['model'])) {
+    $input['model'] = [
+      // Pass through legacy receipt_text.
+      'userEnteredText' => $input['tplParams']['receipt_text'] ?? NULL,
+    ];
+  }
   CRM_Contribute_BAO_Contribution::sendMail($input, [], $params['id']);
   return [];
 }

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -107,6 +107,12 @@ function civicrm_api3_message_template_send($params) {
       unset($params[$field]);
     }
   }
+  if (!isset($params['model'])) {
+    $params['model'] = [
+      // Pass through legacy receipt_text.
+      'userEnteredText' => $params['tplParams']['receipt_text'] ?? NULL,
+    ];
+  }
   if (empty($params['messageTemplateID'])) {
     if (empty($params['workflow'])) {
       // Can't use civicrm_api3_verify_mandatory for this because it would give the wrong field names

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types = 1);
 use Civi\Api4\Address;
 use Civi\Api4\Event;
 use Civi\Api4\LineItem;
@@ -306,8 +307,7 @@ United States<br />',
       'is_default' => 1,
     ]);
     $oldMsg = $result['values'][0]['msg_html'];
-    $pos = strpos($oldMsg, 'Please print this confirmation');
-    $newMsg = substr_replace($oldMsg, '<p>Test event type - {event.event_type_id}</p>', $pos, 0);
+    $newMsg = substr_replace($oldMsg, '<p>Test event type - {event.event_type_id}</p>', 0, 0);
     $this->callAPISuccess('MessageTemplate', 'create', [
       'id' => $result['id'],
       'msg_html' => $newMsg,
@@ -393,6 +393,7 @@ London,',
       $event = $this->eventCreateUnpaid($eventParams);
     }
     $submittedValues['event_id'] = $event['id'];
+    $submittedValues['receipt_text'] = 'Contact the Development Department if you need to make any changes to your registration.';
     return $this->getTestForm('CRM_Event_Form_Participant', $submittedValues, ['cid' => $submittedValues['contact_id']])->processForm(FormWrapper::BUILT);
   }
 

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -298,7 +298,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $form->_mode = 'test';
     $form->_contactID = $this->_individualId;
 
-    $form->testSubmit();
+    $form->postProcess();
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_individualId]);
     $contributionRecur = $this->callAPISuccessGetSingle('ContributionRecur', ['contact_id' => $this->_individualId]);
     $this->assertEquals(1, $contributionRecur['is_email_receipt']);
@@ -631,6 +631,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $form->_mode = $mode;
     $form->setEntityId($this->_membershipID);
     $form->preProcess();
+    $form->buildForm();
     return $form;
   }
 

--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -14,9 +14,9 @@
       </table>
     {/if}
     <table style="font-family: Arial, Verdana, sans-serif;" width="100%" height="100" border="0" cellpadding="5" cellspacing="0">
-      {if $email_comment}
+      {if $userText}
         <tr>
-          <td><font size="1" colspan="3">{$email_comment}</font></td>
+          <td><font size="1" colspan="3">{$userText}</font></td>
         </tr>
       {/if}
       <tr>

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -25,8 +25,8 @@
    <td>
     {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
 
-    {if !empty($event.confirm_email_text) AND (empty($isOnWaitlist) AND empty($isRequireApproval))}
-     <p>{$event.confirm_email_text}</p>
+    {if $userText}
+     <p>{$userText}</p>
     {/if}
 
     {if !empty($isOnWaitlist)}

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -23,8 +23,8 @@
     <tr>
       <td>
         {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-        {if $receipt_text}
-          <p>{$receipt_text|htmlize}</p>
+        {if $userText}
+          <p>{$userText}</p>
         {else}
           <p>{ts}Thank you for this contribution.{/ts}</p>
         {/if}

--- a/xml/templates/message_templates/membership_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_text.tpl
@@ -1,7 +1,7 @@
 {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}{$greeting},{/if}
 
-{if $receipt_text}
-{$receipt_text}
+{if $userTextPlain}
+{$userTextPlain}
 {else}{ts}Thank you for this contribution.{/ts}{/if}
 
 {if !$isShowLineItems}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -21,8 +21,8 @@
   <tr>
    <td>
      {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-    {if !empty($receipt_text)}
-     <p>{$receipt_text|htmlize}</p>
+    {if $userText}
+     <p>{$userText}</p>
     {/if}
     {if {contribution.balance_amount|boolean} && {contribution.is_pay_later|boolean}}
       <p>{contribution.pay_later_receipt}</p>


### PR DESCRIPTION


Overview
----------------------------------------
This makes userEnteredText a property across all WorkflowMessages - with it outputting the smarty variable user_text

We already had receipt_text on the membership forms - but that is a bit too specific
- user is perhaps a bit impersonal - I did contemplate form_text :

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
