### PR TITLE
hook_civicrm_links - Add docblocks and event-checker

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1029,6 +1029,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
             'class' => 'medium-popup',
             'qs' => "reset=1&id=%%id%%&contribution_id=%%contribution_id%%",
             'title' => ts('Edit Payment'),
+            'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::UPDATE),
           ],
         ];
         $paymentEditLink = CRM_Core_Action::formLink(
@@ -4291,6 +4292,7 @@ LIMIT 1;";
         'is_refund' => 0,
       ],
       'extra' => '',
+      'weight' => 0,
     ];
 
     if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
@@ -4308,6 +4310,7 @@ LIMIT 1;";
           'mode' => 'live',
         ],
         'extra' => '',
+        'weight' => 0,
       ];
     }
     if ($contributionStatus !== 'Pending') {
@@ -4324,6 +4327,7 @@ LIMIT 1;";
           'is_refund' => 1,
         ],
         'extra' => '',
+        'weight' => 0,
       ];
     }
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -837,6 +837,7 @@ ORDER BY civicrm_custom_group.weight,
               'qs' => 'reset=1&id=%%id%%&eid=%%eid%%&fid=%%fid%%&action=delete&fcs=%%fcs%%',
               'extra' => 'onclick = "if (confirm( \'' . $deleteExtra
               . '\' ) ) this.href+=\'&amp;confirmed=1\'; else return false;"',
+              'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::DELETE),
             ],
           ];
           $customValue['deleteURL'] = CRM_Core_Action::formLink($deleteURL,

--- a/CRM/Financial/Page/BatchTransaction.php
+++ b/CRM/Financial/Page/BatchTransaction.php
@@ -63,11 +63,13 @@ class CRM_Financial_Page_BatchTransaction extends CRM_Core_Page_Basic {
           'url' => 'civicrm/contact/view/contribution',
           'qs' => 'reset=1&id=%%contid%%&cid=%%cid%%&action=view&context=contribution&selectedChild=contribute',
           'title' => ts('View Contribution'),
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::VIEW),
         ],
         'remove' => [
           'name' => ts('Remove'),
           'title' => ts('Remove Transaction'),
           'extra' => 'onclick = "removeFromBatch(%%id%%);"',
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::DELETE),
         ],
       ];
     }

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -344,7 +344,11 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
         ],
       ];
 
+      // pcp.user.actions emits a malformed set of $links. But it is locked-in via unit-test, so we'll grandfather
+      // the bad one and fire new variants that are well-formed.
       CRM_Utils_Hook::links('pcp.user.actions', 'Pcp', $pcpId, self::$_pcpLinks);
