### PR TITLE
php 8.x Remove conference sessions from core workflow messages

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1147,8 +1147,6 @@ WHERE civicrm_event.is_active = 1
           $participantParams
         );
 
-        $sessions = CRM_Event_Cart_BAO_Conference::get_participant_sessions($participantId);
-
         // @todo - the goal is that all params available to the message template are explicitly defined here rather than
         // 'in a smattering of places'. Note that leakage can happen between mailings when not explicitly defined.
         if ($postProfileID) {
@@ -1172,7 +1170,6 @@ WHERE civicrm_event.is_active = 1
           'customPost_grouptitle' => $customPostTitles,
           'participantID' => $participantId,
           'contactID' => $contactID,
-          'conference_sessions' => $sessions,
           'credit_card_number' => CRM_Utils_System::mungeCreditCard(CRM_Utils_Array::value('credit_card_number', $participantParams)),
           'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format(CRM_Utils_Array::value('credit_card_exp_date', $participantParams))),
           'selfcancelxfer_time' => abs($values['event']['selfcancelxfer_time']),

--- a/ext/eventcart/eventcart.php
+++ b/ext/eventcart/eventcart.php
@@ -33,6 +33,19 @@ function eventcart_civicrm_install() {
 }
 
 /**
+ * Add the conference session variable to the template.
+ *
+ * @param array $params
+ * @param string $template
+ */
+function eventcart_civicrm_alterMailParams(&$params, $template) {
+  $workflow = $params['workflow'] ?? '';
+  if (($workflow === 'event_online_receipt' || $workflow === 'participant_confirm') && !empty($params['tokenContact']['participant']['id'])) {
+    $params['tplParams']['conference_sessions'] = CRM_Event_Cart_BAO_Conference::get_participant_sessions($params['tokenContact']['participant']['id']);
+  }
+}
+
+/**
  * Implements hook_civicrm_enable().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable

--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -17,9 +17,6 @@ pricesetFieldsCount:::{$pricesetFieldsCount}
 {if !empty($isPrimary)}
 isPrimary:::{$isPrimary}
 {/if}
-{if !empty($conference_sessions)}
-conference_sessions:::{$conference_sessions}
-{/if}
 {if !empty($is_pay_later)}
 is_pay_later:::{$is_pay_later}
 {/if}
@@ -39,9 +36,6 @@ event.event_end_date:::{event.end_date|crmDate:"%Y%m%d"}
 event.is_monetary:::{$event.is_monetary}
 {/if}
 event.fee_label:::{event.fee_label}
-{if !empty($conference_sessions)}
-conference_sessions:::{$conference_sessions}
-{/if}
 {if !empty($event.participant_role)}
   event.participant_role::{$event.participant_role}
   defaultRole:::{$defaultRole}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -66,28 +66,6 @@
           </td>
         </tr>
 
-        {if $conference_sessions}
-          <tr>
-            <td colspan="2" {$labelStyle}>
-              {ts}Your schedule:{/ts}
-            </td>
-          </tr>
-          <tr>
-            <td colspan="2" {$valueStyle}>
-              {assign var='group_by_day' value='NA'}
-              {foreach from=$conference_sessions item=session}
-                {if $session.start_date|crmDate:"%Y/%m/%d" != $group_by_day|crmDate:"%Y/%m/%d"}
-                  {assign var='group_by_day' value=$session.start_date}
-                  <em>{$group_by_day|crmDate:"%m/%d/%Y"}</em><br/>
-                {/if}
-                {$session.start_date|crmDate:0:1}{if $session.end_date}-{$session.end_date|crmDate:0:1}{/if} {$session.title}
-                <br/>
-                {if $session.location}&nbsp;&nbsp;&nbsp;&nbsp;{$session.location}<br/>{/if}
-              {/foreach}
-            </td>
-          </tr>
-        {/if}
-
         {if !empty($event.participant_role) and $event.participant_role neq 'Attendee' and !empty($defaultRole)}
           <tr>
             <td {$labelStyle}>

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -56,26 +56,6 @@
        {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
       </td>
      </tr>
-     {if $conference_sessions}
-      <tr>
-       <td colspan="2" {$labelStyle}>
-  {ts}Your schedule:{/ts}
-       </td>
-      </tr>
-      <tr>
-       <td colspan="2" {$valueStyle}>
-  {assign var='group_by_day' value='NA'}
-  {foreach from=$conference_sessions item=session}
-   {if $session.start_date|crmDate:"%Y/%m/%d" != $group_by_day|crmDate:"%Y/%m/%d"}
-    {assign var='group_by_day' value=$session.start_date}
-          <em>{$group_by_day|crmDate:"%m/%d/%Y"}</em><br />
-   {/if}
-   {$session.start_date|crmDate:0:1}{if $session.end_date}-{$session.end_date|crmDate:0:1}{/if} {$session.title}<br />
-   {if $session.location}&nbsp;&nbsp;&nbsp;&nbsp;{$session.location}<br />{/if}
-  {/foreach}
-       </td>
-      </tr>
-     {/if}
      <tr>
       <td {$labelStyle}>
        {ts}Participant Role{/ts}:

--- a/xml/templates/message_templates/participant_confirm_text.tpl
+++ b/xml/templates/message_templates/participant_confirm_text.tpl
@@ -23,24 +23,6 @@ Click this link to go to a web page where you can confirm your registration onli
 ===========================================================
 {$event.event_title}
 {$event.event_start_date|crmDate}{if $event.event_end_date}-{if $event.event_end_date|crmDate:"%Y%m%d" == $event.event_start_date|crmDate:"%Y%m%d"}{$event.event_end_date|crmDate:0:1}{else}{$event.event_end_date|crmDate}{/if}{/if}
-{if $conference_sessions}
-
-
-{ts}Your schedule:{/ts}
-{assign var='group_by_day' value='NA'}
-{foreach from=$conference_sessions item=session}
-{if $session.start_date|crmDate:"%Y/%m/%d" != $group_by_day|crmDate:"%Y/%m/%d"}
-{assign var='group_by_day' value=$session.start_date}
-
-{$group_by_day|crmDate:"%m/%d/%Y"}
-
-
-{/if}
-{$session.start_date|crmDate:0:1}{if $session.end_date}-{$session.end_date|crmDate:0:1}{/if} {$session.title}
-{if $session.location}    {$session.location}{/if}
-{/foreach}
-{/if}
-
 
 {ts}Participant Role{/ts}: {$participant.role}
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove conference sessions from core workflow messages

These cause notices is some circumstance and it seems to make more sense to remove than support them.

They are only available to be configured when the Event Cart is in play so it's not clear it makes sense to fix core code for them

Before
----------------------------------------
Default core online event templates have a section to display conference sessions - which come from the event cart - if not sent during online form flow this results in notices (e.g ipns)

![image](https://github.com/civicrm/civicrm-core/assets/336308/93632a44-d465-4ea4-9543-654ead681f22)


After
----------------------------------------
The sections are removed. The assign is not at this stage

Technical Details
----------------------------------------

The Event cart is kinda on it's way out & I don't think it makes sense to maintain conference sessions in the core templates to support this extension which despite many attempts has never had much use & has always been somewhat broken AFAIK.

Note that this change would affect sites with non-customised templates but the variable would only be assigned in event cart is enabled

Also note the goal is to work towards event-cart type functionality via form builder rather than the existing extension


Comments
----------------------------------------
@mlutfy @mattwire you have both had a go at event cart - is this functionality you use?