### PR TITLE
Ensure event ID is an integer

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -148,7 +148,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
    * @throws \CRM_Core_Exception
    */
   public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
-    $eventID = $this->getFieldValue($row, 'id');
+    $eventID = (int) $this->getFieldValue($row, 'id');
     if (array_key_exists($field, $this->getEventTokenValues($eventID))) {
       foreach ($this->getEventTokenValues($eventID)[$field] as $format => $value) {
         $row->format($format)->tokens($entity, $field, $value ?? '');


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://civicrm.stackexchange.com/questions/45517/eventid-is-string-not-int

Before
----------------------------------------
Error on rendering event tokens on higher php version / stricter

After
----------------------------------------
Value is coerced

Technical Details
----------------------------------------

Presumably this fails on a higher php version that most sites cos on our tests the value is co-erced

Comments
----------------------------------------
Not a regression but good to get fix out sooner than later as it would hit higher php version sites