+      CRM_Utils_Hook::links('pcp.user.actions.add', 'Pcp', $pcpId, self::$_pcpLinks['add']);
+      CRM_Utils_Hook::links('pcp.user.actions.all', 'Pcp', $pcpId, self::$_pcpLinks['all']);
     }
     return self::$_pcpLinks;
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -410,7 +410,7 @@ abstract class CRM_Utils_Hook {
    *   The type of operation being performed.
    * @param string $objectName
    *   The name of the object. This is generally a CamelCase entity (eg `Contact` or `Activity`).
-   *   Historical exceptions: 'CRM_Core_BAO_LocationType'
+   *   Historical exceptions: 'CRM_Core_BAO_LocationType', 'CRM_Core_BAO_MessageTemplate'
    * @param int $objectId
    *   The unique identifier for the object.
    * @param array $links

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -409,11 +409,27 @@ abstract class CRM_Utils_Hook {
    * @param string $op
    *   The type of operation being performed.
    * @param string $objectName
-   *   The name of the object.
+   *   The name of the object. This is generally a CamelCase entity (eg `Contact` or `Activity`).
+   *   Historical exceptions: 'CRM_Core_BAO_LocationType'
    * @param int $objectId
    *   The unique identifier for the object.
    * @param array $links
    *   (optional) the links array (introduced in v3.2).
+   *   Each of the links may have properties:
+   *   - 'name' (string): the link text
+   *   - 'url' (string): the link URL base path (like civicrm/contact/view, and fillable from $values)
+   *   - 'qs' (string|array): the link URL query parameters to be used by sprintf() with $values (like reset=1&cid=%%id%% when $values['id'] is the contact ID)
+   *   - 'title' (string) (optional): the text that appears when hovering over the link
+   *   - 'extra' (optional): additional attributes for the <a> tag (fillable from $values)
+   *   - 'bit' (optional): a binary number that will be filtered by $mask (sending nothing as $links['bit'] means the link will always display)
+   *   - 'ref' (optional, recommended): a CSS class to apply to the <a> tag.
+   *   - 'class' (string): Optional list of CSS classes
+   *   - 'weight' (int): Weight is used to order the links. If not set 0 will be used but e-notices could occur. This was introduced in CiviCRM 5.63 so it will not have any impact on earlier versions of CiviCRM.
+   *   - 'accessKey' (string) (optional): HTML access key. Single letter or empty string.
+   *   - 'icon' (string) (optional): FontAwesome class name
+   *
+   *   Depending on the specific screen, some fields (e.g. `icon`) may be ignored.
+   *   If you have any idea of a clearer rule, then please update the docs.
    * @param int|null $mask
    *   (optional) the bitmask to show/hide links.
    * @param array $values

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -16,14 +16,17 @@ return new class() extends EventCheck implements HookInterface {
   ];
 
   /**
-   * These are contexts where the "url" can be replaced with an onclick handler.
-   * It evidently works on some screens, but it doesn't sound reliable.
-   * They're allowed for backward-compatibility.
+   * These are contexts where the "url" can be replaced by... magic?
    *
    * @var string[]
    */
-  protected $grandfatheredOnClickLinks = [
+  protected $grandfatheredNoUrl = [
+    'basic.CRM_Core_BAO_LocationType.page::CRM_Core_BAO_LocationType',
     'case.tab.row::Activity',
+    'group.selector.row::Group',
+    'job.manage.action::Job',
+    'membershipType.manage.action::MembershipType',
+    'messageTemplate.manage.action::MessageTemplate',
   ];
 
   /**
@@ -72,8 +75,8 @@ return new class() extends EventCheck implements HookInterface {
       if (isset($link['url'])) {
         $this->assertType('string', $link['url'], "$msg: url should be a string");
       }
-      elseif (in_array("$op::$objectName", $this->grandfatheredOnClickLinks)) {
-        $this->assertTrue((bool) preg_match(';onclick;', $link['extra']), "$msg: ");
+      elseif (in_array("$op::$objectName", $this->grandfatheredNoUrl)) {
+        // This context is allowed to have links without urls. God knows why.
       }
       else {
         $this->fail("$msg: url is missing");

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -5,6 +5,12 @@ use Civi\Test\HookInterface;
 
 return new class() extends EventCheck implements HookInterface {
 
+  // There are several properties named "$grandfatherdXyz". These mark itmes which
+  // pass through hook_civicrm_links but deviate from the plain interpretation of the docs.
+  // Auditing or cleaning each would be its own separate project. Please feel free to
+  // do that audit and figure how to normalize it. But for now, the goal of this file is
+  // to limit the chaos - and prevent new/un-documented deviations.
+
   /**
    * These are $objectNames that deviate from the normal "CamelCase" convention.
    * They're allowed for backward-compatibility.
@@ -29,6 +35,16 @@ return new class() extends EventCheck implements HookInterface {
     'membershipType.manage.action::MembershipType',
     'messageTemplate.manage.action::MessageTemplate',
     'basic.CRM_Core_BAO_MessageTemplate.page::CRM_Core_BAO_MessageTemplate',
+  ];
+
+  /**
+   * These variants have anomalous keys that are not documented and do not
+   * appear in most flavors of "hook_civicrm_links".
+   *
+   * @var \string[][]
+   */
+  protected $grandfatheredInvalidKeys = [
+    'pledge.selector.row' => ['is_active'],
   ];
 
   /**
@@ -110,9 +126,12 @@ return new class() extends EventCheck implements HookInterface {
         $this->assertTrue((bool) preg_match(';^fa-[-a-z0-9]+$;', $link['icon']), "$msg: Icon ({$link['icon']}) should be FontAwesome icon class");
       }
 
-      $expectKeys = ['name', 'url', 'qs', 'title', 'extra', 'bit', 'ref', 'class', 'weight', 'accessKey', 'icon'];
+      $expectKeys = array_merge(
+        ['name', 'url', 'qs', 'title', 'extra', 'bit', 'ref', 'class', 'weight', 'accessKey', 'icon'],
+        $this->grandfatheredInvalidKeys[$op] ?? []
+      );
       $extraKeys = array_diff(array_keys($link), $expectKeys);
-      $this->assertEquals([], $extraKeys, "$msg: Link has unrecognized keys: " . json_encode($extraKeys));
+      $this->assertEquals([], $extraKeys, "$msg: Link has unrecognized keys: " . json_encode(array_values($extraKeys)));
     }
   }
 

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -13,6 +13,7 @@ return new class() extends EventCheck implements HookInterface {
    */
   protected $grandfatheredObjectNames = [
     'CRM_Core_BAO_LocationType',
+    'CRM_Core_BAO_MessageTemplate',
   ];
 
   /**
@@ -27,6 +28,7 @@ return new class() extends EventCheck implements HookInterface {
     'job.manage.action::Job',
     'membershipType.manage.action::MembershipType',
     'messageTemplate.manage.action::MessageTemplate',
+    'basic.CRM_Core_BAO_MessageTemplate.page::CRM_Core_BAO_MessageTemplate',
   ];
 
   /**

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -1,0 +1,95 @@
+<?php
+
+use Civi\Test\EventCheck;
+use Civi\Test\HookInterface;
+
+return new class() extends EventCheck implements HookInterface {
+
+  /**
+   * Ensure that the hook data is always well-formed.
+   *
+   * @see \CRM_Utils_Hook::links()
+   */
+  public function hook_civicrm_links($op, $objectName, &$objectId, &$links, &$mask = NULL, &$values = []): void {
+    // fprintf(STDERR, "CHECK hook_civicrm_links($op)\n");
+    $msg = sprintf('Non-conforming hook_civicrm_links(%s, %s)', json_encode($op), json_encode($objectName));
+
+    // These are $objectNames that deviate from the normal "CamelCase" convention.
+    $grandfatheredObjectNames = [
+      'CRM_Core_BAO_LocationType',
+    ];
+    // These are contexts where the "url" can be replaced with an onclick handler. It evidentally works on some screens, but it doesn't sound reliable.
+    $grandfatheredOnClickLinks = [
+      'case.tab.row::Activity',
+    ];
+    // These variants have majorly deviant data in $links. But they are protected by pre-existing unit-tests.
+    $grandfatheredInvalidLinks = [
+      'pcp.user.actions::Pcp',
+    ];
+
+    $this->assertTrue((bool) preg_match(';^\w+(\.\w+)+$;', $op), "$msg: Operation ($op) should be dotted expression");
+    $this->assertTrue((bool) preg_match(';^[A-Z][a-zA-Z0-9]+$;', $objectName) || in_array($objectName, $grandfatheredObjectNames),
+      "$msg: Object name ($objectName) should be a CamelCase name or a grandfathered name");
+
+    // $this->assertType('integer|null', $objectId, "$msg: Object ID ($objectId) should be int|null");
+    $this->assertTrue($objectId === NULL || is_numeric($objectId), "$msg: Object ID ($objectId) should be int|null");
+    // Sometimes it's a string-style int. Patch-welcome if someone wants to clean that up. But this is what it currently does.
+
+    $this->assertType('array', $links, "$msg: Links should be an array");
+    $this->assertType('integer|null', $mask, "$msg: Mask ($mask) should be int}null");
+    $this->assertType('array', $values, "$msg: Values should be an array");
+
+    if (in_array("$op::$objectName", $grandfatheredInvalidLinks)) {
+      return;
+    }
+    foreach ($links as $link) {
+      if (isset($link['name'])) {
+        $this->assertType('string', $link['name'], "$msg: name should be a string");
+      }
+      else {
+        $this->fail("$msg: name is missing");
+      }
+
+      if (isset($link['url'])) {
+        $this->assertType('string', $link['url'], "$msg: url should be a string");
+      }
+      elseif (in_array("$op::$objectName", $grandfatheredOnClickLinks)) {
+        $this->assertTrue((bool) preg_match(';onclick;', $link['extra']), "$msg: ");
+      }
+      else {
+        $this->fail("$msg: url is missing");
+      }
+
+      if (isset($link['qs'])) {
+        $this->assertType('string|array', $link['qs'], "$msg: qs should be a string");
+      }
+      if (isset($link['title'])) {
+        $this->assertType('string', $link['title'], "$msg: title should be a string");
+      }
+      if (isset($link['extra'])) {
+        $this->assertType('string', $link['extra'], "$msg: extra should be a string");
+      }
+      if (isset($link['bit'])) {
+        $this->assertType('integer', $link['bit'], "$msg: bit should be an int");
+      }
+      if (isset($link['ref'])) {
+        $this->assertType('string', $link['ref'], "$msg: ref should be an string");
+      }
+      if (isset($link['class'])) {
+        $this->assertType('string', $link['class'], "$msg: class should be a string");
+      }
+      $this->assertTrue(isset($link['weight']) && is_numeric($link['weight']), "$msg: weight should be numerical");
+      if (isset($link['accessKey'])) {
+        $this->assertTrue(is_string($link['accessKey']) && mb_strlen($link['accessKey']) <= 1, "$msg: accessKey should be a letter");
+      }
+      if (isset($link['icon'])) {
+        $this->assertTrue((bool) preg_match(';^fa-[-a-z0-9]+$;', $link['icon']), "$msg: Icon ({$link['icon']}) should be FontAwesome icon class");
+      }
+
+      $expectKeys = ['name', 'url', 'qs', 'title', 'extra', 'bit', 'ref', 'class', 'weight', 'accessKey', 'icon'];
+      $extraKeys = array_diff(array_keys($link), $expectKeys);
+      $this->assertEquals([], $extraKeys, "$msg: Link has unrecognized keys: " . json_encode($extraKeys));
+    }
+  }
+
+};

--- a/tests/events/hook_civicrm_links.evch.php
+++ b/tests/events/hook_civicrm_links.evch.php
@@ -30,11 +30,22 @@ return new class() extends EventCheck implements HookInterface {
   protected $grandfatheredNoUrl = [
     'basic.CRM_Core_BAO_LocationType.page::CRM_Core_BAO_LocationType',
     'case.tab.row::Activity',
+    'financialItem.batch.row::FinancialItem',
     'group.selector.row::Group',
     'job.manage.action::Job',
     'membershipType.manage.action::MembershipType',
     'messageTemplate.manage.action::MessageTemplate',
     'basic.CRM_Core_BAO_MessageTemplate.page::CRM_Core_BAO_MessageTemplate',
+  ];
+
+  /**
+   * These are deviant values with appear as `$link['bit']` fields. They are documented
+   * (and generally practiced) as integers.
+   *
+   * @var \string[][]
+   */
+  protected $grandfatheredInvalidBits = [
+    'financialItem.batch.row' => ['view', 'assign'],
   ];
 
   /**
@@ -110,7 +121,12 @@ return new class() extends EventCheck implements HookInterface {
         $this->assertType('string', $link['extra'], "$msg: extra should be a string");
       }
       if (isset($link['bit'])) {
-        $this->assertType('integer', $link['bit'], "$msg: bit should be an int");
+        if (in_array($link['bit'], $this->grandfatheredInvalidBits[$op] ?? [])) {
+          // Exception
+        }
+        else {
+          $this->assertType('integer', $link['bit'], "$msg: bit should be an int" . $link['bit']);
+        }
       }
       if (isset($link['ref'])) {
         $this->assertType('string', $link['ref'], "$msg: ref should be an string");


### PR DESCRIPTION
Overview
----------------------------------------

`hook_civicrm_links` is fired in numerous ways (incl ~9 direct calls to `CRM_Utils_hook::links()`, ~96 indirect calls via `CRM_Core_Action::formLink()`). This adds some more docblocks and validation.

(This is an off-shoot of the discussion with @eileenmcnaughton  on https://github.com/civicrm/civicrm-core/pull/26243/files#r1328057493. It seems to me better to have the tests complaining about quirks in `hook_links` rather than random web-pages.)

Before
----------------------------------------

* Docblock on `links()` doesn't explain what's expected
* No systemic validation mechanism

After
----------------------------------------

* Docblock on `links()` (derived from https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_links/)
* Anytime the hook fires within a unit-test, it will validate the data passing through `$links`

Comments
----------------------------------------

* Someday, I'd like to have a flag or extension that we use on dev-sites -- where it runs the event-checker during regular web-browsing...
* I did a partial test-run locally, and it shows some more properties that weren't previously documented. Gonna let CI do a full run and see how many other bits it finds.