### PR TITLE
SearchKit - Don't crash afforms with non-dao entities

### DIFF
--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -29,8 +29,11 @@ class Meta {
    * @return array
    */
   public static function getCalcFields($apiEntity, $apiParams): array {
-    $calcFields = [];
     $api = \Civi\API\Request::create($apiEntity, 'get', $apiParams);
+    if (!is_a($api, '\Civi\Api4\Generic\DAOGetAction')) {
+      return [];
+    }
+    $calcFields = [];
     $selectQuery = new \Civi\Api4\Query\Api4SelectQuery($api);
     $joinMap = $joinCount = [];
     foreach ($apiParams['join'] ?? [] as $join) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression from circa 5.54 that affects search displays embedded in afforms for non-db entities.

Before
----------------------------------------
Cannot create a search for for a non-db entity.

After
----------------------------------------
No more crash.

Technical Details
----------------------------------------
Looks like a regression from 725c21311c5537de0114036b32c92850576a7e3e