### PR TITLE
[REF] Update Zetacomponents/mail to be 1.9.5 to fix email validation …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "tecnickcom/tcpdf" : "6.4.*",
     "totten/ca-config": "~22.11",
     "zetacomponents/base": "1.9.*",
-    "zetacomponents/mail": "~1.9.4",
+    "zetacomponents/mail": "~1.9.5",
     "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^0.18.0",
     "pear/validate_finance_creditcard": "0.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d53a256f9748f1facc1312352b5a9acb",
+    "content-hash": "4a541aad8f31cbb35982d1380c3f1c71",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5491,16 +5491,16 @@
         },
         {
             "name": "zetacomponents/mail",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Mail.git",
-                "reference": "83ba646f36f753c0bbc8b2189c88d41ece326ea0"
+                "reference": "e106e5934a42cd1e37227fa50e79be648d60fa14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/83ba646f36f753c0bbc8b2189c88d41ece326ea0",
-                "reference": "83ba646f36f753c0bbc8b2189c88d41ece326ea0",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/e106e5934a42cd1e37227fa50e79be648d60fa14",
+                "reference": "e106e5934a42cd1e37227fa50e79be648d60fa14",
                 "shasum": ""
             },
             "require": {
@@ -5565,9 +5565,9 @@
             "homepage": "https://github.com/zetacomponents",
             "support": {
                 "issues": "https://github.com/zetacomponents/Mail/issues",
-                "source": "https://github.com/zetacomponents/Mail/tree/1.9.4"
+                "source": "https://github.com/zetacomponents/Mail/tree/1.9.5"
             },
-            "time": "2022-09-14T10:13:21+00:00"
+            "time": "2023-09-06T09:15:46+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
…handling

Overview
----------------------------------------
This updates zetacomponents/mail to the most recent version to better handle email validation 

ping @eileenmcnaughton @agileware-justin 