### PR TITLE
Remove decade-only typo

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -6133,7 +6133,6 @@ AND   displayRelType.is_active = 1
       if (!empty($value['table'])) {
         $regex = "/({$value['table']}\.|{$name})/";
         if (preg_match($regex, $sort)) {
-          $this->_elemnt[$value['element']] = 1;
           $this->_select[$value['element']] = $value['select'];
           $this->_pseudoConstantsSelect[$name]['sorting'] = 1;
           $present[$value['table']] = $value['join'];


### PR DESCRIPTION
This is an undefined property. Nothing accesses the mis-typed version....
![image](https://github.com/civicrm/civicrm-core/assets/336308/07cf61c3-67ec-4555-b6e0-c88144fcf58e)
