### PR TITLE
Add custom field type Hidden

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1132,6 +1132,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
 
         $qf->assign('customUrls', $customUrls);
         break;
+
+      case 'Hidden':
+        $element = $qf->add('hidden', $elementName);
+        break;
     }
 
     switch ($field->data_type) {
@@ -2221,7 +2225,7 @@ WHERE  id IN ( %1, %2 )
 
     // create any option group & values if required
     $allowedOptionTypes = ['String', 'Int', 'Float', 'Money'];
-    if ($htmlType !== 'Text' && in_array($dataType, $allowedOptionTypes, TRUE)) {
+    if (!in_array($htmlType, ['Text', 'Hidden'], TRUE) && in_array($dataType, $allowedOptionTypes, TRUE)) {
       //CRM-16659: if option_value then create an option group for this custom field.
       // An option_type of 2 would be a 'message' from the form layer not to handle
       // the option_values key. If not set then it is not ignored.

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -219,6 +219,11 @@ class CRM_Core_SelectValues {
         'name' => 'Link',
         'label' => ts('Link'),
       ],
+      [
+        'id' => 'Hidden',
+        'name' => 'Hidden',
+        'label' => ts('Hidden'),
+      ],
     ];
   }
 

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -58,10 +58,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
    * @var array[]
    */
   public static $_dataToHTML = [
-    'String' => ['Text', 'Select', 'Radio', 'CheckBox', 'Autocomplete-Select'],
-    'Int' => ['Text', 'Select', 'Radio'],
-    'Float' => ['Text', 'Select', 'Radio'],
-    'Money' => ['Text', 'Select', 'Radio'],
+    'String' => ['Text', 'Select', 'Radio', 'CheckBox', 'Autocomplete-Select', 'Hidden'],
+    'Int' => ['Text', 'Select', 'Radio', 'Hidden'],
+    'Float' => ['Text', 'Select', 'Radio', 'Hidden'],
+    'Money' => ['Text', 'Select', 'Radio', 'Hidden'],
     'Memo' => ['TextArea', 'RichTextEditor'],
     'Date' => ['Select Date'],
     'Boolean' => ['Radio'],

--- a/CRM/Custom/Page/Field.php
+++ b/CRM/Custom/Page/Field.php
@@ -133,27 +133,9 @@ class CRM_Custom_Page_Field extends CRM_Core_Page {
         $action -= CRM_Core_Action::DISABLE;
       }
 
-      switch ($customFieldBAO->data_type) {
-        case "String":
-        case "Int":
-        case "Float":
-        case "Money":
-          // if Multi Select field is selected in custom field
-          if ($customFieldBAO->html_type == 'Text') {
-            $action -= CRM_Core_Action::BROWSE;
-          }
-          break;
-
-        case "ContactReference":
-        case "Memo":
-        case "Date":
-        case "Boolean":
-        case "StateProvince":
-        case "Country":
-        case "File":
-        case "Link":
-          $action -= CRM_Core_Action::BROWSE;
-          break;
+      // Remove link to edit option group if there isn't one
+      if (!$customFieldBAO->option_group_id) {
+        $action -= CRM_Core_Action::BROWSE;
       }
 
       $customFieldDataType = array_column(CRM_Core_BAO_CustomField::dataType(), 'label', 'id');

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -325,6 +325,7 @@ class BasicGetFieldsAction extends BasicGetAction {
           'Email' => ts('Email'),
           'EntityRef' => ts('Autocomplete Entity'),
           'File' => ts('File'),
+          'Hidden' => ts('Hidden'),
           'Location' => ts('Address Location'),
           'Number' => ts('Number'),
           'Radio' => ts('Radio Buttons'),

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -181,6 +181,7 @@
             return !(defn.options || defn.data_type === 'Boolean');
 
           case 'DisplayOnly':
+          case 'Hidden':
             return true;
 
           default:

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Hidden.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Hidden.html
@@ -1,0 +1,1 @@
+<div class="form-inline"></div>

--- a/ext/afform/core/ang/af/fields/Hidden.html
+++ b/ext/afform/core/ang/af/fields/Hidden.html
@@ -1,0 +1,1 @@
+<input type="hidden" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" >

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -14,7 +14,12 @@
     <td class="html-adjust description">{$element.help_pre}</td>
   </tr>
 {/if}
-{if $element.options_per_line}
+{if $element.html_type === 'Hidden'}
+  {* Hidden field - render in hidden row *}
+  <tr class="custom_field-row {$element.element_name}-row hiddenElement">
+    <td>{$formElement.html}</td>
+  </tr>
+{elseif $element.options_per_line}
   <tr class="custom_field-row {$element.element_name}-row">
     <td class="label">{$formElement.label}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -270,7 +270,7 @@
       }
 
       if (_.includes(['String', 'Int', 'Float', 'Money'], dataType)) {
-        if (htmlType !== "Text") {
+        if (!['Text', 'Hidden'].includes(htmlType)) {
           $("#showoption, #searchable", $form).show();
           $("#hideDefault, #hideDesc, #searchByRange", $form).hide();
         } else {
@@ -289,7 +289,7 @@
         $("#showoption").hide();
       }
 
-      if (_.includes(['String', 'Int', 'Float', 'Money'], dataType) && htmlType !== 'Text') {
+      if (_.includes(['String', 'Int', 'Float', 'Money'], dataType) && !['Text', 'Hidden'].includes(htmlType)) {
         if (serialize) {
           $('div[id^=checkbox]', '#optionField').show();
           $('div[id^=radio]', '#optionField').hide();

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -52,7 +52,7 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
       ->execute();
   }
 
-  public function testDisabledFields(): void {
+  public function testDisabledAndHiddenFields(): void {
     // Create a custom group with one enabled and one disabled field
     CustomGroup::create(FALSE)
       ->addValue('extends', 'Activity')
@@ -62,14 +62,20 @@ class CustomFieldGetFieldsTest extends CustomTestBase {
       'records' => [
         ['label' => 'enabled_field'],
         ['label' => 'disabled_field', 'is_active' => FALSE],
+        ['label' => 'hidden_field', 'html_type' => 'Hidden'],
       ],
       'defaults' => ['custom_group_id.name' => 'act_test_grp'],
     ]);
 
-    // Only the enabled field shows up
-    $getFields = Activity::getFields(FALSE)->execute()->column('name');
-    $this->assertContains('act_test_grp.enabled_field', $getFields);
-    $this->assertNotContains('act_test_grp.disabled_field', $getFields);
+    // Only the enabled fields show up
+    $getFields = Activity::getFields(FALSE)->execute()->indexBy('name');
+    $this->assertArrayHasKey('act_test_grp.enabled_field', $getFields);
+    $this->assertArrayHasKey('act_test_grp.hidden_field', $getFields);
+    $this->assertArrayNotHasKey('act_test_grp.disabled_field', $getFields);
+
+    // Hidden field does not have option lists
+    $this->assertFalse($getFields['act_test_grp.hidden_field']['options']);
+    $this->assertNull($getFields['act_test_grp.hidden_field']['suffixes']);
 
     // Disable the entire custom group
     CustomGroup::update(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Adds a "hidden" custom field type which can collect data on forms without being seen (e.g. by storing a value from the url or set by javascript)

Technical Details
------------
- Adds a custom field html_type (aka input_type) of "hidden"
- Also adds a "hidden" input_type to FormBuilder
- This effectively hides the field and the label on any core form, profile, or FormBuilder form.
- This improves the flexibility of FormBuilder. FormBuilder already allows input_types to be changed on a per-form basis, and this adds to the available options. So hidden fields can be un-hidden (widget changed to Textfield) and conversely, regular fields can now be changed to hidden.
- Profiles aren't very flexible, and don't allow html_types to be changed. A hidden field will be that way on every profile.