### PR TITLE
[REF] Fix infinite loop when trying to load a report instance with an…

### DIFF
--- a/CRM/Report/Page/Instance.php
+++ b/CRM/Report/Page/Instance.php
@@ -44,6 +44,7 @@ class CRM_Report_Page_Instance extends CRM_Core_Page {
     $optionVal = CRM_Report_Utils_Report::getValueFromUrl($instanceId);
     $templateInfo = CRM_Core_OptionGroup::getRowValues('report_template', "{$optionVal}", 'value');
     if (empty($templateInfo)) {
+      CRM_Core_Session::singleton()->replaceUserContext(CRM_Utils_System::url('civicrm/report/list', 'reset=1'));
       CRM_Core_Error::statusBounce(ts('You have tried to access a report that does not exist.'));
     }
 


### PR DESCRIPTION
… id that does not exist

Overview
----------------------------------------
This aims to fix an infinite loop issue with CiviCRM Reports. When loading a report instance that doesn't exist e.g. '/civicrm/report/instance/75?reset=1' on the demo sites this can cause an infinite redirect loop because of the replaceUserContext url in L42

Before
----------------------------------------
Infinite redirect loop caused

After
----------------------------------------
No redirect loop and users are bounced back to the report list

ping @demeritcowboy @larssandergreen @eileenmcnaughton @totten 