### PR TITLE
Enable CiviCRM Admin UI extension by default

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtySeven.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtySeven.php
@@ -30,8 +30,8 @@ class CRM_Upgrade_Incremental_php_FiveSixtySeven extends CRM_Upgrade_Incremental
   public function upgrade_5_67_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Make EntityFile.entity_table required', 'alterColumn', 'civicrm_entity_file', 'entity_table', "varchar(64) NOT NULL COMMENT 'physical tablename for entity being joined to file, e.g. civicrm_contact'");
-    $this->addExtensionTask('Enable Authx extension', ['authx'], 1101);
-    $this->addExtensionTask('Enable Afform extension', ['org.civicrm.afform'], 1102);
+    $this->addExtensionTask('Enable Afform + Authx extensions', ['authx', 'org.civicrm.afform'], 1101);
+    $this->addExtensionTask('Enable AdminUI extension', ['civicrm_admin_ui']);
     $this->addTask('Add "civicrm_note" to "note_used_for" option group', 'addNoteNote');
   }
 

--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -47,7 +47,7 @@ php GenerateData.php
 
 ## Prune local data
 $MYSQLCMD -e "DROP TABLE IF EXISTS civicrm_install_canary; DELETE FROM civicrm_cache; DELETE FROM civicrm_setting;"
-$MYSQLCMD -e "DELETE FROM civicrm_extension WHERE full_name NOT IN ('sequentialcreditnotes', 'eventcart', 'greenwich', 'org.civicrm.search_kit', 'org.civicrm.afform', 'authx', 'org.civicrm.flexmailer', 'financialacls', 'contributioncancelactions', 'recaptcha', 'ckeditor4', 'legacycustomsearches', 'civiimport') and full_name NOT LIKE 'civi_%';"
+$MYSQLCMD -e "DELETE FROM civicrm_extension WHERE full_name NOT IN ('sequentialcreditnotes', 'eventcart', 'greenwich', 'org.civicrm.search_kit', 'org.civicrm.afform', 'authx', 'org.civicrm.flexmailer', 'financialacls', 'contributioncancelactions', 'recaptcha', 'ckeditor4', 'legacycustomsearches', 'civiimport', 'civicrm_admin_ui') and full_name NOT LIKE 'civi_%';"
 TABLENAMES=$( echo "show tables like 'civicrm_%'" | $MYSQLCMD | grep ^civicrm_ | xargs )
 
 cd $CIVISOURCEDIR/sql

--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -16,5 +16,6 @@ if (!defined('CIVI_SETUP')) {
     $e->getModel()->extensions[] = 'org.civicrm.search_kit';
     $e->getModel()->extensions[] = 'org.civicrm.afform';
     $e->getModel()->extensions[] = 'authx';
+    $e->getModel()->extensions[] = 'civicrm_admin_ui';
 
   });


### PR DESCRIPTION
Overview
----------------------------------------
The Admin UI extension is stabilizing, with one of the last bits of feature-parity solved by [checking permissions for "Add New" buttons](https://github.com/civicrm/civicrm-core/pull/27407).
Now that [Afform is required by core](https://github.com/civicrm/civicrm-core/pull/27293) we can safely enable this extension on all sites.

Before
-----
Admin UI optional, disabled by default.

After
------
Admin UI optional, enabled by default. It can be turned off if needed, for now. But fair-warning: someday in the not-too-distant future we'll be permanently enabling AdminUI and deleting all the old code for screens being replaced by it.