### PR TITLE
Show Contribution Page receipt text in offline contribution receipt

### DIFF
--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -185,6 +185,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
       'title' => 'Campaign',
       'name' => 'big_campaign',
     ]);
+    $contributionPage = $this->contributionPageCreate(['receipt_text' => 'Thank you!']);
     $this->ids['Contribution']['alice'] = $this->callAPISuccess('Contribution', 'create', [
       'contact_id' => $this->contacts['alice']['id'],
       'receive_date' => date('Ymd', strtotime($this->targetDate)),
@@ -199,6 +200,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
       'cancel_date' => '2021-08-09',
       'contribution_status_id' => 1,
       'campaign_id' => $campaignID,
+      'contribution_page_id' => $contributionPage['id'],
       'soft_credit' => [
         '1' => [
           'contact_id' => $this->contacts['carol']['id'],
@@ -321,7 +323,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
       balance_amount = {contribution.balance_amount}
       campaign_id = {contribution.campaign_id}
       campaign name = {contribution.campaign_id:name}
-      campaign label = {contribution.campaign_id:label}';
+      campaign label = {contribution.campaign_id:label}
+      receipt text = {contribution.contribution_page_id.receipt_text}';
 
     $this->schedule->save();
     $this->callAPISuccess('job', 'send_reminder', []);
@@ -350,6 +353,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTest {
       'campaign_id = 1',
       'campaign name = big_campaign',
       'campaign label = Campaign',
+      'receipt text = Thank you!',
     ];
     $this->mut->checkMailLog($expected);
 

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -21,7 +21,10 @@
   <tr>
    <td>
     {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
-     <p>{ts}Below you will find a receipt for this contribution.{/ts}</p>
+      <p>
+        {if {contribution.contribution_page_id.receipt_text|boolean}}{contribution.contribution_page_id.receipt_text}
+        {else}{ts}Below you will find a receipt for this contribution.{/ts}{/if}
+      </p>
    </td>
   </tr>
   <tr>

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -1,6 +1,9 @@
 {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}{$greeting},{/if}
 
-{ts}Below you will find a receipt for this contribution.{/ts}
+{if {contribution.contribution_page_id.receipt_text|boolean}}
+{contribution.contribution_page_id.receipt_text}
+{else}{ts}Below you will find a receipt for this contribution.{/ts}
+{/if}
 
 ===========================================================
 {ts}Contribution Information{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
Offline contribution receipts are very generic. It would be nice to be able to select a Contribution Page and include the receipt text for that Contribution Page (e.g. thanking a donor for giving to a specific cause or project). This makes that possible in a basic way, with future work to make it more user-friendly detailed below.

Before
----------------------------------------
Intro text in offline contribution receipts is generic.

After
----------------------------------------
If a Contribution Page is selected, the receipt text is used in place of the generic "Below you will find a receipt for this contribution."

Comments
----------------------------------------
Future follow up:
Add a user_text to the New Contribution form once #27162 is worked out. Move the Contribution Page select out of the Additional Details tab so it is more visible and set the default for the new user_text field based on the Contribution Page selected (i.e. make this work the same way it does for events).

Online receipts could also use this token, but see comment below on webform_civicrm using apiv3 to pass in receipt_text.
