### PR TITLE
Move no-longer-shared function back to it's form

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -819,7 +819,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     // build location blocks.
     CRM_Contact_Form_Edit_Lock::buildQuickForm($this);
-    CRM_Contact_Form_Location::buildQuickForm($this);
+    $this->buildLocationForm();
 
     // add attachment
     $this->addField('image_URL', ['maxlength' => '255', 'label' => ts('Browse/Upload Image'), 'accept' => 'image/png, image/jpeg, image/gif']);
@@ -881,6 +881,67 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     $this->assign('oldSubtypes', json_encode($this->_oldSubtypes));
 
     $this->addButtons($buttons);
+  }
+
+  private function buildLocationForm(): void {
+    // required for subsequent AJAX requests.
+    $ajaxRequestBlocks = [];
+    $generateAjaxRequest = 0;
+
+    //build 1 instance of all blocks, without using ajax ...
+    foreach ($this->_blocks as $blockName => $label) {
+      $name = strtolower($blockName);
+
+      $instances = [1];
+      if (!empty($_POST[$name]) && is_array($_POST[$name])) {
+        $instances = array_keys($_POST[$name]);
+      }
+      elseif (!empty($this->_values[$name]) && is_array($this->_values[$name])) {
+        $instances = array_keys($this->_values[$name]);
+      }
+
+      foreach ($instances as $instance) {
+        if ($instance == 1) {
+          $this->assign('addBlock', FALSE);
+          $this->assign('blockId', $instance);
+        }
+        else {
+          //we are going to build other block instances w/ AJAX
+          $generateAjaxRequest++;
+          $ajaxRequestBlocks[$blockName][$instance] = TRUE;
+        }
+        switch ($blockName) {
+          case 'Email':
+            // setDefaults uses this to tell which instance
+            $this->set('Email_Block_Count', $instance);
+            CRM_Contact_Form_Edit_Email::buildQuickForm($this, $instance);
+            // Only display the signature fields if this contact has a CMS account
+            // because they can only send email if they have access to the CRM
+            $ufID = $this->_contactId && CRM_Core_BAO_UFMatch::getUFId($this->_contactId);
+            $this->assign('isAddSignatureFields', (bool) $ufID);
+            if ($ufID) {
+              $this->add('textarea', "email[$instance][signature_text]", ts('Signature (Text)'),
+                ['rows' => 2, 'cols' => 40]
+              );
+              $this->add('wysiwyg', "email[$instance][signature_html]", ts('Signature (HTML)'),
+                ['rows' => 2, 'cols' => 40]
+              );
+            }
+            break;
+
+          default:
+            // @todo This pattern actually adds complexity compared to filling out a switch statement
+            // for the limited number of blocks - as we also have to receive the block count
+            $this->set($blockName . '_Block_Count', $instance);
+            $formName = 'CRM_Contact_Form_Edit_' . $blockName;
+            $formName::buildQuickForm($this);
+        }
+      }
+    }
+
+    //assign to generate AJAX request for building extra blocks.
+    $this->assign('generateAjaxRequest', $generateAjaxRequest);
+    $this->assign('ajaxRequestBlocks', $ajaxRequestBlocks);
   }
 
   /**

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -312,8 +312,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
     // also keep the convention.
     $this->assign('contactId', $this->_contactId);
 
-    // location blocks.
-    CRM_Contact_Form_Location::preProcess($this);
+    $this->preProcessLocation();
 
     // retain the multiple count custom fields value
     if (!empty($_POST['hidden_custom'])) {
@@ -373,6 +372,29 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       }
     }
     $this->assign('paramSubType', $paramSubType ?? '');
+  }
+
+  private function preProcessLocation() {
+    $this->_addBlockName = CRM_Utils_Request::retrieve('block', 'String');
+    $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive');
+
+    $this->assign('addBlock', FALSE);
+    if ($this->_addBlockName && $additionalblockCount) {
+      $this->assign('addBlock', TRUE);
+      $this->assign('blockName', $this->_addBlockName);
+      $this->assign('blockId', $additionalblockCount);
+      $this->set($this->_addBlockName . '_Block_Count', $additionalblockCount);
+    }
+
+    $this->assign('blocks', $this->_blocks);
+    $this->assign('className', 'CRM_Contact_Form_Contact');
+
+    // get address sequence.
+    if (!$addressSequence = $this->get('addressSequence')) {
+      $addressSequence = CRM_Core_BAO_Address::addressSequence();
+      $this->set('addressSequence', $addressSequence);
+    }
+    $this->assign('addressSequence', $addressSequence);
   }
 
   /**

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -25,6 +25,7 @@ class CRM_Contact_Form_Location {
    * @param CRM_Core_Form $form
    */
   public static function buildQuickForm(&$form) {
+    CRM_Core_Error::deprecatedFunctionWarning('internal core function, take a copy');
     // required for subsequent AJAX requests.
     $ajaxRequestBlocks = [];
     $generateAjaxRequest = 0;

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -13,12 +13,15 @@
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ * @deprecated in CiviCRM 5.66, will be removed around CiviCRM 5.76.
  */
 class CRM_Contact_Form_Location {
 
   /**
    * Build the form object.
    *
+   * @deprecated in CiviCRM 5.66, will be removed around CiviCRM 5.76.
    * @param CRM_Core_Form $form
    */
   public static function buildQuickForm(&$form) {

--- a/CRM/Contact/Form/Location.php
+++ b/CRM/Contact/Form/Location.php
@@ -17,34 +17,6 @@
 class CRM_Contact_Form_Location {
 
   /**
-   * Set variables up before form is built.
-   *
-   * @param CRM_Core_Form $form
-   */
-  public static function preProcess($form) {
-    $form->_addBlockName = CRM_Utils_Request::retrieve('block', 'String');
-    $additionalblockCount = CRM_Utils_Request::retrieve('count', 'Positive');
-
-    $form->assign('addBlock', FALSE);
-    if ($form->_addBlockName && $additionalblockCount) {
-      $form->assign('addBlock', TRUE);
-      $form->assign('blockName', $form->_addBlockName);
-      $form->assign('blockId', $additionalblockCount);
-      $form->set($form->_addBlockName . '_Block_Count', $additionalblockCount);
-    }
-
-    $form->assign('blocks', $form->_blocks);
-    $form->assign('className', CRM_Utils_System::getClassName($form));
-
-    // get address sequence.
-    if (!$addressSequence = $form->get('addressSequence')) {
-      $addressSequence = CRM_Core_BAO_Address::addressSequence();
-      $form->set('addressSequence', $addressSequence);
-    }
-    $form->assign('addressSequence', $addressSequence);
-  }
-
-  /**
    * Build the form object.
    *
    * @param CRM_Core_Form $form


### PR DESCRIPTION
Overview
----------------------------------------
[Move no-longer-shared function back to it's form](https://github.com/civicrm/civicrm-core/commit/b2cf791d4ffff30ddaaddcb9cc9051422c203782)



Before
----------------------------------------
Once https://github.com/civicrm/civicrm-core/pull/27212 is merged the function is really only from one form.... including a universe search

![image](https://github.com/civicrm/civicrm-core/assets/336308/92c2fff5-1aa0-43bd-918f-b2a6f6fb075f)

After
----------------------------------------
moved to it's form

Technical Details
----------------------------------------
The buildform has a universe usage so deprecated & copied

![image](https://github.com/civicrm/civicrm-core/assets/336308/e1e60bc8-07a7-40cb-aaf0-f71ed1bb4e21)

Comments
----------------------------------------
Issue created for the non-core use of the internal core function https://lab.civicrm.org/extensions/eventmanagelocations/-/issues/2
