### PR TITLE
Update SMS cannot send message to specify that a mobile phone number is required

### DIFF
--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -10,7 +10,7 @@
 <div class="crm-block crm-form-block crm-contactSMS-form-block">
 {if $suppressedSms > 0}
     <div class="status">
-        <p>{ts count=$suppressedSms plural='SMS will NOT be sent to %count contacts - (no phone number on file, or communication preferences specify DO NOT SMS, or contact is deceased).'}SMS will NOT be sent to %count contact - (no phone number on file, or communication preferences specify DO NOT SMS, or contact is deceased).{/ts}</p>
+        <p>{ts count=$suppressedSms plural='SMS will NOT be sent to %count contacts who have no mobile phone number, who are set to Do not SMS, or who are deceased.'}SMS will NOT be sent to %count contact who has no mobile phone number, who is set to Do not SMS, or who is deceased.{/ts}</p>
     </div>
 {/if}
 {if $extendTargetContacts > 0}


### PR DESCRIPTION
Overview
----------------------------------------
Just a small change to specify that the reason an SMS will not be sent is specifically because there have no **mobile** number, which may not be clear to users. Took the opportunity to make this sentence read a little better.
