### PR TITLE
FiveSixtyFour: disable i18n rewrite on cancel_URL

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyFour.php
@@ -69,7 +69,7 @@ class CRM_Upgrade_Incremental_php_FiveSixtyFour extends CRM_Upgrade_Incremental_
       $dsn = DB::parseDSN($dsn);
       $table = '`' . $dsn['database'] . '`.`log_civicrm_uf_group`';
       CRM_Core_DAO::executeQuery("ALTER TABLE $table CHANGE `post_URL` `post_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to URL on submit.',
-CHANGE `cancel_URL` `cancel_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to URL when Cancel button clicked.'");
+CHANGE `cancel_URL` `cancel_url` varchar(255) DEFAULT NULL COMMENT 'Redirect to URL when Cancel button clicked.'", [], TRUE, NULL, FALSE, FALSE);
     }
     return TRUE;
   }


### PR DESCRIPTION
Overview
----------------------------------------

When running the 5.64 upgrade on a site with multilingual, it can fail because the query tries to change the view instead of the base table.

(To be honest, I mostly saw it on sites with logging enabled, which is not officially supported, but all our sites have logging)