### PR TITLE
Add missing upgrade script for multilingual defaults

### DIFF
--- a/CRM/Core/CodeGen/I18n.php
+++ b/CRM/Core/CodeGen/I18n.php
@@ -38,6 +38,11 @@ class CRM_Core_CodeGen_I18n extends CRM_Core_CodeGen_BaseTask {
       foreach ($table['fields'] as $field) {
         if ($field['localizable']) {
           $required = $field['required'] ? ' NOT NULL' : '';
+          // The setting of default `''` for required fields is a workaround
+          // that makes it work similar to turning off STRICT_TRANS_TABLES, but
+          // means that the database cannot enforce required fields since this
+          // definition is not the same as "required". Ideally, required fields
+          // would be included in every INSERT statement.
           $default = $field['default'] ? ' DEFAULT ' . $field['default'] : ($field['required'] ? " DEFAULT '' " : '');
           $comment = $field['comment'] ? " COMMENT '" . $field['comment'] . "'" : '';
           $columns[$table['name']][$field['name']] = $field['sqlType'] . $required . $default . $comment;

--- a/CRM/Upgrade/Incremental/php/FiveSixtySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtySix.php
@@ -51,6 +51,39 @@ class CRM_Upgrade_Incremental_php_FiveSixtySix extends CRM_Upgrade_Incremental_B
   }
 
   /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_5_66_beta1($rev): void {
+    $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $locales = CRM_Core_I18n::getMultilingual();
+    if ($locales) {
+      // Note these are localizable so need the last param
+      $this->addTask('civicrm_location_type.display_name default', 'alterColumn', 'civicrm_location_type', 'display_name', "varchar(64) NOT NULL DEFAULT '' COMMENT 'Location Type Display Name.'", TRUE);
+      $this->addTask('civicrm_survey.title default', 'alterColumn', 'civicrm_survey', 'title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Title of the Survey.'", TRUE);
+      $this->addTask('civicrm_case_type.title default', 'alterColumn', 'civicrm_case_type', 'title', "varchar(64) NOT NULL DEFAULT '' COMMENT 'Natural language name for Case Type'", TRUE);
+      $this->addTask('civicrm_custom_group.title default', 'alterColumn', 'civicrm_custom_group', 'title', "varchar(64) NOT NULL DEFAULT '' COMMENT 'Friendly Name.'", TRUE);
+      $this->addTask('civicrm_custom_field.label default', 'alterColumn', 'civicrm_custom_field', 'label', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Text for form field label (also friendly name for administering this custom property).'", TRUE);
+      $this->addTask('civicrm_option_value.label default', 'alterColumn', 'civicrm_option_value', 'label', "varchar(512) NOT NULL DEFAULT '' COMMENT 'Option string as displayed to users - e.g. the label in an HTML OPTION tag.'", TRUE);
+      $this->addTask('civicrm_group.title default', 'alterColumn', 'civicrm_group', 'title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Name of Group.'", TRUE);
+      $this->addTask('civicrm_group.frontend_title default', 'alterColumn', 'civicrm_group', 'frontend_title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Alternative public title for this Group.'", TRUE);
+      $this->addTask('civicrm_contribution_page.title default', 'alterColumn', 'civicrm_contribution_page', 'title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Contribution Page title. For top of page display'", TRUE);
+      $this->addTask('civicrm_contribution_page.frontend_title default', 'alterColumn', 'civicrm_contribution_page', 'frontend_title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Contribution Page Public title'", TRUE);
+      $this->addTask('civicrm_product.name default', 'alterColumn', 'civicrm_product', 'name', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Required product/premium name'", TRUE);
+      $this->addTask('civicrm_payment_processor.title default', 'alterColumn', 'civicrm_payment_processor', 'title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Name of processor when shown to CiviCRM administrators.'", TRUE);
+      $this->addTask('civicrm_payment_processor.frontend_title default', 'alterColumn', 'civicrm_payment_processor', 'frontend_title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Name of processor when shown to users making a payment.'", TRUE);
+      $this->addTask('civicrm_membership_type.name default', 'alterColumn', 'civicrm_membership_type', 'name', "varchar(128) NOT NULL DEFAULT '' COMMENT 'Name of Membership Type'", TRUE);
+      $this->addTask('civicrm_price_set.title default', 'alterColumn', 'civicrm_price_set', 'title', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Displayed title for the Price Set.'", TRUE);
+      $this->addTask('civicrm_uf_group.title default', 'alterColumn', 'civicrm_uf_group', 'title', "varchar(64) NOT NULL DEFAULT '' COMMENT 'Form title.'", TRUE);
+      $this->addTask('civicrm_uf_field.label default', 'alterColumn', 'civicrm_uf_field', 'label', "varchar(255) NOT NULL DEFAULT '' COMMENT 'To save label for fields.'", TRUE);
+      $this->addTask('civicrm_price_field.label default', 'alterColumn', 'civicrm_price_field', 'label', "varchar(255) NOT NULL DEFAULT '' COMMENT 'Text for form field label (also friendly name for administering this field).'", TRUE);
+      // END localizable field updates
+    }
+  }
+
+  /**
    * Add fields to civicrm_mail_settings to allow more flexibility for email to activity
    *
    * @param \CRM_Queue_TaskContext $ctx

--- a/CRM/Upgrade/Incremental/php/FiveSixtySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtySix.php
@@ -37,7 +37,7 @@ class CRM_Upgrade_Incremental_php_FiveSixtySix extends CRM_Upgrade_Incremental_B
   public function upgrade_5_66_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Make Contribution.tax_amount required', 'alterColumn', 'civicrm_contribution', 'tax_amount', "decimal(20,2) DEFAULT 0 NOT NULL COMMENT 'Total tax amount of this contribution.'");
-    $this->addTask('Make Contribution.tax_amount required', 'alterColumn', 'civicrm_line_item', 'tax_amount', "decimal(20,2) DEFAULT 0 NOT NULL COMMENT 'tax of each item'");
+    $this->addTask('Make LineItem.tax_amount required', 'alterColumn', 'civicrm_line_item', 'tax_amount', "decimal(20,2) DEFAULT 0 NOT NULL COMMENT 'tax of each item'");
     // These run after the sql file
     $this->addTask('Make Discount.entity_table required', 'alterColumn', 'civicrm_discount', 'entity_table', "varchar(64) NOT NULL COMMENT 'Name of the action(reminder)'");
     $this->addTask('Make ActionSchedule.name required', 'alterColumn', 'civicrm_action_schedule', 'name', "varchar(64) NOT NULL COMMENT 'physical tablename for entity being joined to discount, e.g. civicrm_event'");

--- a/CRM/Upgrade/Incremental/sql/5.66.beta1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/5.66.beta1.mysql.tpl
@@ -1,0 +1,1 @@
+{* file to handle db changes in 5.66.beta1 during upgrade *}


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/27226

Before
----------------------------------------
Inconsistencies in schema between new and existing installs.

After
----------------------------------------
Ok

Technical Details
----------------------------------------
This is mostly about mariadb with STRICT_TRANS_TABLES. You won't notice much difference if STRICT_TRANS_TABLES is off, but multilingual is mostly unusable on mariadb with it on. A simple example is try to create a custom group and some fields.

So the idea is that after the upgrade, mariadb is better in multilingual with STRICT_TRANS_TABLES. But note you can't run the upgrade on multilingual with it on because it will crash before it even gets to the part where it fixes the fields.

Since STRICT_TRANS_TABLES is the default in mariadb, nonmultilingual sites likely have it on. As noted on the other PR the change to `''` as the default changes the meaning of "required" a bit for nonmultilingual, but multilingual have effectively been running with that meaning for a long time anyway.

Comments
----------------------------------------

