### PR TITLE
[REF] Fix bug caused by recent ACL changes where combination of edit …

### DIFF
--- a/CRM/ACL/BAO/ACL.php
+++ b/CRM/ACL/BAO/ACL.php
@@ -259,8 +259,11 @@ SELECT count( a.id )
         $ids = [];
         $clauses[] = self::getGroupClause($excludeIds, 'NOT IN');
       }
-      if (!empty($ids)) {
+      if (!empty($ids) && !$allInclude) {
         $clauses[] = self::getGroupClause($ids, 'IN');
+      }
+      elseif ($allInclude && empty($excludeIds)) {
+        $clauses[] = ' ( 1 ) ';
       }
     }
 

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -1465,6 +1465,81 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
   /**
    * @throws \CRM_Core_Exception
    */
+  public function testContactACLWithAllAllowedWithSpecificAllowedAlso(): void {
+    $this->callAPISuccess('OptionValue', 'create', [
+      'option_group_id' => 'acl_role',
+      'label' => 'Test Multiple allow Specific Groups ACL Role',
+      'value' => 7,
+      'is_active' => 1,
+    ]);
+    $contact1 = $this->individualCreate();
+    $contact2 = $this->individualCreate();
+    $contact3 = $this->individualCreate();
+    $excludeGroup = $this->groupCreate(['title' => 'exclude group also allow', 'name' => 'exclude group also allow']);
+    $otherGroup = $this->groupCreate(['title' => 'Other group also allow', 'name' => 'other group also allow']);
+    $this->callAPISuccess('GroupContact', 'create', [
+      'contact_id' => $contact1,
+      'group_id' => $excludeGroup,
+      'status' => 'Added',
+    ]);
+    $this->callAPISuccess('GroupContact', 'create', [
+      'contact_id' => $contact2,
+      'group_id' => $otherGroup,
+      'status' => 'Added',
+    ]);
+    $aclGroup = $this->groupCreate();
+    ACLEntityRole::create(FALSE)->setValues([
+      'acl_role_id' => 7,
+      'entity_table' => 'civicrm_group',
+      'entity_id' => $aclGroup,
+      'is_active' => 1,
+    ])->execute();
+    $this->callAPISuccess('Acl', 'create', [
+      'name' => 'Test Postive All Groups ACL',
+      'priority' => 6,
+      'entity_table' => 'civicrm_acl_role',
+      'entity_id' => 7,
+      'operation' => 'Edit',
+      'object_table' => 'civicrm_group',
+      'object_id' => 0,
+    ]);
+    $this->callAPISuccess('Acl', 'create', [
+      'name' => 'Test Negative Specific Group ACL',
+      'priority' => 7,
+      'entity_table' => 'civicrm_acl_role',
+      'entity_id' => 7,
+      'operation' => 'Edit',
+      'object_table' => 'civicrm_group',
+      'object_id' => $excludeGroup,
+      'deny' => 0,
+    ]);
+    $userID = $this->createLoggedInUser();
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'view my contact',
+    ];
+    $this->callAPISuccess('GroupContact', 'create', [
+      'contact_id' => $userID,
+      'group_id' => $aclGroup,
+      'status' => 'Added',
+    ]);
+    $this->cleanupCachedPermissions();
+    Civi::cache('metadata')->clear();
+    Civi::$statics['CRM_ACL_BAO_ACL'] = [];
+    $contacts = Contact::get()->addWhere('id', 'IN', [$contact1, $contact2, $contact3])->execute();
+    $this->assertCount(3, $contacts);
+    $this->assertEquals($contact1, $contacts[0]['id']);
+    $this->assertEquals($contact2, $contacts[1]['id']);
+    $this->assertEquals($contact3, $contacts[2]['id']);
+    $groups = CRM_ACL_API::group(CRM_ACL_API::EDIT);
+    $this->assertTrue(in_array($excludeGroup, $groups));
+    Civi::cache('metadata')->clear();
+    Civi::$statics['CRM_ACL_BAO_ACL'] = [];
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function testAllDenyCustomGroupACL(): void {
     // Create 2 multi-record custom entities and 2 regular custom fields
     $customGroups = [];


### PR DESCRIPTION
…all contacts and a specific acl on a group broke the edit all contacts rule and add unit test

Overview
----------------------------------------
This is a variation of the work that @MegaphoneJon did here  https://github.com/civicrm/civicrm-core/pull/27390 but with some differences and it adds a unit test into lock in the fix and goes against the RC

Before
----------------------------------------
If you had two allow rules

1. Edit all Contacts
2. Edit all Contacts in Group x and this had the higher priority this broke rule 1 even tho it is a subset of rule 1

After
----------------------------------------
Above situation fixed

ping @colemanw @MegaphoneJon @eileenmcnaughton 