### PR TITLE
Add Joomla user to group when created from civi profile

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -80,6 +80,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $register = $model->register($values);
 
     $ufID = JUserHelper::getUserId($values['username']);
+    JUserHelper::addUserToGroup($ufID, $userType);
+
     return $ufID;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
User created from submitting of a civicrm profile is not added to the group configured on joomla User options.

Before
----------------------------------------
To replicate

Configure Joomla User Options => `New User Registration Group` set to group eg: "Biker".

<img width="408" alt="image" src="https://github.com/civicrm/civicrm-core/assets/5929648/d488a127-7437-4815-8ab1-f76f0268c62b">

Enable the following setting on a civi profile 

<img width="547" alt="image" src="https://github.com/civicrm/civicrm-core/assets/5929648/b3a2a07b-a5db-4569-9c0a-4a21ebffd533">

Now, when the profile is submitted, the user and contact is created in both Joomla and civicrm, but the joomla contact is not added to the configured group in the CMS.

After
----------------------------------------
User is added to the group correctly.

Technical Details
----------------------------------------
Perhaps the fix should be in joomla to identify if the user is created programatically and do the group assignment, but i see civi already retrieving the default configured group in https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/System/Joomla.php#L63

But, it never uses the variable down in the code. Have used to fix this issue.

