### PR TITLE
dev/core#4568 Don't copy nulls when moving custom fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2045,6 +2045,7 @@ WHERE  id IN ( %1, %2 )
 
     $sql = "INSERT INTO {$newGroup->table_name} (entity_id, `{$field->column_name}`)
             SELECT entity_id, `{$field->column_name}` FROM {$oldGroup->table_name}
+            WHERE `{$field->column_name}` IS NOT NULL
             ON DUPLICATE KEY UPDATE `{$field->column_name}` = {$oldGroup->table_name}.`{$field->column_name}`
             ";
     CRM_Core_DAO::executeQuery($sql);


### PR DESCRIPTION
Overview
----------------------------------------
When moving a custom field that is default NULL, a check is done to see if there is any data in the custom field before allowing a move to a custom field set that extends a different entity. If there is no data (all NULLs), then the move can proceed, but the next step attempts to copy all the NULL values along with the entity ids to the new custom field set table, resulting in an error if we hit an entity id that doesn't exist for the new entity.

The only possible issue with this solution is if the NULL on a custom field was meaningful and we did want to copy it over for some reason. I can't think of why that would be true, but just wanted to flag it. An alternate solution would be to first check if there are any non-null values and only insert rows if there are non-null values.

Before
----------------------------------------
All values, including NULLs are inserted into the new table.

After
----------------------------------------
Only non-NULL values are inserted into the new table.