### PR TITLE
PseudoConstant - Prevent fatal when entity not available

### DIFF
--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -209,8 +209,10 @@ class CRM_Core_PseudoConstant {
     }
 
     // Core field: load schema
-    $dao = new $daoName();
-    $fieldSpec = $dao->getFieldSpec($fieldName);
+    if (class_exists($daoName)) {
+      $dao = new $daoName();
+      $fieldSpec = $dao->getFieldSpec($fieldName);
+    }
 
     // Return false if field doesn't exist.
     if (empty($fieldSpec)) {


### PR DESCRIPTION
Overview
----------------------------------------
Prevents a hard-crash in certain scenarios when metadata is being loaded for an entity that doesn't exist. This is especially likely to happen during upgrades, particuarly the upgrade to 5.64 due to #26208

Before
----------------------------------------
More crashy

After
----------------------------------------
Less crashy

Technical Details
----------------------------------------
This can happen e.g when Views tries to lookup an option value for a disabled extension. See https://github.com/civicrm/civicrm-drupal/pull/656#issuecomment-1094362139
