### PR TITLE
E-notice fix - switch order of and params check around

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -69,7 +69,7 @@
       </div>
   {/if}
 
-{if $title and $className eq 'CRM_Contact_Form_Contact'}
+{if $className eq 'CRM_Contact_Form_Contact' && $title}
 </div>
  </div><!-- /.crm-accordion-body -->
 </div><!-- /.crm-accordion-wrapper -->


### PR DESCRIPTION
Overview
----------------------------------------
Addresses the second line here

![image](https://github.com/civicrm/civicrm-core/assets/336308/deee1720-67b2-49d8-869a-89e220f6b510)
