### PR TITLE
PHP8 date range not rendered correctly

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -2009,10 +2009,10 @@ class CRM_Utils_Date {
     }
     $thisYear = date('Y');
     if (isset($field['start_date_years'])) {
-      $extra['minDate'] = date('Y-m-d', strtotime('-' . ($thisYear - $field['start_date_years']) . ' years'));
+      $extra['minDate'] = date('Y-m-d', strtotime((-1 * ($thisYear - $field['start_date_years'])) . ' years'));
     }
     if (isset($field['end_date_years'])) {
-      $extra['maxDate'] = date('Y-m-d', strtotime('-' . ($thisYear - $field['end_date_years']) . ' years'));
+      $extra['maxDate'] = date('Y-m-d', strtotime((-1 * ($thisYear - $field['end_date_years'])) . ' years'));
     }
     return $extra;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/45480/datepicker-issue-on-membership-and-contribution-edit-pages

Before
----------------------------------------
<img width="574" alt="Screenshot 2023-08-31 at 10 15 11" src="https://github.com/civicrm/civicrm-core/assets/2053075/ca169679-8bdd-426a-9676-683376e9ee40">


After
----------------------------------------
<img width="574" alt="Screenshot 2023-08-31 at 10 15 11" src="https://github.com/civicrm/civicrm-core/assets/2053075/c018915a-7114-48eb-9eec-10b18088128b">
