### PR TITLE
Event Dashboard: show events that have not ended yet

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -364,7 +364,7 @@ SELECT     count(id) as total_events
 FROM       civicrm_event
 WHERE      civicrm_event.is_active = 1 AND
            civicrm_event.is_template = 0 AND
-           civicrm_event.start_date >= DATE_SUB( NOW(), INTERVAL 7 day )
+           (civicrm_event.start_date >= DATE_SUB(NOW(), INTERVAL 7 day) OR (civicrm_event.end_date IS NOT NULL AND civicrm_event.end_date >= NOW()))
            $validEventIDs";
 
     $dao = CRM_Core_DAO::executeQuery($query);
@@ -373,9 +373,7 @@ WHERE      civicrm_event.is_active = 1 AND
       $eventSummary['total_events'] = $dao->total_events;
     }
 
-    if (empty($eventSummary) ||
-      $dao->total_events == 0
-    ) {
+    if (empty($eventSummary['total_events'])) {
       return $eventSummary;
     }
 
@@ -426,7 +424,7 @@ LEFT JOIN  civicrm_pcp_block ON ( civicrm_pcp_block.entity_id = civicrm_event.id
 LEFT JOIN  civicrm_recurring_entity ON ( civicrm_event.id = civicrm_recurring_entity.entity_id AND civicrm_recurring_entity.entity_table = 'civicrm_event' )
 WHERE      civicrm_event.is_active = 1 AND
            civicrm_event.is_template = 0 AND
-           civicrm_event.start_date >= DATE_SUB( NOW(), INTERVAL 7 day )
+           (civicrm_event.start_date >= DATE_SUB(NOW(), INTERVAL 7 day) OR (civicrm_event.end_date IS NOT NULL AND civicrm_event.end_date >= NOW()))
            $validEventIDs
 ORDER BY   civicrm_event.start_date ASC
 $event_summary_limit


### PR DESCRIPTION
Overview
----------------------------------------

For events that span on more than 7 days, they disappear from the Event Dashboard before the event ends.

Before
----------------------------------------

Dashboard displays only events that have a Start Date >= 7 days ago (so an event that started last week is still visible).

After
----------------------------------------

Dashboard displays  events that:

- have a Start Date >= 7 days ago
- or the End Date, if set, is >= now

This way, an event that started more than 7 days ago, but still not finished, will still be visible on the Event Dashboard.

Comments
----------------------------------------

I tried replacing the queries with Api4, but I hit a wall with "Tell a Friend" and figured I should maybe not go down that rabbit hole, as presumably this will be replaced by SearchKit soon.