### PR TITLE
Fix Smarty secure mode for premiums tab

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/Premium.tpl
@@ -12,7 +12,7 @@
   <table class="form-layout-compressed">
     <tr class="crm-contribution-form-block-product_name">
       <td class="label">{$form.product_name.label}</td>
-      <td class="html-adjust">{$form.product_name.html}</td>
+      <td class="html-adjust">{$form.product_name.html|smarty:nodefaults}</td>
     </tr>
   </table>
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix Smarty secure mode for premiums tab


Before
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/5659f33b-be4a-4d75-9789-ebdff6259bf1)


After
----------------------------------------
![image](https://github.com/civicrm/civicrm-core/assets/336308/bc413cec-ecd5-4f17-a620-69e9b193cdba)


Technical Details
----------------------------------------
probably a hierarchical select...

Comments
----------------------------------------
