### PR TITLE
Switch to using token for trxn_id, online contribution receipt

### DIFF
--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -151,13 +151,13 @@
       </tr>
      {/if}
 
-     {if !empty($is_monetary) and !empty($trxn_id)}
+     {if {contribution.trxn_id|boolean}}
       <tr>
        <td {$labelStyle}>
         {ts}Transaction #{/ts}
        </td>
        <td {$valueStyle}>
-        {$trxn_id}
+         {contribution.trxn_id}
        </td>
       </tr>
      {/if}

--- a/xml/templates/message_templates/contribution_online_receipt_text.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_text.tpl
@@ -52,8 +52,8 @@
 
 {ts}Date{/ts}: {$receive_date|crmDate}
 {/if}
-{if !empty($is_monetary) and !empty($trxn_id)}
-{ts}Transaction #{/ts}: {$trxn_id}
+{if {contribution.trxn_id|boolean}}
+{ts}Transaction #{/ts}: {contribution.trxn_id}
 {/if}
 
 {if !empty($is_recur)}


### PR DESCRIPTION
We don't need to check is_monetary - there won't be a transaction ID if not