### PR TITLE
APIv4: Implicit joins for email_primary, etc cause error

### DIFF
--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -78,6 +78,7 @@ class Joiner {
    */
   public static function getExtraJoinSql(array $field, Api4SelectQuery $query): string {
     $prefix = empty($field['explicit_join']) ? '' : $field['explicit_join'] . '.';
+    $prefix .= (empty($field['implicit_join']) ? '' : $field['implicit_join'] . '.');
     $idField = $query->getField($prefix . $field['name'] . '.id');
     return $idField['sql_name'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix [dev/core#4562](https://lab.civicrm.org/dev/core/-/issues/4562)