### PR TITLE
Fix participantTest to not use transactions

### DIFF
--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -17,9 +17,10 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   use CRMTraits_Financial_OrderTrait;
   use CRMTraits_Financial_PriceSetTrait;
 
-  public function setUp(): void {
-    parent::setUp();
-    $this->useTransaction();
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    $this->revertTemplateToReservedTemplate();
+    parent::tearDown();
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -257,18 +257,11 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
       'location_type_id' => 1,
     ]);
 
-    //Get workflow id of event_offline receipt.
-    $workflowId = $this->callAPISuccess('OptionValue', 'get', [
-      'return' => ['id'],
-      'option_group_id' => 'msg_tpl_workflow_event',
-      'name' => 'event_offline_receipt',
-    ]);
-
     //Modify html to contain event_type_id token.
     $result = $this->callAPISuccess('MessageTemplate', 'get', [
       'sequential' => 1,
       'return' => ['id', 'msg_html'],
-      'workflow_id' => $workflowId['id'],
+      'workflow_name' => 'event_offline_receipt',
       'is_default' => 1,
     ]);
     $oldMsg = $result['values'][0]['msg_html'];

--- a/tests/templates/message_templates/event_offline_receipt_html.tpl
+++ b/tests/templates/message_templates/event_offline_receipt_html.tpl
@@ -1,3 +1,2 @@
 event.location:{event.location}
-$location.address.1.display:{$location.address.1.display|nl2br}
-      
+$location.address.1.display:{$location.address.1.display|smarty:nodefaults|nl2br}


### PR DESCRIPTION
Overview
----------------------------------------
Fix participantTest to not use transactions, also pass when smarty debug is enabled

Before
----------------------------------------
Use of transations means we can't add custom data or look in db to debug issues

After
----------------------------------------
no transactions

Technical Details
----------------------------------------
I got well stuck on why this was causing fails - turns out it was the unrelated (but in this PR) issue of text being hardened by smarty due to local config

Comments
----------------------------------------
