### PR TITLE
Pass specific ids rather than ids array

### DIFF
--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -234,24 +234,7 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
       'receipt_from_email' => 'donationFake@civicrm.org',
       'contribution_status' => 'Completed',
     ];
-    $gathered_values = $contribution_bao->_gatherMessageValues(
-      [
-        'payment_processor_id' => $payment_processor['id'],
-        'is_email_receipt' => TRUE,
-      ],
-      $values,
-      [
-        'component' => 'contribute',
-        'contact_id' => $contact_contributor,
-        'contact' => $contact_contributor,
-        'financialType' => $contribution['values'][$contribution['id']]['financial_type_id'],
-        'contributionType' => $contribution['values'][$contribution['id']]['contribution_type_id'],
-        'contributionPage' => $contributionPage['id'],
-        'membership' => [],
-        'paymentProcessor' => $payment_processor['id'],
-        'contribution' => $contribution['id'],
-      ]
-    );
+    $gathered_values = $contribution_bao->_gatherMessageValues($values, NULL, NULL);
 
     $this->assertEquals([
       'receipt_from_name' => 'CiviCRM Fundraising Dept.',


### PR DESCRIPTION

Overview
----------------------------------------
Pass specific ids rather than ids array

Before
----------------------------------------
It is unclear when we pass ids what ids we care about - we call some nasty functions to load these ids & because the usage is hard to track it is hard to stop calling the functions. In this case the only value from `$ids` actually used is `$eventID`. In addition it grabs the `$participantID` from a creepy array `relatedObjects` when we already know it 

After
----------------------------------------
Pass  in the actually-used ids and stop passing in `ids`. Also stop setting an id that we never use (`related_contact`). Stop passing in unused `$input`

Technical Details
----------------------------------------
The function is called from one well-tested place. It also receives a variable it does not use (`$input`)
![image](https://github.com/civicrm/civicrm-core/assets/336308/a4a9e4b7-03bc-4467-960a-80651756c43a)

Comments
----------------------------------------
