### PR TITLE
Make function private, after universe search in EmailProcessor

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -90,7 +90,7 @@ class CRM_Utils_Mail_EmailProcessor {
    * @throws Exception
    * @throws CRM_Core_Exception
    */
-  public static function _process($civiMail, $dao, $is_create_activities) {
+  private static function _process($civiMail, $dao, $is_create_activities) {
     // 0 = activities; 1 = bounce;
     $usedfor = $dao->is_default;
     if ($usedfor == 0) {


### PR DESCRIPTION
Overview
----------------------------------------
Make function private, after universe search in EmailProcessor

Before
----------------------------------------
function is public & static but has no external calls

![image](https://github.com/civicrm/civicrm-core/assets/336308/dcf551b7-12fa-42eb-bd7d-cb28d390e4a7)

![image](https://github.com/civicrm/civicrm-core/assets/336308/77fc342e-8f87-4f4b-bba8-565b80eb1d0d)

![image](https://github.com/civicrm/civicrm-core/assets/336308/f40fda57-7f4e-44e7-be58-cb40e2853a39)

![image](https://github.com/civicrm/civicrm-core/assets/336308/ece7824c-cc63-461f-aa22-1dd1bae41bdd)


After
----------------------------------------
function is private

Technical Details
----------------------------------------

Comments
----------------------------------------
