### PR TITLE
Edit All Groups ACL fix

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -252,7 +252,10 @@ SELECT count( a.id )
           }
         }
       }
-      if (!empty($excludeIds) && !$allInclude) {
+      if ($allInclude) {
+        $clauses[] = 1;
+      }
+      elseif (!empty($excludeIds) && !$allInclude) {
         $ids = array_diff($ids, $excludeIds);
       }
       elseif (!empty($excludeIds) && $allInclude) {


### PR DESCRIPTION
Overview
----------------------------------------
A recent regression means the "Edit All Contacts" ACL (ACL, *not* the CMS permission) no longer works.

I can see that in the recent ACL overhaul there were changes intended to support this, but they appear not to work.

Before
----------------------------------------
Contact with "Edit All Contacts" ACL can't see any contacts with this ACL.

After
----------------------------------------
Contacts are visible, similar to 5.63.

Comments
----------------------------------------
I'm not sure if the "priorities" functionality works, and if so, whether that needs to be accounted for in this particular place in the code.  This change assumes "Edit all Contacts" trumps other ACLs regarless of priority. However, it seems more important to fix the regression and get a priority-sensitive fix in later.

Also, there's an unused `$allExclude` variable that should theoretically handle the "deny" version of this same ACL.  That also doesn't work, but I want to limit the scope of this PR to the regression.