### PR TITLE
[stuck on tests] dev/core#4385 Fix CiviMail create to not schedule for apiv4

### DIFF
--- a/ext/civi_mail/Civi/Api4/Service/Spec/Provider/MailingCreateSpecProvider.php
+++ b/ext/civi_mail/Civi/Api4/Service/Spec/Provider/MailingCreateSpecProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service
+ * @internal
+ */
+class MailingCreateSpecProvider extends AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec): void {
+    // This is a bit of dark-magic - the mailing BAO code is particularly
+    // nasty. It has historically scheduled mailings on create but does not for
+    // api v4 as that is more consistent with the create expectation.
+    $spec->addFieldSpec(new FieldSpec('version', 'Mailing', 'Integer'));
+    $spec->getFieldByName('version')->setDefaultValue(4)->setRequired(TRUE);
+  }
+
+  /**
+   * When does this apply.
+   *
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies(string $entity, string $action): bool {
+    return $entity === 'Mailing' && $action === 'create';
+  }
+
+}

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Mailing;
+use Civi\Api4\MailingJob;
+
 /**
  * Class CRM_Mailing_BAO_MailingTest
  */
@@ -68,9 +71,20 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that the non-crud actions do not occur when creating a mailing using apiv4.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testApiV4DoesNotSchedule(): void {
+    Mailing::create(FALSE)->setValues(['name' => 'bob', 'scheduled_date' => 'tomorrow'])->execute();
+    $jobs = MailingJob::get(FALSE)->execute();
+    $this->assertEquals(0, $jobs->rowCount);
+  }
+
+  /**
    * Test to ensure that using ACL permitted contacts are correctly fetched for bulk mailing
    */
-  public function testgetRecipientsUsingACL(): void {
+  public function testGetRecipientsUsingACL(): void {
     $this->prepareForACLs();
     $this->createLoggedInUser();
     // create hook to build ACL where clause which choses $this->allowedContactId as the only contact to be considered as mail recipient

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -79,13 +79,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_mailing_create.
-   *
-   * @dataProvider versionThreeAndFour
-   *
-   * @param int $version
    */
-  public function testMailerCreateSuccess(int $version): void {
-    $this->_apiversion = $version;
+  public function testMailerCreateSuccess(): void {
     $this->callAPISuccess('Campaign', 'create', ['name' => 'big campaign', 'title' => 'abc']);
     $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now', 'campaign_id' => 'big campaign']);
     $jobs = $this->callAPISuccess('MailingJob', 'get', ['mailing_id' => $result['id']]);
@@ -109,13 +104,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
 
   /**
    * Create a completed mailing (e.g when importing from a provider).
-   *
-   * @dataProvider versionThreeAndFour
-   *
-   * @param int $version
    */
-  public function testMailerCreateCompleted(int $version): void {
-    $this->_apiversion = $version;
+  public function testMailerCreateCompleted(): void {
     $this->_params['body_html'] = 'I am completed so it does not matter if there is an opt out link since I have already been sent by another system';
     $this->_params['is_completed'] = 1;
     $result = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_date' => 'now']);


### PR DESCRIPTION
Overview
----------------------------------------
When we added apiv4 Mailing.create we deliberately updated the BAO code such that the sometimes-unexpected scheduling would not take place when api v4 Mailing.create was called. However, somewhere along the way the BAO stopped receiving the version parameter - causing it to trigger the scheduling code

https://lab.civicrm.org/dev/core/-/issues/4385

Before
----------------------------------------
Scheduling code called by apiv4

After
----------------------------------------
Scheduling code not called

Technical Details
----------------------------------------
We have long agreed that the scheduling should be deliberate, not a by-product of the crud action, as there are varied reasons to create without wanting to schedule (either because the code is not ready or because the mailing is being created to reflect somethign sent through an external system.

However, this is a behavioural change to the api so there might be some dragons. Sadly not having a test eariler I'm unsure when it last worked as intended

Comments
----------------------------------------
