### PR TITLE
fix ordering of contribution page links

### DIFF
--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -112,7 +112,8 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
           'url' => $urlString . 'settings',
           'qs' => $urlParams,
           'uniqueName' => 'settings',
-          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
+          // This needs to be lower than Membership Settings since otherwise the order doesn't make sense
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::VIEW),
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Contribution Amounts'),
@@ -128,7 +129,8 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
           'url' => $urlString . 'membership',
           'qs' => $urlParams,
           'uniqueName' => 'membership',
-          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::VIEW),
+          // This should come after Title
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
         ],
         CRM_Core_Action::EXPORT => [
           'name' => ts('Thank-you and Receipting'),


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/27323 the ordering was set based on the array keys, which is logical, but results in a messed up order:

<img width="165" alt="Screenshot 2023-09-15 092156" src="https://github.com/civicrm/civicrm-core/assets/2967821/be73e9cb-8826-4a09-ac86-7210b43f7a3b">
