### PR TITLE
Fix undefined properties on back-office pledge form

### DIFF
--- a/CRM/Contact/Form/ContactFormTrait.php
+++ b/CRM/Contact/Form/ContactFormTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+use Civi\API\EntityLookupTrait;
+
+/**
+ * Trait implements getContactValue + overridable getContactID functions.
+ *
+ * These are commonly used on forms - although getContactID() would often
+ * be overridden. By using these functions it is not necessary to know
+ * if the Contact ID has already been defined as `getContactID()` will retrieve
+ * them form the values available (unless it is yet to be created).
+ */
+trait CRM_Contact_Form_ContactFormTrait {
+
+  use EntityLookupTrait;
+
+  /**
+   * Get a value for the contact being acted on in the form.
+   *
+   * This can be called from any point in the form flow and if
+   * the contact can not yet be determined it will return NULL.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getContactValue($fieldName) {
+    if ($this->isDefined('Contact')) {
+      return $this->lookup('Contact', $fieldName);
+    }
+    $id = $this->getContactID();
+    if ($id) {
+      // GetContactID may or may not have defined this.
+      if (!$this->isDefined('Contact')) {
+        $this->define('Contact', 'Contact', ['id' => $id]);
+      }
+      return $this->lookup('Contact', $fieldName);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the contact ID.
+   *
+   * Override this for more complex retrieval as required by the form.
+   *
+   * @return int|null
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  public function getContactID(): ?int {
+    $id = (int) CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+    if ($id) {
+      $this->define('Contact', 'Contact', ['id' => $id]);
+    }
+    return $id ?: NULL;
+  }
+
+}

--- a/CRM/Contact/Form/ContactFormTrait.php
+++ b/CRM/Contact/Form/ContactFormTrait.php
@@ -28,10 +28,7 @@ trait CRM_Contact_Form_ContactFormTrait {
     }
     $id = $this->getContactID();
     if ($id) {
-      // GetContactID may or may not have defined this.
-      if (!$this->isDefined('Contact')) {
-        $this->define('Contact', 'Contact', ['id' => $id]);
-      }
+      $this->define('Contact', 'Contact', ['id' => $id]);
       return $this->lookup('Contact', $fieldName);
     }
     return NULL;
@@ -49,9 +46,6 @@ trait CRM_Contact_Form_ContactFormTrait {
    */
   public function getContactID(): ?int {
     $id = (int) CRM_Utils_Request::retrieve('cid', 'Positive', $this);
-    if ($id) {
-      $this->define('Contact', 'Contact', ['id' => $id]);
-    }
     return $id ?: NULL;
   }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -24,6 +24,7 @@ use Civi\API\EntityLookupTrait;
 class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment {
 
   use EntityLookupTrait;
+  use CRM_Contact_Form_ContactFormTrait;
 
   /**
    * Participant ID - use getParticipantID.
@@ -571,25 +572,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     $this->assign('event_is_test', CRM_Utils_Array::value('event_is_test', $defaults[$this->_id]));
     return $defaults[$this->_id];
-  }
-
-  /**
-   * Get a value for the contact being acted on in the form.
-   *
-   * This can be called from any point in the form flow and if
-   * the contact can not yet be determined it will return NULL.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function getContactValue($fieldName) {
-    if ($this->isDefined('Contact')) {
-      return $this->lookup('Contact', $fieldName);
-    }
-    if ($this->getContactID()) {
-      $this->define('Contact', 'Contact', ['id' => $this->getContactID()]);
-      return $this->lookup('Contact', $fieldName);
-    }
-    return NULL;
   }
 
   /**

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -63,20 +63,19 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function preProcess(): void {
-    $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+    $this->_contactID = $this->getContactID();
     $this->_action = CRM_Utils_Request::retrieve('action', 'String',
       $this, FALSE, 'add'
     );
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
-
+    $this->setContext();
     // check for action permissions.
     if (!CRM_Core_Permission::checkActionPermission('CiviPledge', $this->_action)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
 
     $this->assign('action', $this->_action);
-    $this->assign('context', $this->_context);
+    $this->assign('context', $this->getContext());
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
     }
@@ -563,7 +562,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     CRM_Core_Session::setStatus($statusMsg, ts('Payment Due'), 'info');
 
     $buttonName = $this->controller->getButtonName();
-    if ($this->_context === 'standalone') {
+    if ($this->getContext() === 'standalone') {
       if ($buttonName === $this->getButtonName('upload', 'new')) {
         $session->replaceUserContext(CRM_Utils_System::url('civicrm/pledge/add',
           'reset=1&action=add&context=standalone'

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -87,10 +87,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $this->_values = [];
     // current pledge id
     if ($this->_id) {
-      // get the contribution id
-      $this->_contributionID = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_PledgePayment',
-        $this->_id, 'contribution_id', 'pledge_id'
-      );
       $params = ['id' => $this->_id];
       CRM_Pledge_BAO_Pledge::getValues($params, $this->_values);
 

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -21,6 +21,8 @@ use Civi\Api4\PledgePayment;
  * This class generates form components for processing a pledge
  */
 class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
+  use CRM_Contact_Form_ContactFormTrait;
+
   public $_action;
 
   /**
@@ -77,11 +79,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
     $this->assign('context', $this->_context);
     if ($this->_action & CRM_Core_Action::DELETE) {
       return;
-    }
-
-    $displayName = $this->userEmail = NULL;
-    if ($this->_contactID) {
-      [$displayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
     }
 
     $this->setPageTitle(ts('Pledge'));
@@ -169,10 +166,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $defaultPledgeStatus
     ));
 
-    if (isset($this->userEmail)) {
-      $this->assign('email', $this->userEmail);
-    }
-
+    $this->assign('email', $this->getContactValue('email_primary.email'));
     // custom data set defaults
     $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
 
@@ -538,7 +532,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       // send Acknowledgment mail.
       CRM_Pledge_BAO_Pledge::sendAcknowledgment($this, $params);
 
-      $statusMsg .= ' ' . ts('An acknowledgment email has been sent to %1.<br />', [1 => $this->userEmail]);
+      $statusMsg .= ' ' . ts('An acknowledgment email has been sent to %1.<br />', [1 => $this->getContactValue('email_primary.email')]);
       // get the first valid payment id.
       $nextPaymentID = PledgePayment::get()
         ->addWhere('pledge_id', '=', $pledgeID)

--- a/CRM/Pledge/Form/Pledge.php
+++ b/CRM/Pledge/Form/Pledge.php
@@ -99,8 +99,6 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
 
     // get the pledge frequency units.
     $this->_freqUnits = CRM_Core_OptionGroup::values('recur_frequency_units');
-
-    $this->_fromEmails = CRM_Core_BAO_Email::getFromEmail();
   }
 
   /**
@@ -312,8 +310,7 @@ class CRM_Pledge_Form_Pledge extends CRM_Core_Form {
       $this->addElement('checkbox', 'is_acknowledge', ts('Send Acknowledgment?'), NULL,
         ['onclick' => "showHideByValue( 'is_acknowledge', '', 'acknowledgeDate', 'table-row', 'radio', true); showHideByValue( 'is_acknowledge', '', 'fromEmail', 'table-row', 'radio', false );"]
       );
-
-      $this->add('select', 'from_email_address', ts('Receipt From'), $this->_fromEmails, FALSE, ['class' => 'crm-select2 huge']);
+      $this->add('select', 'from_email_address', ts('Receipt From'), CRM_Core_BAO_Email::getFromEmail(), FALSE, ['class' => 'crm-select2 huge']);
     }
 
     $this->add('datepicker', 'acknowledge_date', ts('Acknowledgment Date'), [], FALSE, ['time' => FALSE]);


### PR DESCRIPTION
Overview
----------------------------------------
Fix (some) undefined properties on back-office pledge form

Before
----------------------------------------
Several undefined properties being set / accessed

After
----------------------------------------
All undefined variables in the form removed (mostly using local variables instead)

Technical Details
----------------------------------------
The `_context` property is declared as protected in some places & public in others but the `context` property is on the main `CRM_Core_Form` class & has public getter / setters. I't so ubiquittous I'm temped to set it in `CRM_Core_Form::preProcess` - but this doesn't do that

Comments
----------------------------------------
