### PR TITLE
Remove always-true empty check

### DIFF
--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -163,7 +163,7 @@
       </tr>
      {/if}
 
-     {if '{contribution.payment_instrument_id}' and empty($formValues.hidden_CreditCard)}
+     {if {contribution.payment_instrument_id|boolean}}
       <tr>
        <td {$labelStyle}>
         {ts}Paid By{/ts}

--- a/xml/templates/message_templates/contribution_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_text.tpl
@@ -46,7 +46,7 @@
 {if '{contribution.receipt_date}'}
 {ts}Receipt Date{/ts}: {contribution.receipt_date|crmDate:"shortdate"}
 {/if}
-{if '{contribution.payment_instrument_id}' and empty($formValues.hidden_CreditCard)}
+{if {contribution.payment_instrument_id|boolean}}
 {ts}Paid By{/ts}: {contribution.payment_instrument_id:label}
 {if '{contribution.check_number}'}
 {ts}Check Number{/ts}: {contribution.check_number}


### PR DESCRIPTION
Per https://github.com/civicrm/civicrm-core/pull/27192

hidden_CreditCard is always empty so the check is meaningless.

The newer boolean token check is safer than the quoted string check
