### PR TITLE
Fixes for setting defaults for custom data field of type file

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1796,7 +1796,7 @@ ORDER BY civicrm_custom_group.weight,
         if ($value !== NULL) {
           $formValues[$properties['element_name']] = $value;
         }
-        elseif (isset($submittedValues[$properties['element_name']])) {
+        elseif (isset($submittedValues[$properties['element_name']]) && $properties['data_type'] !== 'File') {
           $properties['element_value'] = $submittedValues[$properties['element_name']];
         }
         unset($properties['customValue']);


### PR DESCRIPTION
Overview
----------------------------------------
Error when saving custom field of type file.

![Screenshot from 2023-08-25 10-21-12](https://github.com/civicrm/civicrm-core/assets/151481/069de698-3784-424a-8197-1d29502ad6e2)

Steps to replicate:

- Create custom data for events
- Add a custom field of type `File`
- Create or update an event by uploading file to above custom field
- Now again just Save the event. It will throw the above mentioned error.

Error can be replicated on dmaster (CiviCRM 5.66.alpha1)