### PR TITLE
[REF] - Cleanup managed entities to all go through `hook_civicrm_managed` and deprecate unnamed entities

### DIFF
--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -53,20 +53,6 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
 
   /**
    * @inheritDoc
-   * @return array
-   * @throws CRM_Core_Exception
-   */
-  public function getManagedEntities() {
-    $entities = array_merge(
-      CRM_Case_ManagedEntities::createManagedCaseTypes(),
-      CRM_Case_ManagedEntities::createManagedActivityTypes(CRM_Case_XMLRepository::singleton(), CRM_Core_ManagedEntities::singleton()),
-      CRM_Case_ManagedEntities::createManagedRelationshipTypes(CRM_Case_XMLRepository::singleton(), CRM_Core_ManagedEntities::singleton())
-    );
-    return $entities;
-  }
-
-  /**
-   * @inheritDoc
    * @param bool $getAllUnconditionally
    * @param bool $descriptions
    *   Whether to return permission descriptions

--- a/CRM/Core/Component/Info.php
+++ b/CRM/Core/Component/Info.php
@@ -140,17 +140,6 @@ abstract class CRM_Core_Component_Info {
   abstract public function getInfo();
 
   /**
-   * Get a list of entities to register via API.
-   *
-   * @return array
-   *   list of entities; same format as CRM_Utils_Hook::managedEntities(&$entities)
-   * @see CRM_Utils_Hook::managedEntities
-   */
-  public function getManagedEntities() {
-    return [];
-  }
-
-  /**
    * Provides permissions that are unwise for Anonymous Roles to have.
    *
    * @return array

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -523,12 +523,6 @@ class CRM_Core_ManagedEntities {
    */
   protected function getDeclarations($modules = NULL): array {
     $declarations = [];
-    // Exclude components if given a module name.
-    if (!$modules || $modules === ['civicrm']) {
-      foreach (CRM_Core_Component::getEnabledComponents() as $component) {
-        $declarations = array_merge($declarations, $component->getManagedEntities());
-      }
-    }
     CRM_Utils_Hook::managed($declarations, $modules);
     $this->validate($declarations);
     foreach (array_keys($declarations) as $name) {

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -525,8 +525,16 @@ class CRM_Core_ManagedEntities {
     $declarations = [];
     CRM_Utils_Hook::managed($declarations, $modules);
     $this->validate($declarations);
-    foreach (array_keys($declarations) as $name) {
-      $declarations[$name] += ['name' => $name];
+    // FIXME: Some well-meaning developer added this a long time ago to support associative arrays
+    // that use the array index as the declaration name. But it probably never worked, because by the time it gets to this point,
+    // lots of implementations of `hook_civicrm_managed()` would have run `$declarations = array_merge($declarations, [...])`
+    // which would have reset the indexes.
+    // Adding a noisy deprecation notice for now, then we should remove this block:
+    foreach ($declarations as $index => $declaration) {
+      if (empty($declaration['name'])) {
+        CRM_Core_Error::deprecatedWarning(sprintf('Managed entity "%s" declared by extension "%s" without a name.', $index, $declaration['module']));
+        $declarations[$index] += ['name' => $index];
+      }
     }
     return $declarations;
   }

--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -1,3 +1,16 @@
 <?php
 
 require_once 'civi_case.civix.php';
+use CRM_Case_ExtensionUtil as E;
+
+/**
+ * Implements hook_civicrm_managed().
+ */
+function civi_case_civicrm_managed(&$entities, $modules) {
+  // Don't optimize for $modules because the below functions delegate to other extensions
+  $entities = array_merge($entities,
+    CRM_Case_ManagedEntities::createManagedCaseTypes(),
+    CRM_Case_ManagedEntities::createManagedActivityTypes(CRM_Case_XMLRepository::singleton(), CRM_Core_ManagedEntities::singleton()),
+    CRM_Case_ManagedEntities::createManagedRelationshipTypes(CRM_Case_XMLRepository::singleton(), CRM_Core_ManagedEntities::singleton())
+  );
+}


### PR DESCRIPTION
Overview
----------------------------------------
A bit of tidying up of the managed entity code.

Technical Details
----------------------------------------
Removes special handling for components.
Deprecates unnamed entities which probably never worked anyway.