### PR TITLE
Replace another badly named undeclared property

### DIFF
--- a/CRM/Contact/Form/Edit/CustomData.php
+++ b/CRM/Contact/Form/Edit/CustomData.php
@@ -31,9 +31,8 @@ class CRM_Contact_Form_Edit_CustomData {
     $customDataType = CRM_Utils_Request::retrieve('type', 'String');
 
     if ($customDataType) {
-      $form->_addBlockName = 'CustomData';
-      $form->assign("addBlock", TRUE);
-      $form->assign("blockName", $form->_addBlockName);
+      $form->assign('addBlock', TRUE);
+      $form->assign('blockName', 'CustomData');
     }
 
     CRM_Custom_Form_CustomData::preProcess($form, NULL, NULL, NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Replace another badly named undeclared property

Before
----------------------------------------
weird undefined property `_addBlockName` set in 2 places and used in 2 (plus some internal places within the functions that do the set)



![image](https://github.com/civicrm/civicrm-core/assets/336308/2ca779db-88fe-49ea-939c-9ccea7f75e4e)

It is set in 2 functions, both called from the `preProcess` for `CRM_Contact_Form_Contact` (only). 

The custom data form sets it to 'CustomData` if there is a type in the url


![image](https://github.com/civicrm/civicrm-core/assets/336308/b0111dd0-1b05-4dcb-b849-a81ebe0cc438)

The location function looks for blocks in the url

![image](https://github.com/civicrm/civicrm-core/assets/336308/036c6893-d113-4259-bb15-30b54434d6c8)

After
----------------------------------------
We do the 2 checks in one function -
```
public function getAjaxBlockName(): string {
    return (string) (CRM_Utils_Request::retrieve('type', 'String') ? 'CustomData' : CRM_Utils_Request::retrieve('block', 'String'));
  }
```

Almost gone - see https://github.com/civicrm/civicrm-core/pull/27214
![image](https://github.com/civicrm/civicrm-core/assets/336308/b8e7d202-f8f3-4b5e-80f5-c3b766e145ca)


Technical Details
----------------------------------------

Comments
----------------------------------------
