### PR TITLE
Stop enabling event_cart on new installs

### DIFF
--- a/sql/civicrm_data/civicrm_extension.sqldata.php
+++ b/sql/civicrm_data/civicrm_extension.sqldata.php
@@ -21,10 +21,6 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_extension', 'INSERT IGNORE INTO
       'name' => 'Theme: Greenwich',
     ],
     [
-      'full_name' => 'eventcart',
-      'name' => 'Event cart',
-    ],
-    [
       'full_name' => 'financialacls',
       'name' => 'Financial ACLs',
     ],

--- a/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
@@ -33,12 +33,19 @@ class CRM_Financial_Form_PaymentFormsTest extends CiviUnitTestCase {
 
   use CRM_Core_Payment_AuthorizeNetTrait;
 
+  public function tearDown(): void {
+    $this->callAPISuccess('Extension', 'disable', ['keys' => ['eventcart']]);
+    $this->callAPISuccess('Extension', 'uninstall', ['keys' => ['eventcart']]);
+    parent::tearDown();
+  }
+
   /**
    * Generic test on event payment forms to make sure they submit without error with payment processing.
    *
    * @throws \CRM_Core_Exception
    */
   public function testEventPaymentForms(): void {
+    $this->callAPISuccess('Extension', 'install', ['keys' => ['eventcart']]);
     $this->createAuthorizeNetProcessor();
     $processors = [$this->ids['PaymentProcessor']['anet']];
     $eventID = $this->eventCreatePaid([


### PR DESCRIPTION


Overview
----------------------------------------
Stop enabling event_cart on new installs

Although we have not fully extracted this, it seems that disabling does not cause any errors, so it makes sense to stop enabling. Once we have been running like this on our dev & demo sites for a while we can disable it for any existing sites that do not have
event cart enabled

Before
----------------------------------------
Event cart core exension enabled on all installs

After
----------------------------------------
Extension no longer enabled on new installs

Technical Details
----------------------------------------

Comments
----------------------------------------
