### PR TITLE
[REF] Ensure that any NULL values in the title field are fixed prior …

### DIFF
--- a/CRM/Upgrade/Incremental/sql/5.63.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.63.alpha1.mysql.tpl
@@ -22,10 +22,18 @@ UPDATE civicrm_contribution_page SET `name` = `id`;
 {if $multilingual}
   {foreach from=$locales item=locale}
     UPDATE `civicrm_contribution_page`
+    SET `title_{$locale}` = ''
+    WHERE `title_{$locale}` IS NULL;
+
+    UPDATE `civicrm_contribution_page`
     SET `frontend_title_{$locale}` = `title_{$locale}`
     WHERE `frontend_title_{$locale}` IS NULL OR `frontend_title_{$locale}` = '';
   {/foreach}
 {else}
+  UPDATE `civicrm_contribution_page`
+  SET `title` = ''
+  WHERE `title` IS NULL;
+
   UPDATE `civicrm_contribution_page`
   SET `frontend_title` = `title`
   WHERE `frontend_title` IS NULL OR `frontend_title` = '';


### PR DESCRIPTION
…to changing the column

Overview
----------------------------------------
On a client site I found that they had a NULL value in a title_en_US column on civicrm_contribution_page and that the altering of the column to be required caused a DB error

Before
----------------------------------------
DB error

After
----------------------------------------
No DB Error

ping @eileenmcnaughton 