### PR TITLE
Fix unnecessary pass-by-ref, minor code improvements

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -667,9 +667,9 @@ $event_summary_limit
    *
    * @return array
    */
-  public static function &getMapInfo(&$id) {
+  public static function getMapInfo($id): array {
 
-    $sql = "
+    $sql = '
 SELECT
    civicrm_event.id AS event_id,
    civicrm_event.title AS display_name,
@@ -691,10 +691,9 @@ FROM
    LEFT JOIN civicrm_location_type ON ( civicrm_location_type.id = civicrm_address.location_type_id )
 WHERE civicrm_address.geo_code_1 IS NOT NULL
   AND civicrm_address.geo_code_2 IS NOT NULL
-  AND civicrm_event.id = " . CRM_Utils_Type::escape($id, 'Integer');
+  AND civicrm_event.id = ' . CRM_Utils_Type::escape($id, 'Integer');
 
-    $dao = new CRM_Core_DAO();
-    $dao->query($sql);
+    $dao = CRM_Core_DAO::executeQuery($sql);
 
     $locations = [];
 

--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -181,8 +181,8 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $locations = CRM_Event_BAO_Event::getMapInfo($this->_id);
     $this->assign('locations', $locations);
     if (!empty($locations) && !empty($values['event']['is_map'])) {
-      $this->assign('mapProvider', $config->mapProvider);
-      $this->assign('mapKey', $config->mapAPIKey);
+      $this->assign('mapProvider', \Civi::settings()->get('mapProvider'));
+      $this->assign('mapKey', \Civi::settings()->get('mapAPIKey'));
       $sumLat = $sumLng = 0;
       $maxLat = $maxLng = -400;
       $minLat = $minLng = 400;


### PR DESCRIPTION
Overview
----------------------------------------
Fix unnecessary pass-by-ref

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/db2eb80f-02fd-4e40-8293-806cd37946ff)


After
----------------------------------------

Technical Details
----------------------------------------
This is just called from a couple of places & they don't do anything magic like leverage the `&` before the function
Comments
----------------------------------------
