### PR TITLE
Remove some unused undeclared properties on SelfSvcTransfer form

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -1995,7 +1995,7 @@ ORDER BY civicrm_email.is_primary DESC";
     else {
       CRM_Utils_Hook::post('create', 'Profile', $contactID, $params);
     }
-    return $contactID;
+    return (int) $contactID;
   }
 
   /**

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -129,9 +129,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
       CRM_Core_Error::statusBounce(ts('You do not have sufficient permission to transfer/cancel this participant.'), $url);
     }
     $this->assign('action', $this->_action);
-    if ($this->_from_participant_id) {
-      $this->assign('participantId', $this->_from_participant_id);
-    }
+    $this->assign('participantId', $this->_from_participant_id);
 
     $details = CRM_Event_BAO_Participant::participantDetails($this->_from_participant_id);
     $selfServiceDetails = CRM_Event_BAO_Participant::getSelfServiceEligibility($this->_from_participant_id, $url, $this->isBackoffice);


### PR DESCRIPTION
Overview
----------------------------------------
Remove some unused undeclared properties on SelfSvcTransfer form

Before
----------------------------------------
A handful of properties are set on the form but not actually used

After
----------------------------------------
still works

![Uploading image.png…]()

Technical Details
----------------------------------------
This smells of copy & paste

Comments
----------------------------------------
