### PR TITLE
PHP8.2 Remove undefined property userName

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -673,7 +673,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
   protected function assignContactEmailDetails() {
     if ($this->getContactID()) {
-      [$displayName, $this->userEmail] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->getContactID());
+      [$displayName] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->getContactID());
       if (!$displayName) {
         $displayName = civicrm_api3('contact', 'getvalue', ['id' => $this->getContactID(), 'return' => 'display_name']);
       }

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -369,9 +369,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     // we need to retrieve email address
     if ($this->_context === 'standalone' && !empty($this->_params['is_email_receipt'])) {
-      list($displayName,
-        $this->userEmail
-        ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactId);
+      [$displayName] = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactId);
       $this->assign('displayName', $displayName);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is causing issues on a bunch of classes when the shared code defines it - but in fact is only used on the ContributionForm

Before
----------------------------------------

![image](https://github.com/civicrm/civicrm-core/assets/336308/67725c77-6e3c-43b3-9fd0-c7ac5c5c910f)

![image](https://github.com/civicrm/civicrm-core/assets/336308/5d25fc5a-107e-4946-90ae-56274a1d665f)

After
----------------------------------------
Property not defined, `getContactValue()` used

Technical Details
----------------------------------------

Comments
----------------------------------------