### PR TITLE
Resurrect Bunny Dance

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -57,10 +57,12 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
 
     $caseTypeName = (isset($params['name'])) ? $params['name'] : CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $params['id'], 'name', 'id', TRUE);
 
-    // function to format definition column
+    // Format definition column
     if (isset($params['definition']) && is_array($params['definition'])) {
       $params['definition'] = self::convertDefinitionToXML($caseTypeName, $params['definition']);
-      CRM_Core_ManagedEntities::scheduleReconciliation();
+      // Ensure entities declared in the definition get created.
+      // @see CRM_Case_ManagedEntities
+      CRM_Core_ManagedEntities::scheduleReconciliation(['civicrm']);
     }
 
     $caseTypeDAO->copyValues($params);

--- a/CRM/Case/ManagedEntities.php
+++ b/CRM/Case/ManagedEntities.php
@@ -58,12 +58,11 @@ class CRM_Case_ManagedEntities {
    * Get a list of managed activity-types by searching CiviCase XML files.
    *
    * @param \CRM_Case_XMLRepository $xmlRepo
-   * @param \CRM_Core_ManagedEntities $me
    *
    * @return array
    * @see CRM_Utils_Hook::managed
    */
-  public static function createManagedActivityTypes(CRM_Case_XMLRepository $xmlRepo, CRM_Core_ManagedEntities $me) {
+  public static function createManagedActivityTypes(CRM_Case_XMLRepository $xmlRepo): array {
     $result = [];
     $validActTypes = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, TRUE, 'name');
 
@@ -102,12 +101,11 @@ class CRM_Case_ManagedEntities {
    * Get a list of managed relationship-types by searching CiviCase XML files.
    *
    * @param \CRM_Case_XMLRepository $xmlRepo
-   * @param \CRM_Core_ManagedEntities $me
    *
    * @return array
    * @see CRM_Utils_Hook::managed
    */
-  public static function createManagedRelationshipTypes(CRM_Case_XMLRepository $xmlRepo, CRM_Core_ManagedEntities $me) {
+  public static function createManagedRelationshipTypes(CRM_Case_XMLRepository $xmlRepo): array {
     $result = [];
 
     if (!isset(Civi::$statics[__CLASS__]['reltypes'])) {

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -32,11 +32,11 @@ class CRM_Case_XMLRepository {
   protected $hookCache = NULL;
 
   /**
-   * Symbolic names of case-types.
+   * Override case types, only used by unit tests
    *
    * @var array|null
    */
-  protected $allCaseTypes = NULL;
+  protected $unitTestCaseTypes = NULL;
 
   /**
    * @param bool $fresh
@@ -52,18 +52,18 @@ class CRM_Case_XMLRepository {
   public function flush() {
     $this->xml = [];
     $this->hookCache = NULL;
-    $this->allCaseTypes = NULL;
+    $this->unitTestCaseTypes = NULL;
     CRM_Core_DAO::$_dbColumnValueCache = [];
   }
 
   /**
    * Class constructor.
    *
-   * @param array $allCaseTypes
+   * @param array $unitTestCaseTypes
    * @param array $xml
    */
-  public function __construct($allCaseTypes = NULL, $xml = []) {
-    $this->allCaseTypes = $allCaseTypes;
+  public function __construct($unitTestCaseTypes = NULL, $xml = []) {
+    $this->unitTestCaseTypes = $unitTestCaseTypes;
     $this->xml = $xml;
   }
 
@@ -215,13 +215,11 @@ class CRM_Case_XMLRepository {
   }
 
   /**
-   * @return array<string> symbolic names of case-types
+   * @return string[]
+   *   symbolic names of case-types
    */
   public function getAllCaseTypes() {
-    if ($this->allCaseTypes === NULL) {
-      $this->allCaseTypes = CRM_Case_PseudoConstant::caseType("name");
-    }
-    return $this->allCaseTypes;
+    return $this->unitTestCaseTypes ?? CRM_Case_PseudoConstant::caseType("name");
   }
 
   /**

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -43,14 +43,15 @@ class CRM_Core_ManagedEntities {
 
   /**
    * Perform an asynchronous reconciliation when the transaction ends.
+   * @param array|null $modules
    */
-  public static function scheduleReconciliation() {
+  public static function scheduleReconciliation(array $modules = NULL) {
     CRM_Core_Transaction::addCallback(
       CRM_Core_Transaction::PHASE_POST_COMMIT,
-      function () {
-        CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+      function ($modules) {
+        CRM_Core_ManagedEntities::singleton(TRUE)->reconcile($modules);
       },
-      [],
+      [$modules],
       'ManagedEntities::reconcile'
     );
   }

--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -7,10 +7,13 @@ use CRM_Case_ExtensionUtil as E;
  * Implements hook_civicrm_managed().
  */
 function civi_case_civicrm_managed(&$entities, $modules) {
-  // Don't optimize for $modules because the below functions delegate to other extensions
-  $entities = array_merge($entities,
-    CRM_Case_ManagedEntities::createManagedCaseTypes(),
-    CRM_Case_ManagedEntities::createManagedActivityTypes(CRM_Case_XMLRepository::singleton(), CRM_Core_ManagedEntities::singleton()),
-    CRM_Case_ManagedEntities::createManagedRelationshipTypes(CRM_Case_XMLRepository::singleton(), CRM_Core_ManagedEntities::singleton())
-  );
+  // Don't optimize for $modules because `createManagedCaseTypes` delegates to other extensions
+  $entities = array_merge($entities, CRM_Case_ManagedEntities::createManagedCaseTypes());
+  // These functions always declare module = civicrm
+  if (!$modules || in_array('civicrm', $modules, TRUE)) {
+    $entities = array_merge($entities,
+      CRM_Case_ManagedEntities::createManagedActivityTypes(CRM_Case_XMLRepository::singleton()),
+      CRM_Case_ManagedEntities::createManagedRelationshipTypes(CRM_Case_XMLRepository::singleton())
+    );
+  }
 }

--- a/mixin/mgd-php@1/example/CRM/BunnyDance.mgd.php
+++ b/mixin/mgd-php@1/example/CRM/BunnyDance.mgd.php
@@ -14,41 +14,40 @@ return [
         'is_active' => TRUE,
         'is_reserved' => TRUE,
         'weight' => 1,
-        // FIXME: At time of writing, if I create a full CaseType with a definition, then the system runs out of memory.
-        // 'definition' => [
-        //   'activityTypes' => [
-        //     ['name' => 'Open Case', 'max_instances' => '1'],
-        //     ['name' => 'Follow up'],
-        //     ['name' => 'Change Case Type'],
-        //     ['name' => 'Change Case Status'],
-        //     ['name' => 'Change Case Start Date'],
-        //     ['name' => 'Link Cases'],
-        //     ['name' => 'Email'],
-        //     ['name' => 'Meeting'],
-        //     ['name' => 'Phone Call'],
-        //     ['name' => 'Nibble'],
-        //   ],
-        //   'activitySets' => [
-        //     [
-        //       'name' => 'standard_timeline',
-        //       'label' => 'Standard Timeline',
-        //       'timeline' => 1,
-        //       'activityTypes' => [
-        //         ['name' => 'Open Case', 'status' => 'Completed'],
-        //         ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
-        //         ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
-        //       ],
-        //     ],
-        //   ],
-        //   'timelineActivityTypes' => [
-        //     ['name' => 'Open Case', 'status' => 'Completed'],
-        //     ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
-        //     ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
-        //   ],
-        //   'caseRoles' => [
-        //     ['name' => 'Case Coordinator', 'creator' => '1', 'manager' => '1'],
-        //   ],
-        // ],
+        'definition' => [
+          'activityTypes' => [
+            ['name' => 'Open Case', 'max_instances' => '1'],
+            ['name' => 'Follow up'],
+            ['name' => 'Change Case Type'],
+            ['name' => 'Change Case Status'],
+            ['name' => 'Change Case Start Date'],
+            ['name' => 'Link Cases'],
+            ['name' => 'Email'],
+            ['name' => 'Meeting'],
+            ['name' => 'Phone Call'],
+            ['name' => 'Nibble'],
+          ],
+          'activitySets' => [
+            [
+              'name' => 'standard_timeline',
+              'label' => 'Standard Timeline',
+              'timeline' => 1,
+              'activityTypes' => [
+                ['name' => 'Open Case', 'status' => 'Completed'],
+                ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
+                ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
+              ],
+            ],
+          ],
+          'timelineActivityTypes' => [
+            ['name' => 'Open Case', 'status' => 'Completed'],
+            ['name' => 'Phone Call', 'reference_offset' => '1', 'reference_select' => 'newest'],
+            ['name' => 'Follow up', 'reference_offset' => '7', 'reference_select' => 'newest'],
+          ],
+          'caseRoles' => [
+            ['name' => 'Case Coordinator', 'creator' => '1', 'manager' => '1'],
+          ],
+        ],
       ],
     ],
   ],

--- a/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
+++ b/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
@@ -24,10 +24,6 @@ class ManagedCaseTypeTest extends \PHPUnit\Framework\Assert {
     $this->assertEquals(TRUE, $items[0]['is_active']);
     $this->assertEquals(1, count($items));
 
-    // This is normally handled by `CRM_Case_BAO_CaseType` calling `CRM_Core_ManagedEntities::scheduleReconciliation`
-    // But due to timing issues with the E2E tests the scheduled reconciliation hasn't happened yet.
-    \Civi\Api4\Managed::reconcile(FALSE)->addModule('civicrm')->execute();
-
     $actTypes = $cv->api4('OptionValue', 'get', [
       'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
     ]);
@@ -47,12 +43,6 @@ class ManagedCaseTypeTest extends \PHPUnit\Framework\Assert {
   public function testUninstalled($cv): void {
     $items = $cv->api4('CaseType', 'get', ['where' => [['name', '=', 'BunnyDance']]]);
     $this->assertEquals(0, count($items));
-
-    // This is normally handled by `CRM_Case_BAO_CaseType` calling `CRM_Core_ManagedEntities::scheduleReconciliation`
-    // But static caching seems to interfere.
-    \Civi\Api4\Managed::reconcile(FALSE)->execute();
-    \CRM_Core_PseudoConstant::flush();
-    \Civi\Api4\Managed::reconcile(FALSE)->addModule('civicrm')->execute();
 
     $actTypes = $cv->api4('OptionValue', 'get', [
       'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],

--- a/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
+++ b/mixin/mgd-php@1/example/tests/mixin/ManagedCaseTypeTest.php
@@ -24,13 +24,15 @@ class ManagedCaseTypeTest extends \PHPUnit\Framework\Assert {
     $this->assertEquals(TRUE, $items[0]['is_active']);
     $this->assertEquals(1, count($items));
 
-    // FIXME: The example is partially disabled - because the full example causes a crash.
-    // Hence, these assertions don't yet pass.
-    // $actTypes = $cv->api4('OptionValue', 'get', [
-    //   'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
-    // ]);
-    // $this->assertEquals('Nibble', $actTypes[0]['name'], 'ActivityType "Nibble" should be auto enabled. It\'s missing.');
-    // $this->assertEquals(TRUE, $actTypes[0]['is_active'], 'ActivityType "Nibble" should be auto enabled. It\'s inactive.');
+    // This is normally handled by `CRM_Case_BAO_CaseType` calling `CRM_Core_ManagedEntities::scheduleReconciliation`
+    // But due to timing issues with the E2E tests the scheduled reconciliation hasn't happened yet.
+    \Civi\Api4\Managed::reconcile(FALSE)->addModule('civicrm')->execute();
+
+    $actTypes = $cv->api4('OptionValue', 'get', [
+      'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],
+    ]);
+    $this->assertEquals('Nibble', $actTypes[0]['name'], 'ActivityType "Nibble" should be auto enabled. It\'s missing.');
+    $this->assertEquals(TRUE, $actTypes[0]['is_active'], 'ActivityType "Nibble" should be auto enabled. It\'s inactive.');
   }
 
   public function testDisabled($cv): void {
@@ -45,6 +47,12 @@ class ManagedCaseTypeTest extends \PHPUnit\Framework\Assert {
   public function testUninstalled($cv): void {
     $items = $cv->api4('CaseType', 'get', ['where' => [['name', '=', 'BunnyDance']]]);
     $this->assertEquals(0, count($items));
+
+    // This is normally handled by `CRM_Case_BAO_CaseType` calling `CRM_Core_ManagedEntities::scheduleReconciliation`
+    // But static caching seems to interfere.
+    \Civi\Api4\Managed::reconcile(FALSE)->execute();
+    \CRM_Core_PseudoConstant::flush();
+    \Civi\Api4\Managed::reconcile(FALSE)->addModule('civicrm')->execute();
 
     $actTypes = $cv->api4('OptionValue', 'get', [
       'where' => [['option_group_id:name', '=', 'activity_type'], ['name', '=', 'Nibble']],


### PR DESCRIPTION
Overview
----------------------------------------
This resolves https://lab.civicrm.org/dev/core/-/issues/3722 with a new approach to #23955 to prevent an infinite loop.

Before
-------------
In unit tests, `BunnyDance.mgd.php` was partially commented out, because uncommenting it gives:

```
Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to al  
  locate 20480 bytes) in /home/homer/buildkit/build/build-0/web/sites/all/mod  
  ules/civicrm/vendor/pear/pear-core-minimal/src/PEAR.php on line 898          
  Remove /home/homer/buildkit/build/build-0/web/sites/default/files/civicrm/e  
  xt/example-mixin                                                             
  Create /home/homer/buildkit/build/build-0/web/sites/default/files/civicrm/e  
  xt/example-mixin for scan-classes@1                                          
  Test scan-classes@1     
```

After
---------
Fatal infinite loop fixed.
Test fixed.

Technical Details
---------------
The problem #23955 wanted to solve was an infinite loop being caused by `Managed->reconcile()` calling itself.
This fixes that problem. And I've confirmed that existing tests do cover the functionality:
- `CRM_Case_BAO_CaseTypeForkTest.testManagerContact`
- `api_v3_CaseTypeTest.testCaseTypeDelete_InUse`

The `ManagedCaseTypeTest` turned out to be broken due to double-caching of the case types pseudoconstant, which was persisting beyond cache flushes. Fixed by removing the double-caching.

Also, while I was looking at it I optimized the `CRM_Case_ManagedEntities` reconcile and dropped some unused variables.