### PR TITLE
Fix variable leakage in online event receipt

### DIFF
--- a/CRM/Event/WorkflowMessage/ParticipantTrait.php
+++ b/CRM/Event/WorkflowMessage/ParticipantTrait.php
@@ -59,6 +59,17 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
   public $participants;
 
   /**
+   * The current participant (if there are multiple this is the one being emailed).
+   *
+   * This uses the same format as the participants array.
+   *
+   * @var array
+   *
+   * @scope tplParams as participant
+   */
+  public $currentParticipant;
+
+  /**
    * Details of the participant contacts.
    *
    * This would normally be loaded but exists to allow the example to set them.
@@ -171,6 +182,22 @@ trait CRM_Event_WorkflowMessage_ParticipantTrait {
         ->addSelect('registered_by_id')->execute()->first();
     }
     return $this->participant;
+  }
+
+  /**
+   * Get the line items and tax information indexed by participant.
+   *
+   * We will likely add profile data to this too. This is so we can iterate through
+   * participants as the primary participant needs to show them all (and the others
+   * need to be able to filter).
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getCurrentParticipant(): array {
+    // @todo - it is only because of some messed up tests which use
+    // the legacy testSubmit function we have ?? []
+    return $this->getParticipants()[$this->participantID] ?? [];
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -10,6 +10,7 @@ use Civi\Test\FormTrait;
  */
 class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
 
+  use CRMTraits_Event_ScenarioTrait;
   use CRMTraits_Financial_PriceSetTrait;
   use CRMTraits_Profile_ProfileTrait;
   use FormTrait;
@@ -293,35 +294,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   public function testTaxMultipleParticipant(): void {
     $this->swapMessageTemplateForTestTemplate('event_online_receipt', 'text');
     $this->createLoggedInUser();
-    $this->eventCreatePaid();
-    $this->addTaxAccountToFinancialType(CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Event Fee'));
-    $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
-      'first_name' => 'Participant1',
-      'last_name' => 'LastName',
-      'email-Primary' => 'participant1@example.com',
-      'additional_participants' => 2,
-      'payment_processor_id' => 0,
-      'priceSetId' => $this->getPriceSetID('PaidEvent'),
-      'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
-      'defaultRole' => 1,
-      'participant_role_id' => '1',
-      'button' => '_qf_Register_upload',
-    ], ['id' => $this->getEventID()])
-      ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
-        'first_name' => 'Participant2',
-        'last_name' => 'LastName',
-        'email-Primary' => 'participant2@example.com',
-        'priceSetId' => $this->getPriceSetID('PaidEvent'),
-        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
-      ])->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
-        'first_name' => 'Participant3',
-        'last_name' => 'LastName',
-        'email-Primary' => 'participant3@example.com',
-        'priceSetId' => $this->getPriceSetID('PaidEvent'),
-        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
-      ])
-      ->addSubsequentForm('CRM_Event_Form_Registration_Confirm')
-      ->processForm();
+    $this->createScenarioMultipleParticipantPendingWithTax();
 
     $participants = $this->callAPISuccess('Participant', 'get', [])['values'];
     $this->assertCount(3, $participants);

