### PR TITLE
Move handling of empty from obscure function to main email handler class 

### DIFF
--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -118,7 +118,7 @@ class CRM_Utils_Mail_EmailProcessor {
 
           // if its the activities that needs to be processed ..
           try {
-            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail, $incomingMail->getAttachments(), $createContact, $emailFields);
+            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail, $incomingMail->getAttachments(), $createContact, $emailFields, [$incomingMail->getFrom()]);
             $activityParams = [
               'activity_type_id' => (int) $dao->activity_type_id,
               'campaign_id' => $dao->campaign_id ? (int) $dao->campaign_id : NULL,
@@ -150,7 +150,6 @@ class CRM_Utils_Mail_EmailProcessor {
                 }
               }
             }
-
             $numAttachments = Civi::settings()->get('max_attachments_backend') ?? CRM_Core_BAO_File::DEFAULT_MAX_ATTACHMENTS_BACKEND;
             for ($i = 1; $i <= $numAttachments; $i++) {
               if (isset($mailParams["attachFile_$i"])) {

--- a/CRM/Utils/Mail/EmailProcessor.php
+++ b/CRM/Utils/Mail/EmailProcessor.php
@@ -77,12 +77,13 @@ class CRM_Utils_Mail_EmailProcessor {
    */
   private static function _process($civiMail, $dao, $is_create_activities) {
     // 0 = activities; 1 = bounce;
-    $usedfor = $dao->is_default;
-    if ($usedfor == 0) {
-      // create an array of all of to, from, cc, bcc that are in use for this Mail Account, so we don't create contacts for emails we aren't adding to the activity
-      $emailFields = array_filter(array_unique(array_merge(explode(",", $dao->activity_targets), explode(",", $dao->activity_assignees), explode(",", $dao->activity_source))));
-      $createContact = !($dao->is_contact_creation_disabled_if_no_match ?? FALSE);
-    }
+    $isBounceProcessing = $dao->is_default;
+    $targetFields = array_filter(explode(',', $dao->activity_targets));
+    $assigneeFields = array_filter(explode(",", $dao->activity_assignees));
+    $sourceFields = array_filter(explode(",", $dao->activity_source));
+    // create an array of all of to, from, cc, bcc that are in use for this Mail Account, so we don't create contacts for emails we aren't adding to the activity.
+    $emailFields = array_merge($targetFields, $assigneeFields, $sourceFields);
+    $createContact = !($dao->is_contact_creation_disabled_if_no_match);
 
     // retrieve the emails
     try {
@@ -104,8 +105,8 @@ class CRM_Utils_Mail_EmailProcessor {
         $queue = $incomingMail->getQueueID();
         $hash = $incomingMail->getHash();
 
-        // preseve backward compatibility
-        if ($usedfor == 0 || $is_create_activities) {
+        // preserve backward compatibility
+        if (!$isBounceProcessing || $is_create_activities) {
           // Mail account may have 'Skip emails which do not have a Case ID
           // or Case hash' option, if its enabled and email is not related
           // to cases - then we need to put email to ignored folder.
@@ -117,33 +118,38 @@ class CRM_Utils_Mail_EmailProcessor {
 
           // if its the activities that needs to be processed ..
           try {
-            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail, $createContact, FALSE, $emailFields);
+            $mailParams = CRM_Utils_Mail_Incoming::parseMailingObject($mail, $incomingMail->getAttachments(), $createContact, $emailFields);
             $activityParams = [
               'activity_type_id' => (int) $dao->activity_type_id,
               'campaign_id' => $dao->campaign_id ? (int) $dao->campaign_id : NULL,
               'status_id' => $dao->activity_status,
+              'subject' => $incomingMail->getSubject(),
+              'activity_date_time' => $incomingMail->getDate(),
+              'details' => $incomingMail->getBody(),
             ];
+            if ($incomingMail->isVerp()) {
+              $activityParams['source_contact_id'] = $incomingMail->lookup('Queue', 'contact_id');
+            }
+            else {
+              $activityParams['source_contact_id'] = $mailParams[$dao->activity_source][0]['id'];
 
-            $activityParams['source_contact_id'] = $mailParams[$dao->activity_source][0]['id'];
-
-            $activityContacts = ['target_contact_id' => 'activity_targets', 'assignee_contact_id' => 'activity_assignees'];
-            foreach ($activityContacts as $activityContact => $daoName) {
-              $activityParams[$activityContact] = [];
-              $activityKeys = array_filter(explode(",", $dao->$daoName));
-              foreach ($activityKeys as $activityKey) {
-                if (is_array($mailParams[$activityKey])) {
-                  foreach ($mailParams[$activityKey] as $keyValue) {
-                    if (!empty($keyValue['id'])) {
-                      $activityParams[$activityContact][] = $keyValue['id'];
+              $activityContacts = [
+                'target_contact_id' => $targetFields,
+                'assignee_contact_id' => $assigneeFields,
+              ];
+              foreach ($activityContacts as $activityContact => $activityKeys) {
+                $activityParams[$activityContact] = [];
+                foreach ($activityKeys as $activityKey) {
+                  if (is_array($mailParams[$activityKey])) {
+                    foreach ($mailParams[$activityKey] as $keyValue) {
+                      if (!empty($keyValue['id'])) {
+                        $activityParams[$activityContact][] = $keyValue['id'];
+                      }
                     }
                   }
                 }
               }
             }
-
-            $activityParams['subject'] = $mailParams['subject'];
-            $activityParams['activity_date_time'] = $mailParams['date'];
-            $activityParams['details'] = $mailParams['body'];
 
             $numAttachments = Civi::settings()->get('max_attachments_backend') ?? CRM_Core_BAO_File::DEFAULT_MAX_ATTACHMENTS_BACKEND;
             for ($i = 1; $i <= $numAttachments; $i++) {
@@ -184,54 +190,13 @@ class CRM_Utils_Mail_EmailProcessor {
 
           switch ($action) {
             case 'b':
-              $text = '';
-              if ($mail->body instanceof ezcMailText) {
-                $text = $mail->body->text;
-              }
-              elseif ($mail->body instanceof ezcMailMultipart) {
-                $text = self::getTextFromMultipart($mail->body);
-              }
-              elseif ($mail->body instanceof ezcMailFile) {
-                $text = file_get_contents($mail->body->__get('fileName'));
-              }
-
-              if (
-                empty($text) &&
-                $mail->subject === 'Delivery Status Notification (Failure)'
-              ) {
-                // Exchange error - CRM-9361
-                foreach ($mail->body->getParts() as $part) {
-                  if ($part instanceof ezcMailDeliveryStatus) {
-                    foreach ($part->recipients as $rec) {
-                      if ($rec['Status'] === '5.1.1') {
-                        if (isset($rec['Description'])) {
-                          $text = $rec['Description'];
-                        }
-                        else {
-                          $text = $rec['Status'] . ' Delivery to the following recipients failed';
-                        }
-                        break;
-                      }
-                    }
-                  }
-                }
-              }
-
-              if (empty($text)) {
-                // If bounce processing fails, just take the raw body. Cf. CRM-11046
-                $text = $mail->generateBody();
-
-                // if text is still empty, lets fudge a blank text so the api call below will succeed
-                if (empty($text)) {
-                  $text = ts('We could not extract the mail body from this bounce message.');
-                }
-              }
+              $text = $incomingMail->getBody();
 
               $activityParams = [
                 'job_id' => $job,
                 'event_queue_id' => $queue,
                 'hash' => $hash,
-                'body' => $text,
+                'body' => $text ?: ts('We could not extract the mail body from this bounce message.'),
                 'version' => 3,
                 // Setting is_transactional means it will rollback if
                 // it crashes part way through creating the bounce.

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -304,6 +304,7 @@ class CRM_Utils_Mail_Incoming {
       }
     }
 
+    $params = [];
     foreach ($emailFields as $field) {
       // to, bcc, cc are arrays of objects, but from is an object, so make it an array of one object so we can handle it the same
       if ($field === 'from') {
@@ -312,7 +313,12 @@ class CRM_Utils_Mail_Incoming {
       else {
         $value = $mail->$field;
       }
-      self::parseAddresses($value, $field, $params, $mail, $createContact);
+      $params[$field] = [];
+      foreach ($value as $address) {
+        $subParam = [];
+        self::parseAddress($address, $subParam, $mail, $createContact);
+        $params[$field][] = $subParam;
+      }
     }
     // format and move attachments to the civicrm area
     if (!empty($attachments)) {
@@ -362,22 +368,6 @@ class CRM_Utils_Mail_Incoming {
       $mail
     );
     $subParam['id'] = $contactID ?: NULL;
-  }
-
-  /**
-   * @param ezcMailAddress[] $addresses
-   * @param $token
-   * @param array $params
-   * @param $mail
-   * @param $createContact
-   */
-  private static function parseAddresses(&$addresses, $token, &$params, &$mail, $createContact = TRUE) {
-    $params[$token] = [];
-    foreach ($addresses as $address) {
-      $subParam = [];
-      self::parseAddress($address, $subParam, $mail, $createContact);
-      $params[$token][] = $subParam;
-    }
   }
 
   /**

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -290,25 +290,17 @@ class CRM_Utils_Mail_Incoming {
    * @param $attachments
    * @param bool $createContact
    * @param array $emailFields
-   *   Which fields to process and create contacts for of from, to, cc, bcc
+   *   Which fields to process and create contacts for - subset of [from, to, cc, bcc],
+   * @param array $from
    *
    * @return array
    */
-  public static function parseMailingObject(&$mail, $attachments, $createContact = TRUE, $emailFields = ['from', 'to', 'cc', 'bcc']) {
-
-    // Sometimes $mail->from is unset because ezcMail didn't handle format
-    // of From header. CRM-19215.
-    if (!isset($mail->from)) {
-      if (preg_match('/^([^ ]*)( (.*))?$/', $mail->getHeader('from'), $matches)) {
-        $mail->from = new ezcMailAddress($matches[1], trim($matches[2]));
-      }
-    }
-
+  public static function parseMailingObject(&$mail, $attachments, $createContact, $emailFields, $from) {
     $params = [];
     foreach ($emailFields as $field) {
       // to, bcc, cc are arrays of objects, but from is an object, so make it an array of one object so we can handle it the same
       if ($field === 'from') {
-        $value = [$mail->$field];
+        $value = $from;
       }
       else {
         $value = $mail->$field;

--- a/CRM/Utils/Mail/Incoming.php
+++ b/CRM/Utils/Mail/Incoming.php
@@ -287,14 +287,14 @@ class CRM_Utils_Mail_Incoming {
 
   /**
    * @param $mail
-   * @param $createContact
-   * @param $requireContact
+   * @param $attachments
+   * @param bool $createContact
    * @param array $emailFields
    *   Which fields to process and create contacts for of from, to, cc, bcc
    *
    * @return array
    */
-  public static function parseMailingObject(&$mail, $createContact = TRUE, $requireContact = TRUE, $emailFields = ['from', 'to', 'cc', 'bcc']) {
+  public static function parseMailingObject(&$mail, $attachments, $createContact = TRUE, $emailFields = ['from', 'to', 'cc', 'bcc']) {
 
     // Sometimes $mail->from is unset because ezcMail didn't handle format
     // of From header. CRM-19215.
@@ -314,15 +314,6 @@ class CRM_Utils_Mail_Incoming {
       }
       self::parseAddresses($value, $field, $params, $mail, $createContact);
     }
-
-    // define other parameters
-    $params['subject'] = $mail->subject;
-    $params['date'] = date("YmdHi00",
-      strtotime($mail->getHeader("Date"))
-    );
-    $attachments = [];
-    $params['body'] = self::formatMailPart($mail->body, $attachments);
-
     // format and move attachments to the civicrm area
     if (!empty($attachments)) {
       $date = date('YmdHis');

--- a/CRM/Utils/Mail/IncomingMail.php
+++ b/CRM/Utils/Mail/IncomingMail.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\API\EntityLookupTrait;
+use Civi\Api4\MailingJob;
+
 /**
  * Incoming mail class.
  *
@@ -18,6 +21,8 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Utils_Mail_IncomingMail {
+
+  use EntityLookupTrait;
 
   /**
    * @var \ezcMail
@@ -43,6 +48,27 @@ class CRM_Utils_Mail_IncomingMail {
    * @var string
    */
   private $hash;
+
+  /**
+   * @var string|null
+   */
+  private $body;
+
+  /**
+   * @return string|null
+   */
+  public function getBody(): ?string {
+    return $this->body;
+  }
+
+  /**
+   * @return array
+   */
+  public function getAttachments(): array {
+    return $this->attachments;
+  }
+
+  private $attachments = [];
 
   public function getAction() : ?string {
     return $this->action;
@@ -70,6 +96,17 @@ class CRM_Utils_Mail_IncomingMail {
   }
 
   /**
+   * @return string
+   */
+  public function getSubject(): string {
+    return (string) $this->mail->subject;
+  }
+
+  public function getDate(): string {
+    return date('YmdHis', strtotime($this->mail->getHeader('Date')));
+  }
+
+  /**
    * Is this a verp email.
    *
    * If the regex didn't find a match then no.
@@ -90,6 +127,7 @@ class CRM_Utils_Mail_IncomingMail {
    */
   public function __construct(ezcMail $mail, string $emailDomain, string $emailLocalPart) {
     $this->mail = $mail;
+    $this->body = CRM_Utils_Mail_Incoming::formatMailPart($mail->body, $this->attachments);
 
     $verpSeparator = preg_quote(\Civi::settings()->get('verpSeparator') ?: '');
     $emailDomain = preg_quote($emailDomain);
@@ -145,6 +183,26 @@ class CRM_Utils_Mail_IncomingMail {
     if (!$matches && preg_match($regex, ($mail->getHeader('Delivered-To') ?? ''), $matches)) {
       [, $this->action, $this->jobID, $this->queueID, $this->hash] = $matches;
     }
+    if ($this->isVerp()) {
+      $queue = CRM_Mailing_Event_BAO_MailingEventQueue::verify($this->getJobID(), $this->getQueueID(), $this->getHash());
+      if (!$queue) {
+        throw new CRM_Core_Exception('Contact could not be found from civimail response');
+      }
+      $this->define('Queue', 'Queue', [
+        'id' => $queue->id,
+        'hash' => $queue->hash,
+        'contact_id' => $queue->contact_id,
+        'job_id' => $queue->contact_id,
+      ]);
+      $this->define('Mailing', 'Mailing', [
+        'id' => MailingJob::get(FALSE)
+          ->addWhere('id', '=', $this->getJobID())
+          ->addSelect('mailing_id')
+          ->execute()
+          ->first()['mailing_id'],
+      ]);
+    }
+
   }
 
 }

--- a/CRM/Utils/Mail/IncomingMail.php
+++ b/CRM/Utils/Mail/IncomingMail.php
@@ -96,6 +96,13 @@ class CRM_Utils_Mail_IncomingMail {
   }
 
   /**
+   * @return ezcMailAddress
+   */
+  public function getFrom(): ezcMailAddress {
+    return $this->mail->from;
+  }
+
+  /**
    * @return string
    */
   public function getSubject(): string {
@@ -126,6 +133,13 @@ class CRM_Utils_Mail_IncomingMail {
    * @throws \CRM_Core_Exception
    */
   public function __construct(ezcMail $mail, string $emailDomain, string $emailLocalPart) {
+    // Sometimes $mail->from is unset because ezcMail didn't handle format
+    // of From header. CRM-19215 (https://issues.civicrm.org/jira/browse/CRM-19215).
+    if (!isset($mail->from)) {
+      if (preg_match('/^([^ ]*)( (.*))?$/', $mail->getHeader('from'), $matches)) {
+        $mail->from = new ezcMailAddress($matches[1], trim($matches[2]));
+      }
+    }
     $this->mail = $mail;
     $this->body = CRM_Utils_Mail_Incoming::formatMailPart($mail->body, $this->attachments);
 

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\ActivityContact;
+
 /**
  * Class CRM_Utils_Mail_EmailProcessorInboundTest
  * @group headless
@@ -152,12 +154,28 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
    * Test messed up from.
    *
    * This ensures fix for https://issues.civicrm.org/jira/browse/CRM-19215.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testBadFrom() :void {
     $email = file_get_contents(__DIR__ . '/data/inbound/test_broken_from.eml');
+    $badEmails = [
+      'foo@example.com' => 'foo@example.com (foo)',
+      "KO'Bananas@benders.com" => "KO'Bananas@benders.com",
+    ];
+    foreach ($badEmails as $index => $badEmail) {
+      $file = fopen(__DIR__ . '/data/mail/test_broken_from.eml' . $index, 'wb');
+      fwrite($file, str_replace('bad-email-placeholder', $badEmail, $email));
+      fclose($file);
+    }
 
-    copy(__DIR__ . '/data/inbound/test_broken_from.eml', __DIR__ . '/data/mail/test_broken_from.eml');
     $this->callAPISuccess('Job', 'fetch_activities', []);
+    $activities = ActivityContact::get()
+      ->addSelect('contact_id.email_primary.email', 'activity_id.activity_type_id:name', 'activity_id.subject')
+      ->addWhere('contact_id.email_primary.email', 'IN', array_keys($badEmails))
+      ->addWhere('record_type_id:name', '=', 'Activity Source')
+      ->execute();
+    $this->assertCount(2, $activities);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -149,6 +149,18 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test messed up from.
+   *
+   * This ensures fix for https://issues.civicrm.org/jira/browse/CRM-19215.
+   */
+  public function testBadFrom() :void {
+    $email = file_get_contents(__DIR__ . '/data/inbound/test_broken_from.eml');
+
+    copy(__DIR__ . '/data/inbound/test_broken_from.eml', __DIR__ . '/data/mail/test_broken_from.eml');
+    $this->callAPISuccess('Job', 'fetch_activities', []);
+  }
+
+  /**
    * test hook_civicrm_emailProcessor
    */
   public function testHookEmailProcessor(): void {
@@ -189,7 +201,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
    * as a fallback if it doesn't match an individual first.
    */
   public function hookImplForEmailProcessorContact($email, $contactID, &$result) {
-    list($mailName, $mailDomain) = CRM_Utils_System::explode('@', $email, 2);
+    [$mailName, $mailDomain] = CRM_Utils_System::explode('@', $email, 2);
     if (empty($mailDomain)) {
       return;
     }

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -113,9 +113,10 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_sample_message.eml';
 
     copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_bounces', []);
+    $this->callAPISuccess('job', 'fetch_bounces', ['is_create_activities' => TRUE]);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/' . $mail);
     $this->checkMailingBounces(1);
+    $this->callAPISuccessGetSingle('Activity', ['source_contact_id' => $this->contactID, 'activity_type_id' => 'Inbound Email']);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/Mail/data/inbound/test_broken_from.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/inbound/test_broken_from.eml
@@ -1,0 +1,15 @@
+Delivered-To: jjj@myorg.org
+Received: by 10.2.13.84 with SMTP id 1234567890;
+        Tue, 08 Aug 2023 10:01:11 +0100 (CET)
+Return-Path: <>
+Message-ID: <abc.def.fhi@test.test>
+Date: Tue, 08 Aug 2023 10:01:07 +0100
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+Content-Disposition: inline
+From: foo@example.com (foo)
+To: jjj@myorg.org
+Subject: This is for hooks
+
+Sample body for hook test.

--- a/tests/phpunit/CRM/Utils/Mail/data/inbound/test_broken_from.eml
+++ b/tests/phpunit/CRM/Utils/Mail/data/inbound/test_broken_from.eml
@@ -8,8 +8,8 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: 8bit
 Content-Disposition: inline
-From: foo@example.com (foo)
+From: bad-email-placeholder
 To: jjj@myorg.org
-Subject: This is for hooks
+Subject: Subject
 
 Sample body for hook test.


### PR DESCRIPTION
Overview
----------------------------------------
[Move handling of empty from obscure function to main email handler class](https://github.com/civicrm/civicrm-core/commit/5384c03efa2324543dd331a20aa2dc580c3ce455)

Before
----------------------------------------
The handling for https://issues.civicrm.org/jira/browse/CRM-19215 is untested & in a weird place

After
----------------------------------------
 I had hoped when adding a test it would now be obsolete. However, the test showed it is still needed for that situation - so I moved it to a more sensible location. Note that I expect the function I moved it out of to be entirely removed 

Technical Details
----------------------------------------

Comments
----------------------------------------