### PR TITLE
Fix notice on unpaid event

### DIFF
--- a/tests/phpunit/CRM/Event/Form/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Form/ParticipantTest.php
@@ -44,6 +44,23 @@ class CRM_Event_Form_ParticipantTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test an unpaid event, test role displays in receipt
+   */
+  public function testSubmitUnPaidEvent(): void {
+    $this->getForm(['is_monetary' => FALSE], [
+      'status_id' => 1,
+      'send_receipt' => 1,
+      'from_email_address' => 'admin@example.com',
+      'register_date' => date('Y-m-d H:i:s'),
+      'role_id' => [
+        CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Volunteer'),
+        CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'role_id', 'Speaker'),
+      ],
+    ])->postProcess();
+    $this->callAPISuccessGetCount('Participant', [], 1);
+  }
+
+  /**
    * Test financial items pending transaction is later altered.
    *
    * @throws \Exception


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice on unpaid event


Before
----------------------------------------
When sending a receipt for a free event notices show...

![image](https://github.com/civicrm/civicrm-core/assets/336308/181f17f3-327b-4118-9c07-038bb1bb337d)

![image](https://github.com/civicrm/civicrm-core/assets/336308/224cb992-1deb-48a1-bda9-9dfa19598705)


After
----------------------------------------
poof

Technical Details
----------------------------------------
We had a couple of other recent regressions in this line that @demeritcowboy found that were similar that we fixed...

Comments
----------------------------------------
