### PR TITLE
Smarty notices - Fix a couple more templates to look for elements not a variable that says the element is present

### DIFF
--- a/CRM/Pledge/BAO/PledgeBlock.php
+++ b/CRM/Pledge/BAO/PledgeBlock.php
@@ -116,6 +116,8 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
    * Build Pledge Block in Contribution Pages.
    *
    * @param CRM_Core_Form $form
+   *
+   * @throws \CRM_Core_Exception
    */
   public static function buildPledgeBlock($form) {
     //build pledge payment fields.
@@ -189,10 +191,7 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       if (empty($payments)) {
         throw new CRM_Core_Exception(ts('Oops. It looks like there is no valid payment status for online payment.'));
       }
-      else {
-        $form->assign('is_pledge_payment', TRUE);
-        $form->addGroup($payments, 'pledge_amount', ts('Make Pledge Payment(s):'), '<br />');
-      }
+      $form->addGroup($payments, 'pledge_amount', ts('Make Pledge Payment(s):'), '<br />');
     }
     else {
 
@@ -209,7 +208,6 @@ class CRM_Pledge_BAO_PledgeBlock extends CRM_Pledge_DAO_PledgeBlock {
       $form->addElement('text', 'pledge_installments', ts('Installments'), ['size' => 3, 'aria-label' => ts('Installments')]);
 
       if (!empty($pledgeBlock['is_pledge_interval'])) {
-        $form->assign('is_pledge_interval', CRM_Utils_Array::value('is_pledge_interval', $pledgeBlock));
         $form->addElement('text', 'pledge_frequency_interval', NULL, ['size' => 3, 'aria-label' => ts('Frequency Intervals')]);
       }
       else {

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -101,7 +101,7 @@
     {if !$ccid}
       {crmRegion name='contribution-main-pledge-block'}
       {if $pledgeBlock}
-        {if $is_pledge_payment}
+        {if array_key_exists('pledge_amount', $form)}
           <div class="crm-public-form-item crm-section {$form.pledge_amount.name}-section">
             <div class="label">{$form.pledge_amount.label}&nbsp;<span class="crm-marker">*</span></div>
             <div class="content">{$form.pledge_amount.html}</div>
@@ -112,7 +112,7 @@
             <div class="label">&nbsp;</div>
             <div class="content">
               {$form.is_pledge.html}&nbsp;
-              {if $is_pledge_interval}
+              {if array_key_exists('pledge_frequency_interval', $form)}
                 {$form.pledge_frequency_interval.html}&nbsp;
               {/if}
               {$form.pledge_frequency_unit.html}<span id="pledge_installments_num">&nbsp;{ts}for{/ts}&nbsp;{$form.pledge_installments.html}&nbsp;{ts}installments.{/ts}</span>


### PR DESCRIPTION
Overview
----------------------------------------
Smarty notices - Fix a couple more templates to look for elements not a variable that says the element is present

Before
----------------------------------------
Rather than just check for the presents of the element the template is looking for the possibly defined variable that says the elements is present

After
----------------------------------------
Checks for the element

Technical Details
----------------------------------------
Checking the actual thing also makes the code more legible

Comments
----------------------------------------
