### PR TITLE
Test Cleanup - Refactor out uses of deprecated `callAPIAndDocument()`

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3432,7 +3432,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    */
   protected function basicCreateTest(int $version): void {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
@@ -3449,7 +3449,7 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
     $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = ['id' => $result['id']];
-    $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/ActivityCaseTest.php
+++ b/tests/phpunit/api/v3/ActivityCaseTest.php
@@ -108,21 +108,21 @@ class api_v3_ActivityCaseTest extends CiviCaseTestCase {
     $this->assertTrue(is_numeric($this->_case['id']));
     $this->assertTrue(is_numeric($this->_otherActivity['id']));
 
-    $getByCaseId = $this->callAPIAndDocument('Activity', 'get', [
+    $getByCaseId = $this->callAPISuccess('Activity', 'get', [
       'case_id' => $this->_case['id'],
-    ], __FUNCTION__, __FILE__);
+    ]);
     $this->assertNotEmpty($getByCaseId['values']);
     $getByCaseId_ids = array_keys($getByCaseId['values']);
 
-    $getByCaseNotNull = $this->callAPIAndDocument('Activity', 'get', [
+    $getByCaseNotNull = $this->callAPISuccess('Activity', 'get', [
       'case_id' => ['IS NOT NULL' => 1],
-    ], __FUNCTION__, __FILE__);
+    ]);
     $this->assertNotEmpty($getByCaseNotNull['values']);
     $getByCaseNotNull_ids = array_keys($getByCaseNotNull['values']);
 
-    $getByCaseNull = $this->callAPIAndDocument('Activity', 'get', [
+    $getByCaseNull = $this->callAPISuccess('Activity', 'get', [
       'case_id' => ['IS NULL' => 1],
-    ], __FUNCTION__, __FILE__);
+    ]);
     $this->assertNotEmpty($getByCaseNull['values']);
     $getByCaseNull_ids = array_keys($getByCaseNull['values']);
 

--- a/tests/phpunit/api/v3/ActivityContactTest.php
+++ b/tests/phpunit/api/v3/ActivityContactTest.php
@@ -47,11 +47,11 @@ class api_v3_ActivityContactTest extends CiviUnitTestCase {
   public function testCreateActivityContact($version) {
     $this->_apiversion = $version;
 
-    $result = $this->callAPIAndDocument('ActivityContact', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('ActivityContact', 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
 
-    $result = $this->callAPIAndDocument('ActivityContact', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('ActivityContact', 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
 
     $this->callAPISuccess('activity_contact', 'delete', ['id' => $result['id']]);
@@ -68,7 +68,7 @@ class api_v3_ActivityContactTest extends CiviUnitTestCase {
     //create one
     $create = $this->callAPISuccess('activity_contact', 'create', $this->_params);
 
-    $result = $this->callAPIAndDocument('activity_contact', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('activity_contact', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('activity_contact', 'get', [
       'id' => $create['id'],

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -377,8 +377,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    */
   public function testActivityReturnTargetAssignee(int $version): void {
     $this->_apiversion = $version;
-    $description = 'Demonstrates setting & retrieving activity target & source.';
-    $subfile = 'GetTargetAndAssignee';
     $params = [
       'source_contact_id' => $this->_contactID,
       'subject' => 'Make-it-Happen Meeting',
@@ -393,7 +391,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'assignee_contact_id' => $this->_contactID,
     ];
 
-    $result = $this->callAPIAndDocument('activity', 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('activity', 'create', $params);
 
     $actContacts = $this->callAPISuccess('ActivityContact', 'get', [
       'activity_id' => $result['id'],
@@ -419,8 +417,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    */
   public function testActivityReturnTargetAssigneeName() {
 
-    $description = "Demonstrates retrieving activity target & source contact names.";
-    $subfile = "GetTargetandAssigneeName";
     $target1 = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'first_name' => 'A', 'last_name' => 'Cat']);
     $target2 = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'first_name' => 'B', 'last_name' => 'Good']);
     $assignee = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'first_name' => 'C', 'last_name' => 'Shore']);
@@ -437,10 +433,10 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     ];
 
     $result = $this->callAPISuccess('activity', 'create', $params);
-    $result = $this->callAPIAndDocument('activity', 'getsingle', [
+    $result = $this->callAPISuccess('activity', 'getsingle', [
       'id' => $result['id'],
       'return' => ['source_contact_name', 'target_contact_name', 'assignee_contact_name', 'subject'],
-    ], __FUNCTION__, __FILE__, $description, $subfile);
+    ]);
 
     $this->assertEquals($params['subject'], $result['subject']);
     $this->assertEquals($source['id'], $result['source_contact_id']);
@@ -458,7 +454,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $result = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
       'id' => $result['id'],
@@ -482,7 +478,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     ]);
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $result = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
       'id' => $result['id'],
@@ -499,8 +495,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   public function testActivityCreateCustomContactRefField() {
 
     $this->callAPISuccess('contact', 'create', ['id' => $this->_contactID, 'sort_name' => 'Contact, Test']);
-    $subfile = 'ContactRefCustomField';
-    $description = "Demonstrates create with Contact Reference Custom Field.";
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params = [
       'custom_group_id' => $ids['custom_group_id'],
@@ -517,11 +511,11 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $customField['id']] = "$this->_contactID";
 
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', [
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+    $result = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $customField['id'] => 1,
       'id' => $result['id'],
-    ], __FUNCTION__, __FILE__, 'Get with Contact Ref Custom Field', 'ContactRefCustomFieldGet');
+    ]);
 
     $this->assertEquals('Anderson, Anthony', $result['values'][$result['id']]['custom_' . $customField['id']]);
     $this->assertEquals($this->_contactID, $result['values'][$result['id']]['custom_' . $customField['id'] . "_id"], ' in line ' . __LINE__);
@@ -606,8 +600,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    */
   public function testActivityGetGoodID1() {
     // Insert rows in civicrm_activity creating activities 4 and 13
-    $description = 'Demonstrates getting assignee_contact_id & using it to get the contact.';
-    $subfile = 'ReturnAssigneeContact';
     $activity = $this->callAPISuccess('activity', 'create', $this->_params);
 
     $contact = $this->callAPISuccess('Contact', 'Create', [
@@ -632,7 +624,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'return' => ['activity_type_id', 'subject'],
     ];
 
-    $result = $this->callAPIAndDocument('Activity', 'Get', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('Activity', 'Get', $params);
 
     $this->assertEquals($activity['id'], $result['id']);
 
@@ -851,8 +843,6 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('Activity', 'Get', [
       'version' => 3,
     ]);
-    $description = "Demonstrates _low filter (at time of writing doesn't work if contact_id is set.";
-    $subFile = "DateTimeLow";
     $this->assertEquals(2, $result['count']);
     $params = [
       'version' => 3,
@@ -860,10 +850,8 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'sequential' => 1,
       'return' => 'activity_date_time',
     ];
-    $result = $this->callAPIAndDocument('Activity', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Activity', 'Get', $params);
     $this->assertEquals(1, $result['count']);
-    $description = "Demonstrates _high filter (at time of writing doesn't work if contact_id is set.";
-    $subFile = 'DateTimeHigh';
     $this->assertEquals('2012-02-16 00:00:00', $result['values'][0]['activity_date_time']);
     $params = [
       'source_contact_id' => $this->_contactID,
@@ -872,7 +860,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'sequential' => 1,
       'return' => 'activity_date_time',
     ];
-    $result = $this->callAPIAndDocument('Activity', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Activity', 'Get', $params);
 
     $this->assertEquals(1, $result['count']);
     $this->assertEquals('2011-01-01 00:00:00', $result['values'][0]['activity_date_time']);
@@ -899,7 +887,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
       'sequential' => 1,
       'return.custom_' . $ids['custom_field_id'] => 1,
     ];
-    $result = $this->callAPIAndDocument('activity', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('activity', 'get', $params);
     $this->assertEquals('custom string', $result['values'][0]['custom_' . $ids['custom_field_id']]);
     $this->customFieldDelete($ids['custom_field_id']);
     $this->customGroupDelete($ids['custom_group_id']);
@@ -947,7 +935,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
   public function testDeleteActivity(): void {
     $result = $this->callAPISuccess('Activity', 'create', $this->_params);
     $params = ['id' => $result['id']];
-    $this->callAPIAndDocument('Activity', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Activity', 'delete', $params);
   }
 
   /**
@@ -1344,7 +1332,7 @@ class api_v3_ActivityTest extends CiviUnitTestCase {
    */
   public function testGetFields() {
     $params = ['action' => 'create'];
-    $result = $this->callAPIAndDocument('activity', 'getfields', $params, __FUNCTION__, __FILE__, NULL, NULL);
+    $result = $this->callAPISuccess('activity', 'getfields', $params);
     $this->assertTrue(is_array($result['values']), 'get fields doesn\'t return values array');
     foreach ($result['values'] as $key => $value) {
       $this->assertTrue(is_array($value), $key . " is not an array");

--- a/tests/phpunit/api/v3/ActivityTypeTest.php
+++ b/tests/phpunit/api/v3/ActivityTypeTest.php
@@ -46,7 +46,7 @@ class api_v3_ActivityTypeTest extends CiviUnitTestCase {
    */
   public function testActivityTypeGet() {
     $params = [];
-    $result = $this->callAPIAndDocument('activity_type', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('activity_type', 'get', $params);
     $this->assertEquals($result['values']['1'], 'Meeting');
   }
 
@@ -62,7 +62,7 @@ class api_v3_ActivityTypeTest extends CiviUnitTestCase {
       'is_optgroup' => 1,
       'is_default' => 0,
     ];
-    $result = $this->callAPIAndDocument('activity_type', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('activity_type', 'create', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -64,7 +64,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
    */
   public function testCreateAddress($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument('Address', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Address', 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->_params, $result['id'], 'address');
@@ -82,9 +82,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
       'location_type_id' => $this->_locationTypeID,
       'contact_id' => $this->_contactID,
     ];
-    $subfile = "AddressParse";
-    $description = "Demonstrates Use of address parsing param.";
-    $result = $this->callAPIAndDocument('address', 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('address', 'create', $params);
     $this->assertEquals(54, $result['values'][$result['id']]['street_number']);
     $this->assertEquals('A', $result['values'][$result['id']]['street_number_suffix']);
     $this->assertEquals('Excelsior Ave.', $result['values'][$result['id']]['street_name']);
@@ -119,7 +117,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
   }
@@ -270,7 +268,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     //create one
     $create = $this->callAPISuccess('address', 'create', $this->_params);
 
-    $result = $this->callAPIAndDocument('address', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('address', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('address', 'get', [
       'location_type_id' => $this->_locationTypeID,
@@ -292,7 +290,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
       'street_name' => $address['values'][$address['id']]['street_name'],
       'return' => ['location_type_id', 'is_primary', 'street_address'],
     ];
-    $result = $this->callAPIAndDocument('Address', 'Get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Address', 'Get', $params);
     $this->assertEquals($address['values'][$address['id']]['location_type_id'], $result['values'][$address['id']]['location_type_id']);
     $this->assertEquals($address['values'][$address['id']]['is_primary'], $result['values'][$address['id']]['is_primary']);
     $this->assertEquals($address['values'][$address['id']]['street_address'], $result['values'][$address['id']]['street_address']);
@@ -323,8 +321,6 @@ class api_v3_AddressTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $create = $this->callAPISuccess('address', 'create', $this->_params);
     $this->callAPISuccess('address', 'create', array_merge($this->_params, ['street_address' => 'yzy']));
-    $subfile = "AddressSort";
-    $description = 'Demonstrates Use of sort filter.';
     $params = [
       'options' => [
         'sort' => 'street_address DESC',
@@ -333,7 +329,7 @@ class api_v3_AddressTest extends CiviUnitTestCase {
       'sequential' => 1,
       'return' => 'street_address',
     ];
-    $result = $this->callAPIAndDocument('Address', 'Get', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('Address', 'Get', $params);
     $this->assertEquals(2, $result['count']);
     $this->assertEquals('Ambachtstraat 23', $result['values'][1]['street_address']);
   }
@@ -346,14 +342,12 @@ class api_v3_AddressTest extends CiviUnitTestCase {
   public function testGetAddressLikeSuccess($version) {
     $this->_apiversion = $version;
     $this->callAPISuccess('address', 'create', $this->_params);
-    $subfile = 'AddressLike';
-    $description = 'Demonstrates Use of Like.';
     $params = [
       'street_address' => ['LIKE' => '%mb%'],
       'sequential' => 1,
       'return' => 'street_address',
     ];
-    $result = $this->callAPIAndDocument('Address', 'Get', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('Address', 'Get', $params);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals('Ambachtstraat 23', $result['values'][0]['street_address']);
   }

--- a/tests/phpunit/api/v3/BatchTest.php
+++ b/tests/phpunit/api/v3/BatchTest.php
@@ -41,7 +41,7 @@ class api_v3_BatchTest extends CiviUnitTestCase {
     $params = [
       'id' => $this->batchCreate(),
     ];
-    $result = $this->callAPIAndDocument('Batch', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Batch', 'get', $params);
     $this->assertEquals($params['id'], $result['id']);
   }
 
@@ -65,7 +65,7 @@ class api_v3_BatchTest extends CiviUnitTestCase {
       'status_id' => 1,
     ];
 
-    $result = $this->callAPIAndDocument('batch', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('batch', 'create', $params);
     $this->assertNotNull($result['id']);
     $this->getAndCheck($params, $result['id'], 'Batch');
   }
@@ -90,7 +90,7 @@ class api_v3_BatchTest extends CiviUnitTestCase {
       'id' => $this->batchCreate(),
     ];
 
-    $result = $this->callAPIAndDocument('batch', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('batch', 'create', $params);
     $this->assertNotNull($result['id']);
     $this->getAndCheck($params, $result['id'], $this->_entity);
   }
@@ -121,7 +121,7 @@ class api_v3_BatchTest extends CiviUnitTestCase {
     $params = [
       'id' => $batchID,
     ];
-    $this->callAPIAndDocument('Batch', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Batch', 'delete', $params);
   }
 
 }

--- a/tests/phpunit/api/v3/CampaignTest.php
+++ b/tests/phpunit/api/v3/CampaignTest.php
@@ -34,9 +34,7 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
    */
   public function testCreateCampaign($version) {
     $this->_apiversion = $version;
-    $description = "Create a campaign - Note use of relative dates here:
-      @link http://www.php.net/manual/en/datetime.formats.relative.php.";
-    $result = $this->callAPIAndDocument('campaign', 'create', $this->params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess('campaign', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck(array_merge($this->params, ['created_date' => '2008-07-05 00:00:00']), $result['id'], 'campaign', TRUE);
@@ -49,7 +47,7 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
   public function testGetCampaign($version) {
     $this->_apiversion = $version;
     $result = $this->callAPISuccess('campaign', 'create', $this->params);
-    $result = $this->callAPIAndDocument('campaign', 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('campaign', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
@@ -63,7 +61,7 @@ class api_v3_CampaignTest extends CiviUnitTestCase {
     $this->callAPISuccess('campaign', 'create', $this->params);
     $entity = $this->callAPISuccess('campaign', 'get', ($this->params));
     $delete = ['id' => $entity['id']];
-    $result = $this->callAPIAndDocument('campaign', 'delete', $delete, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('campaign', 'delete', $delete);
 
     $checkDeleted = $this->callAPISuccess('campaign', 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);

--- a/tests/phpunit/api/v3/CaseContactTest.php
+++ b/tests/phpunit/api/v3/CaseContactTest.php
@@ -49,9 +49,9 @@ class api_v3_CaseContactTest extends CiviCaseTestCase {
   }
 
   public function testCaseContactGet() {
-    $result = $this->callAPIAndDocument('CaseContact', 'get', [
+    $result = $this->callAPISuccess('CaseContact', 'get', [
       'contact_id' => $this->contactID,
-    ], __FUNCTION__, __FILE__);
+    ]);
     $this->assertEquals($this->case['id'], $result['id']);
   }
 
@@ -60,7 +60,7 @@ class api_v3_CaseContactTest extends CiviCaseTestCase {
    */
   public function testCaseContactCreate() {
     $params = $this->params;
-    $result = $this->callAPIAndDocument('CaseContact', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('CaseContact', 'create', $params);
     $id = $result['id'];
 
     // Check result

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -163,7 +163,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     // Test using name instead of value.
     unset($params['case_type_id']);
     $params['case_type'] = $this->caseType;
-    $result = $this->callAPIAndDocument('case', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('case', 'create', $params);
     $id = $result['id'];
 
     // Check result
@@ -217,7 +217,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $result = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
       'id' => $result['id'],

--- a/tests/phpunit/api/v3/ConstantTest.php
+++ b/tests/phpunit/api/v3/ConstantTest.php
@@ -78,9 +78,9 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
    * Test civicrm_constant_get( 'activityType' )
    */
   public function testActivityType() {
-    $result = $this->callAPIAndDocument('constant', 'get', [
+    $result = $this->callAPISuccess('constant', 'get', [
       'name' => 'activityType',
-    ], __FUNCTION__, __FILE__, NULL, NULL, 'get');
+    ]);
     $this->assertTrue($result['count'] > 2, "In line " . __LINE__);
     $this->assertContains('Meeting', $result['values'], "In line " . __LINE__);
   }
@@ -98,7 +98,7 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
     $params = [
       'field' => 'location_type_id',
     ];
-    $result = $this->callAPIAndDocument('address', 'getoptions', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('address', 'getoptions', $params);
     $this->assertTrue($result['count'] > 3, "In line " . __LINE__);
     $this->assertContains('Home', $result['values'], "In line " . __LINE__);
     $this->assertContains('Work', $result['values'], "In line " . __LINE__);
@@ -116,7 +116,7 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
     $params = [
       'field' => 'phone_type_id',
     ];
-    $result = $this->callAPIAndDocument('phone', 'getoptions', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('phone', 'getoptions', $params);
 
     $this->assertEquals(5, $result['count'], "In line " . __LINE__);
     $this->assertContains('Phone', $result['values'], "In line " . __LINE__);
@@ -136,7 +136,7 @@ class api_v3_ConstantTest extends CiviUnitTestCase {
     $params = [
       'field' => 'protocol',
     ];
-    $result = $this->callAPIAndDocument('mail_settings', 'getoptions', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('mail_settings', 'getoptions', $params);
 
     $this->assertEquals(4, $result['count'], "In line " . __LINE__);
     $this->assertContains('IMAP', $result['values'], "In line " . __LINE__);

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -685,8 +685,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
-    $description = 'This demonstrates setting a custom field through the API.';
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
 
     $check = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
@@ -1303,14 +1302,12 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
-    $description = 'This demonstrates setting a custom field through the API.';
-    $subFile = 'CustomFieldGet';
     $result = $this->callAPISuccess($this->_entity, 'create', $params);
 
-    $check = $this->callAPIAndDocument($this->_entity, 'get', [
+    $check = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
       'id' => $result['id'],
-    ], __FUNCTION__, __FILE__, $description, $subFile);
+    ]);
 
     $this->assertEquals('custom string', $check['values'][$check['id']]['custom_' . $ids['custom_field_id']]);
     $fields = ($this->callAPISuccess('contact', 'getfields', $params));
@@ -1347,11 +1344,9 @@ class api_v3_ContactTest extends CiviUnitTestCase {
 
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
-    $description = 'This demonstrates setting a custom field through the API.';
-    $subFile = 'CustomFieldGetReturnSyntaxVariation';
     $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $params = ['return' => 'custom_' . $ids['custom_field_id'], 'id' => $result['id']];
-    $check = $this->callAPIAndDocument($this->_entity, 'get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $check = $this->callAPISuccess($this->_entity, 'get', $params);
 
     $this->assertEquals('custom string', $check['values'][$check['id']]['custom_' . $ids['custom_field_id']]);
     $this->customFieldDelete($ids['custom_field_id']);
@@ -1453,8 +1448,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreateIndividualWithContributionDottedSyntax(): void {
-    $description = 'This demonstrates the syntax to create 2 chained entities.';
-    $subFile = 'ChainTwoWebsites';
     $params = [
       'first_name' => 'abc3',
       'last_name' => 'xyz3',
@@ -1482,9 +1475,9 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       ],
     ];
 
-    $result = $this->callAPIAndDocument('Contact', 'create', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'create', $params);
 
-    // checking child function result not covered in callAPIAndDocument
+    // checking child function result not covered in callAPISuccess
     $this->assertAPISuccess($result['values'][$result['id']]['api.website.create']);
     $this->assertEquals('https://chained.org', $result['values'][$result['id']]['api.website.create.2']['values'][0]['url']);
     $this->assertEquals('https://civicrm.org', $result['values'][$result['id']]['api.website.create']['values'][0]['url']);
@@ -1529,9 +1522,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       ],
     ];
 
-    $description = 'Demonstrates creating two websites as an array.';
-    $subFile = 'ChainTwoWebsitesSyntax2';
-    $result = $this->callAPIAndDocument('Contact', 'create', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'create', $params);
 
     // the callAndDocument doesn't check the chained call
     $this->assertEquals(0, $result['values'][$result['id']]['api.website.create'][0]['is_error']);
@@ -2108,7 +2099,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $params = [
       'id' => $contactID,
     ];
-    $this->callAPIAndDocument('contact', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('contact', 'delete', $params);
   }
 
   /**
@@ -2308,7 +2299,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $params = [
       'email' => 'man2@yahoo.com',
     ];
-    $result = $this->callAPIAndDocument('contact', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('contact', 'get', $params);
     $this->assertEquals('man2@yahoo.com', $result['values'][$result['id']]['email']);
 
     $this->callAPISuccess('contact', 'delete', $contact);
@@ -2704,8 +2695,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
 
     $moreIDs = $this->CustomGroupMultipleCreateWithFields();
-    $description = "This demonstrates the usage of chained api functions.\nIn this case no notes or custom fields have been created.";
-    $subFile = 'APIChainedArray';
     $params = [
       'first_name' => 'abc3',
       'last_name' => 'xyz3',
@@ -2754,7 +2743,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'api.CustomValue.get' => 1,
       'api.Note.get' => 1,
     ];
-    $result = $this->callAPIAndDocument('Contact', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Get', $params);
     // delete the contact
     $this->callAPISuccess('contact', 'delete', $result);
     $this->customGroupDelete($ids['custom_group_id']);
@@ -2816,8 +2805,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testGetIndividualWithChainedArraysFormats(): void {
-    $description = "This demonstrates the usage of chained api functions.\nIn this case no notes or custom fields have been created.";
-    $subFile = 'APIChainedArrayFormats';
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
 
@@ -2867,7 +2854,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'api.Note.get' => 1,
       'api.Membership.getCount' => [],
     ];
-    $result = $this->callAPIAndDocument('Contact', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Get', $params);
     $this->assertEquals(2, $result['values'][$result['id']]['api.Contribution.getCount']);
     $this->assertEquals(0, $result['values'][$result['id']]['api.Note.get']['is_error']);
     $this->assertEquals('https://civicrm.org', $result['values'][$result['id']]['api.website.getValue']);
@@ -2890,8 +2877,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'title' => 'another group',
       'name' => 'another name',
     ]);
-    $description = 'This demonstrates the usage of chained api functions with multiple custom fields.';
-    $subFile = 'APIChainedArrayMultipleCustom';
     $params = [
       'first_name' => 'abc3',
       'last_name' => 'xyz3',
@@ -2952,7 +2937,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'api.Contribution.getCount' => [],
       'api.CustomValue.get' => 1,
     ];
-    $result = $this->callAPIAndDocument('Contact', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Get', $params);
 
     $this->customGroupDelete($ids['custom_group_id']);
     $this->customGroupDelete($moreIDs['custom_group_id']);
@@ -2970,9 +2955,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testChainingValuesCreate(): void {
-    $description = "This demonstrates the usage of chained api functions.  Specifically it has one 'parent function' &
-      2 child functions - one receives values from the parent (Contact) and the other child (Tag).";
-    $subFile = 'APIChainedArrayValuesFromSiblingFunction';
     $params = [
       'display_name' => 'batman',
       'contact_type' => 'Individual',
@@ -2983,7 +2965,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       ],
       'api.entity_tag.create' => ['tag_id' => '$value.api.tag.create'],
     ];
-    $result = $this->callAPIAndDocument('Contact', 'Create', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Create', $params);
     $this->assertEquals(0, $result['values'][$result['id']]['api.entity_tag.create']['is_error']);
   }
 
@@ -2998,11 +2980,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function testContactGetFormatIsSuccessTrue(int $version): void {
     $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
-    $description = "This demonstrates use of the 'format.is_success' param.
-    This param causes only the success or otherwise of the function to be returned as BOOLEAN";
-    $subFile = 'FormatIsSuccess_True';
     $params = ['id' => $contactID, 'format.is_success' => 1];
-    $result = $this->callAPIAndDocument('Contact', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Get', $params);
     $this->assertEquals(1, $result);
     $this->callAPISuccess('Contact', 'Delete', $params);
   }
@@ -3017,11 +2996,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function testContactCreateFormatIsSuccessFalse(int $version): void {
     $this->_apiversion = $version;
 
-    $description = "This demonstrates use of the 'format.is_success' param.
-    This param causes only the success or otherwise of the function to be returned as BOOLEAN";
-    $subFile = 'FormatIsSuccess_Fail';
     $params = ['id' => 500, 'format.is_success' => 1];
-    $result = $this->callAPIAndDocument('Contact', 'Create', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Create', $params);
     $this->assertEquals(0, $result);
   }
 
@@ -3097,11 +3073,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function testContactGetSingleEntityArray(int $version): void {
     $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
-    $description = "This demonstrates use of the 'format.single_entity_array' param.
-      This param causes the only contact to be returned as an array without the other levels.
-      It will be ignored if there is not exactly 1 result";
-    $subFile = 'GetSingleContact';
-    $result = $this->callAPIAndDocument('Contact', 'GetSingle', ['id' => $contactID], __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'GetSingle', ['id' => $contactID]);
     $this->assertEquals('Mr. Test Contact II', $result['display_name']);
     $this->callAPISuccess('Contact', 'Delete', ['id' => $contactID]);
   }
@@ -3117,11 +3089,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function testContactGetFormatCountOnly(int $version): void {
     $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
-    $description = "This demonstrates use of the 'getCount' action.
-      This param causes the count of the only function to be returned as an integer.";
     $params = ['id' => $contactID];
-    $result = $this->callAPIAndDocument('Contact', 'GetCount', $params, __FUNCTION__, __FILE__, $description,
-      'GetCountContact');
+    $result = $this->callAPISuccess('Contact', 'GetCount', $params);
     $this->assertEquals('1', $result);
     $this->callAPISuccess('Contact', 'Delete', $params);
   }
@@ -3137,12 +3106,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function testContactGetFormatIDOnly(int $version): void {
     $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
-    $description = "This demonstrates use of the 'format.id_only' param.
-      This param causes the id of the only entity to be returned as an integer.
-      It will be ignored if there is not exactly 1 result";
-    $subFile = 'FormatOnlyID';
     $params = ['id' => $contactID, 'format.only_id' => 1];
-    $result = $this->callAPIAndDocument('Contact', 'Get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'Get', $params);
     $this->assertEquals($contactID, $result);
     $this->callAPISuccess('Contact', 'Delete', $params);
   }
@@ -3158,12 +3123,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
   public function testContactGetFormatSingleValue(int $version): void {
     $this->_apiversion = $version;
     $contactID = $this->individualCreate(['first_name' => 'Test', 'last_name' => 'Contact']);
-    $description = "This demonstrates use of the 'format.single_value' param.
-      This param causes only a single value of the only entity to be returned as an string.
-      It will be ignored if there is not exactly 1 result";
-    $subFile = 'FormatSingleValue';
     $params = ['id' => $contactID, 'return' => 'display_name'];
-    $result = $this->callAPIAndDocument('Contact', 'getvalue', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('Contact', 'getvalue', $params);
     $this->assertEquals('Mr. Test Contact II', $result);
     $this->callAPISuccess('Contact', 'Delete', $params);
   }
@@ -4027,8 +3988,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test contact getactions.
    */
   public function testGetActions(): void {
-    $description = 'Getting the available actions for an entity.';
-    $result = $this->callAPIAndDocument($this->_entity, 'getactions', [], __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess($this->_entity, 'getactions', []);
     $expected = [
       'create',
       'delete',
@@ -4446,7 +4406,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       $this->assertEquals($contactIDs[1], $result['values'][0]['id']);
     }
 
-    $result = $this->callAPIAndDocument('Contact', 'getmergedfrom', ['contact_id' => $contactIDs[1]], __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess('Contact', 'getmergedfrom', ['contact_id' => $contactIDs[1]])['values'];
     $mergedContactIDs = array_merge(array_diff($contactIDs, [$contactIDs[1]]));
     $this->assertEquals($mergedContactIDs, array_keys($result));
   }
@@ -4614,8 +4574,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testContactGetWithGroupTitleMultipleGroups(): void {
-    $description = 'Get all from group and display contacts.';
-    $subFile = 'GroupFilterUsingContactAPI';
     $contact_params = [
       'contact_type' => 'Individual',
       'first_name' => 'Test2',
@@ -4650,7 +4608,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     foreach ($createdGroupsIds as $id) {
       $this->assertContains((string) $id, $contact_groups);
     }
-    $this->callAPIAndDocument('contact', 'get', ['group' => ['IN' => $createdGroupTitles]], __FUNCTION__, __FILE__, $description, $subFile);
+    $this->callAPISuccess('contact', 'get', ['group' => ['IN' => $createdGroupTitles]]);
     $contact_get2 = $this->callAPISuccess('contact', 'get', ['group' => ['IN' => $createdGroupTitles], 'return' => 'group']);
     $this->assertEquals($created_contact_id, $contact_get2['id']);
     $contact_groups2 = explode(',', $contact_get2['values'][$created_contact_id]['groups']);
@@ -4765,10 +4723,8 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testLoggedInUserAPISupportToken(): void {
-    $description = 'Get contact id of the current logged in user';
-    $subFile = 'ContactIDOfLoggedInUserContactAPI';
     $cid = $this->createLoggedInUser();
-    $contact = $this->callAPIAndDocument('contact', 'get', ['id' => 'user_contact_id'], __FUNCTION__, __FILE__, $description, $subFile);
+    $contact = $this->callAPISuccess('contact', 'get', ['id' => 'user_contact_id']);
     $this->assertEquals($cid, $contact['id']);
   }
 
@@ -4934,7 +4890,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * Test getunique api call for Contact entity
    */
   public function testContactGetUnique(): void {
-    $result = $this->callAPIAndDocument($this->_entity, 'getunique', [], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'getunique', []);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals(['external_identifier'], $result['values']['UI_external_identifier']);
   }

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -118,7 +118,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'currency' => 'NZD',
       'financial_type_id' => 1,
     ];
-    $getResult = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $getResult = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $this->assertEquals(1, $getResult['count']);
   }
 
@@ -561,7 +561,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $this->addProfile('supporter_profile', $this->_ids['contribution_page']);
 
     $submitParams = $this->getSubmitParamsContributionPlusMembership();
-    $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
     $contributions = $this->callAPISuccess('Contribution', 'get', ['contribution_page_id' => $this->_ids['contribution_page'], 'return' => 'contact_id'])['values'];
     $this->assertCount(2, $contributions);
     $membershipPayment = $this->callAPISuccess('MembershipPayment', 'getsingle', ['return' => ['contribution_id', 'membership_id']]);
@@ -828,7 +828,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'frequency_unit' => $this->params['recur_frequency_unit'],
     ]);
 
-    $this->callAPIAndDocument('ContributionPage', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
     $contribution = $this->callAPISuccess('contribution', 'getsingle', [
       'contribution_page_id' => $this->_ids['contribution_page'],
       'contribution_status_id' => 1,
@@ -956,7 +956,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'frequency_unit' => $this->params['recur_frequency_unit'],
     ];
 
-    $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
     $contribution = $this->callAPISuccess('contribution', 'getsingle', [
       'contribution_page_id' => $this->_ids['contribution_page'],
       'contribution_status_id' => 1,
@@ -1058,7 +1058,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'frequency_unit' => 'month',
     ]);
 
-    $this->callAPIAndDocument('ContributionPage', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
     $contributions = $this->callAPISuccess('contribution', 'get', [
       'contribution_page_id' => $this->_ids['contribution_page'],
       'contribution_status_id' => 1,
@@ -1118,7 +1118,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'frequency_unit' => $this->params['recur_frequency_unit'],
     ]);
 
-    $this->callAPIAndDocument('ContributionPage', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('ContributionPage', 'submit', $submitParams);
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', [
       'contribution_page_id' => $this->_ids['contribution_page'],
       'contribution_status_id' => 2,
@@ -1526,7 +1526,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
       'pledge_block_id' => (int) $this->_ids['pledge_block_id'],
     ];
 
-    $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
 
     // Check if contribution created.
     $contribution = $this->callAPISuccess('contribution', 'getsingle', [
@@ -1596,7 +1596,7 @@ class api_v3_ContributionPageTest extends CiviUnitTestCase {
     $pledgePayment = $this->callAPISuccess('pledge_payment', 'get', $params);
     $this->assertEquals(2, $pledgePayment['values'][2]['status_id']);
 
-    $this->callAPIAndDocument('contribution_page', 'submit', $submitParams, __FUNCTION__, __FILE__, 'submit contribution page');
+    $this->callAPISuccess('contribution_page', 'submit', $submitParams);
 
     // Check if contribution created.
     $contribution = $this->callAPISuccess('Contribution', 'getsingle', [

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -65,7 +65,7 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $this->callAPISuccess($this->_entity, 'create', $this->params);
     $getParams = ['amount' => '500'];
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $this->assertEquals(1, $result['count']);
   }
 

--- a/tests/phpunit/api/v3/ContributionSoftTest.php
+++ b/tests/phpunit/api/v3/ContributionSoftTest.php
@@ -87,7 +87,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $params = [
       'id' => $softContribution['id'],
     ];
-    $softContribution = $this->callAPIAndDocument('contribution_soft', 'get', $params, __FUNCTION__, __FILE__);
+    $softContribution = $this->callAPISuccess('contribution_soft', 'get', $params);
     $this->assertEquals(1, $softContribution['count']);
     $this->assertEquals($softContribution['values'][$softContribution['id']]['contribution_id'], $this->_contributionId);
     $this->assertEquals($softContribution['values'][$softContribution['id']]['contact_id'], $this->_softIndividual1Id);
@@ -191,7 +191,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
       'soft_credit_type_id' => 5,
     ];
 
-    $softContribution = $this->callAPIAndDocument('contribution_soft', 'create', $params, __FUNCTION__, __FILE__);
+    $softContribution = $this->callAPISuccess('contribution_soft', 'create', $params);
     $this->assertEquals($softContribution['values'][$softContribution['id']]['contribution_id'], $this->_contributionId);
     $this->assertEquals($softContribution['values'][$softContribution['id']]['contact_id'], $this->_softIndividual1Id);
     $this->assertEquals($softContribution['values'][$softContribution['id']]['amount'], '10');
@@ -293,7 +293,7 @@ class api_v3_ContributionSoftTest extends CiviUnitTestCase {
     $params = [
       'id' => $softContributionID,
     ];
-    $this->callAPIAndDocument('contribution_soft', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('contribution_soft', 'delete', $params);
   }
 
   ///////////////// civicrm_contribution_search methods

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -158,7 +158,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'return' => array_merge(['invoice_number', 'contribution_source'], array_keys($p)),
     ];
 
-    $contributions = $this->callAPIAndDocument('Contribution', 'get', $params, __FUNCTION__, __FILE__);
+    $contributions = $this->callAPISuccess('Contribution', 'get', $params);
 
     $this->assertEquals(1, $contributions['count']);
     $contribution = $contributions['values'][$contributions['id']];
@@ -470,7 +470,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
 
-    $result = $this->callAPIAndDocument($this->entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->entity, 'create', $params);
     $this->assertEquals($result['id'], $result['values'][$result['id']]['id']);
     $check = $this->callAPISuccess($this->entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
@@ -567,9 +567,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       ],
     ];
 
-    $description = 'Create Contribution with Nested Line Items.';
-    $subFile = 'CreateWithNestedLineItems';
-    $contribution = $this->callAPIAndDocument('Contribution', 'create', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
 
     $this->callAPISuccessGetCount('LineItem', [
       'entity_id' => $contribution['id'],
@@ -932,8 +930,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreateContributionWithNote(): void {
-    $description = 'Demonstrates creating contribution with Note Entity.';
-    $subFile = 'ContributionCreateWithNote';
     $params = [
       'contact_id' => $this->individualID,
       'receive_date' => '2012-01-01',
@@ -950,7 +946,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'note' => 'my contribution note',
     ];
 
-    $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $result = $this->callAPISuccess('note', 'get', [
       'entity_table' => 'civicrm_contribution',
       'entity_id' => $contribution['id'],
@@ -994,8 +990,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * This is the test for creating soft credits.
    */
   public function testCreateContributionWithSoftCredit() {
-    $description = 'Demonstrates creating contribution with SoftCredit.';
-    $subfile = 'ContributionCreateWithSoftCredit';
     $contact2 = $this->callAPISuccess('Contact', 'create', [
       'display_name' => 'superman',
       'contact_type' => 'Individual',
@@ -1007,7 +1001,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ];
 
     $params = $this->_params + ['soft_credit' => [1 => $softParams]];
-    $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $result = $this->callAPISuccess('contribution', 'get', ['return' => 'soft_credit', 'sequential' => 1]);
 
     $this->assertEquals($softParams['contact_id'], $result['values'][0]['soft_credit'][1]['contact_id']);
@@ -1019,8 +1013,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   }
 
   public function testCreateContributionWithSoftCreditDefaults() {
-    $description = 'Demonstrates creating contribution with Soft Credit defaults for amount and type.';
-    $subfile = 'ContributionCreateWithSoftCreditDefaults';
     $contact2 = $this->callAPISuccess('Contact', 'create', [
       'display_name' => 'superman',
       'contact_type' => 'Individual',
@@ -1028,7 +1020,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $params = $this->_params + [
       'soft_credit_to' => $contact2['id'],
     ];
-    $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $result = $this->callAPISuccess('contribution', 'get', ['return' => 'soft_credit', 'sequential' => 1]);
 
     $this->assertEquals($contact2['id'], $result['values'][0]['soft_credit'][1]['contact_id']);
@@ -1044,8 +1036,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Test creating contribution with Soft Credit by passing in honor_contact_id.
    */
   public function testCreateContributionWithHonoreeContact() {
-    $description = 'Demonstrates creating contribution with Soft Credit by passing in honor_contact_id.';
-    $subfile = 'ContributionCreateWithHonoreeContact';
     $contact2 = $this->callAPISuccess('Contact', 'create', [
       'display_name' => 'superman',
       'contact_type' => 'Individual',
@@ -1053,7 +1043,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $params = $this->_params + [
       'honor_contact_id' => $contact2['id'],
     ];
-    $contribution = $this->callAPIAndDocument('contribution', 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $result = $this->callAPISuccess('contribution', 'get', ['return' => 'soft_credit', 'sequential' => 1]);
 
     $this->assertEquals($contact2['id'], $result['values'][0]['soft_credit'][1]['contact_id']);
@@ -1204,7 +1194,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     ];
 
-    $contribution = $this->callAPIAndDocument('Contribution', 'create', $params, __FUNCTION__, __FILE__);
+    $contribution = $this->callAPISuccess('Contribution', 'create', $params);
     $contribution = $contribution['values'][$contribution['id']];
     $this->assertEquals($contribution['contact_id'], $this->individualID);
     $this->assertEquals($contribution['total_amount'], 100.00);
@@ -1913,7 +1903,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $params = [
       'id' => $contributionID,
     ];
-    $this->callAPIAndDocument('contribution', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('contribution', 'delete', $params);
   }
 
   /**
@@ -4734,7 +4724,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
    * Test getunique api call for Contribution entity
    */
   public function testContributionGetUnique(): void {
-    $result = $this->callAPIAndDocument($this->entity, 'getunique', [], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->entity, 'getunique', []);
     $this->assertEquals(2, $result['count']);
     $this->assertEquals(['trxn_id'], $result['values']['UI_contrib_trxn_id']);
     $this->assertEquals(['invoice_id'], $result['values']['UI_contrib_invoice_id']);

--- a/tests/phpunit/api/v3/CountryTest.php
+++ b/tests/phpunit/api/v3/CountryTest.php
@@ -34,7 +34,7 @@ class api_v3_CountryTest extends CiviUnitTestCase {
    */
   public function testCreateCountry() {
 
-    $result = $this->callAPIAndDocument('country', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('country', 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
 
@@ -48,7 +48,7 @@ class api_v3_CountryTest extends CiviUnitTestCase {
     //create one
     $create = $this->callAPISuccess('country', 'create', $this->_params);
 
-    $result = $this->callAPIAndDocument('country', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('country', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('country', 'get', [
       'id' => $create['id'],
@@ -81,7 +81,7 @@ class api_v3_CountryTest extends CiviUnitTestCase {
     $params = [
       'iso_code' => $this->_params['iso_code'],
     ];
-    $result = $this->callAPIAndDocument('Country', 'Get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Country', 'Get', $params);
     $this->assertEquals($country['values'][$country['id']]['name'], $result['values'][$country['id']]['name']);
     $this->assertEquals($country['values'][$country['id']]['iso_code'], $result['values'][$country['id']]['iso_code']);
   }

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -72,7 +72,7 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $customField = $this->callAPIAndDocument('custom_field', 'create', $params, __FUNCTION__, __FILE__);
+    $customField = $this->callAPISuccess('custom_field', 'create', $params);
     $customField['label'] = 'Name2';
     $customFieldEdited = $this->callAPISuccess('custom_field', 'create', $customField);
 
@@ -370,17 +370,13 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
       'options' => ['get_options' => 'custom_' . $customField['id']],
       'action' => 'create',
     ];
-    $description = "Demonstrates retrieving metadata with custom field options.";
-    $subfile = "GetFieldsOptions";
-    $fields = $this->callAPIAndDocument('contact', 'getfields', $getFieldsParams, __FUNCTION__, 'ContactTest.php', $description, $subfile);
+    $fields = $this->callAPISuccess('Contact', 'getfields', $getFieldsParams);
     $this->assertArrayHasKey('options', $fields['values']['custom_' . $customField['id']]);
     $this->assertEquals('Label1', $fields['values']['custom_' . $customField['id']]['options'][1]);
     $getOptionsArray = [
       'field' => 'custom_' . $customField['id'],
     ];
-    $description = "Demonstrates retrieving options for a custom field.";
-    $subfile = "GetOptions";
-    $result = $this->callAPIAndDocument('contact', 'getoptions', $getOptionsArray, __FUNCTION__, 'ContactTest.php', $description, '');
+    $result = $this->callAPISuccess('Contact', 'getoptions', $getOptionsArray);
     $this->assertEquals('Label1', $result['values'][1]);
   }
 
@@ -406,7 +402,7 @@ class api_v3_CustomFieldTest extends CiviUnitTestCase {
     $params = [
       'id' => $customField['id'],
     ];
-    $result = $this->callAPIAndDocument('custom_field', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('custom_field', 'delete', $params);
 
     $this->assertAPISuccess($result);
   }

--- a/tests/phpunit/api/v3/CustomGroupTest.php
+++ b/tests/phpunit/api/v3/CustomGroupTest.php
@@ -137,7 +137,7 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
       'is_active' => 1,
     ];
 
-    $result = $this->callAPIAndDocument('custom_group', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('custom_group', 'create', $params);
     $this->assertNotNull($result['id']);
     $this->assertEquals($result['values'][$result['id']]['extends'], 'Individual');
   }
@@ -334,7 +334,7 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
     $params = [
       'id' => $customGroup['id'],
     ];
-    $result = $this->callAPIAndDocument('custom_group', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('custom_group', 'delete', $params);
     $this->assertAPISuccess($result);
   }
 
@@ -345,7 +345,7 @@ class api_v3_CustomGroupTest extends CiviUnitTestCase {
 
     $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $params = [];
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'get', $params);
     $values = $result['values'][$result['id']];
     foreach ($this->_params as $key => $value) {
       if ($key == 'weight') {

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -72,7 +72,7 @@ class api_v3_DomainTest extends CiviUnitTestCase {
   public function testGet(): void {
 
     $params = ['sequential' => 1];
-    $result = $this->callAPIAndDocument('domain', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('domain', 'get', $params);
 
     $this->assertIsArray($result);
 
@@ -148,7 +148,7 @@ class api_v3_DomainTest extends CiviUnitTestCase {
    * Test civicrm_domain_create.
    */
   public function testCreate() {
-    $result = $this->callAPIAndDocument('domain', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('domain', 'create', $this->params);
     $this->assertEquals($result['count'], 1);
     $this->assertNotNull($result['id']);
     $this->assertEquals($result['values'][$result['id']]['name'], $this->params['name']);

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -61,7 +61,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(0, $get['count'], 'Contact not successfully deleted.');
 
-    $result = $this->callAPIAndDocument('email', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('email', 'create', $params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['id']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -81,7 +81,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
   }
@@ -182,7 +182,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     //create one
     $create = $this->callAPISuccess('email', 'create', $params);
 
-    $result = $this->callAPIAndDocument('email', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('email', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('email', 'get', [
       'location_type_id' => $this->_locationTypeID,
@@ -235,7 +235,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
         ],
       ],
     ];
-    $replace1 = $this->callAPIAndDocument('email', 'replace', $replace1Params, __FUNCTION__, __FILE__);
+    $replace1 = $this->callAPISuccess('email', 'replace', $replace1Params);
     $this->assertEquals(5, $replace1['count']);
 
     // check emails at location #1 or #2
@@ -305,8 +305,6 @@ class api_v3_EmailTest extends CiviUnitTestCase {
     ]);
     $this->assertAPISuccess($get);
     $this->assertEquals(0, $get['count'], 'email already exists');
-    $description = 'Demonstrates use of Replace in a nested API call.';
-    $subfile = 'NestedReplaceEmail';
     // initialize email list with three emails at loc #1 and two emails at loc #2
     $getReplace1Params = [
 
@@ -341,7 +339,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
         ],
       ],
     ];
-    $getReplace1 = $this->callAPIAndDocument('contact', 'get', $getReplace1Params, __FUNCTION__, __FILE__, $description, $subfile);
+    $getReplace1 = $this->callAPISuccess('contact', 'get', $getReplace1Params);
     $this->assertEquals(5, $getReplace1['values'][$this->_contactID]['api.email.replace']['count']);
 
     // check emails at location #1 or #2
@@ -451,7 +449,7 @@ class api_v3_EmailTest extends CiviUnitTestCase {
       'email' => 'api@a-team.com',
       'on_hold' => '2',
     ];
-    $result = $this->callAPIAndDocument('email', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('email', 'create', $params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['id']);
     $this->assertNotNull($result['values'][$result['id']]['id']);

--- a/tests/phpunit/api/v3/EntityBatchTest.php
+++ b/tests/phpunit/api/v3/EntityBatchTest.php
@@ -47,7 +47,7 @@ class api_v3_EntityBatchTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreateEntityBatch(): void {
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -58,7 +58,7 @@ class api_v3_EntityBatchTest extends CiviUnitTestCase {
    */
   public function testGetEntityBatch(): void {
     $this->callAPISuccess($this->_entity, 'create', $this->params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
@@ -70,7 +70,7 @@ class api_v3_EntityBatchTest extends CiviUnitTestCase {
   public function testDeleteEntityBatch(): void {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = ['id' => $result['id']];
-    $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/EntityTagTest.php
+++ b/tests/phpunit/api/v3/EntityTagTest.php
@@ -134,7 +134,7 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
     $paramsEntity = [
       'contact_id' => $this->_individualID,
     ];
-    $result = $this->callAPIAndDocument('entity_tag', 'get', $paramsEntity, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('entity_tag', 'get', $paramsEntity);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals($this->_tagID, $result['values'][$result['id']]['tag_id']);
   }
@@ -247,7 +247,7 @@ class api_v3_EntityTagTest extends CiviUnitTestCase {
       'tag_id' => $this->_tagID,
     ];
 
-    $result = $this->callAPIAndDocument('entity_tag', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('entity_tag', 'delete', $params);
     $this->assertEquals($result['removed'], 1);
   }
 

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -141,7 +141,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
       'sequential' => TRUE,
     ];
 
-    $result = $this->callAPIAndDocument('event', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('event', 'get', $params);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals($result['values'][0]['id'], $this->_eventIds[0]);
   }
@@ -219,9 +219,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     ];
     $currentEventParams = array_merge($this->_params[1], $currentEventParams);
     $currentEvent = $this->callAPISuccess('Event', 'Create', $currentEventParams);
-    $description = "Demonstrates use of is.Current option.";
-    $subfile = "IsCurrentOption";
-    $result = $this->callAPIAndDocument('Event', 'Get', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('Event', 'Get', $params);
     $allEvents = $this->callAPISuccess('Event', 'Get', []);
     $this->callAPISuccess('Event', 'Delete', ['id' => $currentEvent['id']]);
     $this->assertEquals(1, $result['count'], 'confirm only one event found in line ' . __LINE__);
@@ -274,8 +272,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
     ];
 
     $currentEvent = $this->callAPISuccess('Event', 'getsingle', $getEventParams);
-    $description = "Demonstrates use of return is_full .";
-    $subfile = "IsFullOption";
     $this->assertEquals(0, $currentEvent['is_full'], ' is full is set in line ' . __LINE__);
     $this->assertEquals(1, $currentEvent['available_places'], 'available places is set in line ' . __LINE__);
     $participant = $this->callAPISuccess('Participant', 'create', [
@@ -284,7 +280,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
       'contact_id' => $contactID,
       'event_id' => $this->_eventIds[0],
     ]);
-    $currentEvent = $this->callAPIAndDocument('Event', 'getsingle', $getEventParams, __FUNCTION__, __FILE__, $description, $subfile);
+    $currentEvent = $this->callAPISuccess('Event', 'getsingle', $getEventParams);
     $this->assertEquals(1, $currentEvent['is_full'], ' is full is set in line ' . __LINE__);
     $this->assertEquals(0, $currentEvent['available_places'], 'available places is set in line ' . __LINE__);
 
@@ -386,7 +382,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $params = $this->_params[0];
     $params['custom_' . $ids['custom_field_id']] = "custom string";
 
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
 
     $check = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $ids['custom_field_id'] => 1,
@@ -463,11 +459,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
     ]);
     $contact_id = $contact_save_result['id'];
 
-    // I have no clue what this $subfile is about. I just copied it from another
-    // unit test.
-    $subfile = 'ContactRefCustomField';
-    $description = "Demonstrates get with Contact Reference Custom Field.";
-
     // Create a custom group, and add a custom contact reference field.
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
     $params = [
@@ -490,13 +481,13 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $params['event_type_id'] = 1;
     $params['custom_' . $customField['id']] = "$contact_id";
 
-    $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $this->callAPISuccess($this->_entity, 'create', $params);
 
     // Retrieve the activity, search for the contact.
-    $result = $this->callAPIAndDocument($this->_entity, 'get', [
+    $result = $this->callAPISuccess($this->_entity, 'get', [
       'return.custom_' . $customField['id'] => 1,
       'custom_' . $customField['id'] => $contact_id,
-    ], __FUNCTION__, __FILE__, $description, $subfile);
+    ]);
 
     $this->assertEquals($test_contact_name, $result['values'][$result['id']]['custom_' . $customField['id']]);
     $this->assertEquals($contact_id, $result['values'][$result['id']]['custom_' . $customField['id'] . "_id"], ' in line ' . __LINE__);
@@ -645,7 +636,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
    */
   public function testCreateEventSuccess($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument('Event', 'Create', $this->_params[0], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Event', 'Create', $this->_params[0]);
     $this->assertArrayHasKey('id', $result['values'][$result['id']]);
     $result = $this->callAPISuccess($this->_entity, 'Get', ['id' => $result['id']]);
     $this->callAPISuccess($this->_entity, 'Delete', ['id' => $result['id']]);
@@ -714,7 +705,7 @@ class api_v3_EventTest extends CiviUnitTestCase {
     $params = [
       'id' => $this->_eventIds[0],
     ];
-    $this->callAPIAndDocument('Event', 'Delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Event', 'Delete', $params);
   }
 
   /**
@@ -861,7 +852,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
    */
   public function testgetfields($version) {
     $this->_apiversion = $version;
-    $description = "Demonstrate use of getfields to interrogate api.";
     $params = ['action' => 'create'];
     $result = $this->callAPISuccess('event', 'getfields', $params);
     $this->assertEquals('is_active', $result['values']['is_active']['name']);
@@ -871,7 +861,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Test api_action param also works.
    */
   public function testgetfieldsRest() {
-    $description = "Demonstrate use of getfields to interrogate api.";
     $params = ['api_action' => 'create'];
     $result = $this->callAPISuccess('event', 'getfields', $params);
     $this->assertEquals(1, $result['values']['is_active']['api.default']);
@@ -881,7 +870,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Skip api4 - output is different
    */
   public function testgetfieldsGet() {
-    $description = "Demonstrate use of getfields to interrogate api.";
     $params = ['action' => 'get'];
     $result = $this->callAPISuccess('event', 'getfields', $params);
     $this->assertEquals('title', $result['values']['event_title']['name']);
@@ -891,7 +879,6 @@ class api_v3_EventTest extends CiviUnitTestCase {
    * Skip api4 - output is different
    */
   public function testgetfieldsDelete() {
-    $description = "Demonstrate use of getfields to interrogate api.";
     $params = ['action' => 'delete'];
     $result = $this->callAPISuccess('event', 'getfields', $params);
     $this->assertEquals(1, $result['values']['id']['api.required']);

--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -96,7 +96,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
     $params = [
       'contact_id' => $this->contactID,
     ];
-    $result = $this->callAPIAndDocument('group_contact', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('group_contact', 'get', $params);
     foreach ($result['values'] as $v) {
       $this->assertEquals($v['title'], $this->groups[$v['group_id']]['title']);
       $this->assertEquals($v['visibility'], $this->groups[$v['group_id']]['visibility']);
@@ -105,14 +105,12 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
   }
 
   public function testGetGroupID() {
-    $description = "Get all from group and display contacts.";
-    $subfile = "GetWithGroupID";
     $params = [
       'group_id' => $this->groupID1,
       'api.group.get' => 1,
       'sequential' => 1,
     ];
-    $result = $this->callAPIAndDocument('group_contact', 'get', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('group_contact', 'get', $params);
     foreach ($result['values'][0]['api.group.get']['values'] as $values) {
       $key = $values['id'];
       $this->assertEquals($values['title'], $this->groups[$key]['title']);
@@ -139,7 +137,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'group_id' => $this->groupID1,
     ];
 
-    $result = $this->callAPIAndDocument('GroupContact', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('GroupContact', 'create', $params);
     $this->assertEquals(1, $result['not_added']);
     $this->assertEquals(1, $result['added']);
     $this->assertEquals(2, $result['total_count']);
@@ -154,7 +152,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'group_id' => $this->groupID1,
     ];
 
-    $result = $this->callAPIAndDocument('group_contact', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('group_contact', 'delete', $params);
     $this->assertEquals(1, $result['removed']);
     $this->assertEquals(1, $result['total_count']);
   }
@@ -165,7 +163,7 @@ class api_v3_GroupContactTest extends CiviUnitTestCase {
       'id' => $result['id'],
       'skip_undelete' => TRUE,
     ];
-    $this->callAPIAndDocument('group_contact', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('group_contact', 'delete', $params);
     $result = $this->callAPISuccess('group_contact', 'get', $params);
     $this->assertEquals(0, $result['count']);
     $this->assertArrayNotHasKey('id', $result);

--- a/tests/phpunit/api/v3/GroupNestingTest.php
+++ b/tests/phpunit/api/v3/GroupNestingTest.php
@@ -79,7 +79,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
       'child_group_id' => $this->ids['Group']['child'],
     ];
 
-    $result = $this->callAPIAndDocument('group_nesting', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('group_nesting', 'get', $params);
     $expected = [
       1 => [
         'id' => 1,
@@ -183,7 +183,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
       'child_group_id' => $this->ids['Group']['child2'],
     ];
 
-    $this->callAPIAndDocument('group_nesting', 'create', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('group_nesting', 'create', $params);
     $this->callAPISuccessGetCount('GroupNesting', $params, 1);
   }
 
@@ -200,7 +200,7 @@ class api_v3_GroupNestingTest extends CiviUnitTestCase {
 
     $result = $this->callAPISuccess('group_nesting', 'get', $params);
     $params = ['id' => $result['id']];
-    $this->callAPIAndDocument('group_nesting', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('group_nesting', 'delete', $params);
     $this->assertEquals(0, $this->callAPISuccess('group_nesting', 'getcount', $params));
   }
 

--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -58,7 +58,7 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
     $paramsGet = [
       'organization_id' => $result['id'],
     ];
-    $result = $this->callAPIAndDocument('group_organization', 'get', $paramsGet, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('group_organization', 'get', $paramsGet);
   }
 
   /**
@@ -119,7 +119,7 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
       'organization_id' => $this->_orgID,
       'group_id' => $this->_groupID,
     ];
-    $result = $this->callAPIAndDocument('group_organization', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('group_organization', 'create', $params);
   }
 
   /**
@@ -189,7 +189,7 @@ class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
     $params = [
       'id' => $result['id'],
     ];
-    $result = $this->callAPIAndDocument('group_organization', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('group_organization', 'delete', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -127,7 +127,7 @@ class api_v3_GroupTest extends CiviUnitTestCase {
     $params = [
       'name' => "Test Group 1",
     ];
-    $group = $this->callAPIAndDocument('group', 'get', $params, __FUNCTION__, __FILE__);
+    $group = $this->callAPISuccess('group', 'get', $params);
     $group = $group['values'];
 
     foreach ($group as $v) {
@@ -308,9 +308,8 @@ class api_v3_GroupTest extends CiviUnitTestCase {
    */
   public function testgetfields($version) {
     $this->_apiversion = $version;
-    $description = "Demonstrate use of getfields to interrogate api.";
     $params = ['action' => 'create'];
-    $result = $this->callAPIAndDocument('group', 'getfields', $params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess('group', 'getfields', $params);
     $this->assertEquals('is_active', $result['values']['is_active']['name']);
   }
 

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -47,7 +47,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
    */
   public function testCreateIm($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument(self::ENTITY, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess(self::ENTITY, 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], self::ENTITY);
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -64,7 +64,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = $this->params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument(self::ENTITY, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess(self::ENTITY, 'create', $params);
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
     $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result['id']]);
   }
@@ -77,7 +77,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
   public function testGetIm($version) {
     $this->_apiversion = $version;
     $this->callAPISuccess(self::ENTITY, 'create', $this->params);
-    $result = $this->callAPIAndDocument(self::ENTITY, 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess(self::ENTITY, 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess(self::ENTITY, 'delete', ['id' => $result['id']]);
@@ -92,7 +92,7 @@ class api_v3_ImTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $result = $this->callAPISuccess(self::ENTITY, 'create', $this->params);
     $deleteParams = ['id' => $result['id']];
-    $this->callAPIAndDocument(self::ENTITY, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess(self::ENTITY, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess(self::ENTITY, 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -101,7 +101,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
    * Create job.
    */
   public function testCreate(): void {
-    $result = $this->callAPIAndDocument('Job', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Job', 'create', $this->_params);
     $this->getAndCheck($this->_params, $result['id'], 'Job');
   }
 
@@ -111,7 +111,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
   public function testClone(): void {
     $createResult = $this->callAPISuccess('Job', 'create', $this->_params);
     $params = ['id' => $createResult['id']];
-    $cloneResult = $this->callAPIAndDocument('Job', 'clone', $params, __FUNCTION__, __FILE__);
+    $cloneResult = $this->callAPISuccess('Job', 'clone', $params);
     $clonedJob = $cloneResult['values'][$cloneResult['id']];
     $this->assertEquals($this->_params['name'] . ' - Copy', $clonedJob['name']);
     $this->assertEquals($this->_params['description'], $clonedJob['description']);
@@ -127,7 +127,7 @@ class api_v3_JobTest extends CiviUnitTestCase {
   public function testDelete(): void {
     $createResult = $this->callAPISuccess('Job', 'create', $this->_params);
     $params = ['id' => $createResult['id']];
-    $this->callAPIAndDocument('Job', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Job', 'delete', $params);
     $this->assertAPIDeleted('Job', $createResult['id']);
   }
 

--- a/tests/phpunit/api/v3/LineItemTest.php
+++ b/tests/phpunit/api/v3/LineItemTest.php
@@ -102,7 +102,7 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
    */
   public function testCreateLineItem(int $version): void {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->params)['values'];
     $this->assertCount(1, $result);
     $this->getAndCheck($this->params, key($result), $this->_entity);
   }
@@ -136,7 +136,7 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
     $getParams = [
       'entity_table' => 'civicrm_contribution',
     ];
-    $getResult = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $getResult = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $this->assertEquals(1, $getResult['count']);
   }
 
@@ -158,7 +158,7 @@ class api_v3_LineItemTest extends CiviUnitTestCase {
     ];
     $getResult = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $deleteParams = ['id' => $getResult['id']];
-    $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get');
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/LocBlockTest.php
+++ b/tests/phpunit/api/v3/LocBlockTest.php
@@ -51,8 +51,7 @@ class api_v3_LocBlockTest extends CiviUnitTestCase {
       'phone_id' => $phone['id'],
       'email_id' => $email['id'],
     ];
-    $description = 'Create locBlock with existing entities';
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $id = $result['id'];
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$id]['id']);
@@ -81,8 +80,7 @@ class api_v3_LocBlockTest extends CiviUnitTestCase {
         'street_address' => '987654321',
       ],
     ];
-    $description = "Create entities and locBlock in 1 api call.";
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateEntities');
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $id = $result['id'];
     $this->assertEquals(1, $result['count']);
 
@@ -92,7 +90,7 @@ class api_v3_LocBlockTest extends CiviUnitTestCase {
       'return' => 'all',
     ];
     // Can't use callAPISuccess with getsingle.
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__, 'Get entities and location block in 1 api call');
+    $result = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $result = array_pop($result['values']);
     $this->assertNotNull($result['email_id']);
     $this->assertNotNull($result['phone_id']);

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -302,8 +302,7 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
     ]
     );
     $email = $this->callAPISuccessGetSingle('email', ['email' => 'dopey@mail.com']);
-    $this->callAPIAndDocument('Logging', 'revert', ['log_conn_id' => 'woot', 'log_date' => $timeStamp], __FILE__, 'Revert');
-    $this->assertEquals('Anthony', $this->callAPISuccessGetValue('contact', ['id' => $contactId, 'return' => 'first_name']));
+    $this->callAPISuccess('Logging', 'revert', ['log_conn_id' => 'woot', 'log_date' => $timeStamp]);
     $this->callAPISuccessGetCount('Email', ['id' => $email['id']], 0);
   }
 
@@ -440,7 +439,7 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
       'api.email.create' => ['email' => 'dopey@mail.com'],
     ]);
     $this->callAPISuccessGetSingle('email', ['email' => 'dopey@mail.com']);
-    $diffs = $this->callAPIAndDocument('Logging', 'get', ['log_conn_id' => 'wooty wop wop'], __FUNCTION__, __FILE__);
+    $diffs = $this->callAPISuccess('Logging', 'get', ['log_conn_id' => 'wooty wop wop']);
     $this->assertLoggingIncludes($diffs['values'], ['to' => 'Dwarf, Dopey']);
     $this->assertLoggingIncludes($diffs['values'], ['to' => 'Mr. Dopey Dwarf II', 'table' => 'civicrm_contact', 'action' => 'Update', 'field' => 'display_name']);
     $this->assertLoggingIncludes($diffs['values'], ['to' => 'dopey@mail.com', 'table' => 'civicrm_email', 'action' => 'Insert', 'field' => 'email']);

--- a/tests/phpunit/api/v3/MailSettingsTest.php
+++ b/tests/phpunit/api/v3/MailSettingsTest.php
@@ -47,7 +47,7 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
   public function testCreateMailSettings($version) {
     $this->_apiversion = $version;
     $this->callAPISuccessGetCount('mail_settings', [], 1);
-    $result = $this->callAPIAndDocument('MailSettings', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('MailSettings', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess('MailSettings', 'delete', ['id' => $result['id']]);
@@ -80,8 +80,8 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
    */
   public function testGetMailSettings($version) {
     $this->_apiversion = $version;
-    $this->callAPIAndDocument('MailSettings', 'create', $this->params, __FUNCTION__, __FILE__);
-    $result = $this->callAPIAndDocument('MailSettings', 'get', $this->params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('MailSettings', 'create', $this->params);
+    $result = $this->callAPISuccess('MailSettings', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess('MailSettings', 'delete', ['id' => $result['id']]);
@@ -95,10 +95,10 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
    */
   public function testDeleteMailSettings($version) {
     $this->_apiversion = $version;
-    $this->callAPIAndDocument('MailSettings', 'create', $this->params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('MailSettings', 'create', $this->params);
     $entity = $this->callAPISuccess('MailSettings', 'get', $this->params);
     $this->assertEquals('setting.com', $entity['values'][$entity['id']]['domain']);
-    $this->callAPIAndDocument('MailSettings', 'delete', ['id' => $entity['id']], __FUNCTION__, __FILE__);
+    $this->callAPISuccess('MailSettings', 'delete', ['id' => $entity['id']]);
     $checkDeleted = $this->callAPISuccess('MailSettings', 'get', []);
     $this->assertEquals('EXAMPLE.ORG', $checkDeleted['values'][$checkDeleted['id']]['domain']);
   }
@@ -112,14 +112,12 @@ class api_v3_MailSettingsTest extends CiviUnitTestCase {
    */
   public function testGetMailSettingsChainDelete($version) {
     $this->_apiversion = $version;
-    $description = "Demonstrates get + delete in the same call.";
-    $subFile = 'ChainedGetDelete';
     $params = [
       'name' => "delete this setting",
       'api.MailSettings.delete' => 1,
     ];
     $this->callAPISuccess('MailSettings', 'create', ['name' => "delete this setting"] + $this->params);
-    $result = $this->callAPIAndDocument('MailSettings', 'get', $params, __FUNCTION__, __FILE__, $description, $subFile);
+    $result = $this->callAPISuccess('MailSettings', 'get', $params);
     $this->assertEquals(0, $this->callAPISuccess('MailSettings', 'getcount', ['name' => "delete this setting"]));
   }
 

--- a/tests/phpunit/api/v3/MailingABTest.php
+++ b/tests/phpunit/api/v3/MailingABTest.php
@@ -71,7 +71,7 @@ class api_v3_MailingABTest extends CiviUnitTestCase {
    * Test civicrm_mailing_create.
    */
   public function testMailingABCreateSuccess() {
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $this->assertTrue(is_numeric($result['id']), "In line " . __LINE__);
     $this->assertEquals($this->_params['group_percentage'], $result['values'][$result['id']]['group_percentage']);
   }

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -87,7 +87,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
   public function testMailerCreateSuccess(int $version): void {
     $this->_apiversion = $version;
     $this->callAPISuccess('Campaign', 'create', ['name' => 'big campaign', 'title' => 'abc']);
-    $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign'], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign']);
     $jobs = $this->callAPISuccess('MailingJob', 'get', ['mailing_id' => $result['id']]);
     $this->assertEquals(1, $jobs['count']);
     // return isn't working on this in getAndCheck so lets not check it for now
@@ -118,7 +118,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $this->_params['body_html'] = 'I am completed so it does not matter if there is an opt out link since I have already been sent by another system';
     $this->_params['is_completed'] = 1;
-    $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now'], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now']);
     $jobs = $this->callAPISuccess('mailing_job', 'get', ['mailing_id' => $result['id']]);
     $this->assertEquals(1, $jobs['count']);
     $this->assertEquals('Complete', $jobs['values'][$jobs['id']]['status']);
@@ -132,7 +132,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
    */
   public function testMailerCreateSuccessNoCreatedID(): void {
     unset($this->_params['created_id']);
-    $result = $this->callAPIAndDocument('mailing', 'create', $this->_params + ['scheduled_date' => 'now'], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now']);
     $this->getAndCheck($this->_params, $result['id'], 'mailing');
   }
 
@@ -371,7 +371,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
       'mailing' => CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing'),
       'group' => CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_group'),
     ];
-    $create = $this->callAPIAndDocument('Mailing', 'create', $params, __FUNCTION__, __FILE__);
+    $create = $this->callAPISuccess('Mailing', 'create', $params);
     // 'Preview should not create any mailing records'
     $this->assertDBQuery($maxIDs['mailing'], 'SELECT MAX(id) FROM civicrm_mailing');
     // 'Preview should not create any mailing_group records'
@@ -681,7 +681,7 @@ class api_v3_MailingTest extends CiviUnitTestCase {
       $this->assertMatchesRegularExpression($expectedFailure, $submitResult['error_message']);
     }
     else {
-      $submitResult = $this->callAPIAndDocument('Mailing', 'submit', $submitParams, __FUNCTION__, __FILE__);
+      $submitResult = $this->callAPISuccess('Mailing', 'submit', $submitParams);
       $this->assertIsNumeric($submitResult['id']);
       $this->assertIsNumeric($submitResult['values'][$id]['scheduled_id']);
       $this->assertEquals($submitParams['scheduled_date'], $submitResult['values'][$id]['scheduled_date']);
@@ -824,7 +824,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
    */
   public function testMailerDeleteSuccess() {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $this->callAPIAndDocument($this->_entity, 'delete', ['id' => $result['id']], __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
     $this->assertAPIDeleted($this->_entity, $result['id']);
   }
 
@@ -832,9 +832,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
    * Test Mailing.gettokens.
    */
   public function testMailGetTokens() {
-    $description = 'Demonstrates fetching tokens for one or more entities (in this case "Contact" and "Mailing").
-      Optionally pass sequential=1 to have output ready-formatted for the select2 widget.';
-    $result = $this->callAPIAndDocument($this->_entity, 'gettokens', ['entity' => ['Contact', 'Mailing']], __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess($this->_entity, 'gettokens', ['entity' => ['Contact', 'Mailing']]);
     $this->assertContains('Contact Type', $result['values']);
 
     // Check that passing "sequential" correctly outputs a hierarchical array
@@ -872,7 +870,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
     $this->callAPISuccess('Mailing', 'get');
     $createId = $create['id'];
     $this->createLoggedInUser();
-    $clone = $this->callAPIAndDocument('Mailing', 'clone', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $clone = $this->callAPISuccess('Mailing', 'clone', ['id' => $create['id']]);
     $cloneId = $clone['id'];
 
     $this->assertNotEquals($createId, $cloneId, 'Create and clone should return different records');

--- a/tests/phpunit/api/v3/MappingFieldTest.php
+++ b/tests/phpunit/api/v3/MappingFieldTest.php
@@ -39,7 +39,7 @@ class api_v3_MappingFieldTest extends CiviUnitTestCase {
   }
 
   public function testCreateMappingField() {
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -47,7 +47,7 @@ class api_v3_MappingFieldTest extends CiviUnitTestCase {
 
   public function testGetMappingField() {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
@@ -56,7 +56,7 @@ class api_v3_MappingFieldTest extends CiviUnitTestCase {
   public function testDeleteMappingField() {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $deleteParams = ['id' => $result['id']];
-    $result = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/MappingTest.php
+++ b/tests/phpunit/api/v3/MappingTest.php
@@ -34,7 +34,7 @@ class api_v3_MappingTest extends CiviUnitTestCase {
   }
 
   public function testCreateMapping(): void {
-    $result = $this->callAPIAndDocument('Mapping', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Mapping', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], 'Mapping');
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -42,7 +42,7 @@ class api_v3_MappingTest extends CiviUnitTestCase {
 
   public function testGetMapping(): void {
     $this->callAPISuccess('Mapping', 'create', $this->params);
-    $result = $this->callAPIAndDocument('Mapping', 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Mapping', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess('Mapping', 'delete', ['id' => $result['id']]);
@@ -51,7 +51,7 @@ class api_v3_MappingTest extends CiviUnitTestCase {
   public function testDeleteMapping(): void {
     $result = $this->callAPISuccess('Mapping', 'create', $this->params);
     $deleteParams = ['id' => $result['id']];
-    $this->callAPIAndDocument('Mapping', 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Mapping', 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess('Mapping', 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/MembershipPaymentTest.php
+++ b/tests/phpunit/api/v3/MembershipPaymentTest.php
@@ -93,7 +93,7 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
       'contribution_id' => $this->_contribution['id'],
       'membership_id' => $membership['id'],
     ];
-    $result = $this->callAPIAndDocument('membership_payment', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('membership_payment', 'create', $params);
     $this->assertEquals($result['values'][$result['id']]['membership_id'], $membership['id'], 'Check Membership Id in line ' . __LINE__);
     $this->assertEquals($result['values'][$result['id']]['contribution_id'], $this->_contribution['id'], 'Check Contribution Id in line ' . __LINE__);
 
@@ -122,7 +122,7 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
     ];
     $this->callAPISuccess('membership_payment', 'create', $params);
 
-    $result = $this->callAPIAndDocument('membership_payment', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('membership_payment', 'get', $params);
     $this->assertEquals($result['values'][$result['id']]['membership_id'], $params['membership_id'], 'Check Membership Id');
     $this->assertEquals($result['values'][$result['id']]['contribution_id'], $params['contribution_id'], 'Check Contribution Id');
   }

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -60,7 +60,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
     $params = [
       'name' => 'test status',
     ];
-    $result = $this->callAPIAndDocument('membership_status', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('membership_status', 'get', $params);
     $this->assertEquals($result['values'][$this->_membershipStatusID]['name'], "test status", "In line " . __LINE__);
   }
 
@@ -92,7 +92,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
     $params = [
       'name' => 'test membership status',
     ];
-    $result = $this->callAPIAndDocument('membership_status', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('membership_status', 'create', $params);
 
     $this->assertNotNull($result['id']);
     $this->membershipStatusDelete($result['id']);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -102,7 +102,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $params = [
       'id' => $membershipID,
     ];
-    $this->callAPIAndDocument('membership', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('membership', 'delete', $params);
     $this->assertDBRowNotExist('CRM_Member_DAO_Membership', $membershipID);
   }
 
@@ -140,7 +140,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $contribParams = [
       'id' => $ContributionCreate['values'][0]['id'],
     ];
-    $this->callAPIAndDocument('membership', 'delete', $memParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('membership', 'delete', $memParams);
     $this->assertDBRowNotExist('CRM_Member_DAO_Membership', $membershipID);
     $this->assertDBRowExist('CRM_Contribute_DAO_Contribution', $ContributionCreate['values'][0]['id']);
     $this->callAPISuccess('Contribution', 'delete', $contribParams);
@@ -381,7 +381,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess($this->_entity, 'create', $params);
 
     $getParams = ['membership_type_id' => $params['membership_type_id'], 'return' => 'custom_' . $ids['custom_field_id']];
-    $check = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $check = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $this->assertEquals('custom string', $check['values'][$result['id']]['custom_' . $ids['custom_field_id']]);
   }
 
@@ -435,7 +435,6 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * Memberships expected.
    */
   public function testGetOnlyActive() {
-    $description = "Demonstrates use of 'filter' active_only' param.";
     $this->_membershipID = $this->contactMembershipCreate($this->_params);
     $params = [
       'contact_id' => $this->_contactID,
@@ -452,7 +451,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       ],
     ];
 
-    $membership = $this->callAPIAndDocument('membership', 'get', $params, __FUNCTION__, __FILE__, $description, 'FilterIsCurrent');
+    $membership = $this->callAPISuccess('membership', 'get', $params);
     $this->assertEquals($membership['values'][$this->_membershipID]['status_id'], $this->_membershipStatusID);
     $this->assertEquals($membership['values'][$this->_membershipID]['contact_id'], $this->_contactID);
 
@@ -863,7 +862,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $result = $this->callAPIAndDocument('membership', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('membership', 'create', $params);
     $this->getAndCheck($params, $result['id'], $this->_entity);
     $this->assertNotNull($result['id']);
     $this->assertEquals($this->_contactID, $result['values'][$result['id']]['contact_id'], " in line " . __LINE__);
@@ -902,7 +901,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
 
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, NULL, 'CreateWithCustomData');
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $check = $this->callAPISuccess($this->_entity, 'get', [
       'id' => $result['id'],
       'contact_id' => $this->_contactID,
@@ -918,15 +917,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, __FILE__);
 
     // Create a new membership, but don't assign anything to the custom field.
-    $params = $this->_params;
-    $result = $this->callAPIAndDocument(
-      $this->_entity,
-      'create',
-      $params,
-      __FUNCTION__,
-      __FILE__,
-      NULL,
-      'SearchWithCustomData');
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
 
     // search memberships with CRM-16036 as custom field value.
     // Since we did not touch the custom field of any membership,
@@ -1080,7 +1071,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__, NULL, 'UpdateCustomData');
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $result = $this->callAPISuccess($this->_entity, 'create', [
       'id' => $result['id'],
       'custom_' . $ids['custom_field_id'] => "new custom",

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -62,7 +62,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $id = $this->membershipTypeCreate(['member_of_contact_id' => $this->_contactID]);
     $params = ['id' => $id];
-    $membershipType = $this->callAPIAndDocument('membership_type', 'get', $params, __FUNCTION__, __FILE__);
+    $membershipType = $this->callAPISuccess('membership_type', 'get', $params);
     $membershipType = $membershipType['values'][$id];
     $this->assertEquals('General', $membershipType['name']);
     $this->assertEquals($membershipType['member_of_contact_id'], $this->_contactID);
@@ -120,7 +120,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
       'visibility' => 'public',
     ];
 
-    $membershipType = $this->callAPIAndDocument('membership_type', 'create', $params, __FUNCTION__, __FILE__);
+    $membershipType = $this->callAPISuccess('membership_type', 'create', $params);
     $this->assertNotNull($membershipType['values']);
     $this->membershipTypeDelete(['id' => $membershipType['id']]);
   }
@@ -241,7 +241,7 @@ class api_v3_MembershipTypeTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $this->organizationCreate()]);
     $params = ['id' => $membershipTypeID];
-    $this->callAPIAndDocument('membership_type', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('membership_type', 'delete', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/MessageTemplateTest.php
+++ b/tests/phpunit/api/v3/MessageTemplateTest.php
@@ -38,7 +38,7 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
    * Test create function succeeds.
    */
   public function testCreate(): void {
-    $result = $this->callAPIAndDocument('MessageTemplate', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('MessageTemplate', 'create', $this->params);
     $this->getAndCheck($this->params, $result['id'], $this->entity);
   }
 
@@ -51,10 +51,10 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
    * behaviours
    */
   public function testGet(): void {
-    $result = $this->callAPIAndDocument('MessageTemplate', 'get', [
+    $result = $this->callAPISuccess('MessageTemplate', 'get', [
       'workflow_name' => 'contribution_invoice_receipt',
       'is_default' => 1,
-    ], __FUNCTION__, __FILE__);
+    ]);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
@@ -64,7 +64,7 @@ class api_v3_MessageTemplateTest extends CiviUnitTestCase {
    */
   public function testDelete(): void {
     $entity = $this->createTestEntity('MessageTemplate', $this->params);
-    $this->callAPIAndDocument('MessageTemplate', 'delete', ['id' => $entity['id']], __FUNCTION__, __FILE__);
+    $this->callAPISuccess('MessageTemplate', 'delete', ['id' => $entity['id']]);
     $checkDeleted = $this->callAPISuccess($this->entity, 'get', [
       'id' => $entity['id'],
     ]);

--- a/tests/phpunit/api/v3/NoteTest.php
+++ b/tests/phpunit/api/v3/NoteTest.php
@@ -105,7 +105,7 @@ class api_v3_NoteTest extends CiviUnitTestCase {
       'entity_table' => 'civicrm_contact',
       'entity_id' => $entityId,
     ];
-    $this->callAPIAndDocument('note', 'get', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('note', 'get', $params);
   }
 
   /**
@@ -159,7 +159,7 @@ class api_v3_NoteTest extends CiviUnitTestCase {
   public function testCreate($version) {
     $this->_apiversion = $version;
 
-    $result = $this->callAPIAndDocument('note', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('note', 'create', $this->_params);
     $this->assertEquals($result['values'][$result['id']]['note'], 'Hello!!! m testing Note');
     $this->assertEquals(date('Y-m-d', strtotime($this->_createdDate)), date('Y-m-d', strtotime($result['values'][$result['id']]['created_date'])));
     $this->assertEquals(date('Y-m-d', strtotime($this->_createdDate)), date('Y-m-d', strtotime($result['values'][$result['id']]['note_date'])));
@@ -301,7 +301,7 @@ class api_v3_NoteTest extends CiviUnitTestCase {
       'id' => $additionalNote['id'],
     ];
 
-    $this->callAPIAndDocument('note', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('note', 'delete', $params);
   }
 
   public function testNoteJoin() {

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -50,7 +50,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
    */
   public function testCreateOpenID($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params)['values'];
     $this->assertCount(1, $result);
     unset($this->_params['sequential']);
     $this->getAndCheck($this->_params, $result[0]['id'], $this->_entity);
@@ -69,7 +69,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess($this->_entity, 'create', $params)['values'];
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result[0]['location_type_id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result[0]['id']]);
   }
@@ -83,7 +83,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
   public function testGetOpenID($version) {
     $this->_apiversion = $version;
     $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->_params, __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess($this->_entity, 'get', $this->_params)['values'];
     $this->assertCount(1, $result);
     $this->assertNotNull($result[0]['id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result[0]['id']]);
@@ -99,7 +99,7 @@ class api_v3_OpenIDTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => $result['id']];
-    $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $checkDeleted = $this->callAPISuccess($this->_entity, 'get');
     $this->assertEquals(0, $checkDeleted['count']);
   }

--- a/tests/phpunit/api/v3/OptionGroupTest.php
+++ b/tests/phpunit/api/v3/OptionGroupTest.php
@@ -52,7 +52,7 @@ class api_v3_OptionGroupTest extends CiviUnitTestCase {
 
   public function testGetOptionGroupByName() {
     $params = ['name' => 'preferred_communication_method'];
-    $result = $this->callAPIAndDocument('option_group', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('option_group', 'get', $params);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals(1, $result['id']);
   }
@@ -81,7 +81,7 @@ class api_v3_OptionGroupTest extends CiviUnitTestCase {
         'format.only_id' => 1,
       ],
     ];
-    $result = $this->callAPIAndDocument('OptionGroup', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('OptionGroup', 'create', $params);
     $this->assertEquals('civicrm_event.amount.560', $result['values'][0]['name']);
     $this->assertTrue(is_int($result['values'][0]['api.OptionValue.create']));
     $this->assertGreaterThan(0, $result['values'][0]['api.OptionValue.create']);
@@ -149,7 +149,7 @@ class api_v3_OptionGroupTest extends CiviUnitTestCase {
    */
   public function testDeleteOptionGroup() {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $this->callAPIAndDocument('OptionGroup', 'delete', ['id' => $result['id']], __FUNCTION__, __FILE__);
+    $this->callAPISuccess('OptionGroup', 'delete', ['id' => $result['id']]);
   }
 
   /**

--- a/tests/phpunit/api/v3/OptionValueTest.php
+++ b/tests/phpunit/api/v3/OptionValueTest.php
@@ -71,8 +71,6 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
    * Test offset param.
    */
   public function testGetSingleValueOptionValueSort() {
-    $description = "Demonstrates use of Sort param (available in many api functions). Also, getsingle.";
-    $subfile = 'SortOption';
     $result = $this->callAPISuccess('option_value', 'getsingle', [
       'option_group_id' => 1,
       'options' => [
@@ -87,7 +85,7 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
         'limit' => 1,
       ],
     ];
-    $result2 = $this->callAPIAndDocument('option_value', 'getsingle', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result2 = $this->callAPISuccess('option_value', 'getsingle', $params);
     $this->assertGreaterThan($result['label'], $result2['label']);
   }
 
@@ -115,7 +113,7 @@ class api_v3_OptionValueTest extends CiviUnitTestCase {
 
   public function testGetOptionGroup() {
     $params = ['option_group_id' => 1];
-    $result = $this->callAPIAndDocument('option_value', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('option_value', 'get', $params);
     $this->assertGreaterThan(1, $result['count']);
   }
 

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -61,7 +61,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
 
     $params = ['contribution_id' => $contribution['id']];
 
-    $order = $this->callAPIAndDocument('Order', 'get', $params, __FUNCTION__, __FILE__);
+    $order = $this->callAPISuccess('Order', 'get', $params);
 
     $this->assertEquals(1, $order['count']);
     $expectedResult = [
@@ -237,7 +237,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
         'is_override' => 1,
       ],
     ];
-    $order = $this->callAPIAndDocument('Order', 'create', $p, __FUNCTION__, __FILE__);
+    $order = $this->callAPISuccess('Order', 'create', $p);
     $params = [
       'contribution_id' => $order['id'],
     ];
@@ -529,7 +529,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       ],
     ];
 
-    $order = $this->callAPIAndDocument('order', 'create', $p, __FUNCTION__, __FILE__, 'Create order for participant', 'CreateOrderParticipant');
+    $order = $this->callAPISuccess('order', 'create', $p);
     $params = ['contribution_id' => $order['id']];
     $order = $this->callAPISuccess('order', 'get', $params);
     $expectedResult = [
@@ -665,7 +665,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
         'contribution_id' => $order['id'],
         'is_test' => TRUE,
       ]);
-      $this->callAPIAndDocument('order', 'delete', $params, __FUNCTION__, __FILE__);
+      $this->callAPISuccess('order', 'delete', $params);
       $order = $this->callAPISuccess('order', 'get', $params);
       $this->assertEquals(0, $order['count']);
     }
@@ -738,7 +738,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     $params = [
       'contribution_id' => $contribution['id'],
     ];
-    $this->callAPIAndDocument('order', 'cancel', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('order', 'cancel', $params);
     $order = $this->callAPISuccess('Order', 'get', $params);
     $expectedResult = [
       $contribution['id'] => [

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -88,10 +88,10 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
    * Check with valid array.
    */
   public function testPaymentCreate(): void {
-    $this->callAPIAndDocument('ParticipantPayment', 'create', [
+    $this->callAPISuccess('ParticipantPayment', 'create', [
       'participant_id' => $this->participantID,
       'contribution_id' => $this->contributionCreate(['contact_id' => $this->individualCreate()]),
-    ], __FUNCTION__, __FILE__);
+    ]);
   }
 
   /**
@@ -227,7 +227,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
     $params = [
       'id' => $participantPaymentID,
     ];
-    $this->callAPIAndDocument('participantPayment', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('participantPayment', 'delete', $params);
   }
 
   /**
@@ -243,7 +243,7 @@ class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
       'contribution_id' => $contributionID,
     ];
 
-    $result = $this->callAPIAndDocument('participantPayment', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('participantPayment', 'get', $params);
     $this->assertEquals($result['values'][$result['id']]['participant_id'], $this->participantID4, 'Check Participant Id');
     $this->assertEquals($result['values'][$result['id']]['contribution_id'], $contributionID, 'Check Contribution Id');
   }

--- a/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
+++ b/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
@@ -35,16 +35,16 @@ class api_v3_ParticipantStatusTypeTest extends CiviUnitTestCase {
   }
 
   public function testCreateParticipantStatusType() {
-    $result = $this->callAPIAndDocument('participant_status_type', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('participant_status_type', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
 
   public function testGetParticipantStatusType() {
-    $result = $this->callAPIAndDocument('participant_status_type', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('participant_status_type', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
 
-    $result = $this->callAPIAndDocument('participant_status_type', 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('participant_status_type', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->id = $result['id'];
@@ -54,7 +54,7 @@ class api_v3_ParticipantStatusTypeTest extends CiviUnitTestCase {
 
     $ParticipantStatusType = $this->callAPISuccess('ParticipantStatusType', 'Create', $this->params);
     $entity = $this->callAPISuccess('participant_status_type', 'get', []);
-    $result = $this->callAPIAndDocument('participant_status_type', 'delete', ['id' => $ParticipantStatusType['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('participant_status_type', 'delete', ['id' => $ParticipantStatusType['id']]);
     $getCheck = $this->callAPISuccess('ParticipantStatusType', 'GET', ['id' => $ParticipantStatusType['id']]);
     $checkDeleted = $this->callAPISuccess('ParticipantStatusType', 'Get', []);
     $this->assertEquals($entity['count'] - 1, $checkDeleted['count']);

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -139,7 +139,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
 
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
 
     $this->assertEquals($result['id'], $result['values'][$result['id']]['id']);
 
@@ -207,7 +207,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
     $params = [
       'id' => $this->ids['Participant']['primary'],
     ];
-    $result = $this->callAPIAndDocument('participant', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('participant', 'get', $params);
     $this->assertEquals($result['values'][$this->ids['Participant']['primary']]['event_id'], $this->getEventID());
     $this->assertEquals('2007-02-19 00:00:00', $result['values'][$this->ids['Participant']['primary']]['participant_register_date']);
     $this->assertEquals('Wimbeldon', $result['values'][$this->ids['Participant']['primary']]['participant_source']);
@@ -643,11 +643,10 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
    * Delete with a get - a 'criteria delete'
    */
   public function testNestedDelete(): void {
-    $description = 'Criteria delete by nesting a GET & a DELETE.';
     $participants = $this->callAPISuccess('Participant', 'Get', []);
     $this->assertEquals(3, $participants['count']);
     $params = ['contact_id' => $this->_contactID2, 'api.participant.delete' => 1];
-    $this->callAPIAndDocument('Participant', 'Get', $params, __FUNCTION__, __FILE__, $description, 'NestedDelete');
+    $this->callAPISuccess('Participant', 'Get', $params);
     $check = $this->callAPISuccess('participant', 'getcount', []);
     $this->assertEquals(1, $check, 'only one participant should be left');
   }
@@ -656,8 +655,6 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
    * Test creation of a participant with an associated contribution.
    */
   public function testCreateParticipantWithPayment(): void {
-    $description = "Single function to create contact with participation & contribution.
-      Note that in the case of 'contribution' the 'create' is implied (api.contribution.create)";
     $params = [
       'contact_type' => 'Individual',
       'display_name' => 'Guru',
@@ -678,7 +675,7 @@ class api_v3_ParticipantTest extends CiviUnitTestCase {
       ],
     ];
 
-    $result = $this->callAPIAndDocument('contact', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateParticipantPayment');
+    $result = $this->callAPISuccess('contact', 'create', $params);
     $this->assertEquals(1, $result['values'][$result['id']]['api.participant_payment.create']['count']);
     $this->callAPISuccess('contact', 'delete', ['id' => $result['id']]);
   }

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -65,7 +65,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
   public function testPaymentProcessorCreate($version) {
     $this->_apiversion = $version;
     $params = $this->_params;
-    $result = $this->callAPIAndDocument('payment_processor', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('payment_processor', 'create', $params);
     $this->callAPISuccessGetSingle('EntityFinancialAccount', ['entity_table' => 'civicrm_payment_processor', 'entity_id' => $result['id']]);
 
     // Test that the option values are flushed so ths can be used straight away.
@@ -141,7 +141,7 @@ class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
       'id' => $result['id'],
     ];
 
-    $this->callAPIAndDocument('payment_processor', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('payment_processor', 'delete', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
@@ -63,7 +63,7 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
       'billing_mode' => 'form',
       'is_recur' => 0,
     ];
-    $result = $this->callAPIAndDocument('PaymentProcessorType', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('PaymentProcessorType', 'create', $params);
     $this->assertNotNull($result['values'][0]['id']);
 
     // mutate $params to match expected return value
@@ -129,7 +129,7 @@ class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
    */
   public function testPaymentProcessorTypeDelete($version) {
     $this->_apiversion = $version;
-    $this->callAPIAndDocument('PaymentProcessorType', 'delete', ['id' => $this->paymentProcessorTypeCreate()], __FUNCTION__, __FILE__);
+    $this->callAPISuccess('PaymentProcessorType', 'delete', ['id' => $this->paymentProcessorTypeCreate()]);
   }
 
   ///////////////// civicrm_payment_processor_type_update

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -52,7 +52,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     CRM_Core_Config::singleton()->userPermissionClass->permissions[] = 'access CiviContribute';
     $this->callAPISuccess('payment', 'get', $params);
 
-    $payment = $this->callAPIAndDocument('payment', 'get', $params, __FUNCTION__, __FILE__);
+    $payment = $this->callAPISuccess('payment', 'get', $params);
     $this->assertEquals(1, $payment['count']);
 
     $expectedResult = [
@@ -411,7 +411,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'contribution_id' => $contribution['id'],
       'total_amount' => 50,
     ];
-    $payment = $this->callAPIAndDocument('payment', 'create', $params, __FUNCTION__, __FILE__);
+    $payment = $this->callAPISuccess('payment', 'create', $params);
     $this->checkPaymentIsValid($payment['id'], $contribution['id']);
 
     $params = [
@@ -492,7 +492,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     foreach ($lineItems as $id => $ignore) {
       $params['line_item'][] = [$id => array_pop($amounts)];
     }
-    $payment = $this->callAPIAndDocument('Payment', 'create', $params, __FUNCTION__, __FILE__, 'Payment with line item', 'CreatePaymentWithLineItems');
+    $payment = $this->callAPISuccess('Payment', 'create', $params);
     $this->checkPaymentIsValid($payment['id'], $contribution['id']);
 
     $params = [
@@ -635,7 +635,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
 
     array_push(CRM_Core_Config::singleton()->userPermissionClass->permissions, 'access CiviCRM', 'edit contributions');
 
-    $this->callAPIAndDocument('payment', 'cancel', $cancelParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('payment', 'cancel', $cancelParams);
 
     $payment = $this->callAPISuccess('payment', 'get', $params);
     $this->assertEquals(2, $payment['count']);
@@ -667,7 +667,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPIFailure('payment', 'delete', $deleteParams, 'API permission check failed for Payment/delete call; insufficient permission: require access CiviCRM and access CiviContribute and delete in CiviContribute');
 
     array_push(CRM_Core_Config::singleton()->userPermissionClass->permissions, 'access CiviCRM', 'delete in CiviContribute');
-    $this->callAPIAndDocument('payment', 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('payment', 'delete', $deleteParams);
     $this->callAPISuccessGetCount('payment', $params, 0);
 
     $this->callAPISuccess('Contribution', 'Delete', ['id' => $contribution['id']]);
@@ -743,7 +743,7 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->callAPIFailure('payment', 'create', $params, 'API permission check failed for Payment/create call; insufficient permission: require access CiviCRM and access CiviContribute and edit contributions');
 
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['administer CiviCRM', 'access CiviContribute', 'access CiviCRM', 'edit contributions'];
-    $payment = $this->callAPIAndDocument('payment', 'create', $params, __FUNCTION__, __FILE__, 'Update Payment', 'UpdatePayment');
+    $payment = $this->callAPISuccess('payment', 'create', $params);
 
     $this->validateAllPayments();
     // Check for proportional cancelled payment against line items.

--- a/tests/phpunit/api/v3/PaymentTokenTest.php
+++ b/tests/phpunit/api/v3/PaymentTokenTest.php
@@ -42,9 +42,7 @@ class api_v3_PaymentTokenTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testCreatePaymentToken(): void {
-    $description = 'Create a payment token - Note use of relative dates here:
-      @link http://www.php.net/manual/en/datetime.formats.relative.php.';
-    $result = $this->callAPIAndDocument('payment_token', 'create', $this->params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess('payment_token', 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->params, $result['id'], 'payment_token', TRUE);
@@ -59,7 +57,7 @@ class api_v3_PaymentTokenTest extends CiviUnitTestCase {
    */
   public function testGetPaymentToken(): void {
     $this->callAPISuccess('payment_token', 'create', $this->params);
-    $result = $this->callAPIAndDocument('payment_token', 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('payment_token', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
@@ -75,7 +73,7 @@ class api_v3_PaymentTokenTest extends CiviUnitTestCase {
     $this->callAPISuccess('payment_token', 'create', $this->params);
     $entity = $this->callAPISuccess('payment_token', 'get', ($this->params));
     $delete = ['id' => $entity['id']];
-    $this->callAPIAndDocument('payment_token', 'delete', $delete, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('payment_token', 'delete', $delete);
 
     $checkDeleted = $this->callAPISuccess('payment_token', 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);

--- a/tests/phpunit/api/v3/PcpTest.php
+++ b/tests/phpunit/api/v3/PcpTest.php
@@ -47,8 +47,7 @@ class api_v3_PcpTest extends CiviUnitTestCase {
    * Test create function succeeds.
    */
   public function testCreatePcp(): void {
-    $result = $this->callAPIAndDocument('Pcp', 'create', $this->params,
-        __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Pcp', 'create', $this->params);
     $this->getAndCheck($this->params, $result['id'], $this->entity);
   }
 
@@ -70,8 +69,7 @@ class api_v3_PcpTest extends CiviUnitTestCase {
    */
   public function testGetPcp(): void {
     $this->createTestEntity('PCP', $this->params);
-    $result = $this->callAPIAndDocument('Pcp', 'get', $this->params,
-        __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Pcp', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
@@ -84,26 +82,20 @@ class api_v3_PcpTest extends CiviUnitTestCase {
     $checkCreated = $this->callAPISuccess($this->entity, 'get',
       ['id' => $entity['id']]);
     $this->assertEquals(1, $checkCreated['count']);
-    $this->callAPIAndDocument('Pcp', 'delete',
-        ['id' => $entity['id']], __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Pcp', 'delete',
+        ['id' => $entity['id']]);
     $checkDeleted = $this->callAPISuccess($this->entity, 'get',
         ['id' => $entity['id']]);
     $this->assertEquals(0, $checkDeleted['count']);
   }
 
   /**
-   * Test & document chained delete pattern.
-   *
-   * Note that explanation of the pattern
-   * is best put in the $description variable as it will then be displayed in the
-   * test generated examples. (these are to be found in the api/examples folder).
+   * Test chained delete pattern.
    */
   public function testGetPcpChainDelete(): void {
-    $description = 'Demonstrates get + delete in the same call.';
     $params = ['title' => 'Pcp title', 'api.Pcp.delete' => 1];
     $this->callAPISuccess('Pcp', 'create', $this->params);
-    $this->callAPIAndDocument('Pcp', 'get', $params, __FUNCTION__,
-        __FILE__, $description, 'ChainedGetDelete');
+    $this->callAPISuccess('Pcp', 'get', $params);
     $this->assertEquals(0, $this->callAPISuccess('Pcp', 'getcount', []));
   }
 

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -55,7 +55,7 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
   public function testCreatePhone($version) {
     $this->_apiversion = $version;
 
-    $result = $this->callAPIAndDocument('Phone', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Phone', 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
 
@@ -75,7 +75,7 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $params = $this->_params;
     unset($params['location_type_id']);
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $params);
     $this->assertEquals(CRM_Core_BAO_LocationType::getDefault()->id, $result['values'][$result['id']]['location_type_id']);
     $this->callAPISuccess($this->_entity, 'delete', ['id' => $result['id']]);
   }
@@ -89,7 +89,7 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
     //create one
     $create = $this->callAPISuccess('phone', 'create', $this->_params);
 
-    $result = $this->callAPIAndDocument('phone', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('phone', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('phone', 'get', [
       'id' => $create['id'],
@@ -129,7 +129,7 @@ class api_v3_PhoneTest extends CiviUnitTestCase {
       'contact_id' => $this->_params['contact_id'],
       'phone' => $phone['values'][$phone['id']]['phone'],
     ];
-    $result = $this->callAPIAndDocument('Phone', 'Get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Phone', 'Get', $params);
     $this->assertEquals($phone['values'][$phone['id']]['location_type_id'], $result['values'][$phone['id']]['location_type_id']);
     $this->assertEquals($phone['values'][$phone['id']]['phone_type_id'], $result['values'][$phone['id']]['phone_type_id']);
     $this->assertEquals($phone['values'][$phone['id']]['is_primary'], $result['values'][$phone['id']]['is_primary']);

--- a/tests/phpunit/api/v3/PledgePaymentTest.php
+++ b/tests/phpunit/api/v3/PledgePaymentTest.php
@@ -43,7 +43,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
 
   public function testGetPledgePayment(): void {
     $params = [];
-    $result = $this->callAPIAndDocument('PledgePayment', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('PledgePayment', 'get', $params);
     $this->assertEquals(5, $result['count']);
   }
 
@@ -174,7 +174,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'status_id' => 1,
       'actual_amount' => 20,
     ];
-    $result = $this->callAPIAndDocument('PledgePayment', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('PledgePayment', 'create', $params);
 
     //check existing updated not new one created - 'create' means add contribution_id in this context
     $afterAdd = $this->callAPISuccess('PledgePayment', 'get', []);
@@ -309,7 +309,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
       'status_id' => 1,
     ];
 
-    $result = $this->callAPIAndDocument('PledgePayment', 'update', $updateParams, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('PledgePayment', 'update', $updateParams);
     $this->getAndCheck(array_merge($params, $updateParams), $result['id'], $this->_entity);
   }
 
@@ -327,7 +327,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
     $deleteParams = [
       'id' => $pledgePayment['id'],
     ];
-    $this->callAPIAndDocument('PledgePayment', 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('PledgePayment', 'delete', $deleteParams);
   }
 
   public function testGetFields(): void {

--- a/tests/phpunit/api/v3/PledgeTest.php
+++ b/tests/phpunit/api/v3/PledgeTest.php
@@ -98,7 +98,7 @@ class api_v3_PledgeTest extends CiviUnitTestCase {
     $params = [
       'pledge_id' => $this->_pledge['id'],
     ];
-    $result = $this->callAPIAndDocument('pledge', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('pledge', 'get', $params);
     $pledge = $result['values'][$this->_pledge['id']];
     $this->assertEquals($this->_individualId, $pledge['contact_id']);
     $this->assertEquals($this->_pledge['id'], $pledge['pledge_id']);
@@ -167,7 +167,7 @@ class api_v3_PledgeTest extends CiviUnitTestCase {
 
     $this->assertEquals(2, $allPledges, 'Check we have 2 pledges to place with in line ' . __LINE__);
     $pledgeGetParams['pledge_start_date_high'] = date('YmdHis', strtotime('2 days ago'));
-    $earlyPledge = $this->callAPIAndDocument('pledge', 'get', $pledgeGetParams, __FUNCTION__, __FILE__, "demonstrates high date filter", "GetFilterHighDate");
+    $earlyPledge = $this->callAPISuccess('pledge', 'get', $pledgeGetParams);
     $this->assertEquals(1, $earlyPledge['count'], ' check only one returned with start date filter in line ' . __LINE__);
     $this->assertEquals($oldPledge['id'], $earlyPledge['id'], ' check correct pledge returned ' . __LINE__);
   }
@@ -246,7 +246,7 @@ class api_v3_PledgeTest extends CiviUnitTestCase {
 
   public function testCreatePledge() {
 
-    $result = $this->callAPIAndDocument('pledge', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('pledge', 'create', $this->_params);
     $this->assertEquals($result['values'][0]['amount'], 100.00);
     $this->assertEquals($result['values'][0]['installments'], 5);
     $this->assertEquals($result['values'][0]['frequency_unit'], 'year');
@@ -505,7 +505,7 @@ class api_v3_PledgeTest extends CiviUnitTestCase {
     $params = [
       'pledge_id' => $pledgeID,
     ];
-    $this->callAPIAndDocument('pledge', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('pledge', 'delete', $params);
   }
 
   /**
@@ -517,7 +517,7 @@ class api_v3_PledgeTest extends CiviUnitTestCase {
     $params = [
       'id' => $pledgeID,
     ];
-    $this->callAPIAndDocument('pledge', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('pledge', 'delete', $params);
   }
 
   /**

--- a/tests/phpunit/api/v3/PriceFieldTest.php
+++ b/tests/phpunit/api/v3/PriceFieldTest.php
@@ -78,7 +78,7 @@ class api_v3_PriceFieldTest extends CiviUnitTestCase {
    */
   public function testCreatePriceField(int $version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->_params, $result['id'], $this->_entity);
@@ -101,7 +101,7 @@ class api_v3_PriceFieldTest extends CiviUnitTestCase {
     $getParams = [
       'name' => 'contribution_amount',
     ];
-    $getResult = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $getResult = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $this->assertEquals(1, $getResult['count']);
     $this->callAPISuccess('price_field', 'delete', ['id' => $createResult['id']]);
   }
@@ -120,7 +120,7 @@ class api_v3_PriceFieldTest extends CiviUnitTestCase {
     $startCount = $this->callAPISuccess($this->_entity, 'getcount', []);
     $createResult = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => $createResult['id']];
-    $deleteResult = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $deleteResult = $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $this->assertAPISuccess($deleteResult);
     $endCount = $this->callAPISuccess($this->_entity, 'getcount', []);
     $this->assertEquals($startCount, $endCount);

--- a/tests/phpunit/api/v3/PriceFieldValueTest.php
+++ b/tests/phpunit/api/v3/PriceFieldValueTest.php
@@ -120,7 +120,7 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
   }
 
   public function testCreatePriceFieldValue() {
-    $result = $this->callAPIAndDocument('PriceFieldValue', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('PriceFieldValue', 'create', $this->params);
     $this->assertAPISuccess($result);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -133,7 +133,7 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
     $getParams = [
       'name' => 'contribution_amount',
     ];
-    $getResult = $this->callAPIAndDocument('PriceFieldValue', 'get', $getParams, __FUNCTION__, __FILE__);
+    $getResult = $this->callAPISuccess('PriceFieldValue', 'get', $getParams);
     $this->assertEquals(1, $getResult['count']);
     $this->callAPISuccess('price_field_value', 'delete', ['id' => $createResult['id']]);
   }
@@ -142,7 +142,7 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
     $startCount = $this->callAPISuccess('PriceFieldValue', 'getcount', []);
     $createResult = $this->callAPISuccess('PriceFieldValue', 'create', $this->params);
     $deleteParams = ['id' => $createResult['id']];
-    $deleteResult = $this->callAPIAndDocument('PriceFieldValue', 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $deleteResult = $this->callAPISuccess('PriceFieldValue', 'delete', $deleteParams);
 
     $endCount = $this->callAPISuccess('PriceFieldValue', 'getcount', []);
     $this->assertEquals($startCount, $endCount);
@@ -164,7 +164,7 @@ class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
       'is_active' => 1,
       'financial_type_id' => 2,
     ];
-    $result = $this->callAPIAndDocument('PriceFieldValue', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('PriceFieldValue', 'create', $params);
     $this->assertEquals($result['values'][$result['id']]['membership_num_terms'], 2);
     $this->assertEquals(1, $result['count']);
     $this->callAPISuccess('PriceFieldValue', 'delete', ['id' => $result['id']]);

--- a/tests/phpunit/api/v3/PriceSetTest.php
+++ b/tests/phpunit/api/v3/PriceSetTest.php
@@ -42,7 +42,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
    * Test create price set.
    */
   public function testCreatePriceSet() {
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->getAndCheck($this->_params, $result['id'], $this->_entity);
@@ -60,7 +60,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
       'financial_type_id' => 1,
       'extends' => [1, 2],
     ];
-    $createResult = $this->callAPIAndDocument($this->_entity, 'create', $createParams, __FUNCTION__, __FILE__);
+    $createResult = $this->callAPISuccess($this->_entity, 'create', $createParams);
 
     // Get priceset we just created.
     $result = $this->callAPISuccess($this->_entity, 'getSingle', [
@@ -86,7 +86,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
     $getParams = [
       'name' => 'default_contribution_amount',
     ];
-    $getResult = $this->callAPIAndDocument($this->_entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $getResult = $this->callAPISuccess($this->_entity, 'get', $getParams);
     $this->assertEquals(1, $getResult['count']);
   }
 
@@ -106,7 +106,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
       'title' => 'event price',
       'extends' => 1,
     ];
-    $createResult = $this->callAPIAndDocument($this->_entity, 'create', $createParams, __FUNCTION__, __FILE__);
+    $createResult = $this->callAPISuccess($this->_entity, 'create', $createParams);
     $result = $this->callAPISuccess($this->_entity, 'get', [
       'id' => $createResult['id'],
     ]);
@@ -117,7 +117,7 @@ class api_v3_PriceSetTest extends CiviUnitTestCase {
     $startCount = $this->callAPISuccess($this->_entity, 'getcount', []);
     $createResult = $this->callAPISuccess($this->_entity, 'create', $this->_params);
     $deleteParams = ['id' => $createResult['id']];
-    $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
     $endCount = $this->callAPISuccess($this->_entity, 'getcount', []);
     $this->assertEquals($startCount, $endCount);
   }

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -120,7 +120,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    $result = $this->callAPIAndDocument('profile', 'get', $params, __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess('profile', 'get', $params)['values'];
     foreach ($expected as $profileField => $value) {
       $this->assertEquals($value, CRM_Utils_Array::value($profileField, $result[$this->_profileID]), ' error message: ' . "missing/mismatching value for $profileField");
     }
@@ -304,11 +304,10 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
   public function testGetFields(): void {
     $this->createIndividualProfile();
     $this->addCustomFieldToProfile($this->_profileID);
-    $result = $this->callAPIAndDocument('profile', 'getfields', [
+    $result = $this->callAPISuccess('profile', 'getfields', [
       'action' => 'submit',
       'profile_id' => $this->_profileID,
-    ], __FUNCTION__, __FILE__,
-      'demonstrates retrieving profile fields passing in an id');
+    ]);
     $this->assertArrayKeyExists('first_name', $result['values']);
     $this->assertEquals('2', $result['values']['first_name']['type']);
     $this->assertEquals('Email', $result['values']['email-primary']['title']);
@@ -438,7 +437,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ], $updateParams);
 
-    $this->callAPIAndDocument('profile', 'submit', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('profile', 'submit', $params);
 
     $getParams = [
       'profile_id' => $this->_profileID,
@@ -674,7 +673,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'state_province-1' => '1000',
     ];
 
-    $result = $this->callAPIAndDocument('profile', 'apply', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('profile', 'apply', $params);
 
     // Expected field values
     $expected['contact'] = [

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -335,7 +335,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'note' => 'note',
     ];
 
-    $result = $this->callAPIAndDocument('Relationship', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Relationship', 'create', $params);
     $relationParams = [
       'id' => $result['id'],
     ];
@@ -480,7 +480,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $this->assertEquals($result['id'], $result['values'][$result['id']]['id']);
 
     $getParams = ['id' => $result['id']];
-    $check = $this->callAPIAndDocument($this->entity, 'get', $getParams, __FUNCTION__, __FILE__);
+    $check = $this->callAPISuccess($this->entity, 'get', $getParams);
     $this->assertEquals("custom string", $check['values'][$check['id']]['custom_' . $ids['custom_field_id']], ' in line ' . __LINE__);
 
     $this->customFieldDelete($ids['custom_field_id']);
@@ -536,7 +536,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
 
     $result = $this->callAPISuccess('relationship', 'create', $params);
     $params = ['id' => $result['id']];
-    $this->callAPIAndDocument('relationship', 'delete', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('relationship', 'delete', $params);
   }
 
   ///////////////// civicrm_relationship_update methods
@@ -834,9 +834,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $rel1 = $this->callAPISuccess('relationship', 'create', $this->_params);
 
     $getParams = ['filters' => ['is_current' => 1]];
-    $description = "Demonstrates is_current filter.";
-    $subfile = 'filterIsCurrent';
-    $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('relationship', 'get', $getParams);
     $this->assertEquals($result['count'], 1);
     $this->AssertEquals($rel1['id'], $result['id']);
 
@@ -910,37 +908,28 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'relationship_type_id' => ['IN' => [$relationType2, $relationType3]],
     ];
 
-    $description = "Demonstrates use of IN filter.";
-    $subfile = 'INRelationshipType';
-
-    $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('relationship', 'get', $getParams);
     $this->assertEquals($result['count'], 2);
     $this->AssertEquals([$rel2['id'], $rel3['id']], array_keys($result['values']));
 
-    $description = "Demonstrates use of NOT IN filter.";
-    $subfile = 'NotInRelationshipType';
     $getParams = [
       'relationship_type_id' => ['NOT IN' => [$relationType2, $relationType3]],
     ];
-    $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('relationship', 'get', $getParams);
     $this->assertEquals($result['count'], 2);
     $this->assertEquals([$rel1['id'], $rel4['id']], array_keys($result['values']));
 
-    $description = 'Demonstrates use of BETWEEN filter.';
-    $subfile = 'BetweenRelationshipType';
     $getParams = [
       'relationship_type_id' => ['BETWEEN' => [$relationType2, $relationType4]],
     ];
-    $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('relationship', 'get', $getParams);
     $this->assertEquals($result['count'], 3);
     $this->AssertEquals([$rel2['id'], $rel3['id'], $rel4['id']], array_keys($result['values']));
 
-    $description = 'Demonstrates use of Not BETWEEN filter.';
-    $subfile = 'NotBetweenRelationshipType';
     $getParams = [
       'relationship_type_id' => ['NOT BETWEEN' => [$relationType2, $relationType4]],
     ];
-    $result = $this->callAPIAndDocument('relationship', 'get', $getParams, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('relationship', 'get', $getParams);
     $this->assertEquals($result['count'], 1);
     $this->assertEquals([$rel1['id']], array_keys($result['values']));
 

--- a/tests/phpunit/api/v3/RelationshipTypeTest.php
+++ b/tests/phpunit/api/v3/RelationshipTypeTest.php
@@ -68,7 +68,7 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
       'is_active' => 1,
       'sequential' => 1,
     ];
-    $result = $this->callAPIAndDocument('relationship_type', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('relationship_type', 'create', $params);
     $this->assertNotNull($result['values'][0]['id']);
     unset($params['sequential']);
     //assertDBState compares expected values in $result to actual values in the DB
@@ -128,7 +128,7 @@ class api_v3_RelationshipTypeTest extends CiviUnitTestCase {
     $params = [
       'id' => $id,
     ];
-    $result = $this->callAPIAndDocument('relationship_type', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('relationship_type', 'delete', $params);
     $this->assertAPIDeleted('relationship_type', $id);
   }
 

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -219,32 +219,31 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
    * Test getrows on Mailing Opened report.
    */
   public function testReportTemplateGetRowsMailingUniqueOpened(): void {
-    $description = 'Retrieve rows from a mailing opened report template.';
     $this->loadXMLDataSet(__DIR__ . '/../../CRM/Mailing/BAO/queryDataset.xml');
 
     // Check total rows without distinct
     global $_REQUEST;
     $_REQUEST['distinct'] = 0;
-    $result = $this->callAPIAndDocument('report_template', 'getrows', [
+    $result = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => 'Mailing/opened',
       'options' => ['metadata' => ['labels', 'title']],
-    ], __FUNCTION__, __FILE__, $description, 'Getrows');
+    ]);
     $this->assertEquals(14, $result['count']);
 
     // Check total rows with distinct
     $_REQUEST['distinct'] = 1;
-    $result = $this->callAPIAndDocument('report_template', 'getrows', [
+    $result = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => 'Mailing/opened',
       'options' => ['metadata' => ['labels', 'title']],
-    ], __FUNCTION__, __FILE__, $description, 'Getrows');
+    ]);
     $this->assertEquals(5, $result['count']);
 
     // Check total rows with distinct by passing NULL value to distinct parameter
     $_REQUEST['distinct'] = NULL;
-    $result = $this->callAPIAndDocument('report_template', 'getrows', [
+    $result = $this->callAPISuccess('report_template', 'getrows', [
       'report_id' => 'Mailing/opened',
       'options' => ['metadata' => ['labels', 'title']],
-    ], __FUNCTION__, __FILE__, $description, 'Getrows');
+    ]);
     $this->assertEquals(5, $result['count']);
   }
 
@@ -326,13 +325,12 @@ class api_v3_ReportTemplateTest extends CiviUnitTestCase {
     if (strpos($reportID, 'logging') === 0) {
       Civi::settings()->set('logging', 1);
     }
-    $description = "Get Statistics from a report (note there isn't much data to get in the test DB).";
     if ($reportID === 'contribute/summary') {
       $this->hookClass->setHook('civicrm_alterReportVar', [$this, 'alterReportVarHook']);
     }
-    $this->callAPIAndDocument('report_template', 'getstatistics', [
+    $this->callAPISuccess('report_template', 'getstatistics', [
       'report_id' => $reportID,
-    ], __FUNCTION__, __FILE__, $description, 'Getstatistics');
+    ]);
   }
 
   /**

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -51,8 +51,8 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
    */
   public function testCreateSavedSearch(): void {
     $contactID = $this->createLoggedInUser();
-    $result = $this->callAPIAndDocument(
-        $this->_entity, 'create', $this->params, __FUNCTION__, __FILE__)['values'];
+    $result = $this->callAPISuccess(
+        $this->_entity, 'create', $this->params)['values'];
     $this->assertCount(1, $result);
     $savedSearch = reset($result);
 
@@ -79,8 +79,8 @@ class api_v3_SavedSearchTest extends CiviUnitTestCase {
         $this->_entity, 'create', $this->params);
 
     // Act:
-    $get_result = $this->callAPIAndDocument(
-        $this->_entity, 'get', ['id' => $create_result['id']], __FUNCTION__, __FILE__);
+    $get_result = $this->callAPISuccess(
+        $this->_entity, 'get', ['id' => $create_result['id']]);
 
     // Assert:
     $this->assertEquals(1, $get_result['count']);

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -90,8 +90,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    */
   public function testGetFields(int $version): void {
     $this->_apiversion = $version;
-    $description = 'Demonstrate return from getfields - see sub-folder for variants';
-    $result = $this->callAPIAndDocument('setting', 'getfields', [], __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess('setting', 'getfields', []);
     $this->assertArrayHasKey('customCSSURL', $result['values']);
 
     $result = $this->callAPISuccess('setting', 'getfields', []);
@@ -222,11 +221,10 @@ class api_v3_SettingTest extends CiviUnitTestCase {
       'domain_id' => $this->domainID2,
       'uniq_email_per_site' => 1,
     ];
-    $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('setting', 'create', $params);
 
     $params = ['uniq_email_per_site' => 1];
-    $description = 'Shows setting a variable for a current domain.';
-    $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateSettingCurrentDomain');
+    $result = $this->callAPISuccess('setting', 'create', $params);
     $this->assertArrayHasKey(CRM_Core_Config::domainID(), $result['values']);
   }
 
@@ -310,13 +308,11 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    */
   public function testCreateSettingMultipleDomains(int $version): void {
     $this->_apiversion = $version;
-    $description = 'Shows setting a variable for all domains.';
-
     $params = [
       'domain_id' => 'all',
       'uniq_email_per_site' => 1,
     ];
-    $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateAllDomains');
+    $result = $this->callAPISuccess('setting', 'create', $params);
 
     $this->assertEquals(1, $result['values'][$this->domainID2]['uniq_email_per_site']);
     $this->assertEquals(1, $result['values'][$this->currentDomain]['uniq_email_per_site']);
@@ -328,8 +324,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
       'return' => 'uniq_email_per_site',
     ];
     // we'll check it with a 'get'
-    $description = 'Shows getting a variable for all domains.';
-    $result = $this->callAPIAndDocument('setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetAllDomains');
+    $result = $this->callAPISuccess('setting', 'get', $params);
 
     $this->assertEquals(1, $result['values'][$this->domainID2]['uniq_email_per_site']);
     $this->assertEquals(1, $result['values'][$this->currentDomain]['uniq_email_per_site']);
@@ -339,8 +334,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
       'domain_id' => [$this->currentDomain, $this->domainID3],
       'uniq_email_per_site' => 0,
     ];
-    $description = 'Shows setting a variable for specified domains.';
-    $result = $this->callAPIAndDocument('setting', 'create', $params, __FUNCTION__, __FILE__, $description, 'CreateSpecifiedDomains');
+    $result = $this->callAPISuccess('setting', 'create', $params);
 
     $this->assertEquals(0, $result['values'][$this->domainID3]['uniq_email_per_site']);
     $this->assertEquals(0, $result['values'][$this->currentDomain]['uniq_email_per_site']);
@@ -348,8 +342,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
       'domain_id' => [$this->currentDomain, $this->domainID2],
       'return' => ['uniq_email_per_site'],
     ];
-    $description = 'Shows getting a variable for specified domains.';
-    $result = $this->callAPIAndDocument('setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetSpecifiedDomains');
+    $result = $this->callAPISuccess('setting', 'get', $params);
     $this->assertEquals(1, $result['values'][$this->domainID2]['uniq_email_per_site']);
     $this->assertEquals(0, $result['values'][$this->currentDomain]['uniq_email_per_site']);
 
@@ -367,13 +360,12 @@ class api_v3_SettingTest extends CiviUnitTestCase {
       'return' => 'uniq_email_per_site',
     ];
 
-    $this->callAPIAndDocument('Setting', 'get', $params, __FUNCTION__, __FILE__);
+    $this->callAPISuccess('Setting', 'get', $params);
 
     $params = [
       'return' => 'uniq_email_per_site',
     ];
-    $description = 'Shows getting a variable for a current domain.';
-    $result = $this->callAPIAndDocument('Setting', 'get', $params, __FUNCTION__, __FILE__, $description, 'GetSettingCurrentDomain');
+    $result = $this->callAPISuccess('Setting', 'get', $params);
     $this->assertArrayHasKey(CRM_Core_Config::domainID(), $result['values']);
   }
 
@@ -467,9 +459,8 @@ class api_v3_SettingTest extends CiviUnitTestCase {
       'name' => 'petition_contacts',
       'group' => 'Campaign Preferences',
     ];
-    $description = 'Demonstrates getvalue action - intended for runtime use as better caching than get.';
 
-    $result = $this->callAPIAndDocument('setting', 'getvalue', $params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess('setting', 'getvalue', $params);
     $this->assertEquals('Petition Contacts', $result);
   }
 
@@ -477,12 +468,10 @@ class api_v3_SettingTest extends CiviUnitTestCase {
    * V3 only - no api4 equivalent.
    */
   public function testGetDefaults(): void {
-    $description = 'Gets defaults setting a variable for a given domain - if no domain is set current is assumed.';
-
     $params = [
       'name' => 'address_format',
     ];
-    $result = $this->callAPIAndDocument('Setting', 'getdefaults', $params, __FUNCTION__, __FILE__, $description, 'GetDefaults');
+    $result = $this->callAPISuccess('Setting', 'getdefaults', $params);
     $this->assertEquals("{contact.address_name}\n{contact.street_address}\n{contact.supplemental_address_1}\n{contact.supplemental_address_2}\n{contact.supplemental_address_3}\n{contact.city}{, }{contact.state_province}{ }{contact.postal_code}\n{contact.country}", $result['values'][CRM_Core_Config::domainID()]['address_format']);
     $params = ['name' => 'mailing_format'];
     $result = $this->callAPISuccess('setting', 'getdefaults', $params);
@@ -511,8 +500,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('setting', 'get');
     //make sure it's set
     $this->assertEquals('xyz', $result['values'][CRM_Core_Config::domainID()]['address_format']);
-    $description = 'Demonstrates reverting a parameter to default value.';
-    $this->callAPIAndDocument('setting', 'revert', $revertParams, __FUNCTION__, __FILE__, $description, '');
+    $this->callAPISuccess('setting', 'revert', $revertParams);
     //make sure it's reverted
     $result = $this->callAPISuccess('setting', 'get');
     $this->assertEquals("{contact.address_name}\n{contact.street_address}\n{contact.supplemental_address_1}\n{contact.supplemental_address_2}\n{contact.supplemental_address_3}\n{contact.city}{, }{contact.state_province}{ }{contact.postal_code}\n{contact.country}", $result['values'][CRM_Core_Config::domainID()]['address_format']);

--- a/tests/phpunit/api/v3/StateProvinceTest.php
+++ b/tests/phpunit/api/v3/StateProvinceTest.php
@@ -33,7 +33,7 @@ class api_v3_StateProvinceTest extends CiviUnitTestCase {
    * @dataProvider versionThreeAndFour
    */
   public function testCreateStateProvince() {
-    $result = $this->callAPIAndDocument('StateProvince', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StateProvince', 'create', $this->_params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess('StateProvince', 'delete', ['id' => $result['id']]);
@@ -47,7 +47,7 @@ class api_v3_StateProvinceTest extends CiviUnitTestCase {
     $create = $this->callAPISuccess('StateProvince', 'create', $this->_params);
 
     // Delete
-    $result = $this->callAPIAndDocument('StateProvince', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StateProvince', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count']);
     $get = $this->callAPISuccess('StateProvince', 'get', [
       'id' => $create['id'],
@@ -80,7 +80,7 @@ class api_v3_StateProvinceTest extends CiviUnitTestCase {
     $params = [
       'name' => $this->_params['name'],
     ];
-    $result = $this->callAPIAndDocument('StateProvince', 'Get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StateProvince', 'Get', $params);
     $this->assertEquals($province['values'][$province['id']]['name'], $result['values'][$province['id']]['name']);
     $this->assertEquals($province['values'][$province['id']]['abbreviation'], $result['values'][$province['id']]['abbreviation']);
   }

--- a/tests/phpunit/api/v3/StatusPreferenceTest.php
+++ b/tests/phpunit/api/v3/StatusPreferenceTest.php
@@ -37,7 +37,7 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
    */
   public function testCreateStatusPreference($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument('StatusPreference', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StatusPreference', 'create', $this->_params);
     $this->assertNotNull($result['id'], 'In line ' . __LINE__);
     $id = $result['id'];
     $this->assertEquals('test_check', $result['values'][$id]['name'], 'In line ' . __LINE__);
@@ -54,7 +54,7 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
     // create one
     $create = $this->callAPISuccess('StatusPreference', 'create', $this->_params);
 
-    $result = $this->callAPIAndDocument('StatusPreference', 'delete', ['id' => $create['id']], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StatusPreference', 'delete', ['id' => $create['id']]);
     $this->assertEquals(1, $result['count'], 'In line ' . __LINE__);
 
     $get = $this->callAPISuccess('StatusPreference', 'get', [
@@ -83,7 +83,7 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
     $params = [
       'id' => $id,
     ];
-    $result = $this->callAPIAndDocument('StatusPreference', 'Get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StatusPreference', 'Get', $params);
     $this->assertEquals($statusPreference['values'][$id]['name'], $result['values'][$id]['name'], 'In line ' . __LINE__);
     $this->assertEquals($statusPreference['values'][$id]['domain_id'], $result['values'][$id]['domain_id'], 'In line ' . __LINE__);
     $this->assertEquals('2015-12-12', $result['values'][$id]['hush_until'], 'In line ' . __LINE__);
@@ -108,7 +108,7 @@ class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     // Any permutation of uppercase/lowercase should work.
     $this->_params['ignore_severity'] = 'cRItical';
-    $result = $this->callAPIAndDocument('StatusPreference', 'create', $this->_params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('StatusPreference', 'create', $this->_params);
     $id = $result['id'];
     $this->assertEquals(5, $result['values'][$id]['ignore_severity'], 'In line ' . __LINE__);
   }

--- a/tests/phpunit/api/v3/SurveyRespondantTest.php
+++ b/tests/phpunit/api/v3/SurveyRespondantTest.php
@@ -39,7 +39,7 @@ class api_v3_SurveyRespondantTest extends CiviUnitTestCase {
    * Test survey respondent get.
    */
   public function testGetSurveyRespondants() {
-    $result = $this->callAPIAndDocument("SurveyRespondant", "get", $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess("SurveyRespondant", "get", $this->params);
   }
 
 }

--- a/tests/phpunit/api/v3/SurveyTest.php
+++ b/tests/phpunit/api/v3/SurveyTest.php
@@ -52,7 +52,7 @@ class api_v3_SurveyTest extends CiviUnitTestCase {
    * Test create function succeeds.
    */
   public function testCreateSurvey(): void {
-    $result = $this->callAPIAndDocument('Survey', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Survey', 'create', $this->params);
     $this->getAndCheck($this->params, $result['id'], $this->entity);
   }
 
@@ -65,7 +65,7 @@ class api_v3_SurveyTest extends CiviUnitTestCase {
    */
   public function testGetSurvey(): void {
     $this->createTestEntity('Survey', $this->params);
-    $result = $this->callAPIAndDocument('Survey', 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('Survey', 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
   }
@@ -75,26 +75,21 @@ class api_v3_SurveyTest extends CiviUnitTestCase {
    */
   public function testDeleteSurvey(): void {
     $entity = $this->createTestEntity('Survey', $this->params);
-    $this->callAPIAndDocument('survey', 'delete', ['id' => $entity['id']], __FUNCTION__, __FILE__);
+    $this->callAPISuccess('survey', 'delete', ['id' => $entity['id']]);
     $checkDeleted = $this->callAPISuccess($this->entity, 'get', []);
     $this->assertEquals(0, $checkDeleted['count']);
   }
 
   /**
-   * Test & document chained delete pattern.
-   *
-   * Note that explanation of the pattern
-   * is best put in the $description variable as it will then be displayed in the
-   * test generated examples. (these are to be found in the api/examples folder).
+   * Test chained delete pattern.
    */
   public function testGetSurveyChainDelete(): void {
-    $description = 'Demonstrates get + delete in the same call.';
     $params = [
       'title' => 'survey title',
       'api.survey.delete' => 1,
     ];
     $this->callAPISuccess('Survey', 'create', $this->params);
-    $this->callAPIAndDocument('Survey', 'get', $params, __FUNCTION__, __FILE__, $description, 'ChainedGetDelete');
+    $this->callAPISuccess('Survey', 'get', $params);
     $this->assertEquals(0, $this->callAPISuccess('survey', 'getcount', []));
   }
 

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -45,7 +45,7 @@ class api_v3_SystemTest extends CiviUnitTestCase {
     $this->assertEquals('abc', Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
 
     $params = [];
-    $this->callAPIAndDocument('system', 'flush', $params, __FUNCTION__, __FILE__, 'Flush all system caches', 'Flush');
+    $this->callAPISuccess('system', 'flush', $params);
 
     $this->assertNull(Civi::cache()->get(CRM_Utils_Cache::cleanKey(self::TEST_CACHE_PATH)));
   }

--- a/tests/phpunit/api/v3/TagTest.php
+++ b/tests/phpunit/api/v3/TagTest.php
@@ -64,7 +64,7 @@ class api_v3_TagTest extends CiviUnitTestCase {
       'id' => $this->tagID,
       'name' => $this->tag['name'],
     ];
-    $result = $this->callAPIAndDocument('tag', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('tag', 'get', $params);
     $this->assertEquals($this->tag['description'], $result['values'][$this->tagID]['description']);
     $this->assertEquals($this->tag['name'], $result['values'][$this->tagID]['name']);
   }
@@ -76,15 +76,13 @@ class api_v3_TagTest extends CiviUnitTestCase {
    */
   public function testGetReturnArray($version) {
     $this->_apiversion = $version;
-    $description = "Demonstrates use of Return as an array.";
-    $subfile = "GetReturnArray";
 
     $params = [
       'id' => $this->tagID,
       'name' => $this->tag['name'],
       'return' => ['name'],
     ];
-    $result = $this->callAPIAndDocument('tag', 'get', $params, __FUNCTION__, __FILE__, $description, $subfile);
+    $result = $this->callAPISuccess('tag', 'get', $params);
     $this->assertTrue(empty($result['values'][$this->tagID]['description']));
     $this->assertEquals($this->tag['name'], $result['values'][$this->tagID]['name']);
   }
@@ -126,7 +124,7 @@ class api_v3_TagTest extends CiviUnitTestCase {
       'name' => 'Super Heros',
       'description' => 'Outside undie-wearers',
     ];
-    $result = $this->callAPIAndDocument('tag', 'create', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('tag', 'create', $params);
     $this->assertNotNull($result['id']);
     $params['used_for'] = 'civicrm_contact';
     $this->getAndCheck($params, $result['id'], 'tag');
@@ -191,24 +189,22 @@ class api_v3_TagTest extends CiviUnitTestCase {
     $params = [
       'id' => $this->tagID,
     ];
-    $result = $this->callAPIAndDocument('tag', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('tag', 'delete', $params);
     unset($this->ids['tag']);
   }
 
   public function testTagGetfields() {
-    $description = "Demonstrate use of getfields to interrogate api.";
     $params = ['action' => 'create'];
-    $result = $this->callAPIAndDocument('tag', 'getfields', $params, __FUNCTION__, __FILE__, $description, NULL);
+    $result = $this->callAPISuccess('tag', 'getfields', $params);
     $this->assertEquals('civicrm_contact', $result['values']['used_for']['api.default']);
   }
 
   public function testTagGetList() {
-    $description = "Demonstrates use of api.getlist for autocomplete and quicksearch applications.";
     $params = [
       'input' => $this->tag['name'],
       'extra' => ['used_for'],
     ];
-    $result = $this->callAPIAndDocument('tag', 'getlist', $params, __FUNCTION__, __FILE__, $description);
+    $result = $this->callAPISuccess('tag', 'getlist', $params);
     $this->assertEquals($this->tag['id'], $result['values'][0]['id']);
     $this->assertEquals($this->tag['description'], $result['values'][0]['description'][0]);
     $this->assertEquals($this->tag['used_for'], $result['values'][0]['extra']['used_for']);

--- a/tests/phpunit/api/v3/UFGroupTest.php
+++ b/tests/phpunit/api/v3/UFGroupTest.php
@@ -120,7 +120,7 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
    */
   public function testUFGroupCreate($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument('uf_group', 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('uf_group', 'create', $this->params);
     $this->assertAPISuccess($result);
     $this->assertEquals($result['values'][$result['id']]['add_to_group_id'], $this->params['add_contact_to_group']);
     $this->assertEquals($result['values'][$result['id']]['limit_listings_group_id'], $this->params['group']);
@@ -201,7 +201,7 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
     $this->_apiversion = $version;
     $result = $this->callAPISuccess('uf_group', 'create', $this->params);
     $params = ['id' => $result['id']];
-    $result = $this->callAPIAndDocument('uf_group', 'get', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('uf_group', 'get', $params);
     $this->assertEquals($result['values'][$result['id']]['add_to_group_id'], $this->params['add_contact_to_group']);
     $this->assertEquals($result['values'][$result['id']]['limit_listings_group_id'], $this->params['group']);
     foreach ($this->params as $key => $value) {
@@ -237,7 +237,7 @@ class api_v3_UFGroupTest extends CiviUnitTestCase {
     $ufGroup = $this->callAPISuccess('uf_group', 'create', $this->params);
     $params = ['id' => $ufGroup['id']];
     $this->assertEquals(1, $this->callAPISuccess('uf_group', 'getcount', $params), "in line " . __LINE__);
-    $result = $this->callAPIAndDocument('uf_group', 'delete', $params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess('uf_group', 'delete', $params);
     $this->assertEquals(0, $this->callAPISuccess('uf_group', 'getcount', $params), "in line " . __LINE__);
   }
 

--- a/tests/phpunit/api/v3/UserTest.php
+++ b/tests/phpunit/api/v3/UserTest.php
@@ -32,7 +32,7 @@ class api_v3_UserTest extends CiviUnitTestCase {
   }
 
   public function testUserGet() {
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertEquals($this->contactID, $result['values'][0]['contact_id']);
     $this->assertEquals(6, $result['values'][0]['id']);
@@ -43,7 +43,7 @@ class api_v3_UserTest extends CiviUnitTestCase {
    * Test retrieval of label metadata.
    */
   public function testGetFields() {
-    $result = $this->callAPIAndDocument($this->_entity, 'getfields', ['action' => 'get'], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'getfields', ['action' => 'get']);
     $this->assertArrayKeyExists('name', $result['values']);
   }
 

--- a/tests/phpunit/api/v3/WebsiteTest.php
+++ b/tests/phpunit/api/v3/WebsiteTest.php
@@ -41,7 +41,7 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
    */
   public function testCreateWebsite($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'create', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->getAndCheck($this->params, $result['id'], $this->_entity);
     $this->assertNotNull($result['values'][$result['id']]['id']);
@@ -54,7 +54,7 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
   public function testGetWebsite($version) {
     $this->_apiversion = $version;
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);
-    $result = $this->callAPIAndDocument($this->_entity, 'get', $this->params, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'get', $this->params);
     $this->assertEquals(1, $result['count']);
     $this->assertNotNull($result['values'][$result['id']]['id']);
     $this->callAPISuccess('website', 'delete', ['id' => $result['id']]);
@@ -72,7 +72,7 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
     $this->assertGreaterThanOrEqual(1, $beforeCount);
 
     $deleteParams = ['id' => $result['id']];
-    $result = $this->callAPIAndDocument($this->_entity, 'delete', $deleteParams, __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'delete', $deleteParams);
 
     $afterCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_website');
     $this->assertEquals($beforeCount - 1, $afterCount);
@@ -100,11 +100,11 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
    * Test retrieval of metadata.
    */
   public function testGetMetadata() {
-    $result = $this->callAPIAndDocument($this->_entity, 'get', [
+    $result = $this->callAPISuccess($this->_entity, 'get', [
       'options' => [
         'metadata' => ['fields'],
       ],
-    ], __FUNCTION__, __FILE__, 'Demonostrates returning field metadata', 'GetWithMetadata');
+    ]);
     $this->assertEquals('Website', $result['metadata']['fields']['url']['title']);
   }
 
@@ -114,7 +114,7 @@ class api_v3_WebsiteTest extends CiviUnitTestCase {
    */
   public function testGetFields($version) {
     $this->_apiversion = $version;
-    $result = $this->callAPIAndDocument($this->_entity, 'getfields', ['action' => 'get'], __FUNCTION__, __FILE__);
+    $result = $this->callAPISuccess($this->_entity, 'getfields', ['action' => 'get']);
     $this->assertArrayKeyExists('url', $result['values']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Stop using a function that no longer does what it says it does.