### PR TITLE
Remove unused variable from function signature

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1447,7 +1447,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
       //retrieve custom information
       $form->_values = [];
-      CRM_Event_Form_Registration::initEventFee($form, $event['id'], FALSE, $this->getPriceSetID());
+      CRM_Event_Form_Registration::initEventFee($form, FALSE, $this->getPriceSetID());
       if ($form->_context === 'standalone' || $form->_context === 'participant') {
         $discountedEvent = CRM_Core_BAO_Discount::getOptionGroup($event['id'], 'civicrm_event');
         if (is_array($discountedEvent)) {

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -171,7 +171,7 @@ class CRM_Event_Form_ParticipantFeeSelection extends CRM_Core_Form {
     //retrieve custom information
     $this->_values = [];
 
-    CRM_Event_Form_Registration::initEventFee($this, $event['id'], $this->_action !== CRM_Core_Action::UPDATE, $this->getPriceSetID());
+    CRM_Event_Form_Registration::initEventFee($this, $this->_action !== CRM_Core_Action::UPDATE, $this->getPriceSetID());
     CRM_Event_Form_Registration_Register::buildAmount($this, TRUE, NULL, $this->getPriceSetID());
 
     if (!CRM_Utils_System::isNull($this->_values['line_items'] ?? NULL)) {

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -300,7 +300,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
       $priceSetID = $this->getPriceSetID();
       if ($priceSetID) {
-        self::initEventFee($this, $this->_eventId, TRUE, $priceSetID);
+        self::initEventFee($this, TRUE, $priceSetID);
         $this->assign('quickConfig', $this->isQuickConfig());
       }
 
@@ -571,15 +571,14 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * Initiate event fee.
    *
    * @param \CRM_Event_Form_Participant|\CRM_Event_Form_Registration|\CRM_Event_Form_ParticipantFeeSelection|\CRM_Event_Form_Task_Register $form
-   * @param int $eventID
    * @param bool $doNotIncludeExpiredFields
    *   See CRM-16456.
    * @param int|null $priceSetId
    *   ID of the price set in use.
    *
-   * @throws \CRM_Core_Exception
+   * @internal function has had several recent signature changes & is expected to be eventually removed.
    */
-  public static function initEventFee(&$form, $eventID, $doNotIncludeExpiredFields, $priceSetId): void {
+  public static function initEventFee($form, $doNotIncludeExpiredFields, $priceSetId): void {
     if (!$priceSetId) {
       CRM_Core_Error::deprecatedWarning('this should not be reachable');
       return;


### PR DESCRIPTION
Overview
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/5663a956-956e-4105-a7b4-10fd43c806d3)


Before
----------------------------------------
Unused parameter passed (that used to be used to get the PriceSetID

After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
