### PR TITLE
Use new lookup trait to eliminate use of undefined properties `userDisplayName`

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -262,17 +262,30 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    * @throws \CRM_Core_Exception
    */
   public function preProcess() {
-    $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
-    if (empty($this->_contactID) && !empty($this->_id) && $this->entity) {
-      $this->_contactID = civicrm_api3($this->entity, 'getvalue', ['id' => $this->_id, 'return' => 'contact_id']);
-    }
-    $this->assign('contactID', $this->_contactID);
-    CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $this->_contactID]);
+    $this->assignContactID();
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');
     $this->_mode = empty($this->_mode) ? CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this) : $this->_mode;
     $this->assign('isBackOffice', $this->isBackOffice);
     $this->assignContactEmailDetails();
     $this->assignPaymentRelatedVariables();
+  }
+
+  /**
+   * Get the contact ID in use.
+   *
+   * Ideally override this as appropriate to the form.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocSignatureIsNotCompleteInspection
+   */
+  public function getContactID():?int {
+    if ($this->_contactID === NULL) {
+      $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+      if (empty($this->_contactID) && !empty($this->_id) && $this->entity) {
+        $this->_contactID = civicrm_api3($this->entity, 'getvalue', ['id' => $this->_id, 'return' => 'contact_id']);
+      }
+    }
+    return $this->_contactID ? (int) $this->_contactID : NULL;
   }
 
   /**
@@ -620,7 +633,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
       $fields["email-{$this->_bltID}"] = 1;
     }
 
-    list($hasBillingField, $addressParams) = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($this->_params, $this->_bltID);
+    [$hasBillingField, $addressParams] = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($this->_params, $this->_bltID);
     $fields = $this->formatParamsForPaymentProcessor($fields);
 
     if ($hasBillingField) {
@@ -735,13 +748,19 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   }
 
   protected function assignContactEmailDetails() {
-    if ($this->_contactID) {
-      list($this->userDisplayName, $this->userEmail) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
+    if ($this->getContactID()) {
+      [$this->userDisplayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->getContactID());
       if (empty($this->userDisplayName)) {
-        $this->userDisplayName = civicrm_api3('contact', 'getvalue', ['id' => $this->_contactID, 'return' => 'display_name']);
+        $this->userDisplayName = civicrm_api3('contact', 'getvalue', ['id' => $this->getContactID(), 'return' => 'display_name']);
       }
       $this->assign('displayName', $this->userDisplayName);
     }
+  }
+
+  protected function assignContactID(): void {
+    $this->assign('contactID', $this->getContactID());
+    CRM_Core_Resources::singleton()
+      ->addVars('coreForm', ['contact_id' => (int) $this->getContactID()]);
   }
 
 }

--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -749,11 +749,11 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
   protected function assignContactEmailDetails() {
     if ($this->getContactID()) {
-      [$this->userDisplayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->getContactID());
-      if (empty($this->userDisplayName)) {
-        $this->userDisplayName = civicrm_api3('contact', 'getvalue', ['id' => $this->getContactID(), 'return' => 'display_name']);
+      [$displayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->getContactID());
+      if (!$displayName) {
+        $displayName = civicrm_api3('contact', 'getvalue', ['id' => $this->getContactID(), 'return' => 'display_name']);
       }
-      $this->assign('displayName', $this->userDisplayName);
+      $this->assign('displayName', $displayName);
     }
   }
 

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -368,11 +368,11 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     $session = CRM_Core_Session::singleton();
 
     // we need to retrieve email address
-    if ($this->_context == 'standalone' && !empty($this->_params['is_email_receipt'])) {
-      list($this->userDisplayName,
+    if ($this->_context === 'standalone' && !empty($this->_params['is_email_receipt'])) {
+      list($displayName,
         $this->userEmail
         ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactId);
-      $this->assign('displayName', $this->userDisplayName);
+      $this->assign('displayName', $displayName);
     }
 
     $this->_params['amount'] = $this->_params['total_amount'];

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -285,7 +285,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $this->assign('feeBlockPaid', FALSE);
 
     // @todo eliminate this duplication.
-    $this->_contactId = $this->_contactID;
+    $this->_contactId = $this->getContactID();
     $this->_eID = CRM_Utils_Request::retrieve('eid', 'Positive', $this);
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $this->_context);
@@ -1515,7 +1515,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         // don't show transaction id in batch update mode
         $path = CRM_Utils_System::currentPath();
         $form->assign('showTransactionId', FALSE);
-        if ($path != 'civicrm/contact/search/basic') {
+        if ($path !== 'civicrm/contact/search/basic') {
           $form->add('text', 'trxn_id', ts('Transaction ID'));
           $form->addRule('trxn_id', ts('Transaction ID already exists in Database.'),
             'objectExists', ['CRM_Contribute_DAO_Contribution', $form->_eventId, 'trxn_id']
@@ -1792,7 +1792,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     $contribParams['is_test'] = 0;
-    if ($form->_action & CRM_Core_Action::PREVIEW || ($params['mode'] ?? NULL) == 'test') {
+    if ($form->_action & CRM_Core_Action::PREVIEW || ($params['mode'] ?? NULL) === 'test') {
       $contribParams['is_test'] = 1;
     }
 
@@ -1941,7 +1941,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   protected function getParticipantValue($fieldName) {
     if (!$this->participantRecord) {
-      $this->participantRecord = civicrm_api3('Participant', 'getsingle', ['id' => $this->_id]);
+      $this->participantRecord = civicrm_api3('Participant', 'getsingle', ['id' => $this->getParticipantID()]);
     }
     return $this->participantRecord[$fieldName] ?? $this->participantRecord['participant_' . $fieldName];
   }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -16,10 +16,14 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\API\EntityLookupTrait;
+
 /**
  * Back office participant form.
  */
 class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment {
+
+  use EntityLookupTrait;
 
   /**
    * Participant ID - use getParticipantID.
@@ -290,8 +294,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->assign('context', $this->_context);
 
-    if ($this->_contactID) {
-      $this->setPageTitle(ts('Event Registration for %1', [1 => $this->userDisplayName]));
+    if ($this->getContactID()) {
+      $this->setPageTitle(ts('Event Registration for %1', [1 => $this->getContactValue('display_name')]));
     }
     else {
       $this->setPageTitle(ts('Event Registration'));
@@ -567,6 +571,25 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     $this->assign('event_is_test', CRM_Utils_Array::value('event_is_test', $defaults[$this->_id]));
     return $defaults[$this->_id];
+  }
+
+  /**
+   * Get a value for the contact being acted on in the form.
+   *
+   * This can be called from any point in the form flow and if
+   * the contact can not yet be determined it will return NULL.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getContactValue($fieldName) {
+    if ($this->isDefined('Contact')) {
+      return $this->lookup('Contact', $fieldName);
+    }
+    if ($this->getContactID()) {
+      $this->define('Contact', 'Contact', ['id' => $this->getContactID()]);
+      return $this->lookup('Contact', $fieldName);
+    }
+    return NULL;
   }
 
   /**
@@ -961,7 +984,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $userName = CRM_Core_Session::singleton()->getLoggedInContactDisplayName();
 
     if ($this->_contactId) {
-      [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);
+      [, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);
     }
 
     //modify params according to parameter used in create
@@ -1381,9 +1404,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   protected function getStatusMsg(array $params, int $numberSent, int $numberNotSent, string $updateStatusMsg): string {
     $statusMsg = '';
     if (($this->_action & CRM_Core_Action::UPDATE)) {
-      $statusMsg = ts('Event registration information for %1 has been updated.', [1 => $this->_contributorDisplayName]);
+      $statusMsg = ts('Event registration information for %1 has been updated.', [1 => $this->getContactValue('display_name')]);
       if (!empty($params['send_receipt']) && $numberSent) {
-        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1', [1 => $this->_contributorEmail]);
+        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1', [1 => $this->getContactValue('email_primary.email')]);
       }
 
       if ($updateStatusMsg) {
@@ -1391,9 +1414,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
     }
     elseif ($this->_action & CRM_Core_Action::ADD) {
-      $statusMsg = ts('Event registration for %1 has been added.', [1 => $this->_contributorDisplayName]);
+      $statusMsg = ts('Event registration for %1 has been added.', [1 => $this->getContactValue('display_name')]);
       if (!empty($params['send_receipt']) && $numberSent) {
-        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1.', [1 => $this->_contributorEmail]);
+        $statusMsg .= ' ' . ts('A confirmation email has been sent to %1.', [1 => $this->getContactValue('email_primary.email')]);
       }
     }
     return $statusMsg;
@@ -1554,9 +1577,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     $form->add('textarea', 'receipt_text', ts('Confirmation Message'));
 
     // Retrieve the name and email of the contact - form will be the TO for receipt email ( only if context is not standalone)
-    if ($form->_context != 'standalone') {
-      if ($form->_contactId) {
-        [$form->_contributorDisplayName, $form->_contributorEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($form->_contactId);
+    if ($form->_context !== 'standalone') {
+      if ($form->getContactID()) {
+        [, $form->_contributorEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($form->_contactId);
         $form->assign('email', $form->_contributorEmail);
       }
       else {
@@ -2172,7 +2195,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
 
     foreach ($this->_contactIds as $num => $contactID) {
       // Retrieve the name and email of the contact - this will be the TO for receipt email
-      [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($contactID);
+      [, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($contactID);
 
       $waitStatus = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Waiting'");
       $waitingStatus = $waitStatus[$params['status_id']] ?? NULL;
@@ -2247,7 +2270,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
       // and the do-not-email option is not checked for that contact
       if ($this->_contributorEmail and !$this->_toDoNotEmail) {
         $sendTemplateParams['from'] = $params['from_email_address'];
-        $sendTemplateParams['toName'] = $this->_contributorDisplayName;
+        $sendTemplateParams['toName'] = $this->getContactValue('display_name');
         $sendTemplateParams['toEmail'] = $this->_contributorEmail;
         $sendTemplateParams['cc'] = $this->_fromEmails['cc'] ?? NULL;
         $sendTemplateParams['bcc'] = $this->_fromEmails['bcc'] ?? NULL;
@@ -2351,6 +2374,30 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    */
   protected function isOverloadFeesMode(): bool {
     return (bool) ($_GET['eventId'] ?? NULL);
+  }
+
+  /**
+   * Get the contact ID in use.
+   *
+   * Ideally override this as appropriate to the form.
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocSignatureIsNotCompleteInspection
+   */
+  public function getContactID():?int {
+    if ($this->_contactID === NULL) {
+      if ($this->getSubmittedValue('contact_id')) {
+        $contactID = $this->getSubmittedValue('contact_id');
+      }
+      else {
+        $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+      }
+      if (!$contactID && $this->getParticipantID()) {
+        $contactID = $this->getParticipantValue('contact_id');
+      }
+      $this->_contactID = $contactID ? (int) $contactID : NULL;
+    }
+    return $this->_contactID;
   }
 
 }

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -79,9 +79,9 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       return;
     }
 
