### PR TITLE
Add "phpstorm" extension

### DIFF
--- a/tools/extensions/phpstorm/Civi/PhpStorm/Generator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/Generator.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Civi\PhpStorm;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Generate metadata about dynamic CiviCRM services for use by PhpStorm.
+ *
+ * @link https://www.jetbrains.com/help/phpstorm/2021.3/ide-advanced-metadata.html
+ */
+class Generator {
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   * @return void
+   */
+  public static function generate(ContainerBuilder $container): void {
+    if (defined('CIVICRM_TEST')) {
+      return;
+    }
+
+    // Not 100% sure which is better. These trade-off in edge-cases of writability and readability.
+    //  - '[civicrm.files]/.phpstorm.meta.php'
+    //  - '[civicrm.compile]/.phpstorm.meta.php'
+    //  - '[civicrm.root]/.phpstorm.meta.php'
+    $file = \Civi::paths()->getPath('[civicrm.files]/.phpstorm.meta.php');
+
+    $data = static::renderMetadata(static::findServices($container));
+    file_put_contents($file, $data);
+  }
+
+  private static function findServices(ContainerBuilder $c): array {
+    $aliases = $c->getAliases();
+    $services = [];
+    foreach ($c->getServiceIds() as $serviceId) {
+      $definition = isset($aliases[$serviceId])
+        ? $c->getDefinition($aliases[$serviceId]) : $c->getDefinition($serviceId);
+
+      $class = $definition->getClass();
+      if ($class) {
+        $services[$serviceId] = $class;
+      }
+      else {
+        // fprintf(STDERR, "INCOMPLETE: Service \"%s\" does not declare a type.\n", $serviceId);
+        $services[$serviceId] = 'mixed';
+      }
+    }
+    return $services;
+  }
+
+  private static function renderMetadata(array $services): string {
+    ob_start();
+    try {
+      printf('<' . "?php\n");
+      printf("namespace PHPSTORM_META {\n");
+      printf("override(\Civi::service(), map(\n");
+      echo str_replace('\\\\', '\\', var_export($services, 1));
+      // PhpStorm 2022.3.1: 'Civi\\Foo' doesn't work, but 'Civi\Foo' does.
+      printf(");\n");
+      printf("}\n");
+    }
+    finally {
+      return ob_get_clean();
+    }
+  }
+
+}

--- a/tools/extensions/phpstorm/info.xml
+++ b/tools/extensions/phpstorm/info.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<extension key="phpstorm" type="module">
+  <file>phpstorm</file>
+  <name>PhpStorm</name>
+  <description>Generate API metadata for PhpStormE</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>Tim Otten</author>
+    <email>totten@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Main Extension Page">http://FIXME</url>
+    <url desc="Documentation">http://FIXME</url>
+    <url desc="Support">http://FIXME</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2023-08-25</releaseDate>
+  <version>1.0</version>
+  <develStage>alpha</develStage>
+  <compatibility>
+    <ver>5.66</ver>
+  </compatibility>
+  <comments>This is a new, undeveloped module</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/PhpStorm</namespace>
+    <format>23.02.1</format>
+    <angularModule>crmPhpstorm</angularModule>
+  </civix>
+  <!-- <mixins>
+    <mixin>mgd-php@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.1</mixin>
+  </mixins> -->
+</extension>

--- a/tools/extensions/phpstorm/info.xml
+++ b/tools/extensions/phpstorm/info.xml
@@ -30,9 +30,12 @@
     <format>23.02.1</format>
     <angularModule>crmPhpstorm</angularModule>
   </civix>
-  <!-- <mixins>
+  <mixins>
+    <mixin>phpstorm@1.0.0</mixin>
+    <!--
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
     <mixin>smarty-v2@1.0.1</mixin>
-  </mixins> -->
+    -->
+  </mixins>
 </extension>

--- a/tools/extensions/phpstorm/mixin/phpstorm@1.0.0.mixin.php
+++ b/tools/extensions/phpstorm/mixin/phpstorm@1.0.0.mixin.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @mixinName phpstorm
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  // We want to register a late-stage listener for hook_civicrm_container, but... it's a special hook.
+  // Therefore, we apply the Shenanigan technique.
+  Civi::dispatcher()->addListener('&hook_civicrm_container', function($container) use ($mixInfo) {
+    if ($mixInfo->isActive()) {
+      \Civi\PhpStorm\Generator::generate($container);
+    }
+  }, -2000);
+
+};

--- a/tools/extensions/phpstorm/phpstorm.civix.php
+++ b/tools/extensions/phpstorm/phpstorm.civix.php
@@ -1,0 +1,200 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Phpstorm_ExtensionUtil {
+  const SHORT_NAME = 'phpstorm';
+  const LONG_NAME = 'phpstorm';
+  const CLASS_PREFIX = 'CRM_Phpstorm';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Phpstorm_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _phpstorm_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _phpstorm_civix_civicrm_install() {
+  _phpstorm_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _phpstorm_civix_civicrm_enable(): void {
+  _phpstorm_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _phpstorm_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _phpstorm_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _phpstorm_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _phpstorm_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _phpstorm_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _phpstorm_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _phpstorm_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _phpstorm_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/tools/extensions/phpstorm/phpstorm.php
+++ b/tools/extensions/phpstorm/phpstorm.php
@@ -1,0 +1,25 @@
+<?php
+
+// require_once 'phpstorm.civix.php';
+// phpcs:disable
+// use CRM_Phpstorm_ExtensionUtil as E;
+// phpcs:enable
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
+ */
+// function phpstorm_civicrm_config(&$config): void {
+//  _phpstorm_civix_civicrm_config($config);
+// }
+
+/**
+ * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+ * @return void
+ * @see \CRM_Utils_Hook::container()
+ */
+function phpstorm_civicrm_container($container): void {
+  // Delegate pattern. There aren't many other ways to listen to this ehook.
+  \Civi\PhpStorm\Generator::generate($container);
+}

--- a/tools/extensions/phpstorm/phpstorm.php
+++ b/tools/extensions/phpstorm/phpstorm.php
@@ -13,13 +13,3 @@
 // function phpstorm_civicrm_config(&$config): void {
 //  _phpstorm_civix_civicrm_config($config);
 // }
-
-/**
- * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
- * @return void
- * @see \CRM_Utils_Hook::container()
- */
-function phpstorm_civicrm_container($container): void {
-  // Delegate pattern. There aren't many other ways to listen to this ehook.
-  \Civi\PhpStorm\Generator::generate($container);
-}


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM has several dynamic interfaces, such as the service-container, CRUD API, and hook system. PhpStorm is a common IDE that ordinarily presents options based on the static structure. This patch implements a process for [integrating some dynamic data](https://www.jetbrains.com/help/phpstorm/2021.3/ide-advanced-metadata.html) into PhpStorm.

Usage
----------------------------------------

Enable the extension:

```bash
cv en phpstorm
```

Whenever the container is rebuilt, this will create a file `[civicrm.files]/.phpstorm.meta.php`. As long as this folder is visible to PhpStorm, it should enable autocompletion for `Civi::service()`:

<img width="685" alt="Screen Shot 2023-08-25 at 4 35 26 AM" src="https://github.com/civicrm/civicrm-core/assets/1336047/0162aa8a-36d1-43cd-9246-eadcab46d312">

Comments
----------------------------------------

This workflow ensures that the list is updated whenever you enable or disable an extension.

There are probably things that could benefit from this, such as `civicrm_api4()` or `addListener()`.
