### PR TITLE
Fix financial transfer test to use form flow, allow all pending to transfer

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1858,7 +1858,7 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
         return $details;
       }
       // Verify participant status is one that can be self-cancelled
-      if (!in_array($details['status'], ['Registered', 'Pending from pay later', 'On waitlist'])) {
+      if (!in_array($details['status'], ['Registered', 'Pending from pay later', 'On waitlist', 'Pending from incomplete transaction'])) {
         $details['eligible'] = FALSE;
         $details['ineligible_message'] = ts('You cannot transfer or cancel your registration for %1 as you are not currently registered for this event.', [1 => $eventTitle]);
         return $details;

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -28,7 +28,7 @@ class FormWrapper {
   /**
    * @var \CRM_Core_Form[]
    */
-  protected $subsequentForms;
+  protected $subsequentForms = [];
 
   private $output;
 


### PR DESCRIPTION

Overview
----------------------------------------
Fix financial transfer test to use form flow, allow all pending to transfer

Before
----------------------------------------
The test to transfer event recipients uses an artificial form flow. In addition I discovered that it supported transferring 'Pending from pay later' but not 'Pending from incomplete transaction' - this didn't make sense to me alongside the other available options (ie Registered is included which might imply a payment processor)

After
----------------------------------------
Test fixed, Pending from incomplete transaction permitted

Technical Details
----------------------------------------

Comments
----------------------------------------
