### PR TITLE
Remove broken recaptcha from profile preview

### DIFF
--- a/templates/CRM/UF/Form/Preview.tpl
+++ b/templates/CRM/UF/Form/Preview.tpl
@@ -25,9 +25,6 @@
         {assign var=zeroField value="Initial Non Existent Fieldset"}
         {assign var=fieldset  value=$zeroField}
         {include file="CRM/UF/Form/Fields.tpl"}
-        {if $addCAPTCHA }
-          {include file='CRM/common/ReCAPTCHA.tpl'}
-        {/if}
         {if $field.groupHelpPost}
           <div class="messages help">{$field.groupHelpPost}</div>
         {/if}


### PR DESCRIPTION

Overview
----------------------------------------
Remove broken recaptcha from profile preview

Before
----------------------------------------

The reCaptcha variable is never assigned to profile preview - resulting in it never rendering (but rendering notices). This code has been broken for a while without someone noticing 


After
----------------------------------------
Removed

Technical Details
----------------------------------------
No core references to assigning the variable & all references to Recaptcha are in the extension
![image](https://github.com/civicrm/civicrm-core/assets/336308/c19b2df0-5487-4de0-ac6e-a44c01a8a280)

The extension does not use a similar method to put Recaptcha on the profile
![image](https://github.com/civicrm/civicrm-core/assets/336308/fd156b7d-f482-48ec-9b22-699e2162973a)


Comments
----------------------------------------
