### PR TITLE
Cleanup presentation of total to improve code & reduce notices

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -359,7 +359,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       CRM_Core_Error::deprecatedFunctionWarning('forms require a price set ID');
     }
     $this->_priceSet = $this->get('priceSet');
-
+    $this->assign('quickConfig', $this->isQuickConfig());
     if (!$this->_values) {
       // get all the values from the dao object
       $this->_values = [];
@@ -410,7 +410,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       ));
 
       $this->assignPaymentProcessor($isPayLater);
-      $this->assign('quickConfig', $this->isQuickConfig());
       // get price info
       // CRM-5095
       $this->initSet($this);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -301,6 +301,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $priceSetID = $this->getPriceSetID();
       if ($priceSetID) {
         self::initEventFee($this, $this->_eventId, TRUE, $priceSetID);
+        $this->assign('quickConfig', $this->isQuickConfig());
       }
 
       // get the profile ids
@@ -583,15 +584,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       CRM_Core_Error::deprecatedWarning('this should not be reachable');
       return;
     }
-    //check if price set is is_config
-    if (is_numeric($priceSetId)) {
-      if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config') && $form->getVar('_name') != 'Participant') {
-        $form->assign('quickConfig', 1);
-      }
-      else {
-        $form->assign('quickConfig', 0);
-      }
-    }
+
     // get price info
     if ($priceSetId) {
       if ($form->_action & CRM_Core_Action::UPDATE) {
@@ -1714,6 +1707,15 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->set('priceSetId', $this->_priceSetId);
     }
     return $this->_priceSetId ?: NULL;
+  }
+
+  /**
+   * Is the price set quick config.
+   *
+   * @return bool
+   */
+  public function isQuickConfig(): bool {
+    return $this->getPriceSetID() && CRM_Price_BAO_PriceSet::isQuickConfig($this->getPriceSetID());
   }
 
 }

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -548,12 +548,7 @@ WHERE  id = %1";
    */
   public static function initSet(&$form, $entityTable = 'civicrm_event', $doNotIncludeExpiredFields = FALSE, $priceSetId = NULL) {
     CRM_Core_Error::deprecatedFunctionWarning('no alternative');
-    //check if price set is is_config
-    if (is_numeric($priceSetId)) {
-      if (CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config') && $form->getVar('_name') != 'Participant') {
-        $form->assign('quickConfig', 1);
-      }
-    }
+
     // get price info
     if ($priceSetId) {
       if ($form->_action & CRM_Core_Action::UPDATE) {
@@ -809,7 +804,6 @@ WHERE  id = %1";
     $priceSet = self::getSetDetail($priceSetId, TRUE, $validFieldsOnly);
     $form->_priceSet = $priceSet[$priceSetId] ?? NULL;
     $validPriceFieldIds = array_keys($form->_priceSet['fields']);
-    $form->assign('quickConfig', (int) CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceSet', $priceSetId, 'is_quick_config'));
 
     // Mark which field should have the auto-renew checkbox, if any. CRM-18305
     if (!empty($form->_membershipTypeValues) && is_array($form->_membershipTypeValues)) {

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -10,7 +10,7 @@
 {* this template is used for adding/editing/deleting contributions and pledge payments *}
 
 {if $priceSetId}
-  {include file="CRM/Price/Form/PriceSet.tpl" context="standalone" extends="Contribution"}
+  {include file="CRM/Price/Form/PriceSet.tpl" context="standalone" extends="Contribution" hideTotal=false}
 {elseif !empty($showAdditionalInfo) and !empty($formType)}
   {include file="CRM/Contribute/Form/AdditionalInfo/$formType.tpl"}
 {else}

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -95,7 +95,7 @@
       {/if}
     {else}
       <div id="priceset-div">
-        {include file="CRM/Price/Form/PriceSet.tpl" extends="Contribution"}
+        {include file="CRM/Price/Form/PriceSet.tpl" extends="Contribution" hideTotal=$quickConfig}
       </div>
     {/if}
 

--- a/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/MainMembershipBlock.tpl
@@ -47,7 +47,7 @@
           {/if}
         {/foreach}
       {/if}
-      {include file="CRM/Price/Form/PriceSet.tpl" extends="Membership"}
+      {include file="CRM/Price/Form/PriceSet.tpl" extends="Membership" hideTotal=$quickConfig}
     </fieldset>
   </div>
   {literal}

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -40,7 +40,7 @@
           <fieldset id="priceset" class="crm-group priceset-group">
             <tr class="crm-event-eventfees-form-block-price_set_amount">
             <td class="label" style="padding-top: 10px;">{$form.amount.label}</td>
-            <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event"}</td>
+            <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event" hideTotal=false}</td>
           </fieldset>
         {else}
           {assign var=isRecordPayment value=0 }

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -114,7 +114,7 @@ CRM.$(function($) {
       <table class='form-layout'>
         <tr class="crm-event-eventfees-form-block-price_set_amount">
           <td class="label" style="padding-top: 10px;">{$form.amount.label}</td>
-          <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event" noCalcValueDisplay=0 context="participant"}</table></td>
+          <td class="view-value"><table class="form-layout">{include file="CRM/Price/Form/PriceSet.tpl" extends="Event" hideTotal=false context="participant"}</table></td>
         </tr>
      {if $paymentInfo}
        <tr><td></td><td>
@@ -126,7 +126,7 @@ CRM.$(function($) {
          </div>
          <div class='label'><strong>{ts}Balance Owed{/ts}</strong></div><div class='content'><strong id='balance-fee'></strong></div>
           </div>
-       {include file='CRM/Price/Form/Calculate.tpl' currencySymbol=$currencySymbol noCalcValueDisplay=1 displayOveride='true'}
+       {include file='CRM/Price/Form/Calculate.tpl' currencySymbol=$currencySymbol hideTotal=1 displayOveride='true'}
        {/if}
       </table>
     </fieldset>

--- a/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
+++ b/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
@@ -36,7 +36,7 @@
 <div class="crm-event-id-{$event.id} crm-block crm-event-additionalparticipant-form-block">
 {if $priceSet}
      <fieldset id="priceset" class="crm-public-form-item crm-group priceset-group"><legend>{$event.fee_label}</legend>
-        {include file="CRM/Price/Form/PriceSet.tpl" extends="Event"}
+        {include file="CRM/Price/Form/PriceSet.tpl" extends="Event" hideTotal=false}
     </fieldset>
 {else}
     {if $paidEvent}

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -81,7 +81,7 @@
     {if $priceSet}
       {if ! $quickConfig}<fieldset id="priceset" class="crm-public-form-item crm-group priceset-group">
         <legend>{$event.fee_label}</legend>{/if}
-      {include file="CRM/Price/Form/PriceSet.tpl" extends="Event"}
+      {include file="CRM/Price/Form/PriceSet.tpl" extends="Event" hideTotal=$quickConfig}
       {include file="CRM/Price/Form/ParticipantCount.tpl"}
       {if ! $quickConfig}</fieldset>{/if}
     {/if}

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -19,7 +19,7 @@
 {/if}
 <div class="spacer"></div>
 {if $priceSetId}
-  {include file="CRM/Price/Form/PriceSet.tpl" context="standalone" extends="Membership"}
+  {include file="CRM/Price/Form/PriceSet.tpl" context="standalone" extends="Membership"  hideTotal=false}
   {literal}
   <script type="text/javascript">
   CRM.$(function($) {
@@ -89,7 +89,7 @@
               <span id='totalAmountORPriceSet'> {ts}OR{/ts}</span>
               <span id='selectPriceSet'>{$form.price_set_id.html}</span>
               {if $buildPriceSet && $priceSet}
-                <div id="priceset"><br/>{include file="CRM/Price/Form/PriceSet.tpl" extends="Membership"}</div>
+                <div id="priceset"><br/>{include file="CRM/Price/Form/PriceSet.tpl" extends="Membership" hideTotal=false}</div>
                 {else}
                 <div id="priceset" class="hiddenElement"></div>
               {/if}

--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -8,8 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 
-{assign var='hideTotal' value=$quickConfig+$noCalcValueDisplay}
-
 <div id="pricesetTotal" class="crm-section section-pricesetTotal">
   <div id="pricelabel" class="label {if $hideTotal}hiddenElement{/if}">
     {if ($extends eq 'Contribution') || ($extends eq 'Membership')}

--- a/templates/CRM/Price/Form/Preview.tpl
+++ b/templates/CRM/Price/Form/Preview.tpl
@@ -20,7 +20,7 @@
     {foreach from=$groupTree item=priceSet key=group_id}
       <fieldset>
         {if $preview_type eq 'group'}<legend>{$setTitle}</legend>{/if}
-        {include file="CRM/Price/Form/PriceSet.tpl"}
+        {include file="CRM/Price/Form/PriceSet.tpl" hideTotal=false}
       </fieldset>
     {/foreach}
   {/strip}


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup presentation of total to improve code & reduce notices

Before
----------------------------------------
The determination of whether to show the total for a price set is made in `calculate.tpl` based on `$quickConfig` and `$noCalcValueDisplay`. The latter is mostly not assigned, causing notices. The former is 'badly assigned' - ie the value assigned is 0 rather than the correct value in the Participant form to prevent the total from being suppressed.

```
{assign var='hideTotal' value=$quickConfig+$noCalcValueDisplay}
```


After
----------------------------------------
I concluded that 

1) it's clearer to assign `hideTotal` appropriately rather than fight with 2 other variables
2) it's OK to always show totals on back office forms - hence passing in false via tpl from them
3) there is one place where a back office form is taking specific action to set `$noCalcValueDisplay` - this might well be historical rather than logical but I opted to just alter that to `hideTotal` to preserve the behaviour
4) the front end forms can continute to set `hideTotal` based on whether `quickConfig` is true
5) some code can come out as a result

Afterwards quickConfig is only used by smarty in these places

![image](https://github.com/civicrm/civicrm-core/assets/336308/b340d68a-9773-41cb-8fb9-84e64d32aa38)
![image](https://github.com/civicrm/civicrm-core/assets/336308/e4aa3315-b3ff-4de1-b228-f8ea99483e2b)


Some after r-run screenshots

back-office quick config
![image](https://github.com/civicrm/civicrm-core/assets/336308/64867ccd-f166-4320-b4c6-0dd4d67e5ef8)


Front end quick config 
![image](https://github.com/civicrm/civicrm-core/assets/336308/ce5ff030-7f3b-46e0-a619-415b1f28ba94)


Separate membership payment

![image](https://github.com/civicrm/civicrm-core/assets/336308/77b8bdb2-69af-4c90-bac3-e2236b39dec0)

Change fee selections
![image](https://github.com/civicrm/civicrm-core/assets/336308/e0fc61d2-5c9f-46ff-a027-9004ecdeee23)


Technical Details
----------------------------------------

Comments
----------------------------------------
