### PR TITLE
Remove unused/ unnecessary table name variables

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2752,7 +2752,7 @@ WHERE  civicrm_mailing_job.id = %1
     }
 
     // Split up the parent jobs into multiple child jobs
-    $mailerJobSize = Civi::settings()->get('mailerJobSize');
+    $mailerJobSize = (int) Civi::settings()->get('mailerJobSize');
     CRM_Mailing_BAO_MailingJob::runJobs_pre($mailerJobSize, $mode);
     CRM_Mailing_BAO_MailingJob::runJobs(NULL, $mode);
     CRM_Mailing_BAO_MailingJob::runJobs_post($mode);


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused/ unnecessary table name variables

Before
----------------------------------------
The query call goes through `$dao->query()` rather than `CRM_Core_DAO::executeQuery()`. This has 2 disadvantages

1) it doesn't do as good a job of cleaning up memory & is subject to leaks
2) it isn't able to handling multilingual table names natively & needs them to be interspersed with the sql


After
----------------------------------------
Switched to preferred `CRM_Core_DAO::executeQuery()`

Technical Details
----------------------------------------
Note the function is only called from one place. I checked the `mailerJobSize` is always a number. I didn't trace mode back. I realised belatedly I should probably have removed the defaults for those variables

@seamuslee001 you will recall we have hit issues when swapping out table name lookups - but those were when the table name was saved to the database in fields like `entity_table` - we haven't hit issues on this type of cleanup

Comments
----------------------------------------
