### PR TITLE
Convert new lines to page breaks when rendering text tokens to html

### DIFF
--- a/Civi/Token/TokenRow.php
+++ b/Civi/Token/TokenRow.php
@@ -280,7 +280,7 @@ class TokenRow {
                 $htmlTokens[$entity][$field] = \CRM_Utils_String::purifyHTML($value);
               }
               else {
-                $htmlTokens[$entity][$field] = is_object($value) ? $value : htmlentities($value, ENT_QUOTES);
+                $htmlTokens[$entity][$field] = is_object($value) ? $value : nl2br(htmlentities($value, ENT_QUOTES));
               }
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
Convert new lines to page breaks when rendering text tokens to html

Before
----------------------------------------
When rendering a token for an plain text as html the new lines are lost. e.g if the text content is 
```
Important text
Other text
```

then there is no line break in the html

After
----------------------------------------
The text is passed through the nl2br function 

Technical Details
----------------------------------------
This really feels like expected behaviour - when entering data in a field where the field supports new lines the new lines should be implemented in any (e.g.) pdfs that leverage the fields as tokens.

Comments
----------------------------------------
The reverse is in https://github.com/civicrm/civicrm-core/pull/27204
