### PR TITLE
dev/core#4542 Fix priority handling in ACLs when dealing with objects…

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -233,7 +233,7 @@ SELECT count( a.id )
       $aclKeys = implode(',', $aclKeys);
       $orderBy = 'a.object_id';
       if (array_key_exists('priority', CRM_ACL_BAO_ACL::getSupportedFields())) {
-        $orderBy .= ',a.priority';
+        $orderBy = 'a.priority,a.object_id';
       }
       $query = "
 SELECT   a.operation, a.object_id,a.deny
@@ -456,7 +456,7 @@ ORDER BY {$orderBy}
     $aclKeys = implode(',', $aclKeys);
     $orderBy = 'a.object_id';
     if (array_key_exists('priority', CRM_ACL_BAO_ACL::getSupportedFields())) {
-      $orderBy .= ',a.priority';
+      $orderBy = 'a.priority,a.object_id';
     }
     $query = "
 SELECT   a.operation,a.object_id,a.deny
@@ -493,7 +493,6 @@ ORDER BY {$orderBy}
             $ids = array_diff($ids, array_keys($allGroups));
           }
         }
-        break;
       }
     }
     return $ids;

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -1456,6 +1456,10 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     $this->assertCount(2, $contacts);
     $this->assertEquals($contact2, $contacts[0]['id']);
     $this->assertEquals($contact3, $contacts[1]['id']);
+    $groups = CRM_ACL_API::group(CRM_ACL_API::EDIT);
+    $this->assertFalse(in_array($excludeGroup, $groups));
+    Civi::cache('metadata')->clear();
+    Civi::$statics['CRM_ACL_BAO_ACL'] = [];
   }
 
   /**


### PR DESCRIPTION
… other than contacts

Overview
----------------------------------------
This fixes a bug in the recently added priority handling for ACLs. This was causing all objects of x rules to be the most regarded if was allow anywhere along. Note this does not seem to have applied to accessing contacts but only other ACL objects (custom fields, groups, etc)

Before
----------------------------------------
Priority doesn't always work for non contact objects

After
----------------------------------------
Priority is fixed 

Technical Details
----------------------------------------
Whilst the code is similar for contacts there wasn't the break that there is in this code https://github.com/civicrm/civicrm-core/blob/master/CRM/ACL/BAO/ACL.php#L252 

ping @colemanw @artfulrobot @TobiasVoigt 