### PR TITLE
Remove references to invalid action

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -20,12 +20,11 @@
 class CRM_Core_Action {
 
   /**
-   * Different possible actions are defined here. Keep in sync with the
-   * constant from CRM_Core_Form for various modes.
+   * Different possible actions are defined here.
    *
    * @var int
    */
-  const
+  public const
     NONE = 0,
     ADD = 1,
     UPDATE = 2,

--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -15,7 +15,7 @@
     {assign var=fieldset  value=$zeroField}
     {include file="CRM/UF/Form/Fields.tpl"}
 
-    {if $field.groupHelpPost && $action neq 4  && $action neq 1028}
+    {if $field.groupHelpPost && $action neq 4}
       <div class="messages help">{$field.groupHelpPost}</div>
     {/if}
 
@@ -25,7 +25,7 @@
       </div>
     {/if}
 
-    {if $mode ne 8 && $action neq 1028 && !$hideFieldset}
+    {if $mode ne 8 && !$hideFieldset}
     </fieldset>
     {/if}
 

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -22,7 +22,7 @@
       {/if}
     {/if}
 
-    {if $mode ne 8 && $action ne 1028 && $action ne 4 && !$hideFieldset}
+    {if $mode ne 8 && $action ne 4 && !$hideFieldset}
       <fieldset class="crm-profile crm-profile-id-{$field.group_id} crm-profile-name-{$field.groupName}"><legend>{$field.groupDisplayTitle}</legend>
     {/if}
 
@@ -31,18 +31,18 @@
     {/if}
     {assign var=fieldset  value=`$field.groupTitle`}
     {assign var=groupHelpPost  value=`$field.groupHelpPost`}
-    {if $field.groupHelpPre && $action neq 4 && $action neq 1028}
+    {if $field.groupHelpPre && $action neq 4}
       <div class="messages help">{$field.groupHelpPre}</div>
     {/if}
   {/if}
 
   {if $field.field_type eq "Formatting"}
-    {if $action neq 4 && $action neq 1028}
+    {if $action neq 4}
       {$field.help_pre}
     {/if}
   {elseif $profileFieldName}
-    {* Show explanatory text for field if not in 'view' or 'preview' modes *}
-    {if $field.help_pre && $action neq 4 && $action neq 1028}
+    {* Show explanatory text for field if not in 'view' mode *}
+    {if $field.help_pre && $action neq 4}
       <div class="crm-section helprow-{$profileFieldName}-section helprow-pre" id="helprow-{$rowIdentifier}">
         <div class="content description">{$field.help_pre}</div>
       </div>
@@ -141,8 +141,8 @@
         <div class="clear"></div>
       </div>
     {/if}
-    {* Show explanatory text for field if not in 'view' or 'preview' modes *}
-    {if $field.help_post && $action neq 4 && $action neq 1028}
+    {* Show explanatory text for field if not in 'view' mode *}
+    {if $field.help_post && $action neq 4}
       <div class="crm-section helprow-{$profileFieldName}-section helprow-post" id="helprow-{$rowIdentifier}">
         <div class="content description">{$field.help_post}</div>
       </div>

--- a/templates/CRM/common/jcalendar.tpl
+++ b/templates/CRM/common/jcalendar.tpl
@@ -36,9 +36,7 @@
 {* CRM-15804 - CiviEvent Date Picker broken in modal dialog *}
 {assign var='displayDate' value=$elementId|cat:"_display"|cat:"_$string"|uniqid}
 
-{if $action neq 1028}
-    <input type="text" name="{$displayDate}" id="{$displayDate}" class="dateplugin" autocomplete="off"/>
-{/if}
+<input type="text" name="{$displayDate}" id="{$displayDate}" class="dateplugin" autocomplete="off"/>
 
 {if $batchUpdate AND $timeElement AND $tElement}
     &nbsp;&nbsp;{$form.field.$elementIndex.$tElement.label}&nbsp;&nbsp;{$form.field.$elementIndex.$tElement.html|crmAddClass:six}
@@ -49,9 +47,8 @@
     {$form.$timeElement.html|crmAddClass:six}
 {/if}
 
-{if $action neq 1028}
-    <a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
-{/if}
+
+ <a href="#" class="crm-hover-button crm-clear-link" title="{ts}Clear{/ts}"><i class="crm-i fa-times" aria-hidden="true"></i></a>
 
 <script type="text/javascript">
     {literal}


### PR DESCRIPTION

Overview
----------------------------------------
Remove references to invalid action - 1028 does not exist 

![image](https://github.com/civicrm/civicrm-core/assets/336308/de9f2a41-a453-405e-9225-797ea23fd24e)

Before
----------------------------------------
A bunch of always true ifs

After
----------------------------------------
gone

Technical Details
----------------------------------------

All these references refer to comparing action to 1028. The comments make is clear that they are looking for 'preview' mode - but preview mode is 1024. The checks are all does-not-equal. So, they would have always been true for a very long time.

Copy & paste is dead long live copy & paste

Comments
----------------------------------------
I checked & in actual preview mode the contents of the if resolve to TRUE