### PR TITLE
php 8 / notices Fix online event receipt to use the same location tokens as offline

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -136,13 +136,13 @@
      {if {event.is_public|boolean}}
       <tr>
        <td colspan="2" {$valueStyle}>
-        {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+        {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
         <a href="{$icalFeed}">{ts}Download iCalendar entry for this event.{/ts}</a>
        </td>
       </tr>
       <tr>
        <td colspan="2" {$valueStyle}>
-        {capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+        {capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
          <a href="{$gCalendar}">{ts}Add event to Google Calendar{/ts}</a>
        </td>
       </tr>

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -68,9 +68,9 @@
 
 
 {if {event.is_public|boolean}}
-{capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+{capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
 {ts}Download iCalendar entry for this event.{/ts} {$icalFeed}
-{capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+{capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
 {ts}Add event to Google Calendar{/ts} {$gCalendar}
 {/if}
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -107,36 +107,61 @@
           </tr>
         {/if}
 
-        {if !empty($location.phone.1.phone) || !empty($location.email.1.email)}
+        {if {event.loc_block_id.phone_id.phone|boolean} || {event.loc_block_id.email_id.email|boolean}}
           <tr>
             <td colspan="2" {$labelStyle}>
               {ts}Event Contacts:{/ts}
             </td>
           </tr>
-          {foreach from=$location.phone item=phone}
-            {if $phone.phone}
-              <tr>
-                <td {$labelStyle}>
-                  {if $phone.phone_type}
-                    {$phone.phone_type_display}
+
+          {if {event.loc_block_id.phone_id.phone|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {if {event.loc_block_id.phone_id.phone_type_id|boolean}}
+                      {event.loc_block_id.phone_id.phone_type_id:label}
                   {else}
-                    {ts}Phone{/ts}
+                      {ts}Phone{/ts}
                   {/if}
-                </td>
-                <td {$valueStyle}>
-                  {$phone.phone} {if $phone.phone_ext}&nbsp;{ts}ext.{/ts} {$phone.phone_ext}{/if}
-                </td>
-              </tr>
-            {/if}
-          {/foreach}
-          {foreach from=$location.email item=eventEmail}
-            {if $eventEmail.email}
-              <tr>
-                <td {$labelStyle}>{ts}Email{/ts}</td>
-                <td {$valueStyle}>{$eventEmail.email}</td>
-              </tr>
-            {/if}
-          {/foreach}
+              </td>
+              <td {$valueStyle}>
+                  {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
+              </td>
+            </tr>
+          {/if}
+          {if {event.loc_block_id.phone_2_id.phone|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                  {if {event.loc_block_id.phone_2_id.phone_type_id|boolean}}
+                      {event.loc_block_id.phone_2_id.phone_type_id:label}
+                  {else}
+                      {ts}Phone{/ts}
+                  {/if}
+              </td>
+              <td {$valueStyle}>
+                  {event.loc_block_id.phone_2_id.phone} {if {event.loc_block_id.phone_2_id.phone_ext|boolean}}&nbsp;{ts}ext.{/ts} {event.loc_block_id.phone_2_id.phone_ext}{/if}
+              </td>
+            </tr>
+          {/if}
+          {if {event.loc_block_id.email_id.email|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                {ts}Email{/ts}
+              </td>
+              <td {$valueStyle}>
+                {event.loc_block_id.email_id.email}
+              </td>
+            </tr>
+          {/if}
+          {if {event.loc_block_id.email_2_id.email|boolean}}
+            <tr>
+              <td {$labelStyle}>
+                {ts}Email{/ts}
+              </td>
+              <td {$valueStyle}>
+                {event.loc_block_id.email_2_id.email}
+              </td>
+            </tr>
+          {/if}
         {/if}
 
         {if {event.is_public|boolean}}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -80,12 +80,12 @@
 {if {event.loc_block_id.phone_id.phone|boolean}}
   {if {event.loc_block_id.phone_id.phone_type_id|boolean}}{event.loc_block_id.phone_id.phone_type_id:label}{else}{ts}Phone{/ts}{/if} {event.loc_block_id.phone_id.phone} {if {event.loc_block_id.phone_id.phone_ext|boolean}} {ts}ext.{/ts} {event.loc_block_id.phone_id.phone_ext}{/if}
 {/if}
-{foreach from=$location.email item=eventEmail}
-{if $eventEmail.email}
-
-{ts}Email{/ts}: {$eventEmail.email}{/if}{/foreach}
+{if {event.loc_block_id.email_id.email|boolean}}
+{ts}Email {/ts}{event.loc_block_id.email_id.email}
 {/if}
-
+{if {event.loc_block_id.email_2_id.email|boolean}}
+{ts}Email {/ts}{event.loc_block_id.email_2_id.email}{/if}
+{/if}
 {if {event.is_public|boolean}}
 {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
 {ts}Download iCalendar entry for this event.{/ts} {$icalFeed}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -87,9 +87,9 @@
 {ts}Email {/ts}{event.loc_block_id.email_2_id.email}{/if}
 {/if}
 {if {event.is_public|boolean}}
-{capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+{capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
 {ts}Download iCalendar entry for this event.{/ts} {$icalFeed}
-{capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id=`$event.id`" h=0 a=1 fe=1}{/capture}
+{capture assign=gCalendar}{crmURL p='civicrm/event/ical' q="gCalendar=1&reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}
 {ts}Add event to Google Calendar{/ts} {$gCalendar}
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
php 8 / notices Fix online event receipt to use the same location tokens as offline

Before
----------------------------------------
The smarty based code is prone to notices

After
----------------------------------------
Aligned to the offline template - renders....

![image](https://github.com/civicrm/civicrm-core/assets/336308/3cb1259b-de7a-4d79-8943-dc4549e3d4d7)

Technical Details
----------------------------------------
Includes the whitespace cleanup

Comments
----------------------------------------
