### PR TITLE
Disable broken unit test

### DIFF
--- a/Civi/Api4/Event/AuthorizeRecordEvent.php
+++ b/Civi/Api4/Event/AuthorizeRecordEvent.php
@@ -16,7 +16,8 @@ use Civi\API\Event\RequestTrait;
 use Civi\Core\Event\GenericHookEvent;
 
 /**
- * Determine if the a user has access to a given record.
+ * Determine if the a user has WRITE access to a given record.
+ * This event does not impact READ access for `get` actions.
  *
  * Event name: 'civi.api4.authorizeRecord'
  */

--- a/tests/phpunit/api/v4/Entity/ConformanceTest.php
+++ b/tests/phpunit/api/v4/Entity/ConformanceTest.php
@@ -147,7 +147,8 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
     $this->checkCreationDenied($entityName, $entityClass);
     $id = $this->checkCreation($entityName, $entityClass);
     $getResult = $this->checkGet($entityName, $id);
-    $this->checkGetAllowed($entityClass, $id, $entityName);
+    // civi.api4.authorizeRecord does not work on `get` actions
+    // $this->checkGetAllowed($entityClass, $id, $entityName);
     $this->checkGetCount($entityClass, $id, $entityName);
     $this->checkUpdateFailsFromCreate($entityClass, $id);
     $this->checkUpdate($entityName, $getResult);
@@ -347,12 +348,7 @@ class ConformanceTest extends Api4TestBase implements HookInterface {
   }
 
   /**
-   * Use a permissioned request for `get()`, with access grnted
-   * via checkAccess event.
-   *
-   * @param \Civi\Api4\Generic\AbstractEntity|string $entityClass
-   * @param int $id
-   * @param string $entity
+   * FIXME: Not working. `civi.api4.authorizeRecord` does not work on `get` actions.
    */
   protected function checkGetAllowed($entityClass, $id, $entity) {
     $this->setCheckAccessGrants(["{$entity}::get" => TRUE]);


### PR DESCRIPTION
Overview
----------------------------------------
Disables a test that wasn't actually testing anything.

Technical Details
-----------
As demonstrated in #27387 the event `civi.api4.authorizeRecord` doesn't actually work on `get` actions. This documents that limitation and removes a test that mistakenly assumed otherwise.

This fixes the false-positive test failure in https://github.com/civicrm/civicrm-core/pull/27379