### PR TITLE
8.x Fix all instances of call Profile template to specify the prefix

### DIFF
--- a/templates/CRM/Campaign/Form/Petition/Signature.tpl
+++ b/templates/CRM/Campaign/Form/Petition/Signature.tpl
@@ -42,11 +42,11 @@
     {/if}
   {else}
     <div class="crm-section crm-petition-contact-profile">
-      {include file="CRM/UF/Form/Block.tpl" fields=$petitionContactProfile hideFieldset=true}
+      {include file="CRM/UF/Form/Block.tpl" fields=$petitionContactProfile hideFieldset=true prefix=false}
     </div>
 
     <div class="crm-section crm-petition-activity-profile">
-      {include file="CRM/UF/Form/Block.tpl" fields=$petitionActivityProfile hideFieldset=true}
+      {include file="CRM/UF/Form/Block.tpl" fields=$petitionActivityProfile hideFieldset=true prefix=false}
     </div>
 
     <div class="crm-submit-buttons">

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -173,7 +173,7 @@
 
   {if $customPre}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
     </fieldset>
   {/if}
 
@@ -272,7 +272,7 @@
 
   {if $customPost}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
     </fieldset>
   {/if}
 

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -214,7 +214,7 @@
       {/if}
 
       <div class="crm-public-form-item crm-group custom_pre_profile-group">
-        {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+        {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
       </div>
 
       {if array_key_exists('pcp_display_in_roll', $form)}
@@ -283,7 +283,7 @@
     {include file="CRM/Core/BillingBlockWrapper.tpl"}
 
     <div class="crm-public-form-item crm-group custom_post_profile-group">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
     </div>
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -220,7 +220,7 @@
 
   {if $customPre}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
     </fieldset>
   {/if}
 
@@ -304,7 +304,7 @@
 
   {if $customPost}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
     </fieldset>
   {/if}
 

--- a/templates/CRM/Contribute/Form/PCP/PCPAccount.tpl
+++ b/templates/CRM/Contribute/Form/PCP/PCPAccount.tpl
@@ -22,7 +22,7 @@
 {else}
 <div class="form-item">
 {include file="CRM/common/CMSUser.tpl"}
-{include file="CRM/UF/Form/Block.tpl" fields=$fields}
+{include file="CRM/UF/Form/Block.tpl" fields=$fields prefix=false}
 </div>
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
+++ b/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
@@ -22,7 +22,7 @@
 {/if}
 
 <div class="crm-public-form-item crm-section custom_pre-section">
-  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPre}
+  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPre prefix=false}
 </div>
 
 {if $priceSet && $allowGroupOnWaitlist}
@@ -49,7 +49,7 @@
 {/if}
 
 <div class="crm-public-form-item crm-section custom_post-section">
-  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPost}
+  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPost prefix=false}
 </div>
 
 <div id="crm-submit-buttons" class="crm-submit-buttons">

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -73,7 +73,7 @@
 
     <div class="crm-public-form-item crm-section custom_pre-section">
       {* Display "Top of page" profile immediately after the introductory text *}
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
     </div>
 
     {if $priceSet}
@@ -135,7 +135,7 @@
     {/if}
 
     <div class="crm-public-form-item crm-section custom_post-section">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
     </div>
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">

--- a/templates/CRM/PCP/Form/PCPAccount.tpl
+++ b/templates/CRM/PCP/Form/PCPAccount.tpl
@@ -26,7 +26,7 @@
 {else}
 <div class="form-item crm-block crm-form-block">
 {include file="CRM/common/CMSUser.tpl"}
-{include file="CRM/UF/Form/Block.tpl" fields=$fields}
+{include file="CRM/UF/Form/Block.tpl" fields=$fields prefix=false}
 
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -15,7 +15,7 @@
   {if $field.groupTitle != $fieldset}
     {if $fieldset != $zeroField}
       {if $groupHelpPost && $action neq 4}
-        <div class="messages help">{$groupHelpPost}</div>
+        <div class="messages help">{$groupHelpPost|smarty:nodefaults|purify}</div>
       {/if}
       {if $mode ne 8}
         </fieldset>
@@ -32,7 +32,7 @@
     {assign var=fieldset  value=`$field.groupTitle`}
     {assign var=groupHelpPost  value=`$field.groupHelpPost`}
     {if $field.groupHelpPre && $action neq 4}
-      <div class="messages help">{$field.groupHelpPre}</div>
+      <div class="messages help">{$field.groupHelpPre|smarty:nodefaults|purify}</div>
     {/if}
   {/if}
 

--- a/templates/CRM/UF/Form/Preview.tpl
+++ b/templates/CRM/UF/Form/Preview.tpl
@@ -24,7 +24,7 @@
         {if $help_pre && $action neq 4}<div class="messages help">{$help_pre}</div>{/if}
         {assign var=zeroField value="Initial Non Existent Fieldset"}
         {assign var=fieldset  value=$zeroField}
-        {include file="CRM/UF/Form/Fields.tpl"}
+        {include file="CRM/UF/Form/Fields.tpl" prefix=false mode=false hideFieldset=false}
         {if $field.groupHelpPost}
           <div class="messages help">{$field.groupHelpPost}</div>
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Fix all instances of call Profile template to specify the prefix

Before
----------------------------------------
In a few places the prefix is specified in the include call, in the others it is left undefined causing notices. I could not find any instances of it being assigned from the form except for `CRM_Profile_Form_Edit` whichis accessed at the url `civicrm/profile/edit?gid=1&reset=1` and assigns `prefix` but perhaps that is just legacy cruft as it never seems to receive it

After
----------------------------------------
Consistently assigning `prefix` to suppress notices

Technical Details
----------------------------------------

Comments
----------------------------------------
