### PR TITLE
dev/core #4556 Show payment block if payment_instrument_id already set

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -135,6 +135,10 @@
       buildPaymentBlock(0);
     });
 
+    if ($('#payment_instrument_id').val()) {
+      buildPaymentBlock(0);
+    }
+
     $('#billing-payment-block').on('crmLoad', function() {
       $('.crm-submit-buttons input').prop('disabled', false);
     })


### PR DESCRIPTION
Overview
----------------------------------------
[See issue.](https://lab.civicrm.org/dev/core/-/issues/4556)

Before
----------------------------------------
Payment block only loaded on change of payment_instrument_id.

After
----------------------------------------
Payment block loaded on page load if payment_instrument_id has a value.