### PR TITLE
Cleanup signature for test function `getFormObject`

### DIFF
--- a/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/BAO/ActivityTest.php
@@ -1636,7 +1636,7 @@ $text
       'campaign_id' => $campaign_id,
       'from_email_address' => 'from@example.com',
       'to' => $contactId1 . '::email@example.com,' . $contactId2 . '::email2@example.com',
-    ], '', []);
+    ]);
     $form->set('cid', $contactId1 . ',' . $contactId2);
     $form->buildForm();
     $form->postProcess();
@@ -1702,7 +1702,7 @@ $textValue
         'name' => $fileUri,
       ],
       'attachDesc_1' => '',
-    ], NULL, []);
+    ]);
     $form->set('cid', $contactId1 . ',' . $contactId2 . ',' . $contactId3);
     $form->buildForm();
     $form->postProcess();
@@ -1752,7 +1752,6 @@ $textValue
     $subject = __FUNCTION__ . ' subject';
     $html = __FUNCTION__ . ' html';
     $text = __FUNCTION__ . ' text';
-    $userID = $loggedInUser;
 
     $filepath = Civi::paths()->getPath('[civicrm.files]/custom');
     $fileName = 'test_email_create.txt';
@@ -1775,7 +1774,7 @@ $textValue
         'name' => $fileUri,
       ],
       'attachDesc_1' => '',
-    ], NULL, []);
+    ]);
     $form->set('cid', $contactId1 . ',' . $contactId2);
     $form->buildForm();
     $form->postProcess();

--- a/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
+++ b/tests/phpunit/CRM/Contact/Form/Task/PrintDocumentTest.php
@@ -47,19 +47,21 @@ class CRM_Contact_Form_Task_PrintDocumentTest extends CiviUnitTestCase {
    *  Assert the content of document
    *
    * @param array $formValues
-   * @param array $type
+   * @param string $type
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function _testDocumentContent($formValues, $type) {
+  public function _testDocumentContent(array $formValues, $type): void {
     $html = [];
     /** @var CRM_Contact_Form_Task_PDF $form */
-    $form = $this->getFormObject('CRM_Contact_Form_Task_PDF', [], NULL, [
+    $form = $this->getSearchFormObject('CRM_Contact_Form_Task_PDF', [], NULL, [
       'radio_ts' => 'ts_sel',
       'task' => CRM_Member_Task::PDF_LETTER,
     ]);
-    list($formValues) = $form->processMessageTemplate($formValues);
-    list($html_message, $zip) = CRM_Utils_PDF_Document::unzipDoc($formValues['document_file_path'], $formValues['document_type']);
+    [$formValues] = $form->processMessageTemplate($formValues);
+    [$html_message, $zip] = CRM_Utils_PDF_Document::unzipDoc($formValues['document_file_path'], $formValues['document_type']);
 
-    foreach ($this->_contactIds as $item => $contactId) {
+    foreach ($this->_contactIds as $contactId) {
       $html[] = CRM_Core_BAO_MessageTemplate::renderTemplate(['messageTemplate' => ['msg_html' => $html_message], 'contactId' => $contactId, 'disableSmarty' => TRUE])['html'];
     }
 

--- a/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
@@ -57,14 +57,14 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
       'is_credit_card_only' => '',
     ];
 
-    $contributionpage = CRM_Contribute_BAO_ContributionPage::create($params);
+    $contributionPage = CRM_Contribute_BAO_ContributionPage::create($params);
 
     // The BAO does not save these
-    $params['id'] = $contributionpage->id;
+    $params['id'] = $contributionPage->id;
     $params['honor_block_title'] = 'In Honor Title EN';
     $params['honor_block_text'] = 'In Honor Text EN';
 
-    $form = $this->getFormObject('CRM_Contribute_Form_ContributionPage_Settings', $params, 'Settings');
+    $form = $this->getFormObject('CRM_Contribute_Form_ContributionPage_Settings', $params);
     $form->postProcess();
 
     // Now update the page with In Honor (soft credit) text in French
@@ -73,11 +73,11 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
     $params['honor_block_title'] = 'In Honor Title FR';
     $params['honor_block_text'] = 'In Honor Text FR';
 
-    $form = $this->getFormObject('CRM_Contribute_Form_ContributionPage_Settings', $params, 'Settings');
+    $form = $this->getFormObject('CRM_Contribute_Form_ContributionPage_Settings', $params);
     $form->postProcess();
 
     $uf = $this->callAPISuccess('UFJoin', 'getsingle', [
-      'entity_id' => $contributionpage->id,
+      'entity_id' => $contributionPage->id,
       'module' => 'soft_credit',
     ]);
 
@@ -88,7 +88,7 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
     $this->assertEquals('In Honor Title FR', $json['soft_credit']['fr_FR']['honor_block_title']);
     $this->assertEquals('In Honor Text FR', $json['soft_credit']['fr_FR']['honor_block_text']);
 
-    $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionpage->id]);
+    $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionPage->id]);
   }
 
 }

