### PR TITLE
Remove old tests that only test test functions

### DIFF
--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -18,52 +18,9 @@
 class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
   /**
-   * Test case for add( ).
-   */
-  public function testAdd(): void {
-
-    //creates a test group contact by recursively creation
-    //lets create 10 groupContacts for fun
-    $groupContacts = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_GroupContact', NULL, 10);
-
-    //check the group contact id is not null for each of them
-    foreach ($groupContacts as $gc) {
-      $this->assertNotNull($gc->id);
-    }
-
-    //cleanup
-    foreach ($groupContacts as $gc) {
-      $gc->deleteTestObjects('CRM_Contact_DAO_GroupContact');
-    }
-  }
-
-  /**
-   * Test case for getGroupId( )
-   */
-  public function testGetGroupId(): void {
-
-    //creates a test groupContact object
-    //force group_id to 1 so we can compare
-    $groupContact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_GroupContact');
-
-    //check the group contact id is not null
-    $this->assertNotNull($groupContact->id);
-
-    $groupId = CRM_Core_DAO::singleValueQuery('select max(id) from civicrm_group');
-
-    $this->assertEquals($groupContact->group_id, $groupId, 'Check for group_id');
-
-    //cleanup
-    $groupContact->deleteTestObjects('CRM_Contact_DAO_GroupContact');
-  }
-
-  /**
    *  Test case for contact search: CRM-6706, CRM-6586 Parent Group search should return contacts from child groups too.
-   *
-   * @throws \Exception
    */
   public function testContactSearchByParentGroup(): void {
-    // create a parent group
     $parentGroup = $this->callAPISuccess('Group', 'create', [
       'title' => 'Parent Group',
       'description' => 'Parent Group',
@@ -86,7 +43,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     ]);
     // Create contact with Gender - Male
     $childSmartGroupContact = $this->individualCreate([
-      'gender_id' => "Male",
+      'gender_id' => 'Male',
       'first_name' => 'C',
     ], 1);
     // then create smart group
@@ -99,56 +56,56 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
       'parents' => $parentGroup['id'],
     ]);
 
-    // Create a contact within parent group
+    // Create a contact within parent group.
     $parentContactParams = [
-      'first_name' => 'Parent1 Fname',
-      'last_name' => 'Parent1 Lname',
+      'first_name' => 'Parent1 First name',
+      'last_name' => 'Parent1 Last name',
       'group' => [$parentGroup['id'] => 1],
     ];
     $parentContact = $this->individualCreate($parentContactParams);
 
-    // create a contact within child dgroup
+    // Create a contact within child group.
     $childContactParams = [
-      'first_name' => 'Child1 Fname',
-      'last_name' => 'Child2 Lname',
+      'first_name' => 'Child1 First name',
+      'last_name' => 'Child2 Last name',
       'group' => [$childGroup['id'] => 1],
     ];
     $childContact = $this->individualCreate($childContactParams);
 
-    // Check if searching by parent group  returns both parent and child group contacts
-    $result = $this->callAPISuccess('contact', 'get', [
+    // Check if searching by parent group  returns both parent and child group contacts.
+    $contacts = $this->callAPISuccess('Contact', 'get', [
       'group' => $parentGroup['id'],
-    ]);
+    ])['values'];
     $validContactIds = [$parentContact, $childContact];
     $resultContactIds = [];
