### PR TITLE
Use internal variable rather than undeclared property

### DIFF
--- a/CRM/Contact/Form/CustomData.php
+++ b/CRM/Contact/Form/CustomData.php
@@ -97,7 +97,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
       if (!empty($entityId)) {
         $subType = CRM_Contact_BAO_Contact::getContactSubType($entityId, ',');
       }
-      CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, NULL, NULL, $entityId);
+      CRM_Custom_Form_CustomData::preProcess($this, NULL, $subType, NULL, CRM_Utils_Request::retrieve('type', 'String', $this), $entityId);
       if ($this->_multiRecordDisplay) {
         $this->_groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this);
         $this->_tableID = $this->_entityId;
@@ -215,7 +215,7 @@ class CRM_Contact_Form_CustomData extends CRM_Core_Form {
     if ($this->_cdType || $this->_multiRecordDisplay == 'single') {
       if ($this->_copyValueId) {
         // cached tree is fetched
-        $groupTree = CRM_Core_BAO_CustomGroup::getTree($this->_type,
+        $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contact',
           NULL,
           $this->_entityId,
           $this->_groupID,

--- a/CRM/Custom/Form/CustomData.php
+++ b/CRM/Custom/Form/CustomData.php
@@ -82,11 +82,9 @@ class CRM_Custom_Form_CustomData {
     &$form, $extendsEntityColumn = NULL, $subType = NULL,
     $groupCount = NULL, $type = NULL, $entityID = NULL, $onlySubType = NULL
   ) {
-    if ($type) {
-      $form->_type = $type;
-    }
-    else {
-      $form->_type = CRM_Utils_Request::retrieve('type', 'String', $form);
+    if (!$type) {
+      CRM_Core_Error::deprecatedWarning('type should be passed in');
+      $type = CRM_Utils_Request::retrieve('type', 'String', $form);
     }
 
     if (!isset($subType)) {
@@ -150,7 +148,7 @@ class CRM_Custom_Form_CustomData {
       $singleRecord = 'new';
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree($form->_type,
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree($type,
       NULL,
       $form->_entityId,
       $gid,


### PR DESCRIPTION
Overview
----------------------------------------
Use internal variable rather than undeclared property

Before
----------------------------------------
The property `$_type` is used in 3 flows which do not interact
- this custom data flow
- a payment form flow
- an internal QF flow
- a mailing action flow

In the context of this flow the propery is not set on any of the forms and is only used in 1 place outside of the specific function (+ 1 deprecated code place)

In the case of the one place it is set - that is specifically reached by using the copy function on a multiple field records
![image](https://github.com/civicrm/civicrm-core/assets/336308/6bb19757-91ad-42d6-920e-6d4dee78da72)

which takes the user to 

![image](https://github.com/civicrm/civicrm-core/assets/336308/b95b3f23-da2c-4a11-8123-b93e44fb289c)

In this case the type will always be a variant of 'Contact' (as we only support multiple record fields for contacts). In addition the group tree function should not care because it already has the id of the civicrm_custom_group to be loaded. However, since it DOES apply a where event when the id is provided, I switched to hard-coding in 'Contact'. I think the right fix is to not require a type when the id is present. We could still get it from the url - that ALSO feels brittle



After
----------------------------------------
Php 8 will be less upset (but still upset) - less uses of this property name

![image](https://github.com/civicrm/civicrm-core/assets/336308/b6cfeb37-b4c9-414e-af74-620c3eb889fb)

Technical Details
----------------------------------------
The gdpr extension calls the deprecated code place. It DOES set the ->_type that is used in the deprecated code

![image](https://github.com/civicrm/civicrm-core/assets/336308/050cc4e5-45c0-4278-b6ea-ef9fbd97004a)

Comments
----------------------------------------
