### PR TITLE
Hardened smarty - fix mishandling of json

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -591,10 +591,10 @@
         var freezeFinancialType = '{/literal}{$freezeFinancialType}{literal}';
         if (!freezeFinancialType) {
           var financialType = $('#financial_type_id').val();
-          var taxRates = '{/literal}{$taxRates}{literal}';
+          var taxRates = '{/literal}{$taxRates|smarty:nodefaults}{literal}';
           var taxTerm = '{/literal}{$taxTerm}{literal}';
           taxRates = JSON.parse(taxRates);
-          var currencies = '{/literal}{$currencies}{literal}';
+          var currencies = '{/literal}{$currencies|smarty:nodefaults}{literal}';
           currencies = JSON.parse(currencies);
           var currencySelect = $('#currency').val();
           var currencySymbol = currencies[currencySelect];


### PR DESCRIPTION
Overview
----------------------------------------
Hardened smarty - fix mishandling of json

Before
----------------------------------------
js error with Smarty-strict mode as the json is double escaped

After
----------------------------------------
Json marked for non-escaping

Technical Details
----------------------------------------

Comments
----------------------------------------
