### PR TITLE
SearchKit - Fix assigning searchDisplay tab count

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchSegmentListing/crmSearchAdminSegmentListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegmentListing/crmSearchAdminSegmentListing.component.js
@@ -5,7 +5,7 @@
   angular.module('crmSearchAdmin').component('crmSearchAdminSegmentListing', {
     bindings: {
       filters: '<',
-      totalCount: '='
+      totalCount: '=?'
     },
     templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayTable.html',
     controller: function($scope, $element, crmApi4, searchMeta, searchDisplayBaseTrait, searchDisplaySortableTrait) {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -45,7 +45,7 @@
         // FIXME: Additional hack to directly update tabHeader for contact summary tab. It would be better to
         // decouple the contactTab code into a separate directive that checks totalCount.
         var contactTab = $element.closest('.crm-contact-page .ui-tabs-panel').attr('id');
-        if (contactTab || typeof ctrl.totalCount !== 'undefined') {
+        if (contactTab || ctrl.hasOwnProperty('totalCount')) {
           $scope.$watch('$ctrl.rowCount', function(rowCount) {
             // Update totalCount only if no user filters are set
             if (typeof rowCount === 'number' && angular.equals({}, ctrl.getAfformFilters())) {

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.component.js
@@ -9,7 +9,7 @@
       apiParams: '<',
       settings: '<',
       filters: '<',
-      totalCount: '='
+      totalCount: '=?'
     },
     require: {
       afFieldset: '?^^afFieldset'

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -9,7 +9,7 @@
       apiParams: '<',
       settings: '<',
       filters: '<',
-      totalCount: '='
+      totalCount: '=?'
     },
     require: {
       afFieldset: '?^^afFieldset'

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -8,7 +8,7 @@
       display: '<',
       settings: '<',
       filters: '<',
-      totalCount: '<'
+      totalCount: '=?'
     },
     require: {
       afFieldset: '?^^afFieldset'


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the regression which was incorrectly fixed with https://github.com/civicrm/civicrm-core/pull/23759.

To Reproduce
----------------
1. Create a search display of type "List" or "Grid"
2. Make an Afform for the display and place it in a contact summary tab
3. Observe an error in your browser console every time you visit the contact summary

Technical Details
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/23759 tried to fix this but only for "Table" displays. The PR succeeded in hiding the error, but at the expense of having the code actually work! This is the correct fix, applied to all display types. Enables assignment of the value (because you can't assign scalar values using one-way binding) but avoids the `$compile:nonassign` error by making it optional.

See https://docs.angularjs.org/api/ng/service/#-scope-
