### PR TITLE
php 8.x Use internal property rather than undefined _type

### DIFF
--- a/CRM/Core/Payment/ProcessorForm.php
+++ b/CRM/Core/Payment/ProcessorForm.php
@@ -31,16 +31,10 @@ class CRM_Core_Payment_ProcessorForm {
    * @throws Exception
    */
   public static function preProcess(&$form, $type = NULL, $mode = NULL) {
+    $type = $type ?: CRM_Utils_Request::retrieve('type', 'String', $form);
     if ($type) {
-      $form->_type = $type;
-    }
-    else {
-      $form->_type = CRM_Utils_Request::retrieve('type', 'String', $form);
-    }
-
-    if ($form->_type) {
       // @todo not sure when this would be true. Never passed in.
-      $form->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($form->_type, $form->_mode);
+      $form->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getPayment($type, $form->_mode);
     }
 
     if (empty($form->_paymentProcessor)) {


### PR DESCRIPTION
Per analysis on https://github.com/civicrm/civicrm-core/pull/27240 - this usage of _type is not referred to from outside of this function

![image](https://github.com/civicrm/civicrm-core/assets/336308/141a8076-c502-48b1-b692-b02554a0eaea)



**After this....**

![image](https://github.com/civicrm/civicrm-core/assets/336308/74a0fdc7-aac2-499c-9d50-20384bbc58ba)
