### PR TITLE
CRM_Core_Module - Generate optional `$label` property

### DIFF
--- a/CRM/Core/Module.php
+++ b/CRM/Core/Module.php
@@ -25,6 +25,13 @@ class CRM_Core_Module {
   public $name;
 
   /**
+   * Pretty name of the module
+   *
+   * @var string
+   */
+  public $label;
+
+  /**
    * Is the module enabled.
    *
    * @var bool
@@ -35,11 +42,15 @@ class CRM_Core_Module {
    * Class constructor.
    *
    * @param string $name
+   *   Unique machine name of the module
    * @param bool $is_active
+   * @param string|null $label
+   *   Pretty name of the module. If omitted, fallback to $name.
    */
-  public function __construct($name, $is_active) {
+  public function __construct($name, $is_active, ?string $label = NULL) {
     $this->name = $name;
     $this->is_active = $is_active;
+    $this->label = $label ?: $name;
   }
 
   /**
@@ -55,7 +66,7 @@ class CRM_Core_Module {
     if ($fresh || !is_array($result)) {
       $result = CRM_Extension_System::singleton()->getMapper()->getModules();
       // pseudo-module for core
-      $result[] = new CRM_Core_Module('civicrm', TRUE);
+      $result[] = new CRM_Core_Module('civicrm', TRUE, ts('CiviCRM Core'));
 
       $config = CRM_Core_Config::singleton();
       $result = array_merge($result, $config->userSystem->getModules());

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -489,7 +489,7 @@ class CRM_Extension_Mapper {
     $dao->type = 'module';
     $dao->find();
     while ($dao->fetch()) {
-      $result[] = new CRM_Core_Module($dao->full_name, $dao->is_active);
+      $result[] = new CRM_Core_Module($dao->full_name, $dao->is_active, $dao->label);
     }
     return $result;
   }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -571,7 +571,9 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
     $module_data = \Drupal::service('extension.list.module')->reset()->getList();
     foreach ($module_data as $module_name => $extension) {
       if (!isset($extension->info['hidden']) && $extension->origin != 'core' && $extension->status == 1) {
-        $modules[] = new CRM_Core_Module('drupal.' . $module_name, TRUE);
+        $modules[] = new CRM_Core_Module('drupal.' . $module_name, TRUE,
+          _ts('%1 (%2)', [1 => $extension->info['name'] ?? $module_name, _ts('Drupal')])
+        );
       }
     }
     return $modules;

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -301,9 +301,11 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
    */
   public function getModules() {
     $result = [];
-    $q = db_query('SELECT name, status FROM {system} WHERE type = \'module\' AND schema_version <> -1');
+    $q = db_query('SELECT name, status, info FROM {system} WHERE type = \'module\' AND schema_version <> -1');
     foreach ($q as $row) {
-      $result[] = new CRM_Core_Module('drupal.' . $row->name, $row->status == 1);
+      $info = $row->info ? \CRM_Utils_String::unserialize($row->info) : [];
+      $label = _ts('%1 (%2)', [1 => $info['name'] ?? $row->name, 2 => _ts(CIVICRM_UF)]);
+      $result[] = new CRM_Core_Module('drupal.' . $row->name, $row->status == 1, $label);
     }
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------

This adds some extra metadata to the `module` finder.  It's a step toward showing a pretty list of options for `Managed.module` in APIv4 Explorer.

Before
----------------------------------------

Generate `name,is_active`

After
----------------------------------------

Generate `name,label,is_active`

Technical Details
----------------------------------------

The module-finder is able to check multiple kinds of modules -- CiviCRM module-extensions, Drupal/Backdrop module-extensions, and Joomla plugin-extensions.

This patch provides labels for CiviCRM module-extensions (*i.e. the most important source; I'd wager 98%+ of managed-entities are in CiviCRM module-extensions*). It also provides labels for Drupal/Backdrop because that was quick/easy. For Joomla plugin-extensions, I was lazy -- it will fallback to showing machine name (which seems OK, considering that it's a tiny niche and tiny impact on DX).