### PR TITLE
SearchKit - Fix autocomplete filters on in-place-edit fields

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -25,6 +25,7 @@
         this.field = {
           data_type: col.edit.data_type,
           input_type: col.edit.input_type,
+          entity: col.edit.entity,
           name: col.edit.value_key,
           options: col.edit.options,
           fk_entity: col.edit.fk_entity,


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:

1. SearchKit - Search for contacts
2. Add "Current Employer ID" field
3. Add a table display and make it editable
4. Preview the display and try in-place-editing an employer

Before
----------------------------------------
List shows all contact types

After
----------------------------------------
Iist is filtered correctly to Organization contact types

Technical Details
----------------------------------------
The callback needs the entity name as well as the field name.
