### PR TITLE
Fix notices when deleting participants

### DIFF
--- a/CRM/Event/Form/Task/Delete.php
+++ b/CRM/Event/Form/Task/Delete.php
@@ -35,18 +35,13 @@ class CRM_Event_Form_Task_Delete extends CRM_Event_Form_Task {
    *
    * @return void
    */
-  public function preProcess() {
+  public function preProcess(): void {
 
     //check for delete
     if (!CRM_Core_Permission::checkActionPermission('CiviEvent', CRM_Core_Action::DELETE)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
     parent::preProcess();
-    foreach ($this->_participantIds as $participantId) {
-      if (CRM_Event_BAO_Participant::isPrimaryParticipant($participantId)) {
-        $this->assign('additionalParticipants', TRUE);
-      }
-    }
   }
 
   /**
@@ -55,14 +50,17 @@ class CRM_Event_Form_Task_Delete extends CRM_Event_Form_Task {
    *
    * @return void
    */
-  public function buildQuickForm() {
-    $deleteParticipants = [
-      1 => ts('Delete this participant record along with associated participant record(s).'),
-      2 => ts('Delete only this participant record.'),
-    ];
-
-    $this->addRadio('delete_participant', NULL, $deleteParticipants, NULL, '<br />');
-    $this->setDefaults(['delete_participant' => 1]);
+  public function buildQuickForm(): void {
+    foreach ($this->_participantIds as $participantId) {
+      if (CRM_Event_BAO_Participant::isPrimaryParticipant($participantId)) {
+        $this->addRadio('delete_participant', NULL, [
+          1 => ts('Delete this participant record along with associated participant record(s).'),
+          2 => ts('Delete only this participant record.'),
+        ], NULL, '<br />');
+        $this->setDefaults(['delete_participant' => 1]);
+        break;
+      }
+    }
 
     $this->addDefaultButtons(ts('Delete Participations'), 'done');
   }
@@ -72,13 +70,14 @@ class CRM_Event_Form_Task_Delete extends CRM_Event_Form_Task {
    *
    *
    * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Core\Exception\DBQueryException
    */
-  public function postProcess() {
+  public function postProcess(): void {
     $params = $this->controller->exportValues($this->_name);
 
     $participantLinks = NULL;
     if (($params['delete_participant'] ?? NULL) == 2) {
-      $links = [];
       foreach ($this->_participantIds as $participantId) {
         $additionalId = (CRM_Event_BAO_Participant::getAdditionalParticipantIds($participantId));
         $participantLinks = (CRM_Event_BAO_Participant::getAdditionalParticipantUrl($additionalId));
@@ -87,7 +86,7 @@ class CRM_Event_Form_Task_Delete extends CRM_Event_Form_Task {
     $deletedParticipants = $additionalCount = 0;
     foreach ($this->_participantIds as $participantId) {
       if (($params['delete_participant'] ?? NULL) == 1) {
-        $primaryParticipantId = CRM_Core_DAO::getFieldValue("CRM_Event_DAO_Participant", $participantId, 'registered_by_id', 'id');
+        $primaryParticipantId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $participantId, 'registered_by_id', 'id');
         if (CRM_Event_BAO_Participant::isPrimaryParticipant($participantId)) {
           $additionalIds = (CRM_Event_BAO_Participant::getAdditionalParticipantIds($participantId));
           $additionalCount += count($additionalIds);

--- a/templates/CRM/Event/Form/Task/Delete.tpl
+++ b/templates/CRM/Event/Form/Task/Delete.tpl
@@ -13,10 +13,10 @@
   {icon icon="fa-info-circle"}{/icon}
   <div>
     <p>{ts}Are you sure you want to delete the selected participations? This delete operation cannot be undone and will delete all transactions and activity associated with these participations.{/ts}</p>
-        <p>{include file="CRM/Event/Form/Task.tpl"}</p>
+    <p>{ts 1=$totalSelectedParticipants}Number of selected participants: %1{/ts}</p>
   </div>
 </div>
-{if $additionalParticipants}
+{if array_key_exists('delete_participant', $form)}
     {$form.delete_participant.html}
 {/if}
 <p>


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices when deleting participants from search results

Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/65c92638-c069-4b8b-97b7-b0a3148bf453)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/7369e95c-4fb1-40d4-b862-270eeb2419df)

Still shows when it should

![image](https://github.com/civicrm/civicrm-core/assets/336308/57e22846-0ad5-4489-8c93-28ec4be4e176)


Technical Details
----------------------------------------
This tpl is not shared with the delete action on a single participant. Nothing is assigned that is used on the `Task.tpl`

Comments
----------------------------------------
Participations? is that a word?