### PR TITLE
standaloneusers: logout function must be static

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -20,7 +20,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
   /**
    * Log out.
    */
-  public function logout() {
+  public static function logout() {
     Security::singleton()->logoutUser();
     // Dump them back on the log-IN page.
     CRM_Utils_System::redirect('/civicrm/login?justLoggedOut');


### PR DESCRIPTION
Overview
----------------------------------------

On CiviCRM Standalone, doing a logout on PHP 8.1 causes the following fatal error:

> PHP Fatal error:  Uncaught TypeError: call_user_func(): Arg
ument  ($callback) must be a valid callback, non-static method CRM_Standaloneusers_Page_Login::logout() cannot be called statically in vendor/civicrm/civicrm-core/CRM/Core/Invoke.php

Can be tested here: https://smaster.demo.civicrm.org/ - when doing a logout, we get a blank screen.