### PR TITLE
Php 8.x clean up notices on Profiles

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -795,6 +795,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
     $this->assign('id', $this->_id);
     $this->assign('mode', $this->_mode);
+    $this->assign('isHideFieldSet', ($this->_mode === self::MODE_CREATE || $this->_mode === self::MODE_EDIT));
     $this->assign('action', $this->_action);
     $this->assign('fields', $this->_fields);
     $this->assign('fieldset', (isset($this->_fieldset)) ? $this->_fieldset : "");

--- a/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/Participant.tpl
+++ b/ext/eventcart/templates/CRM/Event/Cart/Form/Checkout/Participant.tpl
@@ -8,7 +8,7 @@
   <div class="clearfix">
           {assign var=pre value="event[`$event_id`][participant][`$participant_id`][customPre]"}
           <div class="profile-group">
-          {include file="CRM/UF/Form/Block.tpl" fields=$custom.$pre form=$form.field.$participant_id}
+          {include file="CRM/UF/Form/Block.tpl" fields=$custom.$pre form=$form.field.$participant_id hideFieldset=false}
           </div>
 
     <div class="participant-info crm-section form-item">
@@ -23,7 +23,7 @@
           {assign var=post value="event[`$event_id`][participant][`$participant_id`][customPost]"}
           <div style="clear:left"></div>
           <div class="profile-group">
-          {include file="CRM/UF/Form/Block.tpl" fields=$custom.$post form=$form.field.$participant_id}
+          {include file="CRM/UF/Form/Block.tpl" fields=$custom.$post form=$form.field.$participant_id hideFieldset=false}
           </div>
   </div>
     <!--if $form_participant->participant_index > 0-->

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -153,7 +153,7 @@
 
   {if $onbehalfProfile && $onbehalfProfile|@count}
     <div class="crm-group onBehalf_display-group label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
+      {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf' hideFieldset=false}
     </div>
   {/if}
 
@@ -165,7 +165,7 @@
       <div class="display-block">
         <div class="label-left crm-section honoree_profile-section">
           <strong>{$honorName}</strong><br/>
-          {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields mode=8 prefix='honor'}
+          {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields mode=8 prefix='honor' hideFieldset=false}
         </div>
       </div>
     </div>
@@ -173,7 +173,7 @@
 
   {if $customPre}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false hideFieldset=false}
     </fieldset>
   {/if}
 
@@ -272,7 +272,7 @@
 
   {if $customPost}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}
     </fieldset>
   {/if}
 

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -208,13 +208,13 @@
           {/if}
           {/crmRegion}
           <div id="honorType" class="honoree-name-email-section">
-            {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields mode=8 prefix='honor'}
+            {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields mode=8 prefix='honor' hideFieldset=false}
           </div>
         </fieldset>
       {/if}
 
       <div class="crm-public-form-item crm-group custom_pre_profile-group">
-        {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
+        {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false hideFieldset=false}
       </div>
 
       {if array_key_exists('pcp_display_in_roll', $form)}
@@ -283,7 +283,7 @@
     {include file="CRM/Core/BillingBlockWrapper.tpl"}
 
     <div class="crm-public-form-item crm-group custom_post_profile-group">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}
     </div>
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">

--- a/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/OnBehalfOf.tpl
@@ -35,7 +35,7 @@
           </div>
         </div>
       {/if}
-      {include file="CRM/UF/Form/Block.tpl" fields=$onBehalfOfFields mode=8 prefix='onbehalf'}
+      {include file="CRM/UF/Form/Block.tpl" fields=$onBehalfOfFields mode=8 prefix='onbehalf' hideFieldset=true}
     </fieldset>
   {/if}
   {/crmRegion}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -200,7 +200,7 @@
 
   {if $onbehalfProfile && $onbehalfProfile|@count}
     <div class="crm-group onBehalf_display-group label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
+      {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf' hideFieldset=false}
      </div>
   {/if}
 
@@ -212,7 +212,7 @@
       <div class="display-block">
        <div class="label-left crm-section honoree_profile-section">
           <strong>{$honorName}</strong><br/>
-          {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields prefix='honor'}
+          {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields prefix='honor' hideFieldset=false}
         </div>
       </div>
    </div>
@@ -220,7 +220,7 @@
 
   {if $customPre}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false hideFieldset=false}
     </fieldset>
   {/if}
 
