### PR TITLE
fix sort groups on PHP8

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1025,6 +1025,12 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group {
     // CRM-16905 - Sort by count cannot be done with sql
     if (!empty($params['sort']) && strpos($params['sort'], 'count') === 0) {
       usort($values, function($a, $b) {
+        if ($a['count'] === 'unknown') {
+          return -1;
+        }
+        if ($b['count'] === 'unknown') {
+          return 1;
+        }
         return $a['count'] - $b['count'];
       });
       if (strpos($params['sort'], 'desc')) {

--- a/tests/phpunit/CRM/Group/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Group/Page/AjaxTest.php
@@ -531,6 +531,15 @@ class CRM_Group_Page_AjaxTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test sorting, including with smart group.
+   */
+  public function testSmartGroupSort(): void {
+    $this->smartGroupCreate();
+    $this->_params['sort'] = 'count asc';
+    CRM_Contact_BAO_Group::getGroupList($this->_params);
+  }
+
+  /**
    * Don't populate smart group cache when building Group list.
    *
    * It takes forever, especially if you have lots of smart groups.


### PR DESCRIPTION
Overview
----------------------------------------
On the "Manage Groups" screen, sorting by number of contacts gives a fatal error if you have at least one smart group.

Before
----------------------------------------

```
TypeError: Unsupported operand types: int - string

/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Contact/BAO/Group.php:1028
/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Contact/BAO/Group.php:1029
/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CRM/Group/Page/AjaxTest.php:539
/home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:237
/home/jon/local/civicrm-buildkit/extern/phpunit9/phpunit9.phar:2307
```

After
----------------------------------------
Smart groups are sorted at the bottom of the list (descending) or top of the list (ascending).

Technical Details
----------------------------------------
We're trying to sort the "unknown" string compared to integers.

Comments
----------------------------------------
I considered placing the test in another file, but the bug is only triggered by AJAX and this is more closely related to the other tests in this class, despite not technically using AJAX.