### PR TITLE
[php8.x, workflow template] Fix multiple participant online receipt display for quickConfig

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -896,6 +896,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             $params = $this->get('params');
             $amount[$participantNum]['label'] = preg_replace('//', '', $params[$participantNum]['amount_level']);
             $amount[$participantNum]['amount'] = $params[$participantNum]['amount'];
+            // @todo - unused in core offline receipt template from 5.67. Remove at somepoint
             $this->assign('amounts', $amount);
           }
           if ($this->_lineItem) {

--- a/tests/templates/message_templates/event_online_receipt_text.tpl
+++ b/tests/templates/message_templates/event_online_receipt_text.tpl
@@ -31,7 +31,7 @@ event.event_start_date:::{$event.event_start_date|crmDate:"%A"}
 event.event_end_date:::{event.end_date|crmDate:"%Y%m%d"}
 event.is_monetary:::{event.is_monetary|boolean}
 event.fee_label:::{event.fee_label}
-event.participant_role::{event.participant_role_id:label}
+event.participant_role:::{event.participant_role_id:label}
 {if !empty($isShowLocation)}
 isShowLocation:::{$isShowLocation}
 location.address.1.display:::{$location.address.1.display}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -279,14 +279,12 @@
                   <td {$valueStyle}>{$taxDetail.amount|crmMoney:'{contribution.currency}'}</td>
                 </tr>
               {/foreach}
-            {/if}
-            {if $isShowTax && {contribution.tax_amount|boolean}}
               <tr>
                 <td {$labelStyle}>
-                  {ts}Total Tax Amount{/ts}
+                    {ts}Total Tax Amount{/ts}
                 </td>
                 <td {$valueStyle}>
-                  {if $isPrimary}{contribution.tax_amount}{else}{$participant.totals.tax_amount|crmMoney}{/if}
+                    {if $isPrimary}{contribution.tax_amount}{else}{$participant.totals.tax_amount|crmMoney}{/if}
                 </td>
               </tr>
             {/if}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -244,6 +244,22 @@
                 {/if}
               {/foreach}
             {/if}
+            {if !$isShowLineItems}
+              {foreach from=$participants key=index item=currentParticipant}
+                {if $isPrimary || {participant.id} === $currentParticipant.id}
+                  {foreach from=$currentParticipant.line_items key=index item=currentLineItem}
+                  <tr>
+                    <td {$valueStyle}>
+                      {$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if}
+                    </td>
+                    <td {$valueStyle}>
+                      {$currentLineItem.line_total|crmMoney:$currency}
+                    </td>
+                  </tr>
+                  {/foreach}
+                {/if}
+              {/foreach}
+            {/if}
             {if $isShowTax && {contribution.tax_amount|boolean}}
               <tr>
                 <td {$labelStyle}>
@@ -264,17 +280,6 @@
                 </tr>
               {/foreach}
             {/if}
-
-            {if !empty($amounts) && empty($lineItem)}
-              {foreach from=$amounts item=amnt key=level}
-                <tr>
-                  <td colspan="2" {$valueStyle}>
-                    {$amnt.amount|crmMoney:$currency} {$amnt.label}
-                  </td>
-                </tr>
-              {/foreach}
-            {/if}
-
             {if $isShowTax && {contribution.tax_amount|boolean}}
               <tr>
                 <td {$labelStyle}>

--- a/xml/templates/message_templates/event_online_receipt_text.tpl
+++ b/xml/templates/message_templates/event_online_receipt_text.tpl
@@ -131,8 +131,13 @@ You were registered by: {$payer.name}
 {/if}
 {/if}
 
-{if !empty($amounts) && empty($lineItem)}
-{foreach from=$amounts item=amnt key=level}{$amnt.amount|crmMoney:$currency} {$amnt.label}
+{if !$isShowLineItems}
+{foreach from=$participants key=index item=currentParticipant}
+{if $isPrimary || {participant.id} === $currentParticipant.id}
+{foreach from=$currentParticipant.line_items key=index item=currentLineItem}
+{$currentLineItem.label} {if $isPrimary} - {$currentParticipant.contact.display_name}{/if} - {$currentLineItem.line_total|crmMoney:$currency}
+{/foreach}
+{/if}
 {/foreach}
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix multiple participant online receipt display for quickConfig.

Note my goal is to get to the point where this renders the same from anywhere - `$amounts` is only assigned via the form 

Before
----------------------------------------
There is a chunk of code to show the per-participant description but it only fires for the primary participant and is unrelatible outside of the full form flow (eg IPNs)
```
          {if !empty($amounts) && empty($lineItem)}
              {foreach from=$amounts item=amnt key=level}
                <tr>
                  <td colspan="2" {$valueStyle}>
                    {$amnt.amount|crmMoney:$currency} {$amnt.label}
                  </td>
                </tr>
              {/foreach}
            {/if}
```
![image](https://github.com/civicrm/civicrm-core/assets/336308/30609975-85f2-4e69-b625-5366507ab878)

![image](https://github.com/civicrm/civicrm-core/assets/336308/34eed189-20e5-43c1-b351-ef595b42bb67)

After
----------------------------------------
The code no longer relies on 'amounts' being assigned & is consistent across participants. Note I moved the values above the tax since they are tax-ex & it read better. I also aligned to the same table structure, which seemed more logical, although I don't want to scope creep this into a design update

Primary

![image](https://github.com/civicrm/civicrm-core/assets/336308/07ed2790-1d77-465d-9e96-4fa4f720b375)

Subsequent

![image](https://github.com/civicrm/civicrm-core/assets/336308/7b901510-a8c9-431d-a687-97111c5e40dd)



Technical Details
----------------------------------------
I specifically want to use this same code for the offline participant receipt  but I want to check this change is OK first & then the whole financial block will be replicated to be the same in both

Comments
----------------------------------------
Includes open PR https://github.com/civicrm/civicrm-core/pull/27476 which I can rebase out once merged
