### PR TITLE
Update further tests to additional form flow, lock in bug fix

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -54,7 +54,7 @@ trait Api3TestTrait {
         unset($expected[$value]);
       }
     }
-    $this->assertEquals($result, $expected, "api result array comparison failed " . $prefix . print_r($result, TRUE) . ' was compared to ' . print_r($expected, TRUE));
+    $this->assertEquals($result, $expected, 'api result array comparison failed ' . $prefix . print_r($result, TRUE) . ' was compared to ' . print_r($expected, TRUE));
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -45,73 +45,46 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    */
   public function testPaidSubmit(string $thousandSeparator): void {
-    // @todo - figure out why this doesn't pass validate financials
-    $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->setCurrencySeparators($thousandSeparator);
     $mut = new CiviMailUtils($this);
     $paymentProcessorID = $this->processorCreate();
     /** @var \CRM_Core_Payment_Dummy $processor */
     $processor = Civi\Payment\System::singleton()->getById($paymentProcessorID);
     $processor->setDoDirectPaymentResult(['fee_amount' => 1.67]);
-    $event = $this->eventCreatePaid();
-    $individualID = $this->individualCreate();
-    CRM_Event_Form_Registration_Confirm::testSubmit([
-      'id' => $event['id'],
-      'contributeMode' => 'direct',
-      'registerByID' => $individualID,
-      'paymentProcessorObj' => CRM_Financial_BAO_PaymentProcessor::getPayment($paymentProcessorID),
-      'totalAmount' => 8000.67,
-      'params' => [
-        [
-          'first_name' => 'k',
-          'last_name' => 'p',
-          'email-Primary' => 'demo@example.com',
-          'hidden_processor' => '1',
-          'credit_card_number' => '4111111111111111',
-          'cvv2' => '123',
-          'credit_card_exp_date' => [
-            'M' => '1',
-            'Y' => date('Y') + 1,
-          ],
-          'credit_card_type' => 'Visa',
-          'billing_first_name' => 'p',
-          'billing_middle_name' => '',
-          'billing_last_name' => 'p',
-          'billing_street_address-5' => 'p',
-          'billing_city-5' => 'p',
-          'billing_state_province_id-5' => '1061',
-          'billing_postal_code-5' => '7',
-          'billing_country_id-5' => '1228',
-          'priceSetId' => '6',
-          'price_7' => [
-            13 => 1,
-          ],
-          'payment_processor_id' => $paymentProcessorID,
-          'bypass_payment' => '',
-          'is_primary' => 1,
-          'is_pay_later' => 0,
-          'campaign_id' => NULL,
-          'defaultRole' => 1,
-          'participant_role_id' => '1',
-          'currencyID' => 'USD',
-          'amount_level' => 'Tiny-tots (ages 5-8) - 1',
-          'amount' => $this->formatMoneyInput(8000.67),
-          'tax_amount' => NULL,
-          'year' => '2019',
-          'month' => '1',
-          'ip_address' => '127.0.0.1',
-          'invoiceID' => '57adc34957a29171948e8643ce906332',
-          'button' => '_qf_Register_upload',
-          'billing_state_province-5' => 'AP',
-          'billing_country-5' => 'US',
-        ],
+    $event = $this->eventCreatePaid(['payment_processor' => [$paymentProcessorID]]);
+    $this->submitForm($event['id'], [
+      'first_name' => 'k',
+      'last_name' => 'p',
+      'email-Primary' => 'demo@example.com',
+      'hidden_processor' => '1',
+      'credit_card_number' => '4111111111111111',
+      'cvv2' => '123',
+      'credit_card_exp_date' => [
+        'M' => '1',
+        'Y' => date('Y') + 1,
       ],
+      'credit_card_type' => 'Visa',
+      'billing_first_name' => 'p',
+      'billing_middle_name' => '',
+      'billing_last_name' => 'p',
+      'billing_street_address-5' => 'p',
+      'billing_city-5' => 'p',
+      'billing_state_province_id-5' => '1061',
+      'billing_postal_code-5' => '7',
+      'billing_country_id-5' => '1228',
+      'priceSetId' => $this->getPriceSetID('PaidEvent'),
+      'price_' . $this->getPriceFieldID('PaidEvent') => $this->ids['PriceFieldValue']['PaidEvent_standard'],
+      'payment_processor_id' => $paymentProcessorID,
+      'year' => '2019',
+      'month' => '1',
+      'billing_state_province-5' => 'AP',
+      'billing_country-5' => 'US',
     ]);
     $this->callAPISuccessGetCount('Participant', [], 1);
     $contribution = $this->callAPISuccessGetSingle('Contribution', []);
-    $this->assertEquals(8000.67, $contribution['total_amount']);
+    $this->assertEquals(300, $contribution['total_amount']);
     $this->assertEquals(1.67, $contribution['fee_amount']);
-    $this->assertEquals(7999, $contribution['net_amount']);
+    $this->assertEquals(298.33, $contribution['net_amount']);
     $this->assertNotEmpty($contribution['receipt_date']);
     $this->assertNotContains(' (multiple participants)', $contribution['amount_level']);
     $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution['id'], 'DESC');
@@ -138,7 +111,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'entity_table' => 'civicrm_contribution',
       'entity_id' => $contribution['id'],
       'financial_trxn_id' => $financialTrxn['id'],
-      'amount' => '8000.67',
+      'amount' => '300.00',
     ], $entityFinancialTrxns[0], ['id']);
 
     $this->assertAPIArrayComparison([
@@ -319,7 +292,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    */
   public function testTaxMultipleParticipant(): void {
     $this->swapMessageTemplateForTestTemplate('event_online_receipt', 'text');
-    $this->isValidateFinancialsOnPostAssert = FALSE;
+
     $mut = new CiviMailUtils($this);
     $this->createLoggedInUser();
     $this->eventCreatePaid();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes more tests to use full form flow rather than invalid financial data

@colemanw it is actually this change https://github.com/civicrm/civicrm-core/pull/27279/files#diff-c4ddaa8aa71ca49d31466c04cefbb2f1d608a04e3836791a756859d73ef560c2L322 that locked in the other bug fix from my last PR 