### PR TITLE
Update one of our complex confirm tests to use full form flow, fix discovered failure to send to additional participants

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2063,7 +2063,10 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
       LEFT JOIN civicrm_participant         p    ON pp.participant_id  = p.id
       LEFT JOIN civicrm_membership          m    ON m.id  = mp.membership_id
       LEFT JOIN civicrm_pledge_payment      pgp  ON pgp.contribution_id  = c.id
-      WHERE     c.id = $contributionId";
+      WHERE     c.id = $contributionId
+      -- only get the primary recipient
+      AND (p.registered_by_id IS NULL OR p.registered_by_id = 0)
+      ";
 
     $dao = CRM_Core_DAO::executeQuery($query);
     $componentDetails = [];

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -673,6 +673,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
           $params['amount'] = $this->_values['discount'][$discountId][$params['amount']]['value'];
         }
         elseif (empty($params['priceSetId'])) {
+          CRM_Core_Error::deprecatedWarning('unreachable code, prices set always passed as hidden field for monetary events');
           $params['amount'] = $this->_values['fee'][$params['amount']]['value'];
         }
         else {

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -1043,6 +1043,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $params['amount'] = $this->_values['discount'][$discountId][$params['amount']]['value'];
       }
       elseif (empty($params['priceSetId'])) {
+        CRM_Core_Error::deprecatedWarning('unreachable code price set is always set here - passed as a hidden field although we could just load...');
         if (!empty($params['amount'])) {
           $params['amount'] = $this->_values['fee'][$params['amount']]['value'];
         }

--- a/Civi/Test/FormTrait.php
+++ b/Civi/Test/FormTrait.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Test;
 
+use Civi\Test\FormWrappers\EventFormOnline;
 use Civi\Test\FormWrappers\EventFormParticipant;
 
 /**
@@ -28,6 +29,9 @@ trait FormTrait {
   public function getTestForm($formName, $submittedValues, array $urlParameters = []) {
     if ($formName === 'CRM_Event_Form_Participant') {
       return new EventFormParticipant($formName, $submittedValues, $urlParameters);
+    }
+    if ($formName === 'CRM_Event_Form_Registration_Register') {
+      return new EventFormOnline($formName, $submittedValues, $urlParameters);
     }
     return new FormWrapper($formName, $submittedValues, $urlParameters);
   }

--- a/Civi/Test/FormWrappers/EventFormOnline.php
+++ b/Civi/Test/FormWrappers/EventFormOnline.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Civi\Test\FormWrappers;
+
+use Civi\Test\FormWrapper;
+
+/**
+ *
+ */
+class EventFormOnline extends FormWrapper {
+
+  /**
+   * Add another form to process.
+   *
+   * @param string $formName
+   * @param array $formValues
+   *
+   * @return $this
+   */
+  public function addSubsequentForm(string $formName, array $formValues = []): FormWrapper {
+    if ($formName !== 'CRM_Event_Form_Registration_AdditionalParticipant') {
+      return parent::addSubsequentForm($formName, $formValues);
+    }
+    $formNumber = 1;
+    while (!empty($this->subsequentForms['Participant_' . $formNumber])) {
+      $formNumber++;
+    }
+    /* @var \CRM_Core_Form */
+    $form = new $formName(NULL, \CRM_Core_Action::NONE, 'post', 'Participant_' . $formNumber);
+    $form->controller = $this->form->controller;
+    $_SESSION['_' . $this->form->controller->_name . '_container']['values'][$form->getName()] = $formValues;
+    $this->subsequentForms[$form->getName()] = $form;
+    return $this;
+  }
+
+}

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2767,6 +2767,8 @@ class CiviUnitTestCase extends PHPUnit\Framework\TestCase {
    * @noinspection PhpDocMissingThrowsInspection
    */
   protected function addTaxAccountToFinancialType(int $financialTypeID, array $accountParams = []): CRM_Financial_DAO_EntityFinancialAccount {
+    Civi::settings()->set('invoicing', TRUE);
+    unset(\Civi::$statics['CRM_Price_BAO_PriceField']);
     $params = array_merge([
       'name' => 'Sales tax account - test - ' . $financialTypeID,
       'financial_account_type_id' => key(CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name LIKE 'Liability' ")),


### PR DESCRIPTION
Overview
----------------------------------------
Update one of our complex confirm tests to use full form flow, fix discovered failure to send to additional participants

Before
----------------------------------------
This work was primarily about fixing the test to use the full flow. However I hit 2 bugs in the process. I fixed one in this PR & am investigating if https://github.com/civicrm/civicrm-core/pull/26987 addresses the other. The one I hit was that when confirming a event registration with additional participants they were not being emailed once I fixed the test. The reason is the code to get the participant was not only fetching the primary and was using the one it loaded last - so it would prefer a non-primary participant which meant the efforts to load the primary failed later. This wasn't an issue before I fixed the test because the participants were being loaded in the wrong order

After
----------------------------------------
Test still passes because all the participants get the email.... now that part is fixed

Technical Details
----------------------------------------

Comments
----------------------------------------
