### PR TITLE
GettingStarted: add token for System Status

### DIFF
--- a/CRM/Dashlet/Page/GettingStarted.php
+++ b/CRM/Dashlet/Page/GettingStarted.php
@@ -31,6 +31,7 @@ class CRM_Dashlet_Page_GettingStarted extends CRM_Core_Page {
   public static $_tokens = [
     'crmurl' => [
       'configbackend' => 'civicrm/admin/configtask',
+      'systemstatus' => 'civicrm/a/#/status',
     ],
   ];
 


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM offers a "Getting Started" dashlet by default, which recommends reviewing the "checklist" and install extensions, but it does not recommend the System Status, which I think is the better checklist.

![image](https://github.com/civicrm/civicrm-core/assets/254741/7f113701-1c21-43b1-97e6-ea73bd84981c)


Before
----------------------------------------

No token so that the dashlet can link to the status correctly.

After
----------------------------------------

Token available.

Comments
----------------------------------------

The "Manage connected services" link never worked (missing token), and I will remove it (the service is offline).

https://lab.civicrm.org/infra/community-messages/-/commit/aff008b8e9eb1720565ff728a11c602109f137d6