### PR TITLE
Revert "[REF] Update Zetacomponents/mail to be 1.9.5 to fix email validation handling"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "tecnickcom/tcpdf" : "6.4.*",
     "totten/ca-config": "~22.11",
     "zetacomponents/base": "1.9.*",
-    "zetacomponents/mail": "~1.9.5",
+    "zetacomponents/mail": "~1.9.4",
     "marcj/topsort": "~1.1",
     "phpoffice/phpword": "^0.18.0",
     "pear/validate_finance_creditcard": "0.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a541aad8f31cbb35982d1380c3f1c71",
+    "content-hash": "d53a256f9748f1facc1312352b5a9acb",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5491,16 +5491,16 @@
         },
         {
             "name": "zetacomponents/mail",
-            "version": "1.9.5",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Mail.git",
-                "reference": "e106e5934a42cd1e37227fa50e79be648d60fa14"
+                "reference": "83ba646f36f753c0bbc8b2189c88d41ece326ea0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/e106e5934a42cd1e37227fa50e79be648d60fa14",
-                "reference": "e106e5934a42cd1e37227fa50e79be648d60fa14",
+                "url": "https://api.github.com/repos/zetacomponents/Mail/zipball/83ba646f36f753c0bbc8b2189c88d41ece326ea0",
+                "reference": "83ba646f36f753c0bbc8b2189c88d41ece326ea0",
                 "shasum": ""
             },
             "require": {
@@ -5565,9 +5565,9 @@
             "homepage": "https://github.com/zetacomponents",
             "support": {
                 "issues": "https://github.com/zetacomponents/Mail/issues",
-                "source": "https://github.com/zetacomponents/Mail/tree/1.9.5"
+                "source": "https://github.com/zetacomponents/Mail/tree/1.9.4"
             },
-            "time": "2023-09-06T09:15:46+00:00"
+            "time": "2022-09-14T10:13:21+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This reverts commit 020a1178ac869e64691c4e5fd49ee09f01d8f194.

Let's re-visit in master cos this turns out to be a bit more complicated  see https://github.com/zetacomponents/Mail/issues/90

There was no particular driver for this to be in 5.66 - it just got pulled in cos I successfully prodded the upstream merger to merge it. So let's slow it down & worry about it in master

Note that the other email bounce processor work is unrelated