### PR TITLE
8.x Profiles Remove e-notices by removing never assigned help_pre, help_post

### DIFF
--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -10,7 +10,6 @@
 {* Edit or display Profile fields, when embedded in an online contribution or event registration form. *}
 {if ! empty( $fields )}
   {strip}
-    {if $help_pre && $action neq 4}<div class="messages help">{$help_pre}</div>{/if}
     {assign var=zeroField value="Initial Non Existent Fieldset"}
     {assign var=fieldset  value=$zeroField}
     {include file="CRM/UF/Form/Fields.tpl"}
@@ -29,7 +28,6 @@
     </fieldset>
     {/if}
 
-    {if $help_post && $action neq 4}<br /><div class="messages help">{$help_post}</div>{/if}
   {/strip}
 
 {/if} {* fields array is not empty *}


### PR DESCRIPTION
Overview
----------------------------------------
Remove e-notices by removing never assigned help_pre, help_post

Before
----------------------------------------
The `UF/Block.tpl` is invoked from various places - eg online registration form, online contribution page. Despite the name it seems to be unrelated to any help text from the profile (or the event / contribution page). After removal the notices are gone but not the help text associated with the profile on the contribution or event page

![image](https://github.com/civicrm/civicrm-core/assets/336308/0bbd8db2-6a8b-43dc-9d19-f35aed298199)


After
----------------------------------------

Technical Details
----------------------------------------
I could find no place where these values are assigned to the template or places where they are assigned when including the block

Comments
----------------------------------------