-    $this->userDisplayName = $this->userEmail = NULL;
+    $displayName = $this->userEmail = NULL;
     if ($this->_contactID) {
-      [$this->userDisplayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
+      [$displayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
     }
 
     $this->setPageTitle(ts('Pledge'));

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -631,7 +631,7 @@ London,',
 
     $mut->checkMailLog([
       'From: "FIXME" <info@EXAMPLE.ORG>',
-      'To: Anthony Anderson <anthony_anderson@civicrm.org>',
+      'To: "Mr. Anthony Anderson II" <anthony_anderson@civicrm.org>',
       'Subject: Event Confirmation - Annual CiviCRM meet - Mr. Anthony Anderson II',
       'Dear Anthony,Contact the Development Department if you need to make any changes to your registration.',
       'Event Information and Location',


### PR DESCRIPTION
Overview
----------------------------------------
Use new lookup trait to eliminate use of undefined properties `userDisplayName` 

Before
----------------------------------------
Property `_userDisplayName` referenced in multiple places but not defined. The only place where it is reference from a function other than where it is determined is in the Paricipant form preProcess. In addition the participant form also uses `contributorDisplayName` to refer to the same value - this second variant is used to set the message to be displayed to the user at the end (only). It refers to the same contact (the ability to record a payment from a different contact is only available on the Membership forms, not events)

After
----------------------------------------
Rather than define these 2 properties there are 2 approaches
1) use local variables where possible
2) use `getContactValue()` to get the variables when needed in the `setStatus` and `preProcess` functions

Technical Details
----------------------------------------
@colemanw I am using the new `lookup` function here - but I wound up wrapping in it a function - https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:lookup?expand=1#diff-a1c8943f991b49e1c885133fad3edc222523542e1ce97b89d7fbba222197000fR576-R588 because

a) the goal is to be able to call the function anywhere on the form and if the contact is not yet defined it should return NULL - hence it can be used for things like

```
$this->assign('displayName', $this->getContactValue('display_name');

```

b) the contact ID becomes available at [different points in different flows](https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:civicrm-core:lookup?expand=1#diff-a1c8943f991b49e1c885133fad3edc222523542e1ce97b89d7fbba222197000fR2381). If a contact ID (cid) is in the url or an ID is in in the url it can be looked up in `preProcess`. However, it is not available until `postProcess` otherwise. The goal is to be able to look up a value from any part of the form & get the same results.

Note that this `getContactValue()` is on the one form at the moment. That form has pre-existing `getParticipantValue()` & `getEventValue()` functions - all 3 of which would probably wind up in a FormTrait rather than the form once it is settled



Comments
----------------------------------------
Merging https://github.com/civicrm/civicrm-core/pull/27258 will simplify this
