### PR TITLE
[wip] dev/core#2800 Fix Email processor to handle verp addresses for activity creating

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -38,7 +38,7 @@ class CRM_Utils_Mail_EmailProcessor {
     $dao->find();
 
     while ($dao->fetch()) {
-      self::_process(TRUE, $dao, $is_create_activities);
+      self::_process($dao, (bool) $is_create_activities);
     }
   }
 
@@ -58,7 +58,7 @@ class CRM_Utils_Mail_EmailProcessor {
     $found = FALSE;
     while ($dao->fetch()) {
       $found = TRUE;
-      self::_process(FALSE, $dao, TRUE);
+      self::_process($dao, TRUE);
     }
     if (!$found) {
       throw new CRM_Core_Exception(ts('No mailboxes have been configured for Email to Activity Processing'));
@@ -67,7 +67,6 @@ class CRM_Utils_Mail_EmailProcessor {
   }
 
   /**
-   * @param $civiMail
    * @param CRM_Core_DAO_MailSettings $dao
    * @param bool $is_create_activities
    *   Create activities.
@@ -75,7 +74,7 @@ class CRM_Utils_Mail_EmailProcessor {
    * @throws Exception
    * @throws CRM_Core_Exception
    */
-  private static function _process($civiMail, $dao, $is_create_activities) {
+  private static function _process($dao, bool $is_create_activities) {
     // 0 = activities; 1 = bounce;
     $usedfor = $dao->is_default;
     if ($usedfor == 0) {

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -158,8 +158,7 @@ class CRM_Utils_Mail_EmailProcessor {
           }
         }
 
-        // preseve backward compatibility
-        if ($usedfor == 0 || $is_create_activities) {
+        if ($is_create_activities) {
           // Mail account may have 'Skip emails which do not have a Case ID
           // or Case hash' option, if its enabled and email is not related
           // to cases - then we need to put email to ignored folder.

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -67,21 +67,6 @@ class CRM_Utils_Mail_EmailProcessor {
   }
 
   /**
-   * Process the mailbox for all the settings from civicrm_mail_settings.
-   *
-   * @param bool|string $civiMail if true, processing is done in CiviMail context, or Activities otherwise.
-   */
-  public static function process($civiMail = TRUE) {
-    $dao = new CRM_Core_DAO_MailSettings();
-    $dao->domain_id = CRM_Core_Config::domainID();
-    $dao->find();
-
-    while ($dao->fetch()) {
-      self::_process($civiMail, $dao);
-    }
-  }
-
-  /**
    * @param $civiMail
    * @param CRM_Core_DAO_MailSettings $dao
    * @param bool $is_create_activities

--- a/CRM/Utils/Mail/IncomingMail.php
+++ b/CRM/Utils/Mail/IncomingMail.php
@@ -1,0 +1,259 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\API\EntityLookupTrait;
+use Civi\Api4\MailingJob;
+
+/**
+ * Incoming mail class.
+ *
+ * @internal - this is not supported for use from outside of code.
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Utils_Mail_IncomingMail {
+
+  use EntityLookupTrait;
+
+  /**
+   * @var \ezcMail
+   */
+  private $mail;
+
+  /**
+   * @var string
+   */
+  private $action;
+
+  /**
+   * @var int
+   */
+  private $queueID;
+
+  /**
+   * @var int
+   */
+  private $jobID;
+
+  /**
+   * Attachments.
+   *
+   * The files for these have been moved to the files directory.
+   *
+   * @var array
+   */
+  private $attachments;
+
+  /**
+   * Unprocessed attachments.
+   *
+   * @var array
+   */
+  private $attachmentsRaw = [];
+
+  /**
+   * @var string
+   */
+  private $body;
+
+  /**
+   * @return null|string
+   */
+  public function getVerpAction(): ?string {
+    return [
+      'b' => 'bounce',
+      'c' => 'confirm',
+      'u' => 'unsubscribe',
+      'r' => 'reply',
+      'o' => 'opt_out',
+      'e' => 'resubscribe',
+      's' => 'subscribe',
+    ][$this->action] ?? NULL;
+  }
+
+  /**
+   * @return int|null
+   */
+  public function getQueueID(): ?int {
+    return $this->queueID;
+  }
+
+  /**
+   * @return int|null
+   */
+  public function getJobID(): ?int {
+    return $this->jobID;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getHash(): ?string {
+    return $this->hash;
+  }
+
+  /**
+   * Is this a verp email.
+   *
+   * If the regex didn't find a match then no.
+   *
+   * @return bool
+   */
+  public function isVerp(): bool {
+    return (bool) $this->action;
+  }
+
+  /**
+   * @var string
+   */
+  private $hash;
+
+  public function getEmailSubject(): string {
+    return (string) $this->mail->subject;
+  }
+
+  public function getDate() : string {
+    return date('YmdHis', strtotime($this->mail->getHeader('Date')));
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getBody(): ?string {
+    return $this->body;
+  }
+
+  /**
+   * Return the attachments to meet current requirement in EmailProcessor class.
+   *
+   * @internal may change without notice.
+   *
+   * @return array
+   */
+  public function getAttachments(): array {
+    $attachmentArray = [];
+    // format and move attachments to the civicrm area
+    if ($this->attachments === NULL) {
+      $date = date('YmdHis');
+      $this->attachments = [];
+      $config = CRM_Core_Config::singleton();
+      foreach ($this->attachmentsRaw as $i => $iValue) {
+        $attachNum = $i + 1;
+        $fileName = basename($iValue['fullName']);
+        $newName = CRM_Utils_File::makeFileName($fileName);
+        $location = $config->uploadDir . $newName;
+
+        // move file to the civicrm upload directory
+        rename($iValue['fullName'], $location);
+
+        $mimeType = "{$iValue['contentType']}/{$iValue['mimeType']}";
+
+        $attachmentArray[$attachNum] = [
+          'uri' => $fileName,
+          'type' => $mimeType,
+          'upload_date' => $date,
+          'location' => $location,
+        ];
+      }
+    }
+    return $attachmentArray;
+  }
+
+  /**
+   * @param \ezcMail $mail
+   * @param string $emailDomain
+   * @param string $emailLocalPart
+   *
+   * @throws \ezcBasePropertyNotFoundException
+   * @throws \CRM_Core_Exception
+   */
+  public function __construct(ezcMail $mail, string $emailDomain, string $emailLocalPart) {
+    $this->mail = $mail;
+    $this->body = CRM_Utils_Mail_Incoming::formatMailPart($this->mail->body, $this->attachmentsRaw);
+
+    $verpSeparator = preg_quote(\Civi::settings()->get('verpSeparator') ?: '');
+    $emailDomain = preg_quote($emailDomain);
+    $emailLocalPart = preg_quote($emailLocalPart);
+    $twoDigitStringMin = $verpSeparator . '(\d+)' . $verpSeparator . '(\d+)';
+    $twoDigitString = $twoDigitStringMin . $verpSeparator;
+
+    // a common-for-all-actions regex to handle CiviCRM 2.2 address patterns
+    $regex = '/^' . $emailLocalPart . '(b|c|e|o|r|u)' . $twoDigitString . '([0-9a-f]{16})@' . $emailDomain . '$/';
+
+    // a tighter regex for finding bounce info in soft bounces’ mail bodies
+    $rpRegex = '/Return-Path:\s*' . $emailLocalPart . '(b)' . $twoDigitString . '([0-9a-f]{16})@' . $emailDomain . '/';
+
+    // a regex for finding bound info X-Header
+    $rpXHeaderRegex = '/X-CiviMail-Bounce: ' . $emailLocalPart . '(b)' . $twoDigitString . '([0-9a-f]{16})@' . $emailDomain . '/i';
+    // CiviMail in regex and Civimail in header !!!
+    $matches = NULL;
+    foreach ($this->mail->to as $address) {
+      if (preg_match($regex, ($address->email ?? ''), $matches)) {
+        [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
+        break;
+      }
+    }
+
+    // CRM-5471: if $matches is empty, it still might be a soft bounce sent
+    // to another address, so scan the body for ‘Return-Path: …bounce-pattern…’
+    if (!$matches && preg_match($rpRegex, ($mail->generateBody() ?? ''), $matches)) {
+      [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
+    }
+
+    // if $matches is still empty, look for the X-CiviMail-Bounce header
+    // CRM-9855
+    if (!$matches && preg_match($rpXHeaderRegex, ($mail->generateBody() ?? ''), $matches)) {
+      [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
+    }
+    // With Mandrill, the X-CiviMail-Bounce header is produced by generateBody
+    // is base64 encoded
+    // Check all parts
+    if (!$matches) {
+      $all_parts = $mail->fetchParts();
+      foreach ($all_parts as $v_part) {
+        if ($v_part instanceof ezcMailFile) {
+          $p_file = $v_part->__get('fileName');
+          $c_file = file_get_contents($p_file);
+          if (preg_match($rpXHeaderRegex, ($c_file ?? ''), $matches)) {
+            [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
+          }
+        }
+      }
+    }
+
+    // if all else fails, check Delivered-To for possible pattern
+    if (!$matches && preg_match($regex, ($mail->getHeader('Delivered-To') ?? ''), $matches)) {
+      [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
+    }
+    if ($this->isVerp()) {
+      $queue = CRM_Mailing_Event_BAO_MailingEventQueue::verify($this->getJobID(), $this->getQueueID(), $this->getHash());
+      if (!$queue) {
+        throw new CRM_Core_Exception('Contact could not be found from civimail response');
+      }
+      $this->define('Queue', 'Queue', [
+        'id' => $queue->id,
+        'hash' => $queue->hash,
+        'contact_id' => $queue->contact_id,
+        'job_id' => $queue->contact_id,
+      ]);
+      $this->define('Mailing', 'Mailing', [
+        'id' => MailingJob::get(FALSE)
+          ->addWhere('id', '=', $this->getJobID())
+          ->addSelect('mailing_id')
+          ->execute()
+          ->first()['mailing_id'],
+      ]);
+    }
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#2800 Fix Email processor to handle verp addresses for activity creating

Before
----------------------------------------
Processing emails with verp email addresses (CiviMail replies) you can choose to create activities. However these actvities will create new contacts with their emails being the verp email rather than match to appropriate contacts - see 

https://lab.civicrm.org/dev/core/-/issues/2800
https://lab.civicrm.org/documentation/docs/sysadmin/-/issues/217


After
----------------------------------------
Emails are matched to the contact from the mailing

Technical Details
----------------------------------------
This is just about there - but I think I need to split out some PRs to make it reviewable

Comments
----------------------------------------
