### PR TITLE
Fix bug exposed by invalid data warning

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -481,12 +481,6 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     foreach ($participantPayments as $payment) {
       civicrm_api3('ParticipantPayment', 'create', ['id' => $payment['id'], 'participant_id' => $participant->id]);
     }
-    //send a confirmation email to the new participant
-    $this->participantTransfer($participant);
-    //now update registered_by_id
-    $query = "UPDATE civicrm_participant cp SET cp.registered_by_id = %1 WHERE  cp.id = ({$participant->id})";
-    $params = [1 => [$fromParticipantID, 'Integer']];
-    CRM_Core_DAO::executeQuery($query, $params);
     //copy line items to new participant
     $line_items = CRM_Price_BAO_LineItem::getLineItems($fromParticipantID);
     foreach ($line_items as $id => $item) {
@@ -504,6 +498,12 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
       $prevFinancialItem['entity_id'] = $tolineItem->id;
       CRM_Financial_BAO_FinancialItem::create($prevFinancialItem);
     }
+    //send a confirmation email to the new participant
+    $this->participantTransfer($participant);
+    //now update registered_by_id
+    $query = "UPDATE civicrm_participant cp SET cp.registered_by_id = %1 WHERE  cp.id = ({$participant->id})";
+    CRM_Core_DAO::executeQuery($query, [1 => [$fromParticipantID, 'Integer']]);
+
     //now cancel the from participant record, leaving the original line-item(s)
     $value_from = [];
     $value_from['id'] = $fromParticipantID;


### PR DESCRIPTION
Overview
----------------------------------------
Fix bug exposed by invalid data warning

When we added an invalid data warning to sending emails it exposed a minor data issue. When a event registration is being transfered the email is sent before the line item is transfered . This means line item in the email is missing in the email as it does not exist at the right moment in time.

The invalid data issue is not a regression but the potential for someone to become aware of it is


Before
----------------------------------------
No line item data in emails sent to contacts during an event registration transfer

After
----------------------------------------
email sent after the line item is fixed

Technical Details
----------------------------------------
@seamuslee001  this addresses the only real failure cause in https://github.com/civicrm/civicrm-core/pull/27255

Comments
----------------------------------------

