### PR TITLE
Implement OAuthSessionToken

### DIFF
--- a/ext/oauth-client/Civi/Api4/Action/OAuthSessionToken/Delete.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSessionToken/Delete.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Civi\Api4\Action\OAuthSessionToken;
+
+use Civi\Api4\Generic\BasicBatchAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ * Delete one or more $ENTITIES.
+ *
+ * If a `where` parameter is given, it is used to restrict which $ENTITIES
+ * are deleted. Otherwise all are deleted.
+ */
+class Delete extends BasicBatchAction {
+  /**
+   * Criteria for selecting $ENTITIES to delete. This can be left empty, in
+   * which case all $ENTITIES will be deleted.
+   *
+   * @var array
+   */
+  protected $where = [];
+
+  protected function processBatch(Result $result, array $items) {
+    $session = \CRM_Core_Session::singleton();
+    $allTokens = $session->get('OAuthSessionTokens') ?? [];
+    foreach ($items as $item) {
+      unset($allTokens[$item['cardinal']]);
+      $result[] = $item;
+    }
+    $session->set('OAuthSessionTokens', $allTokens);
+  }
+
+}

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -9,6 +9,21 @@ class OAuthSessionToken extends Generic\AbstractEntity {
 
   const ENTITY = 'OAuthSessionToken';
 
+  public static function create($checkPermissions = TRUE): Generic\BasicCreateAction {
+    $action = new Generic\BasicCreateAction(
+      self::ENTITY,
+      __FUNCTION__,
+      function ($item, $createAction) {
+        $session = \CRM_Core_Session::singleton();
+        $all = $session->get('OAuthSessionTokens') ?? [];
+        $all[] = &$item;
+        $item['cardinal'] = array_key_last($all);
+        $session->set('OAuthSessionTokens', $all);
+        return $item;
+      });
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
   public static function deleteAll($checkPermissions = TRUE): AbstractAction {
     return (new class(self::ENTITY, __FUNCTION__) extends AbstractAction {
 
@@ -32,21 +47,6 @@ class OAuthSessionToken extends Generic\AbstractEntity {
     return $action->setCheckPermissions($checkPermissions);
   }
 
-  public static function create($checkPermissions = TRUE): Generic\BasicCreateAction {
-    $action = new Generic\BasicCreateAction(
-      self::ENTITY,
-      __FUNCTION__,
-      function ($item, $createAction) {
-        $session = \CRM_Core_Session::singleton();
-        $all = $session->get('OAuthSessionTokens') ?? [];
-        $all[] = &$item;
-        $item['cardinal'] = array_key_last($all);
-        $session->set('OAuthSessionTokens', $all);
-        return $item;
-      });
-    return $action->setCheckPermissions($checkPermissions);
-  }
-
   /**
    * @param bool $checkPermissions
    * @return Generic\BasicGetFieldsAction
@@ -58,6 +58,7 @@ class OAuthSessionToken extends Generic\AbstractEntity {
           'name' => 'client_id',
           'required' => TRUE,
         ],
+        ['name' => 'cardinal'],
         ['name' => 'grant_type'],
         ['name' => 'tag'],
         ['name' => 'scopes'],
@@ -65,10 +66,10 @@ class OAuthSessionToken extends Generic\AbstractEntity {
         ['name' => 'access_token'],
         ['name' => 'refresh_token'],
         ['name' => 'expires'],
-        ['name' => 'raw'],
         ['name' => 'storage'],
         ['name' => 'resource_owner_name'],
         ['name' => 'resource_owner'],
+        ['name' => 'raw'],
       ];
     });
     return $action->setCheckPermissions($checkPermissions);
@@ -82,6 +83,10 @@ class OAuthSessionToken extends Generic\AbstractEntity {
       "meta" => ["access CiviCRM"],
       "default" => ["administer CiviCRM data"],
     ];
+  }
+
+  protected static function getEntityTitle($plural = FALSE) {
+    return $plural ? ts('OAuth Session Tokens') : ts('OAuth Session Token');
   }
 
 }

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -6,7 +6,7 @@ use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
 
 /**
- * OAuth Access Tokens.
+ * OAuth Access Tokens stored in the session
  *
  * @see https://docs.civicrm.org/dev/en/latest/framework/oauth/#model-token
  *
@@ -17,6 +17,10 @@ use Civi\Api4\Generic\Result;
  */
 class OAuthSessionToken extends Generic\AbstractEntity {
 
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Generic\BasicCreateAction
+   */
   public static function create($checkPermissions = TRUE): Generic\BasicCreateAction {
     $action = new Generic\BasicCreateAction(
       static::getEntityName(),

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -2,9 +2,6 @@
 
 namespace Civi\Api4;
 
-use Civi\Api4\Generic\AbstractAction;
-use Civi\Api4\Generic\Result;
-
 /**
  * OAuth Access Tokens stored in the session
  *
@@ -38,15 +35,13 @@ class OAuthSessionToken extends Generic\AbstractEntity {
     return $action->setCheckPermissions($checkPermissions);
   }
 
-  public static function deleteAll($checkPermissions = TRUE): AbstractAction {
-    return (new class(self::ENTITY, __FUNCTION__) extends AbstractAction {
-
-      public function _run(Result $result) {
-        $result->exchangeArray(OAuthSessionToken::get());
-        \CRM_Core_Session::singleton()->set('OAuthSessionTokens');
-      }
-
-    })->setCheckPermissions($checkPermissions);
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicBatchAction
+   */
+  public static function delete($checkPermissions = TRUE): Generic\BasicBatchAction {
+    $action = new Action\OAuthSessionToken\Delete(static::getEntityName(), __FUNCTION__);
+    return $action->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -25,12 +25,14 @@ class OAuthSessionToken extends Generic\AbstractEntity {
     $action = new Generic\BasicCreateAction(
       static::getEntityName(),
       __FUNCTION__,
-      function ($item, $createAction) {
+      function ($item) {
         $session = \CRM_Core_Session::singleton();
-        $all = $session->get('OAuthSessionTokens') ?? [];
-        $all[] = &$item;
-        $item['cardinal'] = array_key_last($all);
-        $session->set('OAuthSessionTokens', $all);
+        $allTokens = $session->get('OAuthSessionTokens') ?? [];
+        $cardinal = ($session->get('OAuthSessionTokenCount') ?? 0) + 1;
+        $item['cardinal'] = $cardinal;
+        $allTokens[$cardinal] = $item;
+        $session->set('OAuthSessionTokens', $allTokens);
+        $session->set('OAuthSessionTokenCount', $cardinal);
         return $item;
       });
     return $action->setCheckPermissions($checkPermissions);
@@ -69,8 +71,15 @@ class OAuthSessionToken extends Generic\AbstractEntity {
         [
           'name' => 'client_id',
           'required' => TRUE,
+          'data_type' => 'Integer',
+          'fk_entity' => 'OAuthClient',
         ],
-        ['name' => 'cardinal'],
+        [
+          'name' => 'cardinal',
+          'readonly' => TRUE,
+          'data_type' => 'Integer',
+          'description' => 'Order in which the token was created within the current session. Unique within the session.',
+        ],
         ['name' => 'grant_type'],
         ['name' => 'tag'],
         ['name' => 'scopes'],

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Civi\Api4;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+class OAuthSessionToken extends Generic\AbstractEntity {
+
+  const ENTITY = 'OAuthSessionToken';
+
+  public static function deleteAll($checkPermissions = TRUE): AbstractAction {
+    return (new class(self::ENTITY, __FUNCTION__) extends AbstractAction {
+
+      public function _run(Result $result) {
+        $result->exchangeArray(OAuthSessionToken::get());
+        \CRM_Core_Session::singleton()->set('OAuthSessionTokens');
+      }
+
+    })->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetAction
+   */
+  public static function get($checkPermissions = TRUE): Generic\BasicGetAction {
+    $action = new Generic\BasicGetAction(self::ENTITY, __FUNCTION__, function () {
+      $session = \CRM_Core_Session::singleton();
+      return $session->get('OAuthSessionTokens') ?? [];
+    });
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
+  public static function create($checkPermissions = TRUE): Generic\BasicCreateAction {
+    $action = new Generic\BasicCreateAction(
+      self::ENTITY,
+      __FUNCTION__,
+      function ($item, $createAction) {
+        $session = \CRM_Core_Session::singleton();
+        $all = $session->get('OAuthSessionTokens') ?? [];
+        $all[] = &$item;
+        $item['cardinal'] = array_key_last($all);
+        $session->set('OAuthSessionTokens', $all);
+        return $item;
+      });
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Generic\BasicGetFieldsAction
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    $action = new Generic\BasicGetFieldsAction(self::ENTITY, __FUNCTION__, function () {
+      return [
+        [
+          'name' => 'client_id',
+          'required' => TRUE,
+        ],
+        ['name' => 'grant_type'],
+        ['name' => 'tag'],
+        ['name' => 'scopes'],
+        ['name' => 'token_type'],
+        ['name' => 'access_token'],
+        ['name' => 'refresh_token'],
+        ['name' => 'expires'],
+        ['name' => 'raw'],
+        ['name' => 'storage'],
+        ['name' => 'resource_owner_name'],
+        ['name' => 'resource_owner'],
+      ];
+    });
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @return array
+   */
+  public static function permissions() {
+    return [
+      "meta" => ["access CiviCRM"],
+      "default" => ["administer CiviCRM data"],
+    ];
+  }
+
+}

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -17,11 +17,9 @@ use Civi\Api4\Generic\Result;
  */
 class OAuthSessionToken extends Generic\AbstractEntity {
 
-  const ENTITY = 'OAuthSessionToken';
-
   public static function create($checkPermissions = TRUE): Generic\BasicCreateAction {
     $action = new Generic\BasicCreateAction(
-      self::ENTITY,
+      static::getEntityName(),
       __FUNCTION__,
       function ($item, $createAction) {
         $session = \CRM_Core_Session::singleton();
@@ -50,7 +48,7 @@ class OAuthSessionToken extends Generic\AbstractEntity {
    * @return Generic\BasicGetAction
    */
   public static function get($checkPermissions = TRUE): Generic\BasicGetAction {
-    $action = new Generic\BasicGetAction(self::ENTITY, __FUNCTION__, function () {
+    $action = new Generic\BasicGetAction(static::getEntityName(), __FUNCTION__, function () {
       $session = \CRM_Core_Session::singleton();
       return $session->get('OAuthSessionTokens') ?? [];
     });
@@ -62,7 +60,7 @@ class OAuthSessionToken extends Generic\AbstractEntity {
    * @return Generic\BasicGetFieldsAction
    */
   public static function getFields($checkPermissions = TRUE) {
-    $action = new Generic\BasicGetFieldsAction(self::ENTITY, __FUNCTION__, function () {
+    $action = new Generic\BasicGetFieldsAction(static::getEntityName(), __FUNCTION__, function () {
       return [
         [
           'name' => 'client_id',

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -101,7 +101,7 @@ class OAuthSessionToken extends Generic\AbstractEntity {
     ];
   }
 
-  protected static function getEntityTitle($plural = FALSE) {
+  protected static function getEntityTitle(bool $plural = FALSE): string {
     return $plural ? ts('OAuth Session Tokens') : ts('OAuth Session Token');
   }
 

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -5,6 +5,16 @@ namespace Civi\Api4;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
 
+/**
+ * OAuth Access Tokens.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/oauth/#model-token
+ *
+ * @primaryKey cardinal
+ * @searchable none
+ * @since 5.67
+ * @package Civi\Api4
+ */
 class OAuthSessionToken extends Generic\AbstractEntity {
 
   const ENTITY = 'OAuthSessionToken';

--- a/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
+++ b/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
@@ -14,9 +14,8 @@ use League\OAuth2\Client\Token\AccessToken;
  *   may prefer "prompt" nowadays.
  * - Allow one to fetch claims about the resource-owner from the `id_token`
  *   supported by OpenID Connect. This reduces the need for extra round-trips
- *   and proprietary scopes+URLs. To use this, set the the option:
- *
- *    "urlResourceOwnerDetails": "{{use_id_token}}",
+ *   and proprietary scopes+URLs. To use this, set the option:
+ *     "urlResourceOwnerDetails": "{{use_id_token}}",
  * - Allow support for {{tenant}} token in provider URLs, if the provider has
  *   the 'tenancy' option set to TRUE (eg: ms-exchange).
  */

--- a/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
@@ -6,7 +6,7 @@ use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 
 class OAuthTokenFacade {
 
-  const STORAGE_TYPES = ';^OAuth(Sys|Contact)Token$;';
+  const STORAGE_TYPES = ';^OAuth(Sys|Contact|Session)Token$;';
 
   /**
    * Request and store a token.

--- a/ext/oauth-client/Civi/OAuth/TestOAuthDotComProvider.php
+++ b/ext/oauth-client/Civi/OAuth/TestOAuthDotComProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Civi\OAuth;
+
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+
+class TestOAuthDotComProvider extends CiviGenericProvider {
+
+  protected function createResourceOwner(array $response, AccessToken $token): GenericResourceOwner {
+    return new GenericResourceOwner($response, 'name');
+  }
+
+}

--- a/ext/oauth-client/providers/testoauth.com.json
+++ b/ext/oauth-client/providers/testoauth.com.json
@@ -1,0 +1,10 @@
+{
+  "title": "TestOAuth.com",
+  "class": "Civi\\OAuth\\TestOAuthDotComProvider",
+  "options": {
+    "urlAuthorize": "https://testoauth.com/oauth/authorize",
+    "urlAccessToken": "https://testoauth.com/oauth/token",
+    "urlResourceOwnerDetails": "https://testoauth.com/oauth/info",
+    "scopes": ["read"]
+  }
+}

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthSessionTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthSessionTokenTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Create and read session-specific OAuth tokens
+ *
+ * @group headless
+ */
+class api_v4_OAuthSessionTokenTest extends \PHPUnit\Framework\TestCase implements
+    HeadlessInterface,
+    HookInterface,
+    TransactionalInterface {
+
+  // these two traits together give us createLoggedInUser()
+  use Civi\Test\ContactTestTrait;
+  use \Civi\Test\Api3TestTrait;
+
+  public function setUpHeadless(): \Civi\Test\CiviEnvBuilder {
+    return \Civi\Test::headless()->install('oauth-client')->apply();
+  }
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_oauth_client'));
+    $this->assertNull(CRM_Core_Session::singleton()->get('OAuthSessionTokens') ?? NULL);
+  }
+
+  protected function tearDown(): void {
+    CRM_Core_Session::singleton()->reset();
+    parent::tearDown();
+  }
+
+  private function createClient(): ?array {
+    $createClient = Civi\Api4\OAuthClient::create(FALSE)->setValues(
+      [
+        'provider' => 'test_example_1',
+        'guid' => "example-client-guid",
+        'secret' => "example-secret",
+      ]
+    )->execute();
+    $client = $createClient->first();
+    $this->assertTrue(is_numeric($client['id']));
+    return $client;
+  }
+
+  private function getTestTokenCreateValues($client, $secretPrefix) {
+    return [
+      'client_id' => $client['id'],
+      'access_token' => "$secretPrefix-user-access-token",
+      'refresh_token' => "$secretPrefix-user-refresh-token",
+    ];
+  }
+
+  public function testAnonymousSessionCanHoldToken() {
+    self::assertNull(CRM_Core_Session::getLoggedInContactID());
+
+    $client = $this->createClient();
+    $tokenCreateValues = $this->getTestTokenCreateValues($client, 'anon');
+
+    Civi\Api4\OAuthSessionToken::create(FALSE)
+      ->setValues($tokenCreateValues)
+      ->execute();
+
+    $retrievedToken = \Civi\Api4\OAuthSessionToken::get(FALSE)
+      ->addWhere('client_id', '=', $client['id'])
+      ->execute()
+      ->first();
+
+    $this->assertEquals($client['id'], $retrievedToken['client_id']);
+    $this->assertEquals($tokenCreateValues['access_token'], $retrievedToken['access_token']);
+    $this->assertEquals($tokenCreateValues['refresh_token'], $retrievedToken['refresh_token']);
+  }
+
+  public function testAnonymousSessionTokensCanBeDeleted() {
+    self::assertNull(CRM_Core_Session::getLoggedInContactID());
+
+    $client = $this->createClient();
+    $tokenCreateValues = $this->getTestTokenCreateValues($client, 'anon');
+
+    Civi\Api4\OAuthSessionToken::create(FALSE)
+      ->setValues($tokenCreateValues)
+      ->execute();
+
+    \Civi\Api4\OAuthSessionToken::deleteAll(FALSE)
+      ->execute();
+
+    $retrievedTokens = \Civi\Api4\OAuthSessionToken::get(FALSE)
+      ->execute()
+      ->first();
+
+    $this->assertEmpty($retrievedTokens);
+  }
+
+  public function testLoggedInSessionCanHoldToken() {
+    $this->createLoggedInUser();
+    self::assertIsNumeric(CRM_Core_Session::getLoggedInContactID());
+
+    $client = $this->createClient();
+    $tokenCreateValues = $this->getTestTokenCreateValues($client, 'loggedIn');
+
+    Civi\Api4\OAuthSessionToken::create(FALSE)
+      ->setValues($tokenCreateValues)
+      ->execute();
+
+    $retrievedToken = \Civi\Api4\OAuthSessionToken::get(FALSE)
+      ->addWhere('client_id', '=', $client['id'])
+      ->execute()
+      ->first();
+
+    $this->assertEquals($client['id'], $retrievedToken['client_id']);
+    $this->assertEquals($tokenCreateValues['access_token'], $retrievedToken['access_token']);
+    $this->assertEquals($tokenCreateValues['refresh_token'], $retrievedToken['refresh_token']);
+  }
+
+  public function testLoggingOutDeletesTokens() {
+    $this->createLoggedInUser();
+    self::assertIsNumeric(CRM_Core_Session::getLoggedInContactID());
+
+    $client = $this->createClient();
+    $tokenCreateValues = $this->getTestTokenCreateValues($client, 'loggedIn');
+
+    Civi\Api4\OAuthSessionToken::create(FALSE)
+      ->setValues($tokenCreateValues)
+      ->execute();
+
+    // log out
+    CRM_Core_Session::singleton()->reset();
+    self::assertNull(CRM_Core_Session::getLoggedInContactID());
+
+    $retrievedTokens = \Civi\Api4\OAuthSessionToken::get(FALSE)
+      ->execute()
+      ->first();
+
+    $this->assertEmpty($retrievedTokens);
+  }
+
+}

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthSessionTokenTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthSessionTokenTest.php
@@ -84,7 +84,7 @@ class api_v4_OAuthSessionTokenTest extends \PHPUnit\Framework\TestCase implement
       ->setValues($tokenCreateValues)
       ->execute();
 
-    \Civi\Api4\OAuthSessionToken::deleteAll(FALSE)
+    \Civi\Api4\OAuthSessionToken::delete(FALSE)
       ->execute();
 
     $retrievedTokens = \Civi\Api4\OAuthSessionToken::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
A new type of OAuth token storage: OAuthSessionToken. As described under https://docs.civicrm.org/dev/en/latest/framework/oauth/#model-token, "each token [is] strictly associated with one user's interaction with CiviCRM. After the user's momentary interaction, the token can (and probably should) be forgotten."

Technical Details
----------------------------------------
Regarding "the token can (and probably should) be forgotten," I've provided a `deleteAll` action to wipe the board clear. Programmers will be responsible for using this and/or sensible token TTLs. If a user is logged in, logging out will also delete any tokens in the session.

Based on the use cases I can imagine, I have set the permissions bar quite high and am assuming implementations will bypass API4 permissions after putting other case-specific guards in place.