### PR TITLE
Request - Allow empty string or 0 as default values

### DIFF
--- a/CRM/Utils/Request.php
+++ b/CRM/Utils/Request.php
@@ -71,7 +71,6 @@ class CRM_Utils_Request {
    */
   public static function retrieve($name, $type, $store = NULL, $abort = FALSE, $default = NULL, $method = 'REQUEST') {
 
-    $value = NULL;
     switch ($method) {
       case 'GET':
         $value = self::getValue($name, $_GET);
@@ -98,7 +97,7 @@ class CRM_Utils_Request {
       throw new CRM_Core_Exception(ts('Could not find valid value for %1', [1 => $name]));
     }
 
-    if (!isset($value) && $default) {
+    if (!isset($value) && isset($default)) {
       $value = $default;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Makes it easier to fix notices.

Technical Details
----------------------------------------
When trying to solve some notice problems passing the output of this function into `trim()` I tried changing the default to an empty string but it didn't work due to this loosely-typed conditional.