### PR TITLE
Fix Domain Organization form for notices & php8 compliance

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -73,7 +73,6 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
       $this, FALSE, 'view'
     );
-    CRM_Contact_Form_Location::preProcess($this);
   }
 
   /**
@@ -121,6 +120,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
     $this->addField('description', ['label' => ts('Description'), 'size' => 30]);
 
     //build location blocks.
+    $this->assign('addressSequence', CRM_Core_BAO_Address::addressSequence());
     CRM_Contact_Form_Edit_Address::buildQuickForm($this, 1);
     CRM_Contact_Form_Edit_Email::buildQuickForm($this, 1);
     CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -33,8 +33,7 @@ class CRM_Contact_Form_Location {
       $form->set($form->_addBlockName . '_Block_Count', $additionalblockCount);
     }
 
-    if (is_a($form, 'CRM_Event_Form_ManageEvent_Location')
-    || is_a($form, 'CRM_Contact_Form_Domain')) {
+    if (is_a($form, 'CRM_Event_Form_ManageEvent_Location')) {
       $form->_blocks = [
         'Address' => ts('Address'),
         'Email' => ts('Email'),

--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -33,10 +33,15 @@
         <div class="description">{ts}You can also include general email and/or phone contact information in mailings.{/ts} {help id="additional-contact"}</div>
         <table class="form-layout-compressed">
             {* Display the email block *}
-            {include file="CRM/Contact/Form/Edit/Email.tpl" blockId=1}
-
-            {* Display the phone block *}
-            {include file="CRM/Contact/Form/Edit/Phone.tpl" blockId=1}
+          <tr>
+            <td>{ts}Email{/ts}</td>
+            <td>{$form.email.1.email.html|crmAddClass:email}</td>
+          </tr>
+          <tr>
+            <td>{ts}Phone{/ts}</td>
+            <td>{$form.phone.1.phone.html}<span class="crm-phone-ext">{ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.1.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
+            <td colspan="2">{$form.phone.1.phone_type_id.html}</td>
+          </tr>
         </table>
 
     <div class="spacer"></div>

--- a/templates/CRM/Contact/Form/Domain.tpl
+++ b/templates/CRM/Contact/Form/Domain.tpl
@@ -28,7 +28,7 @@
 
     <h3>{ts}Default Organization Address{/ts}</h3>
         <div class="description">{ts 1=&#123;domain.address&#125;}CiviMail mailings must include the sending organization's address. This is done by putting the %1 token in either the body or footer of the mailing. This token may also be used in regular 'Email - send now' messages and in other Message Templates. The token is replaced by the address entered below when the message is sent.{/ts}</div>
-        {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1 masterAddress='' parseStreetAddress=''}
+        {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1 masterAddress='' parseStreetAddress='' className=''}
     <h3>{ts}Organization Contact Information{/ts}</h3>
         <div class="description">{ts}You can also include general email and/or phone contact information in mailings.{/ts} {help id="additional-contact"}</div>
         <table class="form-layout-compressed">

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -11,6 +11,7 @@
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller*}
 {* @var $blockId Contains the current email block id in evaluation, and assigned in the CRM/Contact/Form/Location.php file *}
 
+{* note this is only called from CRM_Contact_Form_Contact in core so the className if clauses are not needed & should be phased out *}
 {if !$addBlock}
   <tr>
     <td>{ts}Email{/ts}

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -11,6 +11,7 @@
 {* @var $form Contains the array for the form elements and other form associated information assigned to the template by the controller*}
 {* @var blockId Contains the current block id, and assigned in the CRM/Contact/Form/Location.php file *}
 
+{* note this is only called from CRM_Contact_Form_Contact in core so the className if clauses are not needed & should be phased out *}
 {if !$addBlock}
   <tr>
     <td>{ts}Phone{/ts}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Fix Domain Organization form for notices & php8 compliance

Before
----------------------------------------
Various notices, undefined property access

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Includes https://github.com/civicrm/civicrm-core/pull/27189 but also addresses the php layer

Comments
----------------------------------------
