### PR TITLE
dev/core#4559 Don't include test, template, deleted entities in SearchDisplay totals

### DIFF
--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -39,7 +39,7 @@ abstract class AbstractGetAction extends AbstractQueryAction {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function setDefaultWhereClause() {
+  public function setDefaultWhereClause() {
     if (!$this->_itemsToGet('id')) {
       $fields = $this->entityFields();
       foreach ($fields as $field) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -63,6 +63,7 @@ class Run extends AbstractRunAction {
       case 'tally':
         unset($apiParams['orderBy'], $apiParams['limit']);
         $api = Request::create($entityName, 'get', $apiParams);
+        $api->setDefaultWhereClause();
         $query = new Api4SelectQuery($api);
         $query->forceSelectId = FALSE;
         $sql = $query->getSql();

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -1697,6 +1697,48 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('$250.00', $result[3]['columns'][0]['val']);
   }
 
+  public function testContributionTotalCountWithTestAndTemplateContributions():void {
+    // Add a source here for the where below, as if we use id, we get the test and template contributions
+    $contributions = $this->saveTestRecords('Contribution', [
+      'records' => [
+        ['is_test' => TRUE, 'source' => 'TestTemplate'],
+        ['is_template' => TRUE, 'source' => 'TestTemplate'],
+        ['source' => 'TestTemplate'],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contribution',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id'],
+          'where' => [['source', '=', 'TestTemplate']],
+        ],
+      ],
+      'display' => [
+        'settings' => [
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'id',
+              'tally' => [
+                'fn' => 'COUNT',
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $return = civicrm_api4('SearchDisplay', 'run', $params);
+    $params['return'] = 'tally';
+    $total = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertEquals($return->rowCount, $total[0]['id']);
+  }
+
   public function testSelectEquations() {
     $activities = $this->saveTestRecords('Activity', [
       'records' => [


### PR DESCRIPTION
Overview
----------------------------------------
[See issue.](https://lab.civicrm.org/dev/core/-/issues/4559) Put this on 5.66. Don't think it is a regression as it has always been like this, but it's a fairly recent bug.

Before
----------------------------------------
Totals include test, template, deleted entities when table results do not.

After
----------------------------------------
Totals do not include test, template, deleted entities when table results do not.