### PR TITLE
Remove some unnecessary variables & pass by ref

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2498,22 +2498,17 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   messages
    * @throws \CRM_Core_Exception
    */
-  public function composeMessageArray(&$input, &$ids, &$values, $returnMessageText = TRUE) {
+  public function composeMessageArray($input, $ids, $values = [], $returnMessageText = TRUE) {
     $ids = array_merge(self::getComponentDetails($this->id), $ids);
     if (empty($ids['contact']) && isset($this->contact_id)) {
       $ids['contact'] = $this->contact_id;
     }
-
-    if (empty($this->_component)) {
-      if (!empty($ids['event'])) {
-        $this->_component = 'event';
-      }
-      else {
-        $this->_component = $input['component'] ?? 'contribute';
-      }
+    if (!empty($ids['event'])) {
+      $this->_component = 'event';
     }
-    // @todo remove strtolower - check consistency
-    $this->_component = strtolower($this->_component);
+    else {
+      $this->_component = 'contribute';
+    }
 
     // If the object is not fully populated then make sure it is - this is a more about legacy paths & cautious
     // refactoring than anything else, and has unit test coverage.

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -122,8 +122,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $values = [];
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertIsArray($msg, 'Message returned as an array in line');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('Membership Type: General', $msg['body']);
@@ -139,9 +138,8 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
   public function testSendMailMembershipObjectsNoLeakage(): void {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
-    $values = [];
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('Membership Type: General', $msg['body']);
 
@@ -154,7 +152,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->input['invoiceID'] = 'abc';
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertEquals('Dr. Donald Duck II', $msg['to']);
     $this->assertStringContainsString('Membership Type: Fowl', $msg['body']);
   }
@@ -168,7 +166,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertIsArray($msg, 'Message not returned as an array');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('Membership Type: General', $msg['body']);
@@ -185,7 +183,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
     $contribution->loadRelatedObjects($this->_processorId, $this->ids);
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertStringContainsString('registration has been received and your status has been updated to Attended.', $msg['body']);
     $this->assertStringContainsString('Annual CiviCRM meet', $msg['html']);
   }
@@ -197,7 +195,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpParticipantObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('Thank you for your registration', $msg['body']);
   }
@@ -230,7 +228,6 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $event->id = $this->_eventId;
     $event->is_email_confirm = FALSE;
     $event->save();
-    $values = [];
     $tablesToTruncate = [
       'civicrm_mailing_spool',
     ];
@@ -238,7 +235,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $contribution->composeMessageArray($this->input, $this->ids);
     $mut->assertMailLogEmpty('no mail should have been send as event set to no confirm');
     $mut->stop();
   }
@@ -252,7 +249,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpPledgeObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids, $values);
+    $msg = $contribution->composeMessageArray($this->input, $this->ids);
     $this->assertStringContainsString('Contribution Information', $msg['html']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove some unnecessary variables does not use the variables passed by reference after the function is called - so they do not need to be by reference. In addition the properties in the `$values` array are tightly coded and never contain `component` so the check for this value in input is obsolete

Before
----------------------------------------
The only non-test usage of `composeMessageArray`

![image](https://github.com/civicrm/civicrm-core/assets/336308/0f7db7a1-3f11-436c-bfd4-c4e53b87b702)


After
----------------------------------------
I was hoping to start replacing some of these properties with the `lookup` - but I have the issue where I don't know if any given entity is defined as I work with the code. In this case it would be enough to have `if ($this->defined['Event'])` because the code 'parts ways' from that point onwards ie

![image](https://github.com/civicrm/civicrm-core/assets/336308/db346ffa-70b5-480e-9311-48d7f38fd04e)

So I wouldn't be constantly doing  `if ($this->defined['Event']){else}` 

Technical Details
----------------------------------------

Comments
----------------------------------------
