### PR TITLE
php8.x Remove never-used undeclared property

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -213,17 +213,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   protected $_component;
 
   /**
-   * Array of fields to display on billingBlock.tpl - this is not fully implemented but basically intent is the panes/fieldsets on this page should
-   * be all in this array in order like
-   *  'credit_card' => array('credit_card_number' ...
-   *  'billing_details' => array('first_name' ...
-   *
-   * such that both the fields and the order can be more easily altered by payment processors & other extensions
-   * @var array
-   */
-  public $billingFieldSets = [];
-
-  /**
    * Monetary fields that may be submitted.
    *
    * These should get a standardised format in the beginPostProcess function.

--- a/CRM/Core/Payment/Form.php
+++ b/CRM/Core/Payment/Form.php
@@ -39,7 +39,6 @@ class CRM_Core_Payment_Form {
    *   ID of the payment processor.
    */
   public static function setPaymentFieldsByProcessor(&$form, $processor, $billing_profile_id = NULL, $isBackOffice = FALSE, $paymentInstrumentID = NULL) {
-    $form->billingFieldSets = [];
     // Load the pay-later processor
     // @todo load this right up where the other processors are loaded initially.
     if (empty($processor)) {
@@ -55,12 +54,10 @@ class CRM_Core_Payment_Form {
     $form->assign('paymentTypeName', $paymentTypeName);
     $form->assign('paymentTypeLabel', self::getPaymentLabel($processor['object']));
     $form->assign('isBackOffice', $isBackOffice);
-    $form->_paymentFields = $form->billingFieldSets[$paymentTypeName]['fields'] = self::getPaymentFieldMetadata($processor);
+    $form->_paymentFields = self::getPaymentFieldMetadata($processor);
     $form->_paymentFields = array_merge($form->_paymentFields, self::getBillingAddressMetadata($processor, $form->_bltID));
     $form->assign('paymentFields', self::getPaymentFields($processor));
     self::setBillingAddressFields($form, $processor);
-    // @todo - this may be obsolete - although potentially it could be used to re-order things in the form.
-    $form->billingFieldSets['billing_name_address-group']['fields'] = [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove never-used undeclared property

Before
----------------------------------------
The property is set but never used. Code comments suggest is was a good intention. Note I broadened the search to `FieldSet` case-specific to be sure

![image](https://github.com/civicrm/civicrm-core/assets/336308/656aa6e1-fb31-4e44-aa1d-d0442ac55b93)

Universe

![image](https://github.com/civicrm/civicrm-core/assets/336308/d5ab89b1-f615-4b6a-8aca-05ccd603088c)



After
----------------------------------------
Removed

Technical Details
----------------------------------------

Comments
----------------------------------------
