### PR TITLE
Remove broken deprecated function

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -358,16 +358,6 @@ class CRM_Utils_Mail {
   }
 
   /**
-   * @param $to
-   * @param $headers
-   * @param $message
-   * @deprecated
-   */
-  public static function logger(&$to, &$headers, &$message) {
-    CRM_Utils_Mail_Logger::log($to, $headers, $message);
-  }
-
-  /**
    * Get the email address itself from a formatted full name + address string
    *
    * Ugly but working.


### PR DESCRIPTION


Overview
----------------------------------------
The function this calls was made private in Feb & no-one has noticed. It's deprecated & I can't find any calls to it so I guess it has been unused-long-time

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/f242b466-d344-47c8-a236-dc7184a624ed)

After
----------------------------------------
poof

Technical Details
----------------------------------------
this one is upsetting phpstorm's equilibrium

Comments
----------------------------------------
