### PR TITLE
(dev/core#4536) Fix 'Primary Membership' filter options in Membership…

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -379,18 +379,13 @@ HERESQL;
     }
   }
 
-  public function getOperationPair($type = "string", $fieldName = NULL) {
+  public function getOperationPair($type = 'string', $fieldName = NULL) {
     //re-name IS NULL/IS NOT NULL for clarity
     if ($fieldName === 'owner_membership_id') {
       $result = [];
+      $result[''] = ts('Any');
       $result['nll'] = ts('Primary members only');
       $result['nnll'] = ts('Non-primary members only');
-      $options = parent::getOperationPair($type, $fieldName);
-      foreach ($options as $key => $label) {
-        if (!array_key_exists($key, $result)) {
-          $result[$key] = $label;
-        }
-      }
     }
     else {
       $result = parent::getOperationPair($type, $fieldName);


### PR DESCRIPTION
… Details report

Overview
----------------------------------------
_Primary Membership_ filter option in _Membership Details_ report has options that don't make sense.

Before
----------------------------------------
![dddsdsd](https://github.com/civicrm/civicrm-core/assets/3455173/a4c32c43-40b4-4f7c-95b0-eb7f94dca39c)

After
----------------------------------------
Remove options that don't make sense and add option to choose _Any_ as well.