### PR TITLE
Improve error handling by using civicrm_api3 not civicrm_api

### DIFF
--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -296,12 +296,6 @@ class CRM_Utils_Mail_Incoming {
    */
   public static function parseMailingObject(&$mail, $createContact = TRUE, $requireContact = TRUE, $emailFields = ['from', 'to', 'cc', 'bcc']) {
 
-    $config = CRM_Core_Config::singleton();
-
-    // get ready for collecting data about this email
-    // and put it in a standardized format
-    $params = ['is_error' => 0];
-
     // Sometimes $mail->from is unset because ezcMail didn't handle format
     // of From header. CRM-19215.
     if (!isset($mail->from)) {


### PR DESCRIPTION
Improve error handling by using civicrm_api3 not civicrm_api - this just moves all the 'doing' for creating the activity into the try-catch block and removes some extraneous setting of `is_error`