### PR TITLE
dev/core#4541 Fix membership leap year bug that causes test failure

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -521,18 +521,18 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
         $date = $membershipDetails->end_date;
       }
       $date = explode('-', $date);
-      // We have to add 1 day first in case it's the end of the month, then subtract afterwards
+      $year = $date[0];
+      $month = $date[1];
+      $day = $date[2];
+
+      // $logStartDate is used for the membership log only, except if the membership is monthly
+      // then we add 1 day first in case it's the end of the month, then subtract afterwards
       // eg. 2018-02-28 should renew to 2018-03-31, if we just added 1 month we'd get 2018-03-28
       $logStartDate = date('Y-m-d', mktime(0, 0, 0,
         (double) $date[1],
         (double) ($date[2] + 1),
         (double) $date[0]
       ));
-
-      $date = explode('-', $logStartDate);
-      $year = $date[0];
-      $month = $date[1];
-      $day = $date[2];
 
       switch ($membershipTypeDetails['duration_unit']) {
         case 'year':
@@ -548,6 +548,10 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
           break;
 
         case 'month':
+          $date = explode('-', $logStartDate);
+          $year = $date[0];
+          $month = $date[1];
+          $day = $date[2] - 1;
           $month = $month + ($numRenewTerms * $membershipTypeDetails['duration_interval']);
           break;
 
@@ -561,7 +565,7 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
       else {
         $endDate = date('Y-m-d', mktime(0, 0, 0,
           $month,
-          $day - 1,
+          $day,
           $year
         ));
       }

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -466,10 +466,6 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
   /**
    * Renew membership with change in membership type.
    *
-   * @fixme Note that this test fails when today is August 29 2019 (and maybe
-   *   other years?): Verify correct end date is calculated after membership
-   *   renewal Failed asserting that two strings are equal.
-   *   Expected-'2021-03-01' Actual+'2021-02-28'
    * @throws \CRM_Core_Exception
    */
   public function testRenewMembership(): void {


### PR DESCRIPTION
Overview
----------------------------------------
This is not really important, but it is annoying to have test failures (every four years on August 29, I suppose).
This just moves the weird add and subtract a day logic for monthly memberships into the month case, instead of doing it for all cases (years, days).

Before
----------------------------------------
A membership expiring on Feb 29, renewed for one year, expires on Feb 28.

After
----------------------------------------
A membership expiring on Feb 29, renewed for one year, expires on Mar 1.