### PR TITLE
Port handling for NULL label

### DIFF
--- a/Civi/ActionSchedule/MappingBase.php
+++ b/Civi/ActionSchedule/MappingBase.php
@@ -52,7 +52,7 @@ abstract class MappingBase extends AutoSubscriber implements MappingInterface {
   }
 
   public function getLabel(): string {
-    return CoreUtil::getInfoItem($this->getEntityName(), 'title');
+    return CoreUtil::getInfoItem($this->getEntityName(), 'title') ?: ts('Unknown');
   }
 
   public function getValueHeader(): string {


### PR DESCRIPTION
Brings across this already-in-5.66 fix
https://github.com/civicrm/civicrm-core/commit/266faa54a04cc2dc6c38162970879d0bb4c064e1#diff-32b263df2455d504f40104d9925cd36b279929d62bbce2e6f60530e077acca1aR59
