### PR TITLE
dev/core#4425 Standalone: Avoid lazy session initialization, fixes non-sticky locale selection

### DIFF
--- a/CRM/Core/Session.php
+++ b/CRM/Core/Session.php
@@ -130,7 +130,9 @@ class CRM_Core_Session {
     if (!isset($this->_session)) {
       // CRM-9483
       if (!isset($_SESSION) && PHP_SAPI !== 'cli') {
-        if ($isRead) {
+        // Standalone does not do lazy sessions and this causes problems with
+        // reading the locale set in the session (lcMessages in ConfigSetting)
+        if ($isRead && CIVICRM_UF !== 'Standalone') {
           return;
         }
         CRM_Core_Config::singleton()->userSystem->sessionStart();


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/4425

To reproduce:

- Administer > System Settings > Extensions: Enable the [update language](https://civicrm.org/extensions/update-language-files) extension, saves time, if you haven't already downloaded the translation files
- Administer > Localization > Languages: Enable two languages (no need for multilingual, just enable a second language)

You should then be able to display pages in different languages, using the `lcMessages=xx_YY` parameter. Ex:

- https://crm.example.org/civicrm?lcMessages=en_US
- https://crm.example.org/civicrm?lcMessages=fr_CA (adapt to the locale you enabled)

This works for a single page, but then does not stick when we navigate to another page.

Before
----------------------------------------

Locale selection is lost when we navigate to another page.

After
----------------------------------------

Locale selection sticks.

Technical Details
----------------------------------------

I tried a bunch of different things, but they all produced weird results. I figured that the `isRead` stuff was mostly added because of Drupal lazy sessions (to avoid a cookie if the page does not require one). It does not really apply for CiviCRM Standalone.

cc @artfulrobot @totten 