-    foreach ($result['values'] as $k => $v) {
-      $resultContactIds[] = $v['contact_id'];
+    foreach ($contacts as $contact) {
+      $resultContactIds[] = $contact['id'];
     }
-    $this->assertEquals(3, count($resultContactIds), 'Check the count of returned values');
+    $this->assertCount(3, $resultContactIds, 'Check the count of returned values');
     $this->assertEquals([], array_diff($validContactIds, $resultContactIds), 'Check that the difference between two arrays should be blank array');
 
-    // Check if searching by child group returns just child group contacts
-    $result = $this->callAPISuccess('contact', 'get', [
+    // Check if searching by child group returns just child group contacts.
+    $contacts = $this->callAPISuccess('Contact', 'get', [
       'group' => $childGroup['id'],
-    ]);
+    ])['values'];
     $validChildContactIds = [$childContact];
     $resultChildContactIds = [];
-    foreach ($result['values'] as $k => $v) {
-      $resultChildContactIds[] = $v['contact_id'];
+    foreach ($contacts as $contact) {
+      $resultChildContactIds[] = $contact['id'];
     }
-    $this->assertEquals(1, count($resultChildContactIds), 'Check the count of returned values');
+    $this->assertCount(1, $resultChildContactIds, 'Check the count of returned values');
     $this->assertEquals([], array_diff($validChildContactIds, $resultChildContactIds), 'Check that the difference between two arrays should be blank array');
 
     // Check if searching by smart child group returns just smart child group contacts
-    $result = $this->callAPISuccess('contact', 'get', [
+    $contacts = $this->callAPISuccess('Contact', 'get', [
       'group' => $childSmartGroup['id'],
-    ]);
+    ])['values'];
     $validChildContactIds = [$childSmartGroupContact];
     $resultChildContactIds = [];
-    foreach ($result['values'] as $k => $v) {
-      $resultChildContactIds[] = $v['contact_id'];
+    foreach ($contacts as $contact) {
+      $resultChildContactIds[] = $contact['id'];
     }
-    $this->assertEquals(1, count($resultChildContactIds), 'Check the count of returned values');
+    $this->assertCount(1, $resultChildContactIds, 'Check the count of returned values');
     $this->assertEquals([], array_diff($validChildContactIds, $resultChildContactIds), 'Check that the difference between two arrays should be blank array');
 
     //cleanup
@@ -159,6 +116,9 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
   /**
    *  CRM-19698: Test case for combine contact search in regular and smart group
+   *
+   * @throws \Civi\Core\Exception\DBQueryException
+   * @throws \CRM_Core_Exception
    */
   public function testContactCombineGroupSearch(): void {
     // create regular group based
@@ -171,21 +131,21 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
     // Create contact with Gender - Male
     $contact1 = $this->individualCreate([
-      'gender_id' => "Male",
+      'gender_id' => 'Male',
       'first_name' => 'A',
     ]);
 
     // Create contact with Gender - Male and in regular group
     $contact2 = $this->individualCreate([
       'group' => [$regularGroup['id'] => 1],
-      'gender_id' => "Male",
+      'gender_id' => 'Male',
       'first_name' => 'B',
     ], 1);
 
     // Create contact with Gender - Female and in regular group
     $contact3 = $this->individualCreate([
       'group' => [$regularGroup['id'] => 1],
-      'gender_id' => "Female",
+      'gender_id' => 'Female',
       'first_name' => 'C',
     ], 1);
 
@@ -223,23 +183,25 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     ];
     foreach ($useCases as $case) {
       $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-      list($select, $from, $where, $having) = $query->query();
+      [, $from, $where] = $query->query();
       $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.* $from $where ORDER BY contact_a.first_name")->fetchAll();
       foreach ($groupContacts as $key => $value) {
         $groupContacts[$key] = $value['id'];
       }
-      $this->assertEquals($case['expected_count'], count($groupContacts));
+      $this->assertCount($case['expected_count'], $groupContacts);
       $this->checkArrayEquals($case['expected_contact'], $groupContacts);
     }
   }
 
   /**
    *  CRM-19333: Test case for contact search on basis of group type
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function testbyGroupType(): void {
+  public function testByGroupType(): void {
     $groupTypes = CRM_Core_BAO_OptionValue::getOptionValuesAssocArrayFromName('group_type');
-    $mailingListGT = array_search('Mailing List', $groupTypes);
-    $accessControlGT = array_search('Access Control', $groupTypes);
+    $mailingListGT = array_search('Mailing List', $groupTypes, TRUE);
+    $accessControlGT = array_search('Access Control', $groupTypes, TRUE);
 
     // create group with group type - Mailing list
     $group1 = $this->callAPISuccess('Group', 'create', [
@@ -292,12 +254,12 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
     foreach ($useCases as $case) {
       $query = new CRM_Contact_BAO_Query(CRM_Contact_BAO_Query::convertFormValues($case['form_value']));
-      list($select, $from, $where, $having) = $query->query();
+      [, $from, $where] = $query->query();
       $groupContacts = CRM_Core_DAO::executeQuery("SELECT DISTINCT contact_a.id, contact_a.first_name $from $where ORDER BY contact_a.first_name")->fetchAll();
       foreach ($groupContacts as $key => $value) {
         $groupContacts[$key] = $value['id'];
       }
-      $this->assertEquals($case['expected_count'], count($groupContacts));
+      $this->assertCount($case['expected_count'], $groupContacts);
       $this->checkArrayEquals($case['expected_contact'], $groupContacts);
     }
   }


### PR DESCRIPTION
These tests are calling the test functions to create & delete contacts- but these are not 'real' functions - ideally we wouldn't even call them in tests. We have lots of cover for the actual functions - so just removing

Some other minor cleanup