### PR TITLE
Fix notices on domain.tpl by just adding what we need

### DIFF
--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -33,10 +33,15 @@
         <div class="description">{ts}You can also include general email and/or phone contact information in mailings.{/ts} {help id="additional-contact"}</div>
         <table class="form-layout-compressed">
             {* Display the email block *}
-            {include file="CRM/Contact/Form/Edit/Email.tpl" blockId=1}
-
-            {* Display the phone block *}
-            {include file="CRM/Contact/Form/Edit/Phone.tpl" blockId=1}
+          <tr>
+            <td>{ts}Email{/ts}</td>
+            <td>{$form.email.1.email.html|crmAddClass:email}</td>
+          </tr>
+          <tr>
+            <td>{ts}Phone{/ts}</td>
+            <td>{$form.phone.1.phone.html}<span class="crm-phone-ext">{ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
+            <td colspan="2">{$form.phone.1.phone_type_id.html}</td>
+          </tr>
         </table>
 
     <div class="spacer"></div>

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -11,6 +11,7 @@
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller*}
 {* @var $blockId Contains the current email block id in evaluation, and assigned in the CRM/Contact/Form/Location.php file *}
 
+{* note this is only called from CRM_Contact_Form_Contact in core so the className if clauses are not needed & should be phased out *}
 {if !$addBlock}
   <tr>
     <td>{ts}Email{/ts}

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -11,6 +11,7 @@
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller*}
 {* @var blockId Contains the current block id, and assigned in the CRM/Contact/Form/Location.php file *}
 
+{* note this is only called from CRM_Contact_Form_Contact in core so the className if clauses are not needed & should be phased out *}
 {if !$addBlock}
   <tr>
     <td>{ts}Phone{/ts}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices on domain.tpl 
Before
----------------------------------------
We have a tonne of smarty notices & php8 error causing offset issues
![image](https://github.com/civicrm/civicrm-core/assets/336308/7d859d67-dbea-4079-8f19-faebe1282af2)


![image](https://github.com/civicrm/civicrm-core/assets/336308/47902503-51e3-4a59-a584-97deecb9f782)


After
----------------------------------------
The errors are gone - I got a minor formatting change - but I don't think it is worse
![image](https://github.com/civicrm/civicrm-core/assets/336308/8395f407-6b62-4086-bacc-102df9947c6b)

Technical Details
----------------------------------------
This form really does just need a couple of fields - not the multi-block complexity, or the add location stuff
 - so let's just add them



Comments
----------------------------------------
