### PR TITLE
Fix fatal on Manage Extensions caused by financialacls links

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -384,7 +384,13 @@ function financialacls_civicrm_alterMenu(array &$menu): void {
   $menu['civicrm/admin/financial/financialType']['access_arguments'] = [['administer CiviCRM Financial Types']];
 }
 
-function financialacls_civicrm_links(string $op, ?string $objectName, ?int $objectID, array &$links, ?int &$mask, array &$values) {
+/**
+ * Hide edit/enable/disable links for memberships of a given Financial Type
+ * Note: The $objectID param can be an int, string or null, hence not typed
+ *
+ * Implements hook_civicrm_links()
+ */
+function financialacls_civicrm_links(string $op, ?string $objectName, $objectID, array &$links, ?int &$mask, array &$values) {
   if ($objectName === 'MembershipType') {
     $financialType = CRM_Core_PseudoConstant::getName('CRM_Member_BAO_MembershipType', 'financial_type_id', CRM_Member_BAO_MembershipType::getMembershipType($objectID)['financial_type_id']);
     $hasEditPermission = CRM_Core_Permission::check('edit contributions of type ' . $financialType);


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a fatal on https://smaster.demo.civicrm.org/civicrm/admin/extensions?reset=1

>  TypeError: financialacls_civicrm_links(): Argument #3 ($objectID) must be of type ?int, string given, called in CRM/Utils/Hook.php on line 292 in financialacls_civicrm_links() (line 387 of ext/financialacls/financialacls.php).

Technical Details
----------------------------------------

When visiting Manage Extensions, the `objectId` passed to the hook, is the string name of the extension (ex: `authx`).

Maybe we should not call the hook from Manage Extensions? I can imagine any ext author doing this mistake, and only realizing the bug much later.

Very recent regression: ce6cca3007aa034a446eeebd6c4c4d5ce527afd7 - and does not seem to be in the RC yet.

cc @eileenmcnaughton 