### PR TITLE
Fix e_warning in smarty `{localize}`

### DIFF
--- a/CRM/Core/Smarty/plugins/block.localize.php
+++ b/CRM/Core/Smarty/plugins/block.localize.php
@@ -26,11 +26,19 @@
  *   {ts} block contents from the template.
  * @param CRM_Core_Smarty $smarty
  *   The Smarty object.
+ * @param bool $repeat
+ *   Confusing variable that means it's either the opening tag or you can use
+ *   it to signal back not to repeat.
  *
  * @return string
  *   multilingualized query
  */
-function smarty_block_localize($params, $text, &$smarty) {
+function smarty_block_localize($params, $text, &$smarty, &$repeat) {
+  if ($repeat) {
+    // For opening tag text is always null
+    return '';
+  }
+
   if (!array_key_exists('multilingual', $smarty->_tpl_vars) || !$smarty->_tpl_vars['multilingual']) {
     return $text;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Passing null to preg_replace.

Before
----------------------------------------
Passing null to preg_replace.


After
----------------------------------------
Not passing null to preg_replace.


Technical Details
----------------------------------------
If you look at how it gets compiled, part of it is like this. Note the first call to smarty_block_localize where it passes null, and $repeat is true.

`$_block_repeat=true;smarty_block_localize($this->_tag_stack[count($this->_tag_stack)-1][1], null, $this, $_block_repeat);while ($_block_repeat) { ob_start(); ?>f1 = something(f2)<?php $_block_content = ob_get_contents(); ob_end_clean(); $_block_repeat=false;echo smarty_block_localize($this->_tag_stack[count($this->_tag_stack)-1][1], $_block_content, $this, $_block_repeat); }`

and you can prove this is what happens if you add this line to the top of smarty_block_localize()

`fprintf(STDERR, "\ntext is " . var_export($text, true) . "\n");`

and then run something like

`cv ev '$s = CRM_Core_Smarty::singleton(); $s->assign("multilingual", 1); $s->assign("locales", ["en_CA", "fr_CA"]); echo $s->fetch("string:{localize field='"'f1'"'}f1 = something(f2){/localize}");'`

You can see it gets called twice, first with null text, then with the actual text.

This double-call is actually documented at https://www.smarty.net/docsv2/en/plugins.block.functions.tpl, and it seems you're expected to use the $repeat parameter to decide/control, so a future todo is look at the other civi smarty block plugins.

Comments
----------------------------------------

