### PR TITLE
dev/core#4425 Standalone: fix lcMessages not sticking; slightly lazy sessions

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -207,14 +207,14 @@ class CRM_Core_BAO_ConfigSetting {
 
     }
     else {
-
       // CRM-11993 - Use default when it's a single-language install.
       $chosenLocale = $defaultLocale;
-
     }
 
-    if (!$session->isEmpty()) {
-      // Always assign the chosen locale to the session.
+    if ($chosenLocale && ($requestLocale ?? NULL) === $chosenLocale) {
+      // If the locale is passed in via lcMessages key on GET or POST data,
+      // and it's valid against our configured locales, we require the session
+      // to store this, even if that means starting an anonymous session.
       $session->set('lcMessages', $chosenLocale);
     }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -47,7 +47,6 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     }
   }
 
-
   /**
    * @inheritdoc
    */

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -35,18 +35,18 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     return !class_exists(\Civi\Standalone\Security::class);
   }
 
-  /**
-   * Start a new session.
-   */
-  public function sessionStart() {
-    parent::sessionStart();
-    if ($this->missingStandaloneExtension()) {
-      // Provide a fake contact and user ID, otherwise we don't get a menu.
-      $session = CRM_Core_Session::singleton();
-      $session->set('userID', 1);
-      $session->set('ufID', 1);
+  public function initialize() {
+    parent::initialize();
+    // Initialize the session if it looks like there might be one.
+    // Case 1: user sends no session cookie: do NOT start the session. May be anon access that does not require session data. Good for caching.
+    // Case 2: user sends a session cookie: start the session, so we can access data like lcMessages for localization (which occurs early in the boot process).
+    // Case 3: user sends a session cookie but it's invalid: start the session, it will be empty and a new cookie will be sent.
+    if (isset($_COOKIE['PHPSESSID'])) {
+      // Note: passing $isRead = FALSE in the arguments will cause the session to be started.
+      CRM_Core_Session::singleton()->initialize(FALSE);
     }
   }
+
 
   /**
    * @inheritdoc


### PR DESCRIPTION
This is an alternative to https://github.com/civicrm/civicrm-core/pull/27266

## Overview

https://lab.civicrm.org/dev/core/-/issues/4425

To reproduce:

- Administer > System Settings > Extensions: Enable the [update language](https://civicrm.org/extensions/update-language-files) extension, saves time, if you haven't already downloaded the translation files
- Administer > Localization > Languages: Enable two languages (no need for multilingual, just enable a second language)

You should then be able to display pages in different languages, using the `lcMessages=xx_YY` parameter. Ex:

- https://crm.example.org/civicrm?lcMessages=en_US
- https://crm.example.org/civicrm?lcMessages=fr_CA (adapt to the locale you enabled)

This works for a single page, but then does not stick when we navigate to another page.

Before
----------------------------------------

Locale selection is lost when we navigate to another page.

After
----------------------------------------

Locale selection sticks.

Notes
-------

See discussion on the original PR (link above)

"Lazy" sessions are means that when an anonymous user accesses a page, no session is created for them (and therefore no cookie is set) unless data is written to `$_SESSION`. It's good because it means we don't waste disk space or create unnecessary cookies just to store an empty session.

Implementing lazy sessions, however, is not entirely trivial because of the way PHP's sessions work. Drupal does it, and I suspect other CMSes do it too, but you do have to write a whole session handler.

This implements a less-lazy strategy. 

- no session is created for a new, anon user whose request never writes session data.
- a session is created if the request has a PHPSESSID cookie set.
- a session is created if the request writes session data.

It solves:

- So for anon users who don't need sessions, we have the desired lazy behaviour.
- For anon users who do need session data, **including those who use lcMessages to translate the UI**, we load their session data and thus can remember lcMessages on other page visits.
- We still have sessions that work.

