### PR TITLE
Remove unnecessary contributeMode reference - just present trxn_id if defined

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -104,7 +104,7 @@
         {if $receive_date}
           {ts}Date{/ts}: <strong>{$receive_date|crmDate}</strong><br />
         {/if}
-        {if $contributeMode ne 'notify' and $is_monetary and ! $is_pay_later and $trxn_id}
+        {if $trxn_id}
           {ts}Transaction #{/ts}: {$trxn_id}<br />
         {/if}
         {if $membership_trx_id}


### PR DESCRIPTION


Overview
----------------------------------------
Remove unnecessary contributeMode reference

Before
----------------------------------------
tpl checks multiple conditions in deciding whether to display trxn_id

After
----------------------------------------
tpl just checks if the value is present

Technical Details
----------------------------------------
If trxn_id is present, then show it.

The variable is always assigned in
https://github.com/civicrm/civicrm-core/blob/2ad38a735f7b26daf99d7b63eb413c6b69f780cb/CRM/Contribute/Form/Contribution/ThankYou.php#L212

So we don't need more (deprecated) conditions

Comments
----------------------------------------