### PR TITLE
Fix offline event form validation bug when switching events

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -807,8 +807,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (empty($values['payment_instrument_id'])) {
         $errorMsg['payment_instrument_id'] = ts('Payment Method is a required field.');
       }
-      if (!empty($values['priceSetId'])) {
-        CRM_Price_BAO_PriceField::priceSetValidation($values['priceSetId'], $values, $errorMsg);
+      if ($self->getPriceSetID()) {
+        CRM_Price_BAO_PriceField::priceSetValidation($self->getPriceSetID(), $values, $errorMsg);
       }
     }
 
@@ -819,9 +819,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       ) ||
       ($self->_id && !$self->_paymentId && isset($self->_values['line_items']) && is_array($self->_values['line_items']))
     ) {
-      $priceSetId = $values['priceSetId'] ?? NULL;
-      if ($priceSetId) {
-        CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $values, $errorMsg, TRUE);
+      // @todo - this seems unreachable.
+      if ($self->getPriceSetID()) {
+        CRM_Price_BAO_PriceField::priceSetValidation($self->getPriceSetID(), $values, $errorMsg, TRUE);
       }
     }
     // For single additions - show validation error if the contact has already been registered


### PR DESCRIPTION
Overview
----------------------------------------
Fix offline event form validation bug when switching events

Before
----------------------------------------
Steps to reproduce

1) do a new offline event registration
2) do a second offline event registration for the same participant. The form will not submit as the participant is already registered. However it will store the hidden 'priceSetId' field on the form.
2) change the event & submit the form
- > validation fails as the fields for the original event were not present

I don't think this has regressed - it's just obscure


After
----------------------------------------
Form gets the `priceSetID`  using `getPriceSetID()` which is more reliable than the weird way

Technical Details
----------------------------------------
I was tempted to remove or put a deprecation notice in the code that seems unreachable. I couldn't figure how to trigger it

Comments
----------------------------------------