--- a/tests/phpunit/CRMTraits/Event/ScenarioTrait.php
+++ b/tests/phpunit/CRMTraits/Event/ScenarioTrait.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Api4\Participant;
+use Civi\Test\EventTestTrait;
+
+/**
+ * Trait to do set up for event scenarios.
+ *
+ * This allows multiple test classes to act on various scenarios. e.g a
+ * user might complete a pending registration using the back office form, an api
+ * call or the horrible front end form overload method.
+ *
+ * It might make sense to move this to Civi\Test for extensions to use
+ * but it might need to 'settle' a bit first as there is a balance to be found
+ * between accepting parameters & winding up with crazy complex functions.
+ */
+trait CRMTraits_Event_ScenarioTrait {
+  use EventTestTrait;
+
+  /**
+   * Create a participant registration with 2 registered_by participants.
+   *
+   * This follows the front end form multiple participant flow with tax enabled.
+   *
+   * @throws \Civi\API\Exception\UnauthorizedException
+   * @throws \CRM_Core_Exception
+   */
+  protected function createScenarioMultipleParticipantPendingWithTax(): void {
+    $this->eventCreatePaid();
+    $this->addTaxAccountToFinancialType(CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Event Fee'));
+    $this->getTestForm('CRM_Event_Form_Registration_Register', [
+      'first_name' => 'Participant1',
+      'last_name' => 'LastName',
+      'email-Primary' => 'participant1@example.com',
+      'additional_participants' => 2,
+      'payment_processor_id' => 0,
+      'priceSetId' => $this->getPriceSetID('PaidEvent'),
+      'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
+      'defaultRole' => 1,
+      'participant_role_id' => '1',
+      'button' => '_qf_Register_upload',
+    ], ['id' => $this->getEventID()])
+      ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
+        'first_name' => 'Participant2',
+        'last_name' => 'LastName',
+        'email-Primary' => 'participant2@example.com',
+        'priceSetId' => $this->getPriceSetID('PaidEvent'),
+        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
+      ])
+      ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
+        'first_name' => 'Participant3',
+        'last_name' => 'LastName',
+        'email-Primary' => 'participant3@example.com',
+        'priceSetId' => $this->getPriceSetID('PaidEvent'),
+        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
+      ])
+      ->addSubsequentForm('CRM_Event_Form_Registration_Confirm')
+      ->processForm();
+    $participants = Participant::get(FALSE)
+      ->addWhere('event_id', '=', $this->getEventID('PaidEvent'))
+      ->addOrderBy('registered_by_id')
+      ->execute();
+    foreach ($participants as $index => $participant) {
+      $identifier = $participant['registered_by_id'] ? 'participant_' . $index : 'primary';
+      $this->setTestEntity('Participant', $participant, $identifier);
+      $this->setTestEntityID('Contact', $participant['contact_id'], $identifier);
+    }
+
+  }
+
+}

