### PR TITLE
Pass html text through a formatter when translating it to tokens

### DIFF
--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -1090,7 +1090,14 @@ United States', $tokenProcessor->getRow(0)->render('message'));
 
     // The `description` does allow HTML. Any funny characters are filtered out of text.
     $messages['event_text'] = 'You signed up for this event: {event.title}: {event.description}';
-    $expected['event_text'] = 'You signed up for this event: The Webinar: Some online webinar thingy. Attendees will need to install the TeleFoo app.';
+    $expected['event_text'] = 'You signed up for this event: The Webinar: Some online webinar thingy.
+
+Attendees will need to install the TeleFoo [1] app.
+
+
+Links:
+------
+[1] http://telefoo.example.com';
 
     $messages['event_html'] = '<p>You signed up for this event:</p> <h3>{event.title}</h3> {event.description}';
     $expected['event_html'] = '<p>You signed up for this event:</p> <h3>The Webinar</h3> <p>Some online webinar thingy.</p> <p>Attendees will need to install the <a href="http://telefoo.example.com">TeleFoo</a> app.</p>';

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Civi\Token;
 
+use Brick\Money\Context\DefaultContext;
+use Brick\Money\Money;
 use Civi\Api4\Website;
 use Civi\Token\Event\TokenRegisterEvent;
 use Civi\Token\Event\TokenValueEvent;
@@ -462,7 +464,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     $this->assertEquals(1, $this->counts['onEvalTokens']);
   }
 
-  public function getFilterExamples() {
+  public function getFilterExamples(): array {
     $exampleTokens = [
       // All the "{my_text.*}" tokens will be treated as plain-text ("text/plain").
       'my_text' => [
@@ -477,7 +479,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
         'and_such' => '<strong>testing &amp; such</strong>',
       ],
       'my_currencies' => [
-        'amount' => \Brick\Money\Money::of(123, 'USD', new \Brick\Money\Context\DefaultContext()),
+        'amount' => Money::of(123, 'USD', new DefaultContext()),
         'currency' => 'EUR',
         'locale' => 'fr_FR',
       ],
@@ -522,7 +524,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
     $testCases['TextMessages with HtmlData'] = [
       'text/plain',
       [
-        'This is {my_rich_text.and_such}...' => 'This is testing & such...',
+        'This is {my_rich_text.and_such}...' => 'This is TESTING & SUCH...',
         'This is {my_rich_text.and_such|lower}...' => 'This is testing & such...',
         'This is {my_rich_text.and_such|upper}!' => 'This is TESTING & SUCH!',
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Convert new lines to page breaks when rendering text tokens to html

Before
----------------------------------------
When rendering a token for an html field as plain text the new lines are lost. e.g if the text content is 
```
<p>Important text</p>
<p>Other text</p>
```

then the text plan version renders 

Important textOther text

After
----------------------------------------
The text is passed through the html converstion function we use elsewhere to get appropriately formatted text from html formatted text

Technical Details
----------------------------------------
As can be seen in the test change this function does additional formatting. However, using an exisitng function seems safer than something narrowly targetted on the line breaks. In general I don't think we have a lot of cases where the text version is heavily used - since html emails are the norm now - but if we ARE rendering html text into text I think it makes sense to do it in a way that is consisent which how we render text versions in other places like header & footer components & within send itself

![image](https://github.com/civicrm/civicrm-core/assets/336308/b6362253-b423-4ac6-aeb1-64c57e140168)


Comments
----------------------------------------
