### PR TITLE
Revert "Update CRM.status for compatability with native js promises"

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -11,7 +11,7 @@
       cancel: '&'
     },
     templateUrl: '~/crmSearchDisplay/crmSearchDisplayEditable.html',
-    controller: function($scope, $element, crmApi4) {
+    controller: function($scope, $element, crmApi4, crmStatus) {
       var ctrl = this,
         initialValue,
         col;
@@ -53,7 +53,7 @@
         const value = formatDataType(ctrl.value);
         if (value !== initialValue) {
           col.edit.record[col.edit.value_key] = value;
-          CRM.status({}, crmApi4(col.edit.entity, col.edit.action, {values: col.edit.record}));
+          crmStatus({}, crmApi4(col.edit.entity, col.edit.action, {values: col.edit.record}));
           ctrl.row.data[col.edit.value_path] = value;
           col.val = formatDisplayValue(value);
         }

--- a/js/Common.js
+++ b/js/Common.js
@@ -1320,11 +1320,12 @@ if (!CRM.vars) CRM.vars = {};
       }
     }
     return (deferred || new $.Deferred())
-      .then(function(data) {
+      .done(function(data) {
         // If the server returns an error msg call the error handler
         var status = $.isPlainObject(data) && (data.is_error || data.status === 'error') ? 'error' : 'success';
         handle(status, data);
-      }, function(data) {
+      })
+      .fail(function(data) {
         handle('error', data);
       });
   };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an unreleased regression caused by https://github.com/civicrm/civicrm-core/pull/27105

Before
----------------------------------------
Loading problem in the message_admin extension

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
#27105 made a global change to `CRM.status` for the sake of SearchKit in-place edit.
That in turn broke https://github.com/civicrm/civicrm-core/blob/e53e0c33b5bdfee975127d081cff927d400858d1/ext/message_admin/ang/crmMsgadm/User.js#L18 (for reasons I don't really understand).
This reverts the global change and uses a service for SearchKit in-place edit instead, which works fine.