### PR TITLE
APIv4 - Proper ACLs for relationship entity

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2274,4 +2274,25 @@ SELECT count(*)
     }
   }
 
+  /**
+   * @param string $entityName
+   * @param string $action
+   * @param array $record
+   * @param int $userID
+   * @return bool
+   * @see CRM_Core_DAO::checkAccess
+   */
+  public static function _checkAccess(string $entityName, string $action, array $record, int $userID): bool {
+    // Delegate relationship permissions to contacts a & b
+    foreach (['a', 'b'] as $ab) {
+      if (empty($record["contact_id_$ab"]) && !empty($record['id'])) {
+        $record["contact_id_$ab"] = CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], "contact_id_$ab");
+      }
+      if (!\Civi\Api4\Utils\CoreUtil::checkAccessDelegated('Contact', 'update', ['id' => $record["contact_id_$ab"]], $userID)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
 }

--- a/Civi/Api4/Relationship.php
+++ b/Civi/Api4/Relationship.php
@@ -30,4 +30,16 @@ class Relationship extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @return array
+   */
+  public static function permissions(): array {
+    return [
+      'meta' => ['access CiviCRM'],
+      // get managed by CRM_Core_BAO::addSelectWhereClause
+      // create/update/delete managed by CRM_Contact_BAO_Relationship::_checkAccess
+      'default' => [],
+    ];
+  }
+
 }

--- a/Civi/Test/ACLPermissionTrait.php
+++ b/Civi/Test/ACLPermissionTrait.php
@@ -121,6 +121,21 @@ trait ACLPermissionTrait {
   }
 
   /**
+   * Only specified contact returned.
+   *
+   * @implements CRM_Utils_Hook::aclWhereClause
+   *
+   * @param $type
+   * @param $tables
+   * @param $whereTables
+   * @param $contactID
+   * @param $where
+   */
+  public function aclWhereMultipleContacts($type, &$tables, &$whereTables, &$contactID, &$where) {
+    $where = " contact_a.id IN (" . implode(', ', $this->allowedContacts) . ")";
+  }
+
+  /**
    * Set up a core ACL.
    *
    * It is recommended that this helper function is accessed through a scenario function.

--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -9,13 +9,13 @@ use Civi\Api4\OptionValue;
  */
 class CRM_Activity_BAO_ActivityTest extends CiviUnitTestCase {
 
+  use Civi\Test\ACLPermissionTrait;
+
   private $allowedContactsACL = [];
 
   private $loggedInUserId = NULL;
 
   private $someContacts = [];
-
-  protected $allowedContacts = [];
 
   /**
    * Set up for test.

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -18,11 +18,6 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
    */
   protected $_permissionedDisabledGroup;
 
-  /**
-   * @var CRM_Utils_Hook_UnitTests
-   */
-  public $hookClass;
-
   protected $_params = [];
 
   public function setUp(): void {

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2872,21 +2872,6 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * Only specified contact returned.
-   *
-   * @implements CRM_Utils_Hook::aclWhereClause
-   *
-   * @param $type
-   * @param $tables
-   * @param $whereTables
-   * @param $contactID
-   * @param $where
-   */
-  public function aclWhereMultipleContacts($type, &$tables, &$whereTables, &$contactID, &$where) {
-    $where = " contact_a.id IN (" . implode(', ', $this->allowedContacts) . ")";
-  }
-
-  /**
    * @implements CRM_Utils_Hook::selectWhereClause
    *
    * @param string $entity


### PR DESCRIPTION
Overview
----------------------------------------
Improves v4 Relationship api to use fine-grained ACLs instead of coarse-grained permission check which was too restrictive.

Before
----------------------------------------
APIv3 and v4 require 'edit all contacts' to create/update/delete relationships. Users without that permission cannot save or delete any relationship even if they have ACL permission for the related contacts.

After
----------------------------------------
APIv3 unchanged, but v4 uses ACLs instead and eliminates the overly-restrictive permission check.
