### PR TITLE
Expose fee_label for event tokens

### DIFF
--- a/CRM/Event/Tokens.php
+++ b/CRM/Event/Tokens.php
@@ -205,7 +205,6 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
           'event_type_id:name',
           'pay_later_text',
           'pay_later_receipt',
-          'fee_label',
           'custom.*',
         ], $this->getExposedFields()))
         ->execute()->first();
@@ -273,6 +272,7 @@ class CRM_Event_Tokens extends CRM_Core_EntityTokens {
       'is_public',
       'confirm_email_text',
       'is_monetary',
+      'fee_label',
     ];
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -721,6 +721,7 @@ event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL
 event.pay_later_receipt :Please transfer funds to our bank account.
 event.custom_1 :my field
 event.confirm_email_text :
+event.fee_label :Event fees
 ';
   }
 
@@ -1020,6 +1021,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{event.pay_later_receipt}' => 'Pay Later Receipt Text',
       '{event.' . $this->getCustomFieldName('text') . '}' => 'Enter text here :: Group with field text',
       '{event.confirm_email_text}' => 'Confirmation Email Text',
+      '{event.fee_label}' => 'Fee Label',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
That's it. This is missing in 5.65 as well, resulting in it being missing from online event confirmation html messages.