### PR TITLE
avoid double clicks on petition page

### DIFF
--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -117,6 +117,13 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
   protected $_image_URL;
 
   /**
+   * Prevent double clicks from creating duplicate or blank records.
+   *
+   * @var bool
+   */
+  public $submitOnce = TRUE;
+
+  /**
    */
   public function __construct() {
     parent::__construct();


### PR DESCRIPTION
Overview
----------------------------------------
Avoid double clicks of a Petition, following the lead set by [this PR](https://github.com/civicrm/civicrm-core/pull/19610).

Before
----------------------------------------

Periodically, I see a pattern in petition signatures: One regular signature followed by one signature in which the contact name, address and email are empty. There is nothing in the contact record except the petition signature activity.  The timestamps are the same. I can't be sure this is a double click, but it seems likely (and unfortunatley I can't figure out how to replicate - no matter how hard and fast I click my little mouse I still only get one signature).

After
----------------------------------------

Well, to be honest, nothing detectable by me has changed. However, signing still works and I am hoping we stop getting the double signature.


Comments
----------------------------------------

Open to suggestions on how to properly test or alternative theories on why this might be happening. Thanks!
