### PR TITLE
dev/core#4112 stop installing legacycustomsearches on new installs

### DIFF
--- a/sql/civicrm_data/civicrm_extension.sqldata.php
+++ b/sql/civicrm_data/civicrm_extension.sqldata.php
@@ -37,10 +37,6 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_extension', 'INSERT IGNORE INTO
       'name' => 'CKEditor4',
     ],
     [
-      'full_name' => 'legacycustomsearches',
-      'name' => 'Custom search framework',
-    ],
-    [
       'full_name' => 'org.civicrm.flexmailer',
       'name' => 'FlexMailer',
       'file' => 'flexmailer',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#4112 stop installing legacycustomsearches on new installs

https://lab.civicrm.org/dev/core/-/issues/4112

Before
----------------------------------------
We are most of the way through separating legacy custom searches from core & we can definitely run with them disabled - so now we are ready to stop installing on new installs

After
----------------------------------------
No change on existing installs but not enabled by default on new installs

Technical Details
----------------------------------------
@seamuslee001 what more do we need to do? regen?

Comments
----------------------------------------
