### PR TITLE
Remove always true if for required role_id field, add test for value

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -990,8 +990,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     //modify params according to parameter used in create
     //participant method (addParticipant)
     $this->_params['participant_status_id'] = $params['status_id'];
-    $this->_params['participant_role_id'] = is_array($params['role_id']) ? $params['role_id'] : explode(',', $params['role_id']);
-    $roleIdWithSeparator = implode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_params['participant_role_id']);
+    $this->_params['participant_role_id'] = $this->getSubmittedValue('role_id');
     $this->assign('participant_status_id', $params['status_id']);
 
     $now = date('YmdHis');
@@ -1046,32 +1045,30 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $contactID = CRM_Contact_BAO_Contact::createProfileContact($params, $fields, $this->_contactId, NULL, NULL, $ctype);
     }
 
-    if (!empty($this->_params['participant_role_id'])) {
-      $customFieldsRole = [];
-      foreach ($this->_params['participant_role_id'] as $roleKey) {
-        $customFieldsRole = CRM_Utils_Array::crmArrayMerge(CRM_Core_BAO_CustomField::getFields('Participant',
-          FALSE, FALSE, $roleKey, $this->_roleCustomDataTypeID), $customFieldsRole);
-      }
-      $customFieldsEvent = CRM_Core_BAO_CustomField::getFields('Participant',
-        FALSE,
-        FALSE,
-        CRM_Utils_Array::value('event_id', $params),
-        $this->_eventNameCustomDataTypeID
-      );
-      $customFieldsEventType = CRM_Core_BAO_CustomField::getFields('Participant',
-        FALSE,
-        FALSE,
-        $this->_eventTypeId,
-        $this->_eventTypeCustomDataTypeID
-      );
-      $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsRole,
-        CRM_Core_BAO_CustomField::getFields('Participant', FALSE, FALSE, NULL, NULL, TRUE)
-      );
-      $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsEvent, $customFields);
-      $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsEventType, $customFields);
-
-      $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, $this->getDefaultEntity());
+    $customFieldsRole = [];
+    foreach ($this->getSubmittedValue('role_id') as $roleKey) {
+      $customFieldsRole = CRM_Utils_Array::crmArrayMerge(CRM_Core_BAO_CustomField::getFields('Participant',
+        FALSE, FALSE, $roleKey, $this->_roleCustomDataTypeID), $customFieldsRole);
     }
+    $customFieldsEvent = CRM_Core_BAO_CustomField::getFields('Participant',
+      FALSE,
+      FALSE,
+      CRM_Utils_Array::value('event_id', $params),
+      $this->_eventNameCustomDataTypeID
+    );
+    $customFieldsEventType = CRM_Core_BAO_CustomField::getFields('Participant',
+      FALSE,
+      FALSE,
+      $this->_eventTypeId,
+      $this->_eventTypeCustomDataTypeID
+    );
+    $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsRole,
+      CRM_Core_BAO_CustomField::getFields('Participant', FALSE, FALSE, NULL, NULL, TRUE)
+    );
+    $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsEvent, $customFields);
+    $customFields = CRM_Utils_Array::crmArrayMerge($customFieldsEventType, $customFields);
+
+    $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, $this->getDefaultEntity());
 
     //do cleanup line  items if participant edit the Event Fee.
     if (($this->_lineItem || !isset($params['proceSetId'])) && !$this->_paymentId && $this->_id) {

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -151,7 +151,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    *
    * @var string
    */
-  public $_mode = NULL;
+  public $_mode;
 
   /**
    * Event ID preselect.

--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -43,6 +43,20 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
     $this->callAPISuccessGetSingle('Participant', ['id' => $form->getParticipantID()]);
   }
 
+  public function testSubmitDualRole(): void {
+    $email = $this->getForm([], [
+      'status_id' => 1,
+      'register_date' => date('Ymd'),
+      'send_receipt' => 1,
+      'from_email_address' => 'admin@email.com',
+      'role_id' => [
+        CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Volunteer'),
+        CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Speaker'),
+      ],
+    ])->postProcess()->getFirstMailBody();
+    $this->assertStringContainsString('Volunteer, Speaker', $email);
+  }
+
   /**
    * Test financial items pending transaction is later altered.
    *


### PR DESCRIPTION
Overview
----------------------------------------
This removes an if that is always true ( view the PR with w=1 to get past the whitespace... https://github.com/civicrm/civicrm-core/pull/27366/files?w=1)

role_id is a required field on the participant form and the register from search that extends it - so we don't need to check if it is filled out.

In addition we know that it is always an array because that's just the type of field it is.

Removing handling for pre-select 2 makes the code clearer...

Before
----------------------------------------
Big if for whether role_id is set but it is a required field on the form so the if condition is always true. Note it is added as a required field in the main `buildQuickForm()` function https://github.com/civicrm/civicrm-core/blob/fcd1b166ced07a4ed90665a3f4ff9f36126987a4/CRM/Event/Form/Participant.php#L698 with the only exception being `overload mode` which doesn't invoke postProcess

![image](https://github.com/civicrm/civicrm-core/assets/336308/97bbef18-8a0e-4467-ae95-783b5bca5c9f)


After
----------------------------------------
if removed, whitespace..

Technical Details
----------------------------------------
Note that the `getSubmittedValue()` method is preferred when looking up what was submitted - because then it's clear that we are working with what the user submitted as opposed to something wrangled

Comments
----------------------------------------