@@ -304,7 +304,7 @@
 
   {if $customPost}
     <fieldset class="label-left crm-profile-view">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}
     </fieldset>
   {/if}
 

--- a/templates/CRM/Contribute/Form/PCP/PCPAccount.tpl
+++ b/templates/CRM/Contribute/Form/PCP/PCPAccount.tpl
@@ -22,7 +22,7 @@
 {else}
 <div class="form-item">
 {include file="CRM/common/CMSUser.tpl"}
-{include file="CRM/UF/Form/Block.tpl" fields=$fields prefix=false}
+{include file="CRM/UF/Form/Block.tpl" fields=$fields prefix=false hideFieldset=false}
 </div>
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
+++ b/templates/CRM/Event/Form/Registration/AdditionalParticipant.tpl
@@ -22,7 +22,7 @@
 {/if}
 
 <div class="crm-public-form-item crm-section custom_pre-section">
-  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPre prefix=false}
+  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPre prefix=false hideFieldset=false}
 </div>
 
 {if $priceSet && $allowGroupOnWaitlist}
@@ -49,7 +49,7 @@
 {/if}
 
 <div class="crm-public-form-item crm-section custom_post-section">
-  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPost prefix=false}
+  {include file="CRM/UF/Form/Block.tpl" fields=$additionalCustomPost prefix=false hideFieldset=false}
 </div>
 
 <div id="crm-submit-buttons" class="crm-submit-buttons">

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -73,7 +73,7 @@
 
     <div class="crm-public-form-item crm-section custom_pre-section">
       {* Display "Top of page" profile immediately after the introductory text *}
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false hideFieldset=false}
     </div>
 
     {if $priceSet}
@@ -135,7 +135,7 @@
     {/if}
 
     <div class="crm-public-form-item crm-section custom_post-section">
-      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false}
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}
     </div>
 
     <div id="crm-submit-buttons" class="crm-submit-buttons">

--- a/templates/CRM/PCP/Form/PCPAccount.tpl
+++ b/templates/CRM/PCP/Form/PCPAccount.tpl
@@ -26,7 +26,7 @@
 {else}
 <div class="form-item crm-block crm-form-block">
 {include file="CRM/common/CMSUser.tpl"}
-{include file="CRM/UF/Form/Block.tpl" fields=$fields prefix=false}
+{include file="CRM/UF/Form/Block.tpl" fields=$fields prefix=false hideFieldset=false}
 
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -192,6 +192,7 @@
     {/if}
 
     {if ($action eq 1 and $mode eq 4 ) or ($action eq 2) or ($action eq 8192)}
+      {assign var=floatStyle value=''}
       {if $action eq 2 and $multiRecordFieldListing}
         <div class="crm-multi-record-custom-field-listing">
           {include file="CRM/Profile/Page/MultipleRecordFieldsListing.tpl" showListing=true}

--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -12,20 +12,36 @@
   {strip}
     {assign var=zeroField value="Initial Non Existent Fieldset"}
     {assign var=fieldset  value=$zeroField}
+    {* Unfortunately uF group information is munged into the uf fields array. We have ot iterate throug
+    to extract it. I n future we could migrate to a version of Block.tpl that expects the UFGroup
+    to be assigned by itself & remove this *}
+    {foreach from=$fields item=field key=fieldName}
+      {assign var=groupHelpPost  value=$field.groupHelpPost}
+      {assign var=groupHelpPre  value=$field.groupHelpPre}
+      {assign var=fieldset  value=$field.groupTitle}
+      {assign var=groupDisplayTitle value=$field.groupDisplayTitle}
+      {assign var=group_id value=$field.group_id}
+      {assign var=groupName value=$field.groupName}
+    {/foreach}
+
+    {if $groupHelpPre && $action neq 4}
+      <div class="messages help">{$groupHelpPre|smarty:nodefaults|purify}</div>
+    {/if}
+
+    {if !$hideFieldset}
+      <fieldset class="crm-profile crm-profile-id-{$group_id} crm-profile-name-{$groupName}"><legend>{$groupDisplayTitle}</legend>
+    {/if}
+
+    {if ($form.formName eq 'Confirm' OR $form.formName eq 'ThankYou') AND $prefix neq 'honor'}
+      <div class="header-dark">{$groupDisplayTitle} </div>
+    {/if}
     {include file="CRM/UF/Form/Fields.tpl"}
 
