### PR TITLE
dev/core#2581 Default to blank for required multi-lingual fields

### DIFF
--- a/CRM/Core/CodeGen/I18n.php
+++ b/CRM/Core/CodeGen/I18n.php
@@ -22,7 +22,7 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
     file_put_contents('../install/langs.php', "<?php \$langs = " . var_export($langs, TRUE) . ";");
   }
 
-  public function generateSchemaStructure() {
+  public function generateSchemaStructure(): void {
     echo "Generating CRM_Core_I18n_SchemaStructure...\n";
     $columns = [];
     $indices = [];
@@ -36,10 +36,10 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
         continue;
       }
       foreach ($table['fields'] as $field) {
-        $required = $field['required'] ? ' NOT NULL' : '';
-        $default = $field['default'] ? ' DEFAULT ' . $field['default'] : '';
-        $comment = $field['comment'] ? " COMMENT '" . $field['comment'] . "'" : '';
         if ($field['localizable']) {
+          $required = $field['required'] ? ' NOT NULL' : '';
+          $default = $field['default'] ? ' DEFAULT ' . $field['default'] : ($field['required'] ? " DEFAULT '' " : '');
+          $comment = $field['comment'] ? " COMMENT '" . $field['comment'] . "'" : '';
           $columns[$table['name']][$field['name']] = $field['sqlType'] . $required . $default . $comment;
           $widgets[$table['name']][$field['name']] = $field['widget'];
         }

--- a/CRM/Core/I18n/SchemaStructure.php
+++ b/CRM/Core/I18n/SchemaStructure.php
@@ -30,7 +30,7 @@ class CRM_Core_I18n_SchemaStructure {
     if (!$result) {
       $result = [
         'civicrm_location_type' => [
-          'display_name' => "varchar(64) NOT NULL COMMENT 'Location Type Display Name.'",
+          'display_name' => "varchar(64) NOT NULL DEFAULT ''  COMMENT 'Location Type Display Name.'",
         ],
         'civicrm_option_group' => [
           'title' => "varchar(255) COMMENT 'Option Group title.'",
@@ -58,7 +58,7 @@ class CRM_Core_I18n_SchemaStructure {
           'label' => "varchar(128) COMMENT 'Label for Membership Status'",
         ],
         'civicrm_survey' => [
-          'title' => "varchar(255) NOT NULL COMMENT 'Title of the Survey.'",
+          'title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Title of the Survey.'",
           'instructions' => "text COMMENT 'Script instructions for volunteers to use for the survey.'",
           'thankyou_title' => "varchar(255) COMMENT 'Title for Thank-you page (header title tag, and display at the top of the page).'",
           'thankyou_text' => "text COMMENT 'text and html allowed. displayed above result on success page'",
@@ -67,7 +67,7 @@ class CRM_Core_I18n_SchemaStructure {
           'label' => "varchar(255) COMMENT 'localized label for display of this status type'",
         ],
         'civicrm_case_type' => [
-          'title' => "varchar(64) NOT NULL COMMENT 'Natural language name for Case Type'",
+          'title' => "varchar(64) NOT NULL DEFAULT ''  COMMENT 'Natural language name for Case Type'",
           'description' => "varchar(255) COMMENT 'Description of the Case Type'",
         ],
         'civicrm_tell_friend' => [
@@ -78,27 +78,27 @@ class CRM_Core_I18n_SchemaStructure {
           'thankyou_text' => "text COMMENT 'Thank you message displayed on success page.'",
         ],
         'civicrm_custom_group' => [
-          'title' => "varchar(64) NOT NULL COMMENT 'Friendly Name.'",
+          'title' => "varchar(64) NOT NULL DEFAULT ''  COMMENT 'Friendly Name.'",
           'help_pre' => "text COMMENT 'Description and/or help text to display before fields in form.'",
           'help_post' => "text COMMENT 'Description and/or help text to display after fields in form.'",
         ],
         'civicrm_custom_field' => [
-          'label' => "varchar(255) NOT NULL COMMENT 'Text for form field label (also friendly name for administering this custom property).'",
+          'label' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Text for form field label (also friendly name for administering this custom property).'",
           'help_pre' => "text COMMENT 'Description and/or help text to display before this field.'",
           'help_post' => "text COMMENT 'Description and/or help text to display after this field.'",
         ],
         'civicrm_option_value' => [
-          'label' => "varchar(512) NOT NULL COMMENT 'Option string as displayed to users - e.g. the label in an HTML OPTION tag.'",
+          'label' => "varchar(512) NOT NULL DEFAULT ''  COMMENT 'Option string as displayed to users - e.g. the label in an HTML OPTION tag.'",
           'description' => "text COMMENT 'Optional description.'",
         ],
         'civicrm_group' => [
-          'title' => "varchar(255) NOT NULL COMMENT 'Name of Group.'",
-          'frontend_title' => "varchar(255) NOT NULL COMMENT 'Alternative public title for this Group.'",
+          'title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Name of Group.'",
+          'frontend_title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Alternative public title for this Group.'",
           'frontend_description' => "text DEFAULT NULL COMMENT 'Alternative public description of the group.'",
         ],
         'civicrm_contribution_page' => [
-          'title' => "varchar(255) NOT NULL COMMENT 'Contribution Page title. For top of page display'",
-          'frontend_title' => "varchar(255) NOT NULL COMMENT 'Contribution Page Public title'",
+          'title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Contribution Page title. For top of page display'",
+          'frontend_title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Contribution Page Public title'",
           'intro_text' => "text COMMENT 'Text and html allowed. Displayed below title.'",
           'pay_later_text' => "text COMMENT 'The text displayed to the user in the main form'",
           'pay_later_receipt' => "text COMMENT 'The receipt sent to the user instead of the normal receipt text'",
@@ -112,16 +112,16 @@ class CRM_Core_I18n_SchemaStructure {
           'footer_text' => "text COMMENT 'Text and html allowed. Displayed at the bottom of the first page of the contribution wizard.'",
         ],
         'civicrm_product' => [
-          'name' => "varchar(255) NOT NULL COMMENT 'Required product/premium name'",
+          'name' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Required product/premium name'",
           'description' => "text COMMENT 'Optional description of the product/premium.'",
           'options' => "text COMMENT 'Store comma-delimited list of color, size, etc. options for the product.'",
         ],
         'civicrm_payment_processor' => [
-          'title' => "varchar(255) NOT NULL COMMENT 'Name of processor when shown to CiviCRM administrators.'",
-          'frontend_title' => "varchar(255) NOT NULL COMMENT 'Name of processor when shown to users making a payment.'",
+          'title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Name of processor when shown to CiviCRM administrators.'",
+          'frontend_title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Name of processor when shown to users making a payment.'",
         ],
         'civicrm_membership_type' => [
-          'name' => "varchar(128) NOT NULL COMMENT 'Name of Membership Type'",
+          'name' => "varchar(128) NOT NULL DEFAULT ''  COMMENT 'Name of Membership Type'",
           'description' => "varchar(255) COMMENT 'Description of Membership Type'",
         ],
         'civicrm_membership_block' => [
@@ -131,7 +131,7 @@ class CRM_Core_I18n_SchemaStructure {
           'renewal_text' => "text COMMENT 'Text to display for member renewal'",
         ],
         'civicrm_price_set' => [
-          'title' => "varchar(255) NOT NULL COMMENT 'Displayed title for the Price Set.'",
+          'title' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Displayed title for the Price Set.'",
           'help_pre' => "text COMMENT 'Description and/or help text to display before fields in form.'",
           'help_post' => "text COMMENT 'Description and/or help text to display after fields in form.'",
         ],
@@ -139,7 +139,7 @@ class CRM_Core_I18n_SchemaStructure {
           'label' => "varchar(255) COMMENT 'dashlet title'",
         ],
         'civicrm_uf_group' => [
-          'title' => "varchar(64) NOT NULL COMMENT 'Form title.'",
+          'title' => "varchar(64) NOT NULL DEFAULT ''  COMMENT 'Form title.'",
           'frontend_title' => "varchar(64) COMMENT 'Profile Form Public title'",
           'help_pre' => "text COMMENT 'Description and/or help text to display before fields in form.'",
           'help_post' => "text COMMENT 'Description and/or help text to display after fields in form.'",
@@ -149,10 +149,10 @@ class CRM_Core_I18n_SchemaStructure {
         'civicrm_uf_field' => [
           'help_post' => "text COMMENT 'Description and/or help text to display after this field.'",
           'help_pre' => "text COMMENT 'Description and/or help text to display before this field.'",
-          'label' => "varchar(255) NOT NULL COMMENT 'To save label for fields.'",
+          'label' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'To save label for fields.'",
         ],
         'civicrm_price_field' => [
-          'label' => "varchar(255) NOT NULL COMMENT 'Text for form field label (also friendly name for administering this field).'",
+          'label' => "varchar(255) NOT NULL DEFAULT ''  COMMENT 'Text for form field label (also friendly name for administering this field).'",
           'help_pre' => "text COMMENT 'Description and/or help text to display before this field.'",
           'help_post' => "text COMMENT 'Description and/or help text to display after this field.'",
         ],

--- a/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionPageTranslationTest.php
@@ -27,6 +27,7 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
     if ($dbLocale) {
       $this->disableMultilingual();
     }
+    $this->quickCleanup(['civicrm_contribution_page']);
     parent::tearDown();
   }
 
@@ -87,8 +88,6 @@ class CRM_Contribute_Form_ContributionPageTranslationTest extends CiviUnitTestCa
     $this->assertEquals('In Honor Text EN', $json['soft_credit']['en_US']['honor_block_text']);
     $this->assertEquals('In Honor Title FR', $json['soft_credit']['fr_FR']['honor_block_title']);
     $this->assertEquals('In Honor Text FR', $json['soft_credit']['fr_FR']['honor_block_text']);
-
-    $this->callAPISuccess('ContributionPage', 'delete', ['id' => $contributionPage->id]);
   }
 
 }

--- a/tests/phpunit/CRM/Core/I18n/SchemaTest.php
+++ b/tests/phpunit/CRM/Core/I18n/SchemaTest.php
@@ -19,7 +19,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
    * Test tables to translate
    * @return array
    */
-  public static function translateTables() {
+  public static function translateTables(): array {
     $tables = [];
     $tables[] = ['civicrm_option_group', 'civicrm_option_group_en_US'];
     $tables[] = ['civicrm_events_in_carts', 'civicrm_events_in_carts'];
@@ -41,9 +41,8 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
    * @param string $expectedRewrite
    *
    * @dataProvider translateTables
-   * @throws \CRM_Core_Exception
    */
-  public function testI18nSchemaRewrite($table, $expectedRewrite) {
+  public function testI18nSchemaRewrite(string $table, string $expectedRewrite): void {
     $this->enableMultilingual();
     $domains = $this->callAPISuccess('Domain', 'get')['values'];
     $this->assertGreaterThan(1, count($domains));
@@ -59,7 +58,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     }
     global $dbLocale;
     $dbLocale = '_en_US';
-    // Test problematic queriy as per CRM-20427
+    // Test problematic query as per CRM-20427
     $query = "Select * FROM {$table}";
     $new_query = CRM_Core_I18n_Schema::rewriteQuery($query);
     $this->assertEquals("Select * FROM {$expectedRewrite}", $new_query);
@@ -67,7 +66,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     $query2 = "Select * FROM {$table} LIMIT 1";
     $new_query2 = CRM_Core_I18n_Schema::rewriteQuery($query2);
     $this->assertEquals("Select * FROM {$expectedRewrite} LIMIT 1", $new_query2);
-    // Test query where there is a 2nd table that shouldn't be re-wrten
+    // Test query where there is a 2nd table that shouldn't be re-writen
     $query3 = "SELECT * FROM {$table} JOIN civicrm_contact LIMIT 1";
     $new_query3 = CRM_Core_I18n_Schema::rewriteQuery($query3);
     $this->assertEquals("SELECT * FROM {$expectedRewrite} JOIN civicrm_contact LIMIT 1", $new_query3);
@@ -84,7 +83,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     // Test Currently skipped for civicrm_option_group and civicrm_event due to issues with the regex.
     // Agreed as not a blocker for CRM-20427 as an issue previously.
     if (!$skip_tests) {
-      $query6 = "SELECT " . '"' . "Fixed the the {$table} ticket" . '"';
+      $query6 = 'SELECT ' . '"' . "Fixed the the {$table} ticket" . '"';
       $new_query6 = CRM_Core_I18n_Schema::rewriteQuery($query6);
       $this->assertEquals($query6, $new_query6);
     }
@@ -92,25 +91,28 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     $query7 = "SELECT * FROM civicrm_foo WHERE foo_id = (SELECT value FROM {$table})";
     $new_query7 = CRM_Core_I18n_Schema::rewriteQuery($query7);
     $this->assertEquals("SELECT * FROM civicrm_foo WHERE foo_id = (SELECT value FROM {$expectedRewrite})", $new_query7);
-    // Test differern verbs
+    // Test different verbs
     $query8 = "DELETE FROM {$table}";
     $new_query8 = CRM_Core_I18n_Schema::rewriteQuery($query8);
     $this->assertEquals("DELETE FROM {$expectedRewrite}", $new_query8);
     // Test Currently skipped for civicrm_option_group and civicrm_event due to issues with the regex.
     // Agreed as not a blocker for CRM-20427 as an issue previously
     if (!$skip_tests) {
-      $query9 = 'INSERT INTO ' . "{$table}" . ' (foo, bar) VALUES (123, "' . "Just a {$table} string" . '")';
+      $query9 = 'INSERT INTO ' . $table . ' (foo, bar) VALUES (123, "' . "Just a {$table} string" . '")';
       $new_query9 = CRM_Core_I18n_Schema::rewriteQuery($query9);
-      $this->assertEquals('INSERT INTO ' . "{$expectedRewrite}" . ' (foo, bar) VALUES (123, "' . "Just a {$table} string" . '")', $new_query9);
+      $this->assertEquals('INSERT INTO ' . $expectedRewrite . ' (foo, bar) VALUES (123, "' . "Just a {$table} string" . '")', $new_query9);
     }
   }
 
+  /**
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
   public function testSchemaBuild(): void {
     $this->enableMultilingual();
     $inUseCollation = CRM_Core_BAO_SchemaHandler::getInUseCollation();
-    $testCreateTable = CRM_Core_DAO::executeQuery("show create table civicrm_price_set", [], TRUE, NULL, FALSE, FALSE);
+    $testCreateTable = CRM_Core_DAO::executeQuery('SHOW create table civicrm_price_set', [], TRUE, NULL, FALSE, FALSE);
     while ($testCreateTable->fetch()) {
-      $this->assertStringContainsString("`title_en_US` varchar(255) COLLATE {$inUseCollation} NOT NULL COMMENT 'Displayed title for the Price Set.'", $testCreateTable->Create_Table);
+      $this->assertStringContainsString("`title_en_US` varchar(255) COLLATE {$inUseCollation} NOT NULL DEFAULT '' COMMENT 'Displayed title for the Price Set.'", $testCreateTable->Create_Table);
       $this->assertStringContainsString("`help_pre_en_US` text COLLATE {$inUseCollation} COMMENT 'Description and/or help text to display before fields in form.'", $testCreateTable->Create_Table);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#444 Default to blank for required multi-lingual fields

Before
----------------------------------------
MariaDB 10.5 or 10.6 do not work with multilingual unless strict mode is enabled per https://lab.civicrm.org/dev/core/-/issues/2581 because it tries to save & hits required fields for languages other than the one being saved to that it has no data for

After
----------------------------------------
The language specific fields have field defaults of an empty string where they are required

Technical Details
----------------------------------------
I was able to verify this locally (on an affected MariaDB) in the test that is cleaned up in this PR.

I thought giving all the translation fields a default of empty string, but opted for the smaller change that just addresses the affected fields

I don't think we need to do upgrades as this has never worked with this config combo 

Comments
----------------------------------------
