### PR TITLE
Stop checking contributeMode in ContributionPage confirm.tpl before displaying billingName

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -246,35 +246,31 @@
     </div>
   {/if}
 
-  {if ( $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) ) or $email }
-    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) }
-      {if $billingName or $address}
-        <div class="crm-group billing_name_address-group">
-          <div class="header-dark">
-            {ts}Billing Name and Address{/ts}
-          </div>
-          <div class="crm-section no-label billing_name-section">
-            <div class="content">{$billingName}</div>
-            <div class="clear"></div>
-          </div>
-          <div class="crm-section no-label billing_address-section">
-            <div class="content">{$address|nl2br}</div>
-            <div class="clear"></div>
-          </div>
-        </div>
-      {/if}
-    {/if}
-    {if !$emailExists}
-      <div class="crm-group contributor_email-group">
+  {if $billingName or $address}
+      <div class="crm-group billing_name_address-group">
         <div class="header-dark">
-          {ts}Your Email{/ts}
+            {ts}Billing Name and Address{/ts}
         </div>
-        <div class="crm-section no-label contributor_email-section">
-          <div class="content">{$email}</div>
+        <div class="crm-section no-label billing_name-section">
+          <div class="content">{$billingName}</div>
+          <div class="clear"></div>
+        </div>
+        <div class="crm-section no-label billing_address-section">
+          <div class="content">{$address|nl2br}</div>
           <div class="clear"></div>
         </div>
       </div>
     {/if}
+  {if !$emailExists && $email}
+    <div class="crm-group contributor_email-group">
+      <div class="header-dark">
+          {ts}Your Email{/ts}
+      </div>
+      <div class="crm-section no-label contributor_email-section">
+        <div class="content">{$email}</div>
+        <div class="clear"></div>
+      </div>
+    </div>
   {/if}
 
   {if in_array('credit_card_number', $form) || in_array('bank_account_number', $form) && ($amount GT 0 OR $minimum_fee GT 0)}


### PR DESCRIPTION
Overview
----------------------------------------
Stop checking contributeMode in ContributionPage confirm.tpl before displaying billingName

Before
----------------------------------------
A whole lot of checks around billingName - but we only need to check whether it is present or not to decide whether to display it. We won't have gathered it if we don't want it...

After
----------------------------------------
It just checks for present of `billingName` and `email` respectively https://github.com/civicrm/civicrm-core/pull/27371/files?w=1

Technical Details
----------------------------------------
There is always a value or NULL in `billingName` so we don't need all these other checks

![image](https://github.com/civicrm/civicrm-core/assets/336308/55369176-bd39-4bb7-9535-58058a5718d2)

Comments
----------------------------------------
The emailExists section makes no sense - but it is always assigned - so it will do what it always did...