--- a/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/EmailTest.php
@@ -47,7 +47,7 @@ class CRM_Contribute_Form_Task_EmailTest extends CiviUnitTestCase {
     $contribution1 = $this->contributionCreate(['contact_id' => $contact2, 'invoice_number' => 'soy']);
     $contribution2 = $this->contributionCreate(['total_amount' => 999, 'contact_id' => $contact1, 'invoice_number' => 'saucy']);
     $contribution3 = $this->contributionCreate(['total_amount' => 999, 'contact_id' => $contact1, 'invoice_number' => 'ranch']);
-    $form = $this->getFormObject('CRM_Contribute_Form_Task_Email', [
+    $form = $this->getSearchFormObject('CRM_Contribute_Form_Task_Email', [
       'cc_id' => '',
       'bcc_id' => '',
       'to' => implode(',', [

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFTest.php
@@ -51,7 +51,7 @@ class CRM_Contribute_Form_Task_PDFTest extends CiviUnitTestCase {
       }
     }
 
-    $form = $this->getFormObject('CRM_Contribute_Form_Task_PDF', [
+    $form = $this->getSearchFormObject('CRM_Contribute_Form_Task_PDF', [
       'receipt_update' => 1,
     ], NULL, $searchValues);
     $form->buildForm();

--- a/tests/phpunit/CRM/Contribute/Form/TaskTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/TaskTest.php
@@ -71,7 +71,7 @@ class CRM_Contribute_Form_TaskTest extends CiviUnitTestCase {
     foreach ($fields as $val) {
       // Assert contribIds are returned in a sorted order.
       /** @var CRM_Contribute_Form_Task $form */
-      $form = $this->getFormObject('CRM_Contribute_Form_Task', ['radio_ts' => 'ts_all'], 'Search');
+      $form = $this->getSearchFormObject('CRM_Contribute_Form_Task', ['radio_ts' => 'ts_all'], 'Search');
       $form->set(CRM_Utils_Sort::SORT_ORDER, "`{$val}` asc");
       CRM_Contribute_Form_Task::preProcessCommon($form);
 

--- a/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
+++ b/tests/phpunit/CRM/Event/Form/Task/BadgeTest.php
@@ -49,7 +49,7 @@ class CRM_Event_Form_Task_BadgeTest extends CiviUnitTestCase {
     $_REQUEST['id'] = $participantID;
     $_REQUEST['cid'] = $contactID;
     /** @var CRM_Event_Form_Task_Badge $form */
-    $form = $this->getFormObject(
+    $form = $this->getSearchFormObject(
       'CRM_Event_Form_Task_Badge',
       ['badge_id' => 1],
       NULL,

--- a/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
+++ b/tests/phpunit/CRM/Mailing/Form/Task/AdhocMailingTest.php
@@ -20,7 +20,6 @@ class CRM_Mailing_Form_Task_AdhocMailingTest extends CiviUnitTestCase {
    * A hidden smart group is a group used for sending emails.
    *
    * @throws \CRM_Core_Exception
-   * @throws \Exception
    */
   public function testCreateHiddenGroupFromSearchBuilder(): void {
     $this->createLoggedInUser();
@@ -33,7 +32,7 @@ class CRM_Mailing_Form_Task_AdhocMailingTest extends CiviUnitTestCase {
       '_qf_Builder_refresh' => 'Search',
       'radio_ts' => '',
     ];
-    $form = $this->getFormObject('CRM_Mailing_Form_Task_AdhocMailing', $formValues, 'Builder');
+    $form = $this->getSearchFormObject('CRM_Mailing_Form_Task_AdhocMailing', $formValues, 'Builder');
     $form->setAction(CRM_Core_Action::PROFILE);
     $form->set('formValues', $formValues);
     $form->set('isSearchBuilder', 1);

--- a/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/LabelTest.php
@@ -30,7 +30,7 @@ class CRM_Member_Form_Task_LabelTest extends CiviUnitTestCase {
     $this->assertArrayHasKey(201, $tasks);
     $this->contactMembershipCreate(['contact_id' => $this->individualCreate()]);
     /** @var CRM_Member_Form_Task_Label $form */
-    $form = $this->getFormObject('CRM_Member_Form_Task_Label', [
+    $form = $this->getSearchFormObject('CRM_Member_Form_Task_Label', [
       'task' => 201,
       'radio_ts' => 'ts_sel',
     ], 'Search');

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
@@ -79,7 +79,7 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
     }
 
     /** @var CRM_Member_Form_Task_PDFLetter $form */
-    $form = $this->getFormObject('CRM_Member_Form_Task_PDFLetter', [
+    $form = $this->getSearchFormObject('CRM_Member_Form_Task_PDFLetter', [
       'subject' => '{contact.first_name} {membership.source}',
       'html_message' => $htmlMessage,
     ], NULL, $searchFormValues);


### PR DESCRIPTION
I want to make form test functions available outside core (to wean some extensions off calling methods on the forms that we no longer call from core. They were copy & paste from when we did). Also, I want to have some nicer form functions.

I think getFormObject is OK-ish but I don't like the parameters that are there to support search tests, so I am trying to split that out to allow signature change on the main function


I expect a jenkins dance as I find any affected tests