### PR TITLE
Fix enotice (possible regression)

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1350,7 +1350,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     }
 
     if (!empty($params['send_receipt'])) {
-      $result = $this->sendReceipts($params, $contributionParams['total_amount'], $customFields, $participants, $lineItem[0], $additionalParticipantDetails);
+      $result = $this->sendReceipts($params, $contributionParams['total_amount'], $customFields, $participants, $lineItem[0] ?? [], $additionalParticipantDetails);
     }
 
     // set the participant id if it is not set


### PR DESCRIPTION
Overview
----------------------------------------
Fix enotice (possible regression)

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/67ff772d-d3fe-4945-b407-2c190c4e1119)

After
----------------------------------------

Technical Details
----------------------------------------
It's clear in the function that lineItem is only defined for add - I hit the enotice editing
    the participant to be paid. Not sure if this is a regression but there was a related one
    fixed in 5.65 or 5.64 so targetting the rc



Comments
----------------------------------------