### PR TITLE
Fix upgrader SQL (5.60) that updates civicrm_job_log

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixty.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixty.php
@@ -56,7 +56,7 @@ class CRM_Upgrade_Incremental_php_FiveSixty extends CRM_Upgrade_Incremental_Base
     CRM_Core_DAO::executeQuery($commentQuery);
 
     // Set job_id = NULL for any that don't have matching jobs (ie. job was deleted).
-    $updateQuery = 'UPDATE civicrm_job_log job_log LEFT JOIN civicrm_job job ON job.id = job_log.id SET job_id = NULL WHERE job.id IS NULL';
+    $updateQuery = 'UPDATE civicrm_job_log job_log LEFT JOIN civicrm_job job ON job.id = job_log.job_id SET job_id = NULL WHERE job.id IS NULL';
     CRM_Core_DAO::executeQuery($updateQuery);
 
     // Add the foreign key


### PR DESCRIPTION
This upgrader has broken SQL, joining civicrm_job.id = civicrm_job_log.id causing crashes on upgrades.

After: fixed the SQL

https://chat.civicrm.org/civicrm/pl/5uyter75rtyctr7jfhsx4p1mqr