### PR TITLE
Declare CRM_Core_Exception in cleanDir, add type hints

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -90,12 +90,12 @@ class CRM_Utils_File {
    * @param bool $rmdir
    * @param bool $verbose
    *
-   * @throws Exception
+   * @throws \CRM_Core_Exception
    */
-  public static function cleanDir($target, $rmdir = TRUE, $verbose = TRUE) {
+  public static function cleanDir(string $target, bool $rmdir = TRUE, bool $verbose = TRUE) {
     static $exceptions = ['.', '..'];
-    if ($target == '' || $target == '/' || !$target) {
-      throw new Exception("Overly broad deletion");
+    if (!$target || $target === '/') {
+      throw new CRM_Core_Exception('Overly broad deletion');
     }
 
     if ($dh = @opendir($target)) {
@@ -894,8 +894,8 @@ HTACCESS;
       case 'image/x-png':
       case 'image/png':
       case 'image/jpg':
-        list($imageWidth, $imageHeight) = getimagesize($path);
-        list($imageThumbWidth, $imageThumbHeight) = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
+        [$imageWidth, $imageHeight] = getimagesize($path);
+        [$imageThumbWidth, $imageThumbHeight] = CRM_Contact_BAO_Contact::getThumbSize($imageWidth, $imageHeight);
         $url = "<a href=\"$url\" class='crm-image-popup'>
           <img src=\"$url\" width=$imageThumbWidth height=$imageThumbHeight/>
           </a>";


### PR DESCRIPTION


Overview
----------------------------------------
The only information our exception imparts is that it is coming from CiviCRM Core  - but we should at least be consistent in that.



Before
----------------------------------------
generic `Exception` thrown

After
----------------------------------------
CRM_Core_Exception thrown

Minor cleanups

Technical Details
----------------------------------------
The type hints are ok because it would be bad to pass something other than a string for dir & I checked core & universe on the 2 booleans

Function only called from tests

![image](https://github.com/civicrm/civicrm-core/assets/336308/4eee7c1a-2380-4b13-b2b3-7b50fb6aabc4)

Universe has some uninstall usages - but also compatible with type hints

![image](https://github.com/civicrm/civicrm-core/assets/336308/c910b09c-b533-4b6e-9136-18dd205c7413)


Comments
----------------------------------------
