### PR TITLE
APIv4 - Demonstrate that test doesn't actually work

### DIFF
--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -355,7 +355,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
    * @param string $entity
    */
   protected function checkGetAllowed($entityClass, $id, $entity) {
-    $this->setCheckAccessGrants(["{$entity}::get" => TRUE]);
+    $this->setCheckAccessGrants(["{$entity}::get" => FALSE]);
     $getResult = $entityClass::get()
       ->addWhere('id', '=', $id)
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
This passes!

Technical Details
-----------
Turns out the `civi.api4.authorizeRecord` doesn't do anything at all for get actions. So even when you flip it to the opposite value, nothing changes.

If the test were to actually test something, it would need to assert that the record IS available with access enabled, and IS NOT available with access revoked. Instead it was only testing one of the two (the one that passes no matter what).