### PR TITLE
Afform - Make Afform Core extension required

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtySeven.php
@@ -29,6 +29,8 @@ class CRM_Upgrade_Incremental_php_FiveSixtySeven extends CRM_Upgrade_Incremental
    */
   public function upgrade_5_67_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addExtensionTask('Enable Authx extension', ['authx'], 1101);
+    $this->addExtensionTask('Enable Afform extension', ['org.civicrm.afform'], 1102);
   }
 
 }

--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -47,7 +47,7 @@ php GenerateData.php
 
 ## Prune local data
 $MYSQLCMD -e "DROP TABLE IF EXISTS civicrm_install_canary; DELETE FROM civicrm_cache; DELETE FROM civicrm_setting;"
-$MYSQLCMD -e "DELETE FROM civicrm_extension WHERE full_name NOT IN ('sequentialcreditnotes', 'eventcart', 'greenwich', 'org.civicrm.search_kit', 'org.civicrm.flexmailer', 'financialacls', 'contributioncancelactions', 'recaptcha', 'ckeditor4', 'legacycustomsearches', 'civiimport') and full_name NOT LIKE 'civi_%';"
+$MYSQLCMD -e "DELETE FROM civicrm_extension WHERE full_name NOT IN ('sequentialcreditnotes', 'eventcart', 'greenwich', 'org.civicrm.search_kit', 'org.civicrm.afform', 'authx', 'org.civicrm.flexmailer', 'financialacls', 'contributioncancelactions', 'recaptcha', 'ckeditor4', 'legacycustomsearches', 'civiimport') and full_name NOT LIKE 'civi_%';"
 TABLENAMES=$( echo "show tables like 'civicrm_%'" | $MYSQLCMD | grep ^civicrm_ | xargs )
 
 cd $CIVISOURCEDIR/sql

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -21,6 +21,7 @@ use CRM_Afform_ExtensionUtil as E;
  * @labelField title
  * @iconField type:icon
  * @searchable none
+ * @since 5.31
  * @package Civi\Api4
  */
 class Afform extends Generic\AbstractEntity {

--- a/ext/afform/core/Civi/Api4/AfformBehavior.php
+++ b/ext/afform/core/Civi/Api4/AfformBehavior.php
@@ -8,6 +8,7 @@ namespace Civi\Api4;
  * Provided by the Afform: Core Runtime extension.
  *
  * @searchable secondary
+ * @since 5.56
  * @package Civi\Api4
  */
 class AfformBehavior extends Generic\AbstractEntity {

--- a/ext/afform/core/Civi/Api4/AfformSubmission.php
+++ b/ext/afform/core/Civi/Api4/AfformSubmission.php
@@ -7,6 +7,7 @@ namespace Civi\Api4;
  * Provided by the Afform: Core Runtime extension.
  *
  * @searchable secondary
+ * @since 5.42
  * @package Civi\Api4
  */
 class AfformSubmission extends Generic\DAOEntity {

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -14,10 +14,13 @@
   </urls>
   <releaseDate>2020-01-09</releaseDate>
   <version>5.67.alpha1</version>
-  <develStage>beta</develStage>
   <compatibility>
     <ver>5.67</ver>
   </compatibility>
+  <develStage>stable</develStage>
+  <tags>
+    <tag>mgmt:required</tag>
+  </tags>
   <comments>The Form Core extension is required to use any dynamic form. To administer and edit forms, also install the FormBuilder extension.</comments>
   <civix>
     <namespace>CRM/Afform</namespace>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -17,6 +17,9 @@
   <releaseDate>2021-02-11</releaseDate>
   <version>5.67.alpha1</version>
   <develStage>stable</develStage>
+  <tags>
+    <tag>mgmt:required</tag>
+  </tags>
   <compatibility>
     <ver>5.67</ver>
   </compatibility>

--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -14,5 +14,7 @@ if (!defined('CIVI_SETUP')) {
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
 
     $e->getModel()->extensions[] = 'org.civicrm.search_kit';
+    $e->getModel()->extensions[] = 'org.civicrm.afform';
+    $e->getModel()->extensions[] = 'authx';
 
   });

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -51,7 +51,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
    *
    * @var string[]
    */
-  protected $toggleExtensions = ['civiimport', 'org.civicrm.afform', 'authx'];
+  protected $toggleExtensions = ['civiimport'];
 
   protected function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1270,6 +1270,9 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'civicrm_address' => [
         0 => 'contact_id',
       ],
+      'civicrm_afform_submission' => [
+        0 => 'contact_id',
+      ],
       'civicrm_batch' => [
         0 => 'created_id',
         1 => 'modified_id',


### PR DESCRIPTION
Overview
----------------------------------------
In order to start replacing core pages & forms with Afform, we need to make it required by CiviCRM core.

Comments
-------
Also requires Authx which is a dependency.
