### PR TITLE
Consolidate Profile Preview with other profile code

### DIFF
--- a/CRM/UF/Form/Preview.php
+++ b/CRM/UF/Form/Preview.php
@@ -48,7 +48,7 @@ class CRM_UF_Form_Preview extends CRM_UF_Form_AbstractPreview {
       }
       $name = $fieldDAO->field_name;
 
-      if ($fieldDAO->field_name == 'phone_and_ext') {
+      if ($fieldDAO->field_name === 'phone_and_ext') {
         $name = 'phone';
       }
 
@@ -85,7 +85,7 @@ class CRM_UF_Form_Preview extends CRM_UF_Form_AbstractPreview {
 
       $fieldArray[$name] = $fields[$name];
 
-      if ($fieldDAO->field_name == 'phone_and_ext') {
+      if ($fieldDAO->field_name === 'phone_and_ext') {
         $phoneExtField = str_replace('phone', 'phone_ext', $name);
         $fieldArray[$phoneExtField] = $fields[$phoneExtField];
       }

--- a/templates/CRM/UF/Form/Preview.tpl
+++ b/templates/CRM/UF/Form/Preview.tpl
@@ -19,15 +19,8 @@
   {if $viewOnly}
   {* wrap in crm-container div so crm styles are used *}
     <div id="crm-container-inner" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
-    {include file="CRM/common/CMSUser.tpl"}
       {strip}
-        {if $help_pre && $action neq 4}<div class="messages help">{$help_pre}</div>{/if}
-        {assign var=zeroField value="Initial Non Existent Fieldset"}
-        {assign var=fieldset  value=$zeroField}
-        {include file="CRM/UF/Form/Fields.tpl" prefix=false mode=false hideFieldset=false}
-        {if $field.groupHelpPost}
-          <div class="messages help">{$field.groupHelpPost}</div>
-        {/if}
+        {include file="CRM/UF/Form/Block.tpl" prefix=false mode=false hideFieldset=false}
       {/strip}
     </div> {* end crm-container div *}
   {else}


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate Profile Preview with other profile code

Before
----------------------------------------
The first 2 notices on the preview form are pure copy & paste - they are never assigned as the form does a very limited assign...

![image](https://github.com/civicrm/civicrm-core/assets/336308/c8bea273-86df-4b1a-aa9e-0d5e4708d54a)

![image](https://github.com/civicrm/civicrm-core/assets/336308/5b036b09-d000-4750-84fc-b85240c9cc4d)

After
----------------------------------------
The second 2 are still in the Block.tpl code - but to be fixed separately. 

![image](https://github.com/civicrm/civicrm-core/assets/336308/52484209-494e-4b72-b133-141208d78194)


Technical Details
----------------------------------------
There is no reason for this not to share the code all the places it is previewing shares

Comments
----------------------------------------
