### PR TITLE
Remove legacy error handling

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -38,14 +38,16 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    * Takes an associative array and creates a contribution object.
    *
    * the function extract all the params it needs to initialize the create a
-   * contribution object. the params array could contain additional unused name/value
-   * pairs
+   * contribution object. the params array could contain additional unused
+   * name/value pairs
    *
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
    *
-   * @return \CRM_Contribute_BAO_ContributionRecur|\CRM_Core_Error
-   * @todo move hook calls / extended logic to create - requires changing calls to call create not add
+   * @return \CRM_Contribute_BAO_ContributionRecur
+   * @throws \CRM_Core_Exception
+   * @todo move hook calls / extended logic to create - requires changing calls
+   *   to call create not add
    */
   public static function add(&$params) {
     if (!empty($params['id'])) {
@@ -59,14 +61,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
     // or invoice ID as an existing recurring contribution
     $duplicates = [];
     if (self::checkDuplicate($params, $duplicates)) {
-      $error = CRM_Core_Error::singleton();
-      $d = implode(', ', $duplicates);
-      $error->push(CRM_Core_Error::DUPLICATE_CONTRIBUTION,
-        'Fatal',
-        [$d],
-        "Found matching recurring contribution(s): $d"
-      );
-      return $error;
+      throw new CRM_Core_Exception("Found matching recurring contribution(s): implode(', ', $duplicates)");
     }
 
     $recurring = new CRM_Contribute_BAO_ContributionRecur();


### PR DESCRIPTION

Overview
----------------------------------------
Remove legacy error handling 

Before
----------------------------------------
ContributionRecur.create returns error object on duplicate match

After
----------------------------------------
ContributionRecur.create throws exception on duplicate match

Technical Details
----------------------------------------
Our practice now is to throw exceptions - this results in a hard fatal within apiv4 usage

Comments
----------------------------------------