### PR TITLE
APIv4 - Add missing input type options

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -327,8 +327,10 @@ class BasicGetFieldsAction extends BasicGetAction {
           'Location' => ts('Address Location'),
           'Number' => ts('Number'),
           'Radio' => ts('Radio Buttons'),
+          'RichTextEditor' => ts('Rich Text Editor'),
           'Select' => ts('Select'),
-          'Text' => ts('Text'),
+          'Text' => ts('Single-Line Text'),
+          'TextArea' => ts('Multi-Line Text'),
         ],
       ],
       [


### PR DESCRIPTION
Overview
----------------------------------------
Makes APIv4 aware of a couple more input types (both core and custom fields can have these types).