### PR TITLE
Upgrade - don't crash on earlier versions of mariadb

### DIFF
--- a/CRM/Upgrade/Snapshot.php
+++ b/CRM/Upgrade/Snapshot.php
@@ -47,7 +47,7 @@ class CRM_Upgrade_Snapshot {
       static::$activationIssues = [];
 
       $version = CRM_Utils_SQL::getDatabaseVersion();
-      if (stripos($version, 'mariadb') !== FALSE) {
+      if ((stripos($version, 'mariadb') !== FALSE) && version_compare($version, '10.6.0', '>=')) {
         // MariaDB briefly (10.6.0-10.6.5) flirted with the idea of phasing-out `COMPRESSED`. By default, snapshots won't work on those versions.
         // https://mariadb.com/kb/en/innodb-compressed-row-format/#read-only
         $roCompressed = CRM_Core_DAO::singleValueQuery('SELECT @@innodb_read_only_compressed');


### PR DESCRIPTION
Overview
----------------------------------------
Crash on mariadb 10.3 (possibly anything less than 10.6)

Before
----------------------------------------
Crash

After
----------------------------------------
Not crash

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/27404 a check was added to avoid crashing for snapshots, but the variable checked doesn't exist in earlier versions. And according to [docs](https://mariadb.com/docs/skysql-dbaas/ref/mdb/system-variables/innodb_read_only_compressed/) might not exist before 10.6?

Comments
----------------------------------------
$version is a string like `10.3.20-MariaDB` but version_compare is cool with that.
