### PR TITLE
Add test cover, use token for `event.is_share`

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -25,15 +25,22 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * Initial test of submit function.
    */
   public function testSubmit(): void {
-    $mut = new CiviMailUtils($this, TRUE);
     $this->submitPaidEvent();
-
-    $mut->checkMailLog([
+    $this->assertSentMailHasStrings([
       'Dear Kim,  Thank you for your registration.  This is a confirmation that your registration has been received and your status has been updated to Registered.',
       'Friday September 16th, 2022 12:00 PM-Saturday September 17th, 2022 12:00 PM',
+      'Add event to Google Calendar',
     ]);
-    $mut->stop();
-    $mut->clearMessages();
+  }
+
+  public function assertSentMailHasStrings(array $strings): void {
+    foreach ($strings as $string) {
+      $this->assertSentMailHasString($string);
+    }
+  }
+
+  public function assertSentMailHasString(string $string): void {
+    $this->assertStringContainsString($string, $this->sentMail[0]);
   }
 
   /**
@@ -645,6 +652,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * @param array $submitValues
    */
   protected function submitPaidEvent(array $submitValues = []): void {
+    $mailUtil = new CiviMailUtils($this, TRUE);
     $this->dummyProcessorCreate();
     $event = $this->eventCreatePaid(['payment_processor' => [$this->ids['PaymentProcessor']['dummy_live']], 'confirm_email_text' => '', 'is_pay_later' => FALSE, 'start_date' => '2022-09-16 12:00', 'end_date' => '2022-09-17 12:00']);
     $this->submitForm($event['id'], array_merge([
@@ -669,6 +677,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'billing_state_province-5' => 'AP',
       'billing_country-5' => 'US',
     ], $submitValues));
+    $this->sentMail = $mailUtil->getAllMessages();
   }
 
   public function testRegistrationWithoutCiviContributeEnabled(): void {

--- a/tests/phpunit/CiviTest/CiviMailUtils.php
+++ b/tests/phpunit/CiviTest/CiviMailUtils.php
@@ -124,9 +124,10 @@ class CiviMailUtils extends PHPUnit\Framework\TestCase {
    * @param string $type
    *   'raw'|'ezc'.
    *
-   * @throws CRM_Core_Exception
-   *
    * @return array(ezcMail)|array(string)
+   *
+   * @noinspection PhpMissingReturnTypeInspection
+   * @noinspection PhpDocMissingThrowsInspection
    */
   public function getAllMessages($type = 'raw') {
     $msgs = [];

--- a/xml/templates/message_templates/event_offline_receipt_text.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_text.tpl
@@ -84,7 +84,7 @@
 
 {$email}
 {/if}
-{if !empty($event.is_monetary)} {* This section for Paid events only.*}
+{if {event.is_monetary|boolean}} {* This section for Paid events only.*}
 
 ==========================================================={if !empty($pricesetFieldsCount) }===================={/if}
 

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -157,7 +157,7 @@
           </tr>
         {/if}
 
-        {if $event.is_share}
+        {if {event.is_share|boolean}}
           <tr>
             <td colspan="2" {$valueStyle}>
               {capture assign=eventUrl}{crmURL p='civicrm/event/info' q="id={event.id}&reset=1" a=true fe=1 h=1}{/capture}

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -96,7 +96,7 @@
 {if !empty($payer.name)}
 You were registered by: {$payer.name}
 {/if}
-{if !empty($event.is_monetary) and empty($isRequireApproval)} {* This section for Paid events only.*}
+{if {event.is_monetary|boolean} and empty($isRequireApproval)} {* This section for Paid events only.*}
 
 ==========================================================={if !empty($pricesetFieldsCount)}===================={/if}
 


### PR DESCRIPTION

Overview
----------------------------------------
Add test cover, use token for `event.is_share`

Before
----------------------------------------
Uses the notice-y `{if !empty($event.is_monetary)} `

After
----------------------------------------
`{if {event.is_monetary|boolean}}`

Technical Details
----------------------------------------
Also fix a couple of places where is_monetary is using the smarty variable.

We have updated & tested is_monetary elsewhere

Comments
----------------------------------------
Test updates are because the way mail will be tested in this class will change when we load the form using the wrapper - this is a mini-step