--- a/tests/phpunit/CRMTraits/Event/ScenarioTrait.php
+++ b/tests/phpunit/CRMTraits/Event/ScenarioTrait.php
@@ -24,7 +24,15 @@ use Civi\Test\EventTestTrait;
  * between accepting parameters & winding up with crazy complex functions.
  */
 trait CRMTraits_Event_ScenarioTrait {
+
   use EventTestTrait;
+
+  /**
+   * Mail sent during form submission.
+   *
+   * @var array
+   */
+  protected $sentMail = [];
 
   /**
    * Create a participant registration with 2 registered_by participants.
@@ -37,7 +45,7 @@ trait CRMTraits_Event_ScenarioTrait {
   protected function createScenarioMultipleParticipantPendingWithTax(): void {
     $this->eventCreatePaid();
     $this->addTaxAccountToFinancialType(CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', 'Event Fee'));
-    $this->getTestForm('CRM_Event_Form_Registration_Register', [
+    $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
       'first_name' => 'Participant1',
       'last_name' => 'LastName',
       'email-Primary' => 'participant1@example.com',
@@ -54,17 +62,18 @@ trait CRMTraits_Event_ScenarioTrait {
         'last_name' => 'LastName',
         'email-Primary' => 'participant2@example.com',
         'priceSetId' => $this->getPriceSetID('PaidEvent'),
-        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
+        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_student'],
       ])
       ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
         'first_name' => 'Participant3',
         'last_name' => 'LastName',
         'email-Primary' => 'participant3@example.com',
         'priceSetId' => $this->getPriceSetID('PaidEvent'),
-        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
+        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_student_plus'],
       ])
       ->addSubsequentForm('CRM_Event_Form_Registration_Confirm')
       ->processForm();
+    $this->sentMail = $form->getMail();
     $participants = Participant::get(FALSE)
       ->addWhere('event_id', '=', $this->getEventID('PaidEvent'))
       ->addOrderBy('registered_by_id')

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -189,12 +189,12 @@
       </tr>
 
       {if $isShowLineItems}
-        {foreach from=$participants key=index item=participant}
-          {if $isPrimary || {participant.id} === $participant.id}
+        {foreach from=$participants key=index item=currentParticipant}
+          {if $isPrimary || {participant.id} === $currentParticipant.id}
           {if $isPrimary && $lineItems|@count GT 1} {* Header for multi participant registration cases. *}
             <tr>
               <td colspan="2" {$labelStyle}>
-                {ts 1=$participant.index}Participant %1{/ts} {$participant.contact.display_name}
+                {ts 1=$currentParticipant.index}Participant %1{/ts} {$currentParticipant.contact.display_name}
               </td>
             </tr>
           {/if}
@@ -213,7 +213,7 @@
                     <th>{ts}Total{/ts}</th>
                       {if !empty($pricesetFieldsCount)}<th>{ts}Total Participants{/ts}</th>{/if}
                   </tr>
-                  {foreach from=$participant.line_items item=line}
+                  {foreach from=$currentParticipant.line_items item=line}
                     <tr>
                       <td {$tdfirstStyle}>{$line.title}</td>
                       <td {$tdStyle} align="middle">{$line.qty}</td>
@@ -234,9 +234,9 @@
                   {if $isShowTax}
                     <tr {$participantTotal}>
                       <td colspan=3>{ts}Participant Total{/ts}</td>
-                      <td colspan=2>{$participant.totals.total_amount_exclusive|crmMoney}</td>
-                      <td colspan=1>{$participant.totals.tax_amount|crmMoney}</td>
-                      <td colspan=2>{$participant.totals.total_amount_inclusive|crmMoney}</td>
+                      <td colspan=2>{$currentParticipant.totals.total_amount_exclusive|crmMoney}</td>
+                      <td colspan=1>{$currentParticipant.totals.tax_amount|crmMoney}</td>
+                      <td colspan=2>{$currentParticipant.totals.total_amount_inclusive|crmMoney}</td>
                     </tr>
                   {/if}
                 </table>


### PR DESCRIPTION
Overview
----------------------------------------
[Fix variable leakage in online event receipt](https://github.com/civicrm/civicrm-core/commit/cecd4fa53b9c0e46e579f6d51a19ff5456929f09)

Before
----------------------------------------
The offline receipt template iterates through the participants in a for-each but the last chunk of assigns is after the for-each. For mulitple participant cases this leaks through from the last participant (note the primary participant will not see it as they get totals values

![image](https://github.com/civicrm/civicrm-core/assets/336308/8286b723-8002-4143-ac0f-086964497311)


After
----------------------------------------
A variable `$participant` is assigned with the value of the participant being emailed. The variable in the for-each is renamed to `$currentParticipant`

Screenshots from r-run with multiple

1) quick config 
![image](https://github.com/civicrm/civicrm-core/assets/336308/a2e35ce4-18e8-47f1-a509-7d11a26a0d89)

![image](https://github.com/civicrm/civicrm-core/assets/336308/30609975-85f2-4e69-b625-5366507ab878)

![image](https://github.com/civicrm/civicrm-core/assets/336308/34eed189-20e5-43c1-b351-ef595b42bb67)

![image](https://github.com/civicrm/civicrm-core/assets/336308/e5a4a68c-fd71-4eec-afd4-f2d2acddea69)

2) not quick config

![image](https://github.com/civicrm/civicrm-core/assets/336308/84ec154e-1e74-42d6-bfb1-8bcbd5d3286d)

![image](https://github.com/civicrm/civicrm-core/assets/336308/d2e31a91-cc24-4cf6-b07e-3d72a655c057)

![image](https://github.com/civicrm/civicrm-core/assets/336308/e42c2396-2b16-4084-8dcb-f544d7fdb106)

![image](https://github.com/civicrm/civicrm-core/assets/336308/0d299b7e-3a87-4ac9-8774-d71243113308)


Technical Details
----------------------------------------
I checked & `$participant` was not being used in the template before we started fixing the template to work with the trait so it is 'free' - but it is not free at the Trait level so the property is called `currentParticipant`

the text version seems to not display multiple participants anyway....

Comments
----------------------------------------
I think we can get away without porting to 5.65 - it's a bit obscure & there are mitigating features like no push update. If we do back port the test won't be porting