### PR TITLE
Remove unused CONST

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -20,13 +20,6 @@
  */
 class CRM_Mailing_Page_View extends CRM_Core_Page {
 
-  /**
-   * Signal to Flexmailer that this version of the class is usable.
-   *
-   * @var bool
-   */
-  const USES_MAILING_PREVIEW_API = 1;
-
   protected $_mailingID;
   protected $_mailing;
   protected $_contactID;


### PR DESCRIPTION
I can't see any evidence flexmailer or anything else still uses it...
![image](https://github.com/civicrm/civicrm-core/assets/336308/3c4fd5fb-b1e0-45dd-9909-10def0cd29c2)
