### PR TITLE
[REF] Improve cron job handling when there is an invalid report insta…

### DIFF
--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -395,45 +395,49 @@ WHERE  inst.report_id = %1";
 
     $optionVal = self::getValueFromUrl($instanceId);
     $messages = ['Report Mail Triggered...'];
-
-    $templateInfo = CRM_Core_OptionGroup::getRowValues('report_template', $optionVal, 'value');
-    $obj = new CRM_Report_Page_Instance();
-    $is_error = 0;
-    if (strstr(CRM_Utils_Array::value('name', $templateInfo), '_Form')) {
-      $instanceInfo = [];
-      CRM_Report_BAO_ReportInstance::retrieve(['id' => $instanceId], $instanceInfo);
-
-      if (!empty($instanceInfo['title'])) {
-        $obj->assign('reportTitle', $instanceInfo['title']);
-      }
-      else {
-        $obj->assign('reportTitle', $templateInfo['label']);
-      }
-
-      $wrapper = new CRM_Utils_Wrapper();
-      $arguments = [
-        'urlToSession' => [
-          [
-            'urlVar' => 'instanceId',
-            'type' => 'Positive',
-            'sessionVar' => 'instanceId',
-            'default' => 'null',
-          ],
-        ],
-        'ignoreKey' => TRUE,
-      ];
-      $messages[] = $wrapper->run($templateInfo['name'], NULL, $arguments);
+    if (empty($optionVal)) {
+      $is_error = 1;
+      $messages[] = 'Did not find a valid instance to execute';
     }
     else {
-      $is_error = 1;
-      if (!$instanceId) {
-        $messages[] = 'Required parameter missing: instanceId';
+      $templateInfo = CRM_Core_OptionGroup::getRowValues('report_template', $optionVal, 'value');
+      $obj = new CRM_Report_Page_Instance();
+      $is_error = 0;
+      if (strstr(CRM_Utils_Array::value('name', $templateInfo), '_Form')) {
+        $instanceInfo = [];
+        CRM_Report_BAO_ReportInstance::retrieve(['id' => $instanceId], $instanceInfo);
+
+        if (!empty($instanceInfo['title'])) {
+          $obj->assign('reportTitle', $instanceInfo['title']);
+        }
+        else {
+          $obj->assign('reportTitle', $templateInfo['label']);
+        }
+
+        $wrapper = new CRM_Utils_Wrapper();
+        $arguments = [
+          'urlToSession' => [
+            [
+              'urlVar' => 'instanceId',
+              'type' => 'Positive',
+              'sessionVar' => 'instanceId',
+              'default' => 'null',
+            ],
+          ],
+          'ignoreKey' => TRUE,
+        ];
+        $messages[] = $wrapper->run($templateInfo['name'], NULL, $arguments);
       }
       else {
-        $messages[] = 'Did not find valid instance to execute';
+        $is_error = 1;
+        if (!$instanceId) {
+          $messages[] = 'Required parameter missing: instanceId';
+        }
+        else {
+          $messages[] = 'Did not find valid instance to execute';
+        }
       }
     }
-
     $result = [
       'is_error' => $is_error,
       'messages' => implode("\n", $messages),


### PR DESCRIPTION
…nce id passed to mail_report job

Overview
----------------------------------------
This aims to better handle cron job reporting for the job.mail_report when an invalid instance id is passed

Before
----------------------------------------
When an invalid instance id e.g. 75 on the demo sites is passed to the job.mail_report you get an error like the following back

```
{
    "error_code": 0,
    "entity": "Job",
    "action": "mail_report",
    "is_error": 1,
    "error_message": " is not of type String"
}
```
which is because $optionVal is blank when passed through to getFieldValue but this is not obvious from the error message

After
----------------------------------------
You get an error message like the following

```
{
    "is_error": 1,
    "error_message": "Report Mail Triggered...\nDid not find a valid instance to execute"
}
```

ping @larssandergreen @demeritcowboy @eileenmcnaughton note it is probably easier to see what is going on if you ignore whitespace by adding ?w=1 into the PR url