### PR TITLE
VersionCheck: replace hash by sid, add the environment

### DIFF
--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -139,8 +139,11 @@ class CRM_Utils_VersionCheck {
     // Non-alpha versions get the full treatment
     if ($this->localVersion && !strpos($this->localVersion, 'alpha')) {
       $this->stats += [
+        // Remove the hash after 2024-09-01 to allow the transition to sid
         'hash' => md5($siteKey . $config->userFrameworkBaseURL),
+        'sid' => Civi::settings()->get('site_id'),
         'uf' => $config->userFramework,
+        'environment' => CRM_Core_Config::environment(),
         'lang' => $config->lcMessages,
         'co' => $config->defaultContactCountry,
         'ufv' => $config->userSystem->getVersion(),


### PR DESCRIPTION
Overview
----------------------------------------

The objective is to phase out the somewhat unreliable "hash" (md5 of the site key) by the "site_id".

The transition is necessary in order to preserve the pingback data.

Comments
----------------------------------------

Both the hash and `site_id` do not account for dev sites correctly, assuming they both have the same key/hash because the site was copied. Although perhaps people are more likely to reset the 'site key' on a dev/prod site, but less likely to change the `site_id`.

There is also a small risk of sites having the same `site_id` if they were copied from a template. We will be able to observe this during the transition period.