### PR TITLE
(dev/core#4521) Upgrader - Enable component-extensions before system-flush

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSixtyThree.php
+++ b/CRM/Upgrade/Incremental/php/FiveSixtyThree.php
@@ -43,7 +43,7 @@ class CRM_Upgrade_Incremental_php_FiveSixtyThree extends CRM_Upgrade_Incremental
 
     $enabledComponents = Civi::settings()->get('enable_components');
     $extensions = array_map(['CRM_Utils_String', 'convertStringToSnakeCase'], $enabledComponents);
-    $this->addExtensionTask('Enable component extensions', $extensions);
+    $this->addSimpleExtensionTask(sprintf('Enable component-extensions (%s)', implode(', ', $extensions)), $extensions);
 
     $this->addTask('Make ContributionPage.name required', 'alterColumn', 'civicrm_contribution_page', 'name', "varchar(255) NOT NULL COMMENT 'Unique name for identifying contribution page'");
     $this->addTask('Make ContributionPage.title required', 'alterColumn', 'civicrm_contribution_page', 'title', "varchar(255) NOT NULL COMMENT 'Contribution Page title. For top of page display'", TRUE);


### PR DESCRIPTION
Overview
----------------------------------------

This aims to reduce a type of upgrade-error that started occurring after 5.62 and 5.63 (which started converting components to extensions). As an a reproducible exemplar, we can use [`membershiprenewallink` scenario from dev/core#4521](https://lab.civicrm.org/dev/core/-/issues/4521#note_151044).

(*This builds on @colemanw's #27378.*)

Before
----------------------------------------

* For an upgrade process that includes 5.63, the sequence of steps includes:
    1. Run all regular numbered upgrade steps (but defer the component-extensions)
    2. Perform a system flush (`doCoreFinish()`). This includes rebuilding a number of structures and various hooks.
    3. Enable the migrated component-extensions.
* In the `membershiprenewallink` scenario, `doCoreFinish()` rebuilds the settings and executes `membershiprenewallink.setting.php`. Executing this requires `Civi\Api4\MembershipTypes`. But this fails because `Civi\Api4\MembershipTypes` has been moved -- the old copy is gone, and a new copy isn't available yet.

After
----------------------------------------

* For an upgrade process that includes 5.63, the sequence of steps includes:
    1. Run all regular numbered upgrade steps (and this includes activating the component-extensions)
    2. Perform a system flush (`doCoreFinish()`). This includes rebuilding a number of structures.
* In the `membershiprenewallink` scenario, `doCoreFinish()` rebuilds the settings and executes `membershiprenewallink.setting.php`. Executing this requires `Civi\Api4\MembershipTypes`, and it works - because the new copy is available.

Comments
----------------------------------------

There have been other problem-reports -- which didn't mention `membershiprenewallink`, and which didn't have steps to reproduce. Recapping MM discussion, the going theory is that they have a structural similarity -- when they reach `doCoreFinish(), the system starts firing hooks, and some hook-listeners expect that the historically-core-API classes are available. Under the theory, this should reduce these other errors. However, since I don't have steps to reproduce other scenarios, I can't speak clearly to them. 