### PR TITLE
Remove long-broken function

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -67,21 +67,6 @@ class CRM_Utils_Mail_EmailProcessor {
   }
 
   /**
-   * Process the mailbox for all the settings from civicrm_mail_settings.
-   *
-   * @param bool|string $civiMail if true, processing is done in CiviMail context, or Activities otherwise.
-   */
-  public static function process($civiMail = TRUE) {
-    $dao = new CRM_Core_DAO_MailSettings();
-    $dao->domain_id = CRM_Core_Config::domainID();
-    $dao->find();
-
-    while ($dao->fetch()) {
-      self::_process($civiMail, $dao);
-    }
-  }
-
-  /**
    * @param $civiMail
    * @param CRM_Core_DAO_MailSettings $dao
    * @param bool $is_create_activities


### PR DESCRIPTION
Overview
----------------------------------------
Function is clearly broken as it would fatal by not passing all the required params to `_process`

![image](https://github.com/civicrm/civicrm-core/assets/336308/81f820d1-b676-4f7c-b9c1-42b42d8d8143)


![image](https://github.com/civicrm/civicrm-core/assets/336308/ad5f8523-bf5f-4be6-999e-2f7712ddc8cd)

That parameter has been required since 2017 https://github.com/civicrm/civicrm-core/commit/3ff238ae7ff2c1e44450a5b98f8e8bcdea456f83#diff-60061a72313165faed2e64c331960fdfcc46a652756d20a130249f21d0c27c79R132