-    {if $field.groupHelpPost && $action neq 4}
-      <div class="messages help">{$field.groupHelpPost}</div>
+    {if $groupHelpPost && $action neq 4}
+      <div class="messages help">{$groupHelpPost|smarty:nodefaults|purify}</div>
     {/if}
-
-    {if $mode eq 4}
-      <div class="crm-submit-buttons">
-        {$form.buttons.html}
-      </div>
-    {/if}
-
-    {if $mode ne 8 && !$hideFieldset}
-    </fieldset>
+    {if !$hideFieldset}
+      </fieldset>
     {/if}
 
   {/strip}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -12,30 +12,6 @@
     {assign var="rowIdentifier" value=$field.name}
   {/if}
 
-  {if $field.groupTitle != $fieldset}
-    {if $fieldset != $zeroField}
-      {if $groupHelpPost && $action neq 4}
-        <div class="messages help">{$groupHelpPost|smarty:nodefaults|purify}</div>
-      {/if}
-      {if $mode ne 8}
-        </fieldset>
-      {/if}
-    {/if}
-
-    {if !$hideFieldset}
-      <fieldset class="crm-profile crm-profile-id-{$field.group_id} crm-profile-name-{$field.groupName}"><legend>{$field.groupDisplayTitle}</legend>
-    {/if}
-
-    {if ($form.formName eq 'Confirm' OR $form.formName eq 'ThankYou') AND $prefix neq 'honor'}
-      <div class="header-dark">{$field.groupDisplayTitle} </div>
-    {/if}
-    {assign var=fieldset  value=`$field.groupTitle`}
-    {assign var=groupHelpPost  value=`$field.groupHelpPost`}
-    {if $field.groupHelpPre && $action neq 4}
-      <div class="messages help">{$field.groupHelpPre|smarty:nodefaults|purify}</div>
-    {/if}
-  {/if}
-
   {if $field.field_type eq "Formatting"}
     {if $action neq 4}
       {$field.help_pre}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -22,7 +22,7 @@
       {/if}
     {/if}
 
-    {if $mode ne 8 && $action ne 4 && !$hideFieldset}
+    {if !$hideFieldset}
       <fieldset class="crm-profile crm-profile-id-{$field.group_id} crm-profile-name-{$field.groupName}"><legend>{$field.groupDisplayTitle}</legend>
     {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
This addresses a good chunk of the notices on the Profile forms - it will take a bit of review

![image](https://github.com/civicrm/civicrm-core/assets/336308/9810b462-463c-4b95-9e48-d3615a152fcc)



Before
----------------------------------------
Lots of notices...


After
----------------------------------------
They seem OK...

Technical Details
----------------------------------------
This code is really confusing but I came to the conclusion that the reason is that the profile (`UFGroup`) details are nested into the `$fields` (`UFFields`) array. What should happen, and does afterwards, is that the group level values are displayed in the `Block.tpl` file and the fields level info is displayed when it iterates through the fields in `Fields.tpl`. The latter is only called from the former (with https://github.com/civicrm/civicrm-core/pull/27482 merged)


I simplifed the decision whether to hide the field set down to one variable, rather than also inspecting `mode`
mode is not assigned as a number except for on one class 

![image](https://github.com/civicrm/civicrm-core/assets/336308/674ff96d-5ee9-4282-a523-2524706c5dcd)

It would be nice not to iterate all the profile fields to get the uf group but I don't think break works in smarty & I doubt it will hurt that much performance wise


Comments
----------------------------------------
I did r-run on online contribution, event, and the links from the Profiles manage screen + the drupal add & edit user
