### PR TITLE
dev/3410#3410 Show 0 rather than nothing when paid amount is zero

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -269,13 +269,13 @@
         </tr>
        {/foreach}
       {/if}
-      {if $totalTaxAmount}
+      {if {contribution.tax_amount|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Total Tax Amount{/ts}
         </td>
         <td {$valueStyle}>
-         {$totalTaxAmount|crmMoney:$currency}
+          {contribution.tax_amount}
         </td>
        </tr>
       {/if}
@@ -284,7 +284,7 @@
          <tr>
            <td {$labelStyle}>{ts}Total Paid{/ts}</td>
            <td {$valueStyle}>
-             {if {contribution.paid_amount|boolean}}{contribution.paid_amount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+             {contribution.paid_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
            </td>
           </tr>
           <tr>
@@ -295,7 +295,7 @@
          <tr>
            <td {$labelStyle}>{ts}Total Amount{/ts}</td>
            <td {$valueStyle}>
-               {if {contribution.total_amount|boolean}}{contribution.total_amount|crmMoney}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+             {contribution.total_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
            </td>
          </tr>
        {/if}

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -139,14 +139,14 @@
 {/foreach}
 {/if}
 
-{if $totalTaxAmount}
-{ts}Total Tax Amount{/ts}: {$totalTaxAmount|crmMoney:$currency}
+{if {contribution.tax_amount|boolean}}
+{ts}Total Tax Amount{/ts}: {contribution.tax_amount}
 {/if}
 {if {event.is_monetary|boolean}}
 
-{if {contribution.balance_amount|boolean}}{ts}Total Paid{/ts}: {if {contribution.paid_amount|boolean}}{contribution.paid_amount}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+{if {contribution.balance_amount|boolean}}{ts}Total Paid{/ts}: {contribution.paid_amount} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 {ts}Balance{/ts}: {contribution.balance_amount}
-{else}{ts}Total Amount{/ts}: {if {contribution.total_amount|boolean}}{contribution.total_amount}{/if} {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
+{else}{ts}Total Amount{/ts}: {contribution.total_amount}  {if !empty($hookDiscount.message)}({$hookDiscount.message}){/if}
 {/if}
 
 {if !empty($pricesetFieldsCount) }


### PR DESCRIPTION
Overview
----------------------------------------
dev/3410#3410 Show 0 rather than nothing when paid amount is zero

Per https://lab.civicrm.org/dev/core/-/issues/3410 the incorrect value is no longer showing - but it is pretty confusing having the title but not the value when the value is 0


Before
----------------------------------------
Note before & after are captured in different ways hence format & presence of tax =  different

![image](https://github.com/civicrm/civicrm-core/assets/336308/1487e9c6-9469-4a2a-8ff6-13fee57ba752)

After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/6ad99400-cf8d-4431-936b-c999e1f2b085)

Technical Details
----------------------------------------


Comments
----------------------------------------

