### PR TITLE
End users are shown this nonsensical message: "There mig…

### DIFF
--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -109,8 +109,6 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
         // Note that for free events there won't be a participant payment either hence moving the status message into the if statement.
         $participantPayment = civicrm_api3('ParticipantPayment', 'get', ['participant_id' => $participantID])['values'];
         if (!empty($participantPayment)) {
-          // no ts() since this should be rare
-          CRM_Core_Session::setStatus('There might be a data problem, contribution id could not be loaded from the line item');
           $participantPayment = reset($participantPayment);
           $this->setContributionID((int) $participantPayment['contribution_id']);
         }


### PR DESCRIPTION
…ht be a data problem, contribution id could not be loaded from the line item"

Overview
----------------------------------------
This message should have been removed in https://github.com/civicrm/civicrm-core/pull/27221

Before
----------------------------------------
End users may be shown this nonsensical message on the website: _There might be a data problem, contribution id could not be loaded from the line item_

After
----------------------------------------
End users are not shown this message on the website.

Technical Details
----------------------------------------

Comments
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4538
https://lab.civicrm.org/dev/core/-/issues/4441

Agileware Ref: CIVICRM-2168