### PR TITLE
Fix dev/core#4550 - Crash when saving repeating event

### DIFF
--- a/CRM/Core/Form/RecurringEntity.php
+++ b/CRM/Core/Form/RecurringEntity.php
@@ -349,6 +349,7 @@ class CRM_Core_Form_RecurringEntity {
           CRM_Core_BAO_ActionSchedule::deleteRecord($params);
           unset($params['id']);
         }
+        $dbParams['name'] = 'repeat_' . $params['used_for'] . '_' . $params['entity_id'];
         $actionScheduleObj = CRM_Core_BAO_ActionSchedule::writeRecord($dbParams);
 
         //exclude dates
@@ -392,7 +393,7 @@ class CRM_Core_Form_RecurringEntity {
           }
         }
 
-        //Set type for API
+        // FIXME: This is the worst way possible to convert a table name to an api entity name
         $apiEntityType = explode("_", $type);
         if (!empty($apiEntityType[1])) {
           $apiType = $apiEntityType[1];
@@ -403,10 +404,11 @@ class CRM_Core_Form_RecurringEntity {
           if (!empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['pre_delete_func']) &&
             !empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['helper_class'])
           ) {
-            $preDeleteResult = call_user_func_array(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['pre_delete_func'], [$params['entity_id']]);
-            if (!empty($preDeleteResult)) {
-              call_user_func([CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['helper_class'], $preDeleteResult]);
-            }
+            // FIXME: This calls `CRM_Event_Form_ManageEvent_Repeat::checkRegistrationForEvents`
+            // which then sets the static variable `CRM_Core_BAO_RecurringEntity::$_entitiesToBeDeleted`
+            // which is then accessed below and used to delete events with no registrations.
+            // I can't think of a worse way to pass a variable back from a function.
+            call_user_func_array(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['pre_delete_func'], [$params['entity_id']]);
           }
           //Ready to execute delete on entities if it has delete function set
           if (!empty(CRM_Core_BAO_RecurringEntity::$_recurringEntityHelper[$params['entity_table']]['delete_func']) &&

--- a/CRM/Upgrade/Incremental/sql/5.66.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.66.alpha1.mysql.tpl
@@ -1,7 +1,7 @@
 {* file to handle db changes in 5.66.alpha1 during upgrade *}
 
 {* Ensure action_schedule.name has a unique value *}
-UPDATE `civicrm_action_schedule` SET name = CONCAT('reminder_', id) WHERE name IS NULL OR name = '';
+UPDATE `civicrm_action_schedule` SET name = COALESCE(CONCAT('repeat_', used_for, '_', entity_value), CONCAT('schedule_', id)) WHERE name IS NULL OR name = '';
 UPDATE `civicrm_action_schedule` a1, `civicrm_action_schedule` a2
 SET a2.name = CONCAT(a2.name, '_', a2.id)
 WHERE a2.name = a1.name AND a2.id > a1.id;

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Scheduled_Reminders.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Scheduled_Reminders.mgd.php
@@ -32,7 +32,9 @@ return [
             'absolute_date',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [
+            ['used_for', 'IS EMPTY'],
+          ],
           'groupBy' => [],
           'join' => [],
           'having' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4550

Technical Details
----------------------------------------
The `civicrm_action_schedule` table is overloaded to store 2 very different types of records:
1. Scheduled Reminder communications
2. Repeating events/activities

This PR solves 3 problems I found when investigating [dev/core#4550](https://lab.civicrm.org/dev/core/-/issues/4550):
1. The unique `name` constraint was causing the creation of repeating/activities to crash, since the latter type of record had never bothered setting a `name`.
2. Incorrect params were being passed to `call_user_func()`, causing a crash when updating the repeating settings on an event. That appears to have been broken since 2014 so I'm very puzzled why no one has reported it yet.
3. The latter type of `civicrm_action_schedule` was being shown in the new AdminUI Scheduled Reminders screen.
