### PR TITLE
Fix MoveField PHP notice

### DIFF
--- a/templates/CRM/Custom/Form/MoveField.tpl
+++ b/templates/CRM/Custom/Form/MoveField.tpl
@@ -14,7 +14,6 @@
                 <span class="description">{ts}Select a different Custom Data Set for this field.{/ts}
             </td>
         </tr>
-        <tr><td class="label">{$form.is_copy.label}</td><td>{$form.is_copy.html}</td></tr>
     </table>
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
See [chat](https://chat.civicrm.org/civicrm/pl/g3sao85nfpgduebpt5ypj7wgca).

is_copy isn't assigned anywhere and in fact looking back in MoveField.php, it appears to have not been assigned as far back as the SVN import. So I'd say if it hasn't done anything in ten years at least, we can stand to lose it, whatever it is supposed to be (I'm guessing some kind of option to copy the field to a different set instead of moving).