### PR TITLE
Make function private to reflect usage

### DIFF
--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -387,7 +387,7 @@ class CRM_Utils_Mail_Incoming {
    * @param $mail
    * @param $createContact
    */
-  public static function parseAddresses(&$addresses, $token, &$params, &$mail, $createContact = TRUE) {
+  private static function parseAddresses(&$addresses, $token, &$params, &$mail, $createContact = TRUE) {
     $params[$token] = [];
     foreach ($addresses as $address) {
       $subParam = [];


### PR DESCRIPTION
A universe search shows it is only called from this class

![image](https://github.com/civicrm/civicrm-core/assets/336308/5cb5f161-5553-4059-bf56-4b8b45c76979)

![image](https://github.com/civicrm/civicrm-core/assets/336308/797fc897-a738-482c-bc6e-d5ef6f34c12d)
