### PR TITLE
[wip] Update offline event receipt (html version) to be more previewable & more consistent

### DIFF
--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -31,6 +31,18 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
   public $isShowTax;
 
   /**
+   * Is it a good idea to show the line item subtotal.
+   *
+   * This would be true if at least one line has a quantity > 1.
+   * Otherwise it is very repetitive.
+   *
+   * @var bool
+   *
+   * @scope tplParams
+   */
+  public $isShowLineSubtotal;
+
+  /**
    * Line items associated with the contribution.
    *
    * @var array
@@ -109,6 +121,25 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
       return FALSE;
     }
     return !$this->order->getPriceSetMetadata()['is_quick_config'];
+    return $this->isShowLineItems;
+  }
+
+  /**
+   * Is it a good idea to show the line item subtotal.
+   *
+   * This would be true if at least one line has a quantity > 1.
+   * Otherwise it is very repetitive.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function getIsShowLineSubtotal(): bool {
+    foreach ($this->getLineItems() as $lineItem) {
+      if ((int) $lineItem['qty'] > 1) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -38,6 +38,19 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   public $isPrimary;
 
   /**
+   * Should a participant count column be shown.
+   *
+   * This would be true if there is a line item on the receipt
+   * with more than one participant in it. Otherwise it's confusing to
+   * show.
+   *
+   * @var bool
+   *
+   * @scope tplParams as isShowParticipantCount
+   */
+  public $isShowParticipantCount;
+
+  /**
    * @var int
    *
    * @scope tokenContext as eventId, tplParams as eventID
@@ -48,7 +61,9 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    * Line items indexed by the participant.
    *
    * The format is otherwise the same as lineItems which is also available on the
-   * template. The by-participant re-keying permits only including the current
+   * template. It also includes totals.
+   *
+   * The by-participant re-keying permits only including the current
    * participant for non-primary participants and
    * creating a by-participant table for the primary participant.
    *
@@ -57,6 +72,17 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
    * @scope tplParams as participants
    */
   public $participants;
+
+  /**
+   * Line items indexed by the participant.
+   *
+   * The format includes the line items and totals that are determined per participant.
+   *
+   * @var array
+   *
+   * @scope tplParams as participantDetail
+   */
+  public $participantDetail;
 
   /**
    * Details of the participant contacts.
@@ -141,7 +167,26 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   }
 
   /**
-   * Set contribution object.
+   * It is a good idea to show the participant count column.
+   *
+   * This would be true if there is a line item on the receipt
+   * with more than one participant in it. Otherwise it's confusing to
+   * show.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function getIsShowParticipantCount(): bool {
+    foreach ($this->getLineItems() as $lineItem) {
+      if ((int) $lineItem['participant_count'] > 1) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Set participant object.
    *
    * @param array $participant
    *
@@ -171,6 +216,19 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
         ->addSelect('registered_by_id')->execute()->first();
     }
     return $this->participant;
+  }
+
+  /**
+   * Get the details for the recipient participant.
+   *
+   * The details include line items and tax break down & hence differ from the
+   * `participant` property which is a simple api entitiy.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getParticipantDetail(): array {
+    return $this->getParticipants()[$this->getParticipantID()];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This fixes the template work in message admin preview and also to show multiple participants more consistently

Multiple participants are only relevant to this receipt in the edge case scenario of sending a receipt to a participant who was registered front office from the back office form. This was pretty wonky. As there is no other info on the form for multiple participants I just did a block of rows for multiple participants

This is intended to align the offline event template with the work done in https://github.com/civicrm/civicrm-core/pull/26574

While there are things I would change (ie why are the online & offline even different) I have only made appearance changes where things were previously wrong or it was in the arrays I was trying to clean up

Before
----------------------------------------
I will update this with screenshots... 

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
