### PR TITLE
dev/core#4537 Ensure that Event Registration email works when CiviCon…

### DIFF
--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -67,6 +67,10 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    */
   protected $participantContacts;
 
+  private function isCiviContributeEnabled(): bool {
+    return array_key_exists('Contribution', \Civi::service('action_object_provider')->getEntities());
+  }
+
   /**
    * @param array $participantContacts
    *
@@ -93,7 +97,7 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    */
   public function setParticipantID(int $participantID) {
     $this->participantID = $participantID;
-    if (!$this->getContributionID()) {
+    if (!$this->getContributionID() && $this->isCiviContributeEnabled()) {
       $lineItem = LineItem::get(FALSE)
         ->addWhere('entity_table', '=', 'civicrm_participant')
         ->addWhere('entity_id', '=', $participantID)
@@ -186,34 +190,36 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
       }
       // Initiate with the current participant to ensure they are first.
       $participants = [$this->participantID => ['id' => $this->participantID, 'tax_rate_breakdown' => []]];
-      foreach ($this->getLineItems() as $lineItem) {
-        if ($lineItem['entity_table'] === 'civicrm_participant') {
-          $participantID = $lineItem['entity_id'];
+      if ($this->isCiviContributeEnabled()) {
+        foreach ($this->getLineItems() as $lineItem) {
+          if ($lineItem['entity_table'] === 'civicrm_participant') {
+            $participantID = $lineItem['entity_id'];
+          }
+          else {
+            // It is not clear if this could ever be true - testing the CiviCRM event
+            // form shows all line items assigned to participants but we should
+            // assign to primary if this can occur.
+            $participantID = $this->getPrimaryParticipantID();
+          }
+          $participants[$participantID]['line_items'][] = $lineItem;
+          if (!isset($participants[$participantID]['totals'])) {
+            $participants[$participantID]['totals'] = ['total_amount_exclusive' => 0, 'tax_amount' => 0, 'total_amount_inclusive' => 0];
+          }
+          $participants[$participantID]['totals']['total_amount_exclusive'] += $lineItem['line_total'];
+          $participants[$participantID]['totals']['tax_amount'] += $lineItem['tax_amount'];
+          $participants[$participantID]['totals']['total_amount_inclusive'] += ($lineItem['line_total'] + $lineItem['tax_amount']);
+          if (!isset($participants[$participantID]['tax_rate_breakdown'])) {
+            $participants[$participantID]['tax_rate_breakdown'] = [];
+          }
+          if (!isset($participants[$participantID]['tax_rate_breakdown'][$lineItem['tax_rate']])) {
+            $participants[$participantID]['tax_rate_breakdown'][$lineItem['tax_rate']] = [
+              'amount' => 0,
+              'rate' => $lineItem['tax_rate'],
+              'percentage' => sprintf('%.2f', $lineItem['tax_rate']),
+            ];
+          }
+          $participants[$participantID]['tax_rate_breakdown'][$lineItem['tax_rate']]['amount'] += $lineItem['tax_amount'];
         }
-        else {
-          // It is not clear if this could ever be true - testing the CiviCRM event
-          // form shows all line items assigned to participants but we should
-          // assign to primary if this can occur.
-          $participantID = $this->getPrimaryParticipantID();
-        }
-        $participants[$participantID]['line_items'][] = $lineItem;
-        if (!isset($participants[$participantID]['totals'])) {
-          $participants[$participantID]['totals'] = ['total_amount_exclusive' => 0, 'tax_amount' => 0, 'total_amount_inclusive' => 0];
-        }
-        $participants[$participantID]['totals']['total_amount_exclusive'] += $lineItem['line_total'];
-        $participants[$participantID]['totals']['tax_amount'] += $lineItem['tax_amount'];
-        $participants[$participantID]['totals']['total_amount_inclusive'] += ($lineItem['line_total'] + $lineItem['tax_amount']);
-        if (!isset($participants[$participantID]['tax_rate_breakdown'])) {
-          $participants[$participantID]['tax_rate_breakdown'] = [];
-        }
-        if (!isset($participants[$participantID]['tax_rate_breakdown'][$lineItem['tax_rate']])) {
-          $participants[$participantID]['tax_rate_breakdown'][$lineItem['tax_rate']] = [
-            'amount' => 0,
-            'rate' => $lineItem['tax_rate'],
-            'percentage' => sprintf('%.2f', $lineItem['tax_rate']),
-          ];
-        }
-        $participants[$participantID]['tax_rate_breakdown'][$lineItem['tax_rate']]['amount'] += $lineItem['tax_amount'];
       }
 
       $count = 1;

--- a/Civi/Test/EventTestTrait.php
+++ b/Civi/Test/EventTestTrait.php
@@ -78,7 +78,7 @@ trait EventTestTrait {
   }
 
   /**
-   * Create a paid event.
+   * Create an unpaid event.
    *
    * @param array $eventParameters
    *   Values to

--- a/Civi/Token/TokenCompatSubscriber.php
+++ b/Civi/Token/TokenCompatSubscriber.php
@@ -56,7 +56,12 @@ class TokenCompatSubscriber implements EventSubscriberInterface {
    */
   public function onRender(TokenRenderEvent $e): void {
     $useSmarty = !empty($e->context['smarty']);
-    $e->string = $e->getTokenProcessor()->visitTokens($e->string, function() {
+    $e->string = $e->getTokenProcessor()->visitTokens($e->string, function($token = NULL, $entity = NULL, $field = NULL, $filterParams = NULL) {
+      if ($filterParams && $filterParams[0] === 'boolean') {
+        // This token was missed during primary rendering, and it's supposed to be coerced to boolean.
+        // Treat an unknown token as false-y.
+        return 0;
+      }
       // For historical consistency, we filter out unrecognized tokens.
       return '';
     });

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -721,4 +721,37 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     ], $submitValues));
   }
 
+  public function testRegistrationWithoutCiviContributeEnabled(): void {
+    $mut = new CiviMailUtils($this, TRUE);
+    $event = $this->eventCreateUnpaid([
+      'has_waitlist' => 1,
+      'max_participants' => 1,
+      'start_date' => 20351021,
+      'end_date' => 20351023,
+      'registration_end_date' => 20351015,
+    ]);
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
+    $this->submitForm(
+      $event['id'], [
+        [
+          'first_name' => 'Bruce No Contribute',
+          'last_name' => 'Wayne',
+          'email-Primary' => 'bruce@gotham.com',
+          'is_primary' => 1,
+          'is_pay_later' => 0,
+          'campaign_id' => NULL,
+          'defaultRole' => 1,
+          'participant_role_id' => '1',
+          'button' => '_qf_Register_upload',
+        ],
+      ]
+    );
+    $mut->checkMailLog([
+      'Dear Bruce No Contribute,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
+    ]);
+    $mut->stop();
+    $mut->clearMessages();
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviContribute');
+  }
+
 }


### PR DESCRIPTION
…tribute component is disabled and add unit test

Overview
----------------------------------------
This fixes an issue where performing an event registration without the CiviContribute Component / Extension enabled errors because LineItem APIv4 class isn't present and also fixes issues with smarty template rendering in similar

Before
----------------------------------------
Event Registration fails without CiviContribute enabled

After
----------------------------------------
Works

ping @eileenmcnaughton @totten @MegaphoneJon 