### PR TITLE
[REF][PHP8.2] Tidy up properties in scheduled jobs

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -23,7 +23,7 @@ class CRM_Core_JobManager {
    *
    * Format is ($id => CRM_Core_ScheduledJob).
    *
-   * @var array
+   * @var CRM_Core_ScheduledJob[]
    */
   public $jobs = NULL;
 
@@ -40,7 +40,7 @@ class CRM_Core_JobManager {
    * Class constructor.
    */
   public function __construct() {
-    $this->jobs = $this->_getJobs();
+    $this->jobs = $this->getJobs();
   }
 
   /**
@@ -76,17 +76,11 @@ class CRM_Core_JobManager {
   }
 
   /**
-   * Class destructor.
-   */
-  public function __destruct() {
-  }
-
-  /**
    * @param $entity
    * @param $action
    */
   public function executeJobByAction($entity, $action) {
-    $job = $this->_getJob(NULL, $entity, $action);
+    $job = $this->getJob(NULL, $entity, $action);
     $this->executeJob($job);
   }
 
@@ -94,7 +88,7 @@ class CRM_Core_JobManager {
    * @param int $id
    */
   public function executeJobById($id) {
-    $job = $this->_getJob($id);
+    $job = $this->getJob($id);
     $this->executeJob($job);
   }
 
@@ -135,7 +129,7 @@ class CRM_Core_JobManager {
       $result = $e;
     }
     CRM_Utils_Hook::postJob($job, $params, $result);
-    $this->logEntry('Finished execution of ' . $job->name . ' with result: ' . $this->_apiResultToMessage($result));
+    $this->logEntry('Finished execution of ' . $job->name . ' with result: ' . $this->apiResultToMessage($result));
     $this->currentJob = FALSE;
 
     //Disable outBound option after executing the job.
@@ -152,7 +146,7 @@ class CRM_Core_JobManager {
    * @return array
    *   ($id => CRM_Core_ScheduledJob)
    */
-  private function _getJobs(): array {
+  private function getJobs(): array {
     $jobs = [];
     $dao = new CRM_Core_DAO_Job();
     $dao->orderBy('name');
@@ -177,7 +171,7 @@ class CRM_Core_JobManager {
    * @return CRM_Core_ScheduledJob
    * @throws Exception
    */
-  private function _getJob($id = NULL, $entity = NULL, $action = NULL) {
+  private function getJob($id = NULL, $entity = NULL, $action = NULL) {
     if (is_null($id) && is_null($action)) {
       throw new CRM_Core_Exception('You need to provide either id or name to use this method');
     }
@@ -258,7 +252,7 @@ class CRM_Core_JobManager {
    *
    * @return string
    */
-  private function _apiResultToMessage($apiResult) {
+  private function apiResultToMessage($apiResult) {
     $status = ($apiResult['is_error'] ?? FALSE) ? ts('Failure') : ts('Success');
     $msg = CRM_Utils_Array::value('error_message', $apiResult, 'empty error_message!');
     $vals = CRM_Utils_Array::value('values', $apiResult, 'empty values!');

--- a/CRM/Core/ScheduledJob.php
+++ b/CRM/Core/ScheduledJob.php
@@ -19,34 +19,123 @@
 class CRM_Core_ScheduledJob {
 
   /**
-   * @var int
-   * @deprecated
-   */
-  public $version = 3;
-
-  /**
+   * Job ID
+   *
    * @var int
    */
   public $id;
 
-  public $name = NULL;
+  /**
+   * Which Domain is this scheduled job for
+   *
+   * @var int
+   */
+  public $domain_id;
 
   /**
+   * Scheduled job run frequency.
+   *
    * @var string
    */
-  public $parameters = '';
+  public $run_frequency;
 
+  /**
+   * When was this cron entry last run
+   *
+   * @var string
+   */
+  public $last_run;
+
+  /**
+   * When is this cron entry scheduled to run
+   *
+   * @var string
+   */
+  public $scheduled_run_date;
+
+  /**
+   * Title of the job
+   *
+   * @var string
+   */
+  public $name;
+
+  /**
+   * Description of the job
+   *
+   * @var string
+   */
+  public $description;
+
+  /**
+   * Entity of the job api call
+   *
+   * @var string
+   */
+  public $api_entity;
+
+  /**
+   * Action of the job api call
+   *
+   * @var string
+   */
+  public $api_action;
+
+  /**
+   * List of parameters to the command.
+   *
+   * @var string
+   */
+  public $parameters;
+
+  /**
+   * Is this job active?
+   *
+   * @var bool
+   */
+  public $is_active;
+
+  /**
+   * Class string
+   *
+   * Set as a URL, when the jobs template is rendered,
+   * but not set in other contexts
+   *
+   * @var string|null
+   */
+  public $action = NULL;
+
+  /**
+   * Action
+   *
+   * @var string
+   * @todo This seems to only ever be set to an empty string and passed through to job.tpl,
+   *       where it is used a HTML `class`. Can this be removed?
+   */
+  public $class;
+
+  /**
+   * Result of parsing multi-line `$parameters` string into an array
+   *
+   * @var array
+   */
   public $apiParams = [];
 
+  /**
+   * Container for error messages
+   *
+   * @var array
+   */
   public $remarks = [];
 
   /**
    * @param array $params
    */
   public function __construct($params) {
-    // Fixme - setting undeclared class properties!
     foreach ($params as $name => $param) {
-      $this->$name = $param;
+      if (property_exists($this, $name)) {
+        $this->$name = $param;
+      }
     }
 
     try {


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up properties in scheduled jobs.

Before
----------------------------------------
`CRM_Core_ScheduledJob` had a lot of dynamically declared properties, which did not work well on PHP 8.2.

After
----------------------------------------
The properties in `CRM_Core_ScheduledJob` basically match those on `CRM_Core_DAO_Job` (i.e. matching the database columns). That made it easy to declare all the expected properties. Going forward only declared properties will be set, due to `if (property_exists($this, $name))`, but I don't think there is ever a scenario where that won't be the case.

Also, some minor tidy-up in `CRM_Core_JobManager` which is the main place where `CRM_Core_ScheduledJob` is used.

Comments
----------------------------------------
This should knock another test failure off on PHP 8.2.
