### PR TITLE
Remove some copy & paste code

### DIFF
--- a/CRM/Event/Form/ManageEvent.php
+++ b/CRM/Event/Form/ManageEvent.php
@@ -99,9 +99,6 @@ class CRM_Event_Form_ManageEvent extends CRM_Core_Form {
     if ($this->_id) {
       $this->_isRepeatingEvent = CRM_Core_BAO_RecurringEntity::getParentFor($this->_id, 'civicrm_event');
       $this->assign('eventId', $this->_id);
-      if (!empty($this->_addBlockName) && empty($this->_addProfileBottom) && empty($this->_addProfileBottomAdd)) {
-        $this->add('hidden', 'id', $this->_id);
-      }
       $this->_single = TRUE;
 
       $eventInfo = \Civi\Api4\Event::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Remove some copy & paste code

Before
----------------------------------------
Handling for `addBlockName` even though it could not be defined here

After
----------------------------------------
poof

Technical Details
----------------------------------------
The only place the property was ever set in the ManageEvent forms was removed here https://github.com/civicrm/civicrm-core/pull/27212 - but would not have been hit in this flow anyway

Comments
----------------------------------------
