### PR TITLE
Scan core `civicrm/managed` directory for entity declarations

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -771,7 +771,7 @@ abstract class CRM_Utils_Hook {
    * @return null
    *   the return value is ignored
    */
-  public static function managed(&$entities, ?array $modules = NULL) {
+  public static function managed(array &$entities, ?array $modules = NULL) {
     $null = NULL;
     self::singleton()->invoke(['entities', 'modules'], $entities, $modules,
       $null, $null, $null, $null,

--- a/Civi/Api4/Service/Spec/Provider/ManagedEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ManagedEntitySpecProvider.php
@@ -52,7 +52,7 @@ class ManagedEntitySpecProvider extends \Civi\Core\Service\AutoService implement
       ->setDescription(ts('Name of extension which provides this package'))
       ->setType('Extra')
       ->setReadonly(TRUE)
-      ->setOptionsCallback(['CRM_Core_PseudoConstant', 'getExtensions'])
+      ->setOptionsCallback(['CRM_Core_BAO_Managed', 'getBaseModules'])
       ->setSqlRenderer([__CLASS__, 'renderBaseModule']);
     $spec->addFieldSpec($field);
 

--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -82,7 +82,7 @@ function dm_install_core() {
   local repo="$1"
   local to="$2"
 
-  for dir in ang css i js PEAR templates bin CRM api extern Reports install mixin settings Civi partials release-notes xml setup sql/civicrm_data ; do
+  for dir in ang css i js PEAR templates bin CRM api extern Reports install managed mixin settings Civi partials release-notes xml setup sql/civicrm_data ; do
     [ -d "$repo/$dir" ] && dm_install_dir "$repo/$dir" "$to/$dir"
   done
 

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -306,7 +306,7 @@ class Afform extends Generic\AbstractEntity {
           'data_type' => 'String',
           'description' => 'Name of extension which provides this form',
           'readonly' => TRUE,
-          'pseudoconstant' => ['callback' => ['CRM_Core_PseudoConstant', 'getExtensions']],
+          'pseudoconstant' => ['callback' => ['CRM_Core_BAO_Managed', 'getBaseModules']],
         ];
         $fields[] = [
           'name' => 'search_displays',

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -13,7 +13,6 @@ namespace Civi\Search;
 
 use Civi\Api4\Action\SearchDisplay\AbstractRunAction;
 use Civi\Api4\Entity;
-use Civi\Api4\Extension;
 use Civi\Api4\Query\SqlEquation;
 use Civi\Api4\Query\SqlFunction;
 use Civi\Api4\SearchDisplay;
@@ -35,8 +34,6 @@ class Admin {
    */
   public static function getAdminSettings():array {
     $schema = self::getSchema();
-    $extensions = Extension::get(FALSE)->addWhere('status', '=', 'installed')
-      ->execute()->indexBy('key')->column('label');
     $data = [
       'schema' => self::addImplicitFKFields($schema),
       'joins' => self::getJoins($schema),
@@ -48,7 +45,7 @@ class Admin {
       'styles' => \CRM_Utils_Array::makeNonAssociative(self::getStyles()),
       'defaultPagerSize' => (int) \Civi::settings()->get('default_pager_size'),
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),
-      'modules' => $extensions,
+      'modules' => \CRM_Core_BAO_Managed::getBaseModules(),
       'defaultContactType' => \CRM_Contact_BAO_ContactType::basicTypeInfo()['Individual']['name'] ?? NULL,
       'defaultDistanceUnit' => \CRM_Utils_Address::getDefaultDistanceUnit(),
       'jobFrequency' => \Civi\Api4\Job::getFields()

--- a/mixin/mgd-php@1/mixin.php
+++ b/mixin/mgd-php@1/mixin.php
@@ -26,7 +26,7 @@ return function ($mixInfo, $bootCache) {
 
     // Optimization: if managed entities were requested for specific module(s),
     // check name and return early if not applicable.
-    if (is_array($event->modules) && !in_array($mixInfo->longName, $event->modules, TRUE)) {
+    if ($event->modules && !in_array($mixInfo->longName, $event->modules, TRUE)) {
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Allows managed entities to be shipped with CiviCRM core, independent of any extensions.

Before
----------------------------------------
Managed entities can only be packaged in extensions.

After
----------------------------------------
They can also be packaged in CiviCRM core.

Technical Details
----------------------------------------
Includes 'CiviCRM Core' as an option for 'module' wherever managed entities are displayed.