### PR TITLE
[REF] Fix Notice Errors on ACL listing page by assigning fields consi…

### DIFF
--- a/CRM/ACL/Page/ACL.php
+++ b/CRM/ACL/Page/ACL.php
@@ -115,6 +115,9 @@ class CRM_ACL_Page_ACL extends CRM_Core_Page_Basic {
           $acl[$dao->id]['object'] = $event[$acl[$dao->id]['object_id']] ?? NULL;
           $acl[$dao->id]['object_name'] = ts('Event');
           break;
+
+        default:
+          $acl[$dao->id]['object'] = $acl[$dao->id]['object_name'] = NULL;
       }
 
       // form all action links


### PR DESCRIPTION
…stently

Overview
----------------------------------------
This aims to fix some warning notices about some keys not always being set on a row in the ACL page listing

Before
----------------------------------------
Warnings
![image](https://github.com/civicrm/civicrm-core/assets/6799125/8098624b-b843-46c3-a23c-194b54dc2576)

After
----------------------------------------
No warnings

ping @eileenmcnaughton @colemanw 