### PR TITLE
[NFC] phpunit 9 compatibility

### DIFF
--- a/tests/phpunit/CRM/Core/Smarty/plugins/UrlTest.php
+++ b/tests/phpunit/CRM/Core/Smarty/plugins/UrlTest.php
@@ -86,7 +86,7 @@ class CRM_Core_Smarty_plugins_UrlTest extends CiviUnitTestCase {
   public function testUrl($expected, $input) {
     $smarty = CRM_Core_Smarty::singleton();
     $actual = $smarty->fetch('string:' . $input);
-    $this->assertRegExp($expected, $actual, "Process input=[$input]");
+    $this->assertMatchesRegularExpression($expected, $actual, "Process input=[$input]");
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
assertRegExp

After
----------------------------------------
assertMatchesRegularExpression

Technical Details
----------------------------------------
I'm not sure why this is coming up now since this isn't a new test but last night some test runs I have in another environment flagged this.

I can see it runs in the PR queue here but for some reason is just a warning:

```
ok 1449 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
ok 1450 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
ok 1451 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
ok 1452 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
ok 1453 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
ok 1454 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
ok 1455 - # Warning assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.
```

Comments
----------------------------------------

