### PR TITLE
[php 8.2] Declare _paymentFields with public visibility

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -137,6 +137,18 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
   public $_honorID = NULL;
 
   /**
+   * Array of payment related fields to potentially display on this form (generally credit card or debit card fields).
+   *
+   * Note that this is not accessed in core except in a function that could use
+   * a local variable but both IATS & TSys access it.
+   *
+   * This is rendered via billingBlock.tpl.
+   *
+   * @var array
+   */
+  public $_paymentFields = [];
+
+  /**
    * The contribution values if an existing contribution
    * @var array
    */


### PR DESCRIPTION
Overview
----------------------------------------
Declare _paymentFields with public visibility

Before
----------------------------------------
CRM_Event_Form_ParticipantTest::testSubmit
Creation of dynamic property CRM_Event_Form_Participant::$_paymentFields is deprecated

After
----------------------------------------
Fixed by declaring publicly 

Technical Details
----------------------------------------
In terms of core usage this could be replaced by a local variable (since the function it is defined in is called from one place right before the same place calls the only core usages). However the variable is accessed from IATs & TSYS. All core declarations are public so there is no conflict


Comments
----------------------------------------