### PR TITLE
Remove Html2text security check, package deleted

### DIFF
--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -287,10 +287,6 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
         "{$packages_path}/OpenFlashChart/php-ofc-library/ofc_upload_image.php",
         \Psr\Log\LogLevel::CRITICAL,
       ],
-      [
-        "{$packages_path}/html2text/class.html2text.inc",
-        \Psr\Log\LogLevel::CRITICAL,
-      ],
     ];
     foreach ($files as $file) {
       if (file_exists($file[0])) {


### PR DESCRIPTION
Overview
----------------------------------------
[PR to remove from packages](https://github.com/civicrm/civicrm-packages/pull/370), as it now comes